### PR TITLE
feat(pnpr): scale shared artifact storage horizontally

### DIFF
--- a/.changeset/calm-caches-scale.md
+++ b/.changeset/calm-caches-scale.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Made the signed shared-artifact cache horizontally scalable with S3-compatible storage and an independent top-level `artifacts` feature toggle.

--- a/.changeset/kind-trees-handshake.md
+++ b/.changeset/kind-trees-handshake.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Allowed pnpm's shared-artifact client to connect to an artifact-only pnpr tier.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6203,6 +6203,7 @@ dependencies = [
 name = "pnpr-shared-artifacts"
 version = "0.0.1"
 dependencies = [
+ "async-trait",
  "base64 0.23.1",
  "futures-util",
  "object_store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6205,6 +6205,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
+ "bytes",
  "futures-util",
  "object_store",
  "pnpm-shared-artifact-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6204,9 +6204,11 @@ name = "pnpr-shared-artifacts"
 version = "0.0.1"
 dependencies = [
  "base64 0.23.1",
+ "futures-util",
+ "object_store",
  "pnpm-shared-artifact-protocol",
+ "pnpr-config",
  "pnpr-error",
- "pnpr-storage",
  "serde",
  "serde_json",
  "sha2",

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -409,14 +409,19 @@ impl PnprClient {
     /// if it's unreachable, isn't a pnpr (404 at `/-/pnpr`), or shares
     /// no protocol version with this client.
     pub async fn handshake(&self) -> Result<(), PnprClientError> {
-        self.fetch_compatible_handshake(None).await?;
+        let capability = self.fetch_handshake(None).await?;
+        if !capability.versions.contains(&PROTOCOL_VERSION) {
+            return Err(PnprClientError::Server(format!(
+                "pnpr server speaks protocol versions {:?}, but this client requires v{PROTOCOL_VERSION}",
+                capability.versions,
+            )));
+        }
         Ok(())
     }
 
     /// Confirm that the server enabled the v0 signed-artifact `PoC`.
     pub async fn handshake_artifacts(&self) -> Result<(), PnprClientError> {
-        let capability =
-            self.fetch_compatible_handshake(Some(self.artifact_request_timeout)).await?;
+        let capability = self.fetch_handshake(Some(self.artifact_request_timeout)).await?;
         if !capability.artifacts.contains(&PROTOCOL_VERSION) {
             return Err(PnprClientError::Server(format!(
                 "pnpr server does not advertise shared artifact protocol v{PROTOCOL_VERSION}",
@@ -425,7 +430,7 @@ impl PnprClient {
         Ok(())
     }
 
-    async fn fetch_compatible_handshake(
+    async fn fetch_handshake(
         &self,
         timeout: Option<Duration>,
     ) -> Result<HandshakeCapability, PnprClientError> {
@@ -442,12 +447,6 @@ impl PnprClient {
             )));
         }
         let body: HandshakeResponse = response.json().await?;
-        if !body.pnpr.versions.contains(&PROTOCOL_VERSION) {
-            return Err(PnprClientError::Server(format!(
-                "pnpr server speaks protocol versions {:?}, but this client requires v{PROTOCOL_VERSION}",
-                body.pnpr.versions,
-            )));
-        }
         Ok(body.pnpr)
     }
 

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -845,6 +845,29 @@ async fn artifact_handshake_is_independent_from_the_resolver_protocol() {
 }
 
 #[tokio::test]
+async fn artifact_blob_download_rejects_bytes_that_do_not_match_the_integrity() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("POST", "/-/pnpr/v0/artifacts/blob")
+        .with_status(200)
+        .with_body("poisoned blob")
+        .create_async()
+        .await;
+    let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(b"expected blob")));
+
+    let error = PnprClient::new(server.url())
+        .download_artifact_blob(
+            &ArtifactBlobRequest { owner: OwnerScope::organization("acme"), integrity },
+            None,
+        )
+        .await
+        .expect_err("a corrupt artifact blob must be rejected");
+
+    assert!(matches!(error, PnprClientError::Protocol(_)), "got: {error}");
+    mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn publishes_resolves_and_verifies_an_organization_artifact() {
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr_artifacts().await;
     let client = PnprClient::new(pnpr_url);

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -827,7 +827,7 @@ async fn artifact_capability_is_disabled_by_default() {
 }
 
 #[tokio::test]
-async fn artifact_handshake_requires_the_base_protocol() {
+async fn artifact_handshake_is_independent_from_the_resolver_protocol() {
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", "/-/pnpr")
@@ -837,11 +837,10 @@ async fn artifact_handshake_requires_the_base_protocol() {
         .create_async()
         .await;
 
-    let error = PnprClient::new(server.url())
+    PnprClient::new(server.url())
         .handshake_artifacts()
         .await
-        .expect_err("artifact capability cannot outlive its base protocol");
-    assert!(error.to_string().contains("speaks protocol versions []"));
+        .expect("artifact-only capability is supported");
     mock.assert_async().await;
 }
 

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -84,7 +84,7 @@ async fn start_pnpr_inner(
     let addr = listener.local_addr().expect("pnpr addr");
 
     let mut config = pnpr::Config::proxy(addr, storage.path().to_path_buf());
-    config.resolver.artifacts = artifacts_enabled;
+    config.artifacts.enabled = artifacts_enabled;
     config.public_url = public_url.unwrap_or_else(|| format!("http://{addr}"));
     config.auth.htpasswd.max_users = pnpr::MaxUsers::Unlimited;
     for (name, upstream) in upstreams {
@@ -964,10 +964,18 @@ async fn artifact_lookup_preserves_script_eligibility_and_allow_build_policy() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 16)]
-async fn concurrent_artifact_publications_respect_the_variant_limit() {
+async fn concurrent_artifact_publications_apply_the_variant_limit_at_read_time() {
     const PUBLICATIONS: usize = 16;
 
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr_artifacts().await;
+    let (fixture, _, _) = signed_artifact_fixture_with_builder_id("ci/concurrent/0");
+    let (payload, _) = fixture.envelope.decode_payload().expect("decode fixture payload");
+    let candidate = ArtifactCandidate {
+        key: fixture.key,
+        package: payload.package,
+        source_integrity: payload.source_integrity,
+        owner: payload.owner,
+    };
     let barrier = Arc::new(Barrier::new(PUBLICATIONS + 1));
     let mut publications = Vec::with_capacity(PUBLICATIONS);
     for index in 0..PUBLICATIONS {
@@ -983,17 +991,25 @@ async fn concurrent_artifact_publications_respect_the_variant_limit() {
     }
     barrier.wait().await;
 
-    let mut accepted = 0;
-    let mut rejected = Vec::new();
     for publication in publications {
-        match publication.await.expect("publication task") {
-            Ok(()) => accepted += 1,
-            Err(err) => rejected.push(err.to_string()),
-        }
+        publication.await.expect("publication task").expect("publish artifact variant");
     }
-    assert_eq!(accepted, pnpm_shared_artifact_protocol::MAX_VARIANTS_PER_CANDIDATE);
-    assert_eq!(rejected.len(), PUBLICATIONS - accepted);
-    assert!(rejected.iter().all(|error| error.contains("variant limit")));
+
+    let response = reqwest::Client::new()
+        .post(format!("{pnpr_url}-/pnpr/v0/artifacts/resolve"))
+        .header(reqwest::header::AUTHORIZATION, pnpr_auth)
+        .json(&pnpm_pnpr_client::ResolveArtifactsRequest { candidates: vec![candidate] })
+        .send()
+        .await
+        .expect("resolve artifacts response")
+        .error_for_status()
+        .expect("successful artifact resolve")
+        .json::<serde_json::Value>()
+        .await
+        .expect("artifact resolve JSON");
+    let variants =
+        response["artifacts"][0]["variants"].as_array().expect("artifact variants array");
+    assert_eq!(variants.len(), pnpm_shared_artifact_protocol::MAX_VARIANTS_PER_CANDIDATE);
 }
 
 #[tokio::test]

--- a/pnpr/client/README.md
+++ b/pnpr/client/README.md
@@ -44,13 +44,17 @@ pnprServer: http://localhost:4000
 
 ## Shared-artifact PoC (`remoteSideEffectsCache`)
 
-Set `resolver.artifacts: true` in pnpr's YAML to advertise and mount the
+Set `artifacts.enabled: true` in pnpr's YAML to advertise and mount the
 organization-scoped v0 endpoints. The feature is off by default. Both the
 TypeScript and Rust CLIs automatically query it during normal and frozen
 lockfile installs when `pnprServer` and `remoteSideEffectsCache` are configured.
 In this PoC, an `organization` owner's name must equal the authenticated pnpr
 username; publisher-owned artifacts are rejected until publisher discovery is
 defined.
+
+With an `s3:` block, artifacts use a reserved `.pnpr-artifacts/v0/` namespace
+in the configured bucket and can be shared by multiple pnpr replicas. Without
+S3 they retain the local `cache/shared-artifacts/v0` layout.
 
 Add the client policy to `pnpm-workspace.yaml`:
 
@@ -134,9 +138,8 @@ Start pnpr with a temporary config that enables account creation and artifacts:
 storage: /tmp/pnpr-shared-artifacts/storage
 cache: /tmp/pnpr-shared-artifacts/cache
 secret: replace-with-a-local-secret-at-least-32-bytes
-resolver:
+artifacts:
   enabled: true
-  artifacts: true
 auth:
   htpasswd:
     file: /tmp/pnpr-shared-artifacts/htpasswd

--- a/pnpr/crates/config/config.yaml
+++ b/pnpr/crates/config/config.yaml
@@ -7,11 +7,11 @@ storage: ./storage
 # to a `.pnpr-cache` subdirectory of `storage`; point it at a separate,
 # ephemeral volume to keep cached upstream content off the durable disk.
 #cache: ./cache
-# Store the hosted (published) packages in an S3-compatible object store
-# instead of the local `storage` directory. Works with AWS S3 (omit
+# Store the hosted (published) packages and enabled shared artifacts in an
+# S3-compatible object store instead of local directories. Works with AWS S3 (omit
 # `endpoint`), Cloudflare R2 (`region: auto` + the account endpoint),
-# MinIO, Backblaze B2, etc. The proxy cache and install-accelerator
-# stores always stay on local disk. Credentials fall back to the
+# MinIO, Backblaze B2, etc. The proxy cache and install-accelerator stores stay
+# on local disk. Credentials fall back to the
 # standard AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY environment
 # variables when not set here.
 #s3:
@@ -44,11 +44,12 @@ storage: ./storage
 # dist-tag, search) is served iff at least one registry is declared under
 # `registries:` below; `--disable-registry` turns it off per tier. The install
 # accelerator has its own toggle. Something must be served: registries, or the
-# resolver. (`/-/ping` and the login/token account endpoints are always
-# served.)
+# resolver, or artifacts. (`/-/ping` and the login/token account endpoints are
+# always served.)
 #resolver:           # install accelerator: /-/pnpr, /-/pnpr/v0/resolve,
 #  enabled: true     # and /-/pnpr/v0/verify-lockfile
-#  artifacts: false  # organization-scoped shared-artifact PoC endpoints
+#artifacts:          # organization-scoped shared-artifact PoC endpoints
+#  enabled: false
 secret: pnpm-registry-mock-secret-key-32
 
 auth:

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -122,6 +122,10 @@ pub struct Config {
     /// default; disable it to run a plain registry with no server-side
     /// resolution. See [`ResolverFeature`].
     pub resolver: ResolverFeature,
+    /// Organization-scoped signed build artifacts. Kept separate from the
+    /// resolver so deployments can scale the compute-bound resolver and the
+    /// I/O-bound artifact store independently. See [`ArtifactsFeature`].
+    pub artifacts: ArtifactsFeature,
     /// Which fetch routes the resolution cache treats as public (fetched
     /// anonymously and shared globally) vs. private, driving the
     /// resolver's route classification.
@@ -217,15 +221,20 @@ pub struct ResolverFeature {
     /// `/-/pnpr/v0/verify-lockfile`). When `false`, none of those routes are
     /// mounted.
     pub enabled: bool,
-    /// Organization-scoped signed artifact endpoints. Off by default while
-    /// the protocol is a proof of concept.
-    pub artifacts: bool,
 }
 
 impl Default for ResolverFeature {
     fn default() -> Self {
-        Self { enabled: true, artifacts: false }
+        Self { enabled: true }
     }
+}
+
+/// Toggle for the signed shared-artifact surface. Off by default while the
+/// protocol is a proof of concept.
+#[derive(Debug, Default, Clone)]
+pub struct ArtifactsFeature {
+    /// Master switch for the artifact publish, lookup, and blob endpoints.
+    pub enabled: bool,
 }
 
 /// CLI-level overrides for the feature toggles, applied *during* config
@@ -240,6 +249,7 @@ impl Default for ResolverFeature {
 pub struct FeatureOverrides {
     pub disable_registry: bool,
     pub disable_resolver: bool,
+    pub disable_artifacts: bool,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -248,7 +258,8 @@ pub struct OsvConfig {
     pub path: Option<PathBuf>,
 }
 
-/// The YAML `s3:` block. Selects the object-store hosted backend.
+/// The YAML `s3:` block. Selects the object store for hosted packages and
+/// enabled shared artifacts.
 /// Credentials fall back to the standard AWS environment variables
 /// (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) when not set here,
 /// so an operator can keep secrets out of the config file. Whole-file
@@ -968,6 +979,10 @@ struct ConfigFile {
     /// deserialize into the struct.
     #[serde(default)]
     resolver: Option<FeatureFile>,
+    /// pnpr-only feature toggle for signed shared artifacts. It is a peer of
+    /// the resolver because deployments may mount either surface alone.
+    #[serde(default)]
+    artifacts: Option<ArtifactsFeatureFile>,
     /// pnpr registries: hosted, upstream, and router origins, each
     /// exposed at `/~<name>/`. The only routing surface — there is no legacy
     /// `upstreams:`/`packages: proxy:` fallback.
@@ -1119,14 +1134,19 @@ struct OsvFile {
 struct FeatureFile {
     #[serde(default = "default_true")]
     enabled: bool,
-    #[serde(default)]
-    artifacts: bool,
 }
 
 impl Default for FeatureFile {
     fn default() -> Self {
-        Self { enabled: true, artifacts: false }
+        Self { enabled: true }
     }
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ArtifactsFeatureFile {
+    #[serde(default)]
+    enabled: bool,
 }
 
 fn default_true() -> bool {
@@ -1256,6 +1276,7 @@ impl Config {
             osv: OsvConfig::default(),
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
+            artifacts: ArtifactsFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
             registries,
@@ -1304,6 +1325,7 @@ impl Config {
             osv: OsvConfig::default(),
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
+            artifacts: ArtifactsFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
             registries,
@@ -1541,10 +1563,11 @@ impl Config {
         let registry =
             RegistryFeature { enabled: !file.registries.is_empty() && !overrides.disable_registry };
         let resolver_file = file.resolver.unwrap_or_default();
-        let resolver = ResolverFeature {
-            enabled: resolver_file.enabled && !overrides.disable_resolver,
-            artifacts: resolver_file.artifacts && !overrides.disable_resolver,
-        };
+        let resolver =
+            ResolverFeature { enabled: resolver_file.enabled && !overrides.disable_resolver };
+        let artifacts_file = file.artifacts.unwrap_or_default();
+        let artifacts =
+            ArtifactsFeature { enabled: artifacts_file.enabled && !overrides.disable_artifacts };
         // Upstream registries (and the credentials some carry) are resolved by
         // `build_registries` below into this map. Resolving an upstream registry's
         // `auth` is strict — an unresolvable token is a config error — so a
@@ -1576,6 +1599,7 @@ impl Config {
             osv,
             registry,
             resolver,
+            artifacts,
             route_policy,
             resolution_cache_secret,
             registries,
@@ -1591,12 +1615,13 @@ impl Config {
     /// endpoints. Checked at config load and again in the serve/router
     /// entry points for programmatically built configs.
     pub fn ensure_a_feature_is_enabled(&self) -> Result<(), RegistryError> {
-        if self.registry.enabled || self.resolver.enabled {
+        if self.registry.enabled || self.resolver.enabled || self.artifacts.enabled {
             Ok(())
         } else {
             Err(RegistryError::InvalidConfig {
                 reason: "nothing to serve: the npm-registry surface is off (no `registries:` \
-                         declared, or `--disable-registry`) and the resolver is disabled"
+                         declared, or `--disable-registry`), the resolver is disabled, and \
+                         artifacts are disabled"
                     .to_string(),
             })
         }

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -271,12 +271,16 @@ fn resolver_block_present_but_empty_defaults_to_enabled() {
 }
 
 #[test]
-fn cli_disabling_both_surfaces_with_bundled_config_errors_without_panicking() {
-    // No config file → the bundled branch. Disabling both surfaces via
+fn cli_disabling_all_surfaces_with_bundled_config_errors_without_panicking() {
+    // No config file → the bundled branch. Disabling all surfaces via
     // CLI must surface a clean error, not panic on the bundled `expect`.
-    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: true };
+    let overrides = FeatureOverrides {
+        disable_registry: true,
+        disable_resolver: true,
+        disable_artifacts: true,
+    };
     let err = Config::resolve_with_overrides(None, None, listen(), None, overrides)
-        .expect_err("both surfaces disabled must error rather than panic");
+        .expect_err("all surfaces disabled must error rather than panic");
     assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
 }
 
@@ -304,15 +308,52 @@ resolver:
 }
 
 #[test]
-fn shared_artifacts_are_an_explicit_resolver_opt_in() {
+fn shared_artifacts_are_an_explicit_top_level_opt_in() {
     let default = Config::from_yaml_str("", Path::new("/x"), listen(), None).unwrap();
-    assert!(!default.resolver.artifacts);
+    assert!(!default.artifacts.enabled);
 
-    let enabled =
+    let enabled = Config::from_yaml_str(
+        "resolver:\n  enabled: false\nartifacts:\n  enabled: true\n",
+        Path::new("/x"),
+        listen(),
+        None,
+    )
+    .unwrap();
+    assert!(!enabled.resolver.enabled);
+    assert!(enabled.artifacts.enabled);
+}
+
+#[test]
+fn nested_artifacts_toggle_is_rejected() {
+    let error =
         Config::from_yaml_str("resolver:\n  artifacts: true\n", Path::new("/x"), listen(), None)
-            .unwrap();
-    assert!(enabled.resolver.enabled);
-    assert!(enabled.resolver.artifacts);
+            .unwrap_err();
+
+    assert!(error.to_string().contains("unknown field `artifacts`"), "{error}");
+}
+
+#[test]
+fn artifact_override_is_independent_from_the_resolver_override() {
+    let yaml = "resolver:\n  enabled: false\nartifacts:\n  enabled: true\n";
+    let enabled = Config::from_yaml_str_with_overrides(
+        yaml,
+        Path::new("/x"),
+        listen(),
+        None,
+        FeatureOverrides::default(),
+    )
+    .unwrap();
+    assert!(enabled.artifacts.enabled);
+
+    let error = Config::from_yaml_str_with_overrides(
+        yaml,
+        Path::new("/x"),
+        listen(),
+        None,
+        FeatureOverrides { disable_artifacts: true, ..FeatureOverrides::default() },
+    )
+    .unwrap_err();
+    assert!(error.to_string().contains("nothing to serve"), "{error}");
 }
 
 #[test]
@@ -321,7 +362,7 @@ fn nothing_to_serve_is_a_config_error() {
     // only `/-/ping` and the account endpoints — a misconfiguration.
     let yaml = "resolver:\n  enabled: false\n";
     let err = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None)
-        .expect_err("a server with neither surface enabled must error");
+        .expect_err("a server with no surface enabled must error");
     assert!(matches!(err, RegistryError::InvalidConfig { .. }));
     assert!(err.to_string().contains("nothing to serve"), "unexpected error: {err}");
 }
@@ -1037,7 +1078,11 @@ registries:
     type: router
     sources: [ghost]
 ";
-    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
+    let overrides = FeatureOverrides {
+        disable_registry: true,
+        disable_resolver: false,
+        disable_artifacts: false,
+    };
     let err =
         Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
             .expect_err("a broken registry graph must fail even with the registry disabled");
@@ -1064,7 +1109,11 @@ registries:
     type: router
     sources: [corp]
 ";
-    let overrides = FeatureOverrides { disable_registry: true, disable_resolver: false };
+    let overrides = FeatureOverrides {
+        disable_registry: true,
+        disable_resolver: false,
+        disable_artifacts: false,
+    };
     let config =
         Config::from_yaml_str_with_overrides(yaml, Path::new("/x"), listen(), None, overrides)
             .expect("a resolver-only tier must not fail on unused upstream credentials");

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -15,11 +15,11 @@ pub use pnpr_auth::{
     identify,
 };
 pub use pnpr_config::{
-    AccessSpec, AuthConfig, BackendConfig, Config, ConfigSource, DEFAULT_CONFIG_YAML,
-    FeatureOverrides, HostedConfig, HostedStoreConfig, HtpasswdConfig, LibsqlSettings, LogConfig,
-    LogFormat, LogLevel, MaxUsers, OsvConfig, PackageAccess, PublicRoute, RegistryFeature,
-    ResolverFeature, RoutePolicy, S3Settings, SqlBackendSettings, Teams, TokensConfig,
-    UpstreamConfig, default_cache_dir,
+    AccessSpec, ArtifactsFeature, AuthConfig, BackendConfig, Config, ConfigSource,
+    DEFAULT_CONFIG_YAML, FeatureOverrides, HostedConfig, HostedStoreConfig, HtpasswdConfig,
+    LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, OsvConfig, PackageAccess,
+    PublicRoute, RegistryFeature, ResolverFeature, RoutePolicy, S3Settings, SqlBackendSettings,
+    Teams, TokensConfig, UpstreamConfig, default_cache_dir,
 };
 pub use pnpr_error::{RegistryError, Result};
 pub use pnpr_policy::{AccessList, AccessToken, Identity, PackageRule, PackageRules};

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -71,6 +71,16 @@ struct Args {
     disable_artifacts: bool,
 }
 
+impl Args {
+    fn feature_overrides(&self) -> pnpr::FeatureOverrides {
+        pnpr::FeatureOverrides {
+            disable_registry: self.disable_registry,
+            disable_resolver: self.disable_resolver,
+            disable_artifacts: self.disable_artifacts,
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Args::parse();
@@ -78,11 +88,7 @@ async fn main() -> miette::Result<()> {
     // Pass the surface-disable flags into parsing so a CLI-disabled surface
     // skips its parse-time work too (e.g. strict upstream token resolution),
     // not just its routes — applying them after `resolve` would be too late.
-    let overrides = pnpr::FeatureOverrides {
-        disable_registry: args.disable_registry,
-        disable_resolver: args.disable_resolver,
-        disable_artifacts: args.disable_artifacts,
-    };
+    let overrides = args.feature_overrides();
     let (mut config, source) = Config::resolve_with_overrides(
         args.config.as_deref(),
         auto_path.as_deref(),

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -64,6 +64,11 @@ struct Args {
     /// loaded config.
     #[arg(long)]
     disable_resolver: bool,
+
+    /// Disable the signed shared-artifact surface. Overrides
+    /// `artifacts.enabled` from the loaded config.
+    #[arg(long)]
+    disable_artifacts: bool,
 }
 
 #[tokio::main]
@@ -76,6 +81,7 @@ async fn main() -> miette::Result<()> {
     let overrides = pnpr::FeatureOverrides {
         disable_registry: args.disable_registry,
         disable_resolver: args.disable_resolver,
+        disable_artifacts: args.disable_artifacts,
     };
     let (mut config, source) = Config::resolve_with_overrides(
         args.config.as_deref(),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -101,6 +101,7 @@ struct AppState {
 
 struct AppInner {
     storage: Storage,
+    artifacts: Option<pnpr_shared_artifacts::SharedArtifactStore>,
     /// One [`Upstream`] per declared upstream, keyed by the same name
     /// used in [`Config::upstreams`]. Built once at router construction
     /// time so each request avoids re-allocating a `ThrottledClient`.
@@ -229,10 +230,8 @@ pub fn try_router_with_auth(mut config: Config, auth: AuthState) -> pnpr_error::
     router_with_auth_and_osv(config, auth, osv_index)
 }
 
-/// Load the OSV index only for surfaces that actually consult it. With
-/// both mounted surfaces disabled rejected earlier, that means any
-/// enabled `osv` config now applies to the resolver, the registry, or
-/// both.
+/// Load the OSV index only for surfaces that consult it. An artifacts-only
+/// tier skips the database because artifact requests do not use OSV data.
 fn load_active_osv_index(config: &Config) -> pnpr_error::Result<Option<Arc<pnpr_osv::OsvIndex>>> {
     if config.resolver.enabled || config.registry.enabled {
         pnpr_osv::load_osv_index(config)
@@ -244,7 +243,7 @@ fn load_active_osv_index(config: &Config) -> pnpr_error::Result<Option<Arc<pnpr_
 /// Run startup side effects and load the auth backends. The registry
 /// needs publish-journal recovery; auth loads on every tier because the
 /// account endpoints (which mint and manage tokens) are always served,
-/// and both mounted surfaces consult caller identity.
+/// and every mounted surface consults caller identity.
 async fn load_startup_auth(config: &Config) -> pnpr_error::Result<AuthState> {
     if config.registry.enabled {
         pnpr_storage::journal::recover_publish_journal(config).await?;
@@ -306,6 +305,7 @@ fn log_enabled_surfaces(config: &Config) {
     tracing::info!(
         registry = config.registry.enabled,
         resolver = config.resolver.enabled,
+        artifacts = config.artifacts.enabled,
         "pnpr surfaces",
     );
 }
@@ -2699,13 +2699,14 @@ async fn serve_ping(State(_state): State<AppState>) -> Response {
 /// client can fail fast against a misconfigured server. `versions`
 /// lists the `/-/pnpr/vN/resolve` protocol versions this server speaks.
 async fn serve_pnpr_handshake(State(state): State<AppState>) -> Response {
+    let versions = state.inner.config.resolver.enabled.then_some(0).into_iter().collect::<Vec<_>>();
     let artifacts =
-        state.inner.config.resolver.artifacts.then_some(0).into_iter().collect::<Vec<_>>();
+        state.inner.config.artifacts.enabled.then_some(0).into_iter().collect::<Vec<_>>();
     (
         StatusCode::OK,
         axum::Json(serde_json::json!({
             "pnpr": {
-                "versions": [0],
+                "versions": versions,
                 "artifacts": artifacts,
             }
         })),
@@ -2713,12 +2714,10 @@ async fn serve_pnpr_handshake(State(state): State<AppState>) -> Response {
         .into_response()
 }
 
-/// 404 stub mounted on the resolver paths when the resolver feature is
-/// disabled. Registered so these specific paths return a clean
-/// not-found — in particular `/-/pnpr`, whose 404 is how a client
-/// detects "no resolver here" — rather than being shadowed by the
-/// registry's catch-all param routes and proxied upstream.
-async fn resolver_disabled() -> Response {
+/// 404 stub mounted on the capability handshake when neither pnpr protocol is
+/// enabled. It prevents the registry catch-all from proxying the probe
+/// upstream.
+async fn pnpr_protocols_disabled() -> Response {
     StatusCode::NOT_FOUND.into_response()
 }
 
@@ -2766,7 +2765,12 @@ async fn serve_publish_artifact(
         Err(err) => return private_no_cache(err.into_response()),
     };
     private_no_cache(
-        match pnpr_shared_artifacts::publish(&state.inner.config.cache_storage, &username, request)
+        match state
+            .inner
+            .artifacts
+            .as_ref()
+            .expect("artifact routes require an artifact store")
+            .publish(&username, request)
             .await
         {
             Ok(true) => StatusCode::CREATED.into_response(),
@@ -2786,7 +2790,12 @@ async fn serve_resolve_artifacts(
         Err(err) => return private_no_cache(err.into_response()),
     };
     private_no_cache(
-        match pnpr_shared_artifacts::resolve(&state.inner.config.cache_storage, &username, &body)
+        match state
+            .inner
+            .artifacts
+            .as_ref()
+            .expect("artifact routes require an artifact store")
+            .resolve(&username, &body)
             .await
         {
             Ok(response) => (StatusCode::OK, axum::Json(response)).into_response(),
@@ -2808,23 +2817,28 @@ async fn serve_artifact_blob(
         .acquire_owned()
         .await
         .expect("the artifact blob verification semaphore is never closed");
-    match pnpr_shared_artifacts::read_blob(&state.inner.config.cache_storage, &username, &body)
+    match state
+        .inner
+        .artifacts
+        .as_ref()
+        .expect("artifact routes require an artifact store")
+        .read_blob(&username, &body)
         .await
     {
-        Ok(Some((file, size))) => Response::builder()
+        Ok(Some(bytes)) => Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/octet-stream")
-            .header(header::CONTENT_LENGTH, size.to_string())
+            .header(header::CONTENT_LENGTH, bytes.len().to_string())
             .header(header::CACHE_CONTROL, "private, max-age=31536000, immutable")
             .header(header::VARY, "Authorization")
-            .body(artifact_blob_response_body(file, permit))
+            .body(artifact_blob_response_body(bytes, permit))
             .expect("static artifact blob response always builds"),
         Ok(None) => private_no_cache(StatusCode::NOT_FOUND.into_response()),
         Err(err) => private_no_cache(err.into_response()),
     }
 }
 
-fn artifact_blob_response_body(file: tokio::fs::File, permit: OwnedSemaphorePermit) -> Body {
+fn artifact_blob_response_body(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Body {
     drop(permit);
-    streaming::stream_file(file)
+    Body::from(bytes)
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -22,7 +22,7 @@ use self::{
 
 use axum::{
     Router,
-    body::Body,
+    body::{Body, Bytes},
     extract::{
         FromRequestParts, Path, RawPathParams, Request, State, connect_info::Connected,
         rejection::RawPathParamsRejection,
@@ -56,7 +56,7 @@ use pnpr_upstream::{
 use serde::Deserialize;
 use serde_json::{Value, json};
 use ssri::Integrity;
-use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
+use std::{collections::HashSet, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// MIME the npm registry uses for the abbreviated install-v1 form.
@@ -91,8 +91,9 @@ const MAX_LOGIN_BODY_BYTES: usize = 64 * 1024;
 const MAX_ARTIFACT_PUBLISH_BODY_BYTES: usize = MAX_PUBLISH_BODY_BYTES;
 const MAX_ARTIFACT_RESOLVE_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARTIFACT_BLOB_BODY_BYTES: usize = 8 * 1024;
-/// Bound concurrent verification scans without letting slow clients retain slots.
+/// Bound concurrent verified artifact responses, including slow clients.
 const MAX_CONCURRENT_ARTIFACT_BLOB_VERIFICATIONS: usize = 4;
+const ARTIFACT_BLOB_RESPONSE_CHUNK_BYTES: usize = 64 * 1024;
 
 #[derive(Clone)]
 struct AppState {
@@ -2167,11 +2168,27 @@ async fn require_resolver_caller(
     request: Request,
     next: Next,
 ) -> Response {
-    match caller_username(&state, request.headers()).await {
+    require_protocol_caller(&state, request, next, "dependency resolution").await
+}
+
+async fn require_artifact_caller(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    require_protocol_caller(&state, request, next, "shared artifacts").await
+}
+
+async fn require_protocol_caller(
+    state: &AppState,
+    request: Request,
+    next: Next,
+    resource: &str,
+) -> Response {
+    match caller_username(state, request.headers()).await {
         Ok(Some(_username)) => next.run(request).await,
         Ok(None) => {
-            RegistryError::Unauthenticated { resource: "dependency resolution".to_string() }
-                .into_response()
+            RegistryError::Unauthenticated { resource: resource.to_string() }.into_response()
         }
         Err(error) => error.into_response(),
     }
@@ -2839,6 +2856,14 @@ async fn serve_artifact_blob(
 }
 
 fn artifact_blob_response_body(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Body {
-    drop(permit);
-    Body::from(bytes)
+    Body::from_stream(futures_util::stream::unfold(
+        (Bytes::from(bytes), permit),
+        |(mut bytes, permit)| async move {
+            if bytes.is_empty() {
+                return None;
+            }
+            let chunk = bytes.split_to(bytes.len().min(ARTIFACT_BLOB_RESPONSE_CHUNK_BYTES));
+            Some((Ok::<_, Infallible>(chunk), (bytes, permit)))
+        },
+    ))
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -22,7 +22,7 @@ use self::{
 
 use axum::{
     Router,
-    body::{Body, Bytes},
+    body::Body,
     extract::{
         FromRequestParts, Path, RawPathParams, Request, State, connect_info::Connected,
         rejection::RawPathParamsRejection,
@@ -56,8 +56,8 @@ use pnpr_upstream::{
 use serde::Deserialize;
 use serde_json::{Value, json};
 use ssri::Integrity;
-use std::{collections::HashSet, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
+use tokio::sync::Semaphore;
 
 /// MIME the npm registry uses for the abbreviated install-v1 form.
 /// Matches what pacquet (and pnpm/npm/yarn) send in `Accept` when
@@ -91,9 +91,8 @@ const MAX_LOGIN_BODY_BYTES: usize = 64 * 1024;
 const MAX_ARTIFACT_PUBLISH_BODY_BYTES: usize = MAX_PUBLISH_BODY_BYTES;
 const MAX_ARTIFACT_RESOLVE_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARTIFACT_BLOB_BODY_BYTES: usize = 8 * 1024;
-/// Bound concurrent verified artifact responses, including slow clients.
+/// Bound concurrent artifact verification scans.
 const MAX_CONCURRENT_ARTIFACT_BLOB_VERIFICATIONS: usize = 4;
-const ARTIFACT_BLOB_RESPONSE_CHUNK_BYTES: usize = 64 * 1024;
 
 #[derive(Clone)]
 struct AppState {
@@ -2834,36 +2833,24 @@ async fn serve_artifact_blob(
         .acquire_owned()
         .await
         .expect("the artifact blob verification semaphore is never closed");
-    match state
+    let result = state
         .inner
         .artifacts
         .as_ref()
         .expect("artifact routes require an artifact store")
         .read_blob(&username, &body)
-        .await
-    {
-        Ok(Some(bytes)) => Response::builder()
+        .await;
+    drop(permit);
+    match result {
+        Ok(Some(blob)) => Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/octet-stream")
-            .header(header::CONTENT_LENGTH, bytes.len().to_string())
+            .header(header::CONTENT_LENGTH, blob.size.to_string())
             .header(header::CACHE_CONTROL, "private, max-age=31536000, immutable")
             .header(header::VARY, "Authorization")
-            .body(artifact_blob_response_body(bytes, permit))
+            .body(Body::from_stream(blob.stream))
             .expect("static artifact blob response always builds"),
         Ok(None) => private_no_cache(StatusCode::NOT_FOUND.into_response()),
         Err(err) => private_no_cache(err.into_response()),
     }
-}
-
-fn artifact_blob_response_body(bytes: Vec<u8>, permit: OwnedSemaphorePermit) -> Body {
-    Body::from_stream(futures_util::stream::unfold(
-        (Bytes::from(bytes), permit),
-        |(mut bytes, permit)| async move {
-            if bytes.is_empty() {
-                return None;
-            }
-            let chunk = bytes.split_to(bytes.len().min(ARTIFACT_BLOB_RESPONSE_CHUNK_BYTES));
-            Some((Ok::<_, Infallible>(chunk), (bytes, permit)))
-        },
-    ))
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -57,7 +57,6 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use ssri::Integrity;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
-use tokio::sync::Semaphore;
 
 /// MIME the npm registry uses for the abbreviated install-v1 form.
 /// Matches what pacquet (and pnpm/npm/yarn) send in `Accept` when
@@ -91,9 +90,6 @@ const MAX_LOGIN_BODY_BYTES: usize = 64 * 1024;
 const MAX_ARTIFACT_PUBLISH_BODY_BYTES: usize = MAX_PUBLISH_BODY_BYTES;
 const MAX_ARTIFACT_RESOLVE_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARTIFACT_BLOB_BODY_BYTES: usize = 8 * 1024;
-/// Bound concurrent artifact verification scans.
-const MAX_CONCURRENT_ARTIFACT_BLOB_VERIFICATIONS: usize = 4;
-
 #[derive(Clone)]
 struct AppState {
     inner: Arc<AppInner>,
@@ -118,7 +114,6 @@ struct AppInner {
     /// two concurrent writers to the same package on this instance can't
     /// lose each other's changes.
     package_locks: StripedLocks,
-    artifact_blob_verifications: Arc<Semaphore>,
     /// Lazily-built engine backing the `/-/pnpr/v0/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,
@@ -2829,19 +2824,14 @@ async fn serve_artifact_blob(
         Ok(username) => username,
         Err(err) => return private_no_cache(err.into_response()),
     };
-    let permit = Arc::clone(&state.inner.artifact_blob_verifications)
-        .acquire_owned()
-        .await
-        .expect("the artifact blob verification semaphore is never closed");
-    let result = state
+    match state
         .inner
         .artifacts
         .as_ref()
         .expect("artifact routes require an artifact store")
         .read_blob(&username, &body)
-        .await;
-    drop(permit);
-    match result {
+        .await
+    {
         Ok(Some(blob)) => Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "application/octet-stream")

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -10,7 +10,6 @@ use axum::{
     routing::{any, delete, get, post, put},
 };
 use indexmap::IndexMap;
-use tokio::sync::Semaphore;
 use tower_http::{
     compression::{
         CompressionLayer,
@@ -27,19 +26,18 @@ use pnpr_upstream::Upstream;
 
 use super::{
     AppInner, AppState, AuthedCaller, MAX_ARTIFACT_BLOB_BODY_BYTES,
-    MAX_ARTIFACT_PUBLISH_BODY_BYTES, MAX_ARTIFACT_RESOLVE_BODY_BYTES,
-    MAX_CONCURRENT_ARTIFACT_BLOB_VERIFICATIONS, MAX_LOGIN_BODY_BYTES, MAX_PUBLISH_BODY_BYTES,
-    StripedLocks, authenticate, compute_upstream_cache_namespace, default_registry_target,
-    delete_package, delete_session_token, delete_tarball, delete_token_by_key, get_dist_tags,
-    get_org_teams, get_profile, get_team_members, get_token_list, get_whoami, loggable_uri,
-    not_found, pnpr_protocols_disabled, private_if_caller_gated, private_no_cache, publish_package,
-    put_login, reject_team_mutation, remove_dist_tag, require_artifact_caller,
-    require_resolver_caller, serve_artifact_blob, serve_batch_publish, serve_packument, serve_ping,
-    serve_pnpr_handshake, serve_publish_artifact, serve_registry_packument, serve_registry_tarball,
-    serve_registry_version_manifest, serve_resolve, serve_resolve_artifacts,
-    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
-    serve_version_manifest, set_dist_tag, staged, tilde_registry, update_packument,
-    upstream_tarball_base,
+    MAX_ARTIFACT_PUBLISH_BODY_BYTES, MAX_ARTIFACT_RESOLVE_BODY_BYTES, MAX_LOGIN_BODY_BYTES,
+    MAX_PUBLISH_BODY_BYTES, StripedLocks, authenticate, compute_upstream_cache_namespace,
+    default_registry_target, delete_package, delete_session_token, delete_tarball,
+    delete_token_by_key, get_dist_tags, get_org_teams, get_profile, get_team_members,
+    get_token_list, get_whoami, loggable_uri, not_found, pnpr_protocols_disabled,
+    private_if_caller_gated, private_no_cache, publish_package, put_login, reject_team_mutation,
+    remove_dist_tag, require_artifact_caller, require_resolver_caller, serve_artifact_blob,
+    serve_batch_publish, serve_packument, serve_ping, serve_pnpr_handshake, serve_publish_artifact,
+    serve_registry_packument, serve_registry_tarball, serve_registry_version_manifest,
+    serve_resolve, serve_resolve_artifacts, serve_revision_tarball, serve_search, serve_tarball,
+    serve_verify_lockfile, serve_version_manifest, set_dist_tag, staged, tilde_registry,
+    update_packument, upstream_tarball_base,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -86,9 +84,6 @@ pub(super) fn router_with_auth_and_osv(
             config,
             auth,
             package_locks: StripedLocks::new(),
-            artifact_blob_verifications: Arc::new(Semaphore::new(
-                MAX_CONCURRENT_ARTIFACT_BLOB_VERIFICATIONS,
-            )),
             resolver: std::sync::OnceLock::new(),
             osv_index,
         }),

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -32,14 +32,13 @@ use super::{
     StripedLocks, authenticate, compute_upstream_cache_namespace, default_registry_target,
     delete_package, delete_session_token, delete_tarball, delete_token_by_key, get_dist_tags,
     get_org_teams, get_profile, get_team_members, get_token_list, get_whoami, loggable_uri,
-    not_found, private_if_caller_gated, private_no_cache, publish_package, put_login,
-    reject_team_mutation, remove_dist_tag, require_resolver_caller, resolver_disabled,
-    serve_artifact_blob, serve_batch_publish, serve_packument, serve_ping, serve_pnpr_handshake,
-    serve_publish_artifact, serve_registry_packument, serve_registry_tarball,
-    serve_registry_version_manifest, serve_resolve, serve_resolve_artifacts,
-    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
-    serve_version_manifest, set_dist_tag, staged, tilde_registry, update_packument,
-    upstream_tarball_base,
+    not_found, pnpr_protocols_disabled, private_if_caller_gated, private_no_cache, publish_package,
+    put_login, reject_team_mutation, remove_dist_tag, require_resolver_caller, serve_artifact_blob,
+    serve_batch_publish, serve_packument, serve_ping, serve_pnpr_handshake, serve_publish_artifact,
+    serve_registry_packument, serve_registry_tarball, serve_registry_version_manifest,
+    serve_resolve, serve_resolve_artifacts, serve_revision_tarball, serve_search, serve_tarball,
+    serve_verify_lockfile, serve_version_manifest, set_dist_tag, staged, tilde_registry,
+    update_packument, upstream_tarball_base,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -51,7 +50,15 @@ pub(super) fn router_with_auth_and_osv(
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
     let registry_enabled = config.registry.enabled;
     let resolver_enabled = config.resolver.enabled;
-    let artifacts_enabled = config.resolver.artifacts;
+    let artifacts_enabled = config.artifacts.enabled;
+    let artifacts = artifacts_enabled
+        .then(|| {
+            pnpr_shared_artifacts::SharedArtifactStore::new(
+                &config.hosted_store,
+                &config.cache_storage,
+            )
+        })
+        .transpose()?;
     // Only the registry routes consult the upstreams, so a resolver-only
     // server builds none — skipping a `ThrottledClient` allocation per
     // configured upstream.
@@ -72,6 +79,7 @@ pub(super) fn router_with_auth_and_osv(
     let state = AppState {
         inner: Arc::new(AppInner {
             storage,
+            artifacts,
             upstreams,
             upstream_cache_namespaces,
             config,
@@ -85,16 +93,15 @@ pub(super) fn router_with_auth_and_osv(
         }),
     };
     // `/-/ping` is a health check and is always served. The two
-    // configurable surfaces — the resolver (install accelerator) and the
-    // npm registry — are each mounted only when their feature is enabled,
-    // so an operator can run resolver-only, registry-only, or both. The
-    // config guarantees at least one is enabled.
+    // configurable surfaces are mounted only when their feature is enabled,
+    // so resolver, registry, and artifacts can be deployed independently.
+    // The config guarantees at least one is enabled.
     let mut router = Router::new().route("/-/ping", get(serve_ping));
     // The account endpoints — adduser/login, whoami, profile, token
     // listing/revocation, logout — are pnpr account management, not
     // npm-registry functionality: they mint and manage the tokens every
     // authenticated surface demands, so they ride every tier alongside
-    // `/-/ping`. A resolver-only tier can then issue its own credentials
+    // `/-/ping`. A resolver- or artifacts-only tier can then issue its own credentials
     // (`pnpm login --registry https://<resolver-host>/`) instead of
     // depending on a registry-serving replica that shares the auth backend.
     //
@@ -123,24 +130,24 @@ pub(super) fn router_with_auth_and_osv(
         .route("/{prefix}/-/npm/v1/tokens", get(get_token_list))
         .route("/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key))
         .route("/{prefix}/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key));
-    // The install-accelerator (resolver) surface, all under the reserved
-    // `/-/pnpr` namespace. `/-/pnpr` is the capability handshake (404 on a
-    // plain registry); `/-/pnpr/v0/resolve` and `/-/pnpr/v0/verify-lockfile`
-    // are the resolver endpoints. The opt-in `artifacts` sub-feature adds the
-    // signed shared-artifact publish, lookup, and blob endpoints. Resolution
-    // works whether or not this process also fronts a registry.
+    // The install-accelerator and shared-artifact surfaces live under the
+    // reserved `/-/pnpr` namespace. The handshake advertises each protocol
+    // independently, so either surface can be mounted on its own.
     //
-    // When the resolver is disabled, only `/-/pnpr` gets a 404 stub: it is
-    // the capability-probe path and overlaps the registry catch-all
+    // When both protocol surfaces are disabled, only `/-/pnpr` gets a 404
+    // stub: it is the capability-probe path and overlaps the registry catch-all
     // (`/-/pnpr` matches `/{first}/{second}`), so without the stub a probe
     // would be proxied upstream, giving a confusing 502 where a client
-    // expects the "no resolver here" 404. The `/-/pnpr/v0/*` endpoints carry
-    // no capability probe, so they are left unmounted rather than stubbed: a
-    // client learns the resolver is absent from the handshake 404 and never
-    // calls them.
+    // expects the "no pnpr protocols here" 404. The `/-/pnpr/v0/*` endpoints
+    // carry no capability probe, so they are left unmounted rather than
+    // stubbed.
+    if resolver_enabled || artifacts_enabled {
+        router = router.route("/-/pnpr", get(serve_pnpr_handshake));
+    } else {
+        router = router.route("/-/pnpr", any(pnpr_protocols_disabled));
+    }
     if resolver_enabled {
         router = router
-            .route("/-/pnpr", get(serve_pnpr_handshake))
             .route(
                 "/-/pnpr/v0/resolve",
                 post(serve_resolve).route_layer(middleware::from_fn_with_state(
@@ -155,44 +162,41 @@ pub(super) fn router_with_auth_and_osv(
                     require_resolver_caller,
                 )),
             );
-        if artifacts_enabled {
-            router = router
-                .route(
-                    "/-/pnpr/v0/artifacts",
-                    put(serve_publish_artifact)
-                        .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_PUBLISH_BODY_BYTES))
-                        .route_layer(middleware::from_fn_with_state(
-                            state.clone(),
-                            require_resolver_caller,
-                        )),
-                )
-                .route(
-                    "/-/pnpr/v0/artifacts/resolve",
-                    post(serve_resolve_artifacts)
-                        .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_RESOLVE_BODY_BYTES))
-                        .route_layer(middleware::from_fn_with_state(
-                            state.clone(),
-                            require_resolver_caller,
-                        )),
-                )
-                .route(
-                    "/-/pnpr/v0/artifacts/blob",
-                    post(serve_artifact_blob)
-                        .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_BLOB_BODY_BYTES))
-                        .route_layer(middleware::from_fn_with_state(
-                            state.clone(),
-                            require_resolver_caller,
-                        )),
-                );
-        }
-    } else {
-        router = router.route("/-/pnpr", any(resolver_disabled));
+    }
+    if artifacts_enabled {
+        router = router
+            .route(
+                "/-/pnpr/v0/artifacts",
+                put(serve_publish_artifact)
+                    .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_PUBLISH_BODY_BYTES))
+                    .route_layer(middleware::from_fn_with_state(
+                        state.clone(),
+                        require_resolver_caller,
+                    )),
+            )
+            .route(
+                "/-/pnpr/v0/artifacts/resolve",
+                post(serve_resolve_artifacts)
+                    .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_RESOLVE_BODY_BYTES))
+                    .route_layer(middleware::from_fn_with_state(
+                        state.clone(),
+                        require_resolver_caller,
+                    )),
+            )
+            .route(
+                "/-/pnpr/v0/artifacts/blob",
+                post(serve_artifact_blob)
+                    .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_BLOB_BODY_BYTES))
+                    .route_layer(middleware::from_fn_with_state(
+                        state.clone(),
+                        require_resolver_caller,
+                    )),
+            );
     }
     // The npm-registry surface: every packument/tarball read, publish,
     // unpublish, dist-tag, and search. When the surface is off (no registries
-    // declared, or `--disable-registry`), none of these routes are mounted
-    // — not merely hidden — so a resolver-only tier exposes no registry
-    // surface at all.
+    // declared, or `--disable-registry`), none of these routes are mounted.
+    // Resolver- and artifacts-only tiers expose no registry surface at all.
     if registry_enabled {
         router = router
             // Batch publish: one request carrying many packages' publish

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -33,12 +33,13 @@ use super::{
     delete_package, delete_session_token, delete_tarball, delete_token_by_key, get_dist_tags,
     get_org_teams, get_profile, get_team_members, get_token_list, get_whoami, loggable_uri,
     not_found, pnpr_protocols_disabled, private_if_caller_gated, private_no_cache, publish_package,
-    put_login, reject_team_mutation, remove_dist_tag, require_resolver_caller, serve_artifact_blob,
-    serve_batch_publish, serve_packument, serve_ping, serve_pnpr_handshake, serve_publish_artifact,
-    serve_registry_packument, serve_registry_tarball, serve_registry_version_manifest,
-    serve_resolve, serve_resolve_artifacts, serve_revision_tarball, serve_search, serve_tarball,
-    serve_verify_lockfile, serve_version_manifest, set_dist_tag, staged, tilde_registry,
-    update_packument, upstream_tarball_base,
+    put_login, reject_team_mutation, remove_dist_tag, require_artifact_caller,
+    require_resolver_caller, serve_artifact_blob, serve_batch_publish, serve_packument, serve_ping,
+    serve_pnpr_handshake, serve_publish_artifact, serve_registry_packument, serve_registry_tarball,
+    serve_registry_version_manifest, serve_resolve, serve_resolve_artifacts,
+    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
+    serve_version_manifest, set_dist_tag, staged, tilde_registry, update_packument,
+    upstream_tarball_base,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -171,7 +172,7 @@ pub(super) fn router_with_auth_and_osv(
                     .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_PUBLISH_BODY_BYTES))
                     .route_layer(middleware::from_fn_with_state(
                         state.clone(),
-                        require_resolver_caller,
+                        require_artifact_caller,
                     )),
             )
             .route(
@@ -180,7 +181,7 @@ pub(super) fn router_with_auth_and_osv(
                     .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_RESOLVE_BODY_BYTES))
                     .route_layer(middleware::from_fn_with_state(
                         state.clone(),
-                        require_resolver_caller,
+                        require_artifact_caller,
                     )),
             )
             .route(
@@ -189,7 +190,7 @@ pub(super) fn router_with_auth_and_osv(
                     .route_layer(DefaultBodyLimit::max(MAX_ARTIFACT_BLOB_BODY_BYTES))
                     .route_layer(middleware::from_fn_with_state(
                         state.clone(),
-                        require_resolver_caller,
+                        require_artifact_caller,
                     )),
             );
     }

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -20,18 +20,14 @@ use std::{
     sync::Arc,
 };
 use tempfile::TempDir;
-use tokio::{fs, sync::Semaphore};
+use tokio::sync::Semaphore;
 use tower::ServiceExt;
 
 #[tokio::test]
 async fn artifact_blob_response_releases_its_verification_slot_before_streaming() {
-    let storage = TempDir::new().unwrap();
-    let path = storage.path().join("blob");
-    fs::write(&path, [1, 2, 3]).await.unwrap();
-    let file = fs::File::open(path).await.unwrap();
     let semaphore = Arc::new(Semaphore::new(1));
     let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
-    let body = artifact_blob_response_body(file, permit);
+    let body = artifact_blob_response_body(vec![1, 2, 3], permit);
     assert!(semaphore.try_acquire().is_ok());
 
     assert_eq!(to_bytes(body, 3).await.unwrap(), &[1, 2, 3][..]);

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -24,13 +24,14 @@ use tokio::sync::Semaphore;
 use tower::ServiceExt;
 
 #[tokio::test]
-async fn artifact_blob_response_releases_its_verification_slot_before_streaming() {
+async fn artifact_blob_response_holds_its_verification_slot_while_streaming() {
     let semaphore = Arc::new(Semaphore::new(1));
     let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
     let body = artifact_blob_response_body(vec![1, 2, 3], permit);
-    assert!(semaphore.try_acquire().is_ok());
+    assert!(semaphore.try_acquire().is_err());
 
     assert_eq!(to_bytes(body, 3).await.unwrap(), &[1, 2, 3][..]);
+    assert!(semaphore.try_acquire().is_ok());
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/server/tests.rs
+++ b/pnpr/crates/pnpr/src/server/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    HostedRevisionDist, HostedRevisionRecord, PeerAddr, RevisionField, artifact_blob_response_body,
+    HostedRevisionDist, HostedRevisionRecord, PeerAddr, RevisionField,
     authentication::{
         bearer_credentials, canonical_ip, cidr_contains, cidr_whitelist_allows, is_write_method,
     },
@@ -20,19 +20,7 @@ use std::{
     sync::Arc,
 };
 use tempfile::TempDir;
-use tokio::sync::Semaphore;
 use tower::ServiceExt;
-
-#[tokio::test]
-async fn artifact_blob_response_holds_its_verification_slot_while_streaming() {
-    let semaphore = Arc::new(Semaphore::new(1));
-    let permit = Arc::clone(&semaphore).acquire_owned().await.unwrap();
-    let body = artifact_blob_response_body(vec![1, 2, 3], permit);
-    assert!(semaphore.try_acquire().is_err());
-
-    assert_eq!(to_bytes(body, 3).await.unwrap(), &[1, 2, 3][..]);
-    assert!(semaphore.try_acquire().is_ok());
-}
 
 #[test]
 fn token_timestamp_millis_saturates_before_i64_conversion() {

--- a/pnpr/crates/pnpr/src/tests.rs
+++ b/pnpr/crates/pnpr/src/tests.rs
@@ -1,4 +1,16 @@
-use super::{RegistryError, redacted_report};
+use super::{Args, RegistryError, redacted_report};
+use clap::Parser as _;
+
+#[test]
+fn disable_artifacts_sets_the_config_override() {
+    let args = Args::try_parse_from(["pnpr", "--disable-artifacts"]).unwrap();
+
+    let overrides = args.feature_overrides();
+
+    assert!(overrides.disable_artifacts);
+    assert!(!overrides.disable_registry);
+    assert!(!overrides.disable_resolver);
+}
 
 #[test]
 fn startup_error_report_redacts_dsn_credentials() {

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2882,6 +2882,37 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
 }
 
 #[tokio::test]
+async fn artifacts_only_advertises_and_mounts_only_the_artifact_protocol() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    config.registry.enabled = false;
+    config.resolver.enabled = false;
+    config.artifacts.enabled = true;
+    let app = router(config);
+
+    let handshake =
+        app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(handshake.status(), StatusCode::OK);
+    assert_eq!(
+        body_json(handshake.into_body()).await,
+        json!({ "pnpr": { "versions": [], "artifacts": [0] } }),
+    );
+
+    let artifact = app
+        .clone()
+        .oneshot(Request::post("/-/pnpr/v0/artifacts/resolve").body(Body::from("{}")).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(artifact.status(), StatusCode::UNAUTHORIZED);
+
+    let resolve = app
+        .oneshot(Request::post("/-/pnpr/v0/resolve").body(Body::from("{}")).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(resolve.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
 async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
     let mut upstream = mockito::Server::new_async().await;
     let mock = upstream

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2904,6 +2904,10 @@ async fn artifacts_only_advertises_and_mounts_only_the_artifact_protocol() {
         .await
         .unwrap();
     assert_eq!(artifact.status(), StatusCode::UNAUTHORIZED);
+    assert!(
+        String::from_utf8_lossy(&body_bytes(artifact.into_body()).await)
+            .contains("shared artifacts"),
+    );
 
     let resolve = app
         .oneshot(Request::post("/-/pnpr/v0/resolve").body(Body::from("{}")).unwrap())

--- a/pnpr/crates/shared-artifacts/Cargo.toml
+++ b/pnpr/crates/shared-artifacts/Cargo.toml
@@ -15,6 +15,7 @@ pnpr-config                   = { workspace = true }
 pnpr-error                    = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
 base64                        = { workspace = true }
+bytes                         = { workspace = true }
 futures-util                  = { workspace = true }
 object_store                  = { workspace = true }
 serde                         = { workspace = true }

--- a/pnpr/crates/shared-artifacts/Cargo.toml
+++ b/pnpr/crates/shared-artifacts/Cargo.toml
@@ -23,5 +23,8 @@ sha2                          = { workspace = true }
 tempfile                      = { workspace = true }
 tokio                         = { workspace = true }
 
+[dev-dependencies]
+async-trait = { workspace = true }
+
 [lints]
 workspace = true

--- a/pnpr/crates/shared-artifacts/Cargo.toml
+++ b/pnpr/crates/shared-artifacts/Cargo.toml
@@ -11,10 +11,12 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
+pnpr-config                   = { workspace = true }
 pnpr-error                    = { workspace = true }
-pnpr-storage                  = { workspace = true }
 pnpm-shared-artifact-protocol = { workspace = true }
 base64                        = { workspace = true }
+futures-util                  = { workspace = true }
+object_store                  = { workspace = true }
 serde                         = { workspace = true }
 serde_json                    = { workspace = true }
 sha2                          = { workspace = true }

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -6,10 +6,11 @@ use std::{
     time::Duration,
 };
 
-use futures_util::StreamExt as _;
+use bytes::Bytes;
+use futures_util::{StreamExt as _, stream::BoxStream};
 use object_store::{
-    ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
-    local::LocalFileSystem, path::Path as ObjectPath,
+    GetOptions, ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload,
+    UpdateVersion, local::LocalFileSystem, path::Path as ObjectPath,
 };
 use pnpm_shared_artifact_protocol::{
     ArtifactBlobRequest, ArtifactCandidate, ArtifactPayload, ArtifactProtocolError,
@@ -48,6 +49,11 @@ enum QuotaCoordination {
 enum QuotaChange {
     Reserve,
     Release,
+}
+
+pub struct ArtifactBlob {
+    pub size: u64,
+    pub stream: BoxStream<'static, object_store::Result<Bytes>>,
 }
 
 /// Shared build-artifact storage. Local deployments use the
@@ -209,7 +215,7 @@ impl SharedArtifactStore {
         Ok(ResolveArtifactsResponse { artifacts })
     }
 
-    pub async fn read_blob(&self, username: &str, body: &[u8]) -> Result<Option<Vec<u8>>> {
+    pub async fn read_blob(&self, username: &str, body: &[u8]) -> Result<Option<ArtifactBlob>> {
         let request: ArtifactBlobRequest = serde_json::from_slice(body)
             .map_err(|err| bad_request(format!("invalid artifact blob request: {err}")))?;
         request.validate().map_err(|err| protocol_error(&err))?;
@@ -219,18 +225,63 @@ impl SharedArtifactStore {
             Err(err) => return Err(err),
         };
         let id = blob_id(&request.integrity).map_err(|err| protocol_error(&err))?;
-        let Some(bytes) =
-            self.read_object_bounded(&format!("{owner}/blobs/{id}"), MAX_FILE_SIZE).await?
-        else {
-            return Ok(None);
+        let path = self.object_path(&format!("{owner}/blobs/{id}"));
+        let result = match self.store.get(&path).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(error) => return Err(error.into()),
         };
-        if hex(&Sha512::digest(&bytes)) != id {
+        let meta = result.meta.clone();
+        if meta.size > MAX_FILE_SIZE {
+            return Err(stored_object_too_large(meta.size, MAX_FILE_SIZE));
+        }
+        let mut size = 0_u64;
+        let mut digest = Sha512::new();
+        let mut stream = result.into_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            size = size
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| stored_object_too_large(u64::MAX, MAX_FILE_SIZE))?;
+            if size > MAX_FILE_SIZE {
+                return Err(stored_object_too_large(size, MAX_FILE_SIZE));
+            }
+            digest.update(&chunk);
+        }
+        if size != meta.size {
+            return Err(RegistryError::Internal {
+                reason: format!(
+                    "stored shared artifact blob metadata declares {} bytes but returned {size}",
+                    meta.size,
+                ),
+            });
+        }
+        if hex(&digest.finalize()) != id {
             return Err(RegistryError::Internal {
                 reason: "stored shared artifact blob failed verification: downloaded bytes do not match the declared digest"
                     .to_string(),
             });
         }
-        Ok(Some(bytes))
+        if meta.e_tag.is_none() && meta.version.is_none() {
+            return Err(RegistryError::Internal {
+                reason:
+                    "stored shared artifact blob has no version identifier for a verified download"
+                        .to_string(),
+            });
+        }
+        let result = self
+            .store
+            .get_opts(&path, GetOptions::new().with_if_match(meta.e_tag).with_version(meta.version))
+            .await?;
+        if result.meta.size != size {
+            return Err(RegistryError::Internal {
+                reason: format!(
+                    "stored shared artifact blob changed size from {size} to {} after verification",
+                    result.meta.size,
+                ),
+            });
+        }
+        Ok(Some(ArtifactBlob { size, stream: result.into_stream() }))
     }
 
     async fn resolve_candidate(
@@ -419,12 +470,7 @@ impl SharedArtifactStore {
         match self.store.get(&self.object_path(relative)).await {
             Ok(result) => {
                 if result.meta.size > max_size {
-                    return Err(RegistryError::Internal {
-                        reason: format!(
-                            "stored shared artifact object has {} bytes; limit is {max_size}",
-                            result.meta.size,
-                        ),
-                    });
+                    return Err(stored_object_too_large(result.meta.size, max_size));
                 }
                 Ok(Some(result.bytes().await?.to_vec()))
             }
@@ -493,6 +539,12 @@ fn verify_stored_blob(id: &str, integrity: &str, size: u64, bytes: &[u8]) -> Res
     verify_blob(integrity, bytes).map_err(|err| RegistryError::Internal {
         reason: format!("stored shared artifact blob failed verification: {err}"),
     })
+}
+
+fn stored_object_too_large(size: u64, max_size: u64) -> RegistryError {
+    RegistryError::Internal {
+        reason: format!("stored shared artifact object has {size} bytes; limit is {max_size}"),
+    }
 }
 
 fn owner_key(username: &str, owner: &OwnerScope) -> Result<String> {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -9,8 +9,8 @@ use std::{
 use bytes::Bytes;
 use futures_util::{StreamExt as _, stream::BoxStream};
 use object_store::{
-    GetOptions, ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload,
-    UpdateVersion, local::LocalFileSystem, path::Path as ObjectPath,
+    ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+    local::LocalFileSystem, path::Path as ObjectPath,
 };
 use pnpm_shared_artifact_protocol::{
     ArtifactBlobRequest, ArtifactCandidate, ArtifactPayload, ArtifactProtocolError,
@@ -21,7 +21,7 @@ use pnpm_shared_artifact_protocol::{
 };
 use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
-use sha2::{Digest as _, Sha256, Sha512};
+use sha2::{Digest as _, Sha256};
 use tokio::time::sleep;
 
 const ARTIFACT_CACHE_DIR: &str = "shared-artifacts/v0";
@@ -231,57 +231,10 @@ impl SharedArtifactStore {
             Err(object_store::Error::NotFound { .. }) => return Ok(None),
             Err(error) => return Err(error.into()),
         };
-        let meta = result.meta.clone();
-        if meta.size > MAX_FILE_SIZE {
-            return Err(stored_object_too_large(meta.size, MAX_FILE_SIZE));
+        if result.meta.size > MAX_FILE_SIZE {
+            return Err(stored_object_too_large(result.meta.size, MAX_FILE_SIZE));
         }
-        let mut size = 0_u64;
-        let mut digest = Sha512::new();
-        let mut stream = result.into_stream();
-        while let Some(chunk) = stream.next().await {
-            let chunk = chunk?;
-            size = size
-                .checked_add(chunk.len() as u64)
-                .ok_or_else(|| stored_object_too_large(u64::MAX, MAX_FILE_SIZE))?;
-            if size > MAX_FILE_SIZE {
-                return Err(stored_object_too_large(size, MAX_FILE_SIZE));
-            }
-            digest.update(&chunk);
-        }
-        if size != meta.size {
-            return Err(RegistryError::Internal {
-                reason: format!(
-                    "stored shared artifact blob metadata declares {} bytes but returned {size}",
-                    meta.size,
-                ),
-            });
-        }
-        if hex(&digest.finalize()) != id {
-            return Err(RegistryError::Internal {
-                reason: "stored shared artifact blob failed verification: downloaded bytes do not match the declared digest"
-                    .to_string(),
-            });
-        }
-        if meta.e_tag.is_none() && meta.version.is_none() {
-            return Err(RegistryError::Internal {
-                reason:
-                    "stored shared artifact blob has no version identifier for a verified download"
-                        .to_string(),
-            });
-        }
-        let result = self
-            .store
-            .get_opts(&path, GetOptions::new().with_if_match(meta.e_tag).with_version(meta.version))
-            .await?;
-        if result.meta.size != size {
-            return Err(RegistryError::Internal {
-                reason: format!(
-                    "stored shared artifact blob changed size from {size} to {} after verification",
-                    result.meta.size,
-                ),
-            });
-        }
-        Ok(Some(ArtifactBlob { size, stream: result.into_stream() }))
+        Ok(Some(ArtifactBlob { size: result.meta.size, stream: result.into_stream() }))
     }
 
     async fn resolve_candidate(

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -1,12 +1,16 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
+    collections::{BTreeMap, HashSet},
     fs::{File, OpenOptions, TryLockError},
-    io::{ErrorKind, SeekFrom},
-    path::{Component, Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
 };
 
+use futures_util::StreamExt as _;
+use object_store::{
+    ObjectMeta, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
+    local::LocalFileSystem, path::Path as ObjectPath,
+};
 use pnpm_shared_artifact_protocol::{
     ArtifactBlobRequest, ArtifactCandidate, ArtifactPayload, ArtifactProtocolError,
     ArtifactVariant, MAX_CANDIDATES, MAX_FILE_SIZE, MAX_RESOLVE_RESPONSE_SIZE,
@@ -14,86 +18,433 @@ use pnpm_shared_artifact_protocol::{
     ResolveArtifactsRequest, ResolveArtifactsResponse, ResolvedArtifact, SignedArtifactEnvelope,
     blob_id, verify_blob,
 };
-use sha2::{Digest as _, Sha256, Sha512};
-use tokio::{
-    fs,
-    io::{AsyncReadExt as _, AsyncSeekExt as _},
-    time::sleep,
-};
-
+use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
-use pnpr_storage::{remove_atomic_write_temps, write_atomic};
+use sha2::{Digest as _, Sha256, Sha512};
+use tokio::time::sleep;
 
 const ARTIFACT_CACHE_DIR: &str = "shared-artifacts/v0";
+const ARTIFACT_OBJECT_PREFIX: &str = ".pnpr-artifacts/v0";
 const ARTIFACT_LOCK_POLL_INTERVAL: Duration = Duration::from_millis(50);
-const ARTIFACT_USAGE_FILE: &str = "usage.json";
-const ARTIFACT_BLOB_READ_CHUNK: usize = 64 * 1024;
-const BLOB_LOCK_STRIPES: usize = 256;
+const ARTIFACT_USAGE_FILE: &str = ".locks/usage.json";
+const ARTIFACT_QUOTA_OBJECT: &str = "quota.json";
 const MAX_OWNER_ARTIFACT_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_GLOBAL_ARTIFACT_BYTES: u64 = 10 * MAX_OWNER_ARTIFACT_BYTES;
-static ARTIFACT_RESERVATION_COUNTER: AtomicU64 = AtomicU64::new(0);
+const QUOTA_WRITE_RETRIES: usize = 32;
 
 #[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
 struct ArtifactUsage {
     global_bytes: u64,
     owner_bytes: BTreeMap<String, u64>,
-    #[serde(default, deserialize_with = "deserialize_pending_usage")]
-    pending: BTreeMap<String, PendingUsage>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct PendingUsage {
-    owner: String,
-    lock: PendingUsageLock,
-    /// Recovery treats the reservation as committed when this file has its reserved size.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    commit_file: Option<String>,
-    files: Vec<PendingUsageFile>,
+#[derive(Debug)]
+enum QuotaCoordination {
+    Local { lock_path: PathBuf },
+    Conditional,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase", tag = "type")]
-enum PendingUsageLock {
-    Entry { entry: String },
-    Owner,
-    Global,
+#[derive(Clone, Copy)]
+enum QuotaChange {
+    Reserve,
+    Release,
 }
 
-#[derive(Debug, serde::Deserialize)]
-struct LegacyPendingUsage {
-    owner: String,
-    files: Vec<PendingUsageFile>,
+/// Shared build-artifact storage. Local deployments use the
+/// `cache/shared-artifacts/v0` layout. Object-store deployments use the same
+/// configured bucket as hosted packages under a reserved namespace, allowing
+/// every replica to observe the same immutable blobs and envelopes.
+#[derive(Debug)]
+pub struct SharedArtifactStore {
+    store: Arc<dyn ObjectStore>,
+    prefix: String,
+    quota: QuotaCoordination,
+    owner_limit: u64,
+    global_limit: u64,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
-struct PendingUsageFile {
-    path: String,
-    size: u64,
-}
+impl SharedArtifactStore {
+    pub fn new(hosted: &HostedStoreConfig, cache_storage: &Path) -> Result<Self> {
+        match hosted {
+            HostedStoreConfig::Fs => {
+                let root = cache_storage.join(ARTIFACT_CACHE_DIR);
+                std::fs::create_dir_all(&root)?;
+                let store: Arc<dyn ObjectStore> =
+                    Arc::new(LocalFileSystem::new_with_prefix(&root)?);
+                Ok(Self {
+                    store,
+                    prefix: String::new(),
+                    quota: QuotaCoordination::Local {
+                        lock_path: root.join(".locks").join("usage.lock"),
+                    },
+                    owner_limit: MAX_OWNER_ARTIFACT_BYTES,
+                    global_limit: MAX_GLOBAL_ARTIFACT_BYTES,
+                })
+            }
+            HostedStoreConfig::S3(settings) => {
+                Ok(Self::object_store(build_s3_store(settings)?, &settings.normalized_prefix()))
+            }
+            HostedStoreConfig::ObjectStore { store, prefix } => {
+                Ok(Self::object_store(Arc::clone(store), &normalize_key_prefix(Some(prefix))))
+            }
+        }
+    }
 
-struct StorageQuotaReservation<'a> {
-    id: &'a str,
-    owner: &'a str,
-    lock: PendingUsageLock,
-    commit_file: Option<String>,
-    locked_blob_locks: &'a BTreeSet<String>,
-    files: Vec<PendingUsageFile>,
-}
+    fn object_store(store: Arc<dyn ObjectStore>, prefix: &str) -> Self {
+        Self {
+            store,
+            prefix: format!("{prefix}{ARTIFACT_OBJECT_PREFIX}/"),
+            quota: QuotaCoordination::Conditional,
+            owner_limit: MAX_OWNER_ARTIFACT_BYTES,
+            global_limit: MAX_GLOBAL_ARTIFACT_BYTES,
+        }
+    }
 
-#[derive(Default)]
-struct PendingUsageReconciliation {
-    usage_changed: bool,
-    blocked_locked_blobs: bool,
-}
+    pub async fn publish(&self, username: &str, request: PublishArtifactRequest) -> Result<bool> {
+        let validated = request.validate().map_err(|err| protocol_error(&err))?;
+        let payload = validated.payload;
+        let mut uploads = validated.blobs;
+        let owner = owner_key(username, &payload.owner)?;
+        let entry = entry_digest(&request.key, &payload.package, &payload.source_integrity);
+        let envelope = request.envelope.digest().map_err(|err| protocol_error(&err))?;
+        let envelope_bytes = serde_json::to_vec(&request.envelope)?;
+        let envelope_size = envelope_bytes.len() as u64;
+        let variant_path = format!("{owner}/entries/{entry}/{envelope}.json");
 
-struct ArtifactRecoveryLocks<'a> {
-    owner: &'a str,
-    publication: &'a PendingUsageLock,
-    active_reservation: Option<&'a str>,
-    adoption_commit_file: Option<&'a str>,
-    owner_locked: bool,
-    blob_locks: &'a BTreeSet<String>,
-    preserved_blob_ids: &'a BTreeSet<String>,
+        if self.object_exists(&variant_path).await? {
+            return Ok(false);
+        }
+
+        let required: BTreeMap<&str, u64> = payload
+            .manifest
+            .added
+            .iter()
+            .map(|file| (file.integrity.as_str(), file.size))
+            .collect();
+        let mut new_blobs = Vec::new();
+        for (integrity, size) in required {
+            let id = blob_id(integrity).map_err(|err| protocol_error(&err))?;
+            let path = format!("{owner}/blobs/{id}");
+            let upload = uploads.remove(integrity);
+            if let Some(bytes) = upload.as_deref() {
+                if bytes.len() as u64 != size {
+                    return Err(bad_request(format!(
+                        "blob {id} has {} bytes but the signed manifest declares {size}",
+                        bytes.len(),
+                    )));
+                }
+                verify_blob(integrity, bytes).map_err(|err| protocol_error(&err))?;
+            }
+            match self.read_object_bounded(&path, size).await? {
+                Some(bytes) => verify_stored_blob(&id, integrity, size, &bytes)?,
+                None => match upload {
+                    Some(bytes) => new_blobs.push((path, bytes)),
+                    None => {
+                        return Err(bad_request(format!(
+                            "signed manifest references blob {id} without uploading it",
+                        )));
+                    }
+                },
+            }
+        }
+
+        let added_bytes = new_blobs.iter().try_fold(envelope_size, |total, entry| {
+            total.checked_add(entry.1.len() as u64).ok_or_else(storage_quota_error)
+        })?;
+        self.reserve_quota(&owner, added_bytes).await?;
+
+        let mut unused_reservation = 0_u64;
+        for (path, bytes) in new_blobs {
+            let size = bytes.len() as u64;
+            if !self.create_object(&path, bytes).await? {
+                unused_reservation += size;
+            }
+        }
+        let created = self.create_object(&variant_path, envelope_bytes).await?;
+        if !created {
+            unused_reservation += envelope_size;
+        }
+        if unused_reservation != 0 {
+            self.change_quota(&owner, unused_reservation, QuotaChange::Release).await?;
+        }
+        Ok(created)
+    }
+
+    pub async fn resolve(&self, username: &str, body: &[u8]) -> Result<ResolveArtifactsResponse> {
+        let request: ResolveArtifactsRequest = serde_json::from_slice(body)
+            .map_err(|err| bad_request(format!("invalid shared artifact lookup: {err}")))?;
+        if request.candidates.len() > MAX_CANDIDATES {
+            return Err(bad_request(format!(
+                "lookup contains {} candidates; limit is {MAX_CANDIDATES}",
+                request.candidates.len(),
+            )));
+        }
+        let mut seen = HashSet::with_capacity(request.candidates.len());
+        let mut artifacts = Vec::new();
+        let mut budget = ResolveBudget {
+            used_bytes: serde_json::to_vec(&ResolveArtifactsResponse { artifacts: Vec::new() })?
+                .len(),
+        };
+        for candidate in request.candidates {
+            candidate.validate().map_err(|err| protocol_error(&err))?;
+            if !seen.insert(candidate.key.clone()) {
+                return Err(bad_request("lookup contains a duplicate candidate".to_string()));
+            }
+            let Some(resolved) = self.resolve_candidate(username, &candidate, &mut budget).await?
+            else {
+                continue;
+            };
+            budget.add_response(&resolved, !artifacts.is_empty())?;
+            artifacts.push(resolved);
+        }
+        Ok(ResolveArtifactsResponse { artifacts })
+    }
+
+    pub async fn read_blob(&self, username: &str, body: &[u8]) -> Result<Option<Vec<u8>>> {
+        let request: ArtifactBlobRequest = serde_json::from_slice(body)
+            .map_err(|err| bad_request(format!("invalid artifact blob request: {err}")))?;
+        request.validate().map_err(|err| protocol_error(&err))?;
+        let owner = match owner_key(username, &request.owner) {
+            Ok(owner) => owner,
+            Err(RegistryError::Forbidden { .. }) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let id = blob_id(&request.integrity).map_err(|err| protocol_error(&err))?;
+        let Some(bytes) =
+            self.read_object_bounded(&format!("{owner}/blobs/{id}"), MAX_FILE_SIZE).await?
+        else {
+            return Ok(None);
+        };
+        if hex(&Sha512::digest(&bytes)) != id {
+            return Err(RegistryError::Internal {
+                reason: "stored shared artifact blob failed verification: downloaded bytes do not match the declared digest"
+                    .to_string(),
+            });
+        }
+        Ok(Some(bytes))
+    }
+
+    async fn resolve_candidate(
+        &self,
+        username: &str,
+        candidate: &ArtifactCandidate,
+        budget: &mut ResolveBudget,
+    ) -> Result<Option<ResolvedArtifact>> {
+        let owner = match owner_key(username, &candidate.owner) {
+            Ok(owner) => owner,
+            Err(RegistryError::Forbidden { .. }) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let entry = entry_digest(&candidate.key, &candidate.package, &candidate.source_integrity);
+        let prefix = format!("{owner}/entries/{entry}/");
+        let mut entries = self.list_objects(Some(&prefix)).await?;
+        entries.retain(|entry| is_variant_file(object_name(&entry.location)));
+        entries.sort_unstable_by(|left, right| left.location.cmp(&right.location));
+        let mut variants = Vec::new();
+        for entry in entries.into_iter().take(MAX_VARIANTS_PER_CANDIDATE) {
+            budget.add_scan(entry.size)?;
+            let Some(bytes) = self.read_object_path(&entry.location).await? else {
+                continue;
+            };
+            let Ok(envelope) = serde_json::from_slice::<SignedArtifactEnvelope>(&bytes) else {
+                continue;
+            };
+            let Ok((payload, _)) = envelope.decode_payload() else {
+                continue;
+            };
+            if artifact_matches_candidate(&payload, candidate) {
+                variants.push(ArtifactVariant { envelope });
+            }
+        }
+        Ok((!variants.is_empty())
+            .then(|| ResolvedArtifact { key: candidate.key.clone(), variants }))
+    }
+
+    async fn reserve_quota(&self, owner: &str, added_bytes: u64) -> Result<()> {
+        self.change_quota(owner, added_bytes, QuotaChange::Reserve).await
+    }
+
+    async fn change_quota(&self, owner: &str, bytes: u64, change: QuotaChange) -> Result<()> {
+        match &self.quota {
+            QuotaCoordination::Local { lock_path } => {
+                let _lock = acquire_artifact_lock(lock_path.clone()).await?;
+                let (mut usage, _) = self.load_usage().await?;
+                self.change_usage(&mut usage, owner, bytes, change)?;
+                self.write_usage(&usage, PutMode::Overwrite).await?;
+                Ok(())
+            }
+            QuotaCoordination::Conditional => {
+                for _ in 0..QUOTA_WRITE_RETRIES {
+                    let (mut usage, version) = self.load_usage().await?;
+                    self.change_usage(&mut usage, owner, bytes, change)?;
+                    let mode = version.map_or(PutMode::Create, PutMode::Update);
+                    match self.write_usage(&usage, mode).await {
+                        Ok(()) => return Ok(()),
+                        Err(RegistryError::ObjectStore(error)) if is_write_conflict(&error) => {}
+                        Err(error) => return Err(error),
+                    }
+                }
+                Err(RegistryError::Internal {
+                    reason: "shared artifact quota changed too often while updating storage"
+                        .to_string(),
+                })
+            }
+        }
+    }
+
+    fn change_usage(
+        &self,
+        usage: &mut ArtifactUsage,
+        owner: &str,
+        bytes: u64,
+        change: QuotaChange,
+    ) -> Result<()> {
+        if matches!(change, QuotaChange::Release) {
+            usage.global_bytes =
+                usage.global_bytes.checked_sub(bytes).ok_or_else(quota_counter_underflow)?;
+            let owner_bytes =
+                usage.owner_bytes.get_mut(owner).ok_or_else(quota_counter_underflow)?;
+            *owner_bytes = owner_bytes.checked_sub(bytes).ok_or_else(quota_counter_underflow)?;
+            return Ok(());
+        }
+        let owner_bytes = usage.owner_bytes.get(owner).copied().unwrap_or(0);
+        let next_owner = owner_bytes.checked_add(bytes).ok_or_else(storage_quota_error)?;
+        let next_global = usage.global_bytes.checked_add(bytes).ok_or_else(storage_quota_error)?;
+        if next_owner > self.owner_limit || next_global > self.global_limit {
+            return Err(storage_quota_error());
+        }
+        usage.global_bytes = next_global;
+        usage.owner_bytes.insert(owner.to_string(), next_owner);
+        Ok(())
+    }
+
+    async fn load_usage(&self) -> Result<(ArtifactUsage, Option<UpdateVersion>)> {
+        let path = self.object_path(self.quota_object());
+        match self.store.get(&path).await {
+            Ok(result) => {
+                let version = UpdateVersion {
+                    e_tag: result.meta.e_tag.clone(),
+                    version: result.meta.version.clone(),
+                };
+                let bytes = result.bytes().await?;
+                Ok((serde_json::from_slice(&bytes)?, Some(version)))
+            }
+            Err(object_store::Error::NotFound { .. }) => Ok((self.scan_usage().await?, None)),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn scan_usage(&self) -> Result<ArtifactUsage> {
+        let mut usage = ArtifactUsage::default();
+        for entry in self.list_objects(None).await? {
+            let Some(relative) = self.relative_path(&entry.location) else { continue };
+            if relative == self.quota_object() || relative.starts_with(".locks/") {
+                continue;
+            }
+            let Some((owner, _)) = relative.split_once('/') else { continue };
+            let size = entry.size;
+            usage.global_bytes =
+                usage.global_bytes.checked_add(size).ok_or_else(storage_quota_error)?;
+            let owner_bytes = usage.owner_bytes.entry(owner.to_string()).or_default();
+            *owner_bytes = owner_bytes.checked_add(size).ok_or_else(storage_quota_error)?;
+        }
+        Ok(usage)
+    }
+
+    async fn write_usage(&self, usage: &ArtifactUsage, mode: PutMode) -> Result<()> {
+        self.store
+            .put_opts(
+                &self.object_path(self.quota_object()),
+                PutPayload::from(serde_json::to_vec(usage)?),
+                PutOptions { mode, ..PutOptions::default() },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn object_exists(&self, relative: &str) -> Result<bool> {
+        match self.store.head(&self.object_path(relative)).await {
+            Ok(_) => Ok(true),
+            Err(object_store::Error::NotFound { .. }) => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn create_object(&self, relative: &str, bytes: Vec<u8>) -> Result<bool> {
+        match self
+            .store
+            .put_opts(
+                &self.object_path(relative),
+                PutPayload::from(bytes),
+                PutOptions { mode: PutMode::Create, ..PutOptions::default() },
+            )
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(error) if is_create_conflict(&error) => Ok(false),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn read_object_bounded(&self, relative: &str, max_size: u64) -> Result<Option<Vec<u8>>> {
+        match self.store.get(&self.object_path(relative)).await {
+            Ok(result) => {
+                if result.meta.size > max_size {
+                    return Err(RegistryError::Internal {
+                        reason: format!(
+                            "stored shared artifact object has {} bytes; limit is {max_size}",
+                            result.meta.size,
+                        ),
+                    });
+                }
+                Ok(Some(result.bytes().await?.to_vec()))
+            }
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn read_object_path(&self, path: &ObjectPath) -> Result<Option<Vec<u8>>> {
+        match self.store.get(path).await {
+            Ok(result) => Ok(Some(result.bytes().await?.to_vec())),
+            Err(object_store::Error::NotFound { .. }) => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn list_objects(&self, relative_prefix: Option<&str>) -> Result<Vec<ObjectMeta>> {
+        let prefix = relative_prefix.map(|prefix| self.object_path(prefix)).or_else(|| {
+            (!self.prefix.is_empty()).then(|| ObjectPath::from(self.prefix.trim_end_matches('/')))
+        });
+        let mut listing = self.store.list(prefix.as_ref());
+        let mut entries = Vec::new();
+        while let Some(entry) = listing.next().await {
+            entries.push(entry?);
+        }
+        Ok(entries)
+    }
+
+    fn object_path(&self, relative: &str) -> ObjectPath {
+        ObjectPath::from(format!("{}{relative}", self.prefix))
+    }
+
+    fn relative_path<'a>(&self, path: &'a ObjectPath) -> Option<&'a str> {
+        path.as_ref().strip_prefix(&self.prefix)
+    }
+
+    fn quota_object(&self) -> &str {
+        match &self.quota {
+            QuotaCoordination::Local { .. } => ARTIFACT_USAGE_FILE,
+            QuotaCoordination::Conditional => ARTIFACT_QUOTA_OBJECT,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_limits(mut self, owner_limit: u64, global_limit: u64) -> Self {
+        self.owner_limit = owner_limit;
+        self.global_limit = global_limit;
+        self
+    }
 }
 
 pub fn parse_publish(body: &[u8]) -> Result<PublishArtifactRequest> {
@@ -101,893 +452,25 @@ pub fn parse_publish(body: &[u8]) -> Result<PublishArtifactRequest> {
         .map_err(|err| bad_request(format!("invalid shared artifact request: {err}")))
 }
 
-pub async fn publish(
-    cache_storage: &Path,
-    username: &str,
-    request: PublishArtifactRequest,
-) -> Result<bool> {
-    let validated = request.validate().map_err(|err| protocol_error(&err))?;
-    let payload = validated.payload;
-    let mut uploads = validated.blobs;
-    let artifact_root = cache_storage.join(ARTIFACT_CACHE_DIR);
-    let owner_dir = owner_dir(cache_storage, username, &payload.owner)?;
-    let owner = owner_usage_key(&owner_dir)?;
-    let entry_digest = entry_digest(&request.key, &payload.package, &payload.source_integrity);
-    let envelope_digest = request.envelope.digest().map_err(|err| protocol_error(&err))?;
-    let required: BTreeMap<&str, u64> =
-        payload.manifest.added.iter().map(|file| (file.integrity.as_str(), file.size)).collect();
-    let blobs_dir = owner_dir.join("blobs");
-    let mut required_by_lock = BTreeMap::<String, Vec<(&str, String, u64)>>::new();
-    for (integrity, size) in required {
-        let id = blob_id(integrity).map_err(|err| protocol_error(&err))?;
-        required_by_lock.entry(blob_lock_key(&owner, &id)).or_default().push((integrity, id, size));
-    }
-    for blobs in required_by_lock.values() {
-        for (integrity, id, size) in blobs {
-            let Some(bytes) = uploads.get(*integrity) else {
-                if !fs::try_exists(blobs_dir.join(id)).await? {
-                    return Err(bad_request(format!(
-                        "signed manifest references blob {id} without uploading it",
-                    )));
-                }
-                continue;
-            };
-            if bytes.len() as u64 != *size {
-                return Err(bad_request(format!(
-                    "blob {id} has {} bytes but the signed manifest declares {}",
-                    bytes.len(),
-                    size,
-                )));
-            }
-            verify_blob(integrity, bytes).map_err(|err| protocol_error(&err))?;
-        }
-    }
-
-    let reservation = reservation_id(&owner, &entry_digest, &envelope_digest);
-    let publication_lock = PendingUsageLock::Entry { entry: entry_digest.clone() };
-    let key_dir = owner_dir.join("entries").join(&entry_digest);
-    let variant_path = key_dir.join(format!("{envelope_digest}.json"));
-    let envelope_bytes = serde_json::to_vec(&request.envelope)?;
-    let variant_file =
-        pending_usage_file(&artifact_root, &variant_path, envelope_bytes.len() as u64)?;
-    let commit_file = variant_file.path.clone();
-    let _entry_lock =
-        acquire_artifact_lock(entry_lock_path(&artifact_root, &owner, &entry_digest)).await?;
-    let locked_blob_locks: BTreeSet<String> = required_by_lock.keys().cloned().collect();
-    let preserved_blob_ids: BTreeSet<String> =
-        required_by_lock.values().flatten().map(|(_, id, _)| id.clone()).collect();
-    let _blob_locks = loop {
-        let owner_recovery_lock =
-            acquire_artifact_lock(owner_lock_path(&artifact_root, &owner)).await?;
-        let mut blob_locks = Vec::with_capacity(locked_blob_locks.len());
-        let mut acquired_all_blob_locks = true;
-        for lock in &locked_blob_locks {
-            let Some(blob_lock) =
-                try_acquire_artifact_lock(blob_lock_path_for_key(&artifact_root, lock)).await?
-            else {
-                acquired_all_blob_locks = false;
-                break;
-            };
-            blob_locks.push(blob_lock);
-        }
-        if acquired_all_blob_locks
-            && reconcile_storage_reservations(
-                &artifact_root,
-                &ArtifactRecoveryLocks {
-                    owner: &owner,
-                    publication: &publication_lock,
-                    active_reservation: Some(&reservation),
-                    adoption_commit_file: Some(&commit_file),
-                    owner_locked: true,
-                    blob_locks: &locked_blob_locks,
-                    preserved_blob_ids: &preserved_blob_ids,
-                },
-            )
-            .await?
-        {
-            break blob_locks;
-        }
-        drop(blob_locks);
-        drop(owner_recovery_lock);
-        sleep(ARTIFACT_LOCK_POLL_INTERVAL).await;
-    };
-
-    let publication_result: Result<bool> = async {
-        let mut new_blobs = Vec::new();
-        for blobs in required_by_lock.into_values() {
-            for (integrity, id, size) in blobs {
-                let path = blobs_dir.join(&id);
-                match uploads.remove(integrity) {
-                    Some(bytes) => {
-                        if !fs::try_exists(&path).await? {
-                            new_blobs.push((path, bytes));
-                        }
-                    }
-                    None => match fs::read(&path).await {
-                        Ok(bytes) => {
-                            if bytes.len() as u64 != size {
-                                return Err(RegistryError::Internal {
-                                    reason: format!(
-                                        "stored shared artifact blob {id} has {} bytes instead of {size}",
-                                        bytes.len(),
-                                    ),
-                                });
-                            }
-                            verify_blob(integrity, &bytes).map_err(|err| {
-                                RegistryError::Internal {
-                                    reason: format!(
-                                        "stored shared artifact blob failed verification: {err}",
-                                    ),
-                                }
-                            })?;
-                        }
-                        Err(err) if err.kind() == ErrorKind::NotFound => {
-                            return Err(bad_request(format!(
-                                "signed manifest references blob {id} without uploading it",
-                            )));
-                        }
-                        Err(err) => return Err(err.into()),
-                    },
-                }
-            }
-        }
-
-        if fs::try_exists(&variant_path).await? {
-            remove_storage_reservation(&artifact_root, &reservation).await?;
-            return Ok(false);
-        }
-        if count_variants(&key_dir).await? >= MAX_VARIANTS_PER_CANDIDATE {
-            return Err(bad_request(format!(
-                "artifact key already has the {MAX_VARIANTS_PER_CANDIDATE}-variant limit",
-            )));
-        }
-
-        let mut pending_files = Vec::with_capacity(new_blobs.len() + 1);
-        for (path, bytes) in &new_blobs {
-            pending_files.push(pending_usage_file(&artifact_root, path, bytes.len() as u64)?);
-        }
-        pending_files.push(variant_file);
-        reserve_storage_quota(
-            &artifact_root,
-            StorageQuotaReservation {
-                id: &reservation,
-                owner: &owner,
-                lock: publication_lock.clone(),
-                commit_file: Some(commit_file),
-                locked_blob_locks: &locked_blob_locks,
-                files: pending_files,
-            },
-        )
-        .await?;
-        for (path, bytes) in new_blobs {
-            write_atomic(&path, &bytes).await?;
-        }
-        write_atomic(&variant_path, &envelope_bytes).await?;
-        if !remove_storage_reservation(&artifact_root, &reservation).await? {
-            return Err(RegistryError::Internal {
-                reason: "shared artifact storage reservation is missing after publication"
-                    .to_string(),
-            });
-        }
-        Ok(true)
-    }
-    .await;
-    match publication_result {
-        Ok(published) => Ok(published),
-        Err(error) => {
-            let preserved_blob_ids = BTreeSet::new();
-            if let Err(rollback_error) = reconcile_storage_reservations(
-                &artifact_root,
-                &ArtifactRecoveryLocks {
-                    owner: &owner,
-                    publication: &publication_lock,
-                    active_reservation: None,
-                    adoption_commit_file: None,
-                    owner_locked: false,
-                    blob_locks: &locked_blob_locks,
-                    preserved_blob_ids: &preserved_blob_ids,
-                },
-            )
-            .await
-            {
-                return Err(RegistryError::Internal {
-                    reason: format!(
-                        "shared artifact publication failed: {error}; rollback failed: {rollback_error}",
-                    ),
-                });
-            }
-            Err(error)
-        }
-    }
-}
-
-async fn reserve_storage_quota(
-    artifact_root: &Path,
-    reservation: StorageQuotaReservation<'_>,
-) -> Result<()> {
-    reserve_storage_quota_with_locks_and_limits(
-        artifact_root,
-        reservation,
-        MAX_OWNER_ARTIFACT_BYTES,
-        MAX_GLOBAL_ARTIFACT_BYTES,
-    )
-    .await
-}
-
-async fn reserve_storage_quota_with_locks_and_limits(
-    artifact_root: &Path,
-    reservation: StorageQuotaReservation<'_>,
-    owner_limit: u64,
-    global_limit: u64,
-) -> Result<()> {
-    let _usage_lock = acquire_artifact_lock(usage_lock_path(artifact_root)).await?;
-    let mut usage = load_artifact_usage(artifact_root).await?;
-    let preserved_blob_ids = BTreeSet::new();
-    let reconciliation = reconcile_pending_usage(
-        artifact_root,
-        &mut usage,
-        &ArtifactRecoveryLocks {
-            owner: reservation.owner,
-            publication: &reservation.lock,
-            active_reservation: Some(reservation.id),
-            adoption_commit_file: reservation.commit_file.as_deref(),
-            owner_locked: false,
-            blob_locks: reservation.locked_blob_locks,
-            preserved_blob_ids: &preserved_blob_ids,
-        },
-    )
-    .await?;
-    if reconciliation.usage_changed {
-        write_artifact_usage(artifact_root, &usage).await?;
-    }
-    let added_bytes = reservation.files.iter().try_fold(0_u64, |total, file| {
-        total.checked_add(file.size).ok_or_else(storage_quota_error)
-    })?;
-    let owner_bytes = usage.owner_bytes.get(reservation.owner).copied().unwrap_or(0);
-    let next_owner_bytes = owner_bytes.checked_add(added_bytes).ok_or_else(storage_quota_error)?;
-    let next_global_bytes =
-        usage.global_bytes.checked_add(added_bytes).ok_or_else(storage_quota_error)?;
-    if next_owner_bytes > owner_limit {
-        return Err(storage_quota_error());
-    }
-    if next_global_bytes > global_limit {
-        return Err(storage_quota_error());
-    }
-    usage.global_bytes = next_global_bytes;
-    usage.owner_bytes.insert(reservation.owner.to_string(), next_owner_bytes);
-    let pending = PendingUsage {
-        owner: reservation.owner.to_string(),
-        lock: reservation.lock,
-        commit_file: reservation.commit_file,
-        files: reservation.files,
-    };
-    merge_pending_usage(&mut usage, reservation.id, pending)?;
-    write_artifact_usage(artifact_root, &usage).await?;
-    Ok(())
-}
-
-async fn remove_storage_reservation(artifact_root: &Path, reservation: &str) -> Result<bool> {
-    let _usage_lock = acquire_artifact_lock(usage_lock_path(artifact_root)).await?;
-    let mut usage = load_artifact_usage(artifact_root).await?;
-    if usage.pending.remove(reservation).is_none() {
-        return Ok(false);
-    }
-    write_artifact_usage(artifact_root, &usage).await?;
-    Ok(true)
-}
-
-async fn reconcile_storage_reservations(
-    artifact_root: &Path,
-    recovery_locks: &ArtifactRecoveryLocks<'_>,
-) -> Result<bool> {
-    let _usage_lock = acquire_artifact_lock(usage_lock_path(artifact_root)).await?;
-    let mut usage = load_artifact_usage(artifact_root).await?;
-    let reconciliation = reconcile_pending_usage(artifact_root, &mut usage, recovery_locks).await?;
-    if reconciliation.usage_changed {
-        write_artifact_usage(artifact_root, &usage).await?;
-    }
-    Ok(!reconciliation.blocked_locked_blobs)
-}
-
-async fn load_artifact_usage(artifact_root: &Path) -> Result<ArtifactUsage> {
-    match fs::read(artifact_usage_path(artifact_root)).await {
-        Ok(bytes) => serde_json::from_slice(&bytes).map_err(Into::into),
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            scan_artifact_usage(artifact_root).await
-        }
-        Err(error) => Err(error.into()),
-    }
-}
-
-async fn scan_artifact_usage(artifact_root: &Path) -> Result<ArtifactUsage> {
-    let global_bytes = stored_bytes(artifact_root, Some(".locks")).await?;
-    let mut owner_bytes = BTreeMap::new();
-    let mut entries = match fs::read_dir(artifact_root).await {
-        Ok(entries) => entries,
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            return Ok(ArtifactUsage::default());
-        }
-        Err(error) => return Err(error.into()),
-    };
-    while let Some(entry) = entries.next_entry().await? {
-        if entry.file_name() == ".locks" || !entry.file_type().await?.is_dir() {
-            continue;
-        }
-        let owner = entry.file_name().into_string().map_err(|_| RegistryError::Internal {
-            reason: "shared artifact owner directory is not valid UTF-8".to_string(),
-        })?;
-        owner_bytes.insert(owner, stored_bytes(&entry.path(), None).await?);
-    }
-    Ok(ArtifactUsage { global_bytes, owner_bytes, pending: BTreeMap::new() })
-}
-
-async fn reconcile_pending_usage(
-    artifact_root: &Path,
-    usage: &mut ArtifactUsage,
-    recovery_locks: &ArtifactRecoveryLocks<'_>,
-) -> Result<PendingUsageReconciliation> {
-    let reservations: Vec<String> = usage.pending.keys().cloned().collect();
-    let mut reconciliation = PendingUsageReconciliation::default();
-    let mut adopted_files = Vec::new();
-    for reservation in reservations {
-        if recovery_locks.active_reservation == Some(reservation.as_str()) {
-            continue;
-        }
-        let pending = usage.pending.get(&reservation).ok_or_else(missing_pending_usage)?;
-        let pending_blob_locks = pending_blob_lock_keys(pending)?;
-        let shares_locked_blobs =
-            pending_blob_locks.iter().any(|lock| recovery_locks.blob_locks.contains(lock));
-        let Some(_reservation_locks) = try_acquire_pending_usage_locks(
-            artifact_root,
-            pending,
-            pending_blob_locks,
-            recovery_locks,
-        )
-        .await?
-        else {
-            reconciliation.blocked_locked_blobs |= shares_locked_blobs;
-            continue;
-        };
-
-        let pending = usage.pending.remove(&reservation).ok_or_else(missing_pending_usage)?;
-        let committed = pending_usage_is_committed(artifact_root, &pending).await?;
-        adopted_files.extend(
-            reconcile_pending_files(artifact_root, usage, pending, committed, recovery_locks)
-                .await?,
-        );
-        reconciliation.usage_changed = true;
-    }
-    if !adopted_files.is_empty() {
-        adopt_recovered_files(usage, recovery_locks, adopted_files)?;
-        reconciliation.usage_changed = true;
-    }
-    Ok(reconciliation)
-}
-
-struct PendingUsageLocks {
-    _publication: Option<File>,
-    _blobs: Vec<File>,
-}
-
-async fn try_acquire_pending_usage_locks(
-    artifact_root: &Path,
-    pending: &PendingUsage,
-    pending_blob_locks: BTreeSet<String>,
-    recovery_locks: &ArtifactRecoveryLocks<'_>,
-) -> Result<Option<PendingUsageLocks>> {
-    let caller_holds_lock = pending.owner == recovery_locks.owner
-        && (&pending.lock == recovery_locks.publication
-            || recovery_locks.owner_locked && matches!(&pending.lock, PendingUsageLock::Owner));
-    let publication = if caller_holds_lock {
-        None
-    } else {
-        let Some(lock) = try_acquire_artifact_lock(pending_lock_path(
-            artifact_root,
-            &pending.owner,
-            &pending.lock,
-        ))
-        .await?
-        else {
-            return Ok(None);
-        };
-        Some(lock)
-    };
-
-    let mut blobs = Vec::new();
-    for lock in pending_blob_locks {
-        if recovery_locks.blob_locks.contains(&lock) {
-            continue;
-        }
-        let Some(lock) =
-            try_acquire_artifact_lock(blob_lock_path_for_key(artifact_root, &lock)).await?
-        else {
-            return Ok(None);
-        };
-        blobs.push(lock);
-    }
-    Ok(Some(PendingUsageLocks { _publication: publication, _blobs: blobs }))
-}
-
-async fn pending_usage_is_committed(artifact_root: &Path, pending: &PendingUsage) -> Result<bool> {
-    let Some(commit_path) = pending.commit_file.as_deref() else {
-        return Ok(true);
-    };
-    let Some(commit_file) = pending.files.iter().find(|file| file.path == commit_path) else {
-        return Ok(false);
-    };
-    let commit_path = pending_usage_path(commit_path)?;
-    stored_file_has_size(&artifact_root.join(commit_path), commit_file.size).await
-}
-
-async fn reconcile_pending_files(
-    artifact_root: &Path,
-    usage: &mut ArtifactUsage,
-    pending: PendingUsage,
-    committed: bool,
-    recovery_locks: &ArtifactRecoveryLocks<'_>,
-) -> Result<Vec<PendingUsageFile>> {
-    let mut adopted_files = Vec::new();
-    for file in pending.files {
-        let relative_path = pending_usage_path(&file.path)?;
-        let path = artifact_root.join(relative_path);
-        remove_atomic_write_temps(&path).await?;
-
-        if committed {
-            if !stored_file_has_size(&path, file.size).await? {
-                release_reserved_bytes(usage, &pending.owner, file.size)?;
-            }
-            continue;
-        }
-
-        let preserved = pending.owner == recovery_locks.owner
-            && pending_blob_id(&pending.owner, &file)?
-                .is_some_and(|blob| recovery_locks.preserved_blob_ids.contains(blob));
-        if preserved && stored_file_has_size(&path, file.size).await? {
-            adopted_files.push(file);
-            continue;
-        }
-
-        match fs::remove_file(&path).await {
-            Ok(()) => {}
-            Err(error) if error.kind() == ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-        release_reserved_bytes(usage, &pending.owner, file.size)?;
-    }
-    Ok(adopted_files)
-}
-
-async fn stored_file_has_size(path: &Path, expected_size: u64) -> Result<bool> {
-    match fs::metadata(path).await {
-        Ok(metadata) => Ok(metadata.is_file() && metadata.len() == expected_size),
-        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
-        Err(error) => Err(error.into()),
-    }
-}
-
-fn adopt_recovered_files(
-    usage: &mut ArtifactUsage,
-    recovery_locks: &ArtifactRecoveryLocks<'_>,
-    files: Vec<PendingUsageFile>,
-) -> Result<()> {
-    let reservation = recovery_locks.active_reservation.ok_or_else(|| RegistryError::Internal {
-        reason: "shared artifact recovery has no adopting storage reservation".to_string(),
-    })?;
-    let commit_file =
-        recovery_locks.adoption_commit_file.ok_or_else(|| RegistryError::Internal {
-            reason: "shared artifact recovery has no adopting commit file".to_string(),
-        })?;
-    merge_pending_usage(
-        usage,
-        reservation,
-        PendingUsage {
-            owner: recovery_locks.owner.to_string(),
-            lock: recovery_locks.publication.clone(),
-            commit_file: Some(commit_file.to_string()),
-            files,
-        },
-    )
-}
-
-fn missing_pending_usage() -> RegistryError {
-    RegistryError::Internal {
-        reason: "shared artifact pending storage reservation disappeared".to_string(),
-    }
-}
-
-fn merge_pending_usage(
-    usage: &mut ArtifactUsage,
-    reservation: &str,
-    pending: PendingUsage,
-) -> Result<()> {
-    if let Some(active) = usage.pending.get_mut(reservation) {
-        if active.owner != pending.owner
-            || active.lock != pending.lock
-            || active.commit_file != pending.commit_file
-        {
-            return Err(RegistryError::Internal {
-                reason: "shared artifact publication has conflicting storage reservations"
-                    .to_string(),
-            });
-        }
-        active.files.extend(pending.files);
-    } else {
-        usage.pending.insert(reservation.to_string(), pending);
-    }
-    Ok(())
-}
-
-fn release_reserved_bytes(usage: &mut ArtifactUsage, owner: &str, bytes: u64) -> Result<()> {
-    usage.global_bytes =
-        usage.global_bytes.checked_sub(bytes).ok_or_else(|| RegistryError::Internal {
-            reason: "shared artifact global usage counter underflow".to_string(),
-        })?;
-    let owner_bytes = usage.owner_bytes.get_mut(owner).ok_or_else(|| RegistryError::Internal {
-        reason: "shared artifact usage state is missing the pending owner".to_string(),
-    })?;
-    *owner_bytes = owner_bytes.checked_sub(bytes).ok_or_else(|| RegistryError::Internal {
-        reason: "shared artifact owner usage counter underflow".to_string(),
-    })?;
-    Ok(())
-}
-
-fn pending_blob_lock_keys(pending: &PendingUsage) -> Result<BTreeSet<String>> {
-    let mut lock_keys = BTreeSet::new();
-    for file in &pending.files {
-        if let Some(blob) = pending_blob_id(&pending.owner, file)? {
-            lock_keys.insert(blob_lock_key(&pending.owner, blob));
-        }
-    }
-    Ok(lock_keys)
-}
-
-fn pending_blob_id<'a>(owner: &str, file: &'a PendingUsageFile) -> Result<Option<&'a str>> {
-    let mut components = pending_usage_path(&file.path)?.components();
-    let (Some(Component::Normal(file_owner)), Some(Component::Normal(kind))) =
-        (components.next(), components.next())
-    else {
-        return Ok(None);
-    };
-    if file_owner != owner || kind != "blobs" {
-        return Ok(None);
-    }
-    let (Some(Component::Normal(blob)), None) = (components.next(), components.next()) else {
-        return Ok(None);
-    };
-    blob.to_str().map(Some).ok_or_else(|| RegistryError::Internal {
-        reason: "shared artifact usage state contains an invalid blob path".to_string(),
-    })
-}
-
-fn pending_usage_path(path: &str) -> Result<&Path> {
-    let path = Path::new(path);
-    if path.as_os_str().is_empty()
-        || !path.components().all(|component| matches!(component, Component::Normal(_)))
-    {
-        return Err(RegistryError::Internal {
-            reason: "shared artifact usage state contains an invalid pending path".to_string(),
-        });
-    }
-    Ok(path)
-}
-
-async fn write_artifact_usage(artifact_root: &Path, usage: &ArtifactUsage) -> Result<()> {
-    write_atomic(&artifact_usage_path(artifact_root), &serde_json::to_vec(usage)?).await
-}
-
-fn artifact_usage_path(artifact_root: &Path) -> PathBuf {
-    artifact_root.join(".locks").join(ARTIFACT_USAGE_FILE)
-}
-
-fn usage_lock_path(artifact_root: &Path) -> PathBuf {
-    artifact_root.join(".locks").join("usage.lock")
-}
-
-fn owner_lock_path(artifact_root: &Path, owner: &str) -> PathBuf {
-    artifact_root
-        .join(".locks")
-        .join("owners")
-        .join(format!("{}.lock", digest_segment(owner.as_bytes())))
-}
-
-fn entry_lock_path(artifact_root: &Path, owner: &str, entry: &str) -> PathBuf {
-    artifact_root
-        .join(".locks")
-        .join("entries")
-        .join(digest_segment(owner.as_bytes()))
-        .join(format!("{}.lock", digest_segment(entry.as_bytes())))
-}
-
-fn blob_lock_key(owner: &str, blob: &str) -> String {
-    let mut bytes = Vec::with_capacity(owner.len() + blob.len() + 1);
-    bytes.extend_from_slice(owner.as_bytes());
-    bytes.push(0);
-    bytes.extend_from_slice(blob.as_bytes());
-    let digest = Sha256::digest(bytes);
-    format!("{:02x}", usize::from(digest[0]) % BLOB_LOCK_STRIPES)
-}
-
-fn blob_lock_path_for_key(artifact_root: &Path, lock: &str) -> PathBuf {
-    artifact_root.join(".locks").join("blobs").join(format!("{lock}.lock"))
-}
-
-fn pending_lock_path(
-    artifact_root: &Path,
-    owner: &str,
-    pending_lock: &PendingUsageLock,
-) -> PathBuf {
-    match pending_lock {
-        PendingUsageLock::Entry { entry } => entry_lock_path(artifact_root, owner, entry),
-        PendingUsageLock::Owner => owner_lock_path(artifact_root, owner),
-        PendingUsageLock::Global => artifact_root.join(".locks").join("publication.lock"),
-    }
-}
-
-fn reservation_id(owner: &str, entry: &str, envelope: &str) -> String {
-    let counter = ARTIFACT_RESERVATION_COUNTER.fetch_add(1, Ordering::Relaxed);
-    let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_nanos();
-    let mut bytes = Vec::with_capacity(owner.len() + entry.len() + envelope.len() + 34);
-    bytes.extend_from_slice(owner.as_bytes());
-    bytes.push(0);
-    bytes.extend_from_slice(entry.as_bytes());
-    bytes.push(0);
-    bytes.extend_from_slice(envelope.as_bytes());
-    bytes.extend_from_slice(&std::process::id().to_ne_bytes());
-    bytes.extend_from_slice(&counter.to_ne_bytes());
-    bytes.extend_from_slice(&timestamp.to_ne_bytes());
-    digest_segment(&bytes)
-}
-
-fn deserialize_pending_usage<'de, Deserializer>(
-    deserializer: Deserializer,
-) -> std::result::Result<BTreeMap<String, PendingUsage>, Deserializer::Error>
-where
-    Deserializer: serde::Deserializer<'de>,
-{
-    #[derive(serde::Deserialize)]
-    #[serde(untagged)]
-    enum PendingUsageState {
-        Current(BTreeMap<String, PendingUsage>),
-        OwnerScoped(BTreeMap<String, Vec<PendingUsageFile>>),
-        Global(Option<LegacyPendingUsage>),
-    }
-
-    Ok(match <PendingUsageState as serde::Deserialize>::deserialize(deserializer)? {
-        PendingUsageState::Current(pending) => pending,
-        PendingUsageState::OwnerScoped(pending) => pending
-            .into_iter()
-            .map(|(owner, files)| {
-                let reservation = format!("legacy-owner-{}", digest_segment(owner.as_bytes()));
-                (
-                    reservation,
-                    PendingUsage { owner, lock: PendingUsageLock::Owner, commit_file: None, files },
-                )
-            })
-            .collect(),
-        PendingUsageState::Global(Some(pending)) => BTreeMap::from([(
-            "legacy-global".to_string(),
-            PendingUsage {
-                owner: pending.owner,
-                lock: PendingUsageLock::Global,
-                commit_file: None,
-                files: pending.files,
-            },
-        )]),
-        PendingUsageState::Global(None) => BTreeMap::new(),
-    })
-}
-
-fn pending_usage_file(artifact_root: &Path, path: &Path, size: u64) -> Result<PendingUsageFile> {
-    let relative_path = path.strip_prefix(artifact_root).map_err(|_| RegistryError::Internal {
-        reason: "shared artifact usage path escaped the artifact root".to_string(),
-    })?;
-    let path = relative_path.to_str().ok_or_else(|| RegistryError::Internal {
-        reason: "shared artifact usage path is not valid UTF-8".to_string(),
-    })?;
-    Ok(PendingUsageFile { path: path.to_string(), size })
-}
-
-fn owner_usage_key(owner_dir: &Path) -> Result<String> {
-    owner_dir.file_name().and_then(|name| name.to_str()).map(ToOwned::to_owned).ok_or_else(|| {
-        RegistryError::Internal {
-            reason: "shared artifact owner directory has no valid name".to_string(),
-        }
-    })
-}
-
-async fn stored_bytes(root: &Path, ignored_root_entry: Option<&str>) -> Result<u64> {
-    let mut directories = vec![root.to_path_buf()];
-    let mut total = 0_u64;
-    while let Some(directory) = directories.pop() {
-        let mut entries = match fs::read_dir(&directory).await {
-            Ok(entries) => entries,
-            Err(error) if error.kind() == ErrorKind::NotFound => continue,
-            Err(error) => return Err(error.into()),
-        };
-        while let Some(entry) = entries.next_entry().await? {
-            if directory == root
-                && ignored_root_entry.is_some_and(|ignored| entry.file_name() == ignored)
-            {
-                continue;
-            }
-            let file_type = entry.file_type().await?;
-            if file_type.is_dir() {
-                directories.push(entry.path());
-            } else if file_type.is_file() {
-                total = total
-                    .checked_add(entry.metadata().await?.len())
-                    .ok_or_else(storage_quota_error)?;
-            }
-        }
-    }
-    Ok(total)
-}
-
-fn storage_quota_error() -> RegistryError {
-    bad_request(format!(
-        "shared artifact storage quota exceeded ({MAX_OWNER_ARTIFACT_BYTES} bytes per owner, {MAX_GLOBAL_ARTIFACT_BYTES} bytes globally)",
-    ))
-}
-
-pub async fn resolve(
-    cache_storage: &Path,
-    username: &str,
-    body: &[u8],
-) -> Result<ResolveArtifactsResponse> {
-    let request: ResolveArtifactsRequest = serde_json::from_slice(body)
-        .map_err(|err| bad_request(format!("invalid shared artifact lookup: {err}")))?;
-    if request.candidates.len() > MAX_CANDIDATES {
-        return Err(bad_request(format!(
-            "lookup contains {} candidates; limit is {MAX_CANDIDATES}",
-            request.candidates.len(),
-        )));
-    }
-    let mut seen = HashSet::with_capacity(request.candidates.len());
-    let mut artifacts = Vec::new();
-    let mut budget = ResolveBudget {
-        used_bytes: serde_json::to_vec(&ResolveArtifactsResponse { artifacts: Vec::new() })?.len(),
-    };
-    for candidate in request.candidates {
-        candidate.validate().map_err(|err| protocol_error(&err))?;
-        if !seen.insert(candidate.key.clone()) {
-            return Err(bad_request("lookup contains a duplicate candidate".to_string()));
-        }
-        let Some(resolved) =
-            resolve_candidate(cache_storage, username, &candidate, &mut budget).await?
-        else {
-            continue;
-        };
-        budget.add_response(&resolved, !artifacts.is_empty())?;
-        artifacts.push(resolved);
-    }
-    Ok(ResolveArtifactsResponse { artifacts })
-}
-
-pub async fn read_blob(
-    cache_storage: &Path,
-    username: &str,
-    body: &[u8],
-) -> Result<Option<(fs::File, u64)>> {
-    let request: ArtifactBlobRequest = serde_json::from_slice(body)
-        .map_err(|err| bad_request(format!("invalid artifact blob request: {err}")))?;
-    request.validate().map_err(|err| protocol_error(&err))?;
-    let owner_dir = match owner_dir(cache_storage, username, &request.owner) {
-        Ok(path) => path,
-        Err(RegistryError::Forbidden { .. }) => return Ok(None),
-        Err(err) => return Err(err),
-    };
-    let id = blob_id(&request.integrity).map_err(|err| protocol_error(&err))?;
-    let mut file = match fs::File::open(owner_dir.join("blobs").join(&id)).await {
-        Ok(file) => file,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err.into()),
-    };
-    let size = file.metadata().await?.len();
-    if size > MAX_FILE_SIZE {
+fn verify_stored_blob(id: &str, integrity: &str, size: u64, bytes: &[u8]) -> Result<()> {
+    if bytes.len() as u64 != size {
         return Err(RegistryError::Internal {
             reason: format!(
-                "stored shared artifact blob has {size} bytes; limit is {MAX_FILE_SIZE}",
+                "stored shared artifact blob {id} has {} bytes instead of {size}",
+                bytes.len(),
             ),
         });
     }
-    let mut digest = Sha512::new();
-    let mut buffer = vec![0_u8; ARTIFACT_BLOB_READ_CHUNK];
-    loop {
-        let read = file.read(&mut buffer).await?;
-        if read == 0 {
-            break;
-        }
-        digest.update(&buffer[..read]);
-    }
-    if hex(&digest.finalize()) != id {
-        return Err(RegistryError::Internal {
-            reason: "stored shared artifact blob failed verification: downloaded bytes do not match the declared digest"
-                .to_string(),
-        });
-    }
-    file.seek(SeekFrom::Start(0)).await?;
-    Ok(Some((file, size)))
+    verify_blob(integrity, bytes).map_err(|err| RegistryError::Internal {
+        reason: format!("stored shared artifact blob failed verification: {err}"),
+    })
 }
 
-async fn resolve_candidate(
-    cache_storage: &Path,
-    username: &str,
-    candidate: &ArtifactCandidate,
-    budget: &mut ResolveBudget,
-) -> Result<Option<ResolvedArtifact>> {
-    let owner_dir = match owner_dir(cache_storage, username, &candidate.owner) {
-        Ok(path) => path,
-        Err(RegistryError::Forbidden { .. }) => return Ok(None),
-        Err(err) => return Err(err),
-    };
-    let key_dir = owner_dir.join("entries").join(entry_digest(
-        &candidate.key,
-        &candidate.package,
-        &candidate.source_integrity,
-    ));
-    let mut entries = match fs::read_dir(key_dir).await {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
-        Err(err) => return Err(err.into()),
-    };
-    let mut paths = Vec::new();
-    while let Some(entry) = entries.next_entry().await? {
-        if entry.file_type().await?.is_file() && is_variant_file(&entry.file_name()) {
-            paths.push(entry.path());
-        }
-    }
-    paths.sort();
-    let mut variants = Vec::new();
-    for path in paths.into_iter().take(MAX_VARIANTS_PER_CANDIDATE) {
-        budget.add_scan(fs::metadata(&path).await?.len())?;
-        let bytes = fs::read(&path).await?;
-        let Ok(envelope) = serde_json::from_slice::<SignedArtifactEnvelope>(&bytes) else {
-            continue;
-        };
-        let Ok((payload, _)) = envelope.decode_payload() else {
-            continue;
-        };
-        if artifact_matches_candidate(&payload, candidate) {
-            variants.push(ArtifactVariant { envelope });
-        }
-    }
-    Ok((!variants.is_empty()).then(|| ResolvedArtifact { key: candidate.key.clone(), variants }))
-}
-
-struct ResolveBudget {
-    used_bytes: usize,
-}
-
-impl ResolveBudget {
-    fn add_scan(&mut self, bytes: u64) -> Result<()> {
-        self.add(usize::try_from(bytes).unwrap_or(usize::MAX))
-    }
-
-    fn add_response(&mut self, artifact: &ResolvedArtifact, needs_comma: bool) -> Result<()> {
-        let serialized_size = serde_json::to_vec(artifact)?.len() + usize::from(needs_comma);
-        self.add(serialized_size)
-    }
-
-    fn add(&mut self, bytes: usize) -> Result<()> {
-        self.used_bytes = self.used_bytes.checked_add(bytes).ok_or_else(resolve_limit_error)?;
-        if self.used_bytes > MAX_RESOLVE_RESPONSE_SIZE {
-            return Err(resolve_limit_error());
-        }
-        Ok(())
-    }
-}
-
-fn resolve_limit_error() -> RegistryError {
-    bad_request(format!(
-        "shared artifact lookup exceeds the {MAX_RESOLVE_RESPONSE_SIZE}-byte budget",
-    ))
-}
-
-fn owner_dir(cache_storage: &Path, username: &str, owner: &OwnerScope) -> Result<PathBuf> {
+fn owner_key(username: &str, owner: &OwnerScope) -> Result<String> {
     match owner {
-        OwnerScope::Organization { name } if name == username => Ok(cache_storage
-            .join(ARTIFACT_CACHE_DIR)
-            .join(digest_segment(owner.namespace().as_bytes()))),
+        OwnerScope::Organization { name } if name == username => {
+            Ok(digest_segment(owner.namespace().as_bytes()))
+        }
         OwnerScope::Organization { .. } | OwnerScope::Publisher { .. } => {
             Err(RegistryError::Forbidden {
                 user: username.to_string(),
@@ -1009,15 +492,6 @@ async fn acquire_artifact_lock(path: PathBuf) -> Result<File> {
     }
 }
 
-async fn try_acquire_artifact_lock(path: PathBuf) -> Result<Option<File>> {
-    let file = tokio::task::spawn_blocking(move || open_lock_file(&path)).await??;
-    match file.try_lock() {
-        Ok(()) => Ok(Some(file)),
-        Err(TryLockError::WouldBlock) => Ok(None),
-        Err(TryLockError::Error(error)) => Err(error.into()),
-    }
-}
-
 fn open_lock_file(path: &Path) -> std::io::Result<File> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -1025,28 +499,31 @@ fn open_lock_file(path: &Path) -> std::io::Result<File> {
     OpenOptions::new().read(true).write(true).create(true).truncate(false).open(path)
 }
 
-async fn count_variants(key_dir: &Path) -> Result<usize> {
-    let mut entries = match fs::read_dir(key_dir).await {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(0),
-        Err(err) => return Err(err.into()),
-    };
-    let mut count = 0;
-    while let Some(entry) = entries.next_entry().await? {
-        if entry.file_type().await?.is_file() && is_variant_file(&entry.file_name()) {
-            count += 1;
-        }
-    }
-    Ok(count)
+fn is_write_conflict(error: &object_store::Error) -> bool {
+    matches!(
+        error,
+        object_store::Error::AlreadyExists { .. }
+            | object_store::Error::Precondition { .. }
+            | object_store::Error::NotFound { .. },
+    )
 }
 
-fn is_variant_file(name: &std::ffi::OsStr) -> bool {
-    name.to_str().is_some_and(|name| {
-        let bytes = name.as_bytes();
-        bytes.len() == 69
-            && bytes[64..] == *b".json"
-            && bytes[..64].iter().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
-    })
+fn is_create_conflict(error: &object_store::Error) -> bool {
+    matches!(
+        error,
+        object_store::Error::AlreadyExists { .. } | object_store::Error::Precondition { .. },
+    )
+}
+
+fn object_name(path: &ObjectPath) -> &str {
+    path.as_ref().rsplit('/').next().unwrap_or_default()
+}
+
+fn is_variant_file(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() == 69
+        && bytes[64..] == *b".json"
+        && bytes[..64].iter().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
 }
 
 fn digest_segment(bytes: &[u8]) -> String {
@@ -1080,6 +557,45 @@ fn artifact_matches_candidate(payload: &ArtifactPayload, candidate: &ArtifactCan
         && payload.package == *package
         && payload.source_integrity == *source_integrity
         && payload.owner == *owner
+}
+
+struct ResolveBudget {
+    used_bytes: usize,
+}
+
+impl ResolveBudget {
+    fn add_scan(&mut self, bytes: u64) -> Result<()> {
+        self.add(usize::try_from(bytes).unwrap_or(usize::MAX))
+    }
+
+    fn add_response(&mut self, artifact: &ResolvedArtifact, needs_comma: bool) -> Result<()> {
+        let serialized_size = serde_json::to_vec(artifact)?.len() + usize::from(needs_comma);
+        self.add(serialized_size)
+    }
+
+    fn add(&mut self, bytes: usize) -> Result<()> {
+        self.used_bytes = self.used_bytes.checked_add(bytes).ok_or_else(resolve_limit_error)?;
+        if self.used_bytes > MAX_RESOLVE_RESPONSE_SIZE {
+            return Err(resolve_limit_error());
+        }
+        Ok(())
+    }
+}
+
+fn resolve_limit_error() -> RegistryError {
+    bad_request(format!(
+        "shared artifact lookup exceeds the {MAX_RESOLVE_RESPONSE_SIZE}-byte budget",
+    ))
+}
+
+fn storage_quota_error() -> RegistryError {
+    bad_request(format!(
+        "shared artifact storage quota exceeded ({MAX_OWNER_ARTIFACT_BYTES} bytes per owner, {MAX_GLOBAL_ARTIFACT_BYTES} bytes globally)",
+    ))
+}
+
+fn quota_counter_underflow() -> RegistryError {
+    RegistryError::Internal { reason: "shared artifact quota counter underflow".to_string() }
 }
 
 fn protocol_error(error: &ArtifactProtocolError) -> RegistryError {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -153,20 +153,29 @@ impl SharedArtifactStore {
         })?;
         self.reserve_quota(&owner, added_bytes).await?;
 
-        let mut unused_reservation = 0_u64;
+        let mut created_bytes = 0_u64;
         for (path, bytes) in new_blobs {
             let size = bytes.len() as u64;
-            if !self.create_object(&path, bytes).await? {
-                unused_reservation += size;
+            match self.create_object(&path, bytes).await {
+                Ok(true) => created_bytes += size,
+                Ok(false) => {}
+                Err(error) => {
+                    self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
+                    return Err(error);
+                }
             }
         }
-        let created = self.create_object(&variant_path, envelope_bytes).await?;
-        if !created {
-            unused_reservation += envelope_size;
+        let created = match self.create_object(&variant_path, envelope_bytes).await {
+            Ok(created) => created,
+            Err(error) => {
+                self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
+                return Err(error);
+            }
+        };
+        if created {
+            created_bytes += envelope_size;
         }
-        if unused_reservation != 0 {
-            self.change_quota(&owner, unused_reservation, QuotaChange::Release).await?;
-        }
+        self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
         Ok(created)
     }
 
@@ -237,11 +246,17 @@ impl SharedArtifactStore {
         };
         let entry = entry_digest(&candidate.key, &candidate.package, &candidate.source_integrity);
         let prefix = format!("{owner}/entries/{entry}/");
-        let mut entries = self.list_objects(Some(&prefix)).await?;
-        entries.retain(|entry| is_variant_file(object_name(&entry.location)));
-        entries.sort_unstable_by(|left, right| left.location.cmp(&right.location));
+        let prefix = self.object_path(&prefix);
+        let mut listing = self.store.list(Some(&prefix));
         let mut variants = Vec::new();
-        for entry in entries.into_iter().take(MAX_VARIANTS_PER_CANDIDATE) {
+        let mut scanned_variants = 0;
+        while scanned_variants < MAX_VARIANTS_PER_CANDIDATE {
+            let Some(entry) = listing.next().await else { break };
+            let entry = entry?;
+            if !is_variant_file(object_name(&entry.location)) {
+                continue;
+            }
+            scanned_variants += 1;
             budget.add_scan(entry.size)?;
             let Some(bytes) = self.read_object_path(&entry.location).await? else {
                 continue;
@@ -262,6 +277,20 @@ impl SharedArtifactStore {
 
     async fn reserve_quota(&self, owner: &str, added_bytes: u64) -> Result<()> {
         self.change_quota(owner, added_bytes, QuotaChange::Reserve).await
+    }
+
+    async fn release_uncommitted(
+        &self,
+        owner: &str,
+        reserved_bytes: u64,
+        created_bytes: u64,
+    ) -> Result<()> {
+        let unused_bytes =
+            reserved_bytes.checked_sub(created_bytes).ok_or_else(quota_counter_underflow)?;
+        if unused_bytes != 0 {
+            self.change_quota(owner, unused_bytes, QuotaChange::Release).await?;
+        }
+        Ok(())
     }
 
     async fn change_quota(&self, owner: &str, bytes: u64, change: QuotaChange) -> Result<()> {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -531,9 +531,7 @@ fn open_lock_file(path: &Path) -> std::io::Result<File> {
 fn is_write_conflict(error: &object_store::Error) -> bool {
     matches!(
         error,
-        object_store::Error::AlreadyExists { .. }
-            | object_store::Error::Precondition { .. }
-            | object_store::Error::NotFound { .. },
+        object_store::Error::AlreadyExists { .. } | object_store::Error::Precondition { .. },
     )
 }
 

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1,32 +1,19 @@
-use std::{
-    collections::{BTreeMap, BTreeSet, HashSet},
-    path::Path,
-    sync::Arc,
-};
+use std::{collections::BTreeMap, sync::Arc};
 
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory};
 use pnpm_shared_artifact_protocol::{
-    ARTIFACT_KIND, ArtifactBlobUpload, ArtifactFile, ArtifactManifest, ArtifactPayload,
-    ArtifactVariant, BuilderProfile, CompatibilityConstraints, MAX_RESOLVE_RESPONSE_SIZE,
-    MAX_VARIANTS_PER_CANDIDATE, OwnerScope, PackageIdentity, PublishArtifactRequest,
-    ResolveArtifactsResponse, ResolvedArtifact, SIGNATURE_ALGORITHM, SignedArtifactEnvelope,
-    blob_id,
+    ARTIFACT_KIND, ArtifactBlobRequest, ArtifactBlobUpload, ArtifactCandidate, ArtifactFile,
+    ArtifactManifest, ArtifactPayload, ArtifactVariant, BuilderProfile, CompatibilityConstraints,
+    MAX_RESOLVE_RESPONSE_SIZE, MAX_VARIANTS_PER_CANDIDATE, OwnerScope, PackageIdentity,
+    PublishArtifactRequest, ResolveArtifactsRequest, ResolveArtifactsResponse, ResolvedArtifact,
+    SIGNATURE_ALGORITHM, SignedArtifactEnvelope,
 };
+use pnpr_config::{HostedStoreConfig, normalize_key_prefix};
 use sha2::{Digest as _, Sha512};
 use tempfile::TempDir;
-use tokio::{fs, sync::Barrier, time::timeout};
 
-use super::{
-    ArtifactRecoveryLocks, ArtifactUsage, BLOB_LOCK_STRIPES, PendingUsage, PendingUsageFile,
-    PendingUsageLock, ResolveBudget, StorageQuotaReservation, acquire_artifact_lock,
-    artifact_usage_path, blob_lock_key, blob_lock_path_for_key, entry_digest, entry_lock_path,
-    is_variant_file, load_artifact_usage, owner_dir, owner_lock_path, owner_usage_key,
-    pending_usage_file, publish, reconcile_storage_reservations,
-    reserve_storage_quota_with_locks_and_limits, stored_bytes, try_acquire_artifact_lock,
-    write_artifact_usage,
-};
-use pnpr_error::Result;
-use pnpr_storage::unique_tmp_path;
+use super::{ArtifactUsage, ResolveBudget, SharedArtifactStore, is_variant_file};
 
 #[test]
 fn resolve_budget_bounds_combined_scanned_and_serialized_bytes() {
@@ -58,844 +45,206 @@ fn resolve_budget_bounds_combined_scanned_and_serialized_bytes() {
 #[test]
 fn variant_files_have_canonical_envelope_digest_names() {
     let digest = "a".repeat(64);
-    assert!(is_variant_file(format!("{digest}.json").as_ref()));
-    assert!(!is_variant_file(format!("{digest}.json.tmp").as_ref()));
-    assert!(!is_variant_file(format!("{}.json", "A".repeat(64)).as_ref()));
-}
-
-#[test]
-fn blob_lock_file_names_are_bounded() {
-    let root = Path::new("shared-artifacts/v0");
-    let paths: HashSet<_> = (0..10_000)
-        .map(|index| {
-            blob_lock_path_for_key(root, &blob_lock_key("owner", &format!("{index:0128x}")))
-        })
-        .collect();
-    assert!(paths.len() <= BLOB_LOCK_STRIPES);
+    assert!(is_variant_file(&format!("{digest}.json")));
+    assert!(!is_variant_file(&format!("{digest}.json.tmp")));
+    assert!(!is_variant_file(&format!("{}.json", "A".repeat(64))));
 }
 
 #[tokio::test]
-async fn publication_storage_is_bounded_per_owner_and_globally() {
+async fn local_store_uses_the_cache_layout_and_round_trips_artifacts() {
     let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let owner = root.join("owner");
-    let other_owner = root.join("other-owner");
-    fs::create_dir_all(&owner).await.unwrap();
-    fs::create_dir_all(&other_owner).await.unwrap();
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    fs::write(owner.join("entry"), b"123456").await.unwrap();
-    fs::write(other_owner.join("entry"), b"123").await.unwrap();
-    fs::write(root.join(".locks/lock-state"), vec![0; 100]).await.unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let request = publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/linux");
+    let integrity = request.blobs[0].integrity.clone();
 
-    let owner_key = owner_usage_key(&owner).unwrap();
-    let pending = pending_usage_file(&root, &owner.join("new-entry"), 4).unwrap();
-    reserve_storage_quota_with_limits(
-        &root,
-        "reservation",
-        &owner_key,
-        "entry",
-        vec![pending],
-        10,
-        13,
-    )
-    .await
-    .unwrap();
+    assert!(store.publish("acme", request.clone()).await.unwrap());
+    assert!(!store.publish("acme", request).await.unwrap());
 
-    let too_large_for_owner = pending_usage_file(&root, &owner.join("owner-overflow"), 5).unwrap();
-    assert!(
-        reserve_storage_quota_with_limits(
-            &root,
-            "owner-overflow",
-            &owner_key,
-            "entry",
-            vec![too_large_for_owner],
-            10,
-            20,
+    let response =
+        store.resolve("acme", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
+    assert_eq!(response.artifacts.len(), 1);
+    assert_eq!(response.artifacts[0].variants.len(), 1);
+
+    let bytes = store
+        .read_blob(
+            "acme",
+            &serde_json::to_vec(&ArtifactBlobRequest {
+                owner: OwnerScope::organization("acme"),
+                integrity,
+            })
+            .unwrap(),
         )
         .await
-        .is_err(),
-    );
-    let too_large_globally = pending_usage_file(&root, &owner.join("global-overflow"), 4).unwrap();
-    assert!(
-        reserve_storage_quota_with_limits(
-            &root,
-            "global-overflow",
-            &owner_key,
-            "entry",
-            vec![too_large_globally],
-            20,
-            12,
-        )
-        .await
-        .is_err(),
-    );
-}
-
-#[tokio::test]
-async fn legacy_pending_usage_is_reconciled() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    fs::write(
-        artifact_usage_path(&root),
-        br#"{"global_bytes":4,"owner_bytes":{"owner":4},"pending":{"owner":"owner","files":[{"path":"owner/missing","size":4}]}}"#,
-    )
-    .await
-    .unwrap();
-
-    reserve_storage_quota_with_limits(&root, "reservation", "owner", "entry", Vec::new(), 10, 10)
-        .await
+        .unwrap()
         .unwrap();
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 0);
-    assert_eq!(usage.owner_bytes.get("owner"), Some(&0));
+    assert_eq!(bytes, b"shared addon");
+    assert!(storage.path().join("shared-artifacts/v0/.locks/usage.json").is_file());
 }
 
 #[tokio::test]
-async fn owner_scoped_pending_usage_is_reconciled() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    fs::write(
-        artifact_usage_path(&root),
-        br#"{"global_bytes":4,"owner_bytes":{"owner":4},"pending":{"owner":[{"path":"owner/missing","size":4}]}}"#,
-    )
-    .await
-    .unwrap();
-
-    reserve_storage_quota_with_limits(&root, "reservation", "owner", "entry", Vec::new(), 10, 10)
-        .await
-        .unwrap();
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 0);
-    assert_eq!(usage.owner_bytes.get("owner"), Some(&0));
-}
-
-#[tokio::test]
-async fn orphaned_atomic_temps_are_removed_before_releasing_quota() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let final_path = root.join("owner/missing");
-    fs::create_dir_all(final_path.parent().unwrap()).await.unwrap();
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    let temp_path = unique_tmp_path(&final_path);
-    fs::write(&temp_path, b"1234").await.unwrap();
-    fs::write(
-        artifact_usage_path(&root),
-        br#"{"global_bytes":4,"owner_bytes":{"owner":4},"pending":{"crashed":{"owner":"owner","lock":{"type":"entry","entry":"entry"},"files":[{"path":"owner/missing","size":4}]}}}"#,
-    )
-    .await
-    .unwrap();
-    let _entry_lock =
-        acquire_artifact_lock(entry_lock_path(&root, "owner", "entry")).await.unwrap();
-
-    reserve_storage_quota_with_limits(&root, "reservation", "owner", "entry", Vec::new(), 10, 10)
-        .await
-        .unwrap();
-
-    assert!(!fs::try_exists(temp_path).await.unwrap());
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 0);
-    assert_eq!(usage.owner_bytes.get("owner"), Some(&0));
-}
-
-#[tokio::test]
-async fn an_incomplete_publication_removes_its_blobs_and_releases_all_quota() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let blob_path = root.join("owner/blobs/blob");
-    fs::create_dir_all(blob_path.parent().unwrap()).await.unwrap();
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    fs::write(&blob_path, b"blob").await.unwrap();
-    fs::write(
-        artifact_usage_path(&root),
-        br#"{"global_bytes":12,"owner_bytes":{"owner":12},"pending":{"crashed":{"owner":"owner","lock":{"type":"owner"},"commit_file":"owner/entries/entry/variant.json","files":[{"path":"owner/blobs/blob","size":4},{"path":"owner/entries/entry/variant.json","size":8}]}}}"#,
-    )
-    .await
-    .unwrap();
-    let _owner_lock = acquire_artifact_lock(owner_lock_path(&root, "owner")).await.unwrap();
-    let empty = BTreeSet::new();
-
-    reconcile_storage_reservations(
-        &root,
-        &ArtifactRecoveryLocks {
-            owner: "owner",
-            publication: &PendingUsageLock::Entry { entry: "current".to_string() },
-            active_reservation: None,
-            adoption_commit_file: None,
-            owner_locked: true,
-            blob_locks: &empty,
-            preserved_blob_ids: &empty,
-        },
-    )
-    .await
-    .unwrap();
-
-    assert!(!fs::try_exists(blob_path).await.unwrap());
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 0);
-    assert_eq!(usage.owner_bytes.get("owner"), Some(&0));
-    assert!(usage.pending.is_empty());
-}
-
-#[tokio::test]
-async fn active_blob_writes_are_not_cleaned_up_by_reconciliation() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let final_path = root.join("owner/blobs/blob");
-    fs::create_dir_all(final_path.parent().unwrap()).await.unwrap();
-    fs::create_dir_all(root.join(".locks")).await.unwrap();
-    let temp_path = unique_tmp_path(&final_path);
-    fs::write(&temp_path, b"1234").await.unwrap();
-    fs::write(
-        artifact_usage_path(&root),
-        br#"{"global_bytes":4,"owner_bytes":{"owner":4},"pending":{"crashed":{"owner":"owner","lock":{"type":"entry","entry":"first-entry"},"files":[{"path":"owner/blobs/blob","size":4}]}}}"#,
-    )
-    .await
-    .unwrap();
-    let blob_lock =
-        acquire_artifact_lock(blob_lock_path_for_key(&root, &blob_lock_key("owner", "blob")))
-            .await
-            .unwrap();
-
-    reserve_storage_quota_with_limits(
-        &root,
-        "reservation",
-        "owner",
-        "second-entry",
-        Vec::new(),
-        10,
-        10,
-    )
-    .await
-    .unwrap();
-
-    assert!(fs::try_exists(&temp_path).await.unwrap());
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 4);
-    assert!(usage.pending.contains_key("crashed"));
-
-    drop(blob_lock);
-    reserve_storage_quota_with_limits(
-        &root,
-        "next-reservation",
-        "owner",
-        "third-entry",
-        Vec::new(),
-        10,
-        10,
-    )
-    .await
-    .unwrap();
-    assert!(!fs::try_exists(temp_path).await.unwrap());
-    assert_eq!(load_artifact_usage(&root).await.unwrap().global_bytes, 0);
-}
-
-#[tokio::test]
-async fn blob_classification_waits_for_complete_rollback_and_preserves_required_blobs() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let owner = "owner";
-    let first_blob = "first-blob";
-    let first_lock = blob_lock_key(owner, first_blob);
-    let second_blob = (0_u64..1024)
-        .map(|index| format!("second-blob-{index}"))
-        .find(|blob| blob_lock_key(owner, blob) != first_lock)
-        .unwrap();
-    let second_lock = blob_lock_key(owner, &second_blob);
-    let blobs_dir = root.join(owner).join("blobs");
-    fs::create_dir_all(&blobs_dir).await.unwrap();
-    let first_path = blobs_dir.join(first_blob);
-    let second_path = blobs_dir.join(&second_blob);
-    fs::write(&first_path, b"first").await.unwrap();
-    fs::write(&second_path, b"second").await.unwrap();
-    let variant_path = root.join(owner).join("entries/crashed/variant.json");
-    let variant_file = pending_usage_file(&root, &variant_path, 1).unwrap();
-    let commit_file = variant_file.path.clone();
-    write_artifact_usage(
-        &root,
-        &ArtifactUsage {
-            global_bytes: 12,
-            owner_bytes: BTreeMap::from([(owner.to_string(), 12)]),
-            pending: BTreeMap::from([(
-                "crashed".to_string(),
-                PendingUsage {
-                    owner: owner.to_string(),
-                    lock: PendingUsageLock::Entry { entry: "crashed".to_string() },
-                    commit_file: Some(commit_file),
-                    files: vec![
-                        pending_usage_file(&root, &first_path, 5).unwrap(),
-                        pending_usage_file(&root, &second_path, 6).unwrap(),
-                        variant_file,
-                    ],
-                },
-            )]),
-        },
-    )
-    .await
-    .unwrap();
-    let current_lock = PendingUsageLock::Entry { entry: "current".to_string() };
-    let _current_entry =
-        acquire_artifact_lock(entry_lock_path(&root, owner, "current")).await.unwrap();
-    let _first_blob =
-        acquire_artifact_lock(blob_lock_path_for_key(&root, &first_lock)).await.unwrap();
-    let second_blob_guard =
-        acquire_artifact_lock(blob_lock_path_for_key(&root, &second_lock)).await.unwrap();
-    let locked_blob_locks = BTreeSet::from([first_lock]);
-    let preserved_blob_ids = BTreeSet::from([first_blob.to_string()]);
-    let current_reservation = "current-reservation";
-    let current_commit_file = "owner/entries/current/variant.json";
-    let recovery_locks = ArtifactRecoveryLocks {
-        owner,
-        publication: &current_lock,
-        active_reservation: Some(current_reservation),
-        adoption_commit_file: Some(current_commit_file),
-        owner_locked: false,
-        blob_locks: &locked_blob_locks,
-        preserved_blob_ids: &preserved_blob_ids,
+async fn object_store_replicas_share_blobs_envelopes_and_quota() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let config = HostedStoreConfig::ObjectStore {
+        store: Arc::clone(&backend),
+        prefix: "packages".to_string(),
     };
+    let first = SharedArtifactStore::new(&config, TempDir::new().unwrap().path()).unwrap();
+    let second = SharedArtifactStore::new(&config, TempDir::new().unwrap().path()).unwrap();
 
-    assert!(!reconcile_storage_reservations(&root, &recovery_locks).await.unwrap());
-    assert!(fs::try_exists(&first_path).await.unwrap());
-    assert!(fs::try_exists(&second_path).await.unwrap());
-    assert!(load_artifact_usage(&root).await.unwrap().pending.contains_key("crashed"));
-
-    drop(second_blob_guard);
-    assert!(reconcile_storage_reservations(&root, &recovery_locks).await.unwrap());
-    assert!(fs::try_exists(first_path).await.unwrap());
-    assert!(!fs::try_exists(second_path).await.unwrap());
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 5);
-    assert_eq!(usage.owner_bytes.get(owner), Some(&5));
-    let adoption = usage.pending.get(current_reservation).unwrap();
-    assert_eq!(adoption.commit_file.as_deref(), Some(current_commit_file));
-    assert_eq!(adoption.files.len(), 1);
-    assert_eq!(
-        Path::new(&adoption.files[0].path),
-        Path::new("owner").join("blobs").join(first_blob),
-    );
-}
-
-#[tokio::test]
-async fn publication_reuses_a_blob_preserved_from_a_stale_transaction() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let artifact_owner =
-        owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let owner = owner_usage_key(&artifact_owner).unwrap();
-    let blob_bytes = b"recovered shared blob";
-    let mut request = publication_request(
-        "acme",
-        "dependency-side-effects:v1:recovered",
-        "ci/recovered",
-        Some(blob_bytes),
-    );
-    let blob = blob_id(&request.blobs[0].integrity).unwrap();
-    request.blobs.clear();
-    let blob_path = artifact_owner.join("blobs").join(&blob);
-    fs::create_dir_all(blob_path.parent().unwrap()).await.unwrap();
-    fs::write(&blob_path, blob_bytes).await.unwrap();
-    let variant_path = artifact_owner.join("entries/crashed/variant.json");
-    let variant_file = pending_usage_file(&root, &variant_path, 1).unwrap();
-    let commit_file = variant_file.path.clone();
-    write_artifact_usage(
-        &root,
-        &ArtifactUsage {
-            global_bytes: blob_bytes.len() as u64 + 1,
-            owner_bytes: BTreeMap::from([(owner.clone(), blob_bytes.len() as u64 + 1)]),
-            pending: BTreeMap::from([(
-                "crashed".to_string(),
-                PendingUsage {
-                    owner: owner.clone(),
-                    lock: PendingUsageLock::Entry { entry: "crashed".to_string() },
-                    commit_file: Some(commit_file),
-                    files: vec![
-                        pending_usage_file(&root, &blob_path, blob_bytes.len() as u64).unwrap(),
-                        variant_file,
-                    ],
-                },
-            )]),
-        },
-    )
-    .await
-    .unwrap();
-
-    assert!(publish(storage.path(), "acme", request).await.unwrap());
-    assert_eq!(fs::read(blob_path).await.unwrap(), blob_bytes);
-    let usage = load_artifact_usage(&root).await.unwrap();
-    let actual_bytes = stored_bytes(&artifact_owner, None).await.unwrap();
-    assert_eq!(usage.global_bytes, actual_bytes);
-    assert_eq!(usage.owner_bytes.get(&owner), Some(&actual_bytes));
-    assert!(usage.pending.is_empty());
-}
-
-#[tokio::test]
-async fn rejected_adoption_reclaims_the_preserved_blob_and_quota() {
-    let storage = TempDir::new().unwrap();
-    for index in 0..MAX_VARIANTS_PER_CANDIDATE {
-        assert!(
-            publish(storage.path(), "acme", publication(&format!("ci/accepted/{index}")))
-                .await
-                .unwrap(),
-        );
-    }
-    let root = storage.path().join("shared-artifacts/v0");
-    let usage_before = fs::read(artifact_usage_path(&root)).await.unwrap();
-    let artifact_owner =
-        owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let owner = owner_usage_key(&artifact_owner).unwrap();
-    let blob_bytes = b"rejected adopted blob";
-    let mut request = publication_request(
-        "acme",
-        "dependency-side-effects:v1:deps=abc",
-        "ci/rejected-adoption",
-        Some(blob_bytes),
-    );
-    let blob = blob_id(&request.blobs[0].integrity).unwrap();
-    request.blobs.clear();
-    let blob_path = artifact_owner.join("blobs").join(&blob);
-    fs::create_dir_all(blob_path.parent().unwrap()).await.unwrap();
-    fs::write(&blob_path, blob_bytes).await.unwrap();
-    let stale_variant_path = artifact_owner.join("entries/crashed/variant.json");
-    let stale_variant = pending_usage_file(&root, &stale_variant_path, 1).unwrap();
-    let stale_commit_file = stale_variant.path.clone();
-    let mut usage = load_artifact_usage(&root).await.unwrap();
-    usage.global_bytes += blob_bytes.len() as u64 + 1;
-    *usage.owner_bytes.get_mut(&owner).unwrap() += blob_bytes.len() as u64 + 1;
-    usage.pending.insert(
-        "crashed".to_string(),
-        PendingUsage {
-            owner,
-            lock: PendingUsageLock::Entry { entry: "crashed".to_string() },
-            commit_file: Some(stale_commit_file),
-            files: vec![
-                pending_usage_file(&root, &blob_path, blob_bytes.len() as u64).unwrap(),
-                stale_variant,
-            ],
-        },
-    );
-    write_artifact_usage(&root, &usage).await.unwrap();
-
-    let error = publish(storage.path(), "acme", request).await.unwrap_err();
-
-    assert!(error.to_string().contains("variant limit"));
-    assert!(!fs::try_exists(blob_path).await.unwrap());
-    assert_eq!(fs::read(artifact_usage_path(&root)).await.unwrap(), usage_before);
-}
-
-/// The full interleaving a rollback would have to survive to strand a committed
-/// artifact: a crash leaves a blob reservation, a second publication commits an
-/// envelope reusing that blob, and a third fails after adopting the same
-/// reservation. The second publication is what closes it — it adopts the stale
-/// reservation itself, so by the time it commits nothing holds the blob pending
-/// for the third publication's rollback to reclaim.
-#[tokio::test]
-async fn a_commit_over_a_stale_reservation_leaves_no_blob_for_a_later_rollback() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let artifact_owner =
-        owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let owner = owner_usage_key(&artifact_owner).unwrap();
-    let blob_bytes = b"shared addon";
-    let blob = blob_id(&format!("sha512-{}", BASE64.encode(Sha512::digest(blob_bytes)))).unwrap();
-    let blob_path = artifact_owner.join("blobs").join(&blob);
-    fs::create_dir_all(blob_path.parent().unwrap()).await.unwrap();
-    fs::write(&blob_path, blob_bytes).await.unwrap();
-    let stale_variant_path = artifact_owner.join("entries/crashed/variant.json");
-    let stale_variant = pending_usage_file(&root, &stale_variant_path, 1).unwrap();
-    write_artifact_usage(
-        &root,
-        &ArtifactUsage {
-            global_bytes: blob_bytes.len() as u64 + 1,
-            owner_bytes: BTreeMap::from([(owner.clone(), blob_bytes.len() as u64 + 1)]),
-            pending: BTreeMap::from([(
-                "crashed".to_string(),
-                PendingUsage {
-                    owner: owner.clone(),
-                    lock: PendingUsageLock::Entry { entry: "crashed".to_string() },
-                    commit_file: Some(stale_variant.path.clone()),
-                    files: vec![
-                        pending_usage_file(&root, &blob_path, blob_bytes.len() as u64).unwrap(),
-                        stale_variant,
-                    ],
-                },
-            )]),
-        },
-    )
-    .await
-    .unwrap();
-
-    // The committing publication adopts the crashed reservation, then clears it.
-    let committed_key = "dependency-side-effects:v1:deps=committed";
     assert!(
-        publish(storage.path(), "acme", publication_with_blob(committed_key, "ci/committed"))
-            .await
-            .unwrap(),
-    );
-    assert!(
-        load_artifact_usage(&root).await.unwrap().pending.is_empty(),
-        "the committed blob is still owned by a pending reservation",
-    );
-
-    // A third publication for another entry now fails past its variant limit.
-    let rejected_key = "dependency-side-effects:v1:deps=rejected";
-    for index in 0..MAX_VARIANTS_PER_CANDIDATE {
-        assert!(
-            publish(
-                storage.path(),
+        first
+            .publish(
                 "acme",
-                publication_with_blob(rejected_key, &format!("ci/accepted/{index}")),
+                publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/first"),
             )
             .await
             .unwrap(),
-        );
-    }
-    let error = publish(storage.path(), "acme", publication_with_blob(rejected_key, "ci/rejected"))
-        .await
-        .unwrap_err();
-
-    assert!(error.to_string().contains("variant limit"), "{error}");
-    assert!(fs::try_exists(&blob_path).await.unwrap(), "the committed artifact lost its blob");
-    assert_eq!(fs::read(&blob_path).await.unwrap(), blob_bytes);
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, stored_bytes(&artifact_owner, None).await.unwrap());
-}
-
-/// Rollback reclaims what the failed publication itself stored, never a blob a
-/// committed artifact still depends on. A publication that finds its blob
-/// already on disk does not reserve it, so the failure has nothing to undo.
-#[tokio::test]
-async fn a_failed_publication_keeps_a_blob_a_committed_artifact_references() {
-    let storage = TempDir::new().unwrap();
-    let shared_bytes = b"shared addon";
-    assert!(
-        publish(
-            storage.path(),
-            "acme",
-            publication_with_blob("dependency-side-effects:v1:deps=committed", "ci/committed"),
-        )
-        .await
-        .unwrap(),
     );
-    let artifact_owner =
-        owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let blob = blob_id(&format!("sha512-{}", BASE64.encode(Sha512::digest(shared_bytes)))).unwrap();
-    let blob_path = artifact_owner.join("blobs").join(&blob);
-    assert!(fs::try_exists(&blob_path).await.unwrap());
-
-    // Fill a second entry to its variant limit so the next publication for it
-    // is rejected after the shared blob has already been accounted for.
-    let rejected_key = "dependency-side-effects:v1:deps=rejected";
-    for index in 0..MAX_VARIANTS_PER_CANDIDATE {
-        assert!(
-            publish(
-                storage.path(),
+    assert!(
+        second
+            .publish(
                 "acme",
-                publication_with_blob(rejected_key, &format!("ci/accepted/{index}")),
+                publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/second"),
             )
             .await
             .unwrap(),
-        );
-    }
-    let error = publish(storage.path(), "acme", publication_with_blob(rejected_key, "ci/rejected"))
-        .await
-        .unwrap_err();
-
-    assert!(error.to_string().contains("variant limit"), "{error}");
-    assert!(fs::try_exists(&blob_path).await.unwrap(), "the committed artifact lost its blob");
-    assert_eq!(fs::read(&blob_path).await.unwrap(), shared_bytes);
-}
-
-#[tokio::test]
-async fn active_entry_reservations_are_not_reconciled() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let owner = "active-owner";
-    let entry = "active-entry";
-    let _entry_lock = acquire_artifact_lock(entry_lock_path(&root, owner, entry)).await.unwrap();
-    let pending = pending_usage_file(&root, &root.join(owner).join("pending"), 4).unwrap();
-    reserve_storage_quota_with_limits(
-        &root,
-        "active-reservation",
-        owner,
-        entry,
-        vec![pending],
-        10,
-        10,
-    )
-    .await
-    .unwrap();
-
-    reserve_storage_quota_with_limits(
-        &root,
-        "other-reservation",
-        owner,
-        "other-entry",
-        Vec::new(),
-        10,
-        10,
-    )
-    .await
-    .unwrap();
-    let usage = load_artifact_usage(&root).await.unwrap();
-    assert_eq!(usage.global_bytes, 4);
-    assert!(usage.pending.contains_key("active-reservation"));
-}
-
-async fn reserve_storage_quota_with_limits(
-    artifact_root: &Path,
-    reservation: &str,
-    owner: &str,
-    entry: &str,
-    files: Vec<PendingUsageFile>,
-    owner_limit: u64,
-    global_limit: u64,
-) -> Result<()> {
-    let locked_blob_locks = BTreeSet::new();
-    reserve_storage_quota_with_locks_and_limits(
-        artifact_root,
-        StorageQuotaReservation {
-            id: reservation,
-            owner,
-            lock: PendingUsageLock::Entry { entry: entry.to_string() },
-            commit_file: None,
-            locked_blob_locks: &locked_blob_locks,
-            files,
-        },
-        owner_limit,
-        global_limit,
-    )
-    .await
-}
-
-#[tokio::test]
-async fn an_unlocked_publication_lock_file_is_reused() {
-    let storage = TempDir::new().unwrap();
-    let path = storage.path().join("publication.lock");
-    fs::write(&path, b"residue").await.unwrap();
-
-    let lock = acquire_artifact_lock(path.clone()).await.unwrap();
-    assert!(path.is_file());
-    drop(lock);
-
-    acquire_artifact_lock(path).await.unwrap();
-}
-
-#[tokio::test]
-async fn an_entry_lock_does_not_block_another_entry() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let acme_dir = owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let acme_owner = owner_usage_key(&acme_dir).unwrap();
-    let _acme_lock = acquire_artifact_lock(entry_lock_path(&root, &acme_owner, "unrelated-entry"))
-        .await
-        .unwrap();
-
-    let published = timeout(
-        std::time::Duration::from_secs(5),
-        publish(storage.path(), "acme", publication_for("acme", "ci/other-entry")),
-    )
-    .await
-    .expect("an unrelated entry must not wait for the held entry lock")
-    .unwrap();
-    assert!(published);
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn a_stalled_entry_does_not_block_an_unrelated_entry_for_the_same_owner() {
-    let storage = TempDir::new().unwrap();
-    let root = storage.path().join("shared-artifacts/v0");
-    let acme_dir = owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let acme_owner = owner_usage_key(&acme_dir).unwrap();
-    let blocked = publication_request(
-        "acme",
-        "dependency-side-effects:v1:blocked",
-        "ci/blocked",
-        Some(b"blocked blob"),
     );
-    let blocked_payload = blocked.validate().unwrap().payload;
-    let blocked_entry =
-        entry_digest(&blocked.key, &blocked_payload.package, &blocked_payload.source_integrity);
-    let blocked_blob = blob_id(&blocked.blobs[0].integrity).unwrap();
-    let blocked_blob_lock = blob_lock_key(&acme_owner, &blocked_blob);
-    let blob_blocker =
-        acquire_artifact_lock(blob_lock_path_for_key(&root, &blocked_blob_lock)).await.unwrap();
-    let cache_storage = storage.path().to_path_buf();
-    let blocked_publication =
-        tokio::spawn(async move { publish(&cache_storage, "acme", blocked).await });
-    timeout(std::time::Duration::from_secs(5), async {
-        loop {
-            if try_acquire_artifact_lock(entry_lock_path(&root, &acme_owner, &blocked_entry))
-                .await
-                .unwrap()
-                .is_none()
-            {
-                break;
-            }
-            tokio::task::yield_now().await;
-        }
-    })
-    .await
-    .expect("the blocked publication must acquire only its entry lock before waiting");
 
-    let unrelated = (0_u64..)
-        .find_map(|index| {
-            let bytes = index.to_le_bytes();
-            let request = publication_request(
-                "acme",
-                "dependency-side-effects:v1:unrelated",
-                "ci/unrelated",
-                Some(&bytes),
-            );
-            let blob = blob_id(&request.blobs[0].integrity).unwrap();
-            (blob_lock_key(&acme_owner, &blob) != blocked_blob_lock).then_some(request)
-        })
-        .unwrap();
-    let published =
-        timeout(std::time::Duration::from_secs(5), publish(storage.path(), "acme", unrelated))
-            .await
-            .expect("an unrelated entry must not wait for the stalled publication")
+    let response =
+        first.resolve("acme", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
+    assert_eq!(response.artifacts[0].variants.len(), 2);
+    let usage_path = object_store::path::Path::from(format!(
+        "{}.pnpr-artifacts/v0/quota.json",
+        normalize_key_prefix(Some("packages")),
+    ));
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
             .unwrap();
-    assert!(published);
-
-    drop(blob_blocker);
-    assert!(blocked_publication.await.unwrap().unwrap());
+    assert_eq!(usage.owner_bytes.len(), 1);
+    assert!(usage.global_bytes > b"shared addon".len() as u64);
 }
 
-#[tokio::test]
-async fn rejected_missing_blobs_do_not_create_lock_files() {
-    let storage = TempDir::new().unwrap();
-    for index in 0..64_u64 {
-        let bytes = index.to_le_bytes();
-        let mut request = publication_request(
-            "acme",
-            &format!("dependency-side-effects:v1:missing={index}"),
-            &format!("ci/missing/{index}"),
-            Some(&bytes),
-        );
-        request.blobs.clear();
-        assert!(publish(storage.path(), "acme", request).await.is_err());
-    }
-
-    let locks = storage.path().join("shared-artifacts/v0/.locks");
-    assert!(!fs::try_exists(locks).await.unwrap());
-}
-
-#[tokio::test]
-async fn duplicate_publication_does_not_rewrite_usage() {
-    let storage = TempDir::new().unwrap();
-    let request = publication("ci/duplicate");
-
-    assert!(publish(storage.path(), "acme", request.clone()).await.unwrap());
-    let usage_path = artifact_usage_path(&storage.path().join("shared-artifacts/v0"));
-    let before = fs::read(&usage_path).await.unwrap();
-
-    assert!(!publish(storage.path(), "acme", request).await.unwrap());
-    assert_eq!(fs::read(usage_path).await.unwrap(), before);
-}
-
-#[tokio::test]
-async fn concurrent_entries_count_a_shared_blob_once() {
-    let storage = TempDir::new().unwrap();
-    let first = publish(
-        storage.path(),
-        "acme",
-        publication_with_blob("dependency-side-effects:v1:first", "ci/first"),
-    );
-    let second = publish(
-        storage.path(),
-        "acme",
-        publication_with_blob("dependency-side-effects:v1:second", "ci/second"),
-    );
-    let (first, second) = tokio::join!(first, second);
-    assert!(first.unwrap());
-    assert!(second.unwrap());
-
-    let root = storage.path().join("shared-artifacts/v0");
-    let owner_dir = owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
-    let owner = owner_usage_key(&owner_dir).unwrap();
-    let usage = load_artifact_usage(&root).await.unwrap();
-    let actual_bytes = stored_bytes(&owner_dir, None).await.unwrap();
-    assert_eq!(usage.global_bytes, actual_bytes);
-    assert_eq!(usage.owner_bytes.get(&owner), Some(&actual_bytes));
-    assert!(usage.pending.is_empty());
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 16)]
-async fn concurrent_publishers_sharing_a_cache_respect_the_variant_limit() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn concurrent_replicas_update_quota_without_lost_writes() {
     const PUBLICATIONS: usize = 16;
 
-    let storage = TempDir::new().unwrap();
-    let barrier = Arc::new(Barrier::new(PUBLICATIONS + 1));
+    let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let mut publications = Vec::with_capacity(PUBLICATIONS);
     for index in 0..PUBLICATIONS {
-        let barrier = Arc::clone(&barrier);
-        let cache_storage = storage.path().to_path_buf();
+        let config =
+            HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
         publications.push(tokio::spawn(async move {
-            barrier.wait().await;
-            publish(&cache_storage, "acme", publication(&format!("ci/concurrent/{index}")))
-                .await
-                .map_err(|err| err.to_string())
+            let scratch = TempDir::new().unwrap();
+            let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+            store.publish("acme", publication(&format!("ci/{index}"))).await
         }));
     }
-    barrier.wait().await;
-
-    let mut accepted = 0;
-    let mut rejected = Vec::new();
     for publication in publications {
-        match publication.await.unwrap() {
-            Ok(true) => accepted += 1,
-            Ok(false) => panic!("all publications have distinct envelopes"),
-            Err(err) => rejected.push(err),
-        }
+        assert!(publication.await.unwrap().unwrap());
     }
-    assert_eq!(accepted, MAX_VARIANTS_PER_CANDIDATE);
-    assert_eq!(rejected.len(), PUBLICATIONS - accepted);
-    assert!(rejected.iter().all(|error| error.contains("variant limit")));
+
+    let usage_path = object_store::path::Path::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    let expected = (0..PUBLICATIONS)
+        .map(|index| {
+            serde_json::to_vec(&publication(&format!("ci/{index}")).envelope).unwrap().len()
+        })
+        .sum::<usize>() as u64;
+    assert_eq!(usage.global_bytes, expected);
 }
 
 #[tokio::test]
-async fn a_variant_limit_rejection_does_not_store_or_charge_uploaded_blobs() {
+async fn concurrent_duplicate_publications_are_charged_once() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let first = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let second = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let request = publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/duplicate");
+    let expected =
+        b"shared addon".len() as u64 + serde_json::to_vec(&request.envelope).unwrap().len() as u64;
+
+    let first_publish = first.publish("acme", request.clone());
+    let second_publish = second.publish("acme", request);
+    let (first, second) = tokio::join!(first_publish, second_publish);
+
+    assert_ne!(first.unwrap(), second.unwrap());
+    let usage_path = object_store::path::Path::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, expected);
+}
+
+#[tokio::test]
+async fn quota_is_reserved_before_objects_are_written() {
     let storage = TempDir::new().unwrap();
-    for index in 0..MAX_VARIANTS_PER_CANDIDATE {
-        assert!(
-            publish(storage.path(), "acme", publication(&format!("ci/accepted/{index}")))
-                .await
-                .unwrap(),
-        );
+    let store =
+        SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap().with_limits(1, 1);
+
+    let error = store.publish("acme", publication("ci/too-large")).await.unwrap_err();
+
+    assert!(error.to_string().contains("quota exceeded"), "{error}");
+    let entries = std::fs::read_dir(storage.path().join("shared-artifacts/v0"))
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .filter(|entry| entry.file_name() != ".locks")
+        .collect::<Vec<_>>();
+    assert!(entries.is_empty(), "quota rejection wrote objects: {entries:?}");
+}
+
+#[tokio::test]
+async fn the_variant_limit_is_applied_at_read_time() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    for index in 0..MAX_VARIANTS_PER_CANDIDATE + 2 {
+        assert!(store.publish("acme", publication(&format!("ci/{index}"))).await.unwrap());
     }
-    let root = storage.path().join("shared-artifacts/v0");
-    let usage_before = fs::read(artifact_usage_path(&root)).await.unwrap();
-    let rejected = publication_request(
-        "acme",
-        "dependency-side-effects:v1:deps=abc",
-        "ci/rejected",
-        Some(b"rejected blob"),
-    );
-    let rejected_blob = blob_id(&rejected.blobs[0].integrity).unwrap();
-    let owner = owner_dir(storage.path(), "acme", &OwnerScope::organization("acme")).unwrap();
 
-    let error = publish(storage.path(), "acme", rejected).await.unwrap_err();
+    let response =
+        store.resolve("acme", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
 
-    assert!(error.to_string().contains("variant limit"));
-    assert!(!fs::try_exists(owner.join("blobs").join(rejected_blob)).await.unwrap());
-    assert_eq!(fs::read(artifact_usage_path(&root)).await.unwrap(), usage_before);
+    assert_eq!(response.artifacts[0].variants.len(), MAX_VARIANTS_PER_CANDIDATE);
+}
+
+#[tokio::test]
+async fn another_owner_cannot_probe_artifacts() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    assert!(store.publish("acme", publication("ci/acme")).await.unwrap());
+
+    let response =
+        store.resolve("mallory", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
+
+    assert!(response.artifacts.is_empty());
+}
+
+fn lookup(owner: &str) -> ResolveArtifactsRequest {
+    ResolveArtifactsRequest {
+        candidates: vec![ArtifactCandidate {
+            key: "dependency-side-effects:v1:deps=abc".to_string(),
+            package: PackageIdentity {
+                name: "native-addon".to_string(),
+                version: "1.0.0".to_string(),
+            },
+            source_integrity: "sha512-source".to_string(),
+            owner: OwnerScope::organization(owner),
+        }],
+    }
 }
 
 fn publication(builder_id: &str) -> PublishArtifactRequest {
-    publication_for("acme", builder_id)
-}
-
-fn publication_for(owner: &str, builder_id: &str) -> PublishArtifactRequest {
-    publication_request(owner, "dependency-side-effects:v1:deps=abc", builder_id, None)
+    publication_request("dependency-side-effects:v1:deps=abc", builder_id, None)
 }
 
 fn publication_with_blob(input_key: &str, builder_id: &str) -> PublishArtifactRequest {
-    publication_request("acme", input_key, builder_id, Some(b"shared addon"))
+    publication_request(input_key, builder_id, Some(b"shared addon"))
 }
 
 fn publication_request(
-    owner: &str,
     input_key: &str,
     builder_id: &str,
     blob: Option<&[u8]>,
@@ -920,7 +269,7 @@ fn publication_request(
         package: PackageIdentity { name: "native-addon".to_string(), version: "1.0.0".to_string() },
         source_integrity: "sha512-source".to_string(),
         input_key: input_key.to_string(),
-        owner: OwnerScope::organization(owner),
+        owner: OwnerScope::organization("acme"),
         builder_id: builder_id.to_string(),
         builder_profile: BuilderProfile {
             image_digest: Some("sha256:image".to_string()),

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1,7 +1,13 @@
-use std::{collections::BTreeMap, sync::Arc};
+use std::{collections::BTreeMap, fmt, sync::Arc};
 
+use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use object_store::{ObjectStore, ObjectStoreExt, memory::InMemory};
+use futures_util::stream::BoxStream;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
+    memory::InMemory, path::Path as ObjectPath,
+};
 use pnpm_shared_artifact_protocol::{
     ARTIFACT_KIND, ArtifactBlobRequest, ArtifactBlobUpload, ArtifactCandidate, ArtifactFile,
     ArtifactManifest, ArtifactPayload, ArtifactVariant, BuilderProfile, CompatibilityConstraints,
@@ -197,6 +203,24 @@ async fn quota_is_reserved_before_objects_are_written() {
 }
 
 #[tokio::test]
+async fn failed_object_writes_release_unused_quota() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites { inner: InMemory::new() });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+
+    store.publish("acme", publication("ci/failure")).await.unwrap_err();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, 0);
+    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), 0);
+}
+
+#[tokio::test]
 async fn the_variant_limit_is_applied_at_read_time() {
     let storage = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
@@ -289,5 +313,98 @@ fn publication_request(
             signature: "MAYCAQECAQE=".to_string(),
         },
         blobs,
+    }
+}
+
+#[derive(Debug)]
+struct FailArtifactWrites {
+    inner: InMemory,
+}
+
+impl fmt::Display for FailArtifactWrites {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("fail artifact writes")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FailArtifactWrites {
+    async fn put_opts(
+        &self,
+        location: &ObjectPath,
+        payload: PutPayload,
+        options: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        if location.as_ref().ends_with("/quota.json") {
+            self.inner.put_opts(location, payload, options).await
+        } else {
+            Err(object_store::Error::Generic {
+                store: "test",
+                source: std::io::Error::other("injected artifact write failure").into(),
+            })
+        }
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &ObjectPath,
+        options: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &ObjectPath,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<ObjectPath>>,
+    ) -> BoxStream<'static, object_store::Result<ObjectPath>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&ObjectPath>,
+        offset: &ObjectPath,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&ObjectPath>,
+    ) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &ObjectPath,
+        to: &ObjectPath,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+
+    async fn rename_opts(
+        &self,
+        from: &ObjectPath,
+        to: &ObjectPath,
+        options: RenameOptions,
+    ) -> object_store::Result<()> {
+        self.inner.rename_opts(from, to, options).await
     }
 }

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, fmt, sync::Arc};
 
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
-use futures_util::stream::BoxStream;
+use futures_util::{StreamExt as _, stream::BoxStream};
 use object_store::{
     CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
@@ -83,7 +83,7 @@ async fn local_store_uses_the_cache_layout_and_round_trips_artifacts() {
     assert_eq!(response.artifacts.len(), 1);
     assert_eq!(response.artifacts[0].variants.len(), 1);
 
-    let bytes = store
+    let mut blob = store
         .read_blob(
             "acme",
             &serde_json::to_vec(&ArtifactBlobRequest {
@@ -95,6 +95,10 @@ async fn local_store_uses_the_cache_layout_and_round_trips_artifacts() {
         .await
         .unwrap()
         .unwrap();
+    let mut bytes = Vec::new();
+    while let Some(chunk) = blob.stream.next().await {
+        bytes.extend_from_slice(&chunk.unwrap());
+    }
     assert_eq!(bytes, b"shared addon");
     assert!(storage.path().join("shared-artifacts/v0/.locks/usage.json").is_file());
 }

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -19,7 +19,9 @@ use pnpr_config::{HostedStoreConfig, normalize_key_prefix};
 use sha2::{Digest as _, Sha512};
 use tempfile::TempDir;
 
-use super::{ArtifactUsage, ResolveBudget, SharedArtifactStore, is_variant_file};
+use super::{
+    ArtifactUsage, ResolveBudget, SharedArtifactStore, is_variant_file, is_write_conflict,
+};
 
 #[test]
 fn resolve_budget_bounds_combined_scanned_and_serialized_bytes() {
@@ -54,6 +56,16 @@ fn variant_files_have_canonical_envelope_digest_names() {
     assert!(is_variant_file(&format!("{digest}.json")));
     assert!(!is_variant_file(&format!("{digest}.json.tmp")));
     assert!(!is_variant_file(&format!("{}.json", "A".repeat(64))));
+}
+
+#[test]
+fn missing_quota_object_writes_are_not_conflicts() {
+    let error = object_store::Error::NotFound {
+        path: "quota.json".to_string(),
+        source: std::io::Error::other("missing quota object").into(),
+    };
+
+    assert!(!is_write_conflict(&error));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Promote shared artifacts to an independent top-level `artifacts.enabled` feature so pnpr can run artifact-only tiers.
- Store immutable blobs and signed envelopes in the configured S3-compatible object store under a reserved namespace, with conditional quota updates shared across replicas.
- Allow the pacquet artifact client to negotiate directly with an artifact-only pnpr tier.
- Keep the local cache layout compatible, enforce the variant cap at read time, and cover replica concurrency, quota, routing, and client behavior.

Closes pnpm/pnpm#14220.

## Squash Commit Body

```text
Promote the signed shared-artifact service from a resolver sub-feature to an independent pnpr surface, allowing artifact-only deployments.

Use the configured object store for immutable artifact blobs and envelopes. Coordinate the durable quota counter with conditional writes so concurrent replicas cannot lose updates, while retaining the existing local cache layout and a small local quota lock for filesystem deployments. Apply the protocol's variant bound while resolving instead of serializing publishers.

Closes pnpm/pnpm#14220.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790424145&installation_model_id=426870&pr_number=14222&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14222&signature=b123514aad3f2f9134b33596d44e11392bacfa80f9a8250d13898b70db790f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared artifact storage now scales across replicas with S3-compatible storage.
  * Artifacts can be enabled independently from package resolution.
  * Added the top-level `artifacts.enabled` setting and `--disable-artifacts` option.
  * Service discovery reports artifact capabilities independently, including artifact-only deployments.
  * Artifact data can be streamed from shared storage.

* **Bug Fixes**
  * Improved concurrent publishing, quota accounting, failed-write recovery, read-time variant limits, and blob integrity validation.

* **Documentation**
  * Updated configuration examples and storage guidance for local and S3-backed artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->