### PR TITLE
fix(cli): recognize the `pm` command prefix

### DIFF
--- a/.changeset/pm-prefix-forces-builtin-command.md
+++ b/.changeset/pm-prefix-forces-builtin-command.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm pm <command>` works again: the `pm` prefix, which forces pnpm's built-in command over a `package.json` script of the same name, is recognized instead of failing with `ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` / `Command "pm" not found`. `pnpm pm clean` and `pnpm pm purge` now remove `node_modules` even when the project (or the workspace root) declares a `clean` / `purge` script [#14226](https://github.com/pnpm/pnpm/issues/14226).

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -11,7 +11,8 @@ use std::path::{Path, PathBuf};
 /// directories of the current project (or every project in the workspace)
 /// without following NTFS junctions into their targets. A `clean` /
 /// `purge` script in `package.json` overrides the built-in command,
-/// mirroring pnpm's `overridableByScript` flag.
+/// mirroring pnpm's `overridableByScript` flag; `pnpm pm clean` /
+/// `pnpm pm purge` runs the built-in regardless.
 #[derive(Debug, clap::Args)]
 pub struct CleanArgs {
     /// Also remove `pnpm-lock.yaml` files.
@@ -45,6 +46,11 @@ const PNPM_HIDDEN_ENTRIES: &[&str] =
 impl CleanArgs {
     pub fn run(self, ctx: &RunCtx<'_>, command_name: &str) -> miette::Result<()> {
         let config = (ctx.config)()?;
+        // A `pm` prefix (`pnpm pm clean`) demands the built-in command, so
+        // no script gets to replace it.
+        if ctx.builtin_command_forced {
+            return clean_builtin(ctx, config, self.lockfile);
+        }
         // A `<command_name>` script in the current project's `package.json`
         // replaces the built-in command.
         if let Some(script) = script_of(read_project_manifest_only(ctx.dir).ok(), command_name)

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -46,8 +46,6 @@ const PNPM_HIDDEN_ENTRIES: &[&str] =
 impl CleanArgs {
     pub fn run(self, ctx: &RunCtx<'_>, command_name: &str) -> miette::Result<()> {
         let config = (ctx.config)()?;
-        // A `pm` prefix (`pnpm pm clean`) demands the built-in command, so
-        // no script gets to replace it.
         if ctx.builtin_command_forced {
             return clean_builtin(ctx, config, self.lockfile);
         }

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -45,6 +45,10 @@ pub(crate) struct RunCtx<'a> {
     /// The top-level `--if-present` spelling (`pnpm --if-present test`);
     /// merged with the flag the script subcommands declare themselves.
     pub(crate) if_present: bool,
+    /// Whether a `pm` prefix (`pnpm pm clean`) forced the built-in
+    /// command, so a `package.json` script of the same name must not
+    /// override it. See [`crate::pm_prefix`].
+    pub(crate) builtin_command_forced: bool,
     pub(crate) config: &'a (dyn Fn() -> miette::Result<&'static mut Config> + Sync),
     /// Like [`Self::config`] but anchored at the pnpm home dir instead of
     /// `--dir`, so a `-g` install can't inherit the caller project's
@@ -174,8 +178,14 @@ impl CliArgs {
     /// tokens already stripped from argv by [`ConfigOverrides::extract`];
     /// they're layered on top of `.npmrc` / `pnpm-workspace.yaml` whenever
     /// `Config` is loaded, mirroring pnpm 11's
-    /// "CLI > yaml > .npmrc > defaults" precedence.
-    pub async fn run(self, config_overrides: &ConfigOverrides) -> miette::Result<()> {
+    /// "CLI > yaml > .npmrc > defaults" precedence. `builtin_command_forced`
+    /// carries the `pm` prefix stripped from argv by
+    /// [`crate::pm_prefix::strip_prefix`].
+    pub async fn run(
+        self,
+        config_overrides: &ConfigOverrides,
+        builtin_command_forced: bool,
+    ) -> miette::Result<()> {
         if self.run_completion_if_requested()? {
             return Ok(());
         }
@@ -437,6 +447,7 @@ impl CliArgs {
             recursive_report_summary: report_summary,
             recursive_parallel: parallel,
             if_present,
+            builtin_command_forced,
             config: &config,
             global_config: &global_config,
             config_self_update: &config_self_update,

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -11,6 +11,7 @@ mod job_control;
 mod leading_separator;
 mod parse_boundary;
 mod path_env;
+mod pm_prefix;
 mod renamed_options;
 mod shim_dispatch;
 mod shorthands;
@@ -81,6 +82,12 @@ fn run_cli() -> miette::Result<()> {
         std::process::exit(exit_code);
     }
     let child_argv = argv_with_alias.iter().skip(1).cloned().collect::<Vec<_>>();
+    // `pnpm pm <cmd>` forces pnpm's built-in `<cmd>` over a `package.json`
+    // script of the same name. The prefix is dropped here, before every
+    // other pass, so the rest of the command line parses as usual; the
+    // child argv above keeps it, since a dispatched pnpm has to force the
+    // built-in too. See `pm_prefix`.
+    let (argv_with_alias, builtin_command_forced) = pm_prefix::strip_prefix(argv_with_alias);
     let (config_overrides, argv) = ConfigOverrides::extract(argv_with_alias);
     // `pnpm with current <cmd>` is sugar for running `<cmd>` in-process with
     // the packageManager / devEngines check disabled; rewrite argv before
@@ -170,7 +177,7 @@ fn run_cli() -> miette::Result<()> {
     // default to 8 MiB, so the limit trips on Windows first). Run it on a
     // thread with a generous, platform-uniform stack instead of the OS
     // default main-thread stack.
-    block_on_runtime("pacquet-main", args.run(&config_overrides))
+    block_on_runtime("pacquet-main", args.run(&config_overrides, builtin_command_forced))
 }
 
 /// Stack size for the thread the command runs on. Generous headroom over

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -82,11 +82,10 @@ fn run_cli() -> miette::Result<()> {
         std::process::exit(exit_code);
     }
     let child_argv = argv_with_alias.iter().skip(1).cloned().collect::<Vec<_>>();
-    // `pnpm pm <cmd>` forces pnpm's built-in `<cmd>` over a `package.json`
-    // script of the same name. The prefix is dropped here, before every
-    // other pass, so the rest of the command line parses as usual; the
-    // child argv above keeps it, since a dispatched pnpm has to force the
-    // built-in too. See `pm_prefix`.
+    // `pnpm pm <cmd>` is stripped before every other pass, so they all see
+    // the command line the prefix stands for; the child argv above keeps
+    // it, since a dispatched pnpm has to force the built-in too. See
+    // `pm_prefix`.
     let (argv_with_alias, builtin_command_forced) = pm_prefix::strip_prefix(argv_with_alias);
     let (config_overrides, argv) = ConfigOverrides::extract(argv_with_alias);
     // `pnpm with current <cmd>` is sugar for running `<cmd>` in-process with

--- a/pnpm/crates/cli/src/pm_prefix.rs
+++ b/pnpm/crates/cli/src/pm_prefix.rs
@@ -1,0 +1,27 @@
+//! `pnpm pm <cmd>` as a way to force pnpm's built-in command.
+//!
+//! A few built-in commands (`clean`, `purge`, ...) step aside when the
+//! current project declares a `package.json` script by the same name. The
+//! `pm` prefix opts out of that: it forces the built-in even when such a
+//! script exists (<https://pnpm.io/cli/pm>).
+//!
+//! `pm` is not a command of its own — it is stripped from argv before clap
+//! parses it, so the rest of the command line is dispatched exactly as if
+//! the prefix had not been typed. Like pnpm, only a `pm` written as the
+//! very first token counts; anywhere else it is an ordinary argument.
+
+use std::ffi::OsString;
+
+/// Split a leading `pm` token off `argv` (program name at index 0),
+/// returning the argv clap should parse and whether the built-in command
+/// was forced.
+pub(crate) fn strip_prefix(mut argv: Vec<OsString>) -> (Vec<OsString>, bool) {
+    let builtin_command_forced = argv.get(1).is_some_and(|token| token == "pm");
+    if builtin_command_forced {
+        argv.remove(1);
+    }
+    (argv, builtin_command_forced)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/pm_prefix/tests.rs
+++ b/pnpm/crates/cli/src/pm_prefix/tests.rs
@@ -1,0 +1,44 @@
+use super::strip_prefix;
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn stripped(tokens: &[&str]) -> (Vec<String>, bool) {
+    let (argv, forced) = strip_prefix(tokens.iter().map(OsString::from).collect());
+    let argv =
+        argv.into_iter().map(|token| token.into_string().expect("test tokens are UTF-8")).collect();
+    (argv, forced)
+}
+
+#[test]
+fn a_leading_pm_token_is_stripped() {
+    let (argv, forced) = stripped(&["pnpm", "pm", "clean", "--lockfile"]);
+    assert_eq!(argv, ["pnpm", "clean", "--lockfile"]);
+    assert!(forced, "the built-in command is forced");
+}
+
+#[test]
+fn a_bare_pm_leaves_no_command() {
+    let (argv, forced) = stripped(&["pnpm", "pm"]);
+    assert_eq!(argv, ["pnpm"]);
+    assert!(forced);
+}
+
+#[test]
+fn a_pm_elsewhere_on_the_command_line_is_an_ordinary_argument() {
+    for tokens in [
+        ["pnpm", "run", "pm"].as_slice(),
+        ["pnpm", "--dir", "pm", "clean"].as_slice(),
+        ["pnpm", "exec", "pm", "clean"].as_slice(),
+    ] {
+        let (argv, forced) = stripped(tokens);
+        assert_eq!(argv, tokens, "tokens: {tokens:?}");
+        assert!(!forced, "tokens: {tokens:?}");
+    }
+}
+
+#[test]
+fn an_argv_without_a_command_is_left_alone() {
+    let (argv, forced) = stripped(&["pnpm"]);
+    assert_eq!(argv, ["pnpm"]);
+    assert!(!forced);
+}

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -288,8 +288,7 @@ mod scripts {
         drop(root);
     }
 
-    /// `pnpm pm clean` forces the built-in command past a `clean` script
-    /// (pnpm/pnpm#14226).
+    /// [pnpm/pnpm#14226](https://github.com/pnpm/pnpm/issues/14226)
     #[test]
     fn pm_clean_runs_the_builtin_when_a_clean_script_exists() {
         let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -309,9 +308,6 @@ mod scripts {
         drop(root);
     }
 
-    /// A workspace whose root declares a `clean` script and holds the
-    /// only seeded `node_modules`, plus a member at `packages/a` to run
-    /// the command from.
     fn workspace_with_a_root_clean_script(workspace: &Path) {
         write_manifest(workspace, &serde_json::json!({ "clean": "echo script-clean-ran" }));
         fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
@@ -341,8 +337,6 @@ mod scripts {
         drop(root);
     }
 
-    /// A `pm` prefix also lifts the refusal to run the built-in from a
-    /// workspace subdirectory whose root declares the script.
     #[test]
     fn pm_clean_runs_the_builtin_from_a_workspace_subdirectory() {
         let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -287,4 +287,79 @@ mod scripts {
 
         drop(root);
     }
+
+    /// `pnpm pm clean` forces the built-in command past a `clean` script
+    /// (pnpm/pnpm#14226).
+    #[test]
+    fn pm_clean_runs_the_builtin_when_a_clean_script_exists() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        write_manifest(&workspace, &serde_json::json!({ "clean": "echo script-clean-ran" }));
+        let node_modules = workspace.join("node_modules");
+        fs::create_dir_all(&node_modules).expect("create node_modules");
+        seed_package(&node_modules, "lodash");
+
+        let output = pacquet.with_args(["pm", "clean"]).output().expect("run pacquet pm clean");
+        assert!(output.status.success(), "pacquet pm clean should succeed");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(!stdout.contains("script-clean-ran"), "the script must not run: {stdout}");
+        assert!(!node_modules.join("lodash").exists(), "the built-in must clean node_modules");
+
+        drop(root);
+    }
+
+    /// A workspace whose root declares a `clean` script and holds the
+    /// only seeded `node_modules`, plus a member at `packages/a` to run
+    /// the command from.
+    fn workspace_with_a_root_clean_script(workspace: &Path) {
+        write_manifest(workspace, &serde_json::json!({ "clean": "echo script-clean-ran" }));
+        fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+            .expect("write pnpm-workspace.yaml");
+        let member = workspace.join("packages").join("a");
+        fs::create_dir_all(&member).expect("create the workspace member");
+        write_manifest(&member, &serde_json::json!({}));
+        let node_modules = workspace.join("node_modules");
+        fs::create_dir_all(&node_modules).expect("create node_modules");
+        seed_package(&node_modules, "lodash");
+    }
+
+    #[test]
+    fn clean_from_a_workspace_subdirectory_refuses_when_the_root_declares_the_script() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        workspace_with_a_root_clean_script(&workspace);
+
+        let output = pacquet
+            .with_args(["clean", "--dir", "packages/a"])
+            .output()
+            .expect("run pacquet clean");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(!output.status.success(), "pacquet clean should fail: {stderr}");
+        assert!(stderr.contains("ERR_PNPM_SCRIPT_OVERRIDE_IN_WORKSPACE_ROOT"), "stderr={stderr}");
+
+        drop(root);
+    }
+
+    /// A `pm` prefix also lifts the refusal to run the built-in from a
+    /// workspace subdirectory whose root declares the script.
+    #[test]
+    fn pm_clean_runs_the_builtin_from_a_workspace_subdirectory() {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+        workspace_with_a_root_clean_script(&workspace);
+
+        let output = pacquet
+            .with_args(["pm", "clean", "--dir", "packages/a"])
+            .output()
+            .expect("run pacquet pm clean");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "pacquet pm clean should succeed: {stderr}");
+        assert!(
+            !workspace.join("node_modules").join("lodash").exists(),
+            "the built-in must clean node_modules",
+        );
+
+        drop(root);
+    }
 }


### PR DESCRIPTION
## Summary

`pnpm pm <command>` is pnpm's escape hatch for running a built-in command that a `package.json` script of the same name would otherwise shadow ([docs](https://pnpm.io/cli/pm)). The Rust CLI never handled the prefix: clap saw `pm` as an unknown subcommand, the run-script fallback claimed it, and `pnpm pm clean` died with

```
Error: ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL

  × Command "pm" not found
```

This adds a pre-parse pass (`crates/cli/src/pm_prefix.rs`, alongside the existing `with_current` / `install_as_add` / `shorthands` passes) that strips a leading `pm` token before clap parses argv, exactly as the TypeScript CLI does in `parseCliArgs`. Like pnpm, only a `pm` written as the very first token counts. The resulting "built-in forced" signal travels through `RunCtx` to `clean` / `purge` — the only commands in the Rust CLI that step aside for a script of their own name today — so `pnpm pm clean` removes `node_modules` even when the project, or the workspace root, declares a `clean` script.

`pm` is not registered as a subcommand (pnpm doesn't either), so it stays out of help and completions and the rest of the command line is dispatched as if the prefix had never been typed. The argv handed to a dispatched pnpm keeps the prefix, since that process has to force the built-in too.

Closes pnpm/pnpm#14226.

**Parity:** the TypeScript CLI already implements this correctly, so this is a Rust-only gap and needs no TypeScript-side change.

**Unrelated bug found while writing the tests** (not fixed here): `pnpm clean` run from a workspace subdirectory cleans the workspace root's `node_modules` for every project instead of each project's own, because `config.modules_dir` is anchored at the workspace root and the leaf is stripped against `--dir`. The TypeScript `clean` resolves `modulesDir` relative to each project. I'll file it separately.

## Squash Commit Body

```text
`pnpm pm <command>` forces pnpm's built-in command over a `package.json`
script of the same name (https://pnpm.io/cli/pm). The Rust CLI had no
handling for the prefix, so clap took `pm` for an unknown subcommand and
the run-script fallback claimed it, failing with
`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL` / `Command "pm" not found`.

Strip a leading `pm` token before clap parses argv, as the TypeScript CLI
does in `parseCliArgs`, and carry the resulting "built-in forced" signal
through `RunCtx` to `clean` / `purge` — the commands that step aside for a
script of their own name today. The prefix is only recognized as the first
token, matching pnpm, and is kept in the argv passed to a dispatched pnpm.

Closes pnpm/pnpm#14226.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790430621&installation_model_id=426870&pr_number=14230&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14230&signature=9f5e5344b6cd123a16e7c22042f1dc74646ecf132b2d47279e24d373f831b8af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `pnpm pm <command>` prefix to force execution of pnpm’s built-in commands when a same-named project script exists.
  * `pnpm pm clean` and `pnpm pm purge` now reliably remove `node_modules`, including when run from workspace subdirectories.
* **Bug Fixes**
  * Prevented conflicts where built-in commands were incorrectly overridden or rejected by project scripts.
* **Documentation**
  * Updated command guidance to explain how the `pm` prefix forces built-in command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->