### PR TITLE
feat: add pipelines, run records, and Cargo build caching

### DIFF
--- a/.changeset/pipeline-cargo-state.md
+++ b/.changeset/pipeline-cargo-state.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+`pnpm pipeline` can reuse local Cargo build state between worktrees with the `tasks.<name>.cargoTargetDir` setting. Restored build directories remain usable after the cache is deleted. Root tasks can participate with `includeWorkspaceRoot: true`.

--- a/.changeset/pipeline-command-poc.md
+++ b/.changeset/pipeline-command-poc.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+Added an experimental `pnpm pipeline [name]` command that runs a named set of workspace tasks the way a CI run would: a frozen install first, then only the projects affected since the merge base with `pipelineBase` (falling back to every project when workspace-root files changed), scheduled over the task graph without bailing, with cached task results restored — declared `outputs` files and replayed logs — instead of re-run. Pipelines are declared under the new `pipelines` setting in `pnpm-workspace.yaml`, and `tasks` entries gain `outputs`, `inputs`, `env`, and `cache` fields that control the task cache.

--- a/.changeset/pipeline-command-poc.md
+++ b/.changeset/pipeline-command-poc.md
@@ -5,3 +5,5 @@
 Added `pnpm pipeline [name]` to install frozen dependencies and run workspace tasks declared in `pipelines`. It selects affected projects and runs their task graph without bailing on task failures.
 
 Task settings now support `outputs`, `inputs`, `env`, and `cache`. Cache hits restore declared outputs and replay the task's logs.
+
+`pnpm pipeline --dry-run` previews the task graph without installing configuration dependencies or executing workspace hooks.

--- a/.changeset/pipeline-command-poc.md
+++ b/.changeset/pipeline-command-poc.md
@@ -2,4 +2,6 @@
 "pacquet": minor
 ---
 
-Added an experimental `pnpm pipeline [name]` command that runs a named set of workspace tasks the way a CI run would: a frozen install first, then only the projects affected since the merge base with `pipelineBase` (falling back to every project when workspace-root files changed), scheduled over the task graph without bailing, with cached task results restored — declared `outputs` files and replayed logs — instead of re-run. Pipelines are declared under the new `pipelines` setting in `pnpm-workspace.yaml`, and `tasks` entries gain `outputs`, `inputs`, `env`, and `cache` fields that control the task cache.
+Added `pnpm pipeline [name]` to install frozen dependencies and run workspace tasks declared in `pipelines`. It selects affected projects and runs their task graph without bailing on task failures.
+
+Task settings now support `outputs`, `inputs`, `env`, and `cache`. Cache hits restore declared outputs and replay the task's logs.

--- a/.changeset/pnpr-pipeline-runs.md
+++ b/.changeset/pnpr-pipeline-runs.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Added an experimental pipeline run-record surface, off by default and enabled with `pipeline.enabled: true`: `pnpm pipeline --report` (or `--report-to <url>`) publishes a run's summary and event stream to `PUT /-/pnpr/v0/pipeline/runs`, runs are append-only and listed at `GET /-/pnpr/v0/pipeline/runs` (with `?workspace=` and `?limit=`), a single run's full record including its events is served at `GET /-/pnpr/v0/pipeline/runs/{workspace}/{runId}`, and `GET /-/pnpr/v0/pipeline` serves a small viewer page over those endpoints.

--- a/.changeset/pnpr-pipeline-runs.md
+++ b/.changeset/pnpr-pipeline-runs.md
@@ -2,4 +2,6 @@
 "@pnpm/pnpr": minor
 ---
 
-Added an experimental pipeline run-record surface, off by default and enabled with `pipeline.enabled: true`: `pnpm pipeline --report` (or `--report-to <url>`) publishes a run's summary and event stream to `PUT /-/pnpr/v0/pipeline/runs`, runs are append-only and listed at `GET /-/pnpr/v0/pipeline/runs` (with `?workspace=` and `?limit=`), a single run's full record including its events is served at `GET /-/pnpr/v0/pipeline/runs/{workspace}/{runId}`, and `GET /-/pnpr/v0/pipeline` serves a small viewer page over those endpoints.
+pnpr can store pipeline run reports with `pipeline.enabled`. Configure each workspace's `access` and `publish` permissions under `pipeline.workspaces`.
+
+`pnpm pipeline --report` and `--report-to` submit run summaries and events. pnpr provides authenticated listing and detail endpoints and a web viewer.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6149,6 +6149,7 @@ dependencies = [
  "pnpr-error",
  "pnpr-osv",
  "pnpr-package-name",
+ "pnpr-pipeline-runs",
  "pnpr-policy",
  "pnpr-pypi",
  "pnpr-registry",
@@ -6297,6 +6298,18 @@ dependencies = [
  "pep508_rs",
  "pnpr-error",
  "serde",
+]
+
+[[package]]
+name = "pnpr-pipeline-runs"
+version = "0.0.1"
+dependencies = [
+ "pnpr-error",
+ "pnpr-storage",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ pnpr-pypi             = { path = "pnpr/crates/pypi" }
 pnpr-registry         = { path = "pnpr/crates/registry" }
 pnpr-storage          = { path = "pnpr/crates/storage" }
 pnpr-route            = { path = "pnpr/crates/route" }
+pnpr-pipeline-runs    = { path = "pnpr/crates/pipeline-runs" }
 pnpr-search           = { path = "pnpr/crates/search" }
 pnpr-shared-artifacts = { path = "pnpr/crates/shared-artifacts" }
 pnpr-upstream         = { path = "pnpr/crates/upstream" }

--- a/deny.toml
+++ b/deny.toml
@@ -79,6 +79,7 @@ exceptions = [
   # below pin it by file hash). Every new `pnpr-*` crate needs an entry here
   # and a matching clarify block, or `Cargo Deny` fails it as unlicensed.
   { name = "pnpr", allow = ["PolyForm-Noncommercial-1.0.0"] },
+  { name = "pnpr-pipeline-runs", allow = ["PolyForm-Noncommercial-1.0.0"] },
   { name = "pnpr-shared-artifacts", allow = ["PolyForm-Noncommercial-1.0.0"] },
   { name = "pnpr-search", allow = ["PolyForm-Noncommercial-1.0.0"] },
   { name = "pnpr-osv", allow = ["PolyForm-Noncommercial-1.0.0"] },
@@ -128,6 +129,11 @@ license-files = [{ path = "../../LICENSE.md", hash = 0x652a978e }]
 
 [[licenses.clarify]]
 name = "pnpr-osv"
+expression = "PolyForm-Noncommercial-1.0.0"
+license-files = [{ path = "../../LICENSE.md", hash = 0x652a978e }]
+
+[[licenses.clarify]]
+name = "pnpr-pipeline-runs"
 expression = "PolyForm-Noncommercial-1.0.0"
 license-files = [{ path = "../../LICENSE.md", hash = 0x652a978e }]
 

--- a/justfile
+++ b/justfile
@@ -115,6 +115,10 @@ codecov:
 micro-benchmark:
   cargo run --bin=micro-benchmark --release
 
+# Compare Rust artifact reuse between two disposable worktrees.
+bench-rust-cache *args:
+  node pnpm/scripts/bench-rust-cache.mjs {{args}}
+
 # Manage registry-mock. The launcher spawns `pnpr`; on
 # Windows you can't overwrite a running .exe, so we pre-build all
 # the test artifacts a subsequent `just test` will need with the

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -59,6 +59,7 @@ pub mod patch_remove;
 pub(crate) mod patch_state;
 pub mod peers;
 pub mod ping;
+pub mod pipeline;
 pub mod pkg;
 pub mod prefix;
 pub mod prune;

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -46,6 +46,7 @@ use super::{
     patch_remove::PatchRemoveArgs,
     peers::PeersArgs,
     ping::PingArgs,
+    pipeline::PipelineArgs,
     pkg::PkgArgs,
     prefix::PrefixArgs,
     prune::PruneArgs,
@@ -645,6 +646,11 @@ pub enum CliCommand {
     Test(ScriptShortcutArgs),
     /// Runs a defined package script.
     Run(RunArgs),
+    /// Runs a named pipeline of workspace tasks the way a CI run would:
+    /// a frozen install, affected-since-base selection, the task graph in
+    /// dependency order without bailing, and cached task results restored
+    /// instead of re-run.
+    Pipeline(PipelineArgs),
     /// Run a shell command in the context of a project.
     Exec(ExecArgs),
     /// Run a package in a temporary environment.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -530,6 +530,7 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
         CliCommand::Install(args) => dispatch_install::install(ctx, args),
         CliCommand::InstallTest(args) => dispatch_install::install_test(ctx, args),
         CliCommand::Ci(args) => dispatch_install::ci(ctx, args),
+        CliCommand::Pipeline(args) => dispatch_install::pipeline(ctx, args),
         CliCommand::Update(args) => dispatch_install::update(ctx, args),
         CliCommand::Outdated(args) => dispatch_query::outdated(ctx, args),
         CliCommand::Audit(args) => dispatch_query::audit(ctx, args),

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -22,7 +22,8 @@ use pnpm_network_web_auth::OtpNonInteractiveError;
 use pnpm_reporter::{ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, SilentReporter};
 use std::{future::Future, path::Path, pin::Pin};
 
-pub(crate) type CommandFuture<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
+pub(crate) type CommandFuture<'a, Output = ()> =
+    Pin<Box<dyn Future<Output = miette::Result<Output>> + Send + 'a>>;
 
 /// The shared context every subcommand handler needs: the canonicalized
 /// `--dir`, the derived `package.json` path, the selected reporter, the

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -414,13 +414,7 @@ pub(super) fn pipeline<'a>(
     let reporter = ctx.reporter;
     let config = ctx.config;
     Ok(Box::pin(async move {
-        let cfg = if let Some(install) = install_future {
-            install.await?
-        } else {
-            let cfg = config()?;
-            apply_update_config(cfg, dir, reporter).await?;
-            cfg
-        };
+        let cfg = if let Some(install) = install_future { install.await? } else { config()? };
         let outcome = run_pipeline(&invocation, cfg, dir, reporter)?;
         // The run is recorded before the failure exit is raised, so a red
         // run reaches the server too.

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -17,7 +17,7 @@ use super::{
     patch::PatchArgs,
     patch_commit::PatchCommitArgs,
     patch_remove::PatchRemoveArgs,
-    pipeline::{PipelineArgs, PipelineInvocation, run_pipeline},
+    pipeline::{PipelineArgs, PipelineInvocation, WatchInvocation, run_pipeline, run_watch},
     pipelines::{
         AddPipeline, DedupePipeline, DeployPipeline, InstallPipeline, PrunePipeline,
         RemovePipeline, UpdatePipeline, apply_install_cli_config,
@@ -353,8 +353,30 @@ pub(super) fn pipeline<'a>(
     ctx: &RunCtx<'a>,
     args: PipelineArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    let PipelineArgs { name, mut install_args, json, no_cache, full, base, report, report_to } =
-        args;
+    if args.watch {
+        let PipelineArgs {
+            name, repo, branch, interval, once, no_cache, report, report_to, ..
+        } = args;
+        let config = ctx.config;
+        return Ok(Box::pin(async move {
+            let cfg = config()?;
+            let invocation = WatchInvocation {
+                pipeline_name: name,
+                repo: repo.expect("clap requires --repo with --watch"),
+                branch,
+                interval: std::time::Duration::from_secs(interval),
+                once,
+                no_cache,
+                report: report || report_to.is_some(),
+                report_to,
+                npmrc_auth_file: cfg.npmrc_auth_file.clone(),
+            };
+            run_watch(&invocation, &cfg.cache_dir)
+        }));
+    }
+    let PipelineArgs {
+        name, mut install_args, json, no_cache, full, base, report, report_to, ..
+    } = args;
     let invocation = PipelineInvocation {
         name,
         // `--dry-run` prints the task graph and runs nothing, the

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -371,7 +371,7 @@ pub(super) fn pipeline<'a>(
                 report_to,
                 npmrc_auth_file: cfg.npmrc_auth_file.clone(),
             };
-            run_watch(&invocation, &cfg.cache_dir)
+            run_watch(&invocation, &cfg.state_dir)
         }));
     }
     let PipelineArgs {
@@ -405,6 +405,7 @@ pub(super) fn pipeline<'a>(
             install.await?;
         }
         let cfg = config()?;
+        apply_update_config(cfg, dir, reporter).await?;
         let outcome = run_pipeline(&invocation, cfg, dir, reporter)?;
         // The run is recorded before the failure exit is raised, so a red
         // run reaches the server too.
@@ -448,7 +449,7 @@ async fn report_pipeline_run(
         return;
     };
     let client = pnpm_pnpr_client::PnprClient::new(server);
-    let authorization = cfg.auth_headers.for_url(server);
+    let authorization = cfg.auth_headers.for_secure_url(server);
     let request = pnpm_pnpr_client::PublishPipelineRunRequest {
         workspace: upload.workspace,
         run_id: upload.run_id,
@@ -456,7 +457,14 @@ async fn report_pipeline_run(
         events: upload.events,
     };
     match client.publish_pipeline_run(&request, authorization.as_deref()).await {
-        Ok(()) => println!("Run recorded on {server} as {}/{}", request.workspace, request.run_id),
+        Ok(()) => emit(&pnpm_reporter::LogEvent::Pnpm(pnpm_reporter::PnpmLog {
+            level: pnpm_reporter::LogLevel::Info,
+            message: format!(
+                "Run recorded on {server} as {}/{}",
+                request.workspace, request.run_id,
+            ),
+            prefix: String::new(),
+        })),
         Err(error) => warn(format!("failed to publish the pipeline run to {server}: {error}")),
     }
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -353,7 +353,8 @@ pub(super) fn pipeline<'a>(
     ctx: &RunCtx<'a>,
     args: PipelineArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    let PipelineArgs { name, mut install_args, json, no_cache, full, base } = args;
+    let PipelineArgs { name, mut install_args, json, no_cache, full, base, report, report_to } =
+        args;
     let invocation = PipelineInvocation {
         name,
         // `--dry-run` prints the task graph and runs nothing, the
@@ -363,6 +364,8 @@ pub(super) fn pipeline<'a>(
         no_cache,
         full,
         base,
+        report: report || report_to.is_some(),
+        report_to,
     };
     install_args.frozen_lockfile = true;
     install_args.dry_run = false;
@@ -380,8 +383,60 @@ pub(super) fn pipeline<'a>(
             install.await?;
         }
         let cfg = config()?;
-        run_pipeline(&invocation, cfg, dir, reporter)
+        let outcome = run_pipeline(&invocation, cfg, dir, reporter)?;
+        // The run is recorded before the failure exit is raised, so a red
+        // run reaches the server too.
+        if invocation.report
+            && let Some(upload) = outcome.upload
+        {
+            report_pipeline_run(cfg, invocation.report_to.as_deref(), upload, reporter).await;
+        }
+        if outcome.failed_tasks > 0 {
+            return Err(super::pipeline::PipelineError::PipelineFail {
+                count: outcome.failed_tasks,
+            }
+            .into());
+        }
+        Ok(())
     }))
+}
+
+/// Publish the run to the configured pnpr server. A run that could not be
+/// reported still ran — the submission failure is a warning, not the
+/// run's exit code.
+async fn report_pipeline_run(
+    cfg: &Config,
+    report_to: Option<&str>,
+    upload: super::pipeline::RunUpload,
+    reporter: ReporterType,
+) {
+    let emit = reporter_emit(reporter);
+    let warn = |message: String| {
+        emit(&pnpm_reporter::LogEvent::Pnpm(pnpm_reporter::PnpmLog {
+            level: pnpm_reporter::LogLevel::Warn,
+            message,
+            prefix: String::new(),
+        }));
+    };
+    let Some(server) = report_to.or(cfg.pnpr_server.as_deref()) else {
+        warn(
+            "--report is set but neither --report-to nor pnprServer names a server; the run was not published"
+                .to_string(),
+        );
+        return;
+    };
+    let client = pnpm_pnpr_client::PnprClient::new(server);
+    let authorization = cfg.auth_headers.for_url(server);
+    let request = pnpm_pnpr_client::PublishPipelineRunRequest {
+        workspace: upload.workspace,
+        run_id: upload.run_id,
+        summary: upload.summary,
+        events: upload.events,
+    };
+    match client.publish_pipeline_run(&request, authorization.as_deref()).await {
+        Ok(()) => println!("Run recorded on {server} as {}/{}", request.workspace, request.run_id),
+        Err(error) => warn(format!("failed to publish the pipeline run to {server}: {error}")),
+    }
 }
 
 pub(super) fn ci<'a>(ctx: &RunCtx<'a>, args: CiArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -17,6 +17,7 @@ use super::{
     patch::PatchArgs,
     patch_commit::PatchCommitArgs,
     patch_remove::PatchRemoveArgs,
+    pipeline::{PipelineArgs, PipelineInvocation, run_pipeline},
     pipelines::{
         AddPipeline, DedupePipeline, DeployPipeline, InstallPipeline, PrunePipeline,
         RemovePipeline, UpdatePipeline, apply_install_cli_config,
@@ -345,6 +346,41 @@ pub(super) fn install_test<'a>(
         }
 
         Ok(())
+    }))
+}
+
+pub(super) fn pipeline<'a>(
+    ctx: &RunCtx<'a>,
+    args: PipelineArgs,
+) -> miette::Result<CommandFuture<'a>> {
+    let PipelineArgs { name, mut install_args, json, no_cache, full, base } = args;
+    let invocation = PipelineInvocation {
+        name,
+        // `--dry-run` prints the task graph and runs nothing, the
+        // install included.
+        dry_run: install_args.dry_run,
+        json,
+        no_cache,
+        full,
+        base,
+    };
+    install_args.frozen_lockfile = true;
+    install_args.dry_run = false;
+
+    let install_future = if invocation.dry_run {
+        None
+    } else {
+        Some(install_with_update_check(ctx, install_args, UpdateCheckPolicy::Skip)?)
+    };
+    let dir = ctx.dir;
+    let reporter = ctx.reporter;
+    let config = ctx.config;
+    Ok(Box::pin(async move {
+        if let Some(install) = install_future {
+            install.await?;
+        }
+        let cfg = config()?;
+        run_pipeline(&invocation, cfg, dir, reporter)
     }))
 }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -236,6 +236,15 @@ fn install_with_update_check<'a>(
     args: InstallArgs,
     update_check_policy: UpdateCheckPolicy,
 ) -> miette::Result<CommandFuture<'a>> {
+    let install = install_with_config(ctx, args, update_check_policy)?;
+    Ok(Box::pin(async move { install.await.map(|_| ()) }))
+}
+
+fn install_with_config<'a>(
+    ctx: &RunCtx<'a>,
+    args: InstallArgs,
+    update_check_policy: UpdateCheckPolicy,
+) -> miette::Result<CommandFuture<'a, &'static Config>> {
     let dir = ctx.dir;
     let manifest_path = ctx.manifest_path;
     let reporter = ctx.reporter;
@@ -295,10 +304,14 @@ fn install_with_update_check<'a>(
             };
             let installed = match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
-                    Box::pin(pipeline.run::<DefaultReporter>()).await
+                    Box::pin(pipeline.run_with_config::<DefaultReporter>()).await
                 }
-                ReporterType::Ndjson => Box::pin(pipeline.run::<NdjsonReporter>()).await,
-                ReporterType::Silent => Box::pin(pipeline.run::<SilentReporter>()).await,
+                ReporterType::Ndjson => {
+                    Box::pin(pipeline.run_with_config::<NdjsonReporter>()).await
+                }
+                ReporterType::Silent => {
+                    Box::pin(pipeline.run_with_config::<SilentReporter>()).await
+                }
             };
             update_notifier::settle(update_check, &installed).await;
             installed
@@ -395,17 +408,19 @@ pub(super) fn pipeline<'a>(
     let install_future = if invocation.dry_run {
         None
     } else {
-        Some(install_with_update_check(ctx, install_args, UpdateCheckPolicy::Skip)?)
+        Some(install_with_config(ctx, install_args, UpdateCheckPolicy::Skip)?)
     };
     let dir = ctx.dir;
     let reporter = ctx.reporter;
     let config = ctx.config;
     Ok(Box::pin(async move {
-        if let Some(install) = install_future {
-            install.await?;
-        }
-        let cfg = config()?;
-        apply_update_config(cfg, dir, reporter).await?;
+        let cfg = if let Some(install) = install_future {
+            install.await?
+        } else {
+            let cfg = config()?;
+            apply_update_config(cfg, dir, reporter).await?;
+            cfg
+        };
         let outcome = run_pipeline(&invocation, cfg, dir, reporter)?;
         // The run is recorded before the failure exit is raised, so a red
         // run reaches the server too.

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -53,6 +53,7 @@ mod report;
 
 use cache::{CacheDisposition, TaskCache};
 use report::RunReport;
+pub use report::RunUpload;
 
 /// The base ref the affected selection falls back to when neither
 /// `--base` nor the `pipelineBase` setting names one.
@@ -92,6 +93,17 @@ pub struct PipelineArgs {
     /// with HEAD). Overrides the `pipelineBase` setting.
     #[clap(long)]
     pub base: Option<String>,
+
+    /// Publish the run's summary and event stream to the configured pnpr
+    /// server (the `pnprServer` setting) once the run settles.
+    #[clap(long)]
+    pub report: bool,
+
+    /// Publish the run to this pnpr server instead of the `pnprServer`
+    /// setting — which also drives install offloading, so a server that
+    /// only stores runs is better named here.
+    #[clap(long = "report-to", value_name = "URL")]
+    pub report_to: Option<String>,
 }
 
 /// The pipeline-specific inputs of one invocation, split off
@@ -103,6 +115,39 @@ pub struct PipelineInvocation {
     pub no_cache: bool,
     pub full: bool,
     pub base: Option<String>,
+    pub report: bool,
+    pub report_to: Option<String>,
+}
+
+/// How the run ended, and what a `--report` submission would carry. The
+/// failure exit is raised by the dispatcher after any reporting, so a
+/// failed run is still recorded.
+pub struct PipelineOutcome {
+    pub failed_tasks: usize,
+    pub upload: Option<RunUpload>,
+}
+
+impl PipelineOutcome {
+    fn without_upload() -> Self {
+        PipelineOutcome { failed_tasks: 0, upload: None }
+    }
+}
+
+/// The identity runs are recorded under on the server: the workspace
+/// directory's name plus the same path hash that keys the local pipeline
+/// data, so two checkouts of one repository stay distinguishable.
+fn workspace_identity(workspace_root: &Path) -> String {
+    let basename: String = workspace_root
+        .file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_default()
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+        .take(50)
+        .collect();
+    let slug = pnpm_crypto_hash::create_short_hash(&workspace_root.to_string_lossy());
+    let basename = basename.trim_start_matches('.');
+    if basename.is_empty() { slug } else { format!("{basename}-{slug}") }
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -137,7 +182,7 @@ pub fn run_pipeline(
     config: &Config,
     dir: &Path,
     reporter: ReporterType,
-) -> miette::Result<()> {
+) -> miette::Result<PipelineOutcome> {
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
     let emit = reporter_emit(reporter);
     let silent = matches!(reporter, ReporterType::Ndjson | ReporterType::Silent);
@@ -177,7 +222,10 @@ pub fn run_pipeline(
         println!("No projects are affected since {base} — nothing to run.");
         let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
         println!("Report: {}", report_dir.display());
-        return Ok(());
+        return Ok(PipelineOutcome {
+            failed_tasks: 0,
+            upload: Some(report.to_upload(workspace_identity(workspace_root))),
+        });
     }
 
     let selected_graph: ProjectGraph<GraphPkg<'_>> = graph
@@ -222,7 +270,7 @@ pub fn run_pipeline(
                 render_task_graph_dry_run(&task_graph, &sequenced_tasks, workspace_root),
             );
         }
-        return Ok(());
+        return Ok(PipelineOutcome::without_upload());
     }
 
     let cache = TaskCache::open(&pipeline_data_dir(config, workspace_root), workspace_root)?;
@@ -313,10 +361,10 @@ pub fn run_pipeline(
     );
     println!("Report: {}", report_dir.display());
 
-    if failed > 0 {
-        return Err(PipelineError::PipelineFail { count: failed }.into());
-    }
-    Ok(())
+    Ok(PipelineOutcome {
+        failed_tasks: failed,
+        upload: Some(report.to_upload(workspace_identity(workspace_root))),
+    })
 }
 
 /// Where the pipeline keeps its task cache, restore records, and run

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -1,0 +1,757 @@
+//! `pnpm pipeline` — run a named set of workspace tasks the way a CI run
+//! would: affected-since-base selection as a pre-pass, the task graph in
+//! dependency order without bailing, cached task results restored instead
+//! of re-run, and a machine-readable account of what happened.
+//!
+//! Proof of concept for the `pnpm ci` RFC (pnpm/rfcs — "pnpm as the CI
+//! engine"), with the task cache of pnpm/rfcs#22 in a local-tier-only
+//! form. The command name is `pipeline` because `pnpm ci` is already the
+//! clean-install command.
+
+use super::{
+    install::InstallArgs,
+    recursive::{ExecutionStatus, Status, discover_workspace_projects},
+    reporter::{ReporterType, reporter_emit},
+    run::{RunContext, ScriptSelector, run_stages},
+};
+use crate::cli_args::recursive::filtered_projects_dependencies;
+use clap::Args;
+use derive_more::{Display, Error};
+use indexmap::IndexMap;
+use miette::{Diagnostic, IntoDiagnostic};
+use pnpm_config::Config;
+use pnpm_executor::ScriptOutput;
+use pnpm_injected_deps_syncer::{SyncInjectedDeps, sync_injected_deps};
+use pnpm_package_manager::{
+    make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
+    pnp_path_for_execution,
+};
+use pnpm_reporter::{LogEvent, LogLevel, PnpmLog};
+use pnpm_workspace::{GraphPkg, Project};
+use pnpm_workspace_projects_filter::{GetChangedProjectsOptions, get_changed_projects};
+use pnpm_workspace_projects_graph::{
+    CreateProjectsGraphOptions, ProjectGraph, create_projects_graph,
+};
+use pnpm_workspace_task_scheduler::{
+    BuildPipelineTaskGraphOptions, ScheduleTasksOptions, SequenceTasksOptions, TaskCompletion,
+    TaskGraph, TaskKey, TaskNode, build_pipeline_task_graph, format_task,
+    render_task_graph_dry_run, schedule_tasks, sequence_tasks, task_graph_to_json,
+};
+use serde_json::Value;
+use std::{
+    collections::{HashMap, HashSet},
+    env,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::Mutex,
+    time::Instant,
+};
+
+mod cache;
+mod capture;
+mod report;
+
+use cache::{CacheDisposition, TaskCache};
+use report::RunReport;
+
+/// The base ref the affected selection falls back to when neither
+/// `--base` nor the `pipelineBase` setting names one.
+const DEFAULT_PIPELINE_BASE: &str = "origin/main";
+
+/// The pipeline `pnpm pipeline` runs when no name is given.
+const DEFAULT_PIPELINE_NAME: &str = "default";
+
+#[derive(Debug, Args)]
+pub struct PipelineArgs {
+    /// The pipeline to run, from the `pipelines` section of
+    /// `pnpm-workspace.yaml`. Defaults to "default".
+    pub name: Option<String>,
+
+    /// The install `pnpm pipeline` performs first is always a frozen
+    /// install; these flags tune the rest of it. `--dry-run` prints the
+    /// task graph without installing or running anything.
+    #[clap(flatten)]
+    pub install_args: InstallArgs,
+
+    /// With `--dry-run`, print the tasks and their resolved dependency
+    /// edges as JSON.
+    #[clap(long)]
+    pub json: bool,
+
+    /// Run every task even when a cached result exists, and overwrite the
+    /// cached entries.
+    #[clap(long = "no-cache")]
+    pub no_cache: bool,
+
+    /// Run the pipeline over every workspace project instead of the
+    /// affected-since-base selection.
+    #[clap(long)]
+    pub full: bool,
+
+    /// The git ref the affected selection diffs against (its merge base
+    /// with HEAD). Overrides the `pipelineBase` setting.
+    #[clap(long)]
+    pub base: Option<String>,
+}
+
+/// The pipeline-specific inputs of one invocation, split off
+/// [`PipelineArgs`] once the install half has been consumed.
+pub struct PipelineInvocation {
+    pub name: Option<String>,
+    pub dry_run: bool,
+    pub json: bool,
+    pub no_cache: bool,
+    pub full: bool,
+    pub base: Option<String>,
+}
+
+#[derive(Debug, Display, Error, Diagnostic)]
+#[non_exhaustive]
+pub enum PipelineError {
+    #[display("No pipelines are defined in pnpm-workspace.yaml")]
+    #[diagnostic(
+        code(ERR_PNPM_NO_PIPELINES),
+        help(
+            "Declare one under the \"pipelines\" key, e.g.\n\npipelines:\n  check:\n    - lint\n    - build\n    - test"
+        )
+    )]
+    NoPipelines,
+
+    #[display("There is no pipeline named \"{name}\". Available pipelines: {available}")]
+    #[diagnostic(code(ERR_PNPM_UNKNOWN_PIPELINE))]
+    UnknownPipeline { name: String, available: String },
+
+    #[display("\"pnpm pipeline\" failed in {count} tasks")]
+    #[diagnostic(code(ERR_PNPM_PIPELINE_FAIL))]
+    PipelineFail {
+        #[error(not(source))]
+        count: usize,
+    },
+}
+
+/// Run the pipeline. The frozen install has already happened by the time
+/// this is called (see `dispatch_install::pipeline`); this is selection,
+/// graph, cache, and report.
+pub fn run_pipeline(
+    invocation: &PipelineInvocation,
+    config: &Config,
+    dir: &Path,
+    reporter: ReporterType,
+) -> miette::Result<()> {
+    let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
+    let emit = reporter_emit(reporter);
+    let silent = matches!(reporter, ReporterType::Ndjson | ReporterType::Silent);
+
+    if config.pipelines.is_empty() {
+        return Err(PipelineError::NoPipelines.into());
+    }
+    let name = invocation.name.as_deref().unwrap_or(DEFAULT_PIPELINE_NAME);
+    let Some(requested_tasks) = config.pipelines.get(name) else {
+        return Err(PipelineError::UnknownPipeline {
+            name: name.to_string(),
+            available: config.pipelines.keys().cloned().collect::<Vec<_>>().join(", "),
+        }
+        .into());
+    };
+
+    let (projects, _patterns) = discover_workspace_projects(workspace_root, config)?;
+    let graph = build_full_graph(&projects, config);
+
+    let base = invocation
+        .base
+        .clone()
+        .or_else(|| config.pipeline_base.clone())
+        .unwrap_or_else(|| DEFAULT_PIPELINE_BASE.to_string());
+    let selection = select_affected_projects(&SelectAffectedOptions {
+        graph: &graph,
+        workspace_root,
+        base: &base,
+        full: invocation.full,
+        config,
+        emit,
+    })?;
+
+    let report = RunReport::new(name, &base, &selection);
+
+    if selection.requested.is_empty() {
+        println!("No projects are affected since {base} — nothing to run.");
+        let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
+        println!("Report: {}", report_dir.display());
+        return Ok(());
+    }
+
+    let selected_graph: ProjectGraph<GraphPkg<'_>> = graph
+        .iter()
+        .filter(|(root, _)| selection.selected.contains(root.as_path()))
+        .map(|(root, node)| (root.clone(), node.clone()))
+        .collect();
+    let project_dependencies =
+        filtered_projects_dependencies(&selected_graph, &graph, None, &HashSet::new());
+
+    let select_scripts = |project: &Path, task_name: &str| -> Vec<String> {
+        let manifest = graph[project].package.project.manifest.value();
+        match ScriptSelector::new(task_name) {
+            Ok(selector) => selector.select(manifest),
+            Err(_) => Vec::new(),
+        }
+    };
+    let task_names: Vec<&str> = requested_tasks.iter().map(String::as_str).collect();
+    let mut task_graph = build_pipeline_task_graph(&BuildPipelineTaskGraphOptions {
+        project_dependencies: &project_dependencies,
+        select_scripts,
+        task_names: &task_names,
+        requested_projects: Some(&selection.requested),
+        tasks: (!config.tasks.is_empty()).then_some(&config.tasks),
+    });
+    let sequenced_tasks = sequence_tasks(
+        &mut task_graph,
+        &SequenceTasksOptions {
+            workspace_dir: workspace_root,
+            ignore_cycles: config.ignore_workspace_cycles,
+            emit,
+        },
+    )?;
+
+    if invocation.dry_run {
+        if invocation.json {
+            let document = task_graph_to_json(&task_graph, workspace_root);
+            println!("{}", serde_json::to_string_pretty(&document).into_diagnostic()?);
+        } else {
+            println!(
+                "{}",
+                render_task_graph_dry_run(&task_graph, &sequenced_tasks, workspace_root)
+            );
+        }
+        return Ok(());
+    }
+
+    let cache = TaskCache::open(&pipeline_data_dir(config, workspace_root), workspace_root)?;
+    // Keys are computed for every task before anything runs, walking the
+    // sequenced order so a task's dependency keys exist when its own is
+    // built. This is also what a distributed tier would need: the whole
+    // plan, priced, without executing.
+    let task_keys = compute_task_keys(&task_graph, &sequenced_tasks, &graph, &cache, config)?;
+
+    capture::install_forward(emit);
+    let concurrency = usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1);
+    let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
+    let base_extra_env: HashMap<String, String> = config.extra_env_with_node_options();
+
+    let statuses: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
+        task_graph
+            .keys()
+            .map(|key| (format_task(key, workspace_root), ExecutionStatus::queued()))
+            .collect(),
+    );
+    let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
+
+    let run_task = |node: &TaskNode| -> TaskCompletion {
+        let key = TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
+        let summary_key = format_task(&key, workspace_root);
+        let outcome = run_pipeline_task(&RunTaskOptions {
+            node,
+            graph: &graph,
+            config,
+            invocation,
+            cache: &cache,
+            task_key: &task_keys[&key],
+            init_cwd: &init_cwd,
+            base_extra_env: &base_extra_env,
+            emit,
+            silent,
+            report: &report,
+            summary_key: &summary_key,
+        });
+        match outcome {
+            Ok(status) => {
+                let failed = status.status == Status::Failure;
+                statuses.lock().expect("status lock is not poisoned")[&summary_key] = status;
+                if failed { TaskCompletion::Failed } else { TaskCompletion::Passed }
+            }
+            Err(error) => {
+                let mut abort = abort.lock().expect("abort slot lock is not poisoned");
+                if abort.is_none() {
+                    *abort = Some(error);
+                }
+                TaskCompletion::Aborted
+            }
+        }
+    };
+    let on_task_skipped = |node: &TaskNode| {
+        let key = TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
+        let summary_key = format_task(&key, workspace_root);
+        statuses.lock().expect("status lock is not poisoned")[&summary_key].status =
+            Status::Skipped;
+        report.task_skipped(&summary_key);
+    };
+    schedule_tasks(
+        &task_graph,
+        &ScheduleTasksOptions {
+            concurrency,
+            bail: false,
+            run_task: &run_task,
+            on_task_skipped: &on_task_skipped,
+        },
+    );
+
+    if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
+        return Err(error);
+    }
+
+    let statuses = statuses.into_inner().expect("status lock is not poisoned");
+    let failed = statuses.values().filter(|status| status.status == Status::Failure).count();
+    let passed = statuses.values().filter(|status| status.status == Status::Passed).count();
+    let skipped = statuses.values().filter(|status| status.status == Status::Skipped).count();
+    let hits = report.cache_hits();
+
+    report.finish(&statuses, &task_keys, workspace_root);
+    let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
+
+    println!(
+        "Pipeline \"{name}\": {total} tasks — {passed} passed ({hits} from cache), {failed} failed, {skipped} skipped.",
+        total = statuses.len(),
+    );
+    println!("Report: {}", report_dir.display());
+
+    if failed > 0 {
+        return Err(PipelineError::PipelineFail { count: failed }.into());
+    }
+    Ok(())
+}
+
+/// Where the pipeline keeps its task cache, restore records, and run
+/// reports: under pnpm's cache directory, keyed by workspace path, so an
+/// install pruning `node_modules` cannot take the cache with it.
+fn pipeline_data_dir(config: &Config, workspace_root: &Path) -> PathBuf {
+    let workspace_slug = pnpm_crypto_hash::create_short_hash(&workspace_root.to_string_lossy());
+    config.cache_dir.join("pipeline").join(workspace_slug)
+}
+
+fn build_full_graph<'a>(projects: &'a [Project], config: &Config) -> ProjectGraph<GraphPkg<'a>> {
+    let graph_options = CreateProjectsGraphOptions {
+        link_workspace_packages: Some(
+            config.link_workspace_packages != pnpm_config::LinkWorkspacePackages::Off,
+        ),
+        ..CreateProjectsGraphOptions::default()
+    };
+    create_projects_graph(
+        projects.iter().map(|project| GraphPkg { project }).collect(),
+        &graph_options,
+    )
+    .graph
+}
+
+/// How the run decided what to cover.
+pub struct Selection {
+    /// The projects whose pipeline tasks the run requests: the changed
+    /// projects and their dependents (never the workspace root: root
+    /// tasks are out of the orchestration's scope).
+    pub requested: Vec<PathBuf>,
+    /// The dependency closure of `requested` — the projects the task
+    /// graph spans. The extra projects participate only through
+    /// `dependsOn` edges (an upstream build pulled in without its lint or
+    /// tests), which is what keeps a task's cache key independent of how
+    /// the run was narrowed, and what guarantees a selected build's
+    /// upstream outputs exist on a fresh machine.
+    pub selected: HashSet<PathBuf>,
+    pub mode: SelectionMode,
+    pub merge_base: Option<String>,
+    pub changed_count: usize,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum SelectionMode {
+    /// Changed projects and their dependents.
+    Affected,
+    /// Every project: `--full`, an unresolvable base, or a change to
+    /// files no project selection can attribute (the workspace root).
+    Full,
+}
+
+struct SelectAffectedOptions<'a> {
+    graph: &'a ProjectGraph<GraphPkg<'a>>,
+    workspace_root: &'a Path,
+    base: &'a str,
+    full: bool,
+    config: &'a Config,
+    emit: fn(&LogEvent),
+}
+
+/// The selection pre-pass: changed projects since the merge base, plus
+/// their transitive dependents. It is an optimization, not the
+/// correctness boundary — any doubt about attribution (the merge base
+/// cannot be resolved, or the diff touches the workspace root, whose
+/// files feed every project) falls through to the full graph.
+fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Result<Selection> {
+    let SelectAffectedOptions { graph, workspace_root, base, full, config, emit } = *options;
+    let all_dirs: Vec<PathBuf> =
+        graph.keys().filter(|dir| dir.as_path() != workspace_root).cloned().collect();
+    let full_selection = |merge_base: Option<String>, changed_count: usize| Selection {
+        requested: all_dirs.clone(),
+        selected: all_dirs.iter().cloned().collect(),
+        mode: SelectionMode::Full,
+        merge_base,
+        changed_count,
+    };
+
+    if full {
+        return Ok(full_selection(None, 0));
+    }
+    let Some(merge_base) = resolve_merge_base(workspace_root, base) else {
+        emit(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Warn,
+            message: format!(
+                "Cannot resolve the merge base of HEAD and {base}; running the pipeline over every project."
+            ),
+            prefix: workspace_root.to_string_lossy().into_owned(),
+        }));
+        return Ok(full_selection(None, 0));
+    };
+
+    let changed = get_changed_projects(
+        graph.keys().cloned().collect(),
+        &merge_base,
+        &GetChangedProjectsOptions {
+            workspace_dir: workspace_root,
+            test_pattern: &config.test_pattern,
+            changed_files_ignore_pattern: &config.changed_files_ignore_pattern,
+        },
+    )
+    .map_err(miette::Report::new)?;
+    let changed_count =
+        changed.changed_projects.len() + changed.ignore_dependent_for_projects.len();
+
+    // A changed file above every package maps to the workspace root
+    // project: the root manifest, the lockfile, a shared config. Those
+    // feed every project in ways project topology cannot see, so pruning
+    // is disabled for the run rather than guessed at.
+    if changed
+        .changed_projects
+        .iter()
+        .chain(&changed.ignore_dependent_for_projects)
+        .any(|dir| dir == workspace_root)
+    {
+        emit(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Warn,
+            message:
+                "The diff touches workspace-root files; running the pipeline over every project."
+                    .to_string(),
+            prefix: workspace_root.to_string_lossy().into_owned(),
+        }));
+        return Ok(full_selection(Some(merge_base), changed_count));
+    }
+
+    let mut dependents: HashMap<&Path, Vec<&Path>> = HashMap::new();
+    for (dir, node) in graph {
+        for dependency in &node.dependencies {
+            dependents.entry(dependency.as_path()).or_default().push(dir.as_path());
+        }
+    }
+    let mut affected: HashSet<PathBuf> = HashSet::new();
+    let mut stack: Vec<&Path> = changed.changed_projects.iter().map(PathBuf::as_path).collect();
+    while let Some(dir) = stack.pop() {
+        if !affected.insert(dir.to_path_buf()) {
+            continue;
+        }
+        stack.extend(dependents.get(dir).into_iter().flatten());
+    }
+    // A project whose only changes match `testPattern` is selected itself
+    // without pulling in its dependents.
+    affected.extend(changed.ignore_dependent_for_projects.iter().cloned());
+    affected.remove(workspace_root);
+
+    // The task graph additionally spans the affected set's transitive
+    // dependencies; see [`Selection::selected`] for why.
+    let mut selected = affected.clone();
+    let mut stack: Vec<PathBuf> = affected.iter().cloned().collect();
+    while let Some(dir) = stack.pop() {
+        for dependency in
+            graph.get(&dir).map(|node| node.dependencies.as_slice()).unwrap_or_default()
+        {
+            if dependency.as_path() != workspace_root && selected.insert(dependency.clone()) {
+                stack.push(dependency.clone());
+            }
+        }
+    }
+
+    // In the workspace graph's deterministic order, which is the
+    // dispatch tie-break order.
+    let requested: Vec<PathBuf> =
+        graph.keys().filter(|dir| affected.contains(dir.as_path())).cloned().collect();
+    Ok(Selection {
+        requested,
+        selected,
+        mode: SelectionMode::Affected,
+        merge_base: Some(merge_base),
+        changed_count,
+    })
+}
+
+/// `merge-base(HEAD, base)`, deepening a shallow clone until the merge
+/// base is reachable. `None` when it cannot be resolved (an unknown ref,
+/// unrelated histories, not a git repository) — the caller falls back to
+/// the full graph.
+fn resolve_merge_base(workspace_root: &Path, base: &str) -> Option<String> {
+    for _ in 0..5 {
+        if let Some(sha) = git_stdout(workspace_root, &["merge-base", "HEAD", base]) {
+            return Some(sha);
+        }
+        let shallow = git_stdout(workspace_root, &["rev-parse", "--is-shallow-repository"]);
+        if shallow.as_deref() != Some("true") {
+            return None;
+        }
+        let _ = Command::new("git")
+            .args(["fetch", "--deepen=200"])
+            .current_dir(workspace_root)
+            .status();
+    }
+    None
+}
+
+fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
+    let output = Command::new("git").args(args).current_dir(cwd).output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let trimmed = stdout.trim();
+    if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
+}
+
+/// The cache key of every task, computed in sequenced order so each
+/// task's dependency keys are already present. Pass-through tasks get
+/// keys too: a dependent's key must account for the chain behind them.
+fn compute_task_keys(
+    task_graph: &TaskGraph,
+    sequenced_tasks: &[TaskKey],
+    graph: &ProjectGraph<GraphPkg<'_>>,
+    cache: &TaskCache,
+    config: &Config,
+) -> miette::Result<HashMap<TaskKey, String>> {
+    let mut keys: HashMap<TaskKey, String> = HashMap::with_capacity(task_graph.len());
+    for key in sequenced_tasks {
+        let node = &task_graph[key];
+        let manifest = graph[node.project.as_path()].package.project.manifest.value();
+        let script_bodies = task_script_bodies(node, manifest, config.enable_pre_post_scripts);
+        let mut dependency_keys: Vec<&str> =
+            node.dependencies.iter().map(|dependency| keys[dependency].as_str()).collect();
+        dependency_keys.sort_unstable();
+        let task_key = cache.compute_task_key(&cache::TaskKeyInputs {
+            node,
+            settings: config.tasks.get(&node.task_name),
+            dependency_keys: &dependency_keys,
+            script_bodies: &script_bodies,
+        })?;
+        keys.insert(key.clone(), task_key);
+    }
+    Ok(keys)
+}
+
+/// The `(stage, body)` pairs the task actually executes, including the
+/// `pre`/`post` hooks when they are enabled — they run as part of the
+/// task and change what it produces, so they are key components.
+fn task_script_bodies(
+    node: &TaskNode,
+    manifest: &Value,
+    enable_pre_post_scripts: bool,
+) -> Vec<(String, String)> {
+    let mut bodies: Vec<(String, String)> = Vec::new();
+    for script in &node.scripts {
+        let stages: Vec<String> = if enable_pre_post_scripts {
+            vec![format!("pre{script}"), script.clone(), format!("post{script}")]
+        } else {
+            vec![script.clone()]
+        };
+        for stage in stages {
+            if let Some(body) = manifest
+                .get("scripts")
+                .and_then(|scripts| scripts.get(&stage))
+                .and_then(Value::as_str)
+            {
+                bodies.push((stage, body.to_string()));
+            }
+        }
+    }
+    bodies
+}
+
+#[derive(Clone, Copy)]
+struct RunTaskOptions<'a, 'graph> {
+    node: &'a TaskNode,
+    graph: &'a ProjectGraph<GraphPkg<'graph>>,
+    config: &'a Config,
+    invocation: &'a PipelineInvocation,
+    cache: &'a TaskCache,
+    task_key: &'a str,
+    init_cwd: &'a Path,
+    base_extra_env: &'a HashMap<String, String>,
+    emit: fn(&LogEvent),
+    silent: bool,
+    report: &'a RunReport,
+    summary_key: &'a str,
+}
+
+/// One task: a cache probe, then either a replayed hit or a real run
+/// that feeds the cache. Never returns `Err` for a script failure — only
+/// for infrastructure errors, which abort the run.
+fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<ExecutionStatus> {
+    let RunTaskOptions {
+        node,
+        graph,
+        config,
+        invocation,
+        cache,
+        task_key,
+        emit,
+        report,
+        summary_key,
+        ..
+    } = *options;
+    let root = node.project.as_path();
+    let settings = config.tasks.get(&node.task_name);
+    let cacheable = !invocation.no_cache
+        && settings
+            .is_some_and(|settings| settings.outputs.is_some() && settings.cache != Some(false));
+    let start = Instant::now();
+    report.task_started(summary_key, task_key);
+
+    if cacheable && let Some(stored) = cache.lookup(task_key) {
+        match cache.restore(&stored, root, summary_key) {
+            Ok(()) => {
+                capture::replay(&stored.scripts, root, emit);
+                sync_injected_deps_if_configured(config, node, graph)?;
+                let duration = start.elapsed().as_secs_f64() * 1e3;
+                report.task_finished(summary_key, Status::Passed, CacheDisposition::Hit, duration);
+                emit(&LogEvent::Pnpm(PnpmLog {
+                    level: LogLevel::Info,
+                    message: format!("{summary_key}: restored from cache"),
+                    prefix: root.to_string_lossy().into_owned(),
+                }));
+                return Ok(ExecutionStatus {
+                    status: Status::Passed,
+                    duration: Some(duration),
+                    prefix: None,
+                    message: None,
+                });
+            }
+            Err(reason) => {
+                // A file the restore cannot account for is the user's;
+                // overwriting it silently is how caches lose trust. The
+                // task runs normally instead.
+                emit(&LogEvent::Pnpm(PnpmLog {
+                    level: LogLevel::Warn,
+                    message: format!("{summary_key}: not restoring from cache: {reason}"),
+                    prefix: root.to_string_lossy().into_owned(),
+                }));
+            }
+        }
+    }
+
+    let execution = execute_task_scripts(options)?;
+    let duration = start.elapsed().as_secs_f64() * 1e3;
+    if execution.status == Status::Passed && cacheable {
+        let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
+        if let Err(error) = cache.store(task_key, root, summary_key, outputs, execution.captured) {
+            emit(&LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Warn,
+                message: format!("{summary_key}: failed to store the task in the cache: {error}"),
+                prefix: root.to_string_lossy().into_owned(),
+            }));
+        }
+    }
+    let disposition = if cacheable { CacheDisposition::Miss } else { CacheDisposition::Bypass };
+    report.task_finished(summary_key, execution.status, disposition, duration);
+    Ok(ExecutionStatus {
+        status: execution.status,
+        duration: Some(duration),
+        prefix: (execution.status == Status::Failure).then(|| root.to_string_lossy().into_owned()),
+        message: execution.message,
+    })
+}
+
+struct TaskExecution {
+    status: Status,
+    message: Option<String>,
+    captured: Vec<capture::CapturedScript>,
+}
+
+/// Run the task's scripts for real, capturing their output stream for
+/// the cache alongside the live reporter rendering.
+fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<TaskExecution> {
+    let RunTaskOptions { node, graph, config, init_cwd, base_extra_env, silent, .. } = *options;
+    let root = node.project.as_path();
+    let manifest = &graph[root].package.project.manifest;
+
+    let mut extra_env = base_extra_env.clone();
+    if let Some(pnp_path) = pnp_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env
+            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
+    }
+    if let Some(package_map_path) = package_map_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env.insert(
+            "NODE_OPTIONS".to_string(),
+            make_node_package_map_option(&package_map_path, node_options),
+        );
+    }
+
+    let root_str = root.to_string_lossy().into_owned();
+    let mut status = Status::Passed;
+    let mut message = None;
+    let mut captured: Vec<capture::CapturedScript> = Vec::new();
+    for selected in &node.scripts {
+        let Some(script) = manifest.script(selected, true).map_err(miette::Report::new)? else {
+            continue;
+        };
+        if script.is_empty() || script == "npx only-allow pnpm" {
+            continue;
+        }
+        if env::var_os("npm_lifecycle_event").is_some_and(|event| event == **selected)
+            && env::var_os("PNPM_SCRIPT_SRC_DIR").is_some_and(|src_dir| Path::new(&src_dir) == root)
+        {
+            continue;
+        }
+        let ctx = RunContext {
+            manifest,
+            dir: root,
+            init_cwd,
+            config,
+            extra_env: &extra_env,
+            silent,
+            output: ScriptOutput::Streamed { dep_path: &root_str, emit: capture::capturing_emit },
+            // The pipeline never bails, so there is no cancellation to
+            // propagate into running children.
+            process_tracker: None,
+        };
+        let exit = run_stages(&ctx, selected, script, &[])?;
+        captured.extend(capture::drain_task(&root_str, selected, config.enable_pre_post_scripts));
+        if !exit.success() {
+            status = Status::Failure;
+            message = Some(format!("command failed with exit code {}", exit.code().unwrap_or(1)));
+            break;
+        }
+    }
+    Ok(TaskExecution { status, message, captured })
+}
+
+/// A cache hit skips the script but must not skip the injected-deps sync
+/// that would have followed it — consumers of an injected dependency
+/// would otherwise keep seeing the previous build.
+fn sync_injected_deps_if_configured(
+    config: &Config,
+    node: &TaskNode,
+    graph: &ProjectGraph<GraphPkg<'_>>,
+) -> miette::Result<()> {
+    if !config.sync_injected_deps_after_scripts.iter().any(|script| node.scripts.contains(script)) {
+        return Ok(());
+    }
+    let manifest = graph[node.project.as_path()].package.project.manifest.value();
+    sync_injected_deps(&SyncInjectedDeps {
+        pkg_name: manifest.get("name").and_then(Value::as_str),
+        pkg_root_dir: &node.project,
+        workspace_dir: config.workspace_dir.as_deref(),
+        manifest_before_scripts: Some(manifest),
+    })?;
+    Ok(())
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -219,7 +219,7 @@ pub fn run_pipeline(
         } else {
             println!(
                 "{}",
-                render_task_graph_dry_run(&task_graph, &sequenced_tasks, workspace_root)
+                render_task_graph_dry_run(&task_graph, &sequenced_tasks, workspace_root),
             );
         }
         return Ok(());
@@ -308,7 +308,7 @@ pub fn run_pipeline(
     let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
 
     println!(
-        "Pipeline \"{name}\": {total} tasks — {passed} passed ({hits} from cache), {failed} failed, {skipped} skipped.",
+        r#"Pipeline "{name}": {total} tasks — {passed} passed ({hits} from cache), {failed} failed, {skipped} skipped."#,
         total = statuses.len(),
     );
     println!("Report: {}", report_dir.display());
@@ -401,7 +401,7 @@ fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Resu
         emit(&LogEvent::Pnpm(PnpmLog {
             level: LogLevel::Warn,
             message: format!(
-                "Cannot resolve the merge base of HEAD and {base}; running the pipeline over every project."
+                "Cannot resolve the merge base of HEAD and {base}; running the pipeline over every project.",
             ),
             prefix: workspace_root.to_string_lossy().into_owned(),
         }));

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -47,10 +47,12 @@ use std::{
     time::Instant,
 };
 
+mod agent;
 mod cache;
 mod capture;
 mod report;
 
+pub use agent::{WatchInvocation, run_watch};
 use cache::{CacheDisposition, TaskCache};
 use report::RunReport;
 pub use report::RunUpload;
@@ -104,6 +106,30 @@ pub struct PipelineArgs {
     /// only stores runs is better named here.
     #[clap(long = "report-to", value_name = "URL")]
     pub report_to: Option<String>,
+
+    /// Watch a git repository and run the pipeline for every new revision
+    /// of a branch, instead of running once against the current
+    /// directory.
+    #[clap(long, requires = "repo")]
+    pub watch: bool,
+
+    /// The repository the watch agent polls and builds — a URL or a local
+    /// path, anything git accepts as a remote.
+    #[clap(long, value_name = "REPO")]
+    pub repo: Option<String>,
+
+    /// The branch the watch agent follows.
+    #[clap(long, default_value = "main", value_name = "NAME")]
+    pub branch: String,
+
+    /// Seconds between polls of the watched repository.
+    #[clap(long, default_value_t = 30, value_name = "SECONDS")]
+    pub interval: u64,
+
+    /// With `--watch`: poll once, build if there is a new revision, and
+    /// exit.
+    #[clap(long, requires = "watch")]
+    pub once: bool,
 }
 
 /// The pipeline-specific inputs of one invocation, split off
@@ -216,7 +242,8 @@ pub fn run_pipeline(
         emit,
     })?;
 
-    let report = RunReport::new(name, &base, &selection);
+    let revision = git_stdout(workspace_root, &["rev-parse", "HEAD"]);
+    let report = RunReport::new(name, &base, &selection, revision);
 
     if selection.requested.is_empty() {
         println!("No projects are affected since {base} — nothing to run.");

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -51,6 +51,7 @@ mod agent;
 mod cache;
 mod capture;
 mod cargo_cache;
+mod paths;
 mod report;
 
 pub use agent::{WatchInvocation, run_watch};
@@ -124,7 +125,7 @@ pub struct PipelineArgs {
     pub branch: String,
 
     /// Seconds between polls of the watched repository.
-    #[clap(long, default_value_t = 30, value_name = "SECONDS")]
+    #[clap(long, default_value_t = 30, value_name = "SECONDS", value_parser = clap::value_parser!(u64).range(1..))]
     pub interval: u64,
 
     /// With `--watch`: poll once, build if there is a new revision, and
@@ -213,6 +214,13 @@ pub fn run_pipeline(
     let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
     let emit = reporter_emit(reporter);
     let silent = matches!(reporter, ReporterType::Ndjson | ReporterType::Silent);
+    let info = |message: String| {
+        emit(&LogEvent::Pnpm(PnpmLog {
+            level: LogLevel::Info,
+            message,
+            prefix: workspace_root.to_string_lossy().into_owned(),
+        }));
+    };
 
     if config.pipelines.is_empty() {
         return Err(PipelineError::NoPipelines.into());
@@ -244,12 +252,12 @@ pub fn run_pipeline(
     })?;
 
     let revision = git_stdout(workspace_root, &["rev-parse", "HEAD"]);
-    let report = RunReport::new(name, &base, &selection, revision);
+    let report = RunReport::new(name, &base, &selection, revision)?;
 
     if selection.requested.is_empty() {
-        println!("No projects are affected since {base} — nothing to run.");
+        info(format!("No projects are affected since {base} — nothing to run."));
         let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
-        println!("Report: {}", report_dir.display());
+        info(format!("Report: {}", report_dir.display()));
         return Ok(PipelineOutcome {
             failed_tasks: 0,
             upload: Some(report.to_upload(workspace_identity(workspace_root))),
@@ -383,11 +391,11 @@ pub fn run_pipeline(
     report.finish(&statuses, &task_keys, workspace_root);
     let report_dir = report.write(&pipeline_data_dir(config, workspace_root))?;
 
-    println!(
+    info(format!(
         r#"Pipeline "{name}": {total} tasks — {passed} passed ({hits} from cache), {failed} failed, {skipped} skipped."#,
         total = statuses.len(),
-    );
-    println!("Report: {}", report_dir.display());
+    ));
+    info(format!("Report: {}", report_dir.display()));
 
     Ok(PipelineOutcome {
         failed_tasks: failed,
@@ -420,8 +428,8 @@ fn build_full_graph<'a>(projects: &'a [Project], config: &Config) -> ProjectGrap
 /// How the run decided what to cover.
 pub struct Selection {
     /// The projects whose pipeline tasks the run requests: the changed
-    /// projects and their dependents (never the workspace root: root
-    /// tasks are out of the orchestration's scope).
+    /// projects and their dependents. Root tasks participate when
+    /// `includeWorkspaceRoot` is enabled.
     pub requested: Vec<PathBuf>,
     /// The dependency closure of `requested` — the projects the task
     /// graph spans. The extra projects participate only through
@@ -537,7 +545,9 @@ fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Resu
     // A project whose only changes match `testPattern` is selected itself
     // without pulling in its dependents.
     affected.extend(changed.ignore_dependent_for_projects.iter().cloned());
-    affected.remove(workspace_root);
+    if !config.include_workspace_root {
+        affected.remove(workspace_root);
+    }
 
     // The task graph additionally spans the affected set's transitive
     // dependencies; see [`Selection::selected`] for why.
@@ -597,9 +607,7 @@ fn git_stdout(cwd: &Path, args: &[&str]) -> Option<String> {
     if trimmed.is_empty() { None } else { Some(trimmed.to_string()) }
 }
 
-/// The cache key of every task, computed in sequenced order so each
-/// task's dependency keys are already present. Pass-through tasks get
-/// keys too: a dependent's key must account for the chain behind them.
+/// Pass-through tasks contribute keys to invalidate their dependents.
 fn compute_task_keys(
     task_graph: &TaskGraph,
     sequenced_tasks: &[TaskKey],
@@ -620,15 +628,17 @@ fn compute_task_keys(
             settings: config.tasks.get(&node.task_name),
             dependency_keys: &dependency_keys,
             script_bodies: &script_bodies,
+            environment: &task_environment(
+                config,
+                &node.project,
+                &config.extra_env_with_node_options(),
+            ),
         })?;
         keys.insert(key.clone(), task_key);
     }
     Ok(keys)
 }
 
-/// The `(stage, body)` pairs the task actually executes, including the
-/// `pre`/`post` hooks when they are enabled — they run as part of the
-/// task and change what it produces, so they are key components.
 fn task_script_bodies(
     node: &TaskNode,
     manifest: &Value,
@@ -670,9 +680,7 @@ struct RunTaskOptions<'a, 'graph> {
     summary_key: &'a str,
 }
 
-/// One task: a cache probe, then either a replayed hit or a real run
-/// that feeds the cache. Never returns `Err` for a script failure — only
-/// for infrastructure errors, which abort the run.
+/// Script failures are returned as statuses. Infrastructure errors abort the run.
 fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<ExecutionStatus> {
     let RunTaskOptions {
         node,
@@ -688,12 +696,7 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     } = *options;
     let root = node.project.as_path();
     let settings = config.tasks.get(&node.task_name);
-    let cacheable = !invocation.no_cache
-        && settings.is_some_and(|settings| {
-            settings.outputs.is_some()
-                && settings.cache != Some(false)
-                && settings.cargo_target_dir.is_none()
-        });
+    let cacheable = task_cacheable(invocation, settings);
     let start = Instant::now();
     report.task_started(summary_key, task_key);
 
@@ -731,9 +734,12 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
 
     let execution = execute_task_with_cargo_cache(options, settings)?;
     let duration = start.elapsed().as_secs_f64() * 1e3;
-    if execution.status == Status::Passed && cacheable {
+    if execution.status == Status::Passed
+        && cacheable
+        && let Some(captured) = execution.captured
+    {
         let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
-        if let Err(error) = cache.store(task_key, root, summary_key, outputs, execution.captured) {
+        if let Err(error) = cache.store(task_key, root, summary_key, outputs, captured) {
             emit(&LogEvent::Pnpm(PnpmLog {
                 level: LogLevel::Warn,
                 message: format!("{summary_key}: failed to store the task in the cache: {error}"),
@@ -827,34 +833,33 @@ fn cargo_cache_warning(options: &RunTaskOptions<'_, '_>, reason: &str) {
 struct TaskExecution {
     status: Status,
     message: Option<String>,
-    captured: Vec<capture::CapturedScript>,
+    captured: Option<Vec<capture::CapturedScript>>,
 }
 
 /// Run the task's scripts for real, capturing their output stream for
 /// the cache alongside the live reporter rendering.
 fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<TaskExecution> {
-    let RunTaskOptions { node, graph, config, init_cwd, base_extra_env, silent, .. } = *options;
+    let RunTaskOptions {
+        node,
+        graph,
+        config,
+        invocation,
+        init_cwd,
+        base_extra_env,
+        silent,
+        emit,
+        ..
+    } = *options;
     let root = node.project.as_path();
     let manifest = &graph[root].package.project.manifest;
 
-    let mut extra_env = base_extra_env.clone();
-    if let Some(pnp_path) = pnp_path_for_execution(config, root) {
-        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
-        extra_env
-            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
-    }
-    if let Some(package_map_path) = package_map_path_for_execution(config, root) {
-        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
-        extra_env.insert(
-            "NODE_OPTIONS".to_string(),
-            make_node_package_map_option(&package_map_path, node_options),
-        );
-    }
-
+    let extra_env = task_environment(config, root, base_extra_env);
+    let capture_output = task_cacheable(invocation, config.tasks.get(&node.task_name));
     let root_str = root.to_string_lossy().into_owned();
     let mut status = Status::Passed;
     let mut message = None;
-    let mut captured: Vec<capture::CapturedScript> = Vec::new();
+    let mut captured = capture_output.then(Vec::new);
+    let mut captured_bytes = 0usize;
     for selected in &node.scripts {
         let Some(script) = manifest.script(selected, true).map_err(miette::Report::new)? else {
             continue;
@@ -874,13 +879,34 @@ fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<Task
             config,
             extra_env: &extra_env,
             silent,
-            output: ScriptOutput::Streamed { dep_path: &root_str, emit: capture::capturing_emit },
+            output: ScriptOutput::Streamed {
+                dep_path: &root_str,
+                emit: if capture_output { capture::capturing_emit } else { emit },
+            },
             // The pipeline never bails, so there is no cancellation to
             // propagate into running children.
             process_tracker: None,
         };
-        let exit = run_stages(&ctx, selected, script, &[])?;
-        captured.extend(capture::drain_task(&root_str, selected, config.enable_pre_post_scripts));
+        let exit = run_stages(&ctx, selected, script, &[]);
+        if capture_output {
+            match capture::drain_task(&root_str, selected, config.enable_pre_post_scripts) {
+                Some(stages) => {
+                    captured_bytes += stages
+                        .iter()
+                        .flat_map(|stage| &stage.lines)
+                        .map(|line| line.line.len() + std::mem::size_of::<capture::CapturedLine>())
+                        .sum::<usize>();
+                    if captured_bytes > capture::MAX_CAPTURE_BYTES {
+                        captured = None;
+                    }
+                    if let Some(captured) = &mut captured {
+                        captured.extend(stages);
+                    }
+                }
+                None => captured = None,
+            }
+        }
+        let exit = exit?;
         if !exit.success() {
             status = Status::Failure;
             message = Some(format!("command failed with exit code {}", exit.code().unwrap_or(1)));
@@ -909,4 +935,38 @@ fn sync_injected_deps_if_configured(
         manifest_before_scripts: Some(manifest),
     })?;
     Ok(())
+}
+
+fn task_cacheable(
+    invocation: &PipelineInvocation,
+    settings: Option<&pnpm_config::TaskSettings>,
+) -> bool {
+    !invocation.no_cache
+        && settings.is_some_and(|settings| {
+            settings.outputs.is_some()
+                && settings.cache != Some(false)
+                && settings.cargo_target_dir.is_none()
+        })
+}
+
+fn task_environment(
+    config: &Config,
+    root: &Path,
+    base_extra_env: &HashMap<String, String>,
+) -> HashMap<String, String> {
+    let mut extra_env = base_extra_env.clone();
+    if let Some(pnp_path) = pnp_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env
+            .insert("NODE_OPTIONS".to_string(), make_node_require_option(&pnp_path, node_options));
+    }
+    if let Some(package_map_path) = package_map_path_for_execution(config, root) {
+        let node_options = extra_env.get("NODE_OPTIONS").map(String::as_str);
+        extra_env.insert(
+            "NODE_OPTIONS".to_string(),
+            make_node_package_map_option(&package_map_path, node_options),
+        );
+    }
+
+    extra_env
 }

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -50,6 +50,7 @@ use std::{
 mod agent;
 mod cache;
 mod capture;
+mod cargo_cache;
 mod report;
 
 pub use agent::{WatchInvocation, run_watch};
@@ -459,8 +460,11 @@ struct SelectAffectedOptions<'a> {
 /// files feed every project) falls through to the full graph.
 fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Result<Selection> {
     let SelectAffectedOptions { graph, workspace_root, base, full, config, emit } = *options;
-    let all_dirs: Vec<PathBuf> =
-        graph.keys().filter(|dir| dir.as_path() != workspace_root).cloned().collect();
+    let all_dirs: Vec<PathBuf> = graph
+        .keys()
+        .filter(|dir| config.include_workspace_root || dir.as_path() != workspace_root)
+        .cloned()
+        .collect();
     let full_selection = |merge_base: Option<String>, changed_count: usize| Selection {
         requested: all_dirs.clone(),
         selected: all_dirs.iter().cloned().collect(),
@@ -685,8 +689,11 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     let root = node.project.as_path();
     let settings = config.tasks.get(&node.task_name);
     let cacheable = !invocation.no_cache
-        && settings
-            .is_some_and(|settings| settings.outputs.is_some() && settings.cache != Some(false));
+        && settings.is_some_and(|settings| {
+            settings.outputs.is_some()
+                && settings.cache != Some(false)
+                && settings.cargo_target_dir.is_none()
+        });
     let start = Instant::now();
     report.task_started(summary_key, task_key);
 
@@ -722,7 +729,7 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
         }
     }
 
-    let execution = execute_task_scripts(options)?;
+    let execution = execute_task_with_cargo_cache(options, settings)?;
     let duration = start.elapsed().as_secs_f64() * 1e3;
     if execution.status == Status::Passed && cacheable {
         let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
@@ -742,6 +749,79 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
         prefix: (execution.status == Status::Failure).then(|| root.to_string_lossy().into_owned()),
         message: execution.message,
     })
+}
+
+fn execute_task_with_cargo_cache(
+    options: &RunTaskOptions<'_, '_>,
+    settings: Option<&pnpm_config::TaskSettings>,
+) -> miette::Result<TaskExecution> {
+    let RunTaskOptions { node, config, invocation, task_key, emit, summary_key, .. } = *options;
+    let root = node.project.as_path();
+    let Some(directory) = settings.and_then(|settings| settings.cargo_target_dir.as_deref()) else {
+        return execute_task_scripts(options);
+    };
+    let cargo = cargo_cache::CargoCache::open(root, directory).into_diagnostic()?;
+    let environment = cargo_cache::cache_environment(
+        options.base_extra_env,
+        settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default(),
+    );
+    let cargo_cacheable =
+        !invocation.no_cache && settings.is_some_and(|settings| settings.cache != Some(false));
+    let snapshot = if cargo_cacheable {
+        match cargo_cache::snapshot_entry(&config.cache_dir, root, task_key, &environment) {
+            Ok(snapshot) => Some(snapshot),
+            Err(error) => {
+                cargo_cache_warning(options, &error.to_string());
+                None
+            }
+        }
+    } else {
+        None
+    };
+    if let Some((entry, key, _)) = &snapshot {
+        match cargo.restore(entry, key) {
+            Ok(true) => emit(&LogEvent::Pnpm(PnpmLog {
+                level: LogLevel::Info,
+                message: format!("{summary_key}: restored Cargo build state"),
+                prefix: root.to_string_lossy().into_owned(),
+            })),
+            Ok(false) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => cargo_cache_warning(options, &error.to_string()),
+        }
+        cargo.prepare(key).into_diagnostic()?;
+    }
+    let mut extra_env = options.base_extra_env.clone();
+    for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_BUILD_DIR"] {
+        extra_env.insert(name.to_string(), cargo.target.to_string_lossy().into_owned());
+    }
+    let execution =
+        execute_task_scripts(&RunTaskOptions { base_extra_env: &extra_env, ..*options })?;
+    if execution.status == Status::Passed
+        && let Some((entry, key, local_packages)) = &snapshot
+    {
+        match cargo_cache::snapshot_entry(&config.cache_dir, root, task_key, &environment) {
+            Ok((_, after, _)) if after == *key => {
+                if let Err(error) = cargo.publish(entry, key, local_packages) {
+                    cargo_cache_warning(options, &error.to_string());
+                }
+            }
+            Ok(_) => cargo_cache_warning(
+                options,
+                "inputs changed during execution; snapshot was not saved",
+            ),
+            Err(error) => cargo_cache_warning(options, &error.to_string()),
+        }
+    }
+    Ok(execution)
+}
+
+fn cargo_cache_warning(options: &RunTaskOptions<'_, '_>, reason: &str) {
+    (options.emit)(&LogEvent::Pnpm(PnpmLog {
+        level: LogLevel::Warn,
+        message: format!("{}: Cargo build cache: {reason}", options.summary_key),
+        prefix: options.node.project.to_string_lossy().into_owned(),
+    }));
 }
 
 struct TaskExecution {

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -83,8 +83,7 @@ pub struct PipelineArgs {
     #[clap(long)]
     pub json: bool,
 
-    /// Run every task even when a cached result exists, and overwrite the
-    /// cached entries.
+    /// Run every task without reading or writing cached results or Cargo snapshots.
     #[clap(long = "no-cache")]
     pub no_cache: bool,
 
@@ -557,7 +556,9 @@ fn select_affected_projects(options: &SelectAffectedOptions<'_>) -> miette::Resu
         for dependency in
             graph.get(&dir).map(|node| node.dependencies.as_slice()).unwrap_or_default()
         {
-            if dependency.as_path() != workspace_root && selected.insert(dependency.clone()) {
+            if (config.include_workspace_root || dependency.as_path() != workspace_root)
+                && selected.insert(dependency.clone())
+            {
                 stack.push(dependency.clone());
             }
         }

--- a/pnpm/crates/cli/src/cli_args/pipeline/agent.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/agent.rs
@@ -1,0 +1,234 @@
+//! The pull-based watch agent: poll a git repository for new revisions of
+//! a branch, materialize each one into a persistent checkout, and run the
+//! pipeline against it in a child process.
+//!
+//! This is the smallest thing that is actually CI — no leasing, no
+//! webhook ingress, no coordinator: one daemon, one repository, one
+//! branch. Execution deliberately happens in a spawned `pnpm pipeline`
+//! process rather than in this one: the agent is the component that runs
+//! arbitrary workspace code, and its blast radius is the child process
+//! and the checkout, nothing else the agent holds.
+
+use pnpm_crypto_hash::create_short_hash;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+pub struct WatchInvocation {
+    pub pipeline_name: Option<String>,
+    /// The repository to poll — a URL or a local path, anything `git`
+    /// accepts as a remote.
+    pub repo: String,
+    pub branch: String,
+    pub interval: Duration,
+    /// Poll once, build if there is a new revision, and exit.
+    pub once: bool,
+    pub no_cache: bool,
+    pub report: bool,
+    pub report_to: Option<String>,
+    /// Forwarded to the child so a build can authenticate its reporting
+    /// (and its installs) from an explicit auth file.
+    pub npmrc_auth_file: Option<PathBuf>,
+}
+
+/// Where the agent keeps its state for one `(repo, branch)`: the
+/// persistent checkout builds run in, and the last revision it built.
+struct AgentDirs {
+    checkout: PathBuf,
+    head_file: PathBuf,
+}
+
+pub fn run_watch(invocation: &WatchInvocation, cache_dir: &Path) -> miette::Result<()> {
+    let agent_dir = cache_dir
+        .join("pipeline")
+        .join("agent")
+        .join(create_short_hash(&format!("{}\0{}", invocation.repo, invocation.branch)));
+    fs::create_dir_all(&agent_dir)
+        .map_err(|error| miette::miette!("creating the agent directory: {error}"))?;
+    // Named after the repository so everything derived from the checkout
+    // path — the run record's workspace identity above all — reads as the
+    // project, not as "checkout".
+    let dirs = AgentDirs {
+        checkout: agent_dir.join(repo_basename(&invocation.repo)),
+        head_file: agent_dir.join("head"),
+    };
+    println!(
+        "Watching {} ({}) every {}s; checkout: {}",
+        invocation.repo,
+        invocation.branch,
+        invocation.interval.as_secs(),
+        dirs.checkout.display(),
+    );
+    loop {
+        match poll_and_build(invocation, &dirs) {
+            Ok(Some(revision)) => println!("Built {revision}."),
+            Ok(None) => println!("{} is up to date.", invocation.branch),
+            // A failed poll (the remote is briefly unreachable, a fetch
+            // hiccup) must not kill a daemon; the next tick retries.
+            Err(error) => eprintln!("[WARN] poll failed: {error}"),
+        }
+        if invocation.once {
+            return Ok(());
+        }
+        std::thread::sleep(invocation.interval);
+    }
+}
+
+/// One tick: compare the remote head with the last revision built, and
+/// build it if they differ. Returns the revision built, or `None` when
+/// there was nothing new.
+fn poll_and_build(
+    invocation: &WatchInvocation,
+    dirs: &AgentDirs,
+) -> miette::Result<Option<String>> {
+    let head = remote_head(&invocation.repo, &invocation.branch)?;
+    let last_built = fs::read_to_string(&dirs.head_file).ok();
+    if last_built.as_deref().map(str::trim) == Some(head.as_str()) {
+        return Ok(None);
+    }
+    materialize(invocation, dirs, &head)?;
+    println!("New revision {head}; running the pipeline…");
+    run_pipeline_in_checkout(invocation, dirs, &head, last_built.as_deref());
+    // Recorded whether the build passed or failed: CI builds a revision
+    // once and the record (submitted before the child's failure exit)
+    // holds the verdict. Only a new revision triggers a new build.
+    fs::write(&dirs.head_file, &head)
+        .map_err(|error| miette::miette!("recording the built revision: {error}"))?;
+    Ok(Some(head))
+}
+
+/// The repository's short name: the last path segment, minus a `.git`
+/// suffix, reduced to the identifier alphabet. Falls back to "checkout"
+/// for a remote it cannot name.
+fn repo_basename(repo: &str) -> String {
+    let tail = repo
+        .trim_end_matches('/')
+        .rsplit(['/', ':'])
+        .next()
+        .unwrap_or_default()
+        .trim_end_matches(".git");
+    let name: String = tail
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+        .take(50)
+        .collect();
+    let name = name.trim_start_matches('.').to_string();
+    if name.is_empty() { "checkout".to_string() } else { name }
+}
+
+fn remote_head(repo: &str, branch: &str) -> miette::Result<String> {
+    let output = Command::new("git")
+        .args(["ls-remote", "--", repo, &format!("refs/heads/{branch}")])
+        .output()
+        .map_err(|error| miette::miette!("running git ls-remote: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr = stderr.trim();
+        return Err(miette::miette!("git ls-remote {repo} failed: {stderr}"));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+        .ok_or_else(|| miette::miette!("branch {branch} does not exist in {repo}"))
+}
+
+/// Clone on first contact, fetch afterwards, and pin the working tree to
+/// exactly `revision`. The checkout is persistent on purpose: gitignored
+/// build outputs and `node_modules` survive between builds, so cache
+/// restores and repeat installs stay warm.
+fn materialize(
+    invocation: &WatchInvocation,
+    dirs: &AgentDirs,
+    revision: &str,
+) -> miette::Result<()> {
+    if dirs.checkout.join(".git").exists() {
+        git_ok(Some(&dirs.checkout), &["fetch", "origin", &invocation.branch])?;
+    } else {
+        git_ok(
+            None,
+            &[
+                "clone",
+                "--branch",
+                &invocation.branch,
+                "--",
+                &invocation.repo,
+                &dirs.checkout.to_string_lossy(),
+            ],
+        )?;
+    }
+    git_ok(Some(&dirs.checkout), &["checkout", "--detach", revision])
+}
+
+fn git_ok(cwd: Option<&Path>, args: &[&str]) -> miette::Result<()> {
+    let mut command = Command::new("git");
+    command.args(args);
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output =
+        command.output().map_err(|error| miette::miette!("running git {args:?}: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    Err(miette::miette!("git {args:?} failed: {stderr}"))
+}
+
+/// Run `pnpm pipeline` against the checkout as a child process. The base
+/// for affected selection is the previously built revision — "what
+/// changed since the last build" is the agent's native question — with
+/// the first build of a checkout running the full graph. A failing build
+/// is the child's verdict to report, not an agent error: the agent logs
+/// it and keeps watching.
+fn run_pipeline_in_checkout(
+    invocation: &WatchInvocation,
+    dirs: &AgentDirs,
+    revision: &str,
+    last_built: Option<&str>,
+) {
+    let program = match std::env::current_exe() {
+        Ok(program) => program,
+        Err(error) => {
+            eprintln!("[WARN] cannot locate the pnpm executable: {error}");
+            return;
+        }
+    };
+    let mut child = Command::new(program);
+    child.arg("pipeline");
+    if let Some(name) = &invocation.pipeline_name {
+        child.arg(name);
+    }
+    child.arg("--dir").arg(&dirs.checkout);
+    match last_built {
+        Some(last_built) => {
+            child.arg("--base").arg(last_built.trim());
+        }
+        None => {
+            child.arg("--full");
+        }
+    }
+    if invocation.no_cache {
+        child.arg("--no-cache");
+    }
+    if invocation.report {
+        child.arg("--report");
+    }
+    if let Some(report_to) = &invocation.report_to {
+        child.arg("--report-to").arg(report_to);
+    }
+    if let Some(auth_file) = &invocation.npmrc_auth_file {
+        child.arg("--npmrc-auth-file").arg(auth_file);
+    }
+    match child.status() {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            eprintln!("[WARN] pipeline for {revision} failed with {status}");
+        }
+        Err(error) => eprintln!("[WARN] failed to spawn the pipeline for {revision}: {error}"),
+    }
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/agent.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/agent.rs
@@ -6,8 +6,8 @@
 //! webhook ingress, no coordinator: one daemon, one repository, one
 //! branch. Execution deliberately happens in a spawned `pnpm pipeline`
 //! process rather than in this one: the agent is the component that runs
-//! arbitrary workspace code, and its blast radius is the child process
-//! and the checkout, nothing else the agent holds.
+//! arbitrary workspace code. The child inherits the agent's permissions;
+//! process separation is not a sandbox.
 
 use pnpm_crypto_hash::create_short_hash;
 use std::{
@@ -41,18 +41,24 @@ struct AgentDirs {
     head_file: PathBuf,
 }
 
-pub fn run_watch(invocation: &WatchInvocation, cache_dir: &Path) -> miette::Result<()> {
-    let agent_dir = cache_dir
+pub fn run_watch(invocation: &WatchInvocation, state_dir: &Path) -> miette::Result<()> {
+    if invocation.interval.is_zero() {
+        return Err(miette::miette!("watch interval must be at least one second"));
+    }
+    let agent_dir = state_dir
         .join("pipeline")
         .join("agent")
         .join(create_short_hash(&format!("{}\0{}", invocation.repo, invocation.branch)));
     fs::create_dir_all(&agent_dir)
         .map_err(|error| miette::miette!("creating the agent directory: {error}"))?;
+    let agent_display = agent_dir.display();
+    let _lock = lock_agent(&agent_dir)
+        .map_err(|error| miette::miette!("locking watch agent {agent_display}: {error}"))?;
     // Named after the repository so everything derived from the checkout
     // path — the run record's workspace identity above all — reads as the
     // project, not as "checkout".
     let dirs = AgentDirs {
-        checkout: agent_dir.join(repo_basename(&invocation.repo)),
+        checkout: agent_dir.join("checkout").join(repo_basename(&invocation.repo)),
         head_file: agent_dir.join("head"),
     };
     println!(
@@ -63,11 +69,13 @@ pub fn run_watch(invocation: &WatchInvocation, cache_dir: &Path) -> miette::Resu
         dirs.checkout.display(),
     );
     loop {
-        match poll_and_build(invocation, &dirs) {
+        let result = poll_and_build(invocation, &dirs);
+        match result {
             Ok(Some(revision)) => println!("Built {revision}."),
             Ok(None) => println!("{} is up to date.", invocation.branch),
             // A failed poll (the remote is briefly unreachable, a fetch
             // hiccup) must not kill a daemon; the next tick retries.
+            Err(error) if invocation.once => return Err(error),
             Err(error) => eprintln!("[WARN] poll failed: {error}"),
         }
         if invocation.once {
@@ -91,11 +99,8 @@ fn poll_and_build(
     }
     materialize(invocation, dirs, &head)?;
     println!("New revision {head}; running the pipeline…");
-    run_pipeline_in_checkout(invocation, dirs, &head, last_built.as_deref());
-    // Recorded whether the build passed or failed: CI builds a revision
-    // once and the record (submitted before the child's failure exit)
-    // holds the verdict. Only a new revision triggers a new build.
-    fs::write(&dirs.head_file, &head)
+    run_pipeline_in_checkout(invocation, dirs, &head, last_built.as_deref())?;
+    pnpm_fs::write_atomic(&dirs.head_file, head.as_bytes())
         .map_err(|error| miette::miette!("recording the built revision: {error}"))?;
     Ok(Some(head))
 }
@@ -160,7 +165,9 @@ fn materialize(
             ],
         )?;
     }
-    git_ok(Some(&dirs.checkout), &["checkout", "--detach", revision])
+    git_ok(Some(&dirs.checkout), &["reset", "--hard", "HEAD"])?;
+    git_ok(Some(&dirs.checkout), &["clean", "-fd"])?;
+    git_ok(Some(&dirs.checkout), &["checkout", "--force", "--detach", revision])
 }
 
 fn git_ok(cwd: Option<&Path>, args: &[&str]) -> miette::Result<()> {
@@ -182,22 +189,16 @@ fn git_ok(cwd: Option<&Path>, args: &[&str]) -> miette::Result<()> {
 /// Run `pnpm pipeline` against the checkout as a child process. The base
 /// for affected selection is the previously built revision — "what
 /// changed since the last build" is the agent's native question — with
-/// the first build of a checkout running the full graph. A failing build
-/// is the child's verdict to report, not an agent error: the agent logs
-/// it and keeps watching.
+/// the first build of a checkout running the full graph. Unsuccessful
+/// children leave the revision pending for the next poll.
 fn run_pipeline_in_checkout(
     invocation: &WatchInvocation,
     dirs: &AgentDirs,
     revision: &str,
     last_built: Option<&str>,
-) {
-    let program = match std::env::current_exe() {
-        Ok(program) => program,
-        Err(error) => {
-            eprintln!("[WARN] cannot locate the pnpm executable: {error}");
-            return;
-        }
-    };
+) -> miette::Result<()> {
+    let program = std::env::current_exe()
+        .map_err(|error| miette::miette!("cannot locate the pnpm executable: {error}"))?;
     let mut child = Command::new(program);
     child.arg("pipeline");
     if let Some(name) = &invocation.pipeline_name {
@@ -227,8 +228,27 @@ fn run_pipeline_in_checkout(
     match child.status() {
         Ok(status) if status.success() => {}
         Ok(status) => {
-            eprintln!("[WARN] pipeline for {revision} failed with {status}");
+            return Err(miette::miette!(
+                "pipeline for {revision} failed with {status}; the revision will be retried"
+            ));
         }
-        Err(error) => eprintln!("[WARN] failed to spawn the pipeline for {revision}: {error}"),
+        Err(error) => {
+            return Err(miette::miette!("failed to run the pipeline for {revision}: {error}"));
+        }
     }
+    Ok(())
 }
+
+fn lock_agent(directory: &Path) -> std::io::Result<fs::File> {
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(directory.join("lock"))?;
+    file.try_lock().map_err(std::io::Error::other)?;
+    Ok(file)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/pipeline/agent/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/agent/tests.rs
@@ -1,0 +1,16 @@
+use super::lock_agent;
+
+#[test]
+fn a_second_watcher_cannot_use_a_running_watchers_checkout() {
+    let directory = tempfile::tempdir().unwrap();
+    let first = lock_agent(directory.path()).unwrap();
+    assert!(
+        lock_agent(directory.path()).is_err(),
+        "a second watcher must not acquire the checkout",
+    );
+    drop(first);
+    assert!(
+        lock_agent(directory.path()).is_ok(),
+        "the checkout must be released when the watcher stops",
+    );
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -1,0 +1,448 @@
+//! The local task cache: content-addressed task results under pnpm's
+//! cache directory. A proof-of-concept tier of the workspace task cache
+//! RFC (pnpm/rfcs#22): keys cover the script text, the declared env
+//! values, the project's tracked files, the upstream task keys, the
+//! lockfile, and the runtime — with the lockfile hashed whole as a
+//! deliberate `PoC` stand-in for the per-importer dependency-graph hash the
+//! RFC specifies.
+
+use super::capture::CapturedScript;
+use pnpm_config::TaskSettings;
+use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file, create_short_hash};
+use pnpm_workspace_task_scheduler::TaskNode;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    env, fs, io,
+    path::{Path, PathBuf},
+    process::Command,
+    sync::{Arc, Mutex},
+};
+use wax::{Glob, Program};
+
+/// How a task met the cache, for the run report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CacheDisposition {
+    Hit,
+    Miss,
+    /// The task is not cacheable (no declared `outputs`, `cache: false`,
+    /// or `--no-cache`).
+    Bypass,
+}
+
+/// One stored task: its captured output streams and the output files it
+/// produced, relative to the project directory.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct StoredTask {
+    pub version: u32,
+    pub task: String,
+    pub files: Vec<String>,
+    pub scripts: Vec<CapturedScript>,
+    /// Where the entry's `outputs/` tree lives; not serialized.
+    #[serde(skip)]
+    pub entry_dir: PathBuf,
+}
+
+pub struct TaskCache {
+    tasks_dir: PathBuf,
+    state_dir: PathBuf,
+    workspace_root: PathBuf,
+    lockfile_hash: String,
+    runtime_fingerprint: String,
+    /// Per-project tracked-file hashes, shared by every task of the
+    /// project: enumeration and hashing run once, per-task input specs
+    /// filter the shared list.
+    project_files: Mutex<HashMap<PathBuf, Arc<Vec<HashedFile>>>>,
+}
+
+#[derive(Debug)]
+struct HashedFile {
+    rel_path: String,
+    hash: String,
+}
+
+/// One entry of a task's last-outputs record: a file the previous run or
+/// restore produced, with the content it left behind.
+#[derive(Debug, Serialize, Deserialize)]
+struct RecordedFile {
+    path: String,
+    hash: String,
+}
+
+pub struct TaskKeyInputs<'a> {
+    pub node: &'a TaskNode,
+    pub settings: Option<&'a TaskSettings>,
+    /// The cache keys of the tasks this task depends on, sorted.
+    pub dependency_keys: &'a [&'a str],
+    /// `(stage, body)` of every script the task runs, in run order.
+    pub script_bodies: &'a [(String, String)],
+}
+
+impl TaskCache {
+    pub fn open(data_dir: &Path, workspace_root: &Path) -> miette::Result<TaskCache> {
+        let tasks_dir = data_dir.join("tasks");
+        let state_dir = data_dir.join("state");
+        fs::create_dir_all(&tasks_dir)
+            .and_then(|()| fs::create_dir_all(&state_dir))
+            .map_err(|error| miette::miette!("creating the pipeline cache directories: {error}"))?;
+        let lockfile_hash = create_hex_hash_from_file(&workspace_root.join("pnpm-lock.yaml"))
+            .unwrap_or_else(|_| "no-lockfile".to_string());
+        let runtime_fingerprint = Command::new("node")
+            .arg("--version")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map_or_else(
+                || "no-node".to_string(),
+                |output| String::from_utf8_lossy(&output.stdout).trim().to_string(),
+            );
+        Ok(TaskCache {
+            tasks_dir,
+            state_dir,
+            workspace_root: workspace_root.to_path_buf(),
+            lockfile_hash,
+            runtime_fingerprint,
+            project_files: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// The task's cache key: `pnpm-pipeline-task:v0` over the components
+    /// the RFC names, NUL-separated and hashed.
+    pub fn compute_task_key(&self, inputs: &TaskKeyInputs<'_>) -> miette::Result<String> {
+        let TaskKeyInputs { node, settings, dependency_keys, script_bodies } = *inputs;
+        let project_rel = self.project_rel(&node.project);
+        let mut components: Vec<String> = vec![
+            "pnpm-pipeline-task:v0".to_string(),
+            project_rel,
+            node.task_name.clone(),
+            format!("lockfile:{}", self.lockfile_hash),
+            format!("runtime:{}", self.runtime_fingerprint),
+        ];
+        for (stage, body) in script_bodies {
+            components.push(format!("script:{stage}={body}"));
+        }
+        for name in settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default() {
+            let value = env::var(name).unwrap_or_default();
+            components.push(format!("env:{name}={value}"));
+        }
+        for file in self.input_files(node, settings)?.iter() {
+            components.push(format!("file:{}={}", file.rel_path, file.hash));
+        }
+        for dependency_key in dependency_keys {
+            components.push(format!("dep:{dependency_key}"));
+        }
+        Ok(create_hex_hash(&components.join("\0")))
+    }
+
+    pub fn lookup(&self, key: &str) -> Option<StoredTask> {
+        let entry_dir = self.entry_dir(key);
+        let meta = fs::read_to_string(entry_dir.join("meta.json")).ok()?;
+        let mut stored: StoredTask = serde_json::from_str(&meta).ok()?;
+        stored.entry_dir = entry_dir;
+        Some(stored)
+    }
+
+    /// Restore a stored task into the working tree. `Err` carries the
+    /// human-readable reason the restore refused — the caller runs the
+    /// task normally.
+    ///
+    /// A file is only ever overwritten or deleted when its current
+    /// content matches what the previous run or restore left there
+    /// (or what the artifact would write anyway). The record therefore
+    /// carries content hashes, not just paths — a path set cannot tell
+    /// "we produced it" apart from "we produced it and the user has
+    /// edited it since".
+    pub fn restore(
+        &self,
+        stored: &StoredTask,
+        project_dir: &Path,
+        task_id: &str,
+    ) -> Result<(), String> {
+        let previous = self.read_output_record(task_id);
+        for rel_path in &stored.files {
+            let target = project_dir.join(rel_path);
+            if !target.exists() {
+                continue;
+            }
+            let target_hash = create_hex_hash_from_file(&target).unwrap_or_default();
+            let ours = previous
+                .iter()
+                .any(|recorded| recorded.path == *rel_path && recorded.hash == target_hash);
+            if ours {
+                continue;
+            }
+            let artifact_hash =
+                create_hex_hash_from_file(&stored.entry_dir.join("outputs").join(rel_path))
+                    .unwrap_or_else(|_| "unreadable".to_string());
+            if target_hash != artifact_hash {
+                return Err(format!(
+                    "{rel_path} in the working tree is not what the previous run produced"
+                ));
+            }
+        }
+        // What the previous run produced and this artifact does not is
+        // stale output; restoring only additions would leave a mixture of
+        // two builds. A stale file the user has edited since is theirs
+        // now, so the restore refuses rather than deleting it.
+        let mut stale: Vec<&RecordedFile> = Vec::new();
+        for recorded in &previous {
+            if stored.files.contains(&recorded.path) {
+                continue;
+            }
+            let target = project_dir.join(&recorded.path);
+            if !target.exists() {
+                continue;
+            }
+            if create_hex_hash_from_file(&target).unwrap_or_default() != recorded.hash {
+                return Err(format!(
+                    "{} was modified after the previous run produced it",
+                    recorded.path
+                ));
+            }
+            stale.push(recorded);
+        }
+        for recorded in stale {
+            let _ = fs::remove_file(project_dir.join(&recorded.path));
+        }
+        let mut record: Vec<RecordedFile> = Vec::with_capacity(stored.files.len());
+        for rel_path in &stored.files {
+            let source = stored.entry_dir.join("outputs").join(rel_path);
+            let target = project_dir.join(rel_path);
+            if let Some(parent) = target.parent() {
+                let _ = fs::create_dir_all(parent);
+            }
+            if let Err(error) = fs::copy(&source, &target) {
+                return Err(format!("copying {rel_path}: {error}"));
+            }
+            record.push(RecordedFile {
+                path: rel_path.clone(),
+                hash: create_hex_hash_from_file(&source).unwrap_or_default(),
+            });
+        }
+        self.write_output_record(task_id, &record);
+        Ok(())
+    }
+
+    /// Store a successful task: its declared outputs and captured logs.
+    pub fn store(
+        &self,
+        key: &str,
+        project_dir: &Path,
+        task_id: &str,
+        outputs: &[String],
+        scripts: Vec<CapturedScript>,
+    ) -> io::Result<()> {
+        let files = collect_output_files(project_dir, outputs)?;
+        let entry_dir = self.entry_dir(key);
+        let staging_dir = entry_dir.with_extension("staging");
+        let _ = fs::remove_dir_all(&staging_dir);
+        fs::create_dir_all(&staging_dir)?;
+        let mut record: Vec<RecordedFile> = Vec::with_capacity(files.len());
+        for rel_path in &files {
+            let target = staging_dir.join("outputs").join(rel_path);
+            if let Some(parent) = target.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::copy(project_dir.join(rel_path), &target)?;
+            record.push(RecordedFile {
+                path: rel_path.clone(),
+                hash: create_hex_hash_from_file(&target)?,
+            });
+        }
+        let meta = StoredTask {
+            version: 1,
+            task: task_id.to_string(),
+            files,
+            scripts,
+            entry_dir: PathBuf::new(),
+        };
+        fs::write(staging_dir.join("meta.json"), serde_json::to_vec_pretty(&meta)?)?;
+        let _ = fs::remove_dir_all(&entry_dir);
+        if let Some(parent) = entry_dir.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::rename(&staging_dir, &entry_dir)?;
+        self.write_output_record(task_id, &record);
+        Ok(())
+    }
+
+    fn entry_dir(&self, key: &str) -> PathBuf {
+        self.tasks_dir.join(&key[..2]).join(key)
+    }
+
+    fn output_record_path(&self, task_id: &str) -> PathBuf {
+        self.state_dir.join(format!("{}.json", create_short_hash(task_id)))
+    }
+
+    fn read_output_record(&self, task_id: &str) -> Vec<RecordedFile> {
+        fs::read_to_string(self.output_record_path(task_id))
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .unwrap_or_default()
+    }
+
+    fn write_output_record(&self, task_id: &str, files: &[RecordedFile]) {
+        if let Ok(contents) = serde_json::to_vec(files) {
+            let _ = fs::write(self.output_record_path(task_id), contents);
+        }
+    }
+
+    fn project_rel(&self, project: &Path) -> String {
+        pathdiff::diff_paths(project, &self.workspace_root)
+            .map(|path| path.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/"))
+            .filter(|path| !path.is_empty())
+            .unwrap_or_else(|| ".".to_string())
+    }
+
+    /// The task's input files with their content hashes: the project's
+    /// tracked (and untracked, unignored) files minus its declared
+    /// outputs and `node_modules`, narrowed by the task's `inputs` globs
+    /// when declared (`+`-prefixed entries add to the default set
+    /// instead).
+    fn input_files(
+        &self,
+        node: &TaskNode,
+        settings: Option<&TaskSettings>,
+    ) -> miette::Result<Arc<Vec<HashedFile>>> {
+        let all = self.hashed_project_files(&node.project)?;
+        let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
+        let inputs = settings.and_then(|settings| settings.inputs.as_deref());
+        let output_globs = compile_globs(outputs)?;
+        let (replace_globs, add_globs) = match inputs {
+            None => (Vec::new(), Vec::new()),
+            Some(patterns) => {
+                let (add, replace): (Vec<&String>, Vec<&String>) =
+                    patterns.iter().partition(|pattern| pattern.starts_with('+'));
+                (
+                    compile_globs_ref(&replace)?,
+                    compile_globs_owned(
+                        &add.iter().map(|pattern| pattern[1..].to_string()).collect::<Vec<_>>(),
+                    )?,
+                )
+            }
+        };
+        let filtered: Vec<HashedFile> = all
+            .iter()
+            .filter(|file| !output_globs.iter().any(|glob| glob.is_match(file.rel_path.as_str())))
+            .filter(|file| {
+                let in_default = replace_globs.is_empty()
+                    || replace_globs.iter().any(|glob| glob.is_match(file.rel_path.as_str()));
+                in_default || add_globs.iter().any(|glob| glob.is_match(file.rel_path.as_str()))
+            })
+            .map(|file| HashedFile { rel_path: file.rel_path.clone(), hash: file.hash.clone() })
+            .collect();
+        Ok(Arc::new(filtered))
+    }
+
+    fn hashed_project_files(&self, project: &Path) -> miette::Result<Arc<Vec<HashedFile>>> {
+        if let Some(files) =
+            self.project_files.lock().expect("project-files lock is not poisoned").get(project)
+        {
+            return Ok(Arc::clone(files));
+        }
+        let output = Command::new("git")
+            .args(["ls-files", "-z", "--cached", "--others", "--exclude-standard"])
+            .current_dir(project)
+            .output()
+            .map_err(|error| {
+                miette::miette!("running git ls-files in {}: {error}", project.display())
+            })?;
+        if !output.status.success() {
+            return Err(miette::miette!(
+                "git ls-files failed in {}: {}",
+                project.display(),
+                String::from_utf8_lossy(&output.stderr).trim(),
+            ));
+        }
+        let mut files: Vec<HashedFile> = Vec::new();
+        for rel_path in output.stdout.split(|byte| *byte == 0) {
+            if rel_path.is_empty() {
+                continue;
+            }
+            let rel_path = String::from_utf8_lossy(rel_path).replace('\\', "/");
+            if rel_path == "node_modules" || rel_path.starts_with("node_modules/") {
+                continue;
+            }
+            // A tracked file deleted from the working tree contributes
+            // nothing; the deletion shows up as the file's absence.
+            let Ok(hash) = create_hex_hash_from_file(&project.join(&rel_path)) else {
+                continue;
+            };
+            files.push(HashedFile { rel_path, hash });
+        }
+        files.sort_by(|left, right| left.rel_path.cmp(&right.rel_path));
+        let files = Arc::new(files);
+        self.project_files
+            .lock()
+            .expect("project-files lock is not poisoned")
+            .insert(project.to_path_buf(), Arc::clone(&files));
+        Ok(files)
+    }
+}
+
+/// The files under `project_dir` the `outputs` globs match, as sorted
+/// `/`-separated relative paths. `node_modules` and `.git` are never
+/// walked.
+fn collect_output_files(project_dir: &Path, outputs: &[String]) -> io::Result<Vec<String>> {
+    let globs = compile_globs(outputs)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidInput, error.to_string()))?;
+    if globs.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut files = Vec::new();
+    let mut stack = vec![project_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        for entry in fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            let file_type = entry.file_type()?;
+            if file_type.is_dir() {
+                let name = entry.file_name();
+                if name != "node_modules" && name != ".git" {
+                    stack.push(path);
+                }
+            } else if file_type.is_file() {
+                let rel_path = path
+                    .strip_prefix(project_dir)
+                    .expect("walked path is under the project directory")
+                    .to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/");
+                if globs.iter().any(|glob| glob.is_match(rel_path.as_str())) {
+                    files.push(rel_path);
+                }
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn compile_globs(patterns: &[String]) -> miette::Result<Vec<Glob<'_>>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            Glob::new(pattern).map_err(|error| miette::miette!("invalid glob {pattern:?}: {error}"))
+        })
+        .collect()
+}
+
+fn compile_globs_ref<'a>(patterns: &[&'a String]) -> miette::Result<Vec<Glob<'a>>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            Glob::new(pattern).map_err(|error| miette::miette!("invalid glob {pattern:?}: {error}"))
+        })
+        .collect()
+}
+
+fn compile_globs_owned(patterns: &[String]) -> miette::Result<Vec<Glob<'static>>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            Glob::new(pattern)
+                .map(Glob::into_owned)
+                .map_err(|error| miette::miette!("invalid glob {pattern:?}: {error}"))
+        })
+        .collect()
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -177,7 +177,7 @@ impl TaskCache {
                     .unwrap_or_else(|_| "unreadable".to_string());
             if target_hash != artifact_hash {
                 return Err(format!(
-                    "{rel_path} in the working tree is not what the previous run produced"
+                    "{rel_path} in the working tree is not what the previous run produced",
                 ));
             }
         }
@@ -197,7 +197,7 @@ impl TaskCache {
             if create_hex_hash_from_file(&target).unwrap_or_default() != recorded.hash {
                 return Err(format!(
                     "{} was modified after the previous run produced it",
-                    recorded.path
+                    recorded.path,
                 ));
             }
             stale.push(recorded);
@@ -341,19 +341,18 @@ impl TaskCache {
         {
             return Ok(Arc::clone(files));
         }
+        let project_display = project.display();
         let output = Command::new("git")
             .args(["ls-files", "-z", "--cached", "--others", "--exclude-standard"])
             .current_dir(project)
             .output()
             .map_err(|error| {
-                miette::miette!("running git ls-files in {}: {error}", project.display())
+                miette::miette!("running git ls-files in {project_display}: {error}")
             })?;
         if !output.status.success() {
-            return Err(miette::miette!(
-                "git ls-files failed in {}: {}",
-                project.display(),
-                String::from_utf8_lossy(&output.stderr).trim(),
-            ));
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stderr = stderr.trim();
+            return Err(miette::miette!("git ls-files failed in {project_display}: {stderr}"));
         }
         let mut files: Vec<HashedFile> = Vec::new();
         for rel_path in output.stdout.split(|byte| *byte == 0) {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -88,8 +88,14 @@ impl TaskCache {
             .map_err(|error| miette::miette!("creating the pipeline cache directories: {error}"))?;
         let lockfile_hash = create_hex_hash_from_file(&workspace_root.join("pnpm-lock.yaml"))
             .unwrap_or_else(|_| "no-lockfile".to_string());
+        // Resolved from the workspace, not the invoking process: with
+        // context-aware toolchains (pnpm's own shims included) the
+        // runtime is a function of the directory, and a `--dir`
+        // invocation must fingerprint the runtime the workspace's
+        // scripts will actually get.
         let runtime_fingerprint = Command::new("node")
             .arg("--version")
+            .current_dir(workspace_root)
             .output()
             .ok()
             .filter(|output| output.status.success())

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -264,8 +264,7 @@ impl TaskCache {
                 hash: create_hex_hash_from_file(&source).unwrap_or_default(),
             });
         }
-        self.write_output_record(task_id, &record);
-        Ok(())
+        self.write_output_record(task_id, &record).map_err(|error| error.to_string())
     }
 
     /// Store a successful task: its declared outputs and captured logs.
@@ -320,8 +319,7 @@ impl TaskCache {
                 }
             }
         }
-        self.write_output_record(task_id, &record);
-        Ok(())
+        self.write_output_record(task_id, &record)
     }
 
     fn matches_snapshot(&self, key: &str, expected: &StoredTask) -> io::Result<bool> {
@@ -357,10 +355,9 @@ impl TaskCache {
             .unwrap_or_default()
     }
 
-    fn write_output_record(&self, task_id: &str, files: &[RecordedFile]) {
-        if let Ok(contents) = serde_json::to_vec(files) {
-            let _ = pnpm_fs::write_atomic(&self.output_record_path(task_id), &contents);
-        }
+    fn write_output_record(&self, task_id: &str, files: &[RecordedFile]) -> io::Result<()> {
+        let contents = serde_json::to_vec(files)?;
+        pnpm_fs::write_atomic(&self.output_record_path(task_id), &contents)
     }
 
     fn project_rel(&self, project: &Path) -> String {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -308,11 +308,38 @@ impl TaskCache {
         fs::write(staging_dir.join("meta.json"), serde_json::to_vec_pretty(&meta)?)?;
         match fs::rename(staging_dir, &entry_dir) {
             Ok(()) => {}
-            Err(_) if entry_dir.is_dir() => {}
-            Err(error) => return Err(error),
+            Err(error) => {
+                let destination_exists = matches!(
+                    error.kind(),
+                    io::ErrorKind::AlreadyExists | io::ErrorKind::DirectoryNotEmpty,
+                ) || cfg!(windows)
+                    && error.kind() == io::ErrorKind::PermissionDenied;
+                // Windows can report access denied when a destination directory already exists.
+                if !destination_exists || !self.matches_snapshot(key, &meta)? {
+                    return Err(error);
+                }
+            }
         }
         self.write_output_record(task_id, &record);
         Ok(())
+    }
+
+    fn matches_snapshot(&self, key: &str, expected: &StoredTask) -> io::Result<bool> {
+        let Some(stored) = self.lookup(key) else {
+            return Ok(false);
+        };
+        if stored.files != expected.files || stored.hashes != expected.hashes {
+            return Ok(false);
+        }
+        for relative in &stored.files {
+            check_ancestors(&stored.entry_dir, &Path::new("outputs").join(relative))?;
+            if create_hex_hash_from_file(&stored.entry_dir.join("outputs").join(relative))?
+                != stored.hashes[relative]
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     fn entry_dir(&self, key: &str) -> PathBuf {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -6,7 +6,10 @@
 //! deliberate `PoC` stand-in for the per-importer dependency-graph hash the
 //! RFC specifies.
 
-use super::capture::CapturedScript;
+use super::{
+    capture::CapturedScript,
+    paths::{check_ancestors, validate_relative_path},
+};
 use pnpm_config::TaskSettings;
 use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file, create_short_hash};
 use pnpm_workspace_task_scheduler::TaskNode;
@@ -18,7 +21,10 @@ use std::{
     process::Command,
     sync::{Arc, Mutex},
 };
-use wax::{Glob, Program};
+use wax::{
+    Glob, Program,
+    walk::{Entry, FileIterator},
+};
 
 /// How a task met the cache, for the run report.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -38,6 +44,7 @@ pub struct StoredTask {
     pub version: u32,
     pub task: String,
     pub files: Vec<String>,
+    pub hashes: HashMap<String, String>,
     pub scripts: Vec<CapturedScript>,
     /// Where the entry's `outputs/` tree lives; not serialized.
     #[serde(skip)]
@@ -76,6 +83,7 @@ pub struct TaskKeyInputs<'a> {
     /// The cache keys of the tasks this task depends on, sorted.
     pub dependency_keys: &'a [&'a str],
     /// `(stage, body)` of every script the task runs, in run order.
+    pub environment: &'a HashMap<String, String>,
     pub script_bodies: &'a [(String, String)],
 }
 
@@ -116,10 +124,12 @@ impl TaskCache {
     /// The task's cache key: `pnpm-pipeline-task:v0` over the components
     /// the RFC names, NUL-separated and hashed.
     pub fn compute_task_key(&self, inputs: &TaskKeyInputs<'_>) -> miette::Result<String> {
-        let TaskKeyInputs { node, settings, dependency_keys, script_bodies } = *inputs;
+        let TaskKeyInputs { node, settings, dependency_keys, script_bodies, environment } = *inputs;
         let project_rel = self.project_rel(&node.project);
         let mut components: Vec<String> = vec![
-            "pnpm-pipeline-task:v0".to_string(),
+            "pnpm-pipeline-task:v1".to_string(),
+            format!("platform:{}:{}", env::consts::OS, env::consts::ARCH),
+            format!("outputs:{:?}", settings.and_then(|settings| settings.outputs.as_ref())),
             project_rel,
             node.task_name.clone(),
             format!("lockfile:{}", self.lockfile_hash),
@@ -129,8 +139,8 @@ impl TaskCache {
             components.push(format!("script:{stage}={body}"));
         }
         for name in settings.and_then(|settings| settings.env.as_deref()).unwrap_or_default() {
-            let value = env::var(name).unwrap_or_default();
-            components.push(format!("env:{name}={value}"));
+            let value = environment.get(name).cloned().or_else(|| env::var(name).ok());
+            components.push(format!("env:{name}={value:?}"));
         }
         for file in self.input_files(node, settings)?.iter() {
             components.push(format!("file:{}={}", file.rel_path, file.hash));
@@ -143,8 +153,12 @@ impl TaskCache {
 
     pub fn lookup(&self, key: &str) -> Option<StoredTask> {
         let entry_dir = self.entry_dir(key);
+        check_ancestors(&self.tasks_dir, entry_dir.strip_prefix(&self.tasks_dir).ok()?).ok()?;
         let meta = fs::read_to_string(entry_dir.join("meta.json")).ok()?;
         let mut stored: StoredTask = serde_json::from_str(&meta).ok()?;
+        if stored.version != 2 {
+            return None;
+        }
         stored.entry_dir = entry_dir;
         Some(stored)
     }
@@ -166,6 +180,28 @@ impl TaskCache {
         task_id: &str,
     ) -> Result<(), String> {
         let previous = self.read_output_record(task_id);
+        let validate = |root: &Path, relative: &str| {
+            validate_relative_path(Path::new(relative))
+                .and_then(|()| check_ancestors(root, Path::new(relative)))
+                .map_err(|error| error.to_string())
+        };
+        for relative in stored
+            .files
+            .iter()
+            .map(String::as_str)
+            .chain(previous.iter().map(|record| record.path.as_str()))
+        {
+            validate(project_dir, relative)?;
+        }
+        for relative in &stored.files {
+            validate(&stored.entry_dir, &format!("outputs/{relative}"))?;
+            let actual =
+                create_hex_hash_from_file(&stored.entry_dir.join("outputs").join(relative))
+                    .map_err(|error| error.to_string())?;
+            if stored.hashes.get(relative) != Some(&actual) {
+                return Err(format!("cached output failed integrity: {relative}"));
+            }
+        }
         for rel_path in &stored.files {
             let target = project_dir.join(rel_path);
             if !target.exists() {
@@ -209,14 +245,16 @@ impl TaskCache {
             stale.push(recorded);
         }
         for recorded in stale {
-            let _ = fs::remove_file(project_dir.join(&recorded.path));
+            validate(project_dir, &recorded.path)?;
+            fs::remove_file(project_dir.join(&recorded.path)).map_err(|error| error.to_string())?;
         }
         let mut record: Vec<RecordedFile> = Vec::with_capacity(stored.files.len());
         for rel_path in &stored.files {
             let source = stored.entry_dir.join("outputs").join(rel_path);
             let target = project_dir.join(rel_path);
+            validate(project_dir, rel_path)?;
             if let Some(parent) = target.parent() {
-                let _ = fs::create_dir_all(parent);
+                fs::create_dir_all(parent).map_err(|error| error.to_string())?;
             }
             if let Err(error) = fs::copy(&source, &target) {
                 return Err(format!("copying {rel_path}: {error}"));
@@ -241,15 +279,18 @@ impl TaskCache {
     ) -> io::Result<()> {
         let files = collect_output_files(project_dir, outputs)?;
         let entry_dir = self.entry_dir(key);
-        let staging_dir = entry_dir.with_extension("staging");
-        let _ = fs::remove_dir_all(&staging_dir);
-        fs::create_dir_all(&staging_dir)?;
+        let parent = entry_dir.parent().expect("cache entry parent");
+        fs::create_dir_all(parent)?;
+        let staging = tempfile::Builder::new().prefix(".publish-").tempdir_in(parent)?;
+        let staging_dir = staging.path();
         let mut record: Vec<RecordedFile> = Vec::with_capacity(files.len());
         for rel_path in &files {
             let target = staging_dir.join("outputs").join(rel_path);
             if let Some(parent) = target.parent() {
                 fs::create_dir_all(parent)?;
             }
+            validate_relative_path(Path::new(rel_path))?;
+            check_ancestors(project_dir, Path::new(rel_path))?;
             fs::copy(project_dir.join(rel_path), &target)?;
             record.push(RecordedFile {
                 path: rel_path.clone(),
@@ -257,18 +298,19 @@ impl TaskCache {
             });
         }
         let meta = StoredTask {
-            version: 1,
+            version: 2,
+            hashes: record.iter().map(|file| (file.path.clone(), file.hash.clone())).collect(),
             task: task_id.to_string(),
             files,
             scripts,
             entry_dir: PathBuf::new(),
         };
         fs::write(staging_dir.join("meta.json"), serde_json::to_vec_pretty(&meta)?)?;
-        let _ = fs::remove_dir_all(&entry_dir);
-        if let Some(parent) = entry_dir.parent() {
-            fs::create_dir_all(parent)?;
+        match fs::rename(staging_dir, &entry_dir) {
+            Ok(()) => {}
+            Err(_) if entry_dir.is_dir() => {}
+            Err(error) => return Err(error),
         }
-        fs::rename(&staging_dir, &entry_dir)?;
         self.write_output_record(task_id, &record);
         Ok(())
     }
@@ -290,7 +332,7 @@ impl TaskCache {
 
     fn write_output_record(&self, task_id: &str, files: &[RecordedFile]) {
         if let Ok(contents) = serde_json::to_vec(files) {
-            let _ = fs::write(self.output_record_path(task_id), contents);
+            let _ = pnpm_fs::write_atomic(&self.output_record_path(task_id), &contents);
         }
     }
 
@@ -396,30 +438,28 @@ fn collect_output_files(project_dir: &Path, outputs: &[String]) -> io::Result<Ve
         return Ok(Vec::new());
     }
     let mut files = Vec::new();
-    let mut stack = vec![project_dir.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        for entry in fs::read_dir(&dir)? {
-            let entry = entry?;
-            let path = entry.path();
-            let file_type = entry.file_type()?;
-            if file_type.is_dir() {
-                let name = entry.file_name();
-                if name != "node_modules" && name != ".git" {
-                    stack.push(path);
-                }
-            } else if file_type.is_file() {
-                let rel_path = path
+    for glob in globs {
+        for entry in glob
+            .walk(project_dir)
+            .not(wax::any(["**/node_modules/**", "**/.git/**"]))
+            .map_err(io::Error::other)?
+        {
+            let entry = entry.map_err(io::Error::other)?;
+            if entry.file_type().is_file() {
+                let relative = entry
+                    .path()
                     .strip_prefix(project_dir)
-                    .expect("walked path is under the project directory")
+                    .map_err(|_| io::Error::other("output glob must stay inside the project"))?
                     .to_string_lossy()
                     .replace(std::path::MAIN_SEPARATOR, "/");
-                if globs.iter().any(|glob| glob.is_match(rel_path.as_str())) {
-                    files.push(rel_path);
-                }
+                validate_relative_path(Path::new(&relative))?;
+                check_ancestors(project_dir, Path::new(&relative))?;
+                files.push(relative);
             }
         }
     }
     files.sort();
+    files.dedup();
     Ok(files)
 }
 
@@ -451,3 +491,6 @@ fn compile_globs_owned(patterns: &[String]) -> miette::Result<Vec<Glob<'static>>
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -26,15 +26,24 @@ fn corrupted_outputs_are_a_miss_before_any_project_changes() {
 fn traversal_in_outputs_or_stale_records_cannot_escape() {
     let (project, _storage, cache) = setup();
     let mut stored = cache.lookup("abcdef").unwrap();
-    for path in ["../outside", "/absolute", "out/../../outside", ".git/config", "node_modules/pkg"]
-    {
+    for path in [
+        "../outside",
+        "/absolute",
+        "out/../../outside",
+        ".git/config",
+        ".GIT/config",
+        "node_modules/pkg",
+        "Node_Modules/pkg",
+    ] {
         stored.files = vec![path.to_string()];
         assert!(cache.restore(&stored, project.path(), "build").is_err(), "must reject {path}");
         stored.files.clear();
-        cache.write_output_record(
-            "build",
-            &[RecordedFile { path: path.to_string(), hash: String::new() }],
-        );
+        cache
+            .write_output_record(
+                "build",
+                &[RecordedFile { path: path.to_string(), hash: String::new() }],
+            )
+            .unwrap();
         assert!(
             cache.restore(&stored, project.path(), "build").is_err(),
             "must reject stale {path}",
@@ -54,13 +63,15 @@ fn symlinked_outputs_cannot_overwrite_or_delete_external_files() {
     let mut stored = cache.lookup("abcdef").unwrap();
     assert!(cache.restore(&stored, project.path(), "build").is_err());
     stored.files.clear();
-    cache.write_output_record(
-        "build",
-        &[RecordedFile {
-            path: "out/result".to_string(),
-            hash: create_hex_hash_from_file(&external).unwrap(),
-        }],
-    );
+    cache
+        .write_output_record(
+            "build",
+            &[RecordedFile {
+                path: "out/result".to_string(),
+                hash: create_hex_hash_from_file(&external).unwrap(),
+            }],
+        )
+        .unwrap();
     assert!(cache.restore(&stored, project.path(), "build").is_err());
     assert_eq!(fs::read_to_string(external).unwrap(), "built");
 }
@@ -120,5 +131,31 @@ fn concurrent_task_publications_leave_a_complete_snapshot() {
     });
     let stored = cache.lookup("abcdef").unwrap();
     cache.restore(&stored, project.path(), "build").unwrap();
+    assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "built");
+}
+
+#[test]
+fn output_record_write_failures_are_reported() {
+    let (project, _storage, cache) = setup();
+    let record_path = cache.output_record_path("build");
+    fs::remove_file(&record_path).unwrap();
+    fs::create_dir(&record_path).unwrap();
+    let stored = cache.lookup("abcdef").unwrap();
+    assert!(cache.restore(&stored, project.path(), "build").is_err());
+    assert!(
+        cache
+            .store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new())
+            .is_err(),
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_project_roots_are_rejected() {
+    let (project, storage, cache) = setup();
+    let link = storage.path().join("linked-project");
+    std::os::unix::fs::symlink(project.path(), &link).unwrap();
+    let stored = cache.lookup("abcdef").unwrap();
+    assert!(cache.restore(&stored, &link, "build").is_err());
     assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "built");
 }

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -1,0 +1,111 @@
+use super::{RecordedFile, TaskCache, collect_output_files};
+#[cfg(unix)]
+use pnpm_crypto_hash::create_hex_hash_from_file;
+use std::fs;
+
+fn setup() -> (tempfile::TempDir, tempfile::TempDir, TaskCache) {
+    let project = tempfile::tempdir().unwrap();
+    let storage = tempfile::tempdir().unwrap();
+    let cache = TaskCache::open(storage.path(), project.path()).unwrap();
+    fs::create_dir(project.path().join("out")).unwrap();
+    fs::write(project.path().join("out/result"), "built").unwrap();
+    cache.store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new()).unwrap();
+    (project, storage, cache)
+}
+
+#[test]
+fn corrupted_outputs_are_a_miss_before_any_project_changes() {
+    let (project, _storage, cache) = setup();
+    let stored = cache.lookup("abcdef").unwrap();
+    fs::write(stored.entry_dir.join("outputs/out/result"), "corrupt").unwrap();
+    assert!(cache.restore(&stored, project.path(), "build").is_err());
+    assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "built");
+}
+
+#[test]
+fn traversal_in_outputs_or_stale_records_cannot_escape() {
+    let (project, _storage, cache) = setup();
+    let mut stored = cache.lookup("abcdef").unwrap();
+    for path in ["../outside", "/absolute", "out/../../outside", ".git/config", "node_modules/pkg"]
+    {
+        stored.files = vec![path.to_string()];
+        assert!(cache.restore(&stored, project.path(), "build").is_err(), "must reject {path}");
+        stored.files.clear();
+        cache.write_output_record(
+            "build",
+            &[RecordedFile { path: path.to_string(), hash: String::new() }],
+        );
+        assert!(
+            cache.restore(&stored, project.path(), "build").is_err(),
+            "must reject stale {path}",
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_outputs_cannot_overwrite_or_delete_external_files() {
+    let (project, _storage, cache) = setup();
+    let outside = tempfile::tempdir().unwrap();
+    let external = outside.path().join("result");
+    fs::write(&external, "built").unwrap();
+    fs::remove_dir_all(project.path().join("out")).unwrap();
+    std::os::unix::fs::symlink(outside.path(), project.path().join("out")).unwrap();
+    let mut stored = cache.lookup("abcdef").unwrap();
+    assert!(cache.restore(&stored, project.path(), "build").is_err());
+    stored.files.clear();
+    cache.write_output_record(
+        "build",
+        &[RecordedFile {
+            path: "out/result".to_string(),
+            hash: create_hex_hash_from_file(&external).unwrap(),
+        }],
+    );
+    assert!(cache.restore(&stored, project.path(), "build").is_err());
+    assert_eq!(fs::read_to_string(external).unwrap(), "built");
+}
+
+#[test]
+fn output_globs_select_only_declared_files_and_deduplicate() {
+    let project = tempfile::tempdir().unwrap();
+    fs::create_dir(project.path().join("out")).unwrap();
+    fs::create_dir(project.path().join("src")).unwrap();
+    fs::write(project.path().join("out/result"), "built").unwrap();
+    fs::write(project.path().join("src/main"), "source").unwrap();
+    assert_eq!(
+        collect_output_files(project.path(), &["out/**".to_string(), "out/result".to_string()])
+            .unwrap(),
+        ["out/result"],
+    );
+}
+
+#[test]
+fn repeat_publication_leaves_the_first_snapshot_complete() {
+    let (project, _storage, cache) = setup();
+    fs::write(project.path().join("out/result"), "changed").unwrap();
+    cache.store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new()).unwrap();
+    let stored = cache.lookup("abcdef").unwrap();
+    assert_eq!(fs::read_to_string(stored.entry_dir.join("outputs/out/result")).unwrap(), "built");
+}
+
+#[test]
+fn concurrent_task_publications_leave_a_complete_snapshot() {
+    let (project, _storage, cache) = setup();
+    fs::remove_dir_all(cache.entry_dir("abcdef")).unwrap();
+    let barrier = std::sync::Barrier::new(2);
+    std::thread::scope(|scope| {
+        let publish = || {
+            barrier.wait();
+            cache
+                .store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new())
+                .unwrap();
+        };
+        let first = scope.spawn(publish);
+        let second = scope.spawn(publish);
+        first.join().unwrap();
+        second.join().unwrap();
+    });
+    let stored = cache.lookup("abcdef").unwrap();
+    cache.restore(&stored, project.path(), "build").unwrap();
+    assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "built");
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -83,9 +83,22 @@ fn output_globs_select_only_declared_files_and_deduplicate() {
 fn repeat_publication_leaves_the_first_snapshot_complete() {
     let (project, _storage, cache) = setup();
     fs::write(project.path().join("out/result"), "changed").unwrap();
-    cache.store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new()).unwrap();
+    let previous = fs::read(cache.output_record_path("build")).unwrap();
+    fs::write(project.path().join("out/new-output"), "new output").unwrap();
+    assert!(
+        cache
+            .store("abcdef", project.path(), "build", &["out/**".to_string()], Vec::new())
+            .is_err(),
+        "conflicting snapshots must not update restoration ownership",
+    );
+    assert_eq!(fs::read(cache.output_record_path("build")).unwrap(), previous);
     let stored = cache.lookup("abcdef").unwrap();
     assert_eq!(fs::read_to_string(stored.entry_dir.join("outputs/out/result")).unwrap(), "built");
+    assert!(
+        cache.restore(&stored, project.path(), "build").is_err(),
+        "the changed working output must be preserved",
+    );
+    assert_eq!(fs::read_to_string(project.path().join("out/new-output")).unwrap(), "new output");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/pipeline/capture.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/capture.rs
@@ -1,0 +1,151 @@
+//! Capture of a task's `pnpm:lifecycle` output stream for the cache, and
+//! its replay on a hit — so a hit renders exactly like a run, through the
+//! same reporter.
+//!
+//! The executor's streamed output takes a plain `fn(&LogEvent)`, so the
+//! capture is a process-global tee: [`capturing_emit`] records lifecycle
+//! events into per-`(project, stage)` buffers and forwards everything to
+//! the real reporter emit installed by [`install_forward`].
+
+use pnpm_reporter::{LifecycleLog, LifecycleMessage, LifecycleStdio, LogEvent, LogLevel};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{LazyLock, Mutex, OnceLock},
+};
+
+/// One captured lifecycle stage: what replaying needs to reconstruct the
+/// `Script` → `Stdio`* → `Exit` event sequence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedScript {
+    pub stage: String,
+    pub command: String,
+    pub lines: Vec<CapturedLine>,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapturedLine {
+    pub stdio: String,
+    pub line: String,
+}
+
+#[derive(Default)]
+struct Buffer {
+    command: String,
+    lines: Vec<CapturedLine>,
+    exit_code: i32,
+}
+
+static FORWARD: OnceLock<fn(&LogEvent)> = OnceLock::new();
+static BUFFERS: LazyLock<Mutex<HashMap<(String, String), Buffer>>> = LazyLock::new(Mutex::default);
+
+pub fn install_forward(emit: fn(&LogEvent)) {
+    let _ = FORWARD.set(emit);
+}
+
+/// The `emit` handed to the executor: tee into the capture buffers, then
+/// forward to the reporter.
+pub fn capturing_emit(event: &LogEvent) {
+    if let LogEvent::Lifecycle(log) = event {
+        match &log.message {
+            LifecycleMessage::Script { dep_path, stage, script, .. } => {
+                with_buffer(dep_path, stage, |buffer| buffer.command.clone_from(script));
+            }
+            LifecycleMessage::Stdio { dep_path, stage, line, stdio, .. } => {
+                let captured = CapturedLine { stdio: stdio_name(*stdio), line: line.clone() };
+                with_buffer(dep_path, stage, |buffer| buffer.lines.push(captured));
+            }
+            LifecycleMessage::Exit { dep_path, stage, exit_code, .. } => {
+                with_buffer(dep_path, stage, |buffer| buffer.exit_code = *exit_code);
+            }
+        }
+    }
+    if let Some(forward) = FORWARD.get() {
+        forward(event);
+    }
+}
+
+/// Take the buffered stages of one task's script out of the registry, in
+/// the order they ran: the `pre` hook, the script, the `post` hook.
+pub fn drain_task(
+    dep_path: &str,
+    script: &str,
+    enable_pre_post_scripts: bool,
+) -> Vec<CapturedScript> {
+    let stages: Vec<String> = if enable_pre_post_scripts {
+        vec![format!("pre{script}"), script.to_string(), format!("post{script}")]
+    } else {
+        vec![script.to_string()]
+    };
+    let mut buffers = BUFFERS.lock().expect("capture buffer lock is not poisoned");
+    stages
+        .into_iter()
+        .filter_map(|stage| {
+            let buffer = buffers.remove(&(dep_path.to_string(), stage.clone()))?;
+            Some(CapturedScript {
+                stage,
+                command: buffer.command,
+                lines: buffer.lines,
+                exit_code: buffer.exit_code,
+            })
+        })
+        .collect()
+}
+
+/// Re-emit a stored task's lifecycle events, so a cache hit renders the
+/// way the original run did.
+pub fn replay(scripts: &[CapturedScript], project_dir: &Path, emit: fn(&LogEvent)) {
+    let dep_path = project_dir.to_string_lossy().into_owned();
+    for script in scripts {
+        emit(&LogEvent::Lifecycle(LifecycleLog {
+            level: LogLevel::Debug,
+            message: LifecycleMessage::Script {
+                dep_path: dep_path.clone(),
+                optional: false,
+                script: script.command.clone(),
+                stage: script.stage.clone(),
+                wd: dep_path.clone(),
+            },
+        }));
+        for line in &script.lines {
+            emit(&LogEvent::Lifecycle(LifecycleLog {
+                level: LogLevel::Debug,
+                message: LifecycleMessage::Stdio {
+                    dep_path: dep_path.clone(),
+                    line: line.line.clone(),
+                    stage: script.stage.clone(),
+                    stdio: stdio_from_name(&line.stdio),
+                    wd: dep_path.clone(),
+                },
+            }));
+        }
+        emit(&LogEvent::Lifecycle(LifecycleLog {
+            level: LogLevel::Debug,
+            message: LifecycleMessage::Exit {
+                dep_path: dep_path.clone(),
+                exit_code: script.exit_code,
+                optional: false,
+                stage: script.stage.clone(),
+                wd: dep_path.clone(),
+            },
+        }));
+    }
+}
+
+fn with_buffer(dep_path: &str, stage: &str, mutate: impl FnOnce(&mut Buffer)) {
+    let mut buffers = BUFFERS.lock().expect("capture buffer lock is not poisoned");
+    mutate(buffers.entry((dep_path.to_string(), stage.to_string())).or_default());
+}
+
+fn stdio_name(stdio: LifecycleStdio) -> String {
+    match stdio {
+        LifecycleStdio::Stdout => "stdout".to_string(),
+        LifecycleStdio::Stderr => "stderr".to_string(),
+    }
+}
+
+fn stdio_from_name(name: &str) -> LifecycleStdio {
+    if name == "stderr" { LifecycleStdio::Stderr } else { LifecycleStdio::Stdout }
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/capture.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/capture.rs
@@ -31,11 +31,30 @@ pub struct CapturedLine {
     pub line: String,
 }
 
+pub(super) const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+
 #[derive(Default)]
 struct Buffer {
     command: String,
     lines: Vec<CapturedLine>,
     exit_code: i32,
+    bytes: usize,
+    exceeded: bool,
+}
+
+impl Buffer {
+    fn push(&mut self, stdio: LifecycleStdio, line: &str) {
+        if self.exceeded {
+            return;
+        }
+        self.bytes = self.bytes.saturating_add(line.len() + std::mem::size_of::<CapturedLine>());
+        if self.bytes > MAX_CAPTURE_BYTES {
+            self.exceeded = true;
+            self.lines.clear();
+            return;
+        }
+        self.lines.push(CapturedLine { stdio: stdio_name(stdio), line: line.to_string() });
+    }
 }
 
 static FORWARD: OnceLock<fn(&LogEvent)> = OnceLock::new();
@@ -54,8 +73,7 @@ pub fn capturing_emit(event: &LogEvent) {
                 with_buffer(dep_path, stage, |buffer| buffer.command.clone_from(script));
             }
             LifecycleMessage::Stdio { dep_path, stage, line, stdio, .. } => {
-                let captured = CapturedLine { stdio: stdio_name(*stdio), line: line.clone() };
-                with_buffer(dep_path, stage, |buffer| buffer.lines.push(captured));
+                with_buffer(dep_path, stage, |buffer| buffer.push(*stdio, line));
             }
             LifecycleMessage::Exit { dep_path, stage, exit_code, .. } => {
                 with_buffer(dep_path, stage, |buffer| buffer.exit_code = *exit_code);
@@ -73,17 +91,19 @@ pub fn drain_task(
     dep_path: &str,
     script: &str,
     enable_pre_post_scripts: bool,
-) -> Vec<CapturedScript> {
+) -> Option<Vec<CapturedScript>> {
     let stages: Vec<String> = if enable_pre_post_scripts {
         vec![format!("pre{script}"), script.to_string(), format!("post{script}")]
     } else {
         vec![script.to_string()]
     };
     let mut buffers = BUFFERS.lock().expect("capture buffer lock is not poisoned");
-    stages
+    let mut exceeded = false;
+    let scripts = stages
         .into_iter()
         .filter_map(|stage| {
             let buffer = buffers.remove(&(dep_path.to_string(), stage.clone()))?;
+            exceeded |= buffer.exceeded;
             Some(CapturedScript {
                 stage,
                 command: buffer.command,
@@ -91,7 +111,8 @@ pub fn drain_task(
                 exit_code: buffer.exit_code,
             })
         })
-        .collect()
+        .collect();
+    (!exceeded).then_some(scripts)
 }
 
 /// Re-emit a stored task's lifecycle events, so a cache hit renders the
@@ -149,3 +170,6 @@ fn stdio_name(stdio: LifecycleStdio) -> String {
 fn stdio_from_name(name: &str) -> LifecycleStdio {
     if name == "stderr" { LifecycleStdio::Stderr } else { LifecycleStdio::Stdout }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/pipeline/capture/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/capture/tests.rs
@@ -1,0 +1,12 @@
+use super::{Buffer, MAX_CAPTURE_BYTES};
+use pnpm_reporter::LifecycleStdio;
+
+#[test]
+fn oversized_logs_release_capture_and_keep_it_disabled() {
+    let mut buffer = Buffer::default();
+    buffer.push(LifecycleStdio::Stdout, "hello");
+    buffer.push(LifecycleStdio::Stdout, &"x".repeat(MAX_CAPTURE_BYTES));
+    buffer.push(LifecycleStdio::Stdout, "after limit");
+    assert!(buffer.exceeded, "oversized stage must bypass the cache");
+    assert!(buffer.lines.is_empty(), "oversized stage must not retain its output");
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
@@ -1,0 +1,418 @@
+use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    env,
+    fs::{self, File, FileTimes, OpenOptions},
+    io,
+    path::{Component, Path, PathBuf},
+    process::Command,
+};
+
+#[cfg(test)]
+mod tests;
+
+const INPUT_RECORD: &str = ".pnpm-cargo-inputs-v1";
+
+pub(super) struct CargoCache {
+    pub target: PathBuf,
+    _lock: File,
+}
+
+#[derive(Serialize, Deserialize)]
+struct Snapshot {
+    key: String,
+    files: Vec<SnapshotFile>,
+    local_packages: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SnapshotFile {
+    path: PathBuf,
+    hash: String,
+}
+
+impl CargoCache {
+    pub fn open(project: &Path, directory: &str) -> io::Result<Self> {
+        let relative = Path::new(directory);
+        validate_relative_path(relative)?;
+        let ignored = Command::new("git")
+            .args(["check-ignore", "--quiet", "--"])
+            .arg(format!("{directory}/"))
+            .current_dir(project)
+            .status()?;
+        if !ignored.success() {
+            return Err(io::Error::other(format!(
+                "Cargo target directory must be ignored by Git: {directory}"
+            )));
+        }
+        let target = project.join(relative);
+        check_ancestors(project, relative)?;
+        let parent = target.parent().expect("relative target has a parent");
+        fs::create_dir_all(parent)?;
+        let common = command_output(
+            "git",
+            &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+            project,
+            &BTreeMap::new(),
+        )?;
+        let locks = Path::new(common.trim()).join("pnpm-cargo-locks");
+        fs::create_dir_all(&locks)?;
+        let lock = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(locks.join(create_hex_hash(&target.to_string_lossy())))?;
+        lock.lock()?;
+        check_ancestors(project, relative)?;
+        Ok(Self { target, _lock: lock })
+    }
+
+    /// Restores only an absent target. Every task still runs, including a hit.
+    pub fn restore(&self, entry: &Path, key: &str) -> io::Result<bool> {
+        self.check_snapshot_location(entry)?;
+        if self.target.try_exists()? {
+            return Ok(false);
+        }
+        let snapshot: Snapshot = serde_json::from_slice(&fs::read(entry.join("manifest.json"))?)?;
+        if snapshot.key != key {
+            return Err(io::Error::other("Cargo snapshot input identity differs"));
+        }
+        let staging = tempfile::Builder::new()
+            .prefix(".pnpm-cargo-restore-")
+            .tempdir_in(self.target.parent().expect("target parent"))?;
+        for file in snapshot.files {
+            validate_relative_path(&file.path)?;
+            check_ancestors(entry, &Path::new("files").join(&file.path))?;
+            let source = entry.join("files").join(&file.path);
+            let target = staging.path().join(&file.path);
+            clone_file(&source, &target)?;
+            if create_hex_hash_from_file(&target)? != file.hash {
+                return Err(io::Error::other(format!(
+                    "Cargo snapshot file failed integrity: {}",
+                    file.path.display()
+                )));
+            }
+        }
+        invalidate_fingerprints(staging.path(), Some(&snapshot.local_packages))?;
+        fs::write(staging.path().join(INPUT_RECORD), key)?;
+        // Cooperating pipeline writers hold the target lock outside the cache.
+        // Cache eviction can remove a source, but never this private staging tree.
+        fs::rename(staging.path(), &self.target)?;
+        Ok(true)
+    }
+
+    pub fn prepare(&self, key: &str) -> io::Result<()> {
+        if self.target.try_exists()?
+            && fs::read_to_string(self.target.join(INPUT_RECORD)).ok().as_deref() != Some(key)
+        {
+            invalidate_fingerprints(&self.target, None)?;
+        }
+        Ok(())
+    }
+
+    pub fn publish(&self, entry: &Path, key: &str, local_packages: &[String]) -> io::Result<()> {
+        self.check_snapshot_location(entry)?;
+        fs::write(self.target.join(INPUT_RECORD), key)?;
+        if entry.try_exists()? {
+            return Ok(());
+        }
+        let parent = entry.parent().expect("snapshot entry has a parent");
+        fs::create_dir_all(parent)?;
+        let staging = tempfile::Builder::new().prefix(".publish-").tempdir_in(parent)?;
+        let mut files = Vec::new();
+        let mut pending = vec![PathBuf::new()];
+        while let Some(relative) = pending.pop() {
+            for item in fs::read_dir(self.target.join(&relative))? {
+                let item = item?;
+                let relative = relative.join(item.file_name());
+                if relative == Path::new(INPUT_RECORD) {
+                    continue;
+                }
+                let kind = item.file_type()?;
+                if kind.is_dir() {
+                    pending.push(relative);
+                } else if kind.is_file() {
+                    let destination = staging.path().join("files").join(&relative);
+                    clone_file(&item.path(), &destination)?;
+                    files.push(SnapshotFile {
+                        path: relative,
+                        hash: create_hex_hash_from_file(&destination)?,
+                    });
+                } else {
+                    return Err(io::Error::other(format!(
+                        "Cargo snapshot contains a non-regular file: {}",
+                        item.path().display()
+                    )));
+                }
+            }
+        }
+        files.sort_by(|left, right| left.path.cmp(&right.path));
+        fs::write(
+            staging.path().join("manifest.json"),
+            serde_json::to_vec(&Snapshot {
+                key: key.to_string(),
+                files,
+                local_packages: local_packages.to_vec(),
+            })?,
+        )?;
+        match fs::rename(staging.path(), entry) {
+            Ok(()) => Ok(()),
+            Err(_) if entry.is_dir() => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn check_snapshot_location(&self, entry: &Path) -> io::Result<()> {
+        let target = pnpm_fs::realpath_missing(&self.target)?;
+        let entry = pnpm_fs::realpath_missing(entry)?;
+        if entry.starts_with(&target) || target.starts_with(&entry) {
+            return Err(io::Error::other(format!(
+                "Cargo snapshot {} overlaps the build directory {}",
+                entry.display(),
+                target.display()
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn snapshot_entry(
+    cache_dir: &Path,
+    project: &Path,
+    task_key: &str,
+    environment: &BTreeMap<String, String>,
+) -> io::Result<(PathBuf, String, Vec<String>)> {
+    let repo = PathBuf::from(
+        command_output("git", &["rev-parse", "--show-toplevel"], project, environment)?.trim(),
+    );
+    let common = command_output(
+        "git",
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+        project,
+        environment,
+    )?;
+    let common = dunce::canonicalize(common.trim())?;
+    let mut inputs = vec!["pnpm-cargo-state:v1".to_string(), task_key.to_string()];
+    inputs.push(command_output("rustc", &["-vV"], project, environment)?);
+    inputs.push(command_output("cargo", &["-vV"], project, environment)?);
+    let metadata: serde_json::Value = serde_json::from_str(&command_output(
+        "cargo",
+        &["metadata", "--format-version=1", "--locked", "--offline"],
+        project,
+        environment,
+    )?)?;
+    let canonical_repo = dunce::canonicalize(&repo)?;
+    let mut local_packages = Vec::new();
+    for package in metadata["packages"]
+        .as_array()
+        .ok_or_else(|| io::Error::other("Cargo metadata has no packages"))?
+    {
+        if package["source"].is_null() {
+            local_packages.push(
+                package["name"]
+                    .as_str()
+                    .ok_or_else(|| io::Error::other("Cargo package has no name"))?
+                    .to_string(),
+            );
+            let manifest = package["manifest_path"]
+                .as_str()
+                .ok_or_else(|| io::Error::other("Cargo metadata has no manifest path"))?;
+            if !dunce::canonicalize(manifest)?.starts_with(&canonical_repo) {
+                return Err(io::Error::other(format!(
+                    "Cargo path dependency is outside the repository: {manifest}"
+                )));
+            }
+        }
+    }
+    inputs.push(serde_json::to_string(environment)?);
+    let paths = command_output(
+        "git",
+        &["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        &repo,
+        environment,
+    )?;
+    let mut paths: Vec<_> = paths.split('\0').filter(|path| !path.is_empty()).collect();
+    paths.sort_unstable();
+    paths.dedup();
+    for path in paths {
+        check_ancestors(&repo, Path::new(path))?;
+        let absolute = repo.join(path);
+        match fs::symlink_metadata(&absolute) {
+            Ok(metadata) if metadata.is_file() => {
+                inputs.push(format!("{path}:{}", create_hex_hash_from_file(&absolute)?));
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Ok(_) => {
+                return Err(io::Error::other(format!(
+                    "Cargo cache input is not a regular file: {}",
+                    absolute.display()
+                )));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    for ancestor in project.ancestors() {
+        for name in ["config", "config.toml"] {
+            add_config(&ancestor.join(".cargo").join(name), project, &mut inputs)?;
+        }
+    }
+    let cargo_home = environment
+        .get("CARGO_HOME")
+        .map(PathBuf::from)
+        .or_else(|| home::home_dir().map(|home| home.join(".cargo")));
+    if let Some(cargo_home) = cargo_home {
+        for name in ["config", "config.toml"] {
+            add_config(&cargo_home.join(name), project, &mut inputs)?;
+        }
+    }
+    let key = create_hex_hash(&serde_json::to_string(&inputs)?);
+    let scope = create_hex_hash(&common.to_string_lossy());
+    Ok((cache_dir.join("cargo-build/v1").join(scope).join(&key), key, local_packages))
+}
+
+pub(super) fn cache_environment(
+    extra: &std::collections::HashMap<String, String>,
+    declared: &[String],
+) -> BTreeMap<String, String> {
+    env::vars()
+        .chain(extra.iter().map(|(key, value)| (key.clone(), value.clone())))
+        .filter(|(key, _)| {
+            key.starts_with("CARGO_")
+                || key.starts_with("RUST")
+                || key.starts_with("CC")
+                || key.starts_with("CXX")
+                || key.starts_with("AR")
+                || key.starts_with("CFLAGS")
+                || key.starts_with("CPPFLAGS")
+                || key.starts_with("LDFLAGS")
+                || key.starts_with("PKG_CONFIG")
+                || key == "PATH"
+                || key == "SDKROOT"
+                || key == "MACOSX_DEPLOYMENT_TARGET"
+                || declared.contains(key)
+        })
+        .filter(|(key, _)| key != "CARGO_TARGET_DIR" && key != "CARGO_BUILD_BUILD_DIR")
+        .collect()
+}
+
+fn add_config(path: &Path, project: &Path, inputs: &mut Vec<String>) -> io::Result<()> {
+    match create_hex_hash_from_file(path) {
+        Ok(hash) => {
+            let relative =
+                pathdiff::diff_paths(path, project).unwrap_or_else(|| path.to_path_buf());
+            inputs.push(format!("cargo-config:{}:{hash}", relative.display()));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    Ok(())
+}
+
+fn command_output(
+    program: &str,
+    args: &[&str],
+    project: &Path,
+    environment: &BTreeMap<String, String>,
+) -> io::Result<String> {
+    let output =
+        Command::new(program).args(args).current_dir(project).envs(environment).output()?;
+    if !output.status.success() {
+        return Err(io::Error::other(format!(
+            "{program} {}: {}",
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr)
+        )));
+    }
+    String::from_utf8(output.stdout).map_err(io::Error::other)
+}
+
+fn validate_relative_path(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty()
+        || path.components().any(|part| !matches!(part, Component::Normal(_)))
+        || path
+            .components()
+            .any(|part| part.as_os_str() == ".git" || part.as_os_str() == "node_modules")
+    {
+        return Err(io::Error::other(format!(
+            "Cargo cache path must stay inside the project: {}",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn check_ancestors(root: &Path, relative: &Path) -> io::Result<()> {
+    let mut path = root.to_path_buf();
+    for component in relative.components() {
+        path.push(component);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::other(format!(
+                    "Cargo cache path is a symlink: {}",
+                    path.display()
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn clone_file(source: &Path, target: &Path) -> io::Result<()> {
+    let metadata = fs::symlink_metadata(source)?;
+    if !metadata.is_file() {
+        return Err(io::Error::other(format!(
+            "Cargo cache file is not regular: {}",
+            source.display()
+        )));
+    }
+    fs::create_dir_all(target.parent().expect("file parent"))?;
+    reflink_copy::reflink_or_copy(source, target)?;
+    File::options()
+        .write(true)
+        .open(target)?
+        .set_times(FileTimes::new().set_modified(metadata.modified()?))?;
+    fs::set_permissions(target, metadata.permissions())
+}
+
+/// Content changes can retain mtimes, and relocated build scripts can retain
+/// the publisher's paths. Invalidate all freshness records for new inputs, or
+/// local units and build-script runs when moving an exact-input snapshot.
+fn invalidate_fingerprints(root: &Path, local_packages: Option<&[String]>) -> io::Result<()> {
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            if entry.file_name() == ".fingerprint" {
+                if let Some(packages) = local_packages {
+                    for fingerprint in fs::read_dir(entry.path())? {
+                        let fingerprint = fingerprint?;
+                        if !fingerprint.file_type()?.is_dir() {
+                            continue;
+                        }
+                        let name = fingerprint.file_name().to_string_lossy().into_owned();
+                        let local =
+                            packages.iter().any(|package| name.starts_with(&format!("{package}-")));
+                        let build_script = fs::read_dir(fingerprint.path())?
+                            .collect::<io::Result<Vec<_>>>()?
+                            .iter()
+                            .any(|file| {
+                                file.file_name().to_string_lossy().starts_with("run-build-script")
+                            });
+                        if local || build_script {
+                            fs::remove_dir_all(fingerprint.path())?;
+                        }
+                    }
+                } else {
+                    fs::remove_dir_all(entry.path())?;
+                }
+            } else {
+                invalidate_fingerprints(&entry.path(), local_packages)?;
+            }
+        }
+    }
+    Ok(())
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
@@ -1,3 +1,4 @@
+use super::paths::{check_ancestors, validate_relative_path};
 use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -5,7 +6,7 @@ use std::{
     env,
     fs::{self, File, FileTimes, OpenOptions},
     io,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     process::Command,
 };
 
@@ -328,40 +329,6 @@ fn command_output(
     String::from_utf8(output.stdout).map_err(io::Error::other)
 }
 
-fn validate_relative_path(path: &Path) -> io::Result<()> {
-    if path.as_os_str().is_empty()
-        || path.components().any(|part| !matches!(part, Component::Normal(_)))
-        || path
-            .components()
-            .any(|part| part.as_os_str() == ".git" || part.as_os_str() == "node_modules")
-    {
-        return Err(io::Error::other(format!(
-            "Cargo cache path must stay inside the project: {}",
-            path.display(),
-        )));
-    }
-    Ok(())
-}
-
-fn check_ancestors(root: &Path, relative: &Path) -> io::Result<()> {
-    let mut path = root.to_path_buf();
-    for component in relative.components() {
-        path.push(component);
-        match fs::symlink_metadata(&path) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                return Err(io::Error::other(format!(
-                    "Cargo cache path is a symlink: {}",
-                    path.display(),
-                )));
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
-        }
-    }
-    Ok(())
-}
-
 fn clone_file(source: &Path, target: &Path) -> io::Result<()> {
     let metadata = fs::symlink_metadata(source)?;
     if !metadata.is_file() {
@@ -372,10 +339,14 @@ fn clone_file(source: &Path, target: &Path) -> io::Result<()> {
     }
     fs::create_dir_all(target.parent().expect("file parent"))?;
     reflink_copy::reflink_or_copy(source, target)?;
-    File::options()
-        .write(true)
-        .open(target)?
-        .set_times(FileTimes::new().set_modified(metadata.modified()?))?;
+    let mut options = File::options();
+    options.read(true);
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::OpenOptionsExt;
+        options.access_mode(windows_sys::Win32::Storage::FileSystem::FILE_WRITE_ATTRIBUTES);
+    }
+    options.open(target)?.set_times(FileTimes::new().set_modified(metadata.modified()?))?;
     fs::set_permissions(target, metadata.permissions())
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache.rs
@@ -43,7 +43,7 @@ impl CargoCache {
             .status()?;
         if !ignored.success() {
             return Err(io::Error::other(format!(
-                "Cargo target directory must be ignored by Git: {directory}"
+                "Cargo target directory must be ignored by Git: {directory}",
             )));
         }
         let target = project.join(relative);
@@ -91,7 +91,7 @@ impl CargoCache {
             if create_hex_hash_from_file(&target)? != file.hash {
                 return Err(io::Error::other(format!(
                     "Cargo snapshot file failed integrity: {}",
-                    file.path.display()
+                    file.path.display(),
                 )));
             }
         }
@@ -143,7 +143,7 @@ impl CargoCache {
                 } else {
                     return Err(io::Error::other(format!(
                         "Cargo snapshot contains a non-regular file: {}",
-                        item.path().display()
+                        item.path().display(),
                     )));
                 }
             }
@@ -171,7 +171,7 @@ impl CargoCache {
             return Err(io::Error::other(format!(
                 "Cargo snapshot {} overlaps the build directory {}",
                 entry.display(),
-                target.display()
+                target.display(),
             )));
         }
         Ok(())
@@ -221,7 +221,7 @@ pub(super) fn snapshot_entry(
                 .ok_or_else(|| io::Error::other("Cargo metadata has no manifest path"))?;
             if !dunce::canonicalize(manifest)?.starts_with(&canonical_repo) {
                 return Err(io::Error::other(format!(
-                    "Cargo path dependency is outside the repository: {manifest}"
+                    "Cargo path dependency is outside the repository: {manifest}",
                 )));
             }
         }
@@ -247,7 +247,7 @@ pub(super) fn snapshot_entry(
             Ok(_) => {
                 return Err(io::Error::other(format!(
                     "Cargo cache input is not a regular file: {}",
-                    absolute.display()
+                    absolute.display(),
                 )));
             }
             Err(error) => return Err(error),
@@ -322,7 +322,7 @@ fn command_output(
         return Err(io::Error::other(format!(
             "{program} {}: {}",
             args.join(" "),
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&output.stderr),
         )));
     }
     String::from_utf8(output.stdout).map_err(io::Error::other)
@@ -337,7 +337,7 @@ fn validate_relative_path(path: &Path) -> io::Result<()> {
     {
         return Err(io::Error::other(format!(
             "Cargo cache path must stay inside the project: {}",
-            path.display()
+            path.display(),
         )));
     }
     Ok(())
@@ -351,7 +351,7 @@ fn check_ancestors(root: &Path, relative: &Path) -> io::Result<()> {
             Ok(metadata) if metadata.file_type().is_symlink() => {
                 return Err(io::Error::other(format!(
                     "Cargo cache path is a symlink: {}",
-                    path.display()
+                    path.display(),
                 )));
             }
             Ok(_) => {}
@@ -367,7 +367,7 @@ fn clone_file(source: &Path, target: &Path) -> io::Result<()> {
     if !metadata.is_file() {
         return Err(io::Error::other(format!(
             "Cargo cache file is not regular: {}",
-            source.display()
+            source.display(),
         )));
     }
     fs::create_dir_all(target.parent().expect("file parent"))?;

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
@@ -230,3 +230,25 @@ fn restoration_falls_back_to_copy_on_tmpfs() {
     fs::remove_dir_all(storage.path()).unwrap();
     assert_eq!(fs::read_to_string(consumer.target.join("state")).unwrap(), "edited");
 }
+
+#[test]
+fn snapshots_preserve_read_only_files() {
+    let publishing_project = project();
+    let storage = tempfile::tempdir().unwrap();
+    let cache = CargoCache::open(publishing_project.path(), "target").unwrap();
+    fs::create_dir(&cache.target).unwrap();
+    let source = cache.target.join("read-only");
+    fs::write(&source, "immutable").unwrap();
+    let mut permissions = fs::metadata(&source).unwrap().permissions();
+    permissions.set_readonly(true);
+    fs::set_permissions(&source, permissions).unwrap();
+    let timestamp = fs::metadata(&source).unwrap().modified().unwrap();
+    let entry = storage.path().join("entry");
+    cache.publish(&entry, "inputs", &[]).unwrap();
+    let restored_project = project();
+    let restored = CargoCache::open(restored_project.path(), "target").unwrap();
+    assert!(restored.restore(&entry, "inputs").unwrap());
+    let metadata = fs::metadata(restored.target.join("read-only")).unwrap();
+    assert!(metadata.permissions().readonly());
+    assert_eq!(metadata.modified().unwrap(), timestamp);
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
@@ -10,17 +10,17 @@ fn project() -> tempfile::TempDir {
 
 #[test]
 fn restored_state_survives_eviction_and_is_independent() {
-    let a = project();
-    let b = project();
+    let first_worktree = project();
+    let second_worktree = project();
     let cache = tempfile::tempdir().unwrap();
     let entry = cache.path().join("entry");
-    let publisher = CargoCache::open(a.path(), "target").unwrap();
+    let publisher = CargoCache::open(first_worktree.path(), "target").unwrap();
     fs::create_dir_all(publisher.target.join("debug/incremental")).unwrap();
     let original = publisher.target.join("debug/incremental/state");
     fs::write(&original, b"original").unwrap();
     let modified = fs::metadata(&original).unwrap().modified().unwrap();
     publisher.publish(&entry, "inputs", &[]).unwrap();
-    let consumer = CargoCache::open(b.path(), "target").unwrap();
+    let consumer = CargoCache::open(second_worktree.path(), "target").unwrap();
     assert!(consumer.restore(&entry, "inputs").unwrap());
     let restored = consumer.target.join("debug/incremental/state");
     assert_eq!(fs::metadata(&restored).unwrap().modified().unwrap(), modified);
@@ -35,11 +35,11 @@ fn restored_state_survives_eviction_and_is_independent() {
 #[test]
 fn incomplete_and_corrupt_snapshots_never_expose_a_target() {
     for corrupt in [false, true] {
-        let a = project();
-        let b = project();
+        let first_worktree = project();
+        let second_worktree = project();
         let cache = tempfile::tempdir().unwrap();
         let entry = cache.path().join("entry");
-        let publisher = CargoCache::open(a.path(), "target").unwrap();
+        let publisher = CargoCache::open(first_worktree.path(), "target").unwrap();
         fs::create_dir(&publisher.target).unwrap();
         fs::write(publisher.target.join("state"), "good").unwrap();
         publisher.publish(&entry, "inputs", &[]).unwrap();
@@ -48,7 +48,7 @@ fn incomplete_and_corrupt_snapshots_never_expose_a_target() {
         } else {
             fs::remove_file(entry.join("files/state")).unwrap();
         }
-        let consumer = CargoCache::open(b.path(), "target").unwrap();
+        let consumer = CargoCache::open(second_worktree.path(), "target").unwrap();
         assert!(consumer.restore(&entry, "inputs").is_err());
         assert!(!consumer.target.exists());
     }
@@ -107,7 +107,7 @@ fn source_configuration_and_environment_changes_select_different_snapshots() {
             .output()
             .unwrap()
             .status
-            .success()
+            .success(),
     );
     let cache = tempfile::tempdir().unwrap();
     let environment = std::collections::BTreeMap::new();
@@ -146,13 +146,13 @@ fn incomplete_publication_is_not_visible_as_a_snapshot() {
 
 #[test]
 fn concurrent_publishers_leave_one_complete_immutable_snapshot() {
-    let a = project();
-    let b = project();
+    let first_worktree = project();
+    let second_worktree = project();
     let cache = tempfile::tempdir().unwrap();
     let entry = cache.path().join("entry");
     let publishers = [
-        CargoCache::open(a.path(), "target").unwrap(),
-        CargoCache::open(b.path(), "target").unwrap(),
+        CargoCache::open(first_worktree.path(), "target").unwrap(),
+        CargoCache::open(second_worktree.path(), "target").unwrap(),
     ];
     for (index, publisher) in publishers.iter().enumerate() {
         fs::create_dir(&publisher.target).unwrap();
@@ -198,20 +198,32 @@ fn snapshot_storage_cannot_overlap_the_build_directory() {
 #[cfg(target_os = "linux")]
 #[test]
 fn restoration_falls_back_to_copy_on_tmpfs() {
-    let a = project();
-    let b = tempfile::tempdir_in("/dev/shm").unwrap();
-    assert!(Command::new("git").arg("init").arg(b.path()).output().unwrap().status.success());
-    fs::write(b.path().join(".gitignore"), "target/\n").unwrap();
+    let first_worktree = project();
+    let second_worktree = tempfile::tempdir_in("/dev/shm").unwrap();
+    assert!(
+        Command::new("git")
+            .arg("init")
+            .arg(second_worktree.path())
+            .output()
+            .unwrap()
+            .status
+            .success(),
+    );
+    fs::write(second_worktree.path().join(".gitignore"), "target/\n").unwrap();
     let storage = tempfile::tempdir().unwrap();
     let entry = storage.path().join("entry");
-    let publisher = CargoCache::open(a.path(), "target").unwrap();
+    let publisher = CargoCache::open(first_worktree.path(), "target").unwrap();
     fs::create_dir(&publisher.target).unwrap();
     fs::write(publisher.target.join("state"), "original").unwrap();
     publisher.publish(&entry, "inputs", &[]).unwrap();
     assert!(
-        reflink_copy::reflink(entry.join("files/state"), b.path().join("clone-probe")).is_err()
+        reflink_copy::reflink(
+            entry.join("files/state"),
+            second_worktree.path().join("clone-probe")
+        )
+        .is_err(),
     );
-    let consumer = CargoCache::open(b.path(), "target").unwrap();
+    let consumer = CargoCache::open(second_worktree.path(), "target").unwrap();
     assert!(consumer.restore(&entry, "inputs").unwrap());
     fs::write(consumer.target.join("state"), "edited").unwrap();
     assert_eq!(fs::read_to_string(entry.join("files/state")).unwrap(), "original");

--- a/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cargo_cache/tests.rs
@@ -1,0 +1,220 @@
+use super::CargoCache;
+use std::{fs, process::Command};
+
+fn project() -> tempfile::TempDir {
+    let project = tempfile::tempdir().unwrap();
+    assert!(Command::new("git").arg("init").arg(project.path()).output().unwrap().status.success());
+    fs::write(project.path().join(".gitignore"), "target/\n").unwrap();
+    project
+}
+
+#[test]
+fn restored_state_survives_eviction_and_is_independent() {
+    let a = project();
+    let b = project();
+    let cache = tempfile::tempdir().unwrap();
+    let entry = cache.path().join("entry");
+    let publisher = CargoCache::open(a.path(), "target").unwrap();
+    fs::create_dir_all(publisher.target.join("debug/incremental")).unwrap();
+    let original = publisher.target.join("debug/incremental/state");
+    fs::write(&original, b"original").unwrap();
+    let modified = fs::metadata(&original).unwrap().modified().unwrap();
+    publisher.publish(&entry, "inputs", &[]).unwrap();
+    let consumer = CargoCache::open(b.path(), "target").unwrap();
+    assert!(consumer.restore(&entry, "inputs").unwrap());
+    let restored = consumer.target.join("debug/incremental/state");
+    assert_eq!(fs::metadata(&restored).unwrap().modified().unwrap(), modified);
+    fs::write(&restored, b"edited").unwrap();
+    assert_eq!(fs::read(&original).unwrap(), b"original");
+    assert_eq!(fs::read(entry.join("files/debug/incremental/state")).unwrap(), b"original");
+    fs::remove_dir_all(cache.path()).unwrap();
+    assert_eq!(fs::read(&restored).unwrap(), b"edited");
+    consumer.prepare("inputs").unwrap();
+}
+
+#[test]
+fn incomplete_and_corrupt_snapshots_never_expose_a_target() {
+    for corrupt in [false, true] {
+        let a = project();
+        let b = project();
+        let cache = tempfile::tempdir().unwrap();
+        let entry = cache.path().join("entry");
+        let publisher = CargoCache::open(a.path(), "target").unwrap();
+        fs::create_dir(&publisher.target).unwrap();
+        fs::write(publisher.target.join("state"), "good").unwrap();
+        publisher.publish(&entry, "inputs", &[]).unwrap();
+        if corrupt {
+            fs::write(entry.join("files/state"), "bad").unwrap();
+        } else {
+            fs::remove_file(entry.join("files/state")).unwrap();
+        }
+        let consumer = CargoCache::open(b.path(), "target").unwrap();
+        assert!(consumer.restore(&entry, "inputs").is_err());
+        assert!(!consumer.target.exists());
+    }
+}
+
+#[test]
+fn existing_target_is_never_replaced_and_changed_inputs_invalidate_freshness() {
+    let root = project();
+    let cache = CargoCache::open(root.path(), "target").unwrap();
+    fs::create_dir_all(cache.target.join("debug/.fingerprint")).unwrap();
+    fs::create_dir_all(cache.target.join("debug/incremental")).unwrap();
+    fs::write(cache.target.join("debug/.fingerprint/stale"), "stale").unwrap();
+    fs::write(cache.target.join("debug/incremental/state"), "keep").unwrap();
+    assert!(!cache.restore(&root.path().join("missing"), "inputs").unwrap());
+    cache.prepare("changed").unwrap();
+    assert!(!cache.target.join("debug/.fingerprint").exists());
+    assert_eq!(fs::read_to_string(cache.target.join("debug/incremental/state")).unwrap(), "keep");
+}
+
+#[test]
+fn target_paths_cannot_escape_or_replace_package_metadata() {
+    let root = project();
+    for path in ["", "../target", "/target", ".git/target", "node_modules/target", "."] {
+        assert!(CargoCache::open(root.path(), path).is_err(), "accepted {path}");
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinks_are_rejected_for_targets_and_snapshots() {
+    let root = project();
+    let outside = tempfile::tempdir().unwrap();
+    std::os::unix::fs::symlink(outside.path(), root.path().join("target")).unwrap();
+    assert!(CargoCache::open(root.path(), "target").is_err());
+    fs::remove_file(root.path().join("target")).unwrap();
+    let cache = CargoCache::open(root.path(), "target").unwrap();
+    fs::create_dir(&cache.target).unwrap();
+    std::os::unix::fs::symlink(outside.path(), cache.target.join("escape")).unwrap();
+    assert!(cache.publish(&outside.path().join("snapshot"), "inputs", &[]).is_err());
+}
+
+#[test]
+fn source_configuration_and_environment_changes_select_different_snapshots() {
+    let root = project();
+    fs::create_dir(root.path().join("src")).unwrap();
+    fs::write(root.path().join("src/lib.rs"), "pub fn value() -> u8 { 1 }").unwrap();
+    fs::write(
+        root.path().join("Cargo.toml"),
+        "[package]\nname = 'cache-fixture'\nversion = '0.1.0'\n[workspace]\n",
+    )
+    .unwrap();
+    assert!(
+        Command::new("cargo")
+            .current_dir(root.path())
+            .args(["generate-lockfile", "--offline"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+    let cache = tempfile::tempdir().unwrap();
+    let environment = std::collections::BTreeMap::new();
+    let key = || super::snapshot_entry(cache.path(), root.path(), "task", &environment).unwrap().1;
+    let original = key();
+    fs::write(root.path().join("src/lib.rs"), "pub fn value() -> u8 { 2 }").unwrap();
+    let changed_source = key();
+    assert_ne!(original, changed_source);
+    fs::create_dir(root.path().join(".cargo")).unwrap();
+    fs::write(
+        root.path().join(".cargo/config.toml"),
+        "[build]\nrustflags = ['--cfg', 'custom_build']\n",
+    )
+    .unwrap();
+    let changed_config = key();
+    assert_ne!(changed_source, changed_config);
+    let environment = std::collections::BTreeMap::from([(
+        "RUSTFLAGS".to_string(),
+        "--cfg another_build".to_string(),
+    )]);
+    let changed_environment =
+        super::snapshot_entry(cache.path(), root.path(), "task", &environment).unwrap().1;
+    assert_ne!(changed_config, changed_environment);
+}
+
+#[test]
+fn incomplete_publication_is_not_visible_as_a_snapshot() {
+    let root = project();
+    let cache = tempfile::tempdir().unwrap();
+    let entry = cache.path().join("entry");
+    fs::create_dir(cache.path().join(".publish-interrupted")).unwrap();
+    let consumer = CargoCache::open(root.path(), "target").unwrap();
+    assert!(consumer.restore(&entry, "inputs").is_err());
+    assert!(!consumer.target.exists());
+}
+
+#[test]
+fn concurrent_publishers_leave_one_complete_immutable_snapshot() {
+    let a = project();
+    let b = project();
+    let cache = tempfile::tempdir().unwrap();
+    let entry = cache.path().join("entry");
+    let publishers = [
+        CargoCache::open(a.path(), "target").unwrap(),
+        CargoCache::open(b.path(), "target").unwrap(),
+    ];
+    for (index, publisher) in publishers.iter().enumerate() {
+        fs::create_dir(&publisher.target).unwrap();
+        fs::write(publisher.target.join("state"), index.to_string()).unwrap();
+    }
+    let barrier = std::sync::Barrier::new(2);
+    std::thread::scope(|scope| {
+        for publisher in &publishers {
+            let barrier = &barrier;
+            let entry = &entry;
+            scope.spawn(move || {
+                barrier.wait();
+                publisher.publish(entry, "inputs", &[]).unwrap();
+            });
+        }
+    });
+    let winner = fs::read(entry.join("files/state")).unwrap();
+    assert!(winner == b"0" || winner == b"1");
+    for publisher in &publishers {
+        fs::write(publisher.target.join("state"), "replacement").unwrap();
+        publisher.publish(&entry, "inputs", &[]).unwrap();
+    }
+    assert_eq!(fs::read(entry.join("files/state")).unwrap(), winner);
+    let consumer_root = project();
+    let consumer = CargoCache::open(consumer_root.path(), "target").unwrap();
+    assert!(consumer.restore(&entry, "inputs").unwrap());
+    assert_eq!(fs::read(consumer.target.join("state")).unwrap(), winner);
+}
+
+#[test]
+fn snapshot_storage_cannot_overlap_the_build_directory() {
+    let root = project();
+    let cache = CargoCache::open(root.path(), "target").unwrap();
+    fs::create_dir(&cache.target).unwrap();
+    fs::write(cache.target.join("state"), "keep").unwrap();
+    for entry in [root.path().to_path_buf(), cache.target.clone(), cache.target.join("nested")] {
+        assert!(cache.publish(&entry, "inputs", &[]).is_err());
+        assert!(cache.restore(&entry, "inputs").is_err());
+    }
+    assert_eq!(fs::read_to_string(cache.target.join("state")).unwrap(), "keep");
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+fn restoration_falls_back_to_copy_on_tmpfs() {
+    let a = project();
+    let b = tempfile::tempdir_in("/dev/shm").unwrap();
+    assert!(Command::new("git").arg("init").arg(b.path()).output().unwrap().status.success());
+    fs::write(b.path().join(".gitignore"), "target/\n").unwrap();
+    let storage = tempfile::tempdir().unwrap();
+    let entry = storage.path().join("entry");
+    let publisher = CargoCache::open(a.path(), "target").unwrap();
+    fs::create_dir(&publisher.target).unwrap();
+    fs::write(publisher.target.join("state"), "original").unwrap();
+    publisher.publish(&entry, "inputs", &[]).unwrap();
+    assert!(
+        reflink_copy::reflink(entry.join("files/state"), b.path().join("clone-probe")).is_err()
+    );
+    let consumer = CargoCache::open(b.path(), "target").unwrap();
+    assert!(consumer.restore(&entry, "inputs").unwrap());
+    fs::write(consumer.target.join("state"), "edited").unwrap();
+    assert_eq!(fs::read_to_string(entry.join("files/state")).unwrap(), "original");
+    fs::remove_dir_all(storage.path()).unwrap();
+    assert_eq!(fs::read_to_string(consumer.target.join("state")).unwrap(), "edited");
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
@@ -6,9 +6,10 @@ use std::{
 pub(super) fn validate_relative_path(path: &Path) -> io::Result<()> {
     if path.as_os_str().is_empty()
         || path.components().any(|part| !matches!(part, Component::Normal(_)))
-        || path
-            .components()
-            .any(|part| part.as_os_str() == ".git" || part.as_os_str() == "node_modules")
+        || path.components().any(|part| {
+            part.as_os_str().eq_ignore_ascii_case(".git")
+                || part.as_os_str().eq_ignore_ascii_case("node_modules")
+        })
     {
         return Err(io::Error::other(format!(
             "Cache path must stay inside the project: {}",
@@ -19,20 +20,23 @@ pub(super) fn validate_relative_path(path: &Path) -> io::Result<()> {
 }
 
 pub(super) fn check_ancestors(root: &Path, relative: &Path) -> io::Result<()> {
+    reject_symlink(root)?;
     let mut path = root.to_path_buf();
     for component in relative.components() {
         path.push(component);
-        match fs::symlink_metadata(&path) {
-            Ok(metadata) if metadata.file_type().is_symlink() => {
-                return Err(io::Error::other(format!(
-                    "Cache path is a symlink: {}",
-                    path.display(),
-                )));
-            }
-            Ok(_) => {}
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
+        reject_symlink(&path)?;
+    }
+    Ok(())
+}
+
+fn reject_symlink(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            return Err(io::Error::other(format!("Cache path is a symlink: {}", path.display())));
         }
+        Ok(_) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
@@ -1,0 +1,38 @@
+use std::{
+    fs, io,
+    path::{Component, Path},
+};
+
+pub(super) fn validate_relative_path(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty()
+        || path.components().any(|part| !matches!(part, Component::Normal(_)))
+        || path
+            .components()
+            .any(|part| part.as_os_str() == ".git" || part.as_os_str() == "node_modules")
+    {
+        return Err(io::Error::other(format!(
+            "Cache path must stay inside the project: {}",
+            path.display(),
+        )));
+    }
+    Ok(())
+}
+
+pub(super) fn check_ancestors(root: &Path, relative: &Path) -> io::Result<()> {
+    let mut path = root.to_path_buf();
+    for component in relative.components() {
+        path.push(component);
+        match fs::symlink_metadata(&path) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(io::Error::other(format!(
+                    "Cache path is a symlink: {}",
+                    path.display(),
+                )));
+            }
+            Ok(_) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/report.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report.rs
@@ -20,6 +20,15 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+/// What a `--report` submission carries to the pnpr server: the same
+/// summary document and event stream the local report files hold.
+pub struct RunUpload {
+    pub workspace: String,
+    pub run_id: String,
+    pub summary: Value,
+    pub events: Vec<Value>,
+}
+
 pub struct RunReport {
     run_id: String,
     pipeline: String,
@@ -125,8 +134,29 @@ impl RunReport {
             ndjson.push('\n');
         }
         fs::write(run_dir.join("events.ndjson"), ndjson).into_diagnostic()?;
+        fs::write(
+            run_dir.join("summary.json"),
+            serde_json::to_vec_pretty(&self.summary_value()).into_diagnostic()?,
+        )
+        .into_diagnostic()?;
+        Ok(run_dir)
+    }
+
+    /// The submission a `--report` run sends to the pnpr server.
+    pub fn to_upload(&self, workspace: String) -> RunUpload {
+        RunUpload {
+            workspace,
+            run_id: self.run_id.clone(),
+            summary: self.summary_value(),
+            events: self.events.lock().expect("event lock is not poisoned").clone(),
+        }
+    }
+
+    /// The summary document: what [`Self::finish`] assembled, or the
+    /// header alone for a run that settled before any task existed.
+    fn summary_value(&self) -> Value {
         let summary = self.summary.lock().expect("summary lock is not poisoned");
-        let summary = if summary.is_null() {
+        if summary.is_null() {
             json!({
                 "runId": self.run_id,
                 "pipeline": self.pipeline,
@@ -136,13 +166,7 @@ impl RunReport {
             })
         } else {
             summary.clone()
-        };
-        fs::write(
-            run_dir.join("summary.json"),
-            serde_json::to_vec_pretty(&summary).into_diagnostic()?,
-        )
-        .into_diagnostic()?;
-        Ok(run_dir)
+        }
     }
 
     fn push(&self, event: Value) {

--- a/pnpm/crates/cli/src/cli_args/pipeline/report.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report.rs
@@ -33,6 +33,7 @@ pub struct RunReport {
     run_id: String,
     pipeline: String,
     base: String,
+    revision: Option<String>,
     selection: Value,
     events: Mutex<Vec<Value>>,
     cache_hits: AtomicUsize,
@@ -40,7 +41,12 @@ pub struct RunReport {
 }
 
 impl RunReport {
-    pub fn new(pipeline: &str, base: &str, selection: &Selection) -> RunReport {
+    pub fn new(
+        pipeline: &str,
+        base: &str,
+        selection: &Selection,
+        revision: Option<String>,
+    ) -> RunReport {
         let mode = match selection.mode {
             SelectionMode::Affected => "affected",
             SelectionMode::Full => "full",
@@ -49,6 +55,7 @@ impl RunReport {
             run_id: format!("{}-{pipeline}", now_millis()),
             pipeline: pipeline.to_string(),
             base: base.to_string(),
+            revision,
             selection: json!({
                 "mode": mode,
                 "mergeBase": selection.merge_base,
@@ -116,6 +123,7 @@ impl RunReport {
             "runId": self.run_id,
             "pipeline": self.pipeline,
             "base": self.base,
+            "revision": self.revision,
             "selection": self.selection,
             "tasks": statuses,
             "taskKeys": keys,
@@ -161,6 +169,7 @@ impl RunReport {
                 "runId": self.run_id,
                 "pipeline": self.pipeline,
                 "base": self.base,
+                "revision": self.revision,
                 "selection": self.selection,
                 "tasks": {},
             })

--- a/pnpm/crates/cli/src/cli_args/pipeline/report.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report.rs
@@ -1,0 +1,155 @@
+//! The machine-readable account of a pipeline run: an event stream
+//! (`events.ndjson`) and a run summary (`summary.json`), written under
+//! the pipeline data directory. The stable task identity is the same
+//! `<workspace-relative dir>#<task>` the dry-run output uses.
+
+use super::{Selection, SelectionMode, cache::CacheDisposition};
+use crate::cli_args::recursive::ExecutionStatus;
+use indexmap::IndexMap;
+use miette::IntoDiagnostic;
+use pnpm_workspace_task_scheduler::{TaskKey, format_task};
+use serde_json::{Value, json};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+pub struct RunReport {
+    run_id: String,
+    pipeline: String,
+    base: String,
+    selection: Value,
+    events: Mutex<Vec<Value>>,
+    cache_hits: AtomicUsize,
+    summary: Mutex<Value>,
+}
+
+impl RunReport {
+    pub fn new(pipeline: &str, base: &str, selection: &Selection) -> RunReport {
+        let mode = match selection.mode {
+            SelectionMode::Affected => "affected",
+            SelectionMode::Full => "full",
+        };
+        RunReport {
+            run_id: format!("{}-{pipeline}", now_millis()),
+            pipeline: pipeline.to_string(),
+            base: base.to_string(),
+            selection: json!({
+                "mode": mode,
+                "mergeBase": selection.merge_base,
+                "changedProjects": selection.changed_count,
+                "requestedProjects": selection.requested.len(),
+                "includedProjects": selection.selected.len(),
+            }),
+            events: Mutex::new(Vec::new()),
+            cache_hits: AtomicUsize::new(0),
+            summary: Mutex::new(Value::Null),
+        }
+    }
+
+    pub fn task_started(&self, task: &str, key: &str) {
+        self.push(json!({
+            "event": "taskStarted",
+            "task": task,
+            "key": key,
+            "at": now_millis(),
+        }));
+    }
+
+    pub fn task_finished(
+        &self,
+        task: &str,
+        status: crate::cli_args::recursive::Status,
+        cache: CacheDisposition,
+        duration_ms: f64,
+    ) {
+        if cache == CacheDisposition::Hit {
+            self.cache_hits.fetch_add(1, Ordering::Relaxed);
+        }
+        self.push(json!({
+            "event": "taskFinished",
+            "task": task,
+            "status": status,
+            "cache": cache,
+            "durationMs": duration_ms,
+            "at": now_millis(),
+        }));
+    }
+
+    pub fn task_skipped(&self, task: &str) {
+        self.push(json!({
+            "event": "taskSkipped",
+            "task": task,
+            "at": now_millis(),
+        }));
+    }
+
+    pub fn cache_hits(&self) -> usize {
+        self.cache_hits.load(Ordering::Relaxed)
+    }
+
+    /// Assemble the summary document once the run has settled.
+    pub fn finish(
+        &self,
+        statuses: &IndexMap<String, ExecutionStatus>,
+        task_keys: &HashMap<TaskKey, String>,
+        workspace_root: &Path,
+    ) {
+        let keys: IndexMap<String, &String> =
+            task_keys.iter().map(|(task, key)| (format_task(task, workspace_root), key)).collect();
+        *self.summary.lock().expect("summary lock is not poisoned") = json!({
+            "runId": self.run_id,
+            "pipeline": self.pipeline,
+            "base": self.base,
+            "selection": self.selection,
+            "tasks": statuses,
+            "taskKeys": keys,
+        });
+    }
+
+    /// Write `events.ndjson` and `summary.json` into the run's directory
+    /// and return it.
+    pub fn write(&self, data_dir: &Path) -> miette::Result<PathBuf> {
+        let run_dir = data_dir.join("runs").join(&self.run_id);
+        fs::create_dir_all(&run_dir).into_diagnostic()?;
+        let events = self.events.lock().expect("event lock is not poisoned");
+        let mut ndjson = String::new();
+        for event in events.iter() {
+            ndjson.push_str(&event.to_string());
+            ndjson.push('\n');
+        }
+        fs::write(run_dir.join("events.ndjson"), ndjson).into_diagnostic()?;
+        let summary = self.summary.lock().expect("summary lock is not poisoned");
+        let summary = if summary.is_null() {
+            json!({
+                "runId": self.run_id,
+                "pipeline": self.pipeline,
+                "base": self.base,
+                "selection": self.selection,
+                "tasks": {},
+            })
+        } else {
+            summary.clone()
+        };
+        fs::write(
+            run_dir.join("summary.json"),
+            serde_json::to_vec_pretty(&summary).into_diagnostic()?,
+        )
+        .into_diagnostic()?;
+        Ok(run_dir)
+    }
+
+    fn push(&self, event: Value) {
+        self.events.lock().expect("event lock is not poisoned").push(event);
+    }
+}
+
+fn now_millis() -> u128 {
+    SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |elapsed| elapsed.as_millis())
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/report.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report.rs
@@ -46,13 +46,17 @@ impl RunReport {
         base: &str,
         selection: &Selection,
         revision: Option<String>,
-    ) -> RunReport {
+    ) -> miette::Result<RunReport> {
+        let mut random = [0u8; 16];
+        getrandom::fill(&mut random)
+            .map_err(|error| miette::miette!("generating a pipeline run ID: {error}"))?;
+        let nonce = u128::from_le_bytes(random);
         let mode = match selection.mode {
             SelectionMode::Affected => "affected",
             SelectionMode::Full => "full",
         };
-        RunReport {
-            run_id: format!("{}-{pipeline}", now_millis()),
+        Ok(RunReport {
+            run_id: format!("{}-{nonce:032x}", now_millis()),
             pipeline: pipeline.to_string(),
             base: base.to_string(),
             revision,
@@ -66,7 +70,7 @@ impl RunReport {
             events: Mutex::new(Vec::new()),
             cache_hits: AtomicUsize::new(0),
             summary: Mutex::new(Value::Null),
-        }
+        })
     }
 
     pub fn task_started(&self, task: &str, key: &str) {
@@ -186,3 +190,6 @@ impl RunReport {
 fn now_millis() -> u128 {
     SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |elapsed| elapsed.as_millis())
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/pipeline/report/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report/tests.rs
@@ -1,0 +1,28 @@
+use super::RunReport;
+use crate::cli_args::pipeline::{Selection, SelectionMode};
+use std::collections::HashSet;
+
+#[test]
+fn empty_selection_upload_has_a_summary_and_an_opaque_run_id() {
+    let selection = Selection {
+        requested: Vec::new(),
+        selected: HashSet::new(),
+        mode: SelectionMode::Affected,
+        merge_base: None,
+        changed_count: 0,
+    };
+    let pipeline = "../../outside/../pipeline";
+    let report = RunReport::new(pipeline, "main", &selection, None).unwrap();
+    let upload = report.to_upload("workspace".to_string());
+    assert_eq!(upload.summary["pipeline"], pipeline);
+    assert_eq!(upload.summary["tasks"], serde_json::json!({}));
+    assert_eq!(upload.summary["selection"]["requestedProjects"], 0);
+    assert!(upload.run_id.bytes().all(|byte| byte.is_ascii_hexdigit() || byte == b'-'));
+    let directory = tempfile::tempdir().unwrap();
+    let written = report.write(directory.path()).unwrap();
+    assert_eq!(written.parent().unwrap(), directory.path().join("runs"));
+    assert_eq!(
+        std::fs::read_to_string(written.join("summary.json")).unwrap(),
+        serde_json::to_string_pretty(&upload.summary).unwrap(),
+    );
+}

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -355,6 +355,12 @@ pub(crate) struct InstallPipeline {
 
 impl InstallPipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
+        self.run_with_config::<Reporter>().await.map(|_| ())
+    }
+
+    pub(crate) async fn run_with_config<Reporter: self::Reporter + 'static>(
+        self,
+    ) -> miette::Result<&'static Config> {
         let InstallPipeline {
             args,
             cfg,
@@ -421,14 +427,14 @@ impl InstallPipeline {
             InstallFamilyPlan::Single => true,
         };
         if !installs_node && !ecosystem_install::is_enabled(cfg) {
-            return Ok(());
+            return Ok(cfg);
         }
 
         let http_client = State::new_http_client(cfg).wrap_err("initialize the install network")?;
         let cfg: &'static Config = cfg;
         let lockfile_only = args.lockfile_only;
         if !ecosystem_install::is_enabled(cfg) {
-            return run_node_install::<Reporter>(
+            run_node_install::<Reporter>(
                 plan,
                 args,
                 cfg,
@@ -437,7 +443,8 @@ impl InstallPipeline {
                 lockfile,
                 http_client,
             )
-            .await;
+            .await?;
+            return Ok(cfg);
         }
         let ecosystem_plan = ecosystem_install::plan::<Reporter>(
             ecosystem_install::InstallContext {
@@ -462,7 +469,8 @@ impl InstallPipeline {
         ecosystem_plan
             .with_task(pnpm_install_coordinator::InstallTask::in_place(Vec::new(), node_install))
             .run()
-            .await
+            .await?;
+        Ok(cfg)
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -1152,6 +1152,7 @@ fn command_name(command: &CliCommand) -> &'static str {
         CliCommand::Add(_) => "add",
         CliCommand::Install(_) => "install",
         CliCommand::InstallTest(_) => "install-test",
+        CliCommand::Pipeline(_) => "pipeline",
         CliCommand::Update(_) => "update",
         CliCommand::Outdated(_) => "outdated",
         CliCommand::Audit(_) => "audit",

--- a/pnpm/crates/cli/src/cli_args/update_notifier.rs
+++ b/pnpm/crates/cli/src/cli_args/update_notifier.rs
@@ -68,7 +68,10 @@ pub(crate) fn spawn(config: &Config, emit: fn(&LogEvent)) -> PendingUpdateCheck 
 /// before the process exits. A command that failed drops the check
 /// instead: the error is what the user needs to read, and nothing was
 /// recorded, so the next command checks again.
-pub(crate) async fn settle(pending: PendingUpdateCheck, outcome: &miette::Result<()>) {
+pub(crate) async fn settle<Output: Sync>(
+    pending: PendingUpdateCheck,
+    outcome: &miette::Result<Output>,
+) {
     let Some(handle) = pending else { return };
     if outcome.is_ok() {
         let _ = handle.await;

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -89,6 +89,7 @@ mod package_manager_check;
 mod patch;
 mod peers;
 mod ping;
+mod pipeline_cache;
 mod pipeline_cargo_cache;
 mod pipeline_watch;
 mod pnpm_compatibility;

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -89,6 +89,7 @@ mod package_manager_check;
 mod patch;
 mod peers;
 mod ping;
+mod pipeline_cargo_cache;
 mod pipeline_watch;
 mod pnpm_compatibility;
 mod pnpr_install;

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -89,6 +89,7 @@ mod package_manager_check;
 mod patch;
 mod peers;
 mod ping;
+mod pipeline_watch;
 mod pnpm_compatibility;
 mod pnpr_install;
 mod pnpx_alias;

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -1,0 +1,98 @@
+use assert_cmd::prelude::*;
+use pnpm_testing_utils::command_env::CommandTestExt;
+use std::{fs, process::Command};
+
+#[test]
+fn configured_environment_changes_invalidate_task_outputs() {
+    let project = tempfile::tempdir().unwrap();
+    assert!(Command::new("git").arg("init").arg(project.path()).output().unwrap().status.success());
+    fs::create_dir(project.path().join("src")).unwrap();
+    fs::write(project.path().join("src/input"), "source").unwrap();
+    fs::write(project.path().join(".gitignore"), "out/\nnode_modules/\n").unwrap();
+    fs::write(project.path().join("package.json"), serde_json::json!({
+        "name": "probe", "version": "1.0.0", "scripts": {
+            "build": r#"node -e "require('fs').mkdirSync('out',{recursive:true});require('fs').writeFileSync('out/result',process.env.BUILD_MODE)""#
+        }
+    }).to_string()).unwrap();
+    fs::write(project.path().join(".pnpmfile.cjs"), "module.exports = { hooks: { updateConfig(config) { config.extraEnv = { ...config.extraEnv, BUILD_MODE: process.env.PIPELINE_TEST_MODE }; return config; } } }").unwrap();
+    let storage = tempfile::tempdir().unwrap();
+    let command = || {
+        let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
+        command
+            .current_dir(project.path())
+            .env("XDG_CACHE_HOME", storage.path())
+            .env("XDG_CONFIG_HOME", storage.path().join("config"));
+        command
+    };
+    for (index, value) in ["one", "two", "two"].into_iter().enumerate() {
+        fs::write(project.path().join("pnpm-workspace.yaml"), String::from("packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n    inputs: ['src/**']\n    outputs: ['out/**']\n    env: [BUILD_MODE]\n")).unwrap();
+        if index == 0 {
+            command()
+                .env("PIPELINE_TEST_MODE", value)
+                .env("BUILD_MODE", "ambient")
+                .arg("install")
+                .assert()
+                .success();
+        }
+        let result = command()
+            .env("PIPELINE_TEST_MODE", value)
+            .env("BUILD_MODE", "ambient")
+            .args(["pipeline", "--full"])
+            .assert()
+            .success();
+        let output = String::from_utf8_lossy(&result.get_output().stdout);
+        assert_eq!(output.contains("restored from cache"), index == 2, "{output}");
+        assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), value);
+    }
+    for reporter in ["ndjson", "silent"] {
+        let result = command()
+            .env("PIPELINE_TEST_MODE", "two")
+            .args(["pipeline", "--full", "--reporter", reporter])
+            .assert()
+            .success();
+        let output = String::from_utf8_lossy(&result.get_output().stdout);
+        assert!(output.is_empty(), "pipeline must not print human output: {output}");
+        let events = String::from_utf8_lossy(&result.get_output().stderr);
+        if reporter == "silent" {
+            assert!(events.is_empty(), "silent pipeline events: {events}");
+        } else {
+            assert!(!events.is_empty(), "NDJSON must contain pipeline events");
+            for line in events.lines() {
+                serde_json::from_str::<serde_json::Value>(line)
+                    .expect("every NDJSON line must be JSON");
+            }
+        }
+    }
+}
+
+#[test]
+fn affected_selection_keeps_an_enabled_workspace_root_dependent() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "demo");
+    fixture.write_file("package.json", r#"{"name":"root","private":true,"scripts":{"build":"echo root"},"dependencies":{"dep":"workspace:*"}}"#);
+    fixture.write_file("pnpm-workspace.yaml", "packages: [pkg]\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n");
+    fixture.write_file(
+        "pkg/package.json",
+        r#"{"name":"dep","version":"1.0.0","scripts":{"build":"echo dep"}}"#,
+    );
+    fixture.write_file("pkg/source", "first");
+    let base = fixture.commit("initial");
+    fixture.write_file("pkg/source", "second");
+    let result = Command::cargo_bin("pnpm")
+        .unwrap()
+        .without_ambient_pnpm_config()
+        .current_dir(root.path().join("demo-src"))
+        .env("XDG_CONFIG_HOME", root.path().join("config"))
+        .args(["pipeline", "--base", &base, "--dry-run", "--json"])
+        .assert()
+        .success();
+    let document: serde_json::Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert!(
+        document["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|task| task["project"] == "." && task["script"] == "build"),
+        "root dependent must participate: {document}",
+    );
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -130,3 +130,38 @@ fn affected_selection_keeps_the_workspace_root_as_an_upstream_dependency() {
         "root dependency must participate: {document}",
     );
 }
+
+#[test]
+fn dry_run_prints_the_graph_without_executing_workspace_code() {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("package.json"),
+        serde_json::json!({
+            "name": "probe", "version": "1.0.0", "scripts": {
+                "build": r#"node -e "throw new Error('dry-run executed build')""#
+            }
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(project.path().join("pnpm-workspace.yaml"), "packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n").unwrap();
+    fs::write(
+        project.path().join(".pnpmfile.cjs"),
+        "throw new Error('dry-run executed workspace configuration')",
+    )
+    .unwrap();
+    let result = Command::cargo_bin("pnpm")
+        .unwrap()
+        .without_ambient_pnpm_config()
+        .current_dir(project.path())
+        .env("XDG_CONFIG_HOME", project.path().join("config"))
+        .args(["pipeline", "--full", "--dry-run", "--json"])
+        .assert()
+        .success();
+    let document: serde_json::Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert_eq!(document["tasks"].as_array().unwrap().len(), 1);
+    assert_eq!(document["tasks"][0]["script"], "build");
+    for path in ["node_modules", "pnpm-lock.yaml", "pnpm-lock.env.yaml"] {
+        assert!(!project.path().join(path).exists(), "dry-run must not create {path}");
+    }
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -8,13 +8,13 @@ fn configured_environment_changes_invalidate_task_outputs() {
     assert!(Command::new("git").arg("init").arg(project.path()).output().unwrap().status.success());
     fs::create_dir(project.path().join("src")).unwrap();
     fs::write(project.path().join("src/input"), "source").unwrap();
-    fs::write(project.path().join(".gitignore"), "out/\nnode_modules/\n").unwrap();
+    fs::write(project.path().join(".gitignore"), "out/\nnode_modules/\nhook-count\n").unwrap();
     fs::write(project.path().join("package.json"), serde_json::json!({
         "name": "probe", "version": "1.0.0", "scripts": {
             "build": r#"node -e "require('fs').mkdirSync('out',{recursive:true});require('fs').writeFileSync('out/result',process.env.BUILD_MODE)""#
         }
     }).to_string()).unwrap();
-    fs::write(project.path().join(".pnpmfile.cjs"), "module.exports = { hooks: { updateConfig(config) { config.extraEnv = { ...config.extraEnv, BUILD_MODE: process.env.PIPELINE_TEST_MODE }; return config; } } }").unwrap();
+    fs::write(project.path().join(".pnpmfile.cjs"), r"module.exports = { hooks: { updateConfig(config) { const fs = require('fs'); const file = require('path').join(__dirname, 'hook-count'); fs.appendFileSync(file, 'called\n'); config.extraEnv = { ...config.extraEnv, BUILD_MODE: process.env.PIPELINE_TEST_MODE }; return config; } } }").unwrap();
     let storage = tempfile::tempdir().unwrap();
     let command = || {
         let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
@@ -34,6 +34,7 @@ fn configured_environment_changes_invalidate_task_outputs() {
                 .assert()
                 .success();
         }
+        fs::write(project.path().join("hook-count"), "").unwrap();
         let result = command()
             .env("PIPELINE_TEST_MODE", value)
             .env("BUILD_MODE", "ambient")
@@ -43,6 +44,7 @@ fn configured_environment_changes_invalidate_task_outputs() {
         let output = String::from_utf8_lossy(&result.get_output().stdout);
         assert_eq!(output.contains("restored from cache"), index == 2, "{output}");
         assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), value);
+        assert_eq!(fs::read_to_string(project.path().join("hook-count")).unwrap(), "called\n");
     }
     for reporter in ["ndjson", "silent"] {
         let result = command()
@@ -94,5 +96,37 @@ fn affected_selection_keeps_an_enabled_workspace_root_dependent() {
             .iter()
             .any(|task| task["project"] == "." && task["script"] == "build"),
         "root dependent must participate: {document}",
+    );
+}
+
+#[test]
+fn affected_selection_keeps_the_workspace_root_as_an_upstream_dependency() {
+    let root = tempfile::tempdir().unwrap();
+    let fixture = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "demo");
+    fixture.write_file(
+        "package.json",
+        r#"{"name":"root","version":"1.0.0","private":true,"scripts":{"build":"echo root"}}"#,
+    );
+    fixture.write_file("pnpm-workspace.yaml", "packages: [pkg]\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: ['^build']\n");
+    fixture.write_file("pkg/package.json", r#"{"name":"dep","version":"1.0.0","scripts":{"build":"echo dep"},"dependencies":{"root":"workspace:*"}}"#);
+    fixture.write_file("pkg/source", "first");
+    let base = fixture.commit("initial");
+    fixture.write_file("pkg/source", "second");
+    let result = Command::cargo_bin("pnpm")
+        .unwrap()
+        .without_ambient_pnpm_config()
+        .current_dir(root.path().join("demo-src"))
+        .env("XDG_CONFIG_HOME", root.path().join("config"))
+        .args(["pipeline", "--base", &base, "--dry-run", "--json"])
+        .assert()
+        .success();
+    let document: serde_json::Value = serde_json::from_slice(&result.get_output().stdout).unwrap();
+    assert!(
+        document["tasks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|task| task["project"] == "." && task["script"] == "build"),
+        "root dependency must participate: {document}",
     );
 }

--- a/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
@@ -31,7 +31,7 @@ fn pnpm(root: &Path, cache: &Path, args: &[&str]) -> String {
     format!(
         "{}{}",
         String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+        String::from_utf8_lossy(&output.stderr),
     )
 }
 
@@ -44,44 +44,44 @@ fn run_binary(root: &Path) -> String {
 #[test]
 fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
     let temp = tempfile::tempdir().unwrap();
-    let a = temp.path().join("a");
-    let b = temp.path().join("b");
+    let first_worktree = temp.path().join("a");
+    let second_worktree = temp.path().join("b");
     let cache = temp.path().join("cache");
-    fs::create_dir_all(a.join("src")).unwrap();
-    git(&a, &["init"]);
-    fs::write(a.join(".gitignore"), "target/\nnode_modules/\n").unwrap();
+    fs::create_dir_all(first_worktree.join("src")).unwrap();
+    git(&first_worktree, &["init"]);
+    fs::write(first_worktree.join(".gitignore"), "target/\nnode_modules/\n").unwrap();
     fs::write(
-        a.join("Cargo.toml"),
+        first_worktree.join("Cargo.toml"),
         "[package]\nname = 'probe'\nversion = '0.1.0'\nedition = '2024'\n[workspace]\n",
     )
     .unwrap();
     fs::write(
-        a.join("src/main.rs"),
+        first_worktree.join("src/main.rs"),
         "fn main() { println!(\"one\"); println!(\"{}\", env!(\"BUILD_ROOT\")); }\n",
     )
     .unwrap();
     fs::write(
-        a.join("build.rs"),
+        first_worktree.join("build.rs"),
         r#"fn main() {
         println!("cargo:rerun-if-changed=build.rs");
         println!("cargo:rustc-env=BUILD_ROOT={}", std::env::var("CARGO_MANIFEST_DIR").unwrap());
     }"#,
     )
     .unwrap();
-    fs::write(a.join("package.json"), r#"{"name":"probe","version":"1.0.0","scripts":{"build":"cargo build --locked --offline && echo task-executed"}}"#).unwrap();
-    fs::write(a.join("pnpm-workspace.yaml"), "packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n    cargoTargetDir: target\n").unwrap();
+    fs::write(first_worktree.join("package.json"), r#"{"name":"probe","version":"1.0.0","scripts":{"build":"cargo build --locked --offline && echo task-executed"}}"#).unwrap();
+    fs::write(first_worktree.join("pnpm-workspace.yaml"), "packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n    cargoTargetDir: target\n").unwrap();
     assert!(
         Command::new("cargo")
-            .current_dir(&a)
+            .current_dir(&first_worktree)
             .args(["generate-lockfile", "--offline"])
             .status()
             .unwrap()
-            .success()
+            .success(),
     );
-    pnpm(&a, &cache, &["install"]);
-    git(&a, &["add", "."]);
+    pnpm(&first_worktree, &cache, &["install"]);
+    git(&first_worktree, &["add", "."]);
     git(
-        &a,
+        &first_worktree,
         &[
             "-c",
             "user.name=Fixture",
@@ -94,18 +94,18 @@ fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
             "fixture",
         ],
     );
-    git(&a, &["worktree", "add", "--detach", b.to_str().unwrap()]);
+    git(&first_worktree, &["worktree", "add", "--detach", second_worktree.to_str().unwrap()]);
 
-    let first = pnpm(&a, &cache, &["pipeline", "--full"]);
+    let first = pnpm(&first_worktree, &cache, &["pipeline", "--full"]);
     assert!(first.contains("task-executed"), "{first}");
     assert!(!first.contains("Cargo build cache:"), "{first}");
-    let second = pnpm(&b, &cache, &["pipeline", "--full"]);
+    let second = pnpm(&second_worktree, &cache, &["pipeline", "--full"]);
     assert!(second.contains("restored Cargo build state"), "{second}");
     assert!(second.contains("task-executed"), "{second}");
-    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
-    assert_eq!(run_binary(&b), format!("one\n{}\n", b.display()));
+    assert_eq!(run_binary(&first_worktree), format!("one\n{}\n", first_worktree.display()));
+    assert_eq!(run_binary(&second_worktree), format!("one\n{}\n", second_worktree.display()));
 
-    let source = b.join("src/main.rs");
+    let source = second_worktree.join("src/main.rs");
     let timestamp = fs::metadata(&source).unwrap().modified().unwrap();
     fs::write(
         &source,
@@ -118,15 +118,15 @@ fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
         .unwrap()
         .set_times(FileTimes::new().set_modified(timestamp))
         .unwrap();
-    pnpm(&b, &cache, &["pipeline", "--full"]);
-    assert_eq!(run_binary(&b), format!("two\n{}\n", b.display()));
-    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+    pnpm(&second_worktree, &cache, &["pipeline", "--full"]);
+    assert_eq!(run_binary(&second_worktree), format!("two\n{}\n", second_worktree.display()));
+    assert_eq!(run_binary(&first_worktree), format!("one\n{}\n", first_worktree.display()));
 
     fs::remove_dir_all(cache.join("pnpm/cargo-build")).unwrap();
-    assert_eq!(run_binary(&b), format!("two\n{}\n", b.display()));
-    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
-    let repeat = pnpm(&a, &cache, &["pipeline", "--full", "--no-cache"]);
+    assert_eq!(run_binary(&second_worktree), format!("two\n{}\n", second_worktree.display()));
+    assert_eq!(run_binary(&first_worktree), format!("one\n{}\n", first_worktree.display()));
+    let repeat = pnpm(&first_worktree, &cache, &["pipeline", "--full", "--no-cache"]);
     assert!(!cache.join("pnpm/cargo-build").exists());
     assert!(repeat.contains("task-executed"), "{repeat}");
-    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+    assert_eq!(run_binary(&first_worktree), format!("one\n{}\n", first_worktree.display()));
 }

--- a/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
@@ -1,0 +1,132 @@
+#![cfg(unix)]
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::command_env::CommandTestExt;
+use std::{
+    fs::{self, File, FileTimes},
+    path::Path,
+    process::Command,
+};
+
+fn git(root: &Path, args: &[&str]) {
+    let output = Command::new("git").current_dir(root).args(args).output().unwrap();
+    assert!(output.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&output.stderr));
+}
+
+fn pnpm(root: &Path, cache: &Path, args: &[&str]) -> String {
+    let result = Command::cargo_bin("pnpm")
+        .unwrap()
+        .with_current_dir(root)
+        .without_ambient_pnpm_config()
+        .with_env("XDG_CACHE_HOME", cache)
+        .with_env("XDG_CONFIG_HOME", cache.join("config"))
+        .with_env("CARGO_INCREMENTAL", "1")
+        .with_env("RUSTC_WRAPPER", "")
+        .with_env("RUSTC_WORKSPACE_WRAPPER", "")
+        .with_args(args)
+        .assert()
+        .success();
+    let output = result.get_output();
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn run_binary(root: &Path) -> String {
+    let output = Command::new(root.join("target/debug/probe")).output().unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
+    let temp = tempfile::tempdir().unwrap();
+    let a = temp.path().join("a");
+    let b = temp.path().join("b");
+    let cache = temp.path().join("cache");
+    fs::create_dir_all(a.join("src")).unwrap();
+    git(&a, &["init"]);
+    fs::write(a.join(".gitignore"), "target/\nnode_modules/\n").unwrap();
+    fs::write(
+        a.join("Cargo.toml"),
+        "[package]\nname = 'probe'\nversion = '0.1.0'\nedition = '2024'\n[workspace]\n",
+    )
+    .unwrap();
+    fs::write(
+        a.join("src/main.rs"),
+        "fn main() { println!(\"one\"); println!(\"{}\", env!(\"BUILD_ROOT\")); }\n",
+    )
+    .unwrap();
+    fs::write(
+        a.join("build.rs"),
+        r#"fn main() {
+        println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rustc-env=BUILD_ROOT={}", std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    }"#,
+    )
+    .unwrap();
+    fs::write(a.join("package.json"), r#"{"name":"probe","version":"1.0.0","scripts":{"build":"cargo build --locked --offline && echo task-executed"}}"#).unwrap();
+    fs::write(a.join("pnpm-workspace.yaml"), "packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n    cargoTargetDir: target\n").unwrap();
+    assert!(
+        Command::new("cargo")
+            .current_dir(&a)
+            .args(["generate-lockfile", "--offline"])
+            .status()
+            .unwrap()
+            .success()
+    );
+    pnpm(&a, &cache, &["install"]);
+    git(&a, &["add", "."]);
+    git(
+        &a,
+        &[
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.com",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+    );
+    git(&a, &["worktree", "add", "--detach", b.to_str().unwrap()]);
+
+    let first = pnpm(&a, &cache, &["pipeline", "--full"]);
+    assert!(first.contains("task-executed"), "{first}");
+    assert!(!first.contains("Cargo build cache:"), "{first}");
+    let second = pnpm(&b, &cache, &["pipeline", "--full"]);
+    assert!(second.contains("restored Cargo build state"), "{second}");
+    assert!(second.contains("task-executed"), "{second}");
+    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+    assert_eq!(run_binary(&b), format!("one\n{}\n", b.display()));
+
+    let source = b.join("src/main.rs");
+    let timestamp = fs::metadata(&source).unwrap().modified().unwrap();
+    fs::write(
+        &source,
+        "fn main() { println!(\"two\"); println!(\"{}\", env!(\"BUILD_ROOT\")); }\n",
+    )
+    .unwrap();
+    File::options()
+        .write(true)
+        .open(&source)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(timestamp))
+        .unwrap();
+    pnpm(&b, &cache, &["pipeline", "--full"]);
+    assert_eq!(run_binary(&b), format!("two\n{}\n", b.display()));
+    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+
+    fs::remove_dir_all(cache.join("pnpm/cargo-build")).unwrap();
+    assert_eq!(run_binary(&b), format!("two\n{}\n", b.display()));
+    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+    let repeat = pnpm(&a, &cache, &["pipeline", "--full", "--no-cache"]);
+    assert!(!cache.join("pnpm/cargo-build").exists());
+    assert!(repeat.contains("task-executed"), "{repeat}");
+    assert_eq!(run_binary(&a), format!("one\n{}\n", a.display()));
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
@@ -44,8 +44,9 @@ fn run_binary(root: &Path) -> String {
 #[test]
 fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
     let temp = tempfile::tempdir().unwrap();
-    let first_worktree = temp.path().join("a");
-    let second_worktree = temp.path().join("b");
+    let root = dunce::canonicalize(temp.path()).unwrap();
+    let first_worktree = root.join("a");
+    let second_worktree = root.join("b");
     let cache = temp.path().join("cache");
     fs::create_dir_all(first_worktree.join("src")).unwrap();
     git(&first_worktree, &["init"]);

--- a/pnpm/crates/cli/tests/suite/pipeline_watch.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_watch.rs
@@ -1,0 +1,89 @@
+//! Watch-agent integration tests: poll a git repository, build new
+//! revisions of a branch in a persistent checkout, and skip ticks with
+//! nothing new. The build scripts run through pacquet's `sh -c`
+//! executor, so the file is gated to Unix like the other run suites.
+#![cfg(unix)]
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::{command_env::CommandTestExt, git_repo::GitRepoFixture};
+use std::{fs, path::Path, path::PathBuf, process::Command};
+
+fn agent_tick(root: &Path, repo: &str) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(root)
+        .without_ambient_pnpm_config()
+        .with_env("XDG_CACHE_HOME", root.join("xdg-cache"))
+        .with_env("XDG_CONFIG_HOME", root.join("xdg-config"))
+        .with_args(["pipeline", "--watch", "--once", "--repo", repo, "--branch", "main"])
+        .assert()
+}
+
+/// The persistent checkout the agent created: the single repo directory
+/// under the agent state dir.
+fn agent_checkout(root: &Path) -> PathBuf {
+    let agents = root.join("xdg-cache").join("pnpm").join("pipeline").join("agent");
+    let state_dir = fs::read_dir(&agents)
+        .expect("agent state dir exists")
+        .next()
+        .expect("one watched (repo, branch)")
+        .expect("read agent state dir")
+        .path();
+    state_dir.join("demo")
+}
+
+#[test]
+fn watch_agent_builds_new_revisions_and_skips_quiet_ticks() {
+    let root = tempfile::Builder::new()
+        .prefix("pacquet-test-")
+        .tempdir()
+        .expect("create temporary directory");
+    let fixture = GitRepoFixture::init(root.path(), "demo");
+    fixture.write_file(".gitignore", "node_modules\nout\n");
+    fixture.write_file(
+        "pnpm-workspace.yaml",
+        "packages:\n  - pkg\npipelines:\n  default:\n    - build\ntasks:\n  build:\n    dependsOn: []\n    outputs: ['out/**']\n",
+    );
+    fixture.write_file(
+        "pkg/package.json",
+        r#"{ "name": "pkg", "version": "1.0.0", "scripts": { "build": "mkdir -p out && cp src/index.txt out/index.txt" } }"#,
+    );
+    fixture.write_file("pkg/src/index.txt", "v1");
+    // The lockfile the checkout's frozen install verifies against.
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(root.path().join("demo-src"))
+        .without_ambient_pnpm_config()
+        .with_env("XDG_CACHE_HOME", root.path().join("xdg-cache"))
+        .with_env("XDG_CONFIG_HOME", root.path().join("xdg-config"))
+        .with_args(["install"])
+        .assert()
+        .success();
+    let first = fixture.commit("one");
+    let repo = root.path().join("demo.git");
+    let repo = repo.to_string_lossy();
+
+    let tick = agent_tick(root.path(), &repo);
+    let stdout = String::from_utf8_lossy(&tick.get_output().stdout).into_owned();
+    tick.success();
+    assert!(stdout.contains(&format!("New revision {first}")), "unexpected output: {stdout}");
+    assert!(stdout.contains("passed"), "unexpected output: {stdout}");
+    let built = agent_checkout(root.path()).join("pkg").join("out").join("index.txt");
+    assert_eq!(fs::read_to_string(&built).expect("first build produced the output"), "v1");
+
+    // Nothing new: no build, no output change.
+    let tick = agent_tick(root.path(), &repo);
+    let stdout = String::from_utf8_lossy(&tick.get_output().stdout).into_owned();
+    tick.success();
+    assert!(stdout.contains("main is up to date"), "unexpected output: {stdout}");
+
+    // A pushed change is picked up and built.
+    fixture.write_file("pkg/src/index.txt", "v2");
+    let second = fixture.commit("two");
+    let tick = agent_tick(root.path(), &repo);
+    let stdout = String::from_utf8_lossy(&tick.get_output().stdout).into_owned();
+    tick.success();
+    assert!(stdout.contains(&format!("New revision {second}")), "unexpected output: {stdout}");
+    assert_eq!(fs::read_to_string(&built).expect("second build refreshed the output"), "v2");
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_watch.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_watch.rs
@@ -7,7 +7,11 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{command_env::CommandTestExt, git_repo::GitRepoFixture};
-use std::{fs, path::Path, path::PathBuf, process::Command};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 fn agent_tick(root: &Path, repo: &str) -> assert_cmd::assert::Assert {
     Command::cargo_bin("pnpm")

--- a/pnpm/crates/cli/tests/suite/pipeline_watch.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_watch.rs
@@ -113,10 +113,12 @@ fn watch_agent_builds_new_revisions_and_skips_quiet_ticks() {
 
 #[test]
 fn watch_agent_refuses_a_zero_poll_interval() {
-    Command::cargo_bin("pnpm")
+    let result = Command::cargo_bin("pnpm")
         .unwrap()
         .without_ambient_pnpm_config()
         .args(["pipeline", "--watch", "--repo", "unused", "--interval", "0"])
         .assert()
         .failure();
+    let error = String::from_utf8_lossy(&result.get_output().stderr);
+    assert!(error.contains("0 is not in 1.."), "{error}");
 }

--- a/pnpm/crates/cli/tests/suite/pipeline_watch.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_watch.rs
@@ -19,6 +19,7 @@ fn agent_tick(root: &Path, repo: &str) -> assert_cmd::assert::Assert {
         .with_current_dir(root)
         .without_ambient_pnpm_config()
         .with_env("XDG_CACHE_HOME", root.join("xdg-cache"))
+        .with_env("XDG_STATE_HOME", root.join("xdg-state"))
         .with_env("XDG_CONFIG_HOME", root.join("xdg-config"))
         .with_args(["pipeline", "--watch", "--once", "--repo", repo, "--branch", "main"])
         .assert()
@@ -27,14 +28,14 @@ fn agent_tick(root: &Path, repo: &str) -> assert_cmd::assert::Assert {
 /// The persistent checkout the agent created: the single repo directory
 /// under the agent state dir.
 fn agent_checkout(root: &Path) -> PathBuf {
-    let agents = root.join("xdg-cache").join("pnpm").join("pipeline").join("agent");
+    let agents = root.join("xdg-state").join("pnpm").join("pipeline").join("agent");
     let state_dir = fs::read_dir(&agents)
         .expect("agent state dir exists")
         .next()
         .expect("one watched (repo, branch)")
         .expect("read agent state dir")
         .path();
-    state_dir.join("demo")
+    state_dir.join("checkout").join("demo")
 }
 
 #[test]
@@ -83,6 +84,9 @@ fn watch_agent_builds_new_revisions_and_skips_quiet_ticks() {
     assert!(stdout.contains("main is up to date"), "unexpected output: {stdout}");
 
     // A pushed change is picked up and built.
+    fs::write(agent_checkout(root.path()).join("pkg/src/index.txt"), "dirty source").unwrap();
+    fs::write(agent_checkout(root.path()).join("pkg/new.txt"), "untracked collision").unwrap();
+    fixture.write_file("pkg/new.txt", "tracked in the next revision");
     fixture.write_file("pkg/src/index.txt", "v2");
     let second = fixture.commit("two");
     let tick = agent_tick(root.path(), &repo);
@@ -90,4 +94,29 @@ fn watch_agent_builds_new_revisions_and_skips_quiet_ticks() {
     tick.success();
     assert!(stdout.contains(&format!("New revision {second}")), "unexpected output: {stdout}");
     assert_eq!(fs::read_to_string(&built).expect("second build refreshed the output"), "v2");
+
+    fixture.write_file(
+        "pkg/package.json",
+        r#"{"name":"pkg","version":"1.0.0","scripts":{"build":"exit 1"}}"#,
+    );
+    let failed = fixture.commit("failing build");
+    for _ in 0..2 {
+        let tick = agent_tick(root.path(), &repo);
+        let stdout = String::from_utf8_lossy(&tick.get_output().stdout).into_owned();
+        tick.failure();
+        assert!(
+            stdout.contains(&format!("New revision {failed}")),
+            "failed revision must remain pending: {stdout}",
+        );
+    }
+}
+
+#[test]
+fn watch_agent_refuses_a_zero_poll_interval() {
+    Command::cargo_bin("pnpm")
+        .unwrap()
+        .without_ambient_pnpm_config()
+        .args(["pipeline", "--watch", "--repo", "unused", "--interval", "0"])
+        .assert()
+        .failure();
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2458,6 +2458,16 @@ pub struct Config {
     /// none.
     pub tasks: IndexMap<String, workspace_yaml::TaskSettings>,
 
+    /// `pipelines` from `pnpm-workspace.yaml`: named sets of task requests
+    /// for `pnpm pipeline`, keyed by pipeline name. Empty when the
+    /// workspace declares none.
+    pub pipelines: IndexMap<String, Vec<String>>,
+
+    /// `pipelineBase` from `pnpm-workspace.yaml`: the git ref
+    /// `pnpm pipeline` resolves its affected-selection merge base against.
+    /// `None` falls back to the command's default.
+    pub pipeline_base: Option<String>,
+
     /// `peerDependencyRules` from `pnpm-workspace.yaml`: customizations
     /// applied when reporting peer-dependency issues. See
     /// [`PeerDependencyRules`].

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1117,6 +1117,12 @@ pub struct TaskSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cache: Option<bool>,
 
+    /// Opt into local Cargo state snapshots for this project-relative target
+    /// directory. Pipeline always executes the task and sets Cargo's target
+    /// and build directories to this path. Overrides output-cache restoration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cargo_target_dir: Option<String>,
+
     /// Fields this version of pnpm does not read, kept so validation can
     /// reject a typo instead of silently ignoring it.
     #[serde(flatten, skip_serializing_if = "IndexMap::is_empty")]
@@ -1132,6 +1138,7 @@ struct RawTaskSettings {
     inputs: Option<Vec<String>>,
     env: Option<Vec<String>>,
     cache: Option<bool>,
+    cargo_target_dir: Option<String>,
     #[serde(flatten)]
     unknown: IndexMap<String, serde_json::Value>,
 }
@@ -1149,6 +1156,7 @@ impl<'de> Deserialize<'de> for TaskSettings {
             inputs: raw.inputs,
             env: raw.env,
             cache: raw.cache,
+            cargo_target_dir: raw.cargo_target_dir,
             unknown: raw.unknown,
         })
     }
@@ -1321,7 +1329,7 @@ pub enum LoadWorkspaceYamlError {
     #[diagnostic(
         code(ERR_PNPM_INVALID_SETTING),
         help(
-            r#"A task declares "concurrency", "dependsOn", "outputs", "inputs", "env", or "cache"."#
+            r#"A task declares "concurrency", "dependsOn", "outputs", "inputs", "env", "cache", or "cargoTargetDir"."#
         )
     )]
     UnknownTaskSettingField { task: String, field: String },

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -977,6 +977,16 @@ pub struct WorkspaceSettings {
     /// declarations, keyed by task (script) name. See [`TaskSettings`].
     pub tasks: Option<IndexMap<String, TaskSettings>>,
 
+    /// `pipelines` from `pnpm-workspace.yaml`: named sets of task requests
+    /// for `pnpm pipeline`, keyed by pipeline name. A pipeline is a set,
+    /// not a sequence — ordering among its tasks is `tasks.dependsOn`'s
+    /// job.
+    pub pipelines: Option<IndexMap<String, Vec<String>>>,
+
+    /// `pipelineBase` from `pnpm-workspace.yaml`: the git ref
+    /// `pnpm pipeline` resolves its affected-selection merge base against.
+    pub pipeline_base: Option<String>,
+
     /// The problem keys [`Self::collect_key_issues`] found in the file this
     /// was parsed from. Not a setting: carried here so the CLI can report
     /// them at the point where it knows how severe they are (see the
@@ -1084,6 +1094,29 @@ pub struct TaskSettings {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<Vec<String>>,
 
+    /// The globs, relative to the project directory, naming the files the
+    /// task produces. Declaring `outputs` (even as `[]`, the positive
+    /// assertion that the task produces no files) is what makes a task
+    /// cacheable by `pnpm pipeline`; a task without the key runs normally.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub outputs: Option<Vec<String>>,
+
+    /// The globs, relative to the project directory, narrowing the task's
+    /// cache-key inputs. Absent, the inputs are every tracked (and
+    /// untracked, unignored) file of the project; a `+`-prefixed entry adds
+    /// to that default instead of replacing it.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputs: Option<Vec<String>>,
+
+    /// Environment variable names whose values participate in the task's
+    /// cache key. Values are hashed into the key, never recorded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub env: Option<Vec<String>>,
+
+    /// `false` opts a task with declared `outputs` out of the cache.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache: Option<bool>,
+
     /// Fields this version of pnpm does not read, kept so validation can
     /// reject a typo instead of silently ignoring it.
     #[serde(flatten, skip_serializing_if = "IndexMap::is_empty")]
@@ -1095,6 +1128,10 @@ pub struct TaskSettings {
 struct RawTaskSettings {
     concurrency: Option<serde_json::Value>,
     depends_on: Option<Vec<String>>,
+    outputs: Option<Vec<String>>,
+    inputs: Option<Vec<String>>,
+    env: Option<Vec<String>>,
+    cache: Option<bool>,
     #[serde(flatten)]
     unknown: IndexMap<String, serde_json::Value>,
 }
@@ -1108,6 +1145,10 @@ impl<'de> Deserialize<'de> for TaskSettings {
             concurrency,
             invalid_concurrency,
             depends_on: raw.depends_on,
+            outputs: raw.outputs,
+            inputs: raw.inputs,
+            env: raw.env,
+            cache: raw.cache,
             unknown: raw.unknown,
         })
     }
@@ -1279,9 +1320,14 @@ pub enum LoadWorkspaceYamlError {
     #[display("The \"tasks['{task}'].{field}\" setting is not a known task setting")]
     #[diagnostic(
         code(ERR_PNPM_INVALID_SETTING),
-        help(r#"A task declares "concurrency" and "dependsOn"."#)
+        help(
+            r#"A task declares "concurrency", "dependsOn", "outputs", "inputs", "env", or "cache"."#
+        )
     )]
     UnknownTaskSettingField { task: String, field: String },
+    #[display("The \"pipelines['{pipeline}']\" setting contains an entry with no task name")]
+    #[diagnostic(code(ERR_PNPM_INVALID_SETTING))]
+    EmptyPipelineTaskName { pipeline: String },
     #[display(
         "The \"tasks['{task}'].concurrency\" setting should be a positive integer, but got {concurrency}"
     )]
@@ -1391,6 +1437,7 @@ impl WorkspaceSettings {
             .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path: path.clone(), source })?;
         settings.validate_registries()?;
         settings.validate_tasks()?;
+        settings.validate_pipelines()?;
         settings.clear_workspace_only_fields();
         settings.warn_about_dropped_keys(&text, &path);
         Ok(Some(settings))
@@ -1442,6 +1489,19 @@ impl WorkspaceSettings {
                         entry: entry.clone(),
                     });
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// The `pipelines` section feeds `pnpm pipeline`'s task requests, which
+    /// reads it without further checks.
+    fn validate_pipelines(&self) -> Result<(), LoadWorkspaceYamlError> {
+        for (pipeline, task_names) in self.pipelines.iter().flatten() {
+            if task_names.iter().any(String::is_empty) {
+                return Err(LoadWorkspaceYamlError::EmptyPipelineTaskName {
+                    pipeline: pipeline.clone(),
+                });
             }
         }
         Ok(())
@@ -1581,8 +1641,11 @@ impl WorkspaceSettings {
         self.packages = None;
         self.catalog = None;
         // Task declarations describe the workspace's own scripts; pnpm's
-        // config-file key filter drops them from the global file too.
+        // config-file key filter drops them from the global file too. The
+        // same holds for the pipelines built from them.
         self.tasks = None;
+        self.pipelines = None;
+        self.pipeline_base = None;
         // A pnpmfile belongs to the project that ships it, and pnpm reads
         // `ignorePnpmfile` from `pnpm-workspace.yaml` and the environment but
         // not from here. Honoring it globally would silently drop a
@@ -1669,6 +1732,7 @@ impl WorkspaceSettings {
             .map_err(|source| LoadWorkspaceYamlError::ParseYaml { path: path.clone(), source })?;
         settings.validate_registries()?;
         settings.validate_tasks()?;
+        settings.validate_pipelines()?;
         settings.reject_repo_controlled_trust_material(&path)?;
         settings.collect_key_issues(&text);
         Ok(Some(settings))
@@ -2041,7 +2105,11 @@ impl WorkspaceSettings {
             registry_supports_time_field,
             allowed_deprecated_versions, update_config, peer_dependency_rules,
             enable_pre_post_scripts, dlx_cache_max_age,
-            allow_unused_patches, tasks,
+            allow_unused_patches, tasks, pipelines,
+        }
+
+        if let Some(pipeline_base) = self.pipeline_base {
+            config.pipeline_base = Some(pipeline_base);
         }
 
         if let Some(virtual_store_type) = virtual_store_type {

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -223,6 +223,8 @@ fn create_config(
         allowed_deprecated_versions: Default::default(),
         update_config: Default::default(),
         tasks: Default::default(),
+        pipelines: Default::default(),
+        pipeline_base: Default::default(),
         peer_dependency_rules: Default::default(),
         auth_headers: Default::default(),
         auth_tokens_by_uri: Default::default(),

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -401,6 +401,18 @@ struct HandshakeResponse {
     pnpr: HandshakeCapability,
 }
 
+/// One `pnpm pipeline` run as `PUT /-/pnpr/v0/pipeline/runs` carries it:
+/// the workspace and run identifiers plus the run's summary document and
+/// event stream, verbatim.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishPipelineRunRequest {
+    pub workspace: String,
+    pub run_id: String,
+    pub summary: serde_json::Value,
+    pub events: Vec<serde_json::Value>,
+}
+
 #[derive(Default, Deserialize)]
 struct HandshakeCapability {
     #[serde(default)]
@@ -539,6 +551,33 @@ impl PnprClient {
             let body = response_body_bounded(response, 64 * 1024).await?;
             return Err(PnprClientError::Server(format!(
                 "/-/pnpr/v0/artifacts returned {status}: {}",
+                String::from_utf8_lossy(&body),
+            )));
+        }
+        Ok(())
+    }
+
+    /// Record one `pnpm pipeline` run on the server. The document is
+    /// stored verbatim; a server without the pipeline surface answers 404.
+    pub async fn publish_pipeline_run(
+        &self,
+        request: &PublishPipelineRunRequest,
+        authorization: Option<&str>,
+    ) -> Result<(), PnprClientError> {
+        let mut put = self
+            .http
+            .put(format!("{}-/pnpr/v0/pipeline/runs", self.base_url))
+            .timeout(self.artifact_request_timeout)
+            .json(request);
+        if let Some(authorization) = authorization {
+            put = put.header("authorization", authorization);
+        }
+        let response = put.send().await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response_body_bounded(response, 64 * 1024).await?;
+            return Err(PnprClientError::Server(format!(
+                "/-/pnpr/v0/pipeline/runs returned {status}: {}",
                 String::from_utf8_lossy(&body),
             )));
         }

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -564,8 +564,13 @@ impl PnprClient {
         request: &PublishPipelineRunRequest,
         authorization: Option<&str>,
     ) -> Result<(), PnprClientError> {
-        let mut put = self
-            .http
+        if authorization.is_some() && !pnpm_network::is_url_secure_for_credentials(&self.base_url) {
+            return Err(PnprClientError::Protocol(
+                "pipeline report credentials require HTTPS or a loopback server".to_string(),
+            ));
+        }
+        let http = Client::builder().redirect(reqwest::redirect::Policy::none()).build()?;
+        let mut put = http
             .put(format!("{}-/pnpr/v0/pipeline/runs", self.base_url))
             .timeout(self.artifact_request_timeout)
             .json(request);

--- a/pnpm/crates/pnpr-client/src/tests.rs
+++ b/pnpm/crates/pnpr-client/src/tests.rs
@@ -401,3 +401,44 @@ fn an_untyped_frame_is_a_protocol_error() {
         panic!("expected a Protocol error");
     };
 }
+
+#[tokio::test]
+async fn pipeline_reports_refuse_credentials_on_non_loopback_http() {
+    let client = PnprClient::new("http://example.invalid");
+    let request = super::PublishPipelineRunRequest {
+        workspace: "demo".to_string(),
+        run_id: "100-run".to_string(),
+        summary: json!({}),
+        events: Vec::new(),
+    };
+    let error = client.publish_pipeline_run(&request, Some("Bearer secret")).await.unwrap_err();
+    assert!(
+        matches!(error, PnprClientError::Protocol(_)),
+        "insecure credentials must be rejected before any request: {error}",
+    );
+}
+
+#[tokio::test]
+async fn pipeline_report_redirects_are_not_followed() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("PUT", "/-/pnpr/v0/pipeline/runs")
+        .with_status(307)
+        .with_header("location", "/unexpected")
+        .create_async()
+        .await;
+    let destination = server.mock("PUT", "/unexpected").expect(0).create_async().await;
+    let client = PnprClient::new(server.url());
+    let request = super::PublishPipelineRunRequest {
+        workspace: "demo".to_string(),
+        run_id: "100-run".to_string(),
+        summary: json!({}),
+        events: Vec::new(),
+    };
+    assert!(
+        client.publish_pipeline_run(&request, Some("Bearer secret")).await.is_err(),
+        "report redirects must not receive credentials",
+    );
+    redirect.assert_async().await;
+    destination.assert_async().await;
+}

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -97,65 +97,159 @@ pub fn build_task_graph<SelectScripts>(
 where
     SelectScripts: Fn(&Path, &str) -> Vec<String>,
 {
-    let mut graph: TaskGraph = IndexMap::new();
-    let mut queue: VecDeque<(PathBuf, String, bool)> = options
-        .project_dependencies
-        .keys()
-        .map(|project| (project.clone(), options.task_name.to_string(), true))
-        .collect();
-    while let Some((project, task_name, requested)) = queue.pop_front() {
-        let key = TaskKey { project: project.clone(), task_name: task_name.clone() };
-        if let Some(existing) = graph.get_mut(&key) {
-            existing.requested |= requested;
-            continue;
-        }
-        let settings = options.tasks.and_then(|tasks| tasks.get(task_name.as_str()));
-        let entries: Vec<String> = match settings {
-            Some(settings) => settings.depends_on.clone().unwrap_or_default(),
-            None => vec![format!("^{task_name}")],
+    build_task_graph_from_seeds(
+        options.project_dependencies,
+        &options.select_scripts,
+        std::slice::from_ref(&options.task_name),
+        options.tasks,
+    )
+}
+
+pub struct BuildPipelineTaskGraphOptions<'a, SelectScripts>
+where
+    SelectScripts: Fn(&Path, &str) -> Vec<String>,
+{
+    /// The dependency edges among the included projects, already resolved
+    /// through the full workspace graph. Tasks are created only for these
+    /// projects, so the map must be dependency-closed: a task's `^` edges
+    /// resolve identically whatever narrowed the run, which is what keeps
+    /// its cache key selection-independent.
+    pub project_dependencies: &'a IndexMap<PathBuf, Vec<PathBuf>>,
+    pub select_scripts: SelectScripts,
+    /// The tasks the pipeline requests; every requested project gets a
+    /// task per name. A pipeline is a set, so the names carry no
+    /// ordering — any ordering among them is `dependsOn`'s job.
+    pub task_names: &'a [&'a str],
+    /// The projects whose tasks the invocation requests — the affected
+    /// set. `None` requests every project of `project_dependencies`. The
+    /// rest of the map participates only through `dependsOn` edges, the
+    /// way an upstream build is pulled in without its lint or tests.
+    pub requested_projects: Option<&'a [PathBuf]>,
+    pub tasks: Option<&'a IndexMap<String, TaskSettings>>,
+}
+
+/// [`build_task_graph`] for a `pnpm pipeline` invocation, which requests
+/// several task names at once across the requested projects.
+pub fn build_pipeline_task_graph<SelectScripts>(
+    options: &BuildPipelineTaskGraphOptions<'_, SelectScripts>,
+) -> TaskGraph
+where
+    SelectScripts: Fn(&Path, &str) -> Vec<String>,
+{
+    let seeded = SeededBuildOptions {
+        project_dependencies: options.project_dependencies,
+        select_scripts: &options.select_scripts,
+        task_names: options.task_names,
+        requested_projects: options.requested_projects,
+        tasks: options.tasks,
+    };
+    seeded.build()
+}
+
+fn build_task_graph_from_seeds<SelectScripts>(
+    project_dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,
+    select_scripts: &SelectScripts,
+    task_names: &[&str],
+    tasks: Option<&IndexMap<String, TaskSettings>>,
+) -> TaskGraph
+where
+    SelectScripts: Fn(&Path, &str) -> Vec<String>,
+{
+    let options = SeededBuildOptions {
+        project_dependencies,
+        select_scripts,
+        task_names,
+        requested_projects: None,
+        tasks,
+    };
+    options.build()
+}
+
+struct SeededBuildOptions<'a, SelectScripts>
+where
+    SelectScripts: Fn(&Path, &str) -> Vec<String>,
+{
+    project_dependencies: &'a IndexMap<PathBuf, Vec<PathBuf>>,
+    select_scripts: &'a SelectScripts,
+    task_names: &'a [&'a str],
+    requested_projects: Option<&'a [PathBuf]>,
+    tasks: Option<&'a IndexMap<String, TaskSettings>>,
+}
+
+impl<SelectScripts> SeededBuildOptions<'_, SelectScripts>
+where
+    SelectScripts: Fn(&Path, &str) -> Vec<String>,
+{
+    fn build(&self) -> TaskGraph {
+        let options = self;
+        let mut graph: TaskGraph = IndexMap::new();
+        let seed_projects: Vec<&PathBuf> = match options.requested_projects {
+            Some(requested) => requested.iter().collect(),
+            None => options.project_dependencies.keys().collect(),
         };
-        let mut dependencies: Vec<TaskKey> = Vec::new();
-        let mut seen: HashSet<TaskKey> = HashSet::new();
-        for entry in &entries {
-            if let Some(dependency_task_name) = entry.strip_prefix('^') {
-                for dependency_project in
-                    options.project_dependencies.get(&project).into_iter().flatten()
-                {
-                    let dependency = TaskKey {
-                        project: dependency_project.clone(),
-                        task_name: dependency_task_name.to_string(),
-                    };
+        let mut queue: VecDeque<(PathBuf, String, bool)> = seed_projects
+            .into_iter()
+            .flat_map(|project| {
+                options
+                    .task_names
+                    .iter()
+                    .map(|task_name| (project.clone(), (*task_name).to_string(), true))
+            })
+            .collect();
+        while let Some((project, task_name, requested)) = queue.pop_front() {
+            let key = TaskKey { project: project.clone(), task_name: task_name.clone() };
+            if let Some(existing) = graph.get_mut(&key) {
+                existing.requested |= requested;
+                continue;
+            }
+            let settings = options.tasks.and_then(|tasks| tasks.get(task_name.as_str()));
+            let entries: Vec<String> = match settings {
+                Some(settings) => settings.depends_on.clone().unwrap_or_default(),
+                None => vec![format!("^{task_name}")],
+            };
+            let mut dependencies: Vec<TaskKey> = Vec::new();
+            let mut seen: HashSet<TaskKey> = HashSet::new();
+            for entry in &entries {
+                if let Some(dependency_task_name) = entry.strip_prefix('^') {
+                    for dependency_project in
+                        options.project_dependencies.get(&project).into_iter().flatten()
+                    {
+                        let dependency = TaskKey {
+                            project: dependency_project.clone(),
+                            task_name: dependency_task_name.to_string(),
+                        };
+                        if seen.insert(dependency.clone()) {
+                            dependencies.push(dependency.clone());
+                            queue.push_back((dependency.project, dependency.task_name, false));
+                        }
+                    }
+                } else {
+                    let dependency = TaskKey { project: project.clone(), task_name: entry.clone() };
                     if seen.insert(dependency.clone()) {
                         dependencies.push(dependency.clone());
                         queue.push_back((dependency.project, dependency.task_name, false));
                     }
                 }
-            } else {
-                let dependency = TaskKey { project: project.clone(), task_name: entry.clone() };
-                if seen.insert(dependency.clone()) {
-                    dependencies.push(dependency.clone());
-                    queue.push_back((dependency.project, dependency.task_name, false));
-                }
             }
+            let scripts = (options.select_scripts)(&project, &task_name);
+            graph.insert(
+                key,
+                TaskNode {
+                    project,
+                    task_name,
+                    concurrency: settings.and_then(|settings| {
+                        settings
+                            .concurrency
+                            .map(|concurrency| usize::try_from(concurrency).unwrap_or(usize::MAX))
+                    }),
+                    scripts,
+                    requested,
+                    dependencies,
+                },
+            );
         }
-        let scripts = (options.select_scripts)(&project, &task_name);
-        graph.insert(
-            key,
-            TaskNode {
-                project,
-                task_name,
-                concurrency: settings.and_then(|settings| {
-                    settings
-                        .concurrency
-                        .map(|concurrency| usize::try_from(concurrency).unwrap_or(usize::MAX))
-                }),
-                scripts,
-                requested,
-                dependencies,
-            },
-        );
+        graph
     }
-    graph
 }
 
 pub struct SequenceTasksOptions<'a> {

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -54,15 +54,10 @@ fn tasks(entries: &[(&str, Option<&[&str]>)]) -> IndexMap<String, TaskSettings> 
     entries
         .iter()
         .map(|(name, depends_on)| {
-            (
-                name.to_string(),
-                TaskSettings {
-                    depends_on: depends_on.map(|entries| {
-                        entries.iter().map(std::string::ToString::to_string).collect()
-                    }),
-                    ..TaskSettings::default()
-                },
-            )
+            let mut settings = TaskSettings::default();
+            settings.depends_on = depends_on
+                .map(|entries| entries.iter().map(std::string::ToString::to_string).collect());
+            (name.to_string(), settings)
         })
         .collect()
 }

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -141,7 +141,7 @@ fn pipeline_graph_requests_every_task_name_only_in_the_requested_projects() {
     });
     assert_eq!(
         keys,
-        vec![key("app", "build"), key("app", "lint"), key("lib", "build"), key("lib", "lint")]
+        vec![key("app", "build"), key("app", "lint"), key("lib", "build"), key("lib", "lint")],
     );
     assert!(graph[&key("app", "build")].requested);
     assert!(graph[&key("app", "lint")].requested);

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    BuildTaskGraphOptions, ScheduleGraphAsyncOptions, ScheduleGraphOptions, ScheduleTasksOptions,
-    SequenceTasksOptions, TaskCompletion, TaskCycle, TaskGraph, TaskKey, TaskNode,
-    build_task_graph, is_serial_task_graph, render_task_graph_dry_run, resume_task_graph_from,
-    reverse_task_graph, schedule_graph, schedule_graph_async, schedule_tasks, sequence_tasks,
-    task_graph_to_json,
+    BuildPipelineTaskGraphOptions, BuildTaskGraphOptions, ScheduleGraphAsyncOptions,
+    ScheduleGraphOptions, ScheduleTasksOptions, SequenceTasksOptions, TaskCompletion, TaskCycle,
+    TaskGraph, TaskKey, TaskNode, build_pipeline_task_graph, build_task_graph,
+    is_serial_task_graph, render_task_graph_dry_run, resume_task_graph_from, reverse_task_graph,
+    schedule_graph, schedule_graph_async, schedule_tasks, sequence_tasks, task_graph_to_json,
 };
 use indexmap::IndexMap;
 use pnpm_config::TaskSettings;
@@ -54,10 +54,15 @@ fn tasks(entries: &[(&str, Option<&[&str]>)]) -> IndexMap<String, TaskSettings> 
     entries
         .iter()
         .map(|(name, depends_on)| {
-            let mut settings = TaskSettings::default();
-            settings.depends_on = depends_on
-                .map(|entries| entries.iter().map(std::string::ToString::to_string).collect());
-            (name.to_string(), settings)
+            (
+                name.to_string(),
+                TaskSettings {
+                    depends_on: depends_on.map(|entries| {
+                        entries.iter().map(std::string::ToString::to_string).collect()
+                    }),
+                    ..TaskSettings::default()
+                },
+            )
         })
         .collect()
 }
@@ -98,6 +103,52 @@ fn build_graph(
         task_name,
         tasks: task_settings,
     })
+}
+
+#[test]
+fn pipeline_graph_requests_every_task_name_only_in_the_requested_projects() {
+    // `app` depends on `lib`; only `app` is requested, so `lib` gets no
+    // requested tasks of its own — but `app#build`'s `^build` edge still
+    // pulls `lib#build` in, keeping the graph (and so a cache key built
+    // over it) identical to what an unnarrowed run resolves.
+    let projects =
+        [("lib", project(&[], &["build", "lint"])), ("app", project(&["lib"], &["build", "lint"]))];
+    let project_dependencies: IndexMap<PathBuf, Vec<PathBuf>> = projects
+        .iter()
+        .map(|(name, project)| {
+            (dir(name), project.dependencies.iter().map(|dependency| dir(dependency)).collect())
+        })
+        .collect();
+    let scripts_by_dir: HashMap<PathBuf, Vec<String>> = projects
+        .iter()
+        .map(|(name, project)| {
+            (dir(name), project.scripts.iter().map(std::string::ToString::to_string).collect())
+        })
+        .collect();
+    let requested = [dir("app")];
+    let graph = build_pipeline_task_graph(&BuildPipelineTaskGraphOptions {
+        project_dependencies: &project_dependencies,
+        select_scripts: |project: &Path, task_name: &str| {
+            scripts_by_dir[project].iter().filter(|script| *script == task_name).cloned().collect()
+        },
+        task_names: &["build", "lint"],
+        requested_projects: Some(&requested),
+        tasks: None,
+    });
+    let mut keys: Vec<TaskKey> = graph.keys().cloned().collect();
+    keys.sort_by(|left, right| {
+        (&left.project, &left.task_name).cmp(&(&right.project, &right.task_name))
+    });
+    assert_eq!(
+        keys,
+        vec![key("app", "build"), key("app", "lint"), key("lib", "build"), key("lib", "lint")]
+    );
+    assert!(graph[&key("app", "build")].requested);
+    assert!(graph[&key("app", "lint")].requested);
+    assert!(!graph[&key("lib", "build")].requested);
+    // Pulled by `app#lint`'s default `^lint`, not requested.
+    assert!(!graph[&key("lib", "lint")].requested);
+    assert_eq!(graph[&key("app", "build")].dependencies, vec![key("lib", "build")]);
 }
 
 #[test]

--- a/pnpm/scripts/bench-rust-cache.md
+++ b/pnpm/scripts/bench-rust-cache.md
@@ -1,0 +1,337 @@
+# Rust cache reuse experiment
+
+Run from the repository root on Linux with Node.js, Cargo, sccache, Git,
+GNU `cp`, and a filesystem supporting reflinks:
+
+```sh
+just bench-rust-cache
+```
+
+The benchmark creates two detached worktrees at `HEAD`. It leaves the current
+checkout and existing compiler caches alone. Cargo dependencies must already
+be downloaded; builds use `--locked --offline`. If dependencies are missing,
+run `cargo fetch --locked` before repeating the benchmark.
+
+The default workload is `pnpm-graph-hasher`. Select another library and its
+crate root together:
+
+```sh
+just bench-rust-cache --package pnpm-store-dir --source pnpm/crates/store-dir/src/lib.rs --rounds 3
+```
+
+Each round compares:
+
+| Mode | Cargo output | Incremental | Compiler cache |
+| --- | --- | --- | --- |
+| `incremental` | Separate directories | Enabled | None |
+| `sccache` | Separate directories | Disabled | One isolated local disk cache |
+| `shared-target` | One writable directory | Enabled | None |
+| `reflink-snapshot` | Separate directories, B cloned from warm A | Enabled | None |
+
+The sccache mode measures the local tier used by the existing pnpr integration.
+It does not measure network transfer or remote cache backfill. Each round
+starts with empty build and compiler-cache directories. The host filesystem
+cache is not flushed. Mode order rotates between rounds. Cargo configuration
+files still apply, including linker and profile settings; wrapper and Rust
+flags environment overrides are controlled by the script.
+
+Each mode builds A, repeats A, builds B, edits B, returns to A, and repeats B.
+The script appends an observable function to the selected crate root in each
+disposable worktree. After every build, it compiles and runs a small consumer
+to verify which source revision the library contains. Consumer compilation,
+execution, and content scanning are outside the timed Cargo invocation.
+An output mismatch is recorded as `correct: false` and printed prominently.
+It disqualifies that strategy regardless of its timing.
+
+Results are written after each mode to `results.json`, with Cargo stderr logs
+beside it, under `bench-work-env/rust-cache-<timestamp>/`. Use `--output` to
+choose a new directory. Build outputs remain available for inspection;
+temporary worktrees are removed on normal completion or a caught error.
+Terminating the process externally may require manual worktree cleanup.
+
+Compare the median for each phase across rounds. Add `snapshotSeconds` to
+`first-b` when comparing the reflink strategy's total restoration cost.
+The `compiled` field lists Cargo units reported as not fresh; an sccache hit
+still appears there. The separate sccache statistics show compiler cache hits.
+
+Storage is scanned after the first B build. SHA-512 plus the executable bit
+matches pnpm CAS's file identity convention. `inodeBytes` counts each hardlinked
+file once; `uniqueBytes` counts identical content once; `duplicateBytes` is the
+difference. This is an upper bound on file-content deduplication, including
+Cargo metadata and incremental files. It excludes CAS manifests and filesystem
+metadata. `allocatedBytes` counts allocated blocks per inode and **does not**
+account for shared reflink extents. It must not be presented as physical disk
+usage for the snapshot strategy. sccache storage is measured separately after
+the final build and must be included when assessing that mode's storage cost.
+
+This experiment does not implement a pnpm CAS backend, model Rust build keys,
+or make shared Cargo directories safe. A fast snapshot result establishes
+only whether preserving and reflinking existing Cargo state merits further
+work. Cross-platform restore, concurrent builds, build-script inputs, and
+cache retention need separate validation before a product implementation.
+
+## Findings, 2026-09-06
+
+Measured revision `ad0b50d5ed16a7224478bd4c8d4843338926df6e` on Linux x86-64,
+Btrfs, a Ryzen 9 9950X3D2 with 32 logical CPUs, Rust 1.97.0, and sccache 0.17.0.
+The host Cargo config selected Clang as linker and `line-tables-only` dev
+debug information. These are exploratory measurements on a developer machine,
+not results from a dedicated performance runner.
+
+The small workload is the median of three rounds of `pnpm-graph-hasher`
+(24 Cargo artifacts). The larger workload is a confirmation run of
+`pnpm-store-dir` (182 artifacts). A preceding three-round larger run reproduced
+the correctness results, but overlapped other compilation during some phases,
+so its timings are omitted here. Snapshot times below include the reflink copy.
+
+| Strategy | Small: first B | Small: edit B | Larger: first B | Larger: edit B | Output checks |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Separate incremental builds | 1.43 s | 0.15 s | 4.75 s | 0.30 s | Passed |
+| Shared local sccache | 1.70 s | 0.23 s | 5.71 s | 0.74 s | Passed |
+| Shared writable target | Disqualified | Disqualified | Disqualified | Disqualified | A returned B's edited code |
+| Independent reflink snapshot | 0.20 s | 0.24 s | 0.71 s | 0.83 s | Passed |
+
+The shared writable target failed the return-to-A check in every tested round.
+Cargo reported the unit as fresh, but the linked consumer returned `1` when
+A's source returned `0`. Sharing a mutable target directory between independent
+worktrees is therefore not a suitable implementation for this feature. Cargo's
+unit freshness state does not give these checkouts independent ownership of the
+output slot. A shared store must publish immutable entries and materialize an
+independent writable build directory for each checkout.
+
+The reflink snapshot reduced second-worktree startup by about 7 times in these
+workloads. It did not speed up the first subsequent edit. That edit was slower
+than editing an existing local incremental build. The experiment establishes
+a worktree-startup opportunity, not an improvement to the steady edit loop.
+
+The larger pair of independently built incremental directories contained
+1,166,904,459 bytes after counting hardlinks once. Unique content occupied
+707,213,087 bytes. The remaining 459,691,372 bytes, about 438 MiB or 39%, is an
+upper bound on additional content deduplication. This does not count manifest
+overhead, and some duplicate extents may already be shared by the filesystem.
+It is not a measured reduction in physical disk allocation.
+
+sccache recorded zero Rust hits in both workloads. The larger workload did
+have three native compiler hits. The different absolute compilation paths
+prevented useful Rust reuse with this setup, consistent with the existing
+[compiler-cache integration documentation](../../pnpr/crates/pnpr/README.md#cargo-compilation-cache).
+Improving path-compatible cache reuse is a separate opportunity from CAS
+deduplication. Relocating the cache directory alone does not address it.
+
+Next, prototype immutable snapshots in a disposable project-build cache with
+clone-or-copy materialization, preserving per-worktree mutable state. Reuse
+CAS primitives without sharing the installed-package store's lifetime.
+Measure publication,
+manifest lookup, hashing, restoration, and the first edit together. Snapshot
+selection must include source identity and the compilation environment;
+the npm dependency-graph key or Cargo.lock alone is insufficient. Do not expose
+the shared writable target strategy as a user feature.
+
+Raw local records for this investigation:
+
+- `bench-work-env/rust-cache-1788720139306/results.json` (small, three rounds)
+- `bench-work-env/rust-cache-1788720193292/results.json` (larger exploratory run)
+- `bench-work-env/rust-cache-1788720328535/results.json` (larger confirmation)
+
+These generated directories are ignored by Git. Running the command above
+produces fresh records with the same schema.
+
+## Fit with local-project build caching
+
+The product boundary is a workspace task that builds a local project, including
+a task that invokes Cargo. A snapshot would preserve that task's incremental
+state between worktrees. This does not require pnpm to manage arbitrary Cargo
+invocations outside its task runner.
+
+There are two different cache contracts:
+
+| Artifact | On a hit | Required identity |
+| --- | --- | --- |
+| Completed task outputs | Restore outputs and skip execution | All task inputs, including upstream task inputs or outputs and the build environment |
+| Incremental build state | Restore private state, then execute the task | A validated snapshot compatibility model plus source identity; never treat a state hit as task completion |
+
+Start with exact-source snapshots. Reusing a snapshot from an older revision
+is a separate capability that needs invalidation tests. Always running Cargo
+is necessary for state restoration, but is not sufficient proof of freshness:
+the shared-target experiment already produced incorrect output after Cargo ran.
+
+### What this checkout already provides
+
+These findings describe `ad0b50d5ed16a7224478bd4c8d4843338926df6e`.
+The local-project cache feature mentioned in the discussion is implemented in
+the open proof-of-concept [pnpm/pnpm PR 14233](https://github.com/pnpm/pnpm/pull/14233),
+on `pnpm-ci-poc`, not in this checkout. Its implementation is described below.
+
+- [`run.rs`](../crates/cli/src/cli_args/run.rs) and its recursive runner execute
+  workspace scripts. [`task_run_state.rs`](https://github.com/pnpm/pnpm/blob/ad0b50d5ed16a7224478bd4c8d4843338926df6e/pnpm/crates/cli/src/cli_args/task_run_state.rs)
+  records task execution for resumption; its invocation identity is not a hash
+  of source-file contents and cannot serve as a build-cache key.
+- [`shared-artifact-protocol`](../crates/shared-artifact-protocol/src/lib.rs)
+  already defines `WorkspaceTask { project, task }`, `workspace-task:v1` artifacts,
+  and organization ownership. The pnpr
+  [store tests](../../pnpr/crates/shared-artifacts/src/tests.rs) include
+  `workspace_task_subjects_round_trip_through_the_store`. This is an existing
+  remote storage integration point, not evidence of a complete CLI task cache.
+- [`shared_side_effects.rs`](../crates/deps-restorer/src/shared_side_effects.rs)
+  connects installation to signed dependency artifacts. Its package integrity,
+  npm graph keys, Node platform selection, and store-index updates are specific
+  to dependencies. Reuse protocol/client capabilities, not this install adapter.
+- [`link_file.rs`](../crates/deps-restorer/src/link_file.rs) has clone-or-copy
+  handling and filesystem fallback tests. Extract reusable filesystem behavior
+  if a task cache needs it; do not make task execution depend on dependency
+  restoration. The macOS
+  [`dir_clone_cache`](../crates/deps-restorer/src/dir_clone_cache.rs) shares GVS
+  slots, so its storage ownership is unsuitable for a separately disposable cache.
+- The [sccache service](../../pnpr/crates/pnpr/README.md#cargo-compilation-cache)
+  shares pnpr artifact infrastructure but uses a separate compiler namespace.
+  It caches compiler results, not Cargo incremental directories. A task snapshot
+  should not masquerade as an sccache entry or a dependency-side-effects artifact.
+
+### Cache removal is part of the contract
+
+Use a dedicated build-cache root outside the package store and GVS. Reusing
+hashing, blob storage, and cloning code must not make installed packages depend
+on this root. Cross-store blob deduplication is outside the initial prototype.
+
+Published snapshots are immutable. Each task receives independent writable
+files through reflinks or copies, never hardlinks to mutable files or symlinks
+back into the cache. Removing the entire cache must leave restored build
+directories and installed dependencies usable. The only subsequent effect is
+a cache miss and rebuilding, assuming the normal build inputs are available.
+
+Restore into staging and expose the completed directory only after validation.
+A missing blob or concurrent eviction discards staging and becomes a miss.
+Do not overwrite an existing live target directory, and do not snapshot it
+while Cargo or another writer is changing it. Publication needs exclusive
+ownership of the build directory and a check that inputs remained stable.
+For multiple workspace tasks sharing a Cargo target, ownership belongs to that
+target directory, not merely to the npm package or task name.
+
+### Cargo-specific gaps
+
+Snapshot selection must account for source contents, local path dependencies,
+Cargo manifests and lockfile, effective Cargo configuration, Cargo/rustc
+versions, host and target, profile, features, flags, linker/native tools, and
+declared build-script or procedural-macro inputs and environment. A Git commit
+alone misses dirty and untracked inputs. Unknown external inputs should exclude
+a task from caching until it has an explicit input contract.
+
+Cargo's [fingerprint documentation](https://doc.rust-lang.org/stable/nightly-rustc/cargo/core/compiler/fingerprint/index.html)
+describes timestamp-based freshness checks. Its
+[build-script documentation](https://doc.rust-lang.org/cargo/reference/build-scripts.html#change-detection)
+also describes file and environment change tracking. Restoring bytes and modes
+alone is not equivalent to the benchmark's `cp --archive`: snapshot metadata,
+source timestamps, and absolute paths need a defined restoration policy.
+Preserving all timestamps blindly is not a correctness solution either.
+
+The current shared artifact manifest contains path, integrity, mode, and size,
+but no timestamps or symlink representation. It caps each file and the total
+artifact at 64 MiB, with at most 10,000 files. The measured larger pair has
+about 707 MB of unique content, so whole-target remote reuse cannot assume this
+protocol's limits are adequate. Measure each snapshot and its largest files.
+Its current platform tag helpers also describe Node platforms, not Rust
+toolchain compatibility. A Rust state format needs an explicit version and
+compatibility rules, distinct from completed task outputs. Avoid raising shared
+limits or marking native artifacts universal just to make a prototype fit.
+
+### Bounded next experiment
+
+Implement a local-only snapshot lifecycle in the benchmark before adding CLI
+settings or remote publication. Use a disposable cache root, an explicit fixture
+input manifest, and independent target directories. Exercise the same lifecycle
+that a workspace task would use: lookup, restore, execute, publish. Keep normal
+existing local incremental builds as the baseline.
+
+Required checks:
+
+1. Restore B, delete the entire snapshot cache, then run and edit both A and B.
+   Verify outputs and confirm installed dependencies remain usable.
+2. Edit B after restoration and verify neither A nor the published snapshot
+   changes. Test reflink and forced-copy restoration separately.
+3. Delete a snapshot or blob during restoration and verify a clean miss with
+   no partial target exposed. Test concurrent publication and interrupted writes.
+4. Change source bytes while retaining size and timestamp, switch branches,
+   change a path dependency, and change build-script file/environment inputs.
+   Compare executable output with an independent clean build each time.
+5. Change profiles, features, compiler flags, target paths, and toolchain identity.
+   Incompatible snapshots must be rejected. Include build scripts and native
+   compilation, beyond the existing library probe.
+6. Measure lookup, hashing, publication, restoration, first build, and first edit
+   together. Report snapshot bytes and file counts alongside timings; the
+   existing startup speedup excludes most cache lifecycle costs.
+
+If these checks pass and total cost remains useful, connect the lifecycle to
+the local-project task cache from PR 14233. Remote support
+then builds on workspace-task artifact infrastructure with a reviewed Rust
+state format, bounded transfer, and trusted publication. No new v11 feature
+is proposed.
+
+### Connection to the pipeline proof of concept
+
+Inspected PR 14233 at `02289dd385955818727b350795d606c46233a19d`.
+Its [`pipeline/cache.rs`](https://github.com/pnpm/pnpm/blob/02289dd385955818727b350795d606c46233a19d/pnpm/crates/cli/src/cli_args/pipeline/cache.rs)
+implements task keys, output collection, copy-based storage/restoration, and
+captured logs. The
+[`pipeline.rs`](https://github.com/pnpm/pnpm/blob/02289dd385955818727b350795d606c46233a19d/pnpm/crates/cli/src/cli_args/pipeline.rs)
+caller skips execution on a successful restore and replays those logs. This is
+the completed-task-output contract above and is a concrete place to integrate
+incremental state around task execution on an output-cache miss.
+
+Its task artifacts live under
+`<cacheDir>/pipeline/<hash-of-workspace-path>/tasks`; restoration records and run
+reports are siblings. Output bytes are copied into the working tree, so removing
+the cache does not unlink restored outputs. Losing restoration records makes
+later restores more conservative about overwriting existing files. Deleting the
+whole pipeline directory also loses local reports, which is separate from
+whether installed projects or built binaries keep working.
+
+Three changes are needed before this can deliver the worktree reuse measured here:
+
+- Separate shared task artifacts from workspace-local restoration records.
+  The current workspace-path namespace prevents A and B from finding the same
+  entry even when their task keys match. Shared keys need repository identity
+  and an appropriate trust scope; removing the workspace prefix alone is not
+  a complete design.
+- Add optional incremental-state restoration on a completed-output miss, then
+  execute the task normally. Keep final outputs and state snapshots separate;
+  declaring `target/**` as outputs would use the existing skip-execution contract
+  and would not implement incremental reuse after a source edit.
+- Extend input/environment identity for Cargo. The PoC hashes script bodies,
+  declared environment variables, selected project files, upstream task keys,
+  the pnpm lockfile, and Node's version. It includes untracked, unignored files,
+  but input globs only filter that enumerated project file set. External Cargo
+  configuration, ignored build inputs, sibling path dependencies, and the Rust
+  toolchain need explicit coverage. Its ordinary `fs::copy` restoration also
+  needs the Cargo metadata and freshness validation described above.
+
+The PR has no remote task-cache tier. Its pnpr integration publishes run records,
+not task outputs. The workspace-task artifact protocol in this checkout is a
+candidate for a later remote tier; it is not wired into the PoC cache. Reuse the
+task-cache lifecycle from the PoC rather than adding an unrelated Cargo command,
+while keeping Rust state compatibility and disposal independently testable.
+
+## Prototype on the pipeline branch
+
+`feat/pipeline-cargo-cache` starts from PR 14233 at
+`02289dd385955818727b350795d606c46233a19d`. See
+[pipeline-cargo-cache.md](pipeline-cargo-cache.md) for the opt-in task setting
+and supported input contract.
+
+The prototype stores immutable directory snapshots in a dedicated disposable
+cache shared by linked Git worktrees. It restores only an absent target, always
+runs the task, and retains independent writable files. It does not implement
+CAS deduplication or remote transfers. The integration test runs a real Cargo
+build in two worktrees, edits source without advancing its timestamp, and
+verifies both binaries before and after deleting the cache.
+
+A build-script relocation test exposed another correctness failure beyond the
+original shared-target experiment: an independent snapshot could retain the
+publishing worktree's path in a generated build-script value after Cargo ran.
+The prototype invalidates local-package and build-script freshness records on
+restoration. Source input changes invalidate all freshness records while
+retaining incremental files. The relocation regression now verifies that each
+binary contains its own worktree path.
+
+The original benchmark's startup measurements do not include this invalidation,
+repository input hashing, snapshot integrity checks, or publication. They must
+not be used as measured speedups for the pipeline implementation.

--- a/pnpm/scripts/bench-rust-cache.mjs
+++ b/pnpm/scripts/bench-rust-cache.mjs
@@ -56,8 +56,9 @@ try {
     registered.push(worktree)
   }
   const sources = worktrees.map(worktree => {
-    const source = path.resolve(worktree, values.source)
-    if (!source.startsWith(`${worktree}${path.sep}`)) throw new Error('--source must be inside the worktree')
+    const worktreeRoot = fs.realpathSync(worktree)
+    const source = fs.realpathSync(path.resolve(worktreeRoot, values.source))
+    if (!source.startsWith(`${worktreeRoot}${path.sep}`)) throw new Error('--source must be inside the worktree')
     return source
   })
   const original = fs.readFileSync(sources[1], 'utf8')

--- a/pnpm/scripts/bench-rust-cache.mjs
+++ b/pnpm/scripts/bench-rust-cache.mjs
@@ -1,0 +1,202 @@
+import { spawnSync } from 'node:child_process'
+import console from 'node:console'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import net from 'node:net'
+import path from 'node:path'
+import { performance } from 'node:perf_hooks'
+import process from 'node:process'
+import { parseArgs } from 'node:util'
+
+const { values } = parseArgs({
+  options: {
+    package: { type: 'string', default: 'pnpm-graph-hasher' },
+    source: { type: 'string', default: 'pnpm/crates/graph-hasher/src/lib.rs' },
+    rounds: { type: 'string', default: '3' },
+    output: { type: 'string' },
+    help: { type: 'boolean' },
+  },
+})
+if (values.help) {
+  console.log('node pnpm/scripts/bench-rust-cache.mjs [--package NAME --source PATH] [--rounds 3] [--output NEW_DIRECTORY]')
+  process.exit(0)
+}
+const rounds = Number(values.rounds)
+if (!Number.isSafeInteger(rounds) || rounds < 1) throw new Error('--rounds must be a positive integer')
+const repo = run('git', ['rev-parse', '--show-toplevel']).trim()
+const revision = run('git', ['rev-parse', 'HEAD'], { cwd: repo }).trim()
+const output = path.resolve(values.output ?? path.join(repo, 'bench-work-env', `rust-cache-${Date.now()}`))
+fs.mkdirSync(path.dirname(output), { recursive: true })
+fs.mkdirSync(output)
+const worktrees = ['a', 'b'].map(name => path.join(output, name))
+const modes = ['incremental', 'sccache', 'shared-target', 'reflink-snapshot']
+const results = []
+const metadata = {
+  revision,
+  package: values.package,
+  source: values.source,
+  rounds,
+  rustc: run('rustc', ['-Vv']).trim(),
+  cargo: run('cargo', ['--version']).trim(),
+  sccache: run('sccache', ['--version']).trim(),
+  platform: process.platform,
+  arch: process.arch,
+}
+const env = Object.fromEntries(Object.entries(process.env).filter(([name]) =>
+  !name.startsWith('SCCACHE_') && !name.startsWith('CARGO_PROFILE_') &&
+  !['RUSTC_WRAPPER', 'RUSTC_WORKSPACE_WRAPPER', 'CARGO_TARGET_DIR', 'CARGO_BUILD_TARGET_DIR',
+    'CARGO_BUILD_BUILD_DIR', 'CARGO_BUILD_INCREMENTAL', 'CARGO_INCREMENTAL',
+    'CARGO_ENCODED_RUSTFLAGS', 'RUSTFLAGS', 'CARGO_MAKEFLAGS'].includes(name)))
+Object.assign(env, { RUSTC_WRAPPER: '', RUSTC_WORKSPACE_WRAPPER: '', RUSTFLAGS: '' })
+fs.writeFileSync(path.join(output, 'sccache.toml'), '')
+const registered = []
+try {
+  for (const worktree of worktrees) {
+    run('git', ['worktree', 'add', '--detach', worktree, revision], { cwd: repo })
+    registered.push(worktree)
+  }
+  const sources = worktrees.map(worktree => {
+    const source = path.resolve(worktree, values.source)
+    if (!source.startsWith(`${worktree}${path.sep}`)) throw new Error('--source must be inside the worktree')
+    return source
+  })
+  const original = fs.readFileSync(sources[1], 'utf8')
+  const sourceAtRevision = revision => `${original}\npub fn pnpm_cache_bench_revision() -> u8 { ${revision} }\n`
+  for (let round = 0; round < rounds; round++) {
+    // Rotate the first mode to reduce systematic filesystem-cache ordering bias.
+    const ordered = modes.slice(round % modes.length).concat(modes.slice(0, round % modes.length))
+    for (const mode of ordered) {
+      const directory = path.join(output, `round-${round + 1}`, mode)
+      fs.mkdirSync(directory, { recursive: true })
+      for (const source of sources) fs.writeFileSync(source, sourceAtRevision(0))
+      const targets = mode === 'shared-target'
+        ? [path.join(directory, 'target'), path.join(directory, 'target')]
+        : ['target-a', 'target-b'].map(name => path.join(directory, name))
+      const buildEnv = { ...env, CARGO_INCREMENTAL: mode === 'sccache' ? '0' : '1' }
+      if (mode === 'sccache') {
+        Object.assign(buildEnv, {
+          RUSTC_WRAPPER: 'sccache',
+          SCCACHE_DIR: path.join(directory, 'sccache'),
+          SCCACHE_CONF: path.join(output, 'sccache.toml'),
+          SCCACHE_CACHED_CONF: path.join(directory, 'cached-config'),
+          SCCACHE_SERVER_PORT: String(await unusedPort()),
+          SCCACHE_CACHE_SIZE: '10G',
+          SCCACHE_IDLE_TIMEOUT: '0',
+        })
+        run('sccache', ['--start-server'], { env: buildEnv })
+      }
+      const result = { round: round + 1, mode, builds: [] }
+      try {
+        build(0, 'first-a')
+        build(0, 'warm-a')
+        if (mode === 'reflink-snapshot') {
+          const start = performance.now()
+          run('cp', ['--archive', '--reflink=always', targets[0], targets[1]])
+          result.snapshotSeconds = (performance.now() - start) / 1000
+        }
+        build(1, 'first-b')
+        result.storage = await measureContent([...new Set(targets)])
+        fs.writeFileSync(sources[1], sourceAtRevision(1))
+        build(1, 'edit-b')
+        build(0, 'return-a')
+        build(1, 'warm-b')
+        if (mode === 'sccache') {
+          result.sccache = JSON.parse(run('sccache', ['--show-stats', '--stats-format', 'json'], { env: buildEnv }))
+          result.sccacheStorage = await measureContent([path.join(directory, 'sccache')])
+        }
+        results.push(result)
+        fs.writeFileSync(path.join(output, 'results.json'), `${JSON.stringify({ metadata, results }, null, 2)}\n`)
+      } finally {
+        for (const worktree of worktrees) run('git', ['restore', '--', values.source], { cwd: worktree })
+        if (mode === 'sccache') run('sccache', ['--stop-server'], { env: buildEnv })
+      }
+
+      function build(index, phase) {
+        const start = performance.now()
+        const stdout = run('cargo', ['build', '--locked', '--offline', '-p', values.package, '--message-format=json'], {
+          cwd: worktrees[index],
+          env: { ...buildEnv, CARGO_TARGET_DIR: targets[index], CARGO_BUILD_BUILD_DIR: targets[index] },
+          stderrFile: path.join(directory, `${phase}.log`),
+        })
+        const seconds = (performance.now() - start) / 1000
+        const artifacts = stdout.split('\n').filter(Boolean).map(line => JSON.parse(line))
+          .filter(message => message.reason === 'compiler-artifact')
+        const compiled = artifacts.filter(artifact => !artifact.fresh).map(artifact => artifact.package_id)
+        const library = artifacts.find(artifact => artifact.target.name === values.package.replaceAll('-', '_') &&
+          artifact.filenames.some(file => file.endsWith('.rlib')))
+        if (!library) throw new Error('--package must name a library with an rlib output')
+        const libraryPath = library.filenames.find(file => file.endsWith('.rlib'))
+        const probeSource = path.join(directory, 'probe.rs')
+        const probeBinary = path.join(directory, 'probe')
+        fs.writeFileSync(probeSource, 'fn main() { println!("{}", cache_probe::pnpm_cache_bench_revision()); }\n')
+        run('rustc', [probeSource, '--edition=2024', '--extern', `cache_probe=${libraryPath}`,
+          '-L', `dependency=${path.join(path.dirname(libraryPath), 'deps')}`, '-o', probeBinary], { cwd: repo, env })
+        const actualRevision = Number(run(probeBinary, []).trim())
+        const expectedRevision = index === 1 && ['edit-b', 'warm-b'].includes(phase) ? 1 : 0
+        const correct = actualRevision === expectedRevision
+        const item = { phase, seconds, fresh: artifacts.length - compiled.length, compiled, expectedRevision, actualRevision, correct }
+        result.builds.push(item)
+        console.log(`round ${round + 1} ${mode} ${phase}: ${seconds.toFixed(3)}s, ${compiled.length} compiled, ${item.fresh} fresh, ${correct ? 'correct' : `WRONG OUTPUT: expected ${expectedRevision}, got ${actualRevision}`}`)
+      }
+    }
+  }
+} finally {
+  for (const worktree of registered) run('git', ['worktree', 'remove', '--force', worktree], { cwd: repo })
+}
+console.log(`Results and build logs: ${output}`)
+
+function run(command, args, options = {}) {
+  const { stderrFile, ...spawnOptions } = options
+  const result = spawnSync(command, args, { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, ...spawnOptions })
+  if (stderrFile) fs.writeFileSync(stderrFile, result.stderr ?? '')
+  if (result.error) throw result.error
+  if (result.status !== 0) throw new Error(`${command} ${args.join(' ')} failed (${result.status}):\n${result.stderr}`)
+  return result.stdout
+}
+
+async function unusedPort() {
+  const server = net.createServer()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const port = server.address().port
+  await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+  return port
+}
+
+async function measureContent(roots) {
+  let logicalBytes = 0
+  let uniqueBytes = 0
+  let files = 0
+  const hashes = new Set()
+  const inodes = new Set()
+  let allocatedBytes = 0
+  let inodeBytes = 0
+  for (const root of roots) await walk(root)
+  return { files, logicalBytes, inodeBytes, uniqueBytes, duplicateBytes: inodeBytes - uniqueBytes, allocatedBytes }
+
+  async function walk(directory) {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const file = path.join(directory, entry.name)
+      if (entry.isDirectory()) {
+        await walk(file)
+      } else if (entry.isFile()) {
+        const stat = fs.statSync(file)
+        const inode = `${stat.dev}:${stat.ino}`
+        if (!inodes.has(inode)) {
+          allocatedBytes += stat.blocks * 512
+          inodeBytes += stat.size
+        }
+        inodes.add(inode)
+        const hash = createHash('sha512')
+        for await (const chunk of fs.createReadStream(file)) hash.update(chunk)
+        const key = `${hash.digest('hex')}:${Boolean(stat.mode & 0o111)}`
+        if (!hashes.has(key)) uniqueBytes += stat.size
+        hashes.add(key)
+        logicalBytes += stat.size
+        files++
+      }
+    }
+  }
+}

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -79,3 +79,32 @@ This is an opt-in, local prototype with a bounded input contract:
 The earlier reflink benchmark did not include these validation and publication
 costs or relocation invalidation. Its startup timings are not performance claims
 for this implementation.
+
+## Pipeline execution and reporting
+
+Completed-task log capture is limited to 1 MiB per task. Tasks with larger logs
+still stream their output, but their completed result is not cached. Cargo tasks
+and tasks with caching disabled do not capture logs in memory.
+
+The watch agent retries unsuccessful child runs. It only acknowledges a revision
+after the child exits successfully. Before switching revisions it discards tracked
+changes and unignored untracked files in its managed checkout. Ignored build
+artifacts remain available. The watch agent is for trusted repositories. Its managed checkout, revision
+record, and exclusive lock live under `stateDir`, outside the disposable cache.
+Run it with the permissions appropriate for the repository it builds. A child process does not isolate repository scripts from the
+agent's credentials or filesystem permissions.
+
+pnpr requires explicit read and publication policies for each report workspace:
+
+```yaml
+pipeline:
+  enabled: true
+  workspaces:
+    demo-abc123:
+      access: [alice, ci-writer]
+      publish: [ci-writer]
+```
+
+Use the workspace identifier carried by the client's run upload. Unconfigured
+workspaces are inaccessible. The viewer lists only readable workspaces and keeps
+its bearer token in the page's memory, without persisting it in browser storage.

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -1,0 +1,81 @@
+# Cargo build state in a pipeline
+
+The experimental pipeline command can share local Cargo build state between
+Git worktrees of the same repository. Enable it for a task in
+`pnpm-workspace.yaml`:
+
+```yaml
+includeWorkspaceRoot: true
+pipelines:
+  default: [build]
+tasks:
+  build:
+    dependsOn: []
+    cargoTargetDir: target
+    env: [MY_BUILD_SETTING]
+```
+
+The corresponding project's `package.json` can contain:
+
+```json
+{
+  "scripts": {
+    "build": "cargo build --locked --offline"
+  }
+}
+```
+
+Add `target/` to `.gitignore`, commit the Cargo lockfile, and run
+`pnpm pipeline --full`. The normal pipeline frozen-install requirement still
+applies. `includeWorkspaceRoot` is needed when the script is at the workspace
+root; workspace packages do not need it.
+
+`cargoTargetDir` is relative to the project that runs the script. pnpm sets both
+`CARGO_TARGET_DIR` and `CARGO_BUILD_BUILD_DIR` to that directory. Do not override
+these variables or pass a different target directory in the script. Give each
+Cargo workspace its own target directory. Do not run external Cargo commands
+against that directory while the pipeline is executing or publishing a snapshot.
+Pipeline invocations using the same target coordinate through a process lock.
+
+Every Cargo task executes, even when a snapshot was restored. Declaring
+`cargoTargetDir` disables completed-output cache hits for that task, including
+when `outputs` is also declared. `--no-cache` and `cache: false` disable snapshot
+reads and writes while retaining the selected local target directory.
+
+A snapshot is restored only into an absent target directory and only for
+matching inputs. Existing target directories retain their local incremental
+state. Changes to input contents invalidate Cargo freshness records even when
+file modification times have not changed. When a snapshot moves between
+worktrees, local-package and build-script freshness records are invalidated to
+avoid retaining the publishing worktree's paths.
+
+Snapshots live under `<cacheDir>/cargo-build/v1`, separately from installed
+packages and the global virtual store. They are scoped to the Git common
+directory, so linked worktrees share them but independent clones do not.
+Restoration uses reflinks where available and copies otherwise. Neither creates
+a live dependency on cached files. Deleting this cache leaves installed packages,
+restored targets, and their binaries usable. A missing or corrupt snapshot is a
+miss; partial restores stay in a temporary directory and are discarded.
+
+This is an opt-in, local prototype with a bounded input contract:
+
+- Source inputs must be tracked or untracked, unignored files inside the Git
+  repository. The snapshot hashes the whole repository input set, including
+  sibling path dependencies, regardless of a task's narrower `inputs` globs.
+  Symlink/submodule inputs and local Cargo packages outside the repository
+  decline caching. Gitignored generated inputs are not covered.
+- Rust/Cargo versions, Cargo configuration in parent directories and Cargo home,
+  declared task environment, and common Rust/native build environment variables
+  participate in the key. Declare additional build-script variables in `env`.
+  Native SDKs, external files, databases, and tools modified in place are not
+  fully fingerprinted. Disable caching for tasks whose inputs are outside this
+  contract.
+- Cargo metadata must resolve with `--locked --offline`. If dependencies are
+  unavailable or metadata fails, the task still runs without snapshot reuse.
+- Snapshots containing symlinks or special files are not published. Remote
+  publication, automatic eviction, reuse from a different source revision, and
+  physical content deduplication across snapshots are not implemented.
+
+The earlier reflink benchmark did not include these validation and publication
+costs or relocation invalidation. Its startup timings are not performance claims
+for this implementation.

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -30,6 +30,10 @@ Add `target/` to `.gitignore`, commit the Cargo lockfile, and run
 applies. `includeWorkspaceRoot` is needed when the script is at the workspace
 root; workspace packages do not need it.
 
+`pnpm pipeline --dry-run` prints the task graph without installing dependencies
+or loading workspace hooks. It uses the declarative configuration, so changes
+made by `updateConfig` hooks are not reflected in the preview.
+
 `cargoTargetDir` is relative to the project that runs the script. pnpm sets both
 `CARGO_TARGET_DIR` and `CARGO_BUILD_BUILD_DIR` to that directory. Do not override
 these variables or pass a different target directory in the script. Give each

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -268,11 +268,11 @@ pub struct ArtifactsFeature {
     /// Master switch for artifact and compiler-cache endpoints.
     pub enabled: bool,
     /// Named compiler caches with independent read and publication policies.
-    pub compiler_caches: IndexMap<String, CompilerCacheAccess>,
+    pub compiler_caches: IndexMap<String, StorageAccess>,
 }
 
 #[derive(Debug, Clone)]
-pub struct CompilerCacheAccess {
+pub struct StorageAccess {
     pub access: AccessList,
     pub publish: AccessList,
 }
@@ -283,6 +283,7 @@ pub struct CompilerCacheAccess {
 pub struct PipelineFeature {
     /// Master switch for the run submission, listing, and viewer endpoints.
     pub enabled: bool,
+    pub workspaces: IndexMap<String, StorageAccess>,
 }
 
 /// CLI-level overrides for the feature toggles, applied *during* config
@@ -1224,12 +1225,12 @@ struct ArtifactsFeatureFile {
     #[serde(default)]
     enabled: bool,
     #[serde(default, rename = "compilerCaches")]
-    compiler_caches: IndexMap<String, CompilerCacheAccessFile>,
+    compiler_caches: IndexMap<String, StorageAccessFile>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct CompilerCacheAccessFile {
+struct StorageAccessFile {
     access: AccessSpec,
     publish: AccessSpec,
 }
@@ -1239,6 +1240,8 @@ struct CompilerCacheAccessFile {
 struct PipelineFeatureFile {
     #[serde(default)]
     enabled: bool,
+    #[serde(default)]
+    workspaces: IndexMap<String, StorageAccessFile>,
 }
 
 fn default_true() -> bool {
@@ -1663,27 +1666,15 @@ impl Config {
         let resolver =
             ResolverFeature { enabled: resolver_file.enabled && !overrides.disable_resolver };
         let artifacts_file = file.artifacts.unwrap_or_default();
-        let mut compiler_caches = IndexMap::new();
-        for (name, policy) in artifacts_file.compiler_caches {
-            validate_registry_name(&name)?;
-            let parse_access = |spec: &AccessSpec| {
-                spec.to_access_list(&Teams::default()).map_err(|reason| {
-                    RegistryError::InvalidConfig {
-                        reason: format!("compiler cache {name:?}: {reason}"),
-                    }
-                })
-            };
-            let access = CompilerCacheAccess {
-                access: parse_access(&policy.access)?,
-                publish: parse_access(&policy.publish)?,
-            };
-            compiler_caches.insert(name, access);
-        }
         let artifacts = ArtifactsFeature {
             enabled: artifacts_file.enabled && !overrides.disable_artifacts,
-            compiler_caches,
+            compiler_caches: parse_storage_access(artifacts_file.compiler_caches)?,
         };
-        let pipeline = PipelineFeature { enabled: file.pipeline.unwrap_or_default().enabled };
+        let pipeline_file = file.pipeline.unwrap_or_default();
+        let pipeline = PipelineFeature {
+            enabled: pipeline_file.enabled,
+            workspaces: parse_storage_access(pipeline_file.workspaces)?,
+        };
         // Upstream registries (and the credentials some carry) are resolved by
         // `build_registries` below into this map. Resolving an upstream registry's
         // `auth` is strict — an unresolvable token is a config error — so a
@@ -2420,3 +2411,24 @@ pub fn default_cache_dir(storage: &Path) -> PathBuf {
 
 #[cfg(test)]
 mod tests;
+
+fn parse_storage_access(
+    policies: IndexMap<String, StorageAccessFile>,
+) -> Result<IndexMap<String, StorageAccess>, RegistryError> {
+    policies
+        .into_iter()
+        .map(|(name, policy)| {
+            validate_registry_name(&name)?;
+            let parse = |spec: &AccessSpec| {
+                spec.to_access_list(&Teams::default()).map_err(|reason| {
+                    RegistryError::InvalidConfig {
+                        reason: format!("storage namespace {name:?}: {reason}"),
+                    }
+                })
+            };
+            let access =
+                StorageAccess { access: parse(&policy.access)?, publish: parse(&policy.publish)? };
+            Ok((name, access))
+        })
+        .collect()
+}

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -130,6 +130,8 @@ pub struct Config {
     /// resolver so deployments can scale the compute-bound resolver and the
     /// I/O-bound artifact store independently. See [`ArtifactsFeature`].
     pub artifacts: ArtifactsFeature,
+    /// The pipeline run-record surface. See [`PipelineFeature`].
+    pub pipeline: PipelineFeature,
     /// Which fetch routes the resolution cache treats as public (fetched
     /// anonymously and shared globally) vs. private, driving the
     /// resolver's route classification.
@@ -273,6 +275,14 @@ pub struct ArtifactsFeature {
 pub struct CompilerCacheAccess {
     pub access: AccessList,
     pub publish: AccessList,
+}
+
+/// Toggle for the pipeline run-record surface (`/-/pnpr/v0/pipeline*`).
+/// Off by default while the surface is a proof of concept.
+#[derive(Debug, Default, Clone)]
+pub struct PipelineFeature {
+    /// Master switch for the run submission, listing, and viewer endpoints.
+    pub enabled: bool,
 }
 
 /// CLI-level overrides for the feature toggles, applied *during* config
@@ -1038,6 +1048,10 @@ struct ConfigFile {
     /// the resolver because deployments may mount either surface alone.
     #[serde(default)]
     artifacts: Option<ArtifactsFeatureFile>,
+    /// pnpr-only feature toggle for the pipeline run-record surface, a peer
+    /// of the artifact store.
+    #[serde(default)]
+    pipeline: Option<PipelineFeatureFile>,
     /// pnpr registries: hosted, upstream, and router origins, each
     /// exposed at `/~<name>/`. The only routing surface — there is no legacy
     /// `upstreams:`/`packages: proxy:` fallback.
@@ -1220,6 +1234,13 @@ struct CompilerCacheAccessFile {
     publish: AccessSpec,
 }
 
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PipelineFeatureFile {
+    #[serde(default)]
+    enabled: bool,
+}
+
 fn default_true() -> bool {
     true
 }
@@ -1349,6 +1370,7 @@ impl Config {
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
             artifacts: ArtifactsFeature::default(),
+            pipeline: PipelineFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
             registries,
@@ -1399,6 +1421,7 @@ impl Config {
             registry: RegistryFeature::default(),
             resolver: ResolverFeature::default(),
             artifacts: ArtifactsFeature::default(),
+            pipeline: PipelineFeature::default(),
             route_policy: RoutePolicy::default(),
             resolution_cache_secret: random_secret(),
             registries,
@@ -1660,6 +1683,7 @@ impl Config {
             enabled: artifacts_file.enabled && !overrides.disable_artifacts,
             compiler_caches,
         };
+        let pipeline = PipelineFeature { enabled: file.pipeline.unwrap_or_default().enabled };
         // Upstream registries (and the credentials some carry) are resolved by
         // `build_registries` below into this map. Resolving an upstream registry's
         // `auth` is strict — an unresolvable token is a config error — so a
@@ -1693,6 +1717,7 @@ impl Config {
             registry,
             resolver,
             artifacts,
+            pipeline,
             route_policy,
             resolution_cache_secret,
             registries,
@@ -1708,13 +1733,17 @@ impl Config {
     /// endpoints. Checked at config load and again in the serve/router
     /// entry points for programmatically built configs.
     pub fn ensure_a_feature_is_enabled(&self) -> Result<(), RegistryError> {
-        if self.registry.enabled || self.resolver.enabled || self.artifacts.enabled {
+        if self.registry.enabled
+            || self.resolver.enabled
+            || self.artifacts.enabled
+            || self.pipeline.enabled
+        {
             Ok(())
         } else {
             Err(RegistryError::InvalidConfig {
                 reason: "nothing to serve: the npm-registry surface is off (no `registries:` \
                          declared, or `--disable-registry`), the resolver is disabled, and \
-                         artifacts are disabled"
+                         artifacts and the pipeline surface are disabled"
                     .to_string(),
             })
         }

--- a/pnpr/crates/pipeline-runs/Cargo.toml
+++ b/pnpr/crates/pipeline-runs/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name                 = "pnpr-pipeline-runs"
+version              = "0.0.1"
+description          = "The pipeline run-record store: append-only CI run summaries and event streams, by workspace"
+publish              = false
+authors.workspace    = true
+edition.workspace    = true
+homepage.workspace   = true
+keywords.workspace   = true
+license-file         = "../../LICENSE.md"
+repository.workspace = true
+
+[dependencies]
+pnpr-error   = { workspace = true }
+pnpr-storage = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+tokio        = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -33,7 +33,8 @@ const RUNS_DIR: &str = "pipeline-runs/v0";
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct PublishPipelineRun {
     /// The workspace the run belongs to. An identifier the client
-    /// chooses, not a path: see [`validate_name`].
+    /// chooses, not a path: the closed alphabet is enforced before any
+    /// path join.
     pub workspace: String,
     pub run_id: String,
     pub summary: Value,

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -1,0 +1,183 @@
+//! The pipeline run-record store: append-only CI run summaries and event
+//! streams, namespaced by workspace. Tier 1 of the pnpm CI-server design —
+//! the server remembers what `pnpm pipeline` runs reported, and nothing
+//! more: it schedules nothing and executes nothing.
+//!
+//! Records are testimony about something that happened once, not
+//! regenerable derived data, so they live under the authoritative
+//! `storage` root rather than the disposable cache root. This
+//! proof-of-concept tier is filesystem-only; an S3-hosted deployment
+//! keeps its run records on the replica's local storage path.
+
+use pnpr_error::{RegistryError, Result};
+use pnpr_storage::write_atomic;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+
+/// Bounds a submission the same way the artifact endpoints bound theirs:
+/// a malformed or hostile client must not be able to grow a record
+/// without limit. The HTTP body limit is the outer bound; these are the
+/// structural ones.
+pub const MAX_NAME_LEN: usize = 100;
+pub const MAX_RUN_EVENTS: usize = 10_000;
+pub const MAX_LIST_RUNS: usize = 200;
+
+const RUNS_DIR: &str = "pipeline-runs/v0";
+
+/// One submitted run: the machine-readable account `pnpm pipeline`
+/// produced, verbatim. The server stores the summary and events as
+/// opaque JSON — their shape belongs to the client, so a client update
+/// does not require a server release.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PublishPipelineRun {
+    /// The workspace the run belongs to. An identifier the client
+    /// chooses, not a path: see [`validate_name`].
+    pub workspace: String,
+    pub run_id: String,
+    pub summary: Value,
+    #[serde(default)]
+    pub events: Vec<Value>,
+}
+
+/// One row of a run listing: the summary without its event stream.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PipelineRunEntry {
+    pub workspace: String,
+    pub run_id: String,
+    pub summary: Value,
+}
+
+pub struct PipelineRunStore {
+    root: PathBuf,
+}
+
+impl PipelineRunStore {
+    pub fn new(storage_root: &Path) -> Result<Self> {
+        let root = storage_root.join(RUNS_DIR);
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    /// Record one run. Append-only: a run id that already exists for the
+    /// workspace is refused rather than overwritten — a results store
+    /// whose history can be rewritten protects nothing.
+    pub async fn publish(&self, run: &PublishPipelineRun) -> Result<()> {
+        validate_name(&run.workspace, "workspace")?;
+        validate_name(&run.run_id, "runId")?;
+        if run.events.len() > MAX_RUN_EVENTS {
+            return Err(RegistryError::BadRequest {
+                reason: format!(
+                    "a run carries at most {MAX_RUN_EVENTS} events, got {}",
+                    run.events.len(),
+                ),
+            });
+        }
+        let path = self.run_path(&run.workspace, &run.run_id);
+        if path.exists() {
+            return Err(RegistryError::BadRequest {
+                reason: format!(
+                    "run {} is already recorded for workspace {} (runs are append-only)",
+                    run.run_id, run.workspace,
+                ),
+            });
+        }
+        std::fs::create_dir_all(path.parent().expect("run path has a workspace parent"))?;
+        let document = serde_json::to_vec(&run)?;
+        write_atomic(&path, &document).await
+    }
+
+    /// The most recent runs, newest first — run ids sort by their leading
+    /// timestamp. `workspace` narrows the listing to one workspace.
+    pub fn list(&self, workspace: Option<&str>, limit: usize) -> Result<Vec<PipelineRunEntry>> {
+        let limit = limit.clamp(1, MAX_LIST_RUNS);
+        let workspaces: Vec<String> = if let Some(workspace) = workspace {
+            validate_name(workspace, "workspace")?;
+            vec![workspace.to_string()]
+        } else {
+            let mut workspaces = Vec::new();
+            for entry in read_dir_or_empty(&self.root)? {
+                let entry = entry?;
+                if entry.file_type()?.is_dir()
+                    && let Some(name) = entry.file_name().to_str()
+                {
+                    workspaces.push(name.to_string());
+                }
+            }
+            workspaces
+        };
+        let mut entries: Vec<PipelineRunEntry> = Vec::new();
+        for workspace in workspaces {
+            for entry in read_dir_or_empty(&self.root.join(&workspace))? {
+                let entry = entry?;
+                let file_name = entry.file_name();
+                let Some(run_id) = file_name.to_str().and_then(|name| name.strip_suffix(".json"))
+                else {
+                    continue;
+                };
+                let Some(record) = read_run(&entry.path())? else { continue };
+                entries.push(PipelineRunEntry {
+                    workspace: workspace.clone(),
+                    run_id: run_id.to_string(),
+                    summary: record.summary,
+                });
+            }
+        }
+        entries.sort_by(|left, right| right.run_id.cmp(&left.run_id));
+        entries.truncate(limit);
+        Ok(entries)
+    }
+
+    /// One run's full record — summary and event stream — or `None` when
+    /// nothing was recorded under that identity.
+    pub fn get(&self, workspace: &str, run_id: &str) -> Result<Option<PublishPipelineRun>> {
+        validate_name(workspace, "workspace")?;
+        validate_name(run_id, "runId")?;
+        read_run(&self.run_path(workspace, run_id))
+    }
+
+    fn run_path(&self, workspace: &str, run_id: &str) -> PathBuf {
+        self.root.join(workspace).join(format!("{run_id}.json"))
+    }
+}
+
+fn read_run(path: &Path) -> Result<Option<PublishPipelineRun>> {
+    let text = match std::fs::read(path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    Ok(Some(serde_json::from_slice(&text)?))
+}
+
+fn read_dir_or_empty(path: &Path) -> Result<Vec<std::io::Result<std::fs::DirEntry>>> {
+    match std::fs::read_dir(path) {
+        Ok(entries) => Ok(entries.collect()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+/// The identifiers key filesystem paths, so their alphabet is closed:
+/// ASCII alphanumerics plus `.`, `_`, `-`, never starting with a dot.
+/// Anything else — separators, traversal, control characters, an empty
+/// string — is refused before it reaches a path join.
+fn validate_name(name: &str, field: &str) -> Result<()> {
+    let valid = !name.is_empty()
+        && name.len() <= MAX_NAME_LEN
+        && !name.starts_with('.')
+        && name.chars().all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'));
+    if valid {
+        return Ok(());
+    }
+    Err(RegistryError::BadRequest {
+        reason: format!(
+            "{field} must be 1-{MAX_NAME_LEN} ASCII alphanumeric/._- characters not starting with a dot",
+        ),
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -10,10 +10,13 @@
 //! keeps its run records on the replica's local storage path.
 
 use pnpr_error::{RegistryError, Result};
-use pnpr_storage::write_atomic;
+use pnpr_storage::write_atomic_new;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::path::{Path, PathBuf};
+use std::{
+    collections::BTreeSet,
+    path::{Path, PathBuf},
+};
 
 /// Bounds a submission the same way the artifact endpoints bound theirs:
 /// a malformed or hostile client must not be able to grow a record
@@ -77,17 +80,19 @@ impl PipelineRunStore {
             });
         }
         let path = self.run_path(&run.workspace, &run.run_id);
-        if path.exists() {
-            return Err(RegistryError::BadRequest {
-                reason: format!(
-                    "run {} is already recorded for workspace {} (runs are append-only)",
-                    run.run_id, run.workspace,
-                ),
-            });
-        }
         std::fs::create_dir_all(path.parent().expect("run path has a workspace parent"))?;
         let document = serde_json::to_vec(&run)?;
-        write_atomic(&path, &document).await
+        match write_atomic_new(&path, &document).await {
+            Err(RegistryError::Io(error)) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                Err(RegistryError::BadRequest {
+                    reason: format!(
+                        "run {} is already recorded for workspace {} (runs are append-only)",
+                        run.run_id, run.workspace,
+                    ),
+                })
+            }
+            result => result,
+        }
     }
 
     /// The most recent runs, newest first — run ids sort by their leading
@@ -109,7 +114,7 @@ impl PipelineRunStore {
             }
             workspaces
         };
-        let mut entries: Vec<PipelineRunEntry> = Vec::new();
+        let mut newest = BTreeSet::new();
         for workspace in workspaces {
             for entry in read_dir_or_empty(&self.root.join(&workspace))? {
                 let entry = entry?;
@@ -118,16 +123,20 @@ impl PipelineRunStore {
                 else {
                     continue;
                 };
-                let Some(record) = read_run(&entry.path())? else { continue };
-                entries.push(PipelineRunEntry {
-                    workspace: workspace.clone(),
-                    run_id: run_id.to_string(),
-                    summary: record.summary,
-                });
+                if entry.file_type()?.is_file() {
+                    newest.insert((run_id.to_string(), workspace.clone()));
+                    if newest.len() > limit {
+                        newest.pop_first();
+                    }
+                }
             }
         }
-        entries.sort_by(|left, right| right.run_id.cmp(&left.run_id));
-        entries.truncate(limit);
+        let mut entries = Vec::with_capacity(newest.len());
+        for (run_id, workspace) in newest.into_iter().rev() {
+            if let Some(record) = self.get(&workspace, &run_id)? {
+                entries.push(PipelineRunEntry { workspace, run_id, summary: record.summary });
+            }
+        }
         Ok(entries)
     }
 
@@ -153,12 +162,15 @@ fn read_run(path: &Path) -> Result<Option<PublishPipelineRun>> {
     Ok(Some(serde_json::from_slice(&text)?))
 }
 
-fn read_dir_or_empty(path: &Path) -> Result<Vec<std::io::Result<std::fs::DirEntry>>> {
-    match std::fs::read_dir(path) {
-        Ok(entries) => Ok(entries.collect()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
-        Err(error) => Err(error.into()),
-    }
+fn read_dir_or_empty(
+    path: &Path,
+) -> Result<impl Iterator<Item = std::io::Result<std::fs::DirEntry>>> {
+    let entries = match std::fs::read_dir(path) {
+        Ok(entries) => Some(entries),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error.into()),
+    };
+    Ok(entries.into_iter().flatten())
 }
 
 /// The identifiers key filesystem paths, so their alphabet is closed:

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -70,7 +70,7 @@ async fn path_shaped_identifiers_are_refused() {
         let rendered = error.to_string();
         assert!(
             rendered.contains("ASCII"),
-            "unexpected error for {workspace}/{run_id}: {rendered}"
+            "unexpected error for {workspace}/{run_id}: {rendered}",
         );
         assert!(store.get(workspace, run_id).is_err(), "get must refuse {workspace}/{run_id}");
     }

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -1,0 +1,77 @@
+use super::{PipelineRunStore, PublishPipelineRun};
+use serde_json::json;
+use tempfile::TempDir;
+
+fn run(workspace: &str, run_id: &str) -> PublishPipelineRun {
+    PublishPipelineRun {
+        workspace: workspace.to_string(),
+        run_id: run_id.to_string(),
+        summary: json!({ "pipeline": "default", "runId": run_id }),
+        events: vec![json!({ "event": "taskStarted", "task": "packages/a#build" })],
+    }
+}
+
+#[tokio::test]
+async fn publish_then_get_roundtrips_the_record() {
+    let root = TempDir::new().expect("create storage root");
+    let store = PipelineRunStore::new(root.path()).expect("open store");
+    store.publish(&run("demo-1234", "100-default")).await.expect("publish");
+
+    let stored = store.get("demo-1234", "100-default").expect("get").expect("run exists");
+    assert_eq!(stored.summary["pipeline"], "default");
+    assert_eq!(stored.events.len(), 1);
+    assert!(store.get("demo-1234", "999-missing").expect("get").is_none());
+}
+
+#[tokio::test]
+async fn list_returns_newest_first_and_honors_the_workspace_filter() {
+    let root = TempDir::new().expect("create storage root");
+    let store = PipelineRunStore::new(root.path()).expect("open store");
+    store.publish(&run("ws-a", "100-default")).await.expect("publish");
+    store.publish(&run("ws-a", "200-default")).await.expect("publish");
+    store.publish(&run("ws-b", "150-default")).await.expect("publish");
+
+    let all = store.list(None, 10).expect("list");
+    let ids: Vec<&str> = all.iter().map(|entry| entry.run_id.as_str()).collect();
+    assert_eq!(ids, ["200-default", "150-default", "100-default"]);
+
+    let only_a = store.list(Some("ws-a"), 10).expect("list");
+    assert_eq!(only_a.len(), 2);
+    assert!(only_a.iter().all(|entry| entry.workspace == "ws-a"));
+
+    let limited = store.list(None, 1).expect("list");
+    assert_eq!(limited.len(), 1);
+    assert_eq!(limited[0].run_id, "200-default");
+}
+
+#[tokio::test]
+async fn a_run_id_is_append_only() {
+    let root = TempDir::new().expect("create storage root");
+    let store = PipelineRunStore::new(root.path()).expect("open store");
+    store.publish(&run("demo", "100-default")).await.expect("publish");
+
+    let error = store.publish(&run("demo", "100-default")).await.expect_err("re-publish refused");
+    let rendered = error.to_string();
+    assert!(rendered.contains("append-only"), "unexpected error: {rendered}");
+}
+
+#[tokio::test]
+async fn path_shaped_identifiers_are_refused() {
+    let root = TempDir::new().expect("create storage root");
+    let store = PipelineRunStore::new(root.path()).expect("open store");
+    for (workspace, run_id) in [
+        ("../escape", "100-default"),
+        ("demo/nested", "100-default"),
+        ("demo", "../escape"),
+        ("demo", ""),
+        (".hidden", "100-default"),
+    ] {
+        let error = store.publish(&run(workspace, run_id)).await.expect_err("refused");
+        let rendered = error.to_string();
+        assert!(
+            rendered.contains("ASCII"),
+            "unexpected error for {workspace}/{run_id}: {rendered}"
+        );
+        assert!(store.get(workspace, run_id).is_err(), "get must refuse {workspace}/{run_id}");
+    }
+}

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -75,3 +75,33 @@ async fn path_shaped_identifiers_are_refused() {
         assert!(store.get(workspace, run_id).is_err(), "get must refuse {workspace}/{run_id}");
     }
 }
+
+#[tokio::test]
+async fn concurrent_publications_cannot_replace_the_winner() {
+    let root = TempDir::new().unwrap();
+    let first_store = PipelineRunStore::new(root.path()).unwrap();
+    let second_store = PipelineRunStore::new(root.path()).unwrap();
+    let first = run("demo", "100-default");
+    let mut second = run("demo", "100-default");
+    second.summary = json!({"publisher": "second"});
+    let first_publication = first_store.publish(&first);
+    let second_publication = second_store.publish(&second);
+    let (first_result, second_result) = tokio::join!(first_publication, second_publication);
+    assert_ne!(first_result.is_ok(), second_result.is_ok(), "exactly one writer must succeed");
+    let expected = if first_result.is_ok() { first.summary } else { second.summary };
+    assert_eq!(first_store.get("demo", "100-default").unwrap().unwrap().summary, expected);
+    assert!(
+        second_store.publish(&run("demo", "100-default")).await.is_err(),
+        "later publication must be refused",
+    );
+    assert_eq!(second_store.get("demo", "100-default").unwrap().unwrap().summary, expected);
+}
+
+#[tokio::test]
+async fn listing_does_not_parse_records_outside_the_requested_page() {
+    let root = TempDir::new().unwrap();
+    let store = PipelineRunStore::new(root.path()).unwrap();
+    store.publish(&run("demo", "200-default")).await.unwrap();
+    std::fs::write(store.run_path("demo", "100-default"), "invalid JSON").unwrap();
+    assert_eq!(store.list(Some("demo"), 1).unwrap()[0].run_id, "200-default");
+}

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -37,6 +37,7 @@ pnpr-registry                 = { workspace = true }
 pnpr-storage                  = { workspace = true }
 pnpr-route                    = { workspace = true }
 pnpr-search                   = { workspace = true }
+pnpr-pipeline-runs            = { workspace = true }
 pnpr-shared-artifacts         = { workspace = true }
 pnpr-upstream                 = { workspace = true }
 pnpm-cargo-resolver           = { workspace = true }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -98,6 +98,10 @@ const MAX_LOGIN_BODY_BYTES: usize = 64 * 1024;
 const MAX_ARTIFACT_PUBLISH_BODY_BYTES: usize = MAX_PUBLISH_BODY_BYTES;
 const MAX_ARTIFACT_RESOLVE_BODY_BYTES: usize = 16 * 1024 * 1024;
 const MAX_ARTIFACT_BLOB_BODY_BYTES: usize = 8 * 1024;
+/// A pipeline run record is a summary plus a bounded event stream; well
+/// under this in practice, with the ceiling guarding against a hostile
+/// client rather than a large workspace.
+const MAX_PIPELINE_RUN_BODY_BYTES: usize = 4 * 1024 * 1024;
 #[derive(Clone)]
 struct AppState {
     inner: Arc<AppInner>,
@@ -107,6 +111,7 @@ struct AppInner {
     storage: Storage,
     artifacts: Option<pnpr_shared_artifacts::SharedArtifactStore>,
     compiler_cache_uploads: tokio::sync::Semaphore,
+    pipeline_runs: Option<pnpr_pipeline_runs::PipelineRunStore>,
     /// One [`Upstream`] per declared upstream, keyed by the same name
     /// used in [`Config::upstreams`]. Built once at router construction
     /// time so each request avoids re-allocating a `ThrottledClient`.
@@ -318,6 +323,7 @@ fn log_enabled_surfaces(config: &Config) {
         registry = config.registry.enabled,
         resolver = config.resolver.enabled,
         artifacts = config.artifacts.enabled,
+        pipeline = config.pipeline.enabled,
         "pnpr surfaces",
     );
 }
@@ -2219,6 +2225,14 @@ async fn require_artifact_caller(
     require_protocol_caller(&state, request, next, "shared artifacts").await
 }
 
+async fn require_pipeline_caller(
+    State(state): State<AppState>,
+    request: Request,
+    next: Next,
+) -> Response {
+    require_protocol_caller(&state, request, next, "pipeline runs").await
+}
+
 async fn require_protocol_caller(
     state: &AppState,
     request: Request,
@@ -2939,6 +2953,106 @@ fn revision_tarball_response(
     private_no_cache(response)
 }
 
+/// `PUT /-/pnpr/v0/pipeline/runs` — record one `pnpm pipeline` run. The
+/// document is stored verbatim; identifiers are validated by the store.
+async fn serve_publish_pipeline_run(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    body: axum::body::Bytes,
+) -> Response {
+    if let Err(err) = require_caller(&identity, "pipeline run publication") {
+        return private_no_cache(err.into_response());
+    }
+    let run: pnpr_pipeline_runs::PublishPipelineRun = match serde_json::from_slice(&body) {
+        Ok(run) => run,
+        Err(err) => {
+            return private_no_cache(
+                RegistryError::BadRequest {
+                    reason: format!("invalid pipeline run document: {err}"),
+                }
+                .into_response(),
+            );
+        }
+    };
+    private_no_cache(
+        match state
+            .inner
+            .pipeline_runs
+            .as_ref()
+            .expect("pipeline routes require a run store")
+            .publish(&run)
+            .await
+        {
+            Ok(()) => StatusCode::CREATED.into_response(),
+            Err(err) => err.into_response(),
+        },
+    )
+}
+
+/// `GET /-/pnpr/v0/pipeline/runs[?workspace=&limit=]` — the most recent
+/// run summaries, newest first.
+async fn serve_list_pipeline_runs(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    uri: axum::http::Uri,
+) -> Response {
+    if let Err(err) = require_caller(&identity, "pipeline runs") {
+        return private_no_cache(err.into_response());
+    }
+    // Parsed by hand: the two recognized parameters do not justify
+    // enabling axum's `query` feature for this one endpoint.
+    let mut workspace: Option<String> = None;
+    let mut limit: usize = 50;
+    for pair in uri.query().unwrap_or_default().split('&') {
+        match pair.split_once('=') {
+            Some(("workspace", value)) if !value.is_empty() => {
+                workspace = Some(value.to_string());
+            }
+            Some(("limit", value)) => {
+                if let Ok(value) = value.parse() {
+                    limit = value;
+                }
+            }
+            _ => {}
+        }
+    }
+    let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
+    private_no_cache(match store.list(workspace.as_deref(), limit) {
+        Ok(runs) => axum::Json(serde_json::json!({ "runs": runs })).into_response(),
+        Err(err) => err.into_response(),
+    })
+}
+
+/// `GET /-/pnpr/v0/pipeline/runs/{workspace}/{run_id}` — one run's full
+/// record, event stream included.
+async fn serve_get_pipeline_run(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    Path((workspace, run_id)): Path<(String, String)>,
+) -> Response {
+    if let Err(err) = require_caller(&identity, "pipeline runs") {
+        return private_no_cache(err.into_response());
+    }
+    let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
+    private_no_cache(match store.get(&workspace, &run_id) {
+        Ok(Some(run)) => axum::Json(run).into_response(),
+        Ok(None) => not_found(),
+        Err(err) => err.into_response(),
+    })
+}
+
+/// `GET /-/pnpr/v0/pipeline` — a self-contained viewer over the run
+/// endpoints. Static HTML with no data of its own: the reads it issues
+/// carry the token the visitor pastes, so the page itself needs no auth.
+async fn serve_pipeline_ui() -> Response {
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+        include_str!("server/pipeline_ui.html"),
+    )
+        .into_response()
+}
+
 fn not_found() -> Response {
     RegistryError::NotFound.into_response()
 }
@@ -2966,12 +3080,14 @@ async fn serve_pnpr_handshake(State(state): State<AppState>) -> Response {
     let artifacts =
         state.inner.config.artifacts.enabled.then_some(0).into_iter().collect::<Vec<_>>();
     let publish = state.inner.config.registry.enabled.then_some(0).into_iter().collect::<Vec<_>>();
+    let pipeline = state.inner.config.pipeline.enabled.then_some(0).into_iter().collect::<Vec<_>>();
     (
         StatusCode::OK,
         axum::Json(serde_json::json!({
             "pnpr": {
                 "versions": versions,
                 "artifacts": artifacts,
+                "pipeline": pipeline,
                 "fixLockfile": fix_lockfile,
                 "ecosystems": ecosystems,
                 "publish": publish,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -2974,6 +2974,9 @@ async fn serve_publish_pipeline_run(
             );
         }
     };
+    if let Err(error) = authorize_pipeline_workspace(&state, &identity, &run.workspace, true) {
+        return private_no_cache(error.into_response());
+    }
     private_no_cache(
         match state
             .inner
@@ -2999,16 +3002,12 @@ async fn serve_list_pipeline_runs(
     if let Err(err) = require_caller(&identity, "pipeline runs") {
         return private_no_cache(err.into_response());
     }
-    // Parsed by hand: the two recognized parameters do not justify
-    // enabling axum's `query` feature for this one endpoint.
     let mut workspace: Option<String> = None;
     let mut limit: usize = 50;
-    for pair in uri.query().unwrap_or_default().split('&') {
-        match pair.split_once('=') {
-            Some(("workspace", value)) if !value.is_empty() => {
-                workspace = Some(value.to_string());
-            }
-            Some(("limit", value)) => {
+    for (key, value) in url::form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "workspace" if !value.is_empty() => workspace = Some(value.into_owned()),
+            "limit" => {
                 if let Ok(value) = value.parse() {
                     limit = value;
                 }
@@ -3016,10 +3015,36 @@ async fn serve_list_pipeline_runs(
             _ => {}
         }
     }
-    let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
-    private_no_cache(match store.list(workspace.as_deref(), limit) {
-        Ok(runs) => axum::Json(serde_json::json!({ "runs": runs })).into_response(),
-        Err(err) => err.into_response(),
+    let limit = limit.clamp(1, pnpr_pipeline_runs::MAX_LIST_RUNS);
+    if let Some(workspace) = &workspace
+        && let Err(error) = authorize_pipeline_workspace(&state, &identity, workspace, false)
+    {
+        return private_no_cache(error.into_response());
+    }
+    let result = tokio::task::spawn_blocking(move || {
+        let store =
+            state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
+        let mut runs = Vec::new();
+        for (name, policy) in &state.inner.config.pipeline.workspaces {
+            if !policy.access.allows(&identity)
+                || workspace.as_ref().is_some_and(|requested| requested != name)
+            {
+                continue;
+            }
+            match store.list(Some(name), limit) {
+                Ok(entries) => runs.extend(entries),
+                Err(error) => return Err(error),
+            }
+            runs.sort_by(|left, right| right.run_id.cmp(&left.run_id));
+            runs.truncate(limit);
+        }
+        Ok::<_, RegistryError>(runs)
+    })
+    .await;
+    private_no_cache(match result {
+        Ok(Ok(runs)) => axum::Json(serde_json::json!({ "runs": runs })).into_response(),
+        Ok(Err(error)) => error.into_response(),
+        Err(error) => RegistryError::Io(std::io::Error::other(error)).into_response(),
     })
 }
 
@@ -3030,8 +3055,8 @@ async fn serve_get_pipeline_run(
     AuthedCaller(identity): AuthedCaller,
     Path((workspace, run_id)): Path<(String, String)>,
 ) -> Response {
-    if let Err(err) = require_caller(&identity, "pipeline runs") {
-        return private_no_cache(err.into_response());
+    if let Err(error) = authorize_pipeline_workspace(&state, &identity, &workspace, false) {
+        return private_no_cache(error.into_response());
     }
     let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
     private_no_cache(match store.get(&workspace, &run_id) {
@@ -3039,6 +3064,27 @@ async fn serve_get_pipeline_run(
         Ok(None) => not_found(),
         Err(err) => err.into_response(),
     })
+}
+
+fn authorize_pipeline_workspace(
+    state: &AppState,
+    identity: &Identity,
+    workspace: &str,
+    publish: bool,
+) -> Result<(), RegistryError> {
+    let username = require_caller(identity, "pipeline runs")?;
+    let policy = state.inner.config.pipeline.workspaces.get(workspace);
+    if !policy.is_some_and(|policy| policy.access.allows(identity)) {
+        return Err(RegistryError::NotFound);
+    }
+    if publish && !policy.is_some_and(|policy| policy.publish.allows(identity)) {
+        return Err(RegistryError::Forbidden {
+            user: username,
+            action: "publish pipeline runs",
+            resource: workspace.to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// `GET /-/pnpr/v0/pipeline` — a self-contained viewer over the run

--- a/pnpr/crates/pnpr/src/server/pipeline_ui.html
+++ b/pnpr/crates/pnpr/src/server/pipeline_ui.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>pnpr pipeline runs</title>
+<style>
+  :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+  body { margin: 2rem auto; max-width: 72rem; padding: 0 1rem; }
+  h1 { font-size: 1.3rem; }
+  .bar { display: flex; gap: .5rem; flex-wrap: wrap; margin-bottom: 1rem; }
+  input { padding: .35rem .5rem; }
+  #token { width: 22rem; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { text-align: left; padding: .4rem .6rem; border-bottom: 1px solid #8884; font-size: .9rem; }
+  .passed { color: #2e7d32; } .failed { color: #c62828; } .skipped { color: #9e9e9e; }
+  .mode { opacity: .7; }
+  #status { opacity: .7; margin: .5rem 0; }
+  pre { overflow-x: auto; background: #8881; padding: .75rem; }
+</style>
+<h1>pnpr pipeline runs</h1>
+<div class="bar">
+  <input id="token" type="password" placeholder="Bearer token (from your .npmrc)">
+  <input id="workspace" placeholder="workspace filter (optional)">
+  <button id="refresh">Refresh</button>
+</div>
+<div id="status">Paste a token and refresh.</div>
+<table hidden id="runs"><thead>
+  <tr><th>Run</th><th>Workspace</th><th>Pipeline</th><th>Base</th><th>Selection</th><th>Tasks</th></tr>
+</thead><tbody></tbody></table>
+<pre hidden id="detail"></pre>
+<script>
+  const token = document.getElementById('token');
+  const status = document.getElementById('status');
+  const table = document.getElementById('runs');
+  const detail = document.getElementById('detail');
+  try { token.value = localStorage.getItem('pnpr-pipeline-token') || ''; } catch {}
+
+  async function api(path) {
+    const response = await fetch(path, { headers: { authorization: 'Bearer ' + token.value } });
+    if (!response.ok) throw new Error(path + ' returned ' + response.status);
+    return response.json();
+  }
+
+  function counts(tasks) {
+    const totals = {};
+    for (const entry of Object.values(tasks || {})) totals[entry.status] = (totals[entry.status] || 0) + 1;
+    return ['passed', 'failure', 'skipped', 'queued']
+      .filter((status) => totals[status])
+      .map((status) => `<span class="${status === 'failure' ? 'failed' : status}">${totals[status]} ${status}</span>`)
+      .join(' · ') || '—';
+  }
+
+  async function refresh() {
+    try { localStorage.setItem('pnpr-pipeline-token', token.value); } catch {}
+    detail.hidden = true;
+    status.textContent = 'Loading…';
+    const workspace = document.getElementById('workspace').value.trim();
+    try {
+      const query = workspace ? '?workspace=' + encodeURIComponent(workspace) : '';
+      const { runs } = await api('/-/pnpr/v0/pipeline/runs' + query);
+      const rows = runs.map((run) => {
+        const selection = run.summary.selection || {};
+        const when = new Date(Number(String(run.runId).split('-')[0])).toLocaleString();
+        return `<tr data-workspace="${run.workspace}" data-run="${run.runId}">
+          <td><a href="#">${when}</a></td><td>${run.workspace}</td>
+          <td>${run.summary.pipeline || '?'}</td><td>${run.summary.base || ''}</td>
+          <td class="mode">${selection.mode || ''} (${selection.requestedProjects ?? '?'} of ${selection.includedProjects ?? '?'})</td>
+          <td>${counts(run.summary.tasks)}</td></tr>`;
+      });
+      table.querySelector('tbody').innerHTML = rows.join('');
+      table.hidden = false;
+      status.textContent = runs.length + ' runs.';
+    } catch (error) {
+      table.hidden = true;
+      status.textContent = String(error);
+    }
+  }
+
+  table.addEventListener('click', async (event) => {
+    const row = event.target.closest('tr[data-run]');
+    if (!row) return;
+    event.preventDefault();
+    try {
+      const run = await api('/-/pnpr/v0/pipeline/runs/' + row.dataset.workspace + '/' + row.dataset.run);
+      detail.textContent = JSON.stringify(run, null, 2);
+      detail.hidden = false;
+    } catch (error) {
+      status.textContent = String(error);
+    }
+  });
+  document.getElementById('refresh').addEventListener('click', refresh);
+</script>

--- a/pnpr/crates/pnpr/src/server/pipeline_ui.html
+++ b/pnpr/crates/pnpr/src/server/pipeline_ui.html
@@ -31,7 +31,6 @@
   const status = document.getElementById('status');
   const table = document.getElementById('runs');
   const detail = document.getElementById('detail');
-  try { token.value = localStorage.getItem('pnpr-pipeline-token') || ''; } catch {}
 
   async function api(path) {
     const response = await fetch(path, { headers: { authorization: 'Bearer ' + token.value } });
@@ -40,16 +39,15 @@
   }
 
   function counts(tasks) {
-    const totals = {};
-    for (const entry of Object.values(tasks || {})) totals[entry.status] = (totals[entry.status] || 0) + 1;
+    const totals = Object.create(null);
+    for (const entry of Object.values(tasks || {})) totals[entry?.status] = (totals[entry?.status] || 0) + 1;
     return ['passed', 'failure', 'skipped', 'queued']
       .filter((status) => totals[status])
-      .map((status) => `<span class="${status === 'failure' ? 'failed' : status}">${totals[status]} ${status}</span>`)
+      .map((status) => `${totals[status]} ${status}`)
       .join(' · ') || '—';
   }
 
   async function refresh() {
-    try { localStorage.setItem('pnpr-pipeline-token', token.value); } catch {}
     detail.hidden = true;
     status.textContent = 'Loading…';
     const workspace = document.getElementById('workspace').value.trim();
@@ -57,15 +55,26 @@
       const query = workspace ? '?workspace=' + encodeURIComponent(workspace) : '';
       const { runs } = await api('/-/pnpr/v0/pipeline/runs' + query);
       const rows = runs.map((run) => {
-        const selection = run.summary.selection || {};
+        const summary = run.summary || {};
+        const selection = summary.selection || {};
         const when = new Date(Number(String(run.runId).split('-')[0])).toLocaleString();
-        return `<tr data-workspace="${run.workspace}" data-run="${run.runId}">
-          <td><a href="#">${when}</a></td><td>${run.workspace}</td>
-          <td>${run.summary.pipeline || '?'}</td><td>${run.summary.base || ''}</td>
-          <td class="mode">${selection.mode || ''} (${selection.requestedProjects ?? '?'} of ${selection.includedProjects ?? '?'})</td>
-          <td>${counts(run.summary.tasks)}</td></tr>`;
+        const row = document.createElement('tr');
+        row.dataset.workspace = run.workspace;
+        row.dataset.run = run.runId;
+        for (const value of [when, run.workspace, summary.pipeline || '?', summary.base || '',
+          `${selection.mode || ''} (${selection.requestedProjects ?? '?'} of ${selection.includedProjects ?? '?'})`,
+          counts(summary.tasks)]) {
+          const cell = document.createElement('td');
+          cell.textContent = String(value);
+          row.append(cell);
+        }
+        const link = document.createElement('a');
+        link.href = '#';
+        link.textContent = when;
+        row.firstChild.replaceChildren(link);
+        return row;
       });
-      table.querySelector('tbody').innerHTML = rows.join('');
+      table.querySelector('tbody').replaceChildren(...rows);
       table.hidden = false;
       status.textContent = runs.length + ' runs.';
     } catch (error) {
@@ -79,7 +88,7 @@
     if (!row) return;
     event.preventDefault();
     try {
-      const run = await api('/-/pnpr/v0/pipeline/runs/' + row.dataset.workspace + '/' + row.dataset.run);
+      const run = await api('/-/pnpr/v0/pipeline/runs/' + encodeURIComponent(row.dataset.workspace) + '/' + encodeURIComponent(row.dataset.run));
       detail.textContent = JSON.stringify(run, null, 2);
       detail.hidden = false;
     } catch (error) {

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -30,16 +30,18 @@ use serde::Deserialize;
 use super::{
     AppInner, AppState, AuthedCaller, MAX_ARTIFACT_BLOB_BODY_BYTES,
     MAX_ARTIFACT_PUBLISH_BODY_BYTES, MAX_ARTIFACT_RESOLVE_BODY_BYTES, MAX_LOGIN_BODY_BYTES,
-    MAX_PUBLISH_BODY_BYTES, StripedLocks, TargetRegistry, addressed_registry, authenticate, batch,
-    caller_scoped, cargo, compiler_cache, compute_upstream_cache_namespace, delete_package,
-    delete_session_token, delete_tarball, delete_token_by_key, get_dist_tags, get_org_teams,
-    get_profile, get_team_members, get_token_list, get_whoami, loggable_uri, not_found,
-    pnpr_protocols_disabled, private_no_cache, publish_package, put_login, pypi,
-    reject_team_mutation, remove_dist_tag, require_artifact_caller, require_resolver_caller,
-    serve_artifact_blob, serve_batch_publish, serve_org_packages, serve_packument, serve_ping,
-    serve_pnpr_handshake, serve_publish_artifact, serve_resolve, serve_resolve_artifacts,
-    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
-    serve_version_manifest, set_dist_tag, staged, update_packument,
+    MAX_PIPELINE_RUN_BODY_BYTES, MAX_PUBLISH_BODY_BYTES, StripedLocks, TargetRegistry,
+    addressed_registry, authenticate, batch, caller_scoped, cargo, compiler_cache,
+    compute_upstream_cache_namespace, delete_package, delete_session_token, delete_tarball,
+    delete_token_by_key, get_dist_tags, get_org_teams, get_profile, get_team_members,
+    get_token_list, get_whoami, loggable_uri, not_found, pnpr_protocols_disabled, private_no_cache,
+    publish_package, put_login, pypi, reject_team_mutation, remove_dist_tag,
+    require_artifact_caller, require_pipeline_caller, require_resolver_caller, serve_artifact_blob,
+    serve_batch_publish, serve_get_pipeline_run, serve_list_pipeline_runs, serve_org_packages,
+    serve_packument, serve_ping, serve_pipeline_ui, serve_pnpr_handshake, serve_publish_artifact,
+    serve_publish_pipeline_run, serve_resolve, serve_resolve_artifacts, serve_revision_tarball,
+    serve_search, serve_tarball, serve_verify_lockfile, serve_version_manifest, set_dist_tag,
+    staged, update_packument,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -62,6 +64,10 @@ pub(super) fn router_with_auth_and_osv(
     let registry_enabled = config.registry.enabled;
     let resolver_enabled = config.resolver.enabled;
     let artifacts_enabled = config.artifacts.enabled;
+    let pipeline_enabled = config.pipeline.enabled;
+    let pipeline_runs = pipeline_enabled
+        .then(|| pnpr_pipeline_runs::PipelineRunStore::new(&config.storage))
+        .transpose()?;
     let artifacts = artifacts_enabled
         .then(|| {
             pnpr_shared_artifacts::SharedArtifactStore::new(
@@ -101,6 +107,7 @@ pub(super) fn router_with_auth_and_osv(
             storage,
             artifacts,
             compiler_cache_uploads: tokio::sync::Semaphore::new(2),
+            pipeline_runs,
             upstreams,
             upstream_cache_namespaces,
             config,
@@ -128,7 +135,7 @@ pub(super) fn router_with_auth_and_osv(
     // expects the "no pnpr protocols here" 404. The `/-/pnpr/v0/*` endpoints
     // carry no capability probe, so they are left unmounted rather than
     // stubbed.
-    if resolver_enabled || artifacts_enabled || registry_enabled {
+    if resolver_enabled || artifacts_enabled || registry_enabled || pipeline_enabled {
         router = router.route("/-/pnpr", get(serve_pnpr_handshake));
     } else {
         router = router.route("/-/pnpr", any(pnpr_protocols_disabled));
@@ -195,6 +202,33 @@ pub(super) fn router_with_auth_and_osv(
                     )),
             );
     }
+    if pipeline_enabled {
+        router = router
+            .route(
+                "/-/pnpr/v0/pipeline/runs",
+                put(serve_publish_pipeline_run)
+                    .get(serve_list_pipeline_runs)
+                    .route_layer(DefaultBodyLimit::max(MAX_PIPELINE_RUN_BODY_BYTES))
+                    .route_layer(middleware::from_fn_with_state(
+                        state.clone(),
+                        require_pipeline_caller,
+                    )),
+            )
+            .route(
+                "/-/pnpr/v0/pipeline/runs/{workspace}/{run_id}",
+                get(serve_get_pipeline_run).route_layer(middleware::from_fn_with_state(
+                    state.clone(),
+                    require_pipeline_caller,
+                )),
+            )
+            // The viewer page is static HTML with no data of its own; the
+            // reads it issues are what authenticate.
+            .route("/-/pnpr/v0/pipeline", get(serve_pipeline_ui));
+    }
+    // The npm-registry surface: every packument/tarball read, publish,
+    // unpublish, dist-tag, and search. When the surface is off (no registries
+    // declared, or `--disable-registry`), none of these routes are mounted.
+    // Resolver- and artifacts-only tiers expose no registry surface at all.
     if registry_enabled {
         let npm = npm_registry_routes();
         router = router

--- a/pnpr/crates/pnpr/tests/pipeline_ui.mjs
+++ b/pnpr/crates/pnpr/tests/pipeline_ui.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import test from 'node:test'
+import vm from 'node:vm'
+
+function element () {
+  return {
+    value: '',
+    dataset: {},
+    children: [],
+    listeners: {},
+    append (child) { this.children.push(child) },
+    replaceChildren (...children) { this.children = children },
+    get firstChild () { return this.children[0] },
+    set innerHTML (value) { throw new Error('HTML interpolation is forbidden: ' + value) },
+    addEventListener (name, callback) { this.listeners[name] = callback },
+  }
+}
+
+test('run data is rendered as text and credentials are not persisted', async () => {
+  const nodes = new Map(['token', 'status', 'runs', 'detail', 'workspace', 'refresh'].map(id => [id, element()]))
+  const body = element()
+  nodes.get('runs').querySelector = () => body
+  const payload = '<img src=x onerror="stealToken()">'
+  const source = readFileSync(new URL('../src/server/pipeline_ui.html', import.meta.url), 'utf8').split('<script>')[1].split('</script>')[0]
+  const context = vm.createContext({
+    document: { getElementById: id => nodes.get(id), createElement: element },
+    fetch: async () => ({ ok: true, json: async () => ({ runs: [{ workspace: payload, runId: '100-default', summary: { pipeline: payload, base: payload, selection: { mode: payload }, tasks: { build: null } } }] }) }),
+    localStorage: new Proxy({}, { get () { throw new Error('credentials must stay in memory') } }),
+  })
+  vm.runInContext(source, context)
+  await context.refresh()
+  assert.equal(body.children.length, 1)
+  const row = body.children[0]
+  assert.equal(row.children[1].textContent, payload)
+  assert.equal(row.children[2].textContent, payload)
+  assert.equal(row.children[3].textContent, payload)
+  assert.equal(row.dataset.workspace, payload)
+})

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3006,7 +3006,7 @@ async fn pipeline_surface_records_lists_and_serves_runs_append_only() {
         app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(
         body_json(handshake.into_body()).await,
-        json!({ "pnpr": { "versions": [], "artifacts": [], "pipeline": [0], "fixLockfile": [] } }),
+        json!({ "pnpr": { "versions": [], "artifacts": [], "pipeline": [0], "fixLockfile": [], "ecosystems": [], "publish": [] } }),
     );
 
     // Reads and writes both authenticate; the viewer page is static HTML
@@ -3159,6 +3159,7 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
             "pnpr": {
                 "versions": [],
                 "artifacts": [],
+                "pipeline": [],
                 "fixLockfile": [],
                 "ecosystems": [],
                 "publish": [0],

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3071,7 +3071,7 @@ async fn pipeline_surface_records_lists_and_serves_runs_append_only() {
     // Append-only: the same run identity is refused, not overwritten.
     let replay = publish(run.clone()).await;
     assert_eq!(replay.status(), StatusCode::BAD_REQUEST);
-    assert!(String::from_utf8_lossy(&body_bytes(replay.into_body()).await).contains("append-only"),);
+    assert!(String::from_utf8_lossy(&body_bytes(replay.into_body()).await).contains("append-only"));
 
     // A path-shaped workspace never reaches a path join.
     let hostile = publish(json!({

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2842,6 +2842,7 @@ async fn resolver_only_serves_resolver_endpoints_and_refuses_registry_routes() {
             "pnpr": {
                 "versions": [0],
                 "artifacts": [],
+                "pipeline": [],
                 "fixLockfile": [0],
                 "ecosystems": ["npm", "cargo", "pypi"],
                 "publish": [],
@@ -2965,6 +2966,7 @@ async fn artifacts_only_advertises_and_mounts_only_the_artifact_protocol() {
             "pnpr": {
                 "versions": [],
                 "artifacts": [0],
+                "pipeline": [],
                 "fixLockfile": [],
                 "ecosystems": [],
                 "publish": [],
@@ -2988,6 +2990,138 @@ async fn artifacts_only_advertises_and_mounts_only_the_artifact_protocol() {
         .await
         .unwrap();
     assert_eq!(resolve.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn pipeline_surface_records_lists_and_serves_runs_append_only() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://upstream.invalid", tmp.path().to_path_buf());
+    config.registry.enabled = false;
+    config.resolver.enabled = false;
+    config.pipeline.enabled = true;
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+    let app = router(config);
+
+    let handshake =
+        app.clone().oneshot(Request::get("/-/pnpr").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(
+        body_json(handshake.into_body()).await,
+        json!({ "pnpr": { "versions": [], "artifacts": [], "pipeline": [0], "fixLockfile": [] } }),
+    );
+
+    // Reads and writes both authenticate; the viewer page is static HTML
+    // with no data of its own and does not.
+    let anonymous = app
+        .clone()
+        .oneshot(Request::get("/-/pnpr/v0/pipeline/runs").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(anonymous.status(), StatusCode::UNAUTHORIZED);
+    let viewer = app
+        .clone()
+        .oneshot(Request::get("/-/pnpr/v0/pipeline").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(viewer.status(), StatusCode::OK);
+
+    let registration = json!({
+        "_id": "org.couchdb.user:alice",
+        "name": "alice",
+        "password": "secret",
+        "email": "alice@example.test",
+        "type": "user",
+        "roles": [],
+    });
+    let logged_in = app
+        .clone()
+        .oneshot(
+            Request::put("/-/user/org.couchdb.user:alice")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&registration).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(logged_in.status(), StatusCode::CREATED);
+    let token = body_json(logged_in.into_body()).await["token"].as_str().unwrap().to_string();
+
+    let run = json!({
+        "workspace": "demo-abc123",
+        "runId": "100-default",
+        "summary": { "pipeline": "default", "tasks": {} },
+        "events": [{ "event": "taskStarted", "task": "packages/a#build" }],
+    });
+    let publish = |body: serde_json::Value| {
+        let app = app.clone();
+        let token = token.clone();
+        async move {
+            app.oneshot(
+                Request::put("/-/pnpr/v0/pipeline/runs")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+    };
+    assert_eq!(publish(run.clone()).await.status(), StatusCode::CREATED);
+
+    // Append-only: the same run identity is refused, not overwritten.
+    let replay = publish(run.clone()).await;
+    assert_eq!(replay.status(), StatusCode::BAD_REQUEST);
+    assert!(String::from_utf8_lossy(&body_bytes(replay.into_body()).await).contains("append-only"),);
+
+    // A path-shaped workspace never reaches a path join.
+    let hostile = publish(json!({
+        "workspace": "../escape",
+        "runId": "100-default",
+        "summary": {},
+    }))
+    .await;
+    assert_eq!(hostile.status(), StatusCode::BAD_REQUEST);
+
+    let listed = app
+        .clone()
+        .oneshot(
+            Request::get("/-/pnpr/v0/pipeline/runs?workspace=demo-abc123")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(listed.status(), StatusCode::OK);
+    let listed = body_json(listed.into_body()).await;
+    assert_eq!(listed["runs"][0]["runId"], "100-default");
+    assert_eq!(listed["runs"][0]["summary"]["pipeline"], "default");
+    assert!(listed["runs"][0].get("events").is_none());
+
+    let fetched = app
+        .clone()
+        .oneshot(
+            Request::get("/-/pnpr/v0/pipeline/runs/demo-abc123/100-default")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(fetched.status(), StatusCode::OK);
+    let fetched = body_json(fetched.into_body()).await;
+    assert_eq!(fetched["events"][0]["event"], "taskStarted");
+
+    let missing = app
+        .oneshot(
+            Request::get("/-/pnpr/v0/pipeline/runs/demo-abc123/999-missing")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2999,6 +2999,17 @@ async fn pipeline_surface_records_lists_and_serves_runs_append_only() {
     config.registry.enabled = false;
     config.resolver.enabled = false;
     config.pipeline.enabled = true;
+    for (workspace, reader, writer) in
+        [("demo-abc123", "alice", "alice"), ("hidden", "bob", "bob"), ("read-only", "alice", "bob")]
+    {
+        config.pipeline.workspaces.insert(
+            workspace.to_string(),
+            pnpr_config::StorageAccess {
+                access: pnpr_policy::AccessList::from_tokens([reader]),
+                publish: pnpr_policy::AccessList::from_tokens([writer]),
+            },
+        );
+    }
     config.auth.htpasswd.max_users = MaxUsers::Unlimited;
     let app = router(config);
 
@@ -3080,7 +3091,46 @@ async fn pipeline_surface_records_lists_and_serves_runs_append_only() {
         "summary": {},
     }))
     .await;
-    assert_eq!(hostile.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(hostile.status(), StatusCode::NOT_FOUND);
+
+    for (workspace, expected) in [
+        ("hidden", StatusCode::NOT_FOUND),
+        ("unknown", StatusCode::NOT_FOUND),
+        ("read-only", StatusCode::FORBIDDEN),
+    ] {
+        assert_eq!(
+            publish(json!({"workspace": workspace, "runId": "100-default", "summary": {}}))
+                .await
+                .status(),
+            expected,
+        );
+    }
+    for path in
+        ["/-/pnpr/v0/pipeline/runs?workspace=hidden", "/-/pnpr/v0/pipeline/runs/hidden/100-default"]
+    {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(path)
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+    let unfiltered = app
+        .clone()
+        .oneshot(
+            Request::get("/-/pnpr/v0/pipeline/runs")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(body_json(unfiltered.into_body()).await["runs"].as_array().unwrap().len(), 1);
 
     let listed = app
         .clone()
@@ -5234,4 +5284,18 @@ async fn a_single_npm_ecosystem_answers_at_the_root() {
     assert_eq!(fetched.status(), StatusCode::OK);
     assert_eq!(body_bytes(fetched.into_body()).await, bytes);
     tarball.assert_async().await;
+}
+
+#[test]
+fn pipeline_viewer_renders_publisher_data_as_text() {
+    let output = std::process::Command::new("node")
+        .args(["--test", concat!(env!("CARGO_MANIFEST_DIR"), "/tests/pipeline_ui.mjs")])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "viewer regression: {}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 }

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -1274,8 +1274,8 @@ async fn write_atomic_with_replace(path: &Path, bytes: &[u8], replace: bool) -> 
         let _ = fs::remove_file(&tmp).await;
         return Err(err.into());
     }
-    if !replace {
-        fs::remove_file(&tmp).await?;
+    if !replace && let Err(err) = fs::remove_file(&tmp).await {
+        tracing::warn!(?err, path = %tmp.display(), "atomic publication temp cleanup failed");
     }
     Ok(())
 }

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -1244,6 +1244,15 @@ pub(crate) fn staged_id_of_meta_object(object: &str) -> Option<&str> {
 }
 
 pub async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    write_atomic_with_replace(path, bytes, true).await
+}
+
+/// Publishes a complete file without replacing an existing destination.
+pub async fn write_atomic_new(path: &Path, bytes: &[u8]) -> Result<()> {
+    write_atomic_with_replace(path, bytes, false).await
+}
+
+async fn write_atomic_with_replace(path: &Path, bytes: &[u8], replace: bool) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).await?;
     }
@@ -1259,9 +1268,14 @@ pub async fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
         return Err(err.into());
     }
     drop(file);
-    if let Err(err) = fs::rename(&tmp, path).await {
+    let committed =
+        if replace { fs::rename(&tmp, path).await } else { fs::hard_link(&tmp, path).await };
+    if let Err(err) = committed {
         let _ = fs::remove_file(&tmp).await;
         return Err(err.into());
+    }
+    if !replace {
+        fs::remove_file(&tmp).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds an experimental `pnpm pipeline [name]` command that composes frozen installation, affected-project selection, workspace task scheduling, local task caching, and run reports. It implements the CI-engine proof of concept discussed in pnpm/rfcs#25, pnpm/rfcs#23, and pnpm/rfcs#22.

- Pipelines select changed projects and their dependents, falling back to the full graph when the base cannot be resolved or workspace-root files change. Tasks run with no-bail semantics and report failed or skipped dependents.
- Completed-task caching restores declared outputs and replays captured logs on a hit. Content-hashed restoration records protect files modified since the preceding run. Task settings include `outputs`, `inputs`, `env`, and `cache`.
- `tasks.<name>.cargoTargetDir` opts into a separate, disposable Cargo build-state cache shared by linked Git worktrees. Snapshots restore only into absent target directories, using reflinks or copies, and the task always executes. Removing cached snapshots leaves restored builds usable. Root tasks can participate with `includeWorkspaceRoot: true`.
- `pnpm pipeline --watch --repo <url> --branch <name>` polls revisions and executes each build in a child process. Unsuccessful runs remain pending for retry. The managed checkout and exclusive lock live under `stateDir`. `--once` runs one polling cycle.
- pnpr gains an authenticated, append-only pipeline run-record API and a small viewer, disabled unless `pipeline.enabled` is set. Each workspace requires explicit `access` and `publish` policies. `--report` and `--report-to` publish run summaries and events, including failed runs. Run records use authoritative storage; they are not disposable build artifacts.

Review fixes confine task-cache paths, verify cached output hashes, bound captured logs, keep publications immutable, and render report values as text. Run IDs are opaque, authenticated report requests require secure transport, and report redirects are refused. The watch agent executes trusted repository code with the runner's permissions; it is not a sandbox.

Cargo snapshots include repository input contents, Cargo/Rust versions, Cargo configuration, and the supported build environment in their identity. Relocation invalidates local-package and build-script freshness records: a regression test demonstrated that otherwise Cargo could preserve the publishing worktree's path in B's binary. Content changes invalidate freshness even when modification times are retained.

This is a Rust-only feature for pnpm v12, with a deliberately bounded prototype scope. The task cache is local; pnpr receives run records, not task outputs or Cargo snapshots. Cargo caching requires the documented input contract and does not yet cover arbitrary external build inputs, automatic eviction, remote publication, or reuse across different source revisions. The original reflink benchmark does not measure the complete pipeline cache lifecycle, so its timings are not presented as speedups for this implementation.

Usage and limitations: `pnpm/scripts/pipeline-cargo-cache.md`. Investigation and benchmark: `pnpm/scripts/bench-rust-cache.md` and `just bench-rust-cache`.

Validation includes the workspace checks and real Cargo builds in two Git worktrees, same-timestamp source edits, build-script relocation, cache deletion, copy fallback, concurrent publication, corrupted/incomplete snapshots, path guards, and the watch-agent integration test. Local tests use an isolated XDG configuration directory to avoid developer configuration changing the registry used by fixtures.

## Squash Commit Body

```text
Compose frozen installation, affected-project selection, workspace task
scheduling, output caching, and run reporting in pnpm pipeline. Add a
polling watch agent and an authenticated pnpr run-record service.

Keep completed task results separate from Cargo incremental state.
Opted-in Cargo tasks share immutable snapshots across linked worktrees,
materialize private writable targets, and always execute. Keep snapshot
storage separate from installed-package storage so eviction cannot break
existing builds or installations.

Key Cargo snapshots by repository inputs and compilation environment.
Invalidate local-unit and build-script freshness after relocation, and
invalidate freshness after content changes even when mtimes are retained.
Use staged, integrity-checked restoration and coordinate pipeline writers
through locks outside the disposable cache.

Document the prototype's input, storage, and remote-service limitations.
Add regression coverage for worktree reuse, relocation, deletion,
concurrency, copy fallback, and invalid snapshot handling.

Related to pnpm/rfcs#22, pnpm/rfcs#23, and pnpm/rfcs#25.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the experimental `pnpm pipeline` command for CI-style workspace task execution.
  - Added affected-project selection, dependency-aware scheduling, dry runs, failure reporting, and task-result caching.
  - Added Cargo build-state reuse across worktrees, including restoration after cache deletion.
  - Added pipeline watch mode with retry handling for new revisions.
  - Added optional pipeline run reporting with access controls, authenticated storage, browsing, and run details.
  - Added configuration for pipeline definitions, task inputs, outputs, environments, caching, and workspace-root tasks.

- **Documentation**
  - Added guidance for pipelines, task caching, Cargo caching, and cache benchmarking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->