### PR TITLE
feat: add per-task concurrency limits

### DIFF
--- a/.changeset/task-concurrency-limits.md
+++ b/.changeset/task-concurrency-limits.md
@@ -1,0 +1,16 @@
+---
+"@pnpm/types": minor
+"@pnpm/config.reader": minor
+"@pnpm/workspace.task-scheduler": minor
+"@pnpm/exec.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Added per-task concurrency limits to workspace task orchestration. Set `tasks.<name>.concurrency` in `pnpm-workspace.yaml` to limit how many instances of that task may run across workspace projects at once:
+
+```yaml
+tasks:
+  build:
+    concurrency: 2
+```

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -118,6 +118,7 @@ pub async fn exec_recursive(
             let node = TaskNode {
                 project: project.clone(),
                 task_name: command_name.clone(),
+                concurrency: None,
                 scripts: vec![command_name.clone()],
                 requested: true,
                 dependencies: dependencies

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -154,6 +154,63 @@ fn recursive_run_respects_workspace_concurrency() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_respects_task_concurrency() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": { "build": "sh ../track-task-concurrency.sh" },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", manifest("project-1")),
+            ("project-2", manifest("project-2")),
+            ("project-3", manifest("project-3")),
+        ],
+    );
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        concat!(
+            "packages:\n",
+            "  - project-1\n",
+            "  - project-2\n",
+            "  - project-3\n",
+            "tasks:\n",
+            "  build:\n",
+            "    concurrency: 1\n",
+        ),
+    )
+    .expect("write task settings");
+    write_executable(
+        &workspace.join("track-task-concurrency.sh"),
+        r#"if mkdir ../build-active 2>/dev/null; then
+  owns_lock=1
+else
+  touch ../exceeded-task-concurrency
+fi
+sleep 0.2
+touch ran.txt
+[ "$owns_lock" = 1 ] && rmdir ../build-active
+"#,
+    );
+
+    pacquet.with_args(["--workspace-concurrency=3", "-r", "run", "build"]).assert().success();
+
+    assert!(
+        !workspace.join("exceeded-task-concurrency").exists(),
+        "only one build task should run at a time",
+    );
+    for name in ["project-1", "project-2", "project-3"] {
+        assert!(workspace.join(name).join("ran.txt").exists(), "{name} should have run");
+    }
+
+    drop(root);
+}
+
 /// Without a workspace-level loader, recursive run preloads the `.pnp.cjs`
 /// belonging to each selected project rather than resolving once from the
 /// invocation directory.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -977,6 +977,10 @@ pub struct UpdateSettings {
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TaskSettings {
+    /// Maximum number of instances of this task that may run at once.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub concurrency: Option<i64>,
+
     /// The tasks that must complete before this one may start. A `^name`
     /// entry names the task in each of the project's workspace
     /// dependencies; a bare `name` entry names the task in the same
@@ -1159,8 +1163,16 @@ pub enum LoadWorkspaceYamlError {
     #[diagnostic(code(ERR_PNPM_INVALID_SETTING))]
     PrefixDeclaredTwice { prefix: String },
     #[display("The \"tasks['{task}'].{field}\" setting is not a known task setting")]
-    #[diagnostic(code(ERR_PNPM_INVALID_SETTING), help(r#"A task declares "dependsOn"."#))]
+    #[diagnostic(
+        code(ERR_PNPM_INVALID_SETTING),
+        help(r#"A task declares "concurrency" and "dependsOn"."#)
+    )]
     UnknownTaskSettingField { task: String, field: String },
+    #[display(
+        "The \"tasks['{task}'].concurrency\" setting should be a positive integer, but got {concurrency}"
+    )]
+    #[diagnostic(code(ERR_PNPM_INVALID_SETTING))]
+    InvalidTaskConcurrency { task: String, concurrency: i64 },
     #[display(
         "The \"tasks['{task}'].dependsOn\" setting contains an entry with no task name: {entry:?}"
     )]
@@ -1274,6 +1286,14 @@ impl WorkspaceSettings {
                 return Err(LoadWorkspaceYamlError::UnknownTaskSettingField {
                     task: task.clone(),
                     field: field.clone(),
+                });
+            }
+            if let Some(concurrency) = settings.concurrency
+                && concurrency < 1
+            {
+                return Err(LoadWorkspaceYamlError::InvalidTaskConcurrency {
+                    task: task.clone(),
+                    concurrency,
                 });
             }
             for entry in settings.depends_on.iter().flatten() {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -974,11 +974,14 @@ pub struct UpdateSettings {
 /// One task's entry in the `tasks` section. A task name is a script name:
 /// `pnpm -r run <name>` runs the task named `<name>` in every selected
 /// project.
-#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TaskSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<i64>,
+
+    #[serde(skip)]
+    invalid_concurrency: Option<serde_json::Value>,
 
     /// The tasks that must complete before this one may start. A `^name`
     /// entry names the task in each of the project's workspace
@@ -996,6 +999,29 @@ pub struct TaskSettings {
     /// reject a typo instead of silently ignoring it.
     #[serde(flatten, skip_serializing_if = "IndexMap::is_empty")]
     pub unknown: IndexMap<String, serde_json::Value>,
+}
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase", default)]
+struct RawTaskSettings {
+    concurrency: Option<serde_json::Value>,
+    depends_on: Option<Vec<String>>,
+    #[serde(flatten)]
+    unknown: IndexMap<String, serde_json::Value>,
+}
+
+impl<'de> Deserialize<'de> for TaskSettings {
+    fn deserialize<De: Deserializer<'de>>(deserializer: De) -> Result<Self, De::Error> {
+        let raw = RawTaskSettings::deserialize(deserializer)?;
+        let concurrency = raw.concurrency.as_ref().and_then(serde_json::Value::as_i64);
+        let invalid_concurrency = raw.concurrency.filter(|value| value.as_i64().is_none());
+        Ok(Self {
+            concurrency,
+            invalid_concurrency,
+            depends_on: raw.depends_on,
+            unknown: raw.unknown,
+        })
+    }
 }
 
 /// `updateConfig` entry: settings that tune `pnpm update`.
@@ -1171,7 +1197,7 @@ pub enum LoadWorkspaceYamlError {
         "The \"tasks['{task}'].concurrency\" setting should be a positive integer, but got {concurrency}"
     )]
     #[diagnostic(code(ERR_PNPM_INVALID_SETTING))]
-    InvalidTaskConcurrency { task: String, concurrency: i64 },
+    InvalidTaskConcurrency { task: String, concurrency: String },
     #[display(
         "The \"tasks['{task}'].dependsOn\" setting contains an entry with no task name: {entry:?}"
     )]
@@ -1292,7 +1318,13 @@ impl WorkspaceSettings {
             {
                 return Err(LoadWorkspaceYamlError::InvalidTaskConcurrency {
                     task: task.clone(),
-                    concurrency,
+                    concurrency: concurrency.to_string(),
+                });
+            }
+            if let Some(concurrency) = settings.invalid_concurrency.as_ref() {
+                return Err(LoadWorkspaceYamlError::InvalidTaskConcurrency {
+                    task: task.clone(),
+                    concurrency: concurrency.to_string(),
                 });
             }
             for entry in settings.depends_on.iter().flatten() {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -977,7 +977,6 @@ pub struct UpdateSettings {
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default)]
 pub struct TaskSettings {
-    /// Maximum number of instances of this task that may run at once.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub concurrency: Option<i64>,
 

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2884,7 +2884,7 @@ fn parses_a_valid_tasks_section_and_applies_it() {
         concat!(
             "packages:\n  - packages/*\n",
             "tasks:\n",
-            "  build:\n    dependsOn: ['^build']\n",
+            "  build:\n    concurrency: 2\n    dependsOn: ['^build']\n",
             "  test:\n    dependsOn: ['build']\n",
             "  lint: {}\n",
         ),
@@ -2902,6 +2902,7 @@ fn parses_a_valid_tasks_section_and_applies_it() {
         config.tasks.get("build").unwrap().depends_on.as_deref(),
         Some(&["^build".to_string()][..]),
     );
+    assert_eq!(config.tasks.get("build").unwrap().concurrency, Some(2));
     assert_eq!(
         config.tasks.get("test").unwrap().depends_on.as_deref(),
         Some(&["build".to_string()][..]),
@@ -2944,5 +2945,41 @@ fn rejects_a_depends_on_entry_with_no_task_name() {
         error,
         LoadWorkspaceYamlError::EmptyTaskDependsOnEntry { ref task, ref entry }
             if task == "build" && entry == "^"
+    ));
+}
+
+#[test]
+fn rejects_zero_task_concurrency() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "packages:\n  - packages/*\ntasks:\n  build:\n    concurrency: 0\n",
+    )
+    .unwrap();
+
+    let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
+    dbg!(&error);
+    assert!(matches!(
+        error,
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, concurrency: 0 }
+            if task == "build"
+    ));
+}
+
+#[test]
+fn rejects_negative_task_concurrency() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "packages:\n  - packages/*\ntasks:\n  build:\n    concurrency: -1\n",
+    )
+    .unwrap();
+
+    let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
+    dbg!(&error);
+    assert!(matches!(
+        error,
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, concurrency: -1 }
+            if task == "build"
     ));
 }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2922,7 +2922,6 @@ fn rejects_an_unknown_task_setting_field() {
     .unwrap();
 
     let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
-    dbg!(&error);
     assert!(matches!(
         error,
         LoadWorkspaceYamlError::UnknownTaskSettingField { ref task, ref field }
@@ -2940,7 +2939,6 @@ fn rejects_a_depends_on_entry_with_no_task_name() {
     .unwrap();
 
     let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
-    dbg!(&error);
     assert!(matches!(
         error,
         LoadWorkspaceYamlError::EmptyTaskDependsOnEntry { ref task, ref entry }
@@ -2958,11 +2956,10 @@ fn rejects_zero_task_concurrency() {
     .unwrap();
 
     let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
-    dbg!(&error);
     assert!(matches!(
         error,
-        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, concurrency: 0 }
-            if task == "build"
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, ref concurrency }
+            if task == "build" && concurrency == "0"
     ));
 }
 
@@ -2976,10 +2973,43 @@ fn rejects_negative_task_concurrency() {
     .unwrap();
 
     let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
-    dbg!(&error);
     assert!(matches!(
         error,
-        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, concurrency: -1 }
-            if task == "build"
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, ref concurrency }
+            if task == "build" && concurrency == "-1"
+    ));
+}
+
+#[test]
+fn rejects_fractional_task_concurrency_as_an_invalid_setting() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "packages:\n  - packages/*\ntasks:\n  build:\n    concurrency: 1.5\n",
+    )
+    .unwrap();
+
+    let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
+    assert!(matches!(
+        error,
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, ref concurrency }
+            if task == "build" && concurrency == "1.5"
+    ));
+}
+
+#[test]
+fn rejects_string_task_concurrency_as_an_invalid_setting() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(WORKSPACE_MANIFEST_FILENAME),
+        "packages:\n  - packages/*\ntasks:\n  build:\n    concurrency: '2'\n",
+    )
+    .unwrap();
+
+    let error = WorkspaceSettings::load_at(dir.path()).unwrap_err();
+    assert!(matches!(
+        error,
+        LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, ref concurrency }
+            if task == "build" && concurrency == r#""2""#
     ));
 }

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -36,7 +36,6 @@ pub struct TaskKey {
 pub struct TaskNode {
     pub project: PathBuf,
     pub task_name: String,
-    /// Maximum number of instances of this task that may run at once.
     pub concurrency: Option<usize>,
     /// The scripts of the project that the task name selected — several
     /// when the task name is a `RegExp` selector. Empty when the project has

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -36,6 +36,8 @@ pub struct TaskKey {
 pub struct TaskNode {
     pub project: PathBuf,
     pub task_name: String,
+    /// Maximum number of instances of this task that may run at once.
+    pub concurrency: Option<usize>,
     /// The scripts of the project that the task name selected — several
     /// when the task name is a `RegExp` selector. Empty when the project has
     /// no such script: the task is then a pass-through that runs nothing,
@@ -108,11 +110,11 @@ where
             existing.requested |= requested;
             continue;
         }
-        let entries: Vec<String> =
-            match options.tasks.and_then(|tasks| tasks.get(task_name.as_str())) {
-                Some(settings) => settings.depends_on.clone().unwrap_or_default(),
-                None => vec![format!("^{task_name}")],
-            };
+        let settings = options.tasks.and_then(|tasks| tasks.get(task_name.as_str()));
+        let entries: Vec<String> = match settings {
+            Some(settings) => settings.depends_on.clone().unwrap_or_default(),
+            None => vec![format!("^{task_name}")],
+        };
         let mut dependencies: Vec<TaskKey> = Vec::new();
         let mut seen: HashSet<TaskKey> = HashSet::new();
         for entry in &entries {
@@ -138,7 +140,21 @@ where
             }
         }
         let scripts = (options.select_scripts)(&project, &task_name);
-        graph.insert(key, TaskNode { project, task_name, scripts, requested, dependencies });
+        graph.insert(
+            key,
+            TaskNode {
+                project,
+                task_name,
+                concurrency: settings.and_then(|settings| {
+                    settings
+                        .concurrency
+                        .map(|concurrency| usize::try_from(concurrency).unwrap_or(usize::MAX))
+                }),
+                scripts,
+                requested,
+                dependencies,
+            },
+        );
     }
     graph
 }
@@ -510,12 +526,63 @@ impl<'a, Run, Skip> ScheduleGraphAsyncOptions<'a, Run, Skip> {
 
 struct SchedulerState {
     ready: VecDeque<usize>,
+    concurrency_groups: HashMap<String, ConcurrencyGroup>,
     pending_dependencies: Vec<usize>,
     blocked: Vec<bool>,
     settled: Vec<bool>,
     unsettled: usize,
     in_flight: usize,
     stop_dispatch: bool,
+}
+
+struct ConcurrencyGroup {
+    limit: usize,
+    reserved: usize,
+    waiting: VecDeque<usize>,
+}
+
+struct NodeConcurrencyLimit {
+    group: String,
+    limit: usize,
+}
+
+impl SchedulerState {
+    fn make_ready(&mut self, index: usize, limits: &[Option<NodeConcurrencyLimit>]) {
+        let Some(limit) = &limits[index] else {
+            self.ready.push_back(index);
+            return;
+        };
+        let admitted = {
+            let group = self.concurrency_groups.entry(limit.group.clone()).or_insert_with(|| {
+                ConcurrencyGroup { limit: limit.limit, reserved: 0, waiting: VecDeque::new() }
+            });
+            if group.reserved < group.limit {
+                group.reserved += 1;
+                true
+            } else {
+                group.waiting.push_back(index);
+                false
+            }
+        };
+        if admitted {
+            self.ready.push_back(index);
+        }
+    }
+
+    fn release_concurrency(&mut self, index: usize, limits: &[Option<NodeConcurrencyLimit>]) {
+        let Some(limit) = &limits[index] else { return };
+        let next = {
+            let group = self
+                .concurrency_groups
+                .get_mut(&limit.group)
+                .expect("running task has a concurrency group");
+            group.reserved -= 1;
+            group.waiting.pop_front().inspect(|_| group.reserved += 1)
+        };
+        if let Some(next) = next {
+            self.ready.push_back(next);
+        }
+    }
 }
 
 /// Dispatch every task whose dependencies have all completed successfully,
@@ -542,9 +609,18 @@ where
         }
     };
     let on_node_skipped = |key: &TaskKey| (options.on_task_skipped)(&graph[key]);
-    schedule_graph(
+    let concurrency_limit = |key: &TaskKey| {
+        let node = &graph[key];
+        let concurrency = node.concurrency?;
+        (!node.scripts.is_empty()).then(|| NodeConcurrencyLimit {
+            group: node.task_name.clone(),
+            limit: concurrency.max(1),
+        })
+    };
+    schedule_graph_with_concurrency_limits(
         &dependencies,
         &ScheduleGraphOptions::new(options.concurrency, options.bail, &run_node, &on_node_skipped),
+        &concurrency_limit,
     )
     .expect("failed to start a task scheduler worker");
 }
@@ -561,6 +637,20 @@ where
     Run: Fn(Node) -> TaskCompletion + Sync,
     Skip: Fn(&Node) + Sync,
 {
+    schedule_graph_with_concurrency_limits(graph, options, &|_| None)
+}
+
+fn schedule_graph_with_concurrency_limits<Node, Run, Skip, Limit>(
+    graph: &IndexMap<Node, Vec<Node>>,
+    options: &ScheduleGraphOptions<'_, Run, Skip>,
+    concurrency_limit: &Limit,
+) -> Result<(), std::io::Error>
+where
+    Node: Clone + Eq + std::hash::Hash + Sync,
+    Run: Fn(Node) -> TaskCompletion + Sync,
+    Skip: Fn(&Node) + Sync,
+    Limit: Fn(&Node) -> Option<NodeConcurrencyLimit>,
+{
     if graph.is_empty() {
         return Ok(());
     }
@@ -572,6 +662,8 @@ where
         order.iter().enumerate().map(|(index, node)| (node, index)).collect();
     let index_of: HashMap<&Node, usize> =
         graph.keys().enumerate().map(|(index, key)| (key, index)).collect();
+    let concurrency_limits: Vec<Option<NodeConcurrencyLimit>> =
+        graph.keys().map(concurrency_limit).collect();
     let mut dependents: Vec<Vec<usize>> = vec![Vec::new(); graph.len()];
     let mut pending_dependencies: Vec<usize> = vec![0; graph.len()];
     for (index, (node, dependencies)) in graph.iter().enumerate() {
@@ -585,20 +677,22 @@ where
             dependents[index_of[dependency]].push(index);
         }
     }
-    let state = Mutex::new(SchedulerState {
-        ready: pending_dependencies
-            .iter()
-            .enumerate()
-            .filter(|(_, pending)| **pending == 0)
-            .map(|(index, _)| index)
-            .collect(),
+    let mut initial_state = SchedulerState {
+        ready: VecDeque::new(),
+        concurrency_groups: HashMap::new(),
         pending_dependencies,
         blocked: vec![false; graph.len()],
         settled: vec![false; graph.len()],
         unsettled: graph.len(),
         in_flight: 0,
         stop_dispatch: false,
-    });
+    };
+    for index in 0..graph.len() {
+        if initial_state.pending_dependencies[index] == 0 {
+            initial_state.make_ready(index, &concurrency_limits);
+        }
+    }
+    let state = Mutex::new(initial_state);
     let progress = Condvar::new();
 
     let complete = |state: &mut SchedulerState, index: usize| {
@@ -607,7 +701,7 @@ where
         for &dependent in &dependents[index] {
             state.pending_dependencies[dependent] -= 1;
             if state.pending_dependencies[dependent] == 0 && !state.blocked[dependent] {
-                state.ready.push_back(dependent);
+                state.make_ready(dependent, &concurrency_limits);
             }
         }
     };
@@ -670,6 +764,7 @@ where
                     drop(panic_guard);
                     guard = state.lock().expect("task scheduler state lock is not poisoned");
                     guard.in_flight -= 1;
+                    guard.release_concurrency(index, &concurrency_limits);
                     match completion {
                         TaskCompletion::Passed => complete(&mut guard, index),
                         TaskCompletion::Failed => {

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -399,7 +399,7 @@ fn task_concurrency_does_not_block_an_independent_task_group() {
     schedule_tasks(
         &graph,
         &ScheduleTasksOptions {
-            concurrency: 3,
+            concurrency: 2,
             bail: true,
             run_task: &|node| {
                 if node.project == first_build_project && node.task_name == "build" {

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -1,8 +1,9 @@
 use super::{
     BuildTaskGraphOptions, ScheduleGraphAsyncOptions, ScheduleGraphOptions, ScheduleTasksOptions,
-    SequenceTasksOptions, TaskCompletion, TaskCycle, TaskGraph, TaskKey, build_task_graph,
-    is_serial_task_graph, render_task_graph_dry_run, resume_task_graph_from, reverse_task_graph,
-    schedule_graph, schedule_graph_async, schedule_tasks, sequence_tasks, task_graph_to_json,
+    SequenceTasksOptions, TaskCompletion, TaskCycle, TaskGraph, TaskKey, TaskNode,
+    build_task_graph, is_serial_task_graph, render_task_graph_dry_run, resume_task_graph_from,
+    reverse_task_graph, schedule_graph, schedule_graph_async, schedule_tasks, sequence_tasks,
+    task_graph_to_json,
 };
 use indexmap::IndexMap;
 use pnpm_config::TaskSettings;
@@ -53,16 +54,10 @@ fn tasks(entries: &[(&str, Option<&[&str]>)]) -> IndexMap<String, TaskSettings> 
     entries
         .iter()
         .map(|(name, depends_on)| {
-            (
-                name.to_string(),
-                TaskSettings {
-                    concurrency: None,
-                    depends_on: depends_on.map(|entries| {
-                        entries.iter().map(std::string::ToString::to_string).collect()
-                    }),
-                    unknown: IndexMap::new(),
-                },
-            )
+            let mut settings = TaskSettings::default();
+            settings.depends_on = depends_on
+                .map(|entries| entries.iter().map(std::string::ToString::to_string).collect());
+            (name.to_string(), settings)
         })
         .collect()
 }
@@ -380,6 +375,63 @@ fn scheduler_respects_task_concurrency_across_projects() {
     );
 
     assert_eq!(max_active.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn task_concurrency_does_not_block_an_independent_task_group() {
+    let task_node = |project: &str, task_name: &str| TaskNode {
+        project: dir(project),
+        task_name: task_name.to_string(),
+        concurrency: Some(1),
+        scripts: vec![task_name.to_string()],
+        requested: true,
+        dependencies: Vec::new(),
+    };
+    let graph = IndexMap::from([
+        (key("a", "build"), task_node("a", "build")),
+        (key("b", "build"), task_node("b", "build")),
+        (key("c", "lint"), task_node("c", "lint")),
+    ]);
+    let first_build_project = dir("a");
+    let lint_project = dir("c");
+    let first_build = (Mutex::new((false, false)), Condvar::new());
+    let ran = Mutex::new(Vec::new());
+    schedule_tasks(
+        &graph,
+        &ScheduleTasksOptions {
+            concurrency: 3,
+            bail: true,
+            run_task: &|node| {
+                if node.project == first_build_project && node.task_name == "build" {
+                    ran.lock().unwrap().push("a#build");
+                    let (state, progress) = &first_build;
+                    let mut state = state.lock().unwrap();
+                    state.0 = true;
+                    progress.notify_all();
+                    let (_state, timeout) = progress
+                        .wait_timeout_while(state, Duration::from_secs(5), |state| !state.1)
+                        .unwrap();
+                    assert!(!timeout.timed_out(), "the independent lint task did not run");
+                } else if node.project == lint_project && node.task_name == "lint" {
+                    let (state, progress) = &first_build;
+                    let state = state.lock().unwrap();
+                    let (mut state, timeout) = progress
+                        .wait_timeout_while(state, Duration::from_secs(5), |state| !state.0)
+                        .unwrap();
+                    assert!(!timeout.timed_out(), "the first build task did not run");
+                    ran.lock().unwrap().push("c#lint");
+                    state.1 = true;
+                    progress.notify_all();
+                } else {
+                    ran.lock().unwrap().push("b#build");
+                }
+                TaskCompletion::Passed
+            },
+            on_task_skipped: &|_| {},
+        },
+    );
+
+    assert_eq!(ran.into_inner().unwrap(), vec!["a#build", "c#lint", "b#build"]);
 }
 
 #[test]

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -10,7 +10,11 @@ use pnpm_reporter::LogEvent;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::{Condvar, Mutex},
+    sync::{
+        Condvar, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
 };
 
 const WORKSPACE_DIR: &str = "/workspace";
@@ -52,6 +56,7 @@ fn tasks(entries: &[(&str, Option<&[&str]>)]) -> IndexMap<String, TaskSettings> 
             (
                 name.to_string(),
                 TaskSettings {
+                    concurrency: None,
                     depends_on: depends_on.map(|entries| {
                         entries.iter().map(std::string::ToString::to_string).collect()
                     }),
@@ -129,6 +134,19 @@ fn explicitly_empty_depends_on_means_the_task_depends_on_nothing() {
     );
 
     assert!(graph[&key("a", "lint")].dependencies.is_empty());
+}
+
+#[test]
+fn task_carries_its_configured_concurrency_limit_into_the_graph() {
+    let mut settings = tasks(&[("build", Some(&[]))]);
+    settings.get_mut("build").unwrap().concurrency = Some(1);
+    let graph = build_graph(
+        &[("a", project(&[], &["build"])), ("b", project(&[], &["build"]))],
+        "build",
+        Some(&settings),
+    );
+
+    assert_eq!(graph.values().map(|node| node.concurrency).collect::<Vec<_>>(), vec![Some(1); 2]);
 }
 
 #[test]
@@ -328,6 +346,70 @@ fn scheduler_runs_tasks_in_dependency_order() {
         vec![dir("c").to_string_lossy().into_owned(), dir("a").to_string_lossy().into_owned()],
     );
     assert_eq!(skipped.into_inner().unwrap(), vec![dir("b").to_string_lossy().into_owned()]);
+}
+
+#[test]
+fn scheduler_respects_task_concurrency_across_projects() {
+    let mut settings = tasks(&[("build", Some(&[]))]);
+    settings.get_mut("build").unwrap().concurrency = Some(1);
+    let graph = build_graph(
+        &[
+            ("a", project(&[], &["build"])),
+            ("b", project(&[], &["build"])),
+            ("c", project(&[], &["build"])),
+        ],
+        "build",
+        Some(&settings),
+    );
+    let active = AtomicUsize::new(0);
+    let max_active = AtomicUsize::new(0);
+    schedule_tasks(
+        &graph,
+        &ScheduleTasksOptions {
+            concurrency: 3,
+            bail: true,
+            run_task: &|_| {
+                let current = active.fetch_add(1, Ordering::SeqCst) + 1;
+                max_active.fetch_max(current, Ordering::SeqCst);
+                std::thread::sleep(Duration::from_millis(20));
+                active.fetch_sub(1, Ordering::SeqCst);
+                TaskCompletion::Passed
+            },
+            on_task_skipped: &|_| {},
+        },
+    );
+
+    assert_eq!(max_active.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn task_waiting_for_a_concurrency_permit_stays_undispatched_after_bail() {
+    let mut settings = tasks(&[("build", Some(&[]))]);
+    settings.get_mut("build").unwrap().concurrency = Some(1);
+    let graph = build_graph(
+        &[
+            ("a", project(&[], &["build"])),
+            ("b", project(&[], &["build"])),
+            ("c", project(&[], &["build"])),
+        ],
+        "build",
+        Some(&settings),
+    );
+    let ran = Mutex::new(Vec::new());
+    schedule_tasks(
+        &graph,
+        &ScheduleTasksOptions {
+            concurrency: 3,
+            bail: true,
+            run_task: &|node| {
+                ran.lock().unwrap().push(node.project.clone());
+                TaskCompletion::Failed
+            },
+            on_task_skipped: &|_| {},
+        },
+    );
+
+    assert_eq!(ran.into_inner().unwrap(), vec![dir("a")]);
 }
 
 #[test]

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -107,7 +107,7 @@ export function getOptionsFromPnpmSettings (
 }
 
 /** The fields a `tasks` entry may carry. Anything else is a typo. */
-const TASK_SETTING_FIELDS = new Set(['dependsOn'])
+const TASK_SETTING_FIELDS = new Set(['concurrency', 'dependsOn'])
 
 // The section feeds the task-graph builder of `pnpm -r run`, which reads it
 // without further checks — a malformed entry has to be rejected here rather
@@ -122,6 +122,11 @@ function assertValidTasks (tasks: unknown): asserts tasks is NonNullable<PnpmSet
       throw new PnpmError('INVALID_SETTING',
         `The "${taskPath}.${field}" setting is not a known task setting.`,
         { hint: `A task declares ${quoteAndJoin([...TASK_SETTING_FIELDS])}.` })
+    }
+    const concurrency = (task as { concurrency?: unknown }).concurrency
+    if (concurrency != null && (!Number.isInteger(concurrency) || (concurrency as number) < 1)) {
+      throw new PnpmError('INVALID_SETTING',
+        `The "${taskPath}.concurrency" setting should be a positive integer, but got ${JSON.stringify(concurrency)}`)
     }
     const dependsOn = (task as { dependsOn?: unknown }).dependsOn
     if (dependsOn == null) continue

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -671,13 +671,13 @@ test('getOptionsFromPnpmSettings() rejects an unknown virtualStoreType', () => {
 test('getOptionsFromPnpmSettings() passes a valid tasks section through', () => {
   const options = getOptionsFromPnpmSettings(process.cwd(), {
     tasks: {
-      build: { dependsOn: ['^build'] },
+      build: { concurrency: 2, dependsOn: ['^build'] },
       test: { dependsOn: ['build'] },
       lint: {},
     },
   })
   expect(options.tasks).toStrictEqual({
-    build: { dependsOn: ['^build'] },
+    build: { concurrency: 2, dependsOn: ['^build'] },
     test: { dependsOn: ['build'] },
     lint: {},
   })
@@ -705,4 +705,10 @@ test('getOptionsFromPnpmSettings() rejects a dependsOn entry with no task name',
   expect(() => getOptionsFromPnpmSettings(process.cwd(), {
     tasks: { build: { dependsOn: ['^'] } },
   })).toThrow(/The "tasks\['build'\].dependsOn" setting contains an entry with no task name: "\^"/)
+})
+
+test.each([0, -1, 1.5, '2'])('getOptionsFromPnpmSettings() rejects invalid task concurrency %p', (concurrency) => {
+  expect(() => getOptionsFromPnpmSettings(process.cwd(), {
+    tasks: { build: { concurrency } } as never,
+  })).toThrow(/The "tasks\['build'\].concurrency" setting should be a positive integer/)
 })

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -246,6 +246,8 @@ export interface WorkspaceTasks {
 }
 
 export interface WorkspaceTaskSettings {
+  /** Maximum number of instances of this task that may run at once. */
+  concurrency?: number
   /**
    * The tasks that must complete before this one may start. A `^name` entry
    * names the task in each of the project's workspace dependencies; a bare

--- a/pnpm11/core/types/src/package.ts
+++ b/pnpm11/core/types/src/package.ts
@@ -246,7 +246,6 @@ export interface WorkspaceTasks {
 }
 
 export interface WorkspaceTaskSettings {
-  /** Maximum number of instances of this task that may run at once. */
   concurrency?: number
   /**
    * The tasks that must complete before this one may start. A `^name` entry

--- a/pnpm11/exec/commands/test/runTasks.e2e.ts
+++ b/pnpm11/exec/commands/test/runTasks.e2e.ts
@@ -144,6 +144,49 @@ test('a task with an explicitly empty dependsOn starts without waiting for anyth
   expect(server.getLines()).toStrictEqual(['dependent', 'dependency'])
 })
 
+test('a task concurrency limit applies across workspace projects', async () => {
+  preparePackages(['project-a', 'project-b', 'project-c'].map((name) => ({
+    name,
+    version: '1.0.0',
+    scripts: {
+      build: `node ../concurrency-probe.cjs ${name}`,
+    },
+  })))
+  fs.writeFileSync(path.join(process.cwd(), 'concurrency-probe.cjs'), `const fs = require('fs')
+const path = require('path')
+const lock = path.join(__dirname, 'build-active')
+let ownsLock = false
+try {
+  fs.mkdirSync(lock)
+  ownsLock = true
+} catch (error) {
+  if (error.code !== 'EEXIST') throw error
+  fs.writeFileSync(path.join(__dirname, 'exceeded-task-concurrency'), '')
+}
+setTimeout(() => {
+  if (ownsLock) fs.rmdirSync(lock)
+  fs.writeFileSync(path.join(__dirname, 'ran-' + process.argv[2]), '')
+}, 200)
+`)
+
+  await run.handler({
+    ...DEFAULT_OPTS,
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    dir: process.cwd(),
+    recursive: true,
+    tasks: {
+      build: { concurrency: 1 },
+    },
+    workspaceConcurrency: 4,
+    workspaceDir: process.cwd(),
+  }, ['build'])
+
+  expect(fs.existsSync(path.join(process.cwd(), 'exceeded-task-concurrency'))).toBe(false)
+  for (const name of ['project-a', 'project-b', 'project-c']) {
+    expect(fs.existsSync(path.join(process.cwd(), `ran-${name}`))).toBe(true)
+  }
+})
+
 test('a project without the script is reported skipped and does not sever the chain', async () => {
   await using server = await createTestIpcServer()
 

--- a/pnpm11/workspace/task-scheduler/src/taskGraph.ts
+++ b/pnpm11/workspace/task-scheduler/src/taskGraph.ts
@@ -15,6 +15,8 @@ export type TaskKey = string
 export interface TaskNode {
   project: ProjectRootDir
   taskName: string
+  /** Maximum number of instances of this task that may run at once. */
+  concurrency?: number
   /**
    * The scripts of the project that the task name selected — several when the
    * task name is a RegExp selector. Empty when the project has no such
@@ -85,12 +87,19 @@ export function buildTaskGraph (opts: BuildTaskGraphOptions): TaskGraph {
     graph.set(key, {
       project,
       taskName,
+      concurrency: taskConcurrency(opts.tasks, taskName),
       scripts: opts.selectScripts(opts.scriptsByProject(project), taskName),
       requested,
       dependencies: [...dependencies],
     })
   }
   return graph
+}
+
+function taskConcurrency (tasks: WorkspaceTasks | undefined, taskName: string): number | undefined {
+  return tasks != null && Object.hasOwn(tasks, taskName)
+    ? tasks[taskName].concurrency
+    : undefined
 }
 
 export function taskKey (project: ProjectRootDir, taskName: string): TaskKey {

--- a/pnpm11/workspace/task-scheduler/src/taskGraph.ts
+++ b/pnpm11/workspace/task-scheduler/src/taskGraph.ts
@@ -15,7 +15,6 @@ export type TaskKey = string
 export interface TaskNode {
   project: ProjectRootDir
   taskName: string
-  /** Maximum number of instances of this task that may run at once. */
   concurrency?: number
   /**
    * The scripts of the project that the task name selected — several when the

--- a/pnpm11/workspace/task-scheduler/src/taskScheduler.ts
+++ b/pnpm11/workspace/task-scheduler/src/taskScheduler.ts
@@ -61,7 +61,7 @@ export async function scheduleTasks (graph: TaskGraph, opts: ScheduleTasksOption
   for (const [key, node] of graph) {
     dependencies.set(key, node.dependencies)
   }
-  await scheduleGraph(dependencies, {
+  await scheduleGraphWithConcurrencyLimits(dependencies, {
     bail: opts.bail,
     finishInFlight: false,
     runNode: async (key) => {
@@ -73,6 +73,11 @@ export async function scheduleTasks (graph: TaskGraph, opts: ScheduleTasksOption
       return opts.runTask(node, key)
     },
     onNodeSkipped: (key) => opts.onTaskSkipped(graph.get(key)!, key),
+  }, (key) => {
+    const node = graph.get(key)!
+    return node.concurrency == null || node.scripts.length === 0
+      ? undefined
+      : { group: node.taskName, limit: normalizeConcurrency(node.concurrency) }
   })
 }
 
@@ -86,6 +91,26 @@ export async function scheduleGraph<Node> (
   graph: DependencyGraph<Node>,
   opts: ScheduleGraphOptions<Node>
 ): Promise<void> {
+  await scheduleGraphWithConcurrencyLimits(graph, opts)
+}
+
+interface ConcurrencyLimit {
+  group: string
+  limit: number
+}
+
+interface ConcurrencyGroup<Node> {
+  limit: number
+  reserved: number
+  waiting: Node[]
+  waitingHead: number
+}
+
+async function scheduleGraphWithConcurrencyLimits<Node> (
+  graph: DependencyGraph<Node>,
+  opts: ScheduleGraphOptions<Node>,
+  concurrencyLimit?: (node: Node) => ConcurrencyLimit | undefined
+): Promise<void> {
   // A rejection violates runTask's contract; held here so the run still
   // fails with it rather than silently resolving. First error wins: a
   // rejection landing only after something else already stopped the run is
@@ -97,6 +122,8 @@ export async function scheduleGraph<Node> (
   const pendingDependencyCount = new Map<Node, number>()
   const dependents = new Map<Node, Node[]>()
   const ready: Node[] = []
+  const nodeConcurrencyGroups = new Map<Node, string>()
+  const concurrencyGroups = new Map<string, ConcurrencyGroup<Node>>()
   const order = graphSequencer(graph).order
   const orderIndex = new Map(order.map((node, index) => [node, index]))
   for (const [node, dependencies] of graph) {
@@ -104,9 +131,6 @@ export async function scheduleGraph<Node> (
       (dependency) => orderIndex.get(dependency)! < orderIndex.get(node)!
     )
     pendingDependencyCount.set(node, orderedDependencies.length)
-    if (orderedDependencies.length === 0) {
-      ready.push(node)
-    }
     for (const dependency of orderedDependencies) {
       let list = dependents.get(dependency)
       if (list == null) {
@@ -118,6 +142,45 @@ export async function scheduleGraph<Node> (
   const blocked = new Set<Node>()
   let stopDispatch = false
   let unsettled = graph.size
+
+  const makeReady = (node: Node): void => {
+    const concurrency = concurrencyLimit?.(node)
+    if (concurrency == null) {
+      ready.push(node)
+      return
+    }
+    nodeConcurrencyGroups.set(node, concurrency.group)
+    let group = concurrencyGroups.get(concurrency.group)
+    if (group == null) {
+      concurrencyGroups.set(concurrency.group, group = {
+        limit: concurrency.limit,
+        reserved: 0,
+        waiting: [],
+        waitingHead: 0,
+      })
+    }
+    if (group.reserved < group.limit) {
+      group.reserved++
+      ready.push(node)
+    } else {
+      group.waiting.push(node)
+    }
+  }
+
+  const releaseConcurrency = (node: Node): void => {
+    const groupName = nodeConcurrencyGroups.get(node)
+    if (groupName == null) return
+    const group = concurrencyGroups.get(groupName)!
+    group.reserved--
+    if (group.waitingHead < group.waiting.length) {
+      group.reserved++
+      ready.push(group.waiting[group.waitingHead++])
+    }
+  }
+
+  for (const [node, count] of pendingDependencyCount) {
+    if (count === 0) makeReady(node)
+  }
 
   await new Promise<void>((resolve) => {
     const settleIfDone = (): void => {
@@ -134,7 +197,7 @@ export async function scheduleGraph<Node> (
         const remaining = pendingDependencyCount.get(dependent)! - 1
         pendingDependencyCount.set(dependent, remaining)
         if (remaining === 0 && !blocked.has(dependent)) {
-          ready.push(dependent)
+          makeReady(dependent)
         }
       }
     }
@@ -190,10 +253,12 @@ export async function scheduleGraph<Node> (
         active++
         opts.runNode(node).then((completion) => {
           active--
+          releaseConcurrency(node)
           settle(node, completion)
           pump()
         }, (error: unknown) => {
           active--
+          releaseConcurrency(node)
           // runTask's contract is to never reject; treated as an abort, and
           // the error resurfaces once the scheduler settles.
           if (!rejected) {

--- a/pnpm11/workspace/task-scheduler/test/taskGraph.test.ts
+++ b/pnpm11/workspace/task-scheduler/test/taskGraph.test.ts
@@ -60,6 +60,17 @@ test('an explicitly empty dependsOn means the task depends on nothing', () => {
   expect(graph.get(taskKey(dir('a'), 'lint'))!.dependencies).toStrictEqual([])
 })
 
+test('a task carries its configured concurrency limit into the graph', () => {
+  const graph = buildGraph({
+    a: { scripts: ['build'] },
+    b: { scripts: ['build'] },
+  }, 'build', {
+    build: { concurrency: 1, dependsOn: [] },
+  })
+
+  expect([...graph.values()].map((node) => node.concurrency)).toStrictEqual([1, 1])
+})
+
 test('a project without the script becomes a pass-through node that keeps the chain', () => {
   const graph = buildGraph({
     a: { dependencies: ['b'], scripts: ['build'] },
@@ -282,7 +293,7 @@ interface FakeProject {
 function buildGraph (
   projects: Record<string, FakeProject>,
   taskName: string,
-  tasks?: Record<string, { dependsOn?: string[] }>
+  tasks?: Record<string, { concurrency?: number, dependsOn?: string[] }>
 ): TaskGraph {
   const scriptsByDir = new Map<ProjectRootDir, PackageScripts>(
     Object.entries(projects).map(([name, project]) => [

--- a/pnpm11/workspace/task-scheduler/test/taskScheduler.test.ts
+++ b/pnpm11/workspace/task-scheduler/test/taskScheduler.test.ts
@@ -112,6 +112,62 @@ test('an aborted task stops dispatch and the scheduler still settles', async () 
   expect(ran).toStrictEqual(['/workspace/a'])
 })
 
+test('task concurrency limits instances without blocking other task names', async () => {
+  let releaseFirstBuild!: () => void
+  const firstBuild = new Promise<void>((resolve) => {
+    releaseFirstBuild = resolve
+  })
+  let activeBuilds = 0
+  let maxActiveBuilds = 0
+  const ran: string[] = []
+  const graph = independentTaskGraph([
+    ['a', 'build', 1],
+    ['b', 'build', 1],
+    ['c', 'lint', 1],
+  ])
+
+  await scheduleTasks(graph, {
+    bail: true,
+    runTask: async (node) => {
+      ran.push(`${node.project}#${node.taskName}`)
+      if (node.taskName === 'build') {
+        activeBuilds++
+        maxActiveBuilds = Math.max(maxActiveBuilds, activeBuilds)
+        if (node.project.endsWith('/a')) await firstBuild
+        activeBuilds--
+      } else {
+        releaseFirstBuild()
+      }
+      return 'passed'
+    },
+    onTaskSkipped: () => {},
+  })
+
+  expect(maxActiveBuilds).toBe(1)
+  expect(ran).toStrictEqual([
+    '/workspace/a#build',
+    '/workspace/c#lint',
+    '/workspace/b#build',
+  ])
+})
+
+test('a task waiting for a concurrency permit stays undispatched after bail', async () => {
+  const ran: string[] = []
+  await scheduleTasks(independentTaskGraph([
+    ['a', 'build', 1],
+    ['b', 'build', 1],
+    ['c', 'build', 1],
+  ]), {
+    bail: true,
+    runTask: async (node) => {
+      ran.push(node.project)
+      return 'failed'
+    },
+    onTaskSkipped: () => {},
+  })
+  expect(ran).toStrictEqual(['/workspace/a'])
+})
+
 test('a rejected runTask stops dispatch and resurfaces as the scheduler\'s failure', async () => {
   const graph = chainGraph()
   const ran: string[] = []
@@ -142,4 +198,19 @@ function chainGraph (): TaskGraph {
     previous = key
   }
   return graph
+}
+
+function independentTaskGraph (tasks: Array<[string, string, number]>): TaskGraph {
+  return new Map(tasks.map(([name, taskName, concurrency]) => {
+    const project = `/workspace/${name}` as ProjectRootDir
+    const key = taskKey(project, taskName)
+    return [key, {
+      project,
+      taskName,
+      concurrency,
+      scripts: [taskName],
+      requested: true,
+      dependencies: [],
+    }] as const
+  }))
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Adds `tasks.<name>.concurrency` to `pnpm-workspace.yaml`, limiting how many instances of a named task may run across workspace projects at once.

The shared task scheduler reserves per-task permits before dispatch. Permit waiters therefore do not consume the global workspace concurrency, and remain undispatched if `--bail` stops the run. TypeScript pnpm and pacquet implement and validate the same setting.

Related to pnpm/pnpm#14211 (item 3, per-task concurrency limits).

## Squash Commit Body

```text
Add an optional positive-integer concurrency limit to workspace task settings and carry it onto resolved task nodes.

Reserve permits in the dependency-ready scheduler rather than inside workers. This lets unrelated task names use available workspace capacity, while tasks waiting on their own limit remain undispatched and do not start after a bailed failure.

Implement matching configuration validation, scheduling behavior, and integration coverage in the TypeScript CLI and pacquet.

Implements the per-task concurrency extension from pnpm/pnpm#14211.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790429199&installation_model_id=426870&pr_number=14229&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14229&signature=7215bfcafdf839bc41c57de01bf322a78a07e077b4c7b741669b5445820a6a7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-task concurrency limits for workspace tasks through `pnpm-workspace.yaml`.
  * Limits apply across workspace projects independently by task name.
  * Tasks without a configured limit continue using existing scheduling behavior.
  * Waiting tasks resume automatically when capacity becomes available.

* **Bug Fixes**
  * Invalid concurrency values, including zero, negative numbers, decimals, and non-numeric values, now produce clear validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->