### PR TITLE
fix(cli): report the released pnpm version in doctor

### DIFF
--- a/.changeset/doctor-reports-the-released-version.md
+++ b/.changeset/doctor-reports-the-released-version.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm doctor` reporting a version that does not match `pnpm --version` [pnpm/pnpm#14225](https://github.com/pnpm/pnpm/issues/14225).

--- a/pnpm/crates/cli/src/cli_args/doctor.rs
+++ b/pnpm/crates/cli/src/cli_args/doctor.rs
@@ -9,7 +9,7 @@
 
 use crate::cli_args::ping::PingArgs;
 use clap::Args;
-use pnpm_config::Config;
+use pnpm_config::{Config, PNPM_VERSION};
 use serde::Serialize;
 use std::{
     fmt::Write as _,
@@ -167,10 +167,9 @@ impl DoctorArgs {
 }
 
 fn check_versions() -> CheckResult {
-    let pnpm_version = env!("CARGO_PKG_VERSION");
     let detail = match node_version() {
-        Some(node_version) => format!("pnpm {pnpm_version}, Node.js {node_version}"),
-        None => format!("pnpm {pnpm_version}"),
+        Some(node_version) => format!("pnpm {PNPM_VERSION}, Node.js {node_version}"),
+        None => format!("pnpm {PNPM_VERSION}"),
     };
     CheckResult::pass("Versions", detail)
 }

--- a/pnpm/crates/cli/src/cli_args/doctor/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/doctor/tests.rs
@@ -97,6 +97,5 @@ fn last_line_skips_trailing_blanks() {
 #[test]
 fn check_versions_reports_the_released_pnpm_version() {
     let detail = check_versions().detail.expect("versions detail");
-    dbg!(&detail);
     assert!(detail.starts_with(&format!("pnpm {PNPM_VERSION}")), "{detail}");
 }

--- a/pnpm/crates/cli/src/cli_args/doctor/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/doctor/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    CheckResult, CheckStatus, DoctorReport, can_write_to_dir, last_line, probe_link_capabilities,
-    render_report, status_mark,
+    CheckResult, CheckStatus, DoctorReport, can_write_to_dir, check_versions, last_line,
+    probe_link_capabilities, render_report, status_mark,
 };
+use pnpm_config::PNPM_VERSION;
 use pretty_assertions::assert_eq;
 
 fn report(checks: Vec<CheckResult>) -> DoctorReport {
@@ -89,4 +90,13 @@ fn can_write_to_dir_rejects_a_missing_dir() {
 fn last_line_skips_trailing_blanks() {
     assert_eq!(last_line("first\nERR_PNPM_BROKEN  it broke\n\n"), "ERR_PNPM_BROKEN  it broke");
     assert_eq!(last_line(""), "");
+}
+
+/// The `cli` crate carries a placeholder `Cargo.toml` version, so the check
+/// has to report the released version that `pnpm --version` prints.
+#[test]
+fn check_versions_reports_the_released_pnpm_version() {
+    let detail = check_versions().detail.expect("versions detail");
+    dbg!(&detail);
+    assert!(detail.starts_with(&format!("pnpm {PNPM_VERSION}")), "{detail}");
 }


### PR DESCRIPTION
## Summary

`pnpm doctor` printed `pnpm 0.0.1` while `pnpm -v` printed `12.0.0`. The versions check read `env!("CARGO_PKG_VERSION")`, which is the `cli` crate's own `Cargo.toml` version, and that is a `0.0.1` placeholder rather than the released version. It now reads `pnpm_config::PNPM_VERSION`, the same constant `pnpm --version` and the default reporter use.

Fixes pnpm/pnpm#14225.

The TypeScript CLI is unaffected: its `doctor` already formats the detail from `packageManager.version`, so this only restores parity rather than diverging from it.

## Squash Commit Body

```text
The versions check in `pnpm doctor` reported `env!("CARGO_PKG_VERSION")`. That
resolves to the `cli` crate's own manifest version, which is the `0.0.1`
placeholder every crate in the workspace carries, not the version the binary
ships as. Users saw `pnpm 0.0.1` from `doctor` and `12.0.0` from `pnpm -v` on
the same install, which makes the first line of a diagnostics report useless
for the thing diagnostics are usually pasted into: a bug report.

`pnpm_config::PNPM_VERSION` is the single source of truth the `--version` flag
and the default reporter already read, so the check now reads it too.

Fixes pnpm/pnpm#14225.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users, it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790428121&installation_model_id=426870&pr_number=14227&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14227&signature=61c3c17d8f16e5143ca2ea3bee8214d1becba4b5dcb148f69e3998627c5724f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm doctor` so its reported pnpm version now matches the version shown by `pnpm --version`.

* **Tests**
  * Added coverage to verify that version checks display the released pnpm version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->