### PR TITLE
fix(pnpr): reclaim orphaned shared artifact blobs

### DIFF
--- a/.changeset/clean-artifact-orphans.md
+++ b/.changeset/clean-artifact-orphans.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+pnpr reclaims unreferenced shared artifact blobs after ambiguous object-storage write failures once active publications drain.

--- a/.changeset/retry-windows-dir-lock-release.md
+++ b/.changeset/retry-windows-dir-lock-release.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed intermittent `Access is denied` failures when concurrent global commands hand off the global bin lock on Windows.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6211,6 +6211,7 @@ dependencies = [
  "base64 0.23.1",
  "bytes",
  "futures-util",
+ "getrandom 0.4.3",
  "object_store",
  "pnpm-shared-artifact-protocol",
  "pnpr-config",
@@ -6220,6 +6221,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1373,9 +1373,18 @@ fn recursive_run_bail_summary_records_every_in_flight_result() {
         &[
             (
                 "fails",
-                manifest("fails", "while [ ! -f ../passes/ran.txt ]; do sleep 0.01; done; exit 1"),
+                manifest(
+                    "fails",
+                    "i=0; while [ ! -f ../passes/ran.txt ] && [ $i -lt 1000 ]; do i=$((i + 1)); sleep 0.01; done; [ -f ../passes/ran.txt ] || exit 2; touch failed.txt; exit 1",
+                ),
             ),
-            ("passes", manifest("passes", "touch ran.txt")),
+            (
+                "passes",
+                manifest(
+                    "passes",
+                    "touch ran.txt; i=0; while [ ! -f ../fails/failed.txt ] && [ $i -lt 1000 ]; do i=$((i + 1)); sleep 0.01; done; [ -f ../fails/failed.txt ]",
+                ),
+            ),
         ],
     );
 

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1365,12 +1365,18 @@ fn recursive_run_report_summary_records_every_package_status() {
 }
 
 #[test]
-fn recursive_run_bail_summary_records_every_completed_batch_result() {
+fn recursive_run_bail_summary_records_every_in_flight_result() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     let manifest = |name: &str, body: &str| json!({ "name": name, "version": "1.0.0", "scripts": { "build": body } });
     write_workspace(
         &workspace,
-        &[("fails", manifest("fails", "exit 1")), ("passes", manifest("passes", "true"))],
+        &[
+            (
+                "fails",
+                manifest("fails", "while [ ! -f ../passes/ran.txt ]; do sleep 0.01; done; exit 1"),
+            ),
+            ("passes", manifest("passes", "touch ran.txt")),
+        ],
     );
 
     pacquet

--- a/pnpm/crates/fs/src/dir_lock.rs
+++ b/pnpm/crates/fs/src/dir_lock.rs
@@ -16,12 +16,16 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     thread::sleep,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 /// How often the lock directory is retried while another process holds
 /// it.
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// How long a Windows lock-directory release may keep a competing
+/// `create_dir` in the delete-pending state.
+const RELEASE_RETRY_BUDGET: Duration = Duration::from_secs(1);
 
 /// Names the file inside the lock directory that records who took it.
 const OWNER_FILE: &str = "owner";
@@ -58,13 +62,22 @@ impl DirLock {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let deadline = SystemTime::now() + wait;
+        let deadline = Instant::now() + wait;
+        let mut release_retry_started = None;
         loop {
             match fs::create_dir(&path) {
                 Ok(()) => return claim(path).map(Some),
+                Err(error) if is_transient_release_error(&error) => {
+                    let started = release_retry_started.get_or_insert_with(Instant::now);
+                    if Instant::now() >= deadline || started.elapsed() >= RELEASE_RETRY_BUDGET {
+                        return Err(error);
+                    }
+                    sleep(POLL_INTERVAL);
+                    continue;
+                }
                 Err(error) if error.kind() != io::ErrorKind::AlreadyExists => return Err(error),
                 // Held by someone else: fall through to the wait below.
-                Err(_) => {}
+                Err(_) => release_retry_started = None,
             }
             if is_abandoned(&path, abandoned_after) {
                 // Best-effort: whoever removes it first wins the next
@@ -73,11 +86,25 @@ impl DirLock {
                 let _ = fs::remove_dir_all(&path);
                 continue;
             }
-            if SystemTime::now() >= deadline {
+            if Instant::now() >= deadline {
                 return Ok(None);
             }
             sleep(POLL_INTERVAL);
         }
+    }
+}
+
+fn is_transient_release_error(
+    #[cfg_attr(not(windows), allow(unused, reason = "only inspected on Windows"))]
+    error: &io::Error,
+) -> bool {
+    #[cfg(windows)]
+    {
+        matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
+    }
+    #[cfg(not(windows))]
+    {
+        false
     }
 }
 

--- a/pnpm/crates/fs/src/dir_lock/tests.rs
+++ b/pnpm/crates/fs/src/dir_lock/tests.rs
@@ -1,5 +1,5 @@
 use super::DirLock;
-use std::{fs, thread::sleep, time::Duration};
+use std::{fs, io, thread::sleep, time::Duration};
 use tempfile::tempdir;
 
 /// How long the tests age a lock before declaring it abandoned, and the
@@ -100,4 +100,16 @@ fn claiming_a_directory_that_cannot_hold_the_record_fails() {
     let error = super::claim(path.clone()).expect_err("an unrecordable lock is not taken");
 
     assert!(!path.exists(), "the lock directory is given back: {error}");
+}
+
+#[test]
+fn transient_release_error_classifier_is_windows_specific() {
+    for kind in [io::ErrorKind::PermissionDenied, io::ErrorKind::ResourceBusy] {
+        let error = io::Error::from(kind);
+        assert_eq!(super::is_transient_release_error(&error), cfg!(windows), "{kind:?}");
+    }
+
+    for kind in [io::ErrorKind::NotFound, io::ErrorKind::InvalidInput, io::ErrorKind::Other] {
+        assert!(!super::is_transient_release_error(&io::Error::from(kind)), "{kind:?}");
+    }
 }

--- a/pnpr/client/README.md
+++ b/pnpr/client/README.md
@@ -197,14 +197,17 @@ The PoC implements the main trust boundary from the
 
 Publication reserves quota before immutable, create-only object writes. S3
 replicas coordinate the quota counter with conditional writes; local storage
-uses an advisory lock around its counter. Ambiguous object-store write failures
-remain charged because the object may have been committed before the error was
-returned. This can conservatively overcount storage, but cannot allow the 1 GiB
-per-owner or 10 GiB global limits to be exceeded. The eight-variant response cap
-is enforced while resolving artifacts. With artifact writers quiesced, operators
-can reconcile conservative overcount by removing the object-store `quota.json`
-or local `.locks/usage.json`; the next publication rebuilds it from stored
-objects.
+uses an advisory lock around its counter. Publications register before reading
+or writing blobs. After an ambiguous object-store write failure, one replica
+waits for those registrations to drain, blocks new publications, removes blobs
+that no stored envelope references, and rebuilds quota from physical objects.
+This keeps the 1 GiB per-owner and 10 GiB global limits fail-safe without
+permanently charging ordinary failed writes. A terminated process can leave a
+registration or reclamation gate behind. With artifact writers quiesced,
+operators can recover by removing the object-store `quota.json` or local
+`.locks/usage.json`; the next publication rebuilds the counter and runs
+reclamation. The eight-variant response cap is enforced while resolving
+artifacts.
 
 ### v0 compatibility tags
 

--- a/pnpr/crates/shared-artifacts/Cargo.toml
+++ b/pnpr/crates/shared-artifacts/Cargo.toml
@@ -17,12 +17,14 @@ pnpm-shared-artifact-protocol = { workspace = true }
 base64                        = { workspace = true }
 bytes                         = { workspace = true }
 futures-util                  = { workspace = true }
+getrandom                     = { workspace = true }
 object_store                  = { workspace = true }
 serde                         = { workspace = true }
 serde_json                    = { workspace = true }
 sha2                          = { workspace = true }
 tempfile                      = { workspace = true }
 tokio                         = { workspace = true }
+tracing                       = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashSet},
     fs::{File, OpenOptions, TryLockError},
     path::{Path, PathBuf},
     sync::Arc,
@@ -31,12 +31,20 @@ const ARTIFACT_USAGE_FILE: &str = ".locks/usage.json";
 const ARTIFACT_QUOTA_OBJECT: &str = "quota.json";
 const MAX_OWNER_ARTIFACT_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_GLOBAL_ARTIFACT_BYTES: u64 = 10 * MAX_OWNER_ARTIFACT_BYTES;
+const MAX_ACTIVE_PUBLICATIONS: usize = 1024;
 const QUOTA_WRITE_RETRIES: usize = 32;
+const RECLAMATION_WAIT_RETRIES: usize = 600;
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 struct ArtifactUsage {
     global_bytes: u64,
     owner_bytes: BTreeMap<String, u64>,
+    #[serde(default)]
+    active_publications: BTreeSet<String>,
+    #[serde(default)]
+    reclamation_needed: bool,
+    #[serde(default)]
+    reclamation: Option<String>,
 }
 
 #[derive(Debug)]
@@ -56,10 +64,20 @@ pub struct ArtifactBlob {
     pub stream: BoxStream<'static, object_store::Result<Bytes>>,
 }
 
+struct PreparedPublication {
+    payload: ArtifactPayload,
+    uploads: BTreeMap<String, Vec<u8>>,
+    owner: String,
+    envelope_bytes: Vec<u8>,
+    variant_path: String,
+}
+
 /// Shared build-artifact storage. Local deployments use the
 /// `cache/shared-artifacts/v0` layout. Object-store deployments use the same
 /// configured bucket as hosted packages under a reserved namespace, allowing
-/// every replica to observe the same immutable blobs and envelopes.
+/// every replica to observe the same immutable blobs and envelopes. The quota
+/// document also acts as a distributed reclamation gate: publications register
+/// before reading objects, and a collector can start only after that set drains.
 #[derive(Debug)]
 pub struct SharedArtifactStore {
     store: Arc<dyn ObjectStore>,
@@ -107,15 +125,29 @@ impl SharedArtifactStore {
     }
 
     pub async fn publish(&self, username: &str, request: PublishArtifactRequest) -> Result<bool> {
-        let validated = request.validate().map_err(|err| protocol_error(&err))?;
-        let payload = validated.payload;
-        let mut uploads = validated.blobs;
-        let owner = owner_key(username, &payload.owner)?;
-        let entry = entry_digest(&request.key, &payload.package, &payload.source_integrity);
-        let envelope = request.envelope.digest().map_err(|err| protocol_error(&err))?;
-        let envelope_bytes = serde_json::to_vec(&request.envelope)?;
+        let prepared = prepare_publication(username, &request)?;
+        let publication = artifact_operation_id()?;
+        self.begin_publication(&publication).await?;
+        let mut reclamation_needed = false;
+        let result = self.publish_active(prepared, &mut reclamation_needed).await;
+        let finish = self.finish_publication(&publication, reclamation_needed).await;
+        if finish.is_ok()
+            && let Err(error) = self.try_reclaim_unreferenced_blobs().await
+        {
+            tracing::warn!(%error, "shared artifact reclamation failed");
+        }
+        finish?;
+        result
+    }
+
+    async fn publish_active(
+        &self,
+        prepared: PreparedPublication,
+        reclamation_needed: &mut bool,
+    ) -> Result<bool> {
+        let PreparedPublication { payload, mut uploads, owner, envelope_bytes, variant_path } =
+            prepared;
         let envelope_size = envelope_bytes.len() as u64;
-        let variant_path = format!("{owner}/entries/{entry}/{envelope}.json");
 
         if self.object_exists(&variant_path).await? {
             return Ok(false);
@@ -157,7 +189,10 @@ impl SharedArtifactStore {
         let added_bytes = new_blobs.iter().try_fold(envelope_size, |total, entry| {
             total.checked_add(entry.1.len() as u64).ok_or_else(storage_quota_error)
         })?;
-        self.reserve_quota(&owner, added_bytes).await?;
+        if let Err(error) = self.reserve_quota(&owner, added_bytes).await {
+            *reclamation_needed = matches!(&error, RegistryError::ObjectStore(_));
+            return Err(error);
+        }
 
         let mut retained_bytes = 0_u64;
         for (path, bytes) in new_blobs {
@@ -166,6 +201,7 @@ impl SharedArtifactStore {
                 Ok(true) => retained_bytes += size,
                 Ok(false) => {}
                 Err(error) => {
+                    *reclamation_needed = true;
                     retained_bytes += size;
                     self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
                     return Err(error);
@@ -175,6 +211,7 @@ impl SharedArtifactStore {
         let created = match self.create_object(&variant_path, envelope_bytes).await {
             Ok(created) => created,
             Err(error) => {
+                *reclamation_needed = true;
                 retained_bytes += envelope_size;
                 self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
                 return Err(error);
@@ -183,7 +220,10 @@ impl SharedArtifactStore {
         if created {
             retained_bytes += envelope_size;
         }
-        self.release_uncommitted(&owner, added_bytes, retained_bytes).await?;
+        if let Err(error) = self.release_uncommitted(&owner, added_bytes, retained_bytes).await {
+            *reclamation_needed = matches!(&error, RegistryError::ObjectStore(_));
+            return Err(error);
+        }
         Ok(created)
     }
 
@@ -281,6 +321,205 @@ impl SharedArtifactStore {
             .then(|| ResolvedArtifact { key: candidate.key.clone(), variants }))
     }
 
+    async fn begin_publication(&self, publication: &str) -> Result<()> {
+        for _ in 0..RECLAMATION_WAIT_RETRIES {
+            let begun = match self
+                .mutate_usage(|usage| {
+                    if usage.reclamation.is_some() {
+                        return Ok(false);
+                    }
+                    if usage.active_publications.len() >= MAX_ACTIVE_PUBLICATIONS {
+                        return Err(RegistryError::Internal {
+                            reason: "shared artifact publication concurrency limit reached"
+                                .to_string(),
+                        });
+                    }
+                    if !usage.active_publications.insert(publication.to_string()) {
+                        return Err(RegistryError::Internal {
+                            reason: "shared artifact publication is already active".to_string(),
+                        });
+                    }
+                    Ok(true)
+                })
+                .await
+            {
+                Ok(begun) => begun,
+                Err(error) => {
+                    if self.load_usage().await?.0.active_publications.contains(publication) {
+                        return Ok(());
+                    }
+                    return Err(error);
+                }
+            };
+            if begun {
+                return Ok(());
+            }
+            sleep(ARTIFACT_LOCK_POLL_INTERVAL).await;
+        }
+        Err(RegistryError::Internal {
+            reason: "shared artifact reclamation did not finish before publication timed out"
+                .to_string(),
+        })
+    }
+
+    async fn finish_publication(&self, publication: &str, reclamation_needed: bool) -> Result<()> {
+        let finished = self
+            .mutate_usage(|usage| {
+                if !usage.active_publications.remove(publication) {
+                    return Err(RegistryError::Internal {
+                        reason: "shared artifact publication is not registered as active"
+                            .to_string(),
+                    });
+                }
+                usage.reclamation_needed |= reclamation_needed;
+                Ok(true)
+            })
+            .await;
+        match finished {
+            Ok(true) => Ok(()),
+            Ok(false) => Err(RegistryError::Internal {
+                reason: "shared artifact publication finish did not update usage".to_string(),
+            }),
+            Err(error) => {
+                if !self.load_usage().await?.0.active_publications.contains(publication) {
+                    return Ok(());
+                }
+                Err(error)
+            }
+        }
+    }
+
+    async fn try_reclaim_unreferenced_blobs(&self) -> Result<()> {
+        let reclamation = artifact_operation_id()?;
+        let acquired = match self
+            .mutate_usage(|usage| {
+                if !usage.reclamation_needed
+                    || !usage.active_publications.is_empty()
+                    || usage.reclamation.is_some()
+                {
+                    return Ok(false);
+                }
+                usage.reclamation = Some(reclamation.clone());
+                Ok(true)
+            })
+            .await
+        {
+            Ok(acquired) => acquired,
+            Err(error) => {
+                if self.load_usage().await?.0.reclamation.as_deref() == Some(reclamation.as_str()) {
+                    true
+                } else {
+                    return Err(error);
+                }
+            }
+        };
+        if !acquired {
+            return Ok(());
+        }
+
+        match self.reclaim_unreferenced_blobs().await {
+            Ok(usage) => {
+                if let Err(error) = self.complete_reclamation(&reclamation, usage).await {
+                    self.abort_reclamation(&reclamation).await?;
+                    return Err(error);
+                }
+            }
+            Err(error) => {
+                self.abort_reclamation(&reclamation).await?;
+                return Err(error);
+            }
+        }
+        Ok(())
+    }
+
+    async fn reclaim_unreferenced_blobs(&self) -> Result<ArtifactUsage> {
+        let referenced_blobs = self.referenced_blobs().await?;
+        let mut listing = self.list_objects(None);
+        while let Some(entry) = listing.next().await {
+            let entry = entry?;
+            let Some(relative) = self.relative_path(&entry.location) else { continue };
+            if is_blob_path(relative) && !referenced_blobs.contains(relative) {
+                self.store.delete(&entry.location).await?;
+            }
+        }
+        self.scan_usage().await
+    }
+
+    async fn referenced_blobs(&self) -> Result<HashSet<String>> {
+        let mut referenced = HashSet::new();
+        let mut listing = self.list_objects(None);
+        while let Some(entry) = listing.next().await {
+            let entry = entry?;
+            let Some(relative) = self.relative_path(&entry.location) else { continue };
+            let Some(owner) = entry_owner(relative) else { continue };
+            if entry.size > MAX_RESOLVE_RESPONSE_SIZE as u64 {
+                continue;
+            }
+            let Some(bytes) = self.read_object_path(&entry.location).await? else {
+                continue;
+            };
+            let Ok(envelope) = serde_json::from_slice::<SignedArtifactEnvelope>(&bytes) else {
+                continue;
+            };
+            let Ok((payload, _)) = envelope.decode_payload() else {
+                continue;
+            };
+            if digest_segment(payload.owner.namespace().as_bytes()) != owner {
+                continue;
+            }
+            for file in payload.manifest.added {
+                let Ok(id) = blob_id(&file.integrity) else { continue };
+                referenced.insert(format!("{owner}/blobs/{id}"));
+            }
+        }
+        Ok(referenced)
+    }
+
+    async fn complete_reclamation(
+        &self,
+        reclamation: &str,
+        mut rebuilt: ArtifactUsage,
+    ) -> Result<()> {
+        rebuilt.reclamation = None;
+        rebuilt.reclamation_needed = false;
+        let changed = self
+            .mutate_usage(|usage| {
+                if usage.reclamation.as_deref() != Some(reclamation) {
+                    return Err(RegistryError::Internal {
+                        reason: "shared artifact reclamation ownership changed".to_string(),
+                    });
+                }
+                if !usage.active_publications.is_empty() {
+                    return Err(RegistryError::Internal {
+                        reason: "shared artifact publication started during reclamation"
+                            .to_string(),
+                    });
+                }
+                *usage = rebuilt.clone();
+                Ok(true)
+            })
+            .await?;
+        if !changed {
+            return Err(RegistryError::Internal {
+                reason: "shared artifact reclamation did not update usage".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn abort_reclamation(&self, reclamation: &str) -> Result<()> {
+        self.mutate_usage(|usage| {
+            if usage.reclamation.as_deref() != Some(reclamation) {
+                return Ok(false);
+            }
+            usage.reclamation = None;
+            usage.reclamation_needed = true;
+            Ok(true)
+        })
+        .await?;
+        Ok(())
+    }
+
     async fn reserve_quota(&self, owner: &str, added_bytes: u64) -> Result<()> {
         self.change_quota(owner, added_bytes, QuotaChange::Reserve).await
     }
@@ -300,22 +539,46 @@ impl SharedArtifactStore {
     }
 
     async fn change_quota(&self, owner: &str, bytes: u64, change: QuotaChange) -> Result<()> {
+        let changed = self
+            .mutate_usage(|usage| {
+                self.change_usage(usage, owner, bytes, change)?;
+                Ok(true)
+            })
+            .await?;
+        if !changed {
+            return Err(RegistryError::Internal {
+                reason: "shared artifact quota update did not change usage".to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn mutate_usage(
+        &self,
+        mutation: impl Fn(&mut ArtifactUsage) -> Result<bool>,
+    ) -> Result<bool> {
         match &self.quota {
             QuotaCoordination::Local { lock_path } => {
                 let _lock = acquire_artifact_lock(lock_path.clone()).await?;
                 let (mut usage, _) = self.load_usage().await?;
-                self.change_usage(&mut usage, owner, bytes, change)?;
+                if !mutation(&mut usage)? {
+                    return Ok(false);
+                }
                 self.write_usage(&usage, PutMode::Overwrite).await?;
-                Ok(())
+                Ok(true)
             }
             QuotaCoordination::Conditional => {
-                for _ in 0..QUOTA_WRITE_RETRIES {
+                for attempt in 0..QUOTA_WRITE_RETRIES {
                     let (mut usage, version) = self.load_usage().await?;
-                    self.change_usage(&mut usage, owner, bytes, change)?;
+                    if !mutation(&mut usage)? {
+                        return Ok(false);
+                    }
                     let mode = version.map_or(PutMode::Create, PutMode::Update);
                     match self.write_usage(&usage, mode).await {
-                        Ok(()) => return Ok(()),
-                        Err(RegistryError::ObjectStore(error)) if is_write_conflict(&error) => {}
+                        Ok(()) => return Ok(true),
+                        Err(RegistryError::ObjectStore(error)) if is_write_conflict(&error) => {
+                            sleep(quota_write_retry_delay(attempt)).await;
+                        }
                         Err(error) => return Err(error),
                     }
                 }
@@ -364,14 +627,20 @@ impl SharedArtifactStore {
                 let bytes = result.bytes().await?;
                 Ok((serde_json::from_slice(&bytes)?, Some(version)))
             }
-            Err(object_store::Error::NotFound { .. }) => Ok((self.scan_usage().await?, None)),
+            Err(object_store::Error::NotFound { .. }) => {
+                let mut usage = self.scan_usage().await?;
+                usage.reclamation_needed = usage.global_bytes != 0;
+                Ok((usage, None))
+            }
             Err(error) => Err(error.into()),
         }
     }
 
     async fn scan_usage(&self) -> Result<ArtifactUsage> {
         let mut usage = ArtifactUsage::default();
-        for entry in self.list_objects(None).await? {
+        let mut listing = self.list_objects(None);
+        while let Some(entry) = listing.next().await {
+            let entry = entry?;
             let Some(relative) = self.relative_path(&entry.location) else { continue };
             if relative == self.quota_object() || relative.starts_with(".locks/") {
                 continue;
@@ -442,16 +711,14 @@ impl SharedArtifactStore {
         }
     }
 
-    async fn list_objects(&self, relative_prefix: Option<&str>) -> Result<Vec<ObjectMeta>> {
+    fn list_objects(
+        &self,
+        relative_prefix: Option<&str>,
+    ) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
         let prefix = relative_prefix.map(|prefix| self.object_path(prefix)).or_else(|| {
             (!self.prefix.is_empty()).then(|| ObjectPath::from(self.prefix.trim_end_matches('/')))
         });
-        let mut listing = self.store.list(prefix.as_ref());
-        let mut entries = Vec::new();
-        while let Some(entry) = listing.next().await {
-            entries.push(entry?);
-        }
-        Ok(entries)
+        self.store.list(prefix.as_ref())
     }
 
     fn object_path(&self, relative: &str) -> ObjectPath {
@@ -480,6 +747,26 @@ impl SharedArtifactStore {
 pub fn parse_publish(body: &[u8]) -> Result<PublishArtifactRequest> {
     serde_json::from_slice(body)
         .map_err(|err| bad_request(format!("invalid shared artifact request: {err}")))
+}
+
+fn prepare_publication(
+    username: &str,
+    request: &PublishArtifactRequest,
+) -> Result<PreparedPublication> {
+    let validated = request.validate().map_err(|err| protocol_error(&err))?;
+    let payload = validated.payload;
+    let owner = owner_key(username, &payload.owner)?;
+    let entry = entry_digest(&request.key, &payload.package, &payload.source_integrity);
+    let envelope = request.envelope.digest().map_err(|err| protocol_error(&err))?;
+    let envelope_bytes = serde_json::to_vec(&request.envelope)?;
+    let variant_path = format!("{owner}/entries/{entry}/{envelope}.json");
+    Ok(PreparedPublication {
+        payload,
+        uploads: validated.blobs,
+        owner,
+        envelope_bytes,
+        variant_path,
+    })
 }
 
 fn verify_stored_blob(id: &str, integrity: &str, size: u64, bytes: &[u8]) -> Result<()> {
@@ -558,6 +845,44 @@ fn is_variant_file(name: &str) -> bool {
     bytes.len() == 69
         && bytes[64..] == *b".json"
         && bytes[..64].iter().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(byte))
+}
+
+fn is_blob_path(relative: &str) -> bool {
+    let mut segments = relative.split('/');
+    let (Some(owner), Some("blobs"), Some(blob), None) =
+        (segments.next(), segments.next(), segments.next(), segments.next())
+    else {
+        return false;
+    };
+    is_digest_segment(owner) && !blob.is_empty()
+}
+
+fn entry_owner(relative: &str) -> Option<&str> {
+    let mut segments = relative.split('/');
+    let (Some(owner), Some("entries"), Some(entry), Some(variant), None) =
+        (segments.next(), segments.next(), segments.next(), segments.next(), segments.next())
+    else {
+        return None;
+    };
+    (is_digest_segment(owner) && is_digest_segment(entry) && is_variant_file(variant))
+        .then_some(owner)
+}
+
+fn is_digest_segment(segment: &str) -> bool {
+    segment.len() == 64
+        && segment.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn quota_write_retry_delay(attempt: usize) -> Duration {
+    Duration::from_millis(1 << attempt.min(6))
+}
+
+fn artifact_operation_id() -> Result<String> {
+    let mut bytes = [0_u8; 16];
+    getrandom::fill(&mut bytes).map_err(|error| RegistryError::Internal {
+        reason: format!("could not generate a shared artifact operation ID: {error}"),
+    })?;
+    Ok(hex(&bytes))
 }
 
 fn digest_segment(bytes: &[u8]) -> String {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -32,6 +32,7 @@ const ARTIFACT_QUOTA_OBJECT: &str = "quota.json";
 const MAX_OWNER_ARTIFACT_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_GLOBAL_ARTIFACT_BYTES: u64 = 10 * MAX_OWNER_ARTIFACT_BYTES;
 const MAX_ACTIVE_PUBLICATIONS: usize = 1024;
+const PUBLICATION_FINISH_RETRIES: usize = 8;
 const QUOTA_WRITE_RETRIES: usize = 32;
 const RECLAMATION_WAIT_RETRIES: usize = 600;
 
@@ -363,30 +364,43 @@ impl SharedArtifactStore {
     }
 
     async fn finish_publication(&self, publication: &str, reclamation_needed: bool) -> Result<()> {
-        let finished = self
-            .mutate_usage(|usage| {
-                if !usage.active_publications.remove(publication) {
+        for attempt in 0..PUBLICATION_FINISH_RETRIES {
+            let finished = self
+                .mutate_usage(|usage| {
+                    if !usage.active_publications.remove(publication) {
+                        return Err(RegistryError::Internal {
+                            reason: "shared artifact publication is not registered as active"
+                                .to_string(),
+                        });
+                    }
+                    usage.reclamation_needed |= reclamation_needed;
+                    Ok(true)
+                })
+                .await;
+            match finished {
+                Ok(true) => return Ok(()),
+                Ok(false) => {
                     return Err(RegistryError::Internal {
-                        reason: "shared artifact publication is not registered as active"
+                        reason: "shared artifact publication finish did not update usage"
                             .to_string(),
                     });
                 }
-                usage.reclamation_needed |= reclamation_needed;
-                Ok(true)
-            })
-            .await;
-        match finished {
-            Ok(true) => Ok(()),
-            Ok(false) => Err(RegistryError::Internal {
-                reason: "shared artifact publication finish did not update usage".to_string(),
-            }),
-            Err(error) => {
-                if !self.load_usage().await?.0.active_publications.contains(publication) {
-                    return Ok(());
+                Err(error) => {
+                    let retry_error = match self.load_usage().await {
+                        Ok((usage, _)) if !usage.active_publications.contains(publication) => {
+                            return Ok(());
+                        }
+                        Ok(_) => error,
+                        Err(read_error) => read_error,
+                    };
+                    if attempt + 1 == PUBLICATION_FINISH_RETRIES {
+                        return Err(retry_error);
+                    }
+                    sleep(quota_write_retry_delay(attempt)).await;
                 }
-                Err(error)
             }
         }
+        unreachable!("publication finish loop returns on its final attempt")
     }
 
     async fn try_reclaim_unreferenced_blobs(&self) -> Result<()> {
@@ -874,7 +888,10 @@ fn is_digest_segment(segment: &str) -> bool {
 }
 
 fn quota_write_retry_delay(attempt: usize) -> Duration {
-    Duration::from_millis(1 << attempt.min(6))
+    let base = 1_u64 << attempt.min(6);
+    let mut random = [0_u8; 1];
+    let jitter = if getrandom::fill(&mut random).is_ok() { u64::from(random[0]) % base } else { 0 };
+    Duration::from_millis(base + jitter)
 }
 
 fn artifact_operation_id() -> Result<String> {

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -20,7 +20,8 @@ use sha2::{Digest as _, Sha512};
 use tempfile::TempDir;
 
 use super::{
-    ArtifactUsage, ResolveBudget, SharedArtifactStore, is_variant_file, is_write_conflict,
+    ArtifactUsage, ResolveBudget, SharedArtifactStore, artifact_operation_id, is_variant_file,
+    is_write_conflict, owner_key,
 };
 
 #[test]
@@ -66,6 +67,17 @@ fn missing_quota_object_writes_are_not_conflicts() {
     };
 
     assert!(!is_write_conflict(&error));
+}
+
+#[test]
+fn quota_state_from_before_reclamation_coordination_remains_readable() {
+    let usage: ArtifactUsage =
+        serde_json::from_str(r#"{"global_bytes":12,"owner_bytes":{"owner":12}}"#).unwrap();
+
+    assert_eq!(usage.global_bytes, 12);
+    assert!(usage.active_publications.is_empty());
+    assert!(!usage.reclamation_needed);
+    assert!(usage.reclamation.is_none());
 }
 
 #[tokio::test]
@@ -219,14 +231,70 @@ async fn quota_is_reserved_before_objects_are_written() {
 }
 
 #[tokio::test]
-async fn failed_object_writes_retain_quota_for_the_ambiguous_attempt() {
-    let backend: Arc<dyn ObjectStore> =
-        Arc::new(FailArtifactWrites { inner: InMemory::new(), commit_before_error: false });
+async fn failed_object_writes_reconcile_quota_to_physical_storage() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+    });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
     let scratch = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
-    let request = publication("ci/failure");
+    store.publish("acme", publication("ci/failure")).await.unwrap_err();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, 0);
+    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), 0);
+}
+
+#[tokio::test]
+async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: true,
+        fail_deletes: false,
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let request =
+        publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/ambiguous-commit");
+    store.publish("acme", request).await.unwrap_err();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, 0);
+    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), 0);
+    let mut objects = backend.list(None);
+    let mut physical_bytes = 0_u64;
+    while let Some(object) = objects.next().await {
+        let object = object.unwrap();
+        if !object.location.as_ref().ends_with("/quota.json") {
+            physical_bytes += object.size;
+        }
+    }
+    assert_eq!(physical_bytes, 0);
+}
+
+#[tokio::test]
+async fn committed_envelope_writes_that_report_failure_remain_charged() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: true,
+        fail_deletes: false,
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let request = publication("ci/ambiguous-envelope");
     let expected_usage = serde_json::to_vec(&request.envelope).unwrap().len() as u64;
 
     store.publish("acme", request).await.unwrap_err();
@@ -240,34 +308,101 @@ async fn failed_object_writes_retain_quota_for_the_ambiguous_attempt() {
 }
 
 #[tokio::test]
-async fn committed_object_writes_that_report_failure_remain_charged() {
-    let backend: Arc<dyn ObjectStore> =
-        Arc::new(FailArtifactWrites { inner: InMemory::new(), commit_before_error: true });
+async fn reclamation_waits_for_publications_on_other_replicas() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let first = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let second = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let first_publication = artifact_operation_id().unwrap();
+    let second_publication = artifact_operation_id().unwrap();
+    first.begin_publication(&first_publication).await.unwrap();
+    second.begin_publication(&second_publication).await.unwrap();
+
+    let owner = owner_key("acme", &OwnerScope::organization("acme")).unwrap();
+    let orphan = ObjectPath::from(format!(".pnpr-artifacts/v0/{owner}/blobs/orphan"));
+    backend.put(&orphan, PutPayload::from_static(b"orphan")).await.unwrap();
+    first.reserve_quota(&owner, 6).await.unwrap();
+
+    first.finish_publication(&first_publication, true).await.unwrap();
+    first.try_reclaim_unreferenced_blobs().await.unwrap();
+    assert!(backend.head(&orphan).await.is_ok());
+
+    second.finish_publication(&second_publication, false).await.unwrap();
+    second.try_reclaim_unreferenced_blobs().await.unwrap();
+    assert!(matches!(backend.head(&orphan).await, Err(object_store::Error::NotFound { .. })));
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert_eq!(usage.global_bytes, 0);
+    assert!(usage.active_publications.is_empty());
+    assert!(!usage.reclamation_needed);
+    assert!(usage.reclamation.is_none());
+}
+
+#[tokio::test]
+async fn reclamation_preserves_blobs_referenced_by_committed_envelopes() {
+    let backend: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
     let scratch = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
-    let request =
-        publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/ambiguous-commit");
-    let expected_usage = b"shared addon".len() as u64;
+    let request = publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/referenced");
+    let integrity = request.blobs[0].integrity.clone();
+    store.publish("acme", request).await.unwrap();
 
-    store.publish("acme", request).await.unwrap_err();
+    let publication = artifact_operation_id().unwrap();
+    store.begin_publication(&publication).await.unwrap();
+    let owner = owner_key("acme", &OwnerScope::organization("acme")).unwrap();
+    let orphan = ObjectPath::from(format!(".pnpr-artifacts/v0/{owner}/blobs/orphan"));
+    backend.put(&orphan, PutPayload::from_static(b"orphan")).await.unwrap();
+    store.reserve_quota(&owner, 6).await.unwrap();
+    store.finish_publication(&publication, true).await.unwrap();
+    store.try_reclaim_unreferenced_blobs().await.unwrap();
+
+    assert!(matches!(backend.head(&orphan).await, Err(object_store::Error::NotFound { .. })));
+    let blob = store
+        .read_blob(
+            "acme",
+            &serde_json::to_vec(&ArtifactBlobRequest {
+                owner: OwnerScope::organization("acme"),
+                integrity,
+            })
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(blob.is_some());
+}
+
+#[tokio::test]
+async fn failed_reclamation_releases_its_gate_for_later_retries() {
+    let inner = InMemory::new();
+    let owner = owner_key("acme", &OwnerScope::organization("acme")).unwrap();
+    let orphan = ObjectPath::from(format!(".pnpr-artifacts/v0/{owner}/blobs/orphan"));
+    inner.put(&orphan, PutPayload::from_static(b"orphan")).await.unwrap();
+    let backend: Arc<dyn ObjectStore> =
+        Arc::new(FailArtifactWrites { inner, commit_before_error: false, fail_deletes: true });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let publication = artifact_operation_id().unwrap();
+    store.begin_publication(&publication).await.unwrap();
+    store.reserve_quota(&owner, 6).await.unwrap();
+    store.finish_publication(&publication, true).await.unwrap();
+
+    store.try_reclaim_unreferenced_blobs().await.unwrap_err();
 
     let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
     let usage: ArtifactUsage =
         serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
             .unwrap();
-    assert_eq!(usage.global_bytes, expected_usage);
-    assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), expected_usage);
-    let mut objects = backend.list(None);
-    let mut physical_bytes = 0_u64;
-    while let Some(object) = objects.next().await {
-        let object = object.unwrap();
-        if !object.location.as_ref().ends_with("/quota.json") {
-            physical_bytes += object.size;
-        }
-    }
-    assert_eq!(physical_bytes, expected_usage);
+    assert!(usage.reclamation.is_none());
+    assert!(usage.reclamation_needed);
+    assert!(backend.head(&orphan).await.is_ok());
 }
 
 #[tokio::test]
@@ -370,6 +505,7 @@ fn publication_request(
 struct FailArtifactWrites {
     inner: InMemory,
     commit_before_error: bool,
+    fail_deletes: bool,
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -419,7 +555,19 @@ impl ObjectStore for FailArtifactWrites {
         &self,
         locations: BoxStream<'static, object_store::Result<ObjectPath>>,
     ) -> BoxStream<'static, object_store::Result<ObjectPath>> {
-        self.inner.delete_stream(locations)
+        if self.fail_deletes {
+            locations
+                .map(|location| {
+                    location?;
+                    Err(object_store::Error::Generic {
+                        store: "test",
+                        source: std::io::Error::other("injected artifact deletion failure").into(),
+                    })
+                })
+                .boxed()
+        } else {
+            self.inner.delete_stream(locations)
+        }
     }
 
     fn list(

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1,4 +1,11 @@
-use std::{collections::BTreeMap, fmt, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+};
 
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
@@ -236,6 +243,7 @@ async fn failed_object_writes_reconcile_quota_to_physical_storage() {
         inner: InMemory::new(),
         commit_before_error: false,
         fail_deletes: false,
+        fail_next_quota_write: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -257,6 +265,7 @@ async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
         inner: InMemory::new(),
         commit_before_error: true,
         fail_deletes: false,
+        fail_next_quota_write: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -289,6 +298,7 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
         inner: InMemory::new(),
         commit_before_error: true,
         fail_deletes: false,
+        fail_next_quota_write: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -305,6 +315,33 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
             .unwrap();
     assert_eq!(usage.global_bytes, expected_usage);
     assert_eq!(usage.owner_bytes.values().copied().sum::<u64>(), expected_usage);
+}
+
+#[tokio::test]
+async fn publication_finish_retries_a_transient_quota_write_failure() {
+    let fail_next_quota_write = Arc::new(AtomicBool::new(false));
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+        fail_next_quota_write: Some(Arc::clone(&fail_next_quota_write)),
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let publication = artifact_operation_id().unwrap();
+    store.begin_publication(&publication).await.unwrap();
+    fail_next_quota_write.store(true, Ordering::SeqCst);
+
+    store.finish_publication(&publication, true).await.unwrap();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    assert!(usage.active_publications.is_empty());
+    assert!(usage.reclamation_needed);
 }
 
 #[tokio::test]
@@ -383,8 +420,12 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
     let owner = owner_key("acme", &OwnerScope::organization("acme")).unwrap();
     let orphan = ObjectPath::from(format!(".pnpr-artifacts/v0/{owner}/blobs/orphan"));
     inner.put(&orphan, PutPayload::from_static(b"orphan")).await.unwrap();
-    let backend: Arc<dyn ObjectStore> =
-        Arc::new(FailArtifactWrites { inner, commit_before_error: false, fail_deletes: true });
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner,
+        commit_before_error: false,
+        fail_deletes: true,
+        fail_next_quota_write: None,
+    });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
     let scratch = TempDir::new().unwrap();
@@ -506,6 +547,7 @@ struct FailArtifactWrites {
     inner: InMemory,
     commit_before_error: bool,
     fail_deletes: bool,
+    fail_next_quota_write: Option<Arc<AtomicBool>>,
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -523,6 +565,16 @@ impl ObjectStore for FailArtifactWrites {
         options: PutOptions,
     ) -> object_store::Result<PutResult> {
         if location.as_ref().ends_with("/quota.json") {
+            if self
+                .fail_next_quota_write
+                .as_ref()
+                .is_some_and(|fail| fail.swap(false, Ordering::SeqCst))
+            {
+                return Err(object_store::Error::Generic {
+                    store: "test",
+                    source: std::io::Error::other("injected quota write failure").into(),
+                });
+            }
             self.inner.put_opts(location, payload, options).await
         } else {
             if self.commit_before_error {


### PR DESCRIPTION
## Summary

- Coordinate shared-artifact publications through the quota document so reclamation starts only after active writers drain and blocks new writers while it runs.
- After an ambiguous object-store write failure, retain blobs referenced by valid stored envelopes, delete unreferenced blobs, and rebuild quota from the remaining physical objects.
- Retry transient publication-cleanup failures, jitter quota CAS backoff, keep the quota schema backward-compatible, and document crash recovery.
- Cover multi-replica publication, committed and uncommitted transport failures, referenced-blob retention, retryable deletion failures, and deterministic in-flight bail summaries.
- Retry the transient Windows delete-pending error exposed by CI when concurrent pacquet global commands hand off their directory lock.

The reclamation behavior is pnpr-only and has no TypeScript CLI or pacquet counterpart. The directory-lock follow-up is an internal pacquet filesystem fix for a Windows CI failure encountered on this branch.

Related to pnpm/pnpm#14220.

## Squash Commit Body

```text
Ambiguous object-store failures can commit a shared-artifact blob while returning an error. Conservatively retaining the reserved quota prevents limit bypasses, but can permanently charge storage that no committed envelope references.

Register each publication in the conditionally written quota document before it reads or creates immutable objects. When an ambiguous failure marks reclamation as necessary, let one replica acquire a token after all active publications drain. The token blocks new publications while the collector derives reachability from stored envelopes, removes unreferenced blobs, rescans physical usage, and atomically replaces the quota state. Preserve the retry marker when collection fails, retry transient cleanup failures from live requests, jitter conditional-write backoff, and retain the documented quiesced quota-reset procedure for registrations or tokens left by terminated processes.

Also synchronize the recursive-run bail summary regression with bounded marker waits so it deterministically exercises recording a task that was in flight when another task failed without risking a hung test.

On Windows, a competing `create_dir` can report `AccessDenied` while the prior lock directory is delete-pending. Retry that platform-specific transient error within the caller's wait and a one-second release budget, while continuing to report persistent permission failures.

Related to pnpm/pnpm#14220.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared artifact recovery after ambiguous storage write failures.
  * Reclaims unreferenced artifact data and reconciles quota usage with physical storage.
  * Coordinates concurrent publications more safely during cleanup and retries.
  * Recursive runs now include results from all in-flight tasks when stopped by bail.
  * Reduced intermittent Windows permission errors when concurrent commands release global locks.

* **Documentation**
  * Updated artifact publication guidance, including recovery and quota-rebuild behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->