### PR TITLE
fix(pnpr): retain quota after ambiguous artifact writes

### DIFF
--- a/.changeset/safe-artifact-quota.md
+++ b/.changeset/safe-artifact-quota.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+Kept shared artifact quota accounting fail-safe when object storage reports an ambiguous write failure.

--- a/.changeset/safe-artifact-quota.md
+++ b/.changeset/safe-artifact-quota.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Kept shared artifact quota accounting fail-safe when object storage reports an ambiguous write failure.
+pnpr retains shared artifact quota after object storage reports an ambiguous write failure.

--- a/pnpr/client/README.md
+++ b/pnpr/client/README.md
@@ -195,10 +195,16 @@ The PoC implements the main trust boundary from the
   request when `--ignore-scripts` is effective.
 - `downloadSharedArtifactBlob` recomputes SHA-512 before returning bytes.
 
-Publication serializes the variant-count check and envelope write with a
-cross-process filesystem lock, so pnpr processes sharing one local cache enforce
-the eight-variant cap together. The PoC rejects writes above 1 GiB per owner or
-10 GiB across the server's artifact cache.
+Publication reserves quota before immutable, create-only object writes. S3
+replicas coordinate the quota counter with conditional writes; local storage
+uses an advisory lock around its counter. Ambiguous object-store write failures
+remain charged because the object may have been committed before the error was
+returned. This can conservatively overcount storage, but cannot allow the 1 GiB
+per-owner or 10 GiB global limits to be exceeded. The eight-variant response cap
+is enforced while resolving artifacts. With artifact writers quiesced, operators
+can reconcile conservative overcount by removing the object-store `quota.json`
+or local `.locks/usage.json`; the next publication rebuilds it from stored
+objects.
 
 ### v0 compatibility tags
 

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -159,14 +159,15 @@ impl SharedArtifactStore {
         })?;
         self.reserve_quota(&owner, added_bytes).await?;
 
-        let mut created_bytes = 0_u64;
+        let mut retained_bytes = 0_u64;
         for (path, bytes) in new_blobs {
             let size = bytes.len() as u64;
             match self.create_object(&path, bytes).await {
-                Ok(true) => created_bytes += size,
+                Ok(true) => retained_bytes += size,
                 Ok(false) => {}
                 Err(error) => {
-                    self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
+                    retained_bytes += size;
+                    self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
                     return Err(error);
                 }
             }
@@ -174,14 +175,15 @@ impl SharedArtifactStore {
         let created = match self.create_object(&variant_path, envelope_bytes).await {
             Ok(created) => created,
             Err(error) => {
-                self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
+                retained_bytes += envelope_size;
+                self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
                 return Err(error);
             }
         };
         if created {
-            created_bytes += envelope_size;
+            retained_bytes += envelope_size;
         }
-        self.release_uncommitted(&owner, added_bytes, created_bytes).await?;
+        self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
         Ok(created)
     }
 
@@ -287,10 +289,10 @@ impl SharedArtifactStore {
         &self,
         owner: &str,
         reserved_bytes: u64,
-        created_bytes: u64,
+        retained_bytes: u64,
     ) -> Result<()> {
         let unused_bytes =
-            reserved_bytes.checked_sub(created_bytes).ok_or_else(quota_counter_underflow)?;
+            reserved_bytes.checked_sub(retained_bytes).ok_or_else(quota_counter_underflow)?;
         if unused_bytes != 0 {
             self.change_quota(owner, unused_bytes, QuotaChange::Release).await?;
         }

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -219,21 +219,55 @@ async fn quota_is_reserved_before_objects_are_written() {
 }
 
 #[tokio::test]
-async fn failed_object_writes_release_unused_quota() {
-    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites { inner: InMemory::new() });
+async fn failed_object_writes_retain_quota_for_the_ambiguous_attempt() {
+    let backend: Arc<dyn ObjectStore> =
+        Arc::new(FailArtifactWrites { inner: InMemory::new(), commit_before_error: false });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
     let scratch = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let request = publication("ci/failure");
+    let expected_usage = serde_json::to_vec(&request.envelope).unwrap().len() as u64;
 
-    store.publish("acme", publication("ci/failure")).await.unwrap_err();
+    store.publish("acme", request).await.unwrap_err();
 
     let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
     let usage: ArtifactUsage =
         serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
             .unwrap();
-    assert_eq!(usage.global_bytes, 0);
-    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), 0);
+    assert_eq!(usage.global_bytes, expected_usage);
+    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), expected_usage);
+}
+
+#[tokio::test]
+async fn committed_object_writes_that_report_failure_remain_charged() {
+    let backend: Arc<dyn ObjectStore> =
+        Arc::new(FailArtifactWrites { inner: InMemory::new(), commit_before_error: true });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let request =
+        publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/ambiguous-commit");
+    let expected_usage = b"shared addon".len() as u64;
+
+    store.publish("acme", request).await.unwrap_err();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, expected_usage);
+    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), expected_usage);
+    let mut objects = backend.list(None);
+    let mut physical_bytes = 0_u64;
+    while let Some(object) = objects.next().await {
+        let object = object.unwrap();
+        if !object.location.as_ref().ends_with("/quota.json") {
+            physical_bytes += object.size;
+        }
+    }
+    assert_eq!(physical_bytes, expected_usage);
 }
 
 #[tokio::test]
@@ -335,6 +369,7 @@ fn publication_request(
 #[derive(Debug)]
 struct FailArtifactWrites {
     inner: InMemory,
+    commit_before_error: bool,
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -354,6 +389,9 @@ impl ObjectStore for FailArtifactWrites {
         if location.as_ref().ends_with("/quota.json") {
             self.inner.put_opts(location, payload, options).await
         } else {
+            if self.commit_before_error {
+                self.inner.put_opts(location, payload, options).await?;
+            }
             Err(object_store::Error::Generic {
                 store: "test",
                 source: std::io::Error::other("injected artifact write failure").into(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Follow-up to pnpm/pnpm#14222 and the [post-merge review finding](https://github.com/pnpm/pnpm/pull/14222#discussion_r3871897837).

- Treat a non-conflict object creation error as ambiguous: retain quota for the attempted object because the backend may have committed it before reporting a transport failure.
- Continue releasing quota reserved for objects that were never attempted.
- Add regressions for failures both before and after the backing store commits the object, and verify that committed physical bytes remain accounted for.
- Correct the shared-artifact storage documentation and describe how operators can rebuild a conservatively overcounted quota counter.

## Squash Commit Body

```text
Object-store write errors do not prove that a create-only write failed. A
backend can commit an artifact and then return a transport error, so releasing
that object reservation can make the quota counter smaller than physical
storage.

Retain quota for every attempted object on non-conflict errors while still
releasing the reservation for later, unattempted objects. This deliberately
prefers conservative overcounting to allowing the storage limits to be
exceeded. Document the recovery procedure and cover both pre-commit and
post-commit failure paths.

Follow-up to pnpm/pnpm#14222.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publication quota accounting when object storage reports ambiguous write failures.
  * Ensured storage usage remains conservatively counted when data may have been persisted despite an error.
  * Preserved quota limits while preventing undercounting of retained artifacts.

* **Documentation**
  * Updated publication quota documentation to reflect reservation, reconciliation, and storage-specific enforcement behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->