### PR TITLE
fix: keep the declared specifier of an overridden dependency on update

### DIFF
--- a/.changeset/keep-catalog-reference-of-overridden-dependency.md
+++ b/.changeset/keep-catalog-reference-of-overridden-dependency.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm update` no longer replaces the specifier a project declares for a dependency that is also listed in `overrides`. A `catalog:` reference stays a `catalog:` reference, and a declared range stays as written, instead of being rewritten to the version the override resolved to [#12115](https://github.com/pnpm/pnpm/issues/12115).

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1054,6 +1054,21 @@ fn set_named_catalog(workspace: &Path, catalog: &str, entries: &[(&str, &str)]) 
     fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
 }
 
+/// Append an `overrides:` block with the given `(name, specifier)` entries
+/// to the harness-written `pnpm-workspace.yaml`.
+fn set_overrides(workspace: &Path, entries: &[(&str, &str)]) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("overrides:\n");
+    for (name, spec) in entries {
+        writeln!(yaml, r#"  "{name}": "{spec}""#).unwrap();
+    }
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+}
+
 fn read_workspace_yaml(workspace: &Path) -> String {
     fs::read_to_string(workspace.join("pnpm-workspace.yaml")).expect("read pnpm-workspace.yaml")
 }
@@ -1130,6 +1145,50 @@ fn update_catalog_bumps_the_entry_within_its_range() {
     assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
     let yaml = read_workspace_yaml(&workspace);
     assert!(yaml.contains("^100.1.0"), "catalog entry should be bumped to ^100.1.0: {yaml}");
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}
+
+/// A dependency declared through the catalog and listed in `overrides`
+/// reaches the resolver with the override's specifier, so the version the
+/// run resolves must not be written back over the `catalog:` reference
+/// (pnpm/pnpm#12115).
+#[test]
+fn update_keeps_the_catalog_reference_of_an_overridden_dependency() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "grp1", &[(DEP, "^100.0.0")]);
+    set_overrides(&workspace, &[(DEP, "^100.0.0"), (FOO, "100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1", "{FOO}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update"]).assert().success();
+
+    // Both declarations are the overrides' input, not their output: neither
+    // the `catalog:` reference nor the declared range may be replaced by the
+    // version the override resolved to.
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
+    assert_eq!(dep_spec(&workspace, FOO).as_deref(), Some("^100.0.0"));
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}
+
+/// `--latest` reaches the manifest through its own pre-install rewrite, so
+/// it needs the `catalog:` reference to survive an override of its own.
+#[test]
+fn update_latest_keeps_the_catalog_reference_of_an_overridden_dependency() {
+    let (root, workspace, anchor) = setup();
+
+    set_named_catalog(&workspace, "grp1", &[(DEP, "^100.0.0")]);
+    set_overrides(&workspace, &[(DEP, "^100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "catalog:grp1" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update", "--latest"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("catalog:grp1"));
     pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, anchor));

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -27,8 +27,12 @@ use std::{
 /// back here for the update to write into `package.json` — or into the
 /// catalog entry the dependency points at.
 pub struct ManifestSpecBumps {
-    /// Direct-dependency aliases per importer id whose range may move.
-    pub targets: BTreeMap<String, HashSet<String>>,
+    /// Per importer id, the direct-dependency aliases whose range may move,
+    /// each mapped to the specifier its `package.json` declares. The
+    /// declaration is what tells a range the update owns from one an override
+    /// replaced before the resolver read it: only a lockfile entry that still
+    /// carries the declared text is bumped.
+    pub targets: BTreeMap<String, HashMap<String, String>>,
     /// The range operator to write when the declaration pins none.
     pub range_spec_style: RangeSpecStyle,
     /// What the resolve settled on, for the declarations whose text changed.
@@ -68,11 +72,20 @@ pub(crate) fn apply_manifest_spec_bumps(lockfile: &mut Lockfile, bumps: &Manifes
         BTreeMap::new();
     let mut cataloged: HashSet<(String, PkgName)> = HashSet::new();
 
-    for (importer_id, aliases) in &bumps.targets {
+    for (importer_id, targets) in &bumps.targets {
         let Some(importer) = lockfile.importers.get(importer_id) else { continue };
-        for alias in aliases {
+        for (alias, manifest_specifier) in targets {
             let Ok(alias) = PkgName::parse(alias.as_str()) else { continue };
             let Some((group, declared)) = declared_dependency(importer, &alias) else { continue };
+            // An override — or another manifest hook — replaced this entry
+            // before the resolver read it, so the version the run resolved
+            // answers the override rather than the declaration. Leaving both
+            // the lockfile entry and `package.json` alone keeps the two
+            // agreeing and keeps the declaration, a `catalog:` reference
+            // included (pnpm/pnpm#12115).
+            if declared.specifier != *manifest_specifier {
+                continue;
+            }
             if let Some(catalog_name) = parse_catalog_protocol(&declared.specifier) {
                 cataloged.insert((catalog_name.to_string(), alias));
                 continue;

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -28,11 +28,11 @@ use std::{
 /// catalog entry the dependency points at.
 pub struct ManifestSpecBumps {
     /// Per importer id, the direct-dependency aliases whose range may move,
-    /// each mapped to the specifier its `package.json` declares. The
-    /// declaration is what tells a range the update owns from one an override
-    /// replaced before the resolver read it: only a lockfile entry that still
-    /// carries the declared text is bumped.
-    pub targets: BTreeMap<String, HashMap<String, String>>,
+    /// each mapped to the group its `package.json` declares it under and the
+    /// specifier declared there. The declaration is what tells a range the
+    /// update owns from one an override replaced before the resolver read it:
+    /// only a lockfile entry that still carries the declared text is bumped.
+    pub targets: BTreeMap<String, HashMap<String, (DependencyGroup, String)>>,
     /// The range operator to write when the declaration pins none.
     pub range_spec_style: RangeSpecStyle,
     /// What the resolve settled on, for the declarations whose text changed.
@@ -74,9 +74,12 @@ pub(crate) fn apply_manifest_spec_bumps(lockfile: &mut Lockfile, bumps: &Manifes
 
     for (importer_id, targets) in &bumps.targets {
         let Some(importer) = lockfile.importers.get(importer_id) else { continue };
-        for (alias, manifest_specifier) in targets {
+        for (alias, (manifest_group, manifest_specifier)) in targets {
             let Ok(alias) = PkgName::parse(alias.as_str()) else { continue };
-            let Some((group, declared)) = declared_dependency(importer, &alias) else { continue };
+            let Some((group, declared)) = declared_dependency(importer, &alias, *manifest_group)
+            else {
+                continue;
+            };
             // An override — or another manifest hook — replaced this entry
             // before the resolver read it, so the version the run resolved
             // answers the override rather than the declaration. Leaving both
@@ -215,14 +218,19 @@ type DependencyGroupIndex = usize;
 const IMPORTER_GROUPS: [DependencyGroup; 3] =
     [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
 
+/// The importer's entry for `alias` under the group the manifest declares it
+/// in. Anchoring on that group rather than on the first map that happens to
+/// carry the alias keeps a dependency declared in more than one group reading
+/// and rewriting the same entry.
 fn declared_dependency<'a>(
     importer: &'a ProjectSnapshot,
     alias: &PkgName,
+    group: DependencyGroup,
 ) -> Option<(DependencyGroupIndex, &'a ResolvedDependencySpec)> {
-    [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies]
-        .into_iter()
-        .enumerate()
-        .find_map(|(index, group)| Some((index, group.as_ref()?.get(alias)?)))
+    let index = IMPORTER_GROUPS.iter().position(|candidate| *candidate == group)?;
+    let maps =
+        [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
+    Some((index, maps[index].as_ref()?.get(alias)?))
 }
 
 fn dependency_maps_mut(importer: &mut ProjectSnapshot) -> [Option<&mut ResolvedDependencyMap>; 3] {

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -1,6 +1,29 @@
-use super::{bumped_range, split_npm_alias};
-use pnpm_lockfile::ImporterDepVersion;
+use super::{ManifestSpecBumps, apply_manifest_spec_bumps, bumped_range, split_npm_alias};
+use pnpm_lockfile::{ImporterDepVersion, Lockfile, PkgName, ResolvedDependencyMap};
+use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
+use std::collections::{BTreeMap, HashMap};
+
+fn lockfile(source: &str) -> Lockfile {
+    serde_saphyr::from_str(source).expect("parse lockfile")
+}
+
+fn specifier_of(group: Option<&ResolvedDependencyMap>, alias: &str) -> String {
+    let alias = PkgName::parse(alias).expect("parse the alias");
+    group.expect("the group is declared")[&alias].specifier.clone()
+}
+
+fn bumps(targets: &[(&str, DependencyGroup, &str)]) -> ManifestSpecBumps {
+    let targets = targets
+        .iter()
+        .map(|(alias, group, declared)| ((*alias).to_string(), (*group, (*declared).to_string())))
+        .collect::<HashMap<_, _>>();
+    ManifestSpecBumps {
+        targets: BTreeMap::from([(".".to_string(), targets)]),
+        range_spec_style: RangeSpecStyle::Major,
+        applied: std::sync::Mutex::default(),
+    }
+}
 
 fn bump(declared: &str, version: &str) -> Option<String> {
     let version = version.parse::<ImporterDepVersion>().expect("parse the resolved version");
@@ -93,4 +116,60 @@ fn npm_aliases_split_into_the_prefix_they_keep() {
     assert_eq!(split_npm_alias("npm:@scope/foo@^1.0.0"), Some(("npm:@scope/foo@", "^1.0.0")));
     assert_eq!(split_npm_alias("npm:^1.0.0"), Some(("npm:", "^1.0.0")));
     assert_eq!(split_npm_alias("workspace:^1.0.0"), None);
+}
+
+/// A package declared in more than one direct group has one entry per group,
+/// each with its own range. The bump has to read and rewrite the entry under
+/// the group the declaration came from.
+#[test]
+fn a_bump_moves_the_entry_of_the_group_the_manifest_declared() {
+    let mut lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.0.0
+    devDependencies:
+      foo:
+        specifier: ^2.0.0
+        version: 2.1.0
+",
+    );
+
+    let bumps = bumps(&[("foo", DependencyGroup::Dev, "^2.0.0")]);
+    apply_manifest_spec_bumps(&mut lockfile, &bumps);
+
+    let importer = &lockfile.importers["."];
+    assert_eq!(specifier_of(importer.dev_dependencies.as_ref(), "foo"), "^2.1.0");
+    assert_eq!(specifier_of(importer.dependencies.as_ref(), "foo"), "^1.0.0");
+    let applied = bumps.applied.into_inner().expect("never poisoned");
+    let expected = (DependencyGroup::Dev, "^2.1.0".to_string());
+    assert_eq!(applied.manifests["."]["foo"], expected);
+}
+
+/// The declared text is what the resolver read. When the lockfile entry
+/// carries something else — an override replaced the declaration before
+/// resolution — the entry is not the update's to move (pnpm/pnpm#12115).
+#[test]
+fn a_declaration_an_override_replaced_is_left_alone() {
+    let mut lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.2.0
+",
+    );
+
+    let bumps = bumps(&[("foo", DependencyGroup::Prod, "catalog:")]);
+    apply_manifest_spec_bumps(&mut lockfile, &bumps);
+
+    assert_eq!(specifier_of(lockfile.importers["."].dependencies.as_ref(), "foo"), "^1.0.0");
+    assert!(bumps.applied.into_inner().expect("never poisoned").is_empty());
 }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -702,9 +702,9 @@ struct UpdatePreparation {
     preferred_versions_override: PreferredVersions,
     persist_manifest: bool,
     /// Direct dependencies whose declared range the install may move onto
-    /// the version it resolves, each mapped to the specifier the manifest
-    /// declares for it. See [`crate::ManifestSpecBumps`].
-    bump_targets: HashMap<String, String>,
+    /// the version it resolves, each mapped to the group and specifier the
+    /// manifest declares for it. See [`crate::ManifestSpecBumps`].
+    bump_targets: HashMap<String, (DependencyGroup, String)>,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -715,7 +715,7 @@ struct SelectedUpdatePreparation {
     preferred_versions_override: PreferredVersions,
     persist_indices: Vec<usize>,
     /// [`UpdatePreparation::bump_targets`] per importer id.
-    bump_targets: BTreeMap<String, HashMap<String, String>>,
+    bump_targets: BTreeMap<String, HashMap<String, (DependencyGroup, String)>>,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -889,7 +889,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                 rewrites.push((name.clone(), *group, specifier));
             }
             if save && !latest {
-                bump_targets.insert(name.clone(), previous.clone());
+                bump_targets.entry(name.clone()).or_insert_with(|| (*group, previous.clone()));
             }
             drop_targets.insert(name.clone(), None);
         }
@@ -914,10 +914,10 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         let patterns =
             selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
         let matcher = create_matcher(&patterns);
-        for (name, _, previous) in &direct {
+        for (name, group, previous) in &direct {
             if matcher.matches(name) {
                 if save {
-                    bump_targets.insert(name.clone(), previous.clone());
+                    bump_targets.entry(name.clone()).or_insert_with(|| (*group, previous.clone()));
                 }
                 drop_targets.insert(name.clone(), None);
             }
@@ -1067,7 +1067,9 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         rewritten.filter(|specifier| specifier != previous)
                     } else {
                         if save && requested.is_none() {
-                            bump_targets.insert(name.clone(), previous.clone());
+                            bump_targets
+                                .entry(name.clone())
+                                .or_insert_with(|| (*group, previous.clone()));
                         }
                         requested
                     }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -50,7 +50,7 @@ use pnpm_resolving_resolver_base::{
 use pnpm_tarball::MemCache;
 use pnpm_workspace_range_resolver::resolve_workspace_range;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -702,8 +702,9 @@ struct UpdatePreparation {
     preferred_versions_override: PreferredVersions,
     persist_manifest: bool,
     /// Direct dependencies whose declared range the install may move onto
-    /// the version it resolves. See [`crate::ManifestSpecBumps`].
-    bump_targets: HashSet<String>,
+    /// the version it resolves, each mapped to the specifier the manifest
+    /// declares for it. See [`crate::ManifestSpecBumps`].
+    bump_targets: HashMap<String, String>,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -714,7 +715,7 @@ struct SelectedUpdatePreparation {
     preferred_versions_override: PreferredVersions,
     persist_indices: Vec<usize>,
     /// [`UpdatePreparation::bump_targets`] per importer id.
-    bump_targets: BTreeMap<String, HashSet<String>>,
+    bump_targets: BTreeMap<String, HashMap<String, String>>,
     updated_catalogs: Catalogs,
     catalogs_override: Option<Catalogs>,
     workspace_dir_for_catalogs: Option<PathBuf>,
@@ -823,7 +824,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
     // A compatible bump cannot name its version before the resolve, so the
     // matched names are collected here and the install reports back what it
     // settled on.
-    let mut bump_targets = HashSet::new();
+    let mut bump_targets = HashMap::new();
     let max_depth = UpdateDepth::new(depth);
     // Bare-name selectors with depth update matching names at any depth.
     let use_name_matcher = !selectors.is_empty()
@@ -888,7 +889,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                 rewrites.push((name.clone(), *group, specifier));
             }
             if save && !latest {
-                bump_targets.insert(name.clone());
+                bump_targets.insert(name.clone(), previous.clone());
             }
             drop_targets.insert(name.clone(), None);
         }
@@ -913,10 +914,10 @@ async fn prepare_manifest<Reporter: self::Reporter>(
         let patterns =
             selectors.iter().map(|selector| selector.pattern.clone()).collect::<Vec<_>>();
         let matcher = create_matcher(&patterns);
-        for (name, _, _) in &direct {
+        for (name, _, previous) in &direct {
             if matcher.matches(name) {
                 if save {
-                    bump_targets.insert(name.clone());
+                    bump_targets.insert(name.clone(), previous.clone());
                 }
                 drop_targets.insert(name.clone(), None);
             }
@@ -1066,7 +1067,7 @@ async fn prepare_manifest<Reporter: self::Reporter>(
                         rewritten.filter(|specifier| specifier != previous)
                     } else {
                         if save && requested.is_none() {
-                            bump_targets.insert(name.clone());
+                            bump_targets.insert(name.clone(), previous.clone());
                         }
                         requested
                     }

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -2578,6 +2578,100 @@ describe('update', () => {
     expect(updatedCatalogs!.default?.['@pnpm.e2e/foo']).toMatch(/^[\^~]?100\.1\.0$/)
   })
 
+  // Regression test for https://github.com/pnpm/pnpm/issues/12115
+  // A dependency that is both declared through the catalog and listed in
+  // "overrides" is handed to the resolver with the override's specifier, so the
+  // resolved version must not be written back over the "catalog:" reference.
+  test('update via install mutation preserves catalog: for an overridden dependency (issue #12115)', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+        '@pnpm.e2e/bar': '^100.0.0',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '^1.0.0' },
+      },
+      overrides: {
+        '@pnpm.e2e/foo': '^1.0.0',
+        '@pnpm.e2e/bar': '100.0.0',
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    expect(readLockfile().importers.project1.dependencies).toStrictEqual({
+      '@pnpm.e2e/bar': { specifier: '100.0.0', version: '100.0.0' },
+      '@pnpm.e2e/foo': { specifier: '^1.0.0', version: '1.3.0' },
+    })
+
+    // Simulate `pnpm update -r` by using the "install" mutation with update=true
+    // and updatePackageManifest=true, without specifying any dependencySelectors.
+    const { updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        mutation: 'install' as const,
+        update: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    // Both declarations are the overrides' input, not their output: neither the
+    // "catalog:" reference nor the declared range may be replaced by the version
+    // the override resolved to.
+    expect(updatedProjects[0]?.manifest.dependencies).toStrictEqual({
+      '@pnpm.e2e/foo': 'catalog:',
+      '@pnpm.e2e/bar': '^100.0.0',
+    })
+  })
+
+  // `pnpm update --latest -r` is what the issue reports, and it reaches the
+  // manifest through the same writer.
+  test('update via install mutation with updateToLatest preserves catalog: for an overridden dependency (issue #12115)', async () => {
+    await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+
+    const { options, projects } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/foo': 'catalog:',
+      },
+    }])
+
+    const mutateOpts = {
+      ...options,
+      lockfileOnly: true,
+      catalogs: {
+        default: { '@pnpm.e2e/foo': '^1.0.0' },
+      },
+      overrides: {
+        '@pnpm.e2e/foo': '^1.0.0',
+      },
+    }
+
+    await mutateModules(installProjects(projects), mutateOpts)
+
+    const { updatedProjects } = await mutateModules(
+      installProjects(projects).map((project) => ({
+        ...project,
+        mutation: 'install' as const,
+        update: true,
+        updateToLatest: true,
+        updatePackageManifest: true,
+      })),
+      mutateOpts
+    )
+
+    expect(updatedProjects[0]?.manifest.dependencies).toStrictEqual({
+      '@pnpm.e2e/foo': 'catalog:',
+    })
+  })
+
   // Test with multiple catalog dependencies: ensures that the index alignment in
   // updateProjectManifest is correct when some deps are catalog and some are not.
   test('update via install mutation preserves catalog: with mixed deps (issue #11658)', async () => {

--- a/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
@@ -1,4 +1,5 @@
 import {
+  getSpecFromPackageManifest,
   type PackageSpecObject,
   updateProjectManifestObject,
 } from '@pnpm/pkg-manifest.utils'
@@ -19,13 +20,20 @@ export async function updateProjectManifest (
     throw new Error('Cannot save because no package.json found')
   }
   const specsToUpsert: PackageSpecObject[] = []
+  const declaredSpecifiers = new Map<string, string>()
   for (const rdd of opts.directDependencies) {
     const wantedDep = rdd.wantedDependency
     if (wantedDep?.updateSpec !== true) continue
+    const declaredSpecifier = getDeclaredSpecifierReplacedByHook(importer, rdd)
+    if (declaredSpecifier != null) {
+      declaredSpecifiers.set(rdd.alias, declaredSpecifier)
+    }
     specsToUpsert.push({
       alias: rdd.alias,
       peer: importer.peer,
-      bareSpecifier: getBareSpecifierToSave(wantedDep, rdd, opts.preserveWorkspaceProtocol),
+      bareSpecifier: declaredSpecifier == null
+        ? getBareSpecifierToSave(wantedDep, rdd, opts.preserveWorkspaceProtocol)
+        : wantedDep.bareSpecifier,
       resolvedVersion: rdd.version,
       rangeSpecStyle: importer.rangeSpecStyle,
       saveType: importer.targetDependenciesField,
@@ -53,10 +61,40 @@ export async function updateProjectManifest (
     ? await updateProjectManifestObject(
       importer.rootDir,
       importer.originalManifest,
-      specsToUpsert
+      declaredSpecifiers.size === 0
+        ? specsToUpsert
+        : specsToUpsert.map((spec) => declaredSpecifiers.has(spec.alias)
+          ? { ...spec, bareSpecifier: declaredSpecifiers.get(spec.alias) }
+          : spec)
     )
     : undefined
   return [hookedManifest, originalManifest]
+}
+
+/**
+ * The specifier the project declares on disk for a direct dependency whose
+ * entry a `readPackage` hook — a version override, most often — replaced in
+ * the manifest handed to the resolver. `undefined` when the declaration is
+ * what resolution followed, and the update owns it.
+ *
+ * The version resolution settled on answers the hook, not the declaration, so
+ * neither manifest's entry is the update's to move: writing the resolved range
+ * over them bakes the override into every project that declares the package —
+ * replacing a `catalog:` reference with a version (pnpm/pnpm#12115) — and
+ * contradicts the override on the next install.
+ *
+ * A dependency this run names with a specifier of its own (`pnpm add foo@2`)
+ * is exempt: that request is the manifest's new specifier.
+ */
+function getDeclaredSpecifierReplacedByHook (
+  importer: ImporterToResolve,
+  rdd: ResolvedDirectDependency
+): string | undefined {
+  if (importer.originalManifest == null) return undefined
+  const hookedSpecifier = getSpecFromPackageManifest(importer.manifest, rdd.alias)
+  if (hookedSpecifier === '' || hookedSpecifier !== rdd.wantedDependency?.bareSpecifier) return undefined
+  const declaredSpecifier = getSpecFromPackageManifest(importer.originalManifest, rdd.alias)
+  return declaredSpecifier !== '' && declaredSpecifier !== hookedSpecifier ? declaredSpecifier : undefined
 }
 
 function getBareSpecifierToSave (


### PR DESCRIPTION
## Summary

`pnpm update` rewrote every direct dependency's `package.json` entry to the range resolution settled on. For a dependency that `overrides` also claims, the resolver never read that entry: the overrides hook replaces it in the manifest handed to resolution, so the version that comes back answers the override, not the declaration. Writing it back destroyed what the project actually declared — most visibly a `catalog:` reference, which became a pinned version and dropped the project out of the catalog.

That is why the reproductions in the issue all need *both* a `catalog:` dependency and an `overrides:` entry for the same package: a catalog dependency nobody overrides keeps its reference, and PR pnpm/pnpm#11711 already covers that path.

The same rewrite also bakes an override into a plain range: `"@pnpm.e2e/bar": "^100.0.0"` with `overrides: { '@pnpm.e2e/bar': '100.0.0' }` became `"100.0.0"` in `package.json`. Both are fixed here.

**TypeScript** — `updateProjectManifest` now keeps what each manifest declares when the hooked manifest's entry differs from the on-disk one and the resolver followed the hooked one. A dependency the run names with a specifier of its own (`pnpm add foo@2`) is exempt and still writes that request.

**pacquet** — the update reaches the same entries through `ManifestSpecBumps`, whose targets now carry the specifier `package.json` declares. A bump whose lockfile entry no longer matches that text is skipped, so the lockfile and the manifest stay in agreement. `--latest` already preserved the reference (it rewrites from the on-disk manifest before the install); the new test guards that.

Closes pnpm/pnpm#12115
Closes pnpm/pnpm#11658

### Known adjacent bug, not fixed here

If an override's value is *textually identical* to the declared range (`"foo": "^1.0.0"` + `overrides: { foo: '^1.0.0' }`), `pnpm update` still moves the declaration to `^1.1.0` while the override holds the resolver's view at `^1.0.0`, and the next `--frozen-lockfile` install fails with a specifier mismatch. That predates this change and needs the "is this alias claimed by an override" signal rather than a text comparison; I'll file it separately.

## Squash Commit Body

```text
`pnpm update` rewrote every direct dependency's `package.json` entry to the
range resolution settled on. For a dependency that `overrides` also claims,
the resolver never read that entry: the overrides hook replaced it in the
manifest handed to resolution, so the version that came back answers the
override. Writing it back destroyed what the project actually declared —
most visibly a `catalog:` reference, which became a pinned version and
dropped the project out of the catalog.

The manifest writer now keeps the declaration on disk whenever the hooked
manifest's entry differs from it and the resolver followed the hooked one.
A dependency the run names with a specifier of its own (`pnpm add foo@2`)
still writes that request.

pacquet reaches the same entries through `ManifestSpecBumps`, whose targets
now carry the specifier `package.json` declares; a bump whose lockfile entry
no longer matches it is skipped, leaving the lockfile and the manifest
agreeing.

Closes pnpm/pnpm#12115
Closes pnpm/pnpm#11658
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790424900&installation_model_id=426870&pr_number=14223&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14223&signature=d98d680af47bc5991a2b5b9c3c6864ce359d62c641efc19cd8ebb81d30838735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm update` and `pnpm update --latest` now preserve dependency declarations in `package.json`, including `catalog:` references and declared version ranges, when overrides are applied.
  * Resolved override or package-hook versions no longer replace the specifications originally written by the project.
  * Updates correctly preserve declarations that appear in multiple dependency sections.
  * Frozen-lockfile installations continue to succeed after updates involving catalogs and overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->