### PR TITLE
fix: keep a declared range an override repeats verbatim

### DIFF
--- a/.changeset/keep-declared-range-an-override-repeats.md
+++ b/.changeset/keep-declared-range-an-override-repeats.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/hooks.read-package-hook": patch
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm update` no longer moves the range a project declares for a dependency that `overrides` also lists, even when the override repeats that range verbatim. Previously the updated `package.json` disagreed with the lockfile, so the next `pnpm install --frozen-lockfile` failed with a specifier mismatch [#14224](https://github.com/pnpm/pnpm/issues/14224).

--- a/.changeset/keep-declared-range-an-override-repeats.md
+++ b/.changeset/keep-declared-range-an-override-repeats.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/hooks.read-package-hook": patch
+"@pnpm/hooks.read-package-hook": minor
 "@pnpm/installing.deps-installer": patch
 "@pnpm/installing.deps-resolver": patch
 "pacquet": patch

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -1175,6 +1175,26 @@ fn update_keeps_the_catalog_reference_of_an_overridden_dependency() {
     drop((root, anchor));
 }
 
+/// An override claims a dependency even when it repeats the range the project
+/// declares, so the declared range is not the update's to move: the overrides
+/// hook rewrites it back before the resolver reads it, and the lockfile would
+/// then record a specifier the manifest never shows (pnpm/pnpm#14224).
+#[test]
+fn update_keeps_a_declared_range_an_override_repeats() {
+    let (root, workspace, anchor) = setup();
+
+    set_overrides(&workspace, &[(DEP, "^100.0.0")]);
+    write_manifest(&workspace, &format!(r#"{{ "{DEP}": "^100.0.0" }}"#));
+    pacquet(&workspace, ["install"]).assert().success();
+
+    pacquet(&workspace, ["update"]).assert().success();
+
+    assert_eq!(dep_spec(&workspace, DEP).as_deref(), Some("^100.0.0"));
+    pacquet(&workspace, ["install", "--frozen-lockfile"]).assert().success();
+
+    drop((root, anchor));
+}
+
 /// `--latest` reaches the manifest through its own pre-install rewrite, so
 /// it needs the `catalog:` reference to survive an override of its own.
 #[test]

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1263,6 +1263,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 lockfile_dir,
                 resolved_time,
                 manifest_spec_bumps,
+                versions_overrider: versions_overrider.as_deref(),
             })?;
             return finish_lockfile_only::<Reporter>(LockfileOnlyOptions {
                 built_lockfile,
@@ -1305,6 +1306,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             lockfile_dir,
             resolved_time,
             manifest_spec_bumps,
+            versions_overrider: versions_overrider.as_deref(),
         })?;
         tracing::info!(
             target: "pacquet::install::phase",
@@ -2066,6 +2068,10 @@ struct FreshLockfileBuildOptions<'a> {
     resolved_time: BTreeMap<String, String>,
     /// See [`InstallWithFreshLockfile::manifest_spec_bumps`].
     manifest_spec_bumps: Option<&'a crate::ManifestSpecBumps>,
+    /// The override set the run resolved under. Consulted only alongside
+    /// [`Self::manifest_spec_bumps`], to leave a declaration an override
+    /// governs where the project wrote it.
+    versions_overrider: Option<&'a crate::VersionsOverrider>,
 }
 
 /// Build the fresh lockfile, then — under a filtered install — splice it
@@ -2078,6 +2084,8 @@ fn build_lockfile(
     let selected_importer_ids = opts.selected_importer_ids;
     let lockfile_dir = opts.lockfile_dir;
     let manifest_spec_bumps = opts.manifest_spec_bumps;
+    let versions_overrider = opts.versions_overrider;
+    let importer_manifests = opts.importer_manifests;
     let freshly_resolved = build_fresh_lockfile(opts).map_err(|error| {
         InstallWithFreshLockfileError::DependenciesGraphToLockfile(Box::new(error))
     })?;
@@ -2095,7 +2103,15 @@ fn build_lockfile(
         _ => freshly_resolved,
     };
     if let Some(bumps) = manifest_spec_bumps {
-        crate::manifest_spec_bumps::apply_manifest_spec_bumps(&mut built, bumps);
+        let overridden =
+            versions_overrider.filter(|overrider| !overrider.is_empty()).map(|overrider| {
+                crate::manifest_spec_bumps::OverriddenDeclarations { overrider, importer_manifests }
+            });
+        crate::manifest_spec_bumps::apply_manifest_spec_bumps(
+            &mut built,
+            bumps,
+            overridden.as_ref(),
+        );
     }
     Ok(built)
 }
@@ -2122,6 +2138,7 @@ fn build_fresh_lockfile(
         update_reuse_scope,
         update_reuse_scopes_by_importer,
         manifest_spec_bumps: _,
+        versions_overrider: _,
     } = opts;
     let mut importers = BTreeMap::new();
     for (id, manifest) in importer_manifests {

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -1,5 +1,6 @@
 //! Moving an update's declared ranges onto the versions it resolved.
 
+use crate::VersionsOverrider;
 use node_semver::Range;
 use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_lockfile::{
@@ -7,7 +8,7 @@ use pnpm_lockfile::{
     ResolvedDependencySpec,
 };
 use pnpm_lockfile_preferred_versions::get_version_selector_type;
-use pnpm_package_manifest::DependencyGroup;
+use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_registry::RangeSpecStyle;
 use pnpm_resolving_npm_resolver::{calc_version_range, infer_range_spec_style};
 use pnpm_resolving_resolver_base::VersionSelectorType;
@@ -59,6 +60,28 @@ impl AppliedSpecBumps {
     }
 }
 
+/// The override set an update runs under, paired with the importer manifests
+/// whose own name and version a `parent>child` override key is matched
+/// against.
+///
+/// An override governs a declaration even when it repeats it verbatim, and a
+/// declaration an override governs is not the update's to move: the hook
+/// rewrites the bumped text away before the next resolve reads it, leaving a
+/// lockfile specifier the manifest never shows and a `--frozen-lockfile`
+/// install that rejects the pair (pnpm/pnpm#14224).
+pub(crate) struct OverriddenDeclarations<'a> {
+    pub overrider: &'a VersionsOverrider,
+    pub importer_manifests: &'a BTreeMap<String, &'a PackageManifest>,
+}
+
+impl OverriddenDeclarations<'_> {
+    fn governs(&self, importer_id: &str, alias: &str, declared: &str) -> bool {
+        self.importer_manifests.get(importer_id).is_some_and(|manifest| {
+            self.overrider.overrides_dependency(manifest.value(), alias, declared)
+        })
+    }
+}
+
 /// Rewrite the targeted ranges in `lockfile` — which this run built and has
 /// not written yet — around the versions it records, and report them into
 /// [`ManifestSpecBumps::applied`].
@@ -67,7 +90,11 @@ impl AppliedSpecBumps {
 /// agreeing with the `package.json` the update writes afterwards: the two
 /// carry the same text, and the version recorded against it satisfies it by
 /// construction.
-pub(crate) fn apply_manifest_spec_bumps(lockfile: &mut Lockfile, bumps: &ManifestSpecBumps) {
+pub(crate) fn apply_manifest_spec_bumps(
+    lockfile: &mut Lockfile,
+    bumps: &ManifestSpecBumps,
+    overridden: Option<&OverriddenDeclarations<'_>>,
+) {
     let mut manifests: BTreeMap<String, HashMap<PkgName, (DependencyGroupIndex, String)>> =
         BTreeMap::new();
     let mut cataloged: HashSet<(String, PkgName)> = HashSet::new();
@@ -75,17 +102,24 @@ pub(crate) fn apply_manifest_spec_bumps(lockfile: &mut Lockfile, bumps: &Manifes
     for (importer_id, targets) in &bumps.targets {
         let Some(importer) = lockfile.importers.get(importer_id) else { continue };
         for (alias, (manifest_group, manifest_specifier)) in targets {
+            // An override — or another manifest hook — governs this entry, so
+            // the version the run resolved answers the override rather than
+            // the declaration. Leaving the lockfile entry and `package.json`
+            // alone keeps the two agreeing and keeps the declaration, a
+            // `catalog:` reference included (pnpm/pnpm#12115). An override
+            // that repeats the declaration verbatim rewrites nothing, which
+            // is why the text comparison below cannot stand in for this
+            // (pnpm/pnpm#14224).
+            if overridden.is_some_and(|overridden| {
+                overridden.governs(importer_id, alias, manifest_specifier)
+            }) {
+                continue;
+            }
             let Ok(alias) = PkgName::parse(alias.as_str()) else { continue };
             let Some((group, declared)) = declared_dependency(importer, &alias, *manifest_group)
             else {
                 continue;
             };
-            // An override — or another manifest hook — replaced this entry
-            // before the resolver read it, so the version the run resolved
-            // answers the override rather than the declaration. Leaving both
-            // the lockfile entry and `package.json` alone keeps the two
-            // agreeing and keeps the declaration, a `catalog:` reference
-            // included (pnpm/pnpm#12115).
             if declared.specifier != *manifest_specifier {
                 continue;
             }

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -1,6 +1,6 @@
 //! Moving an update's declared ranges onto the versions it resolved.
 
-use crate::VersionsOverrider;
+use crate::{OverriddenDependencyMatcher, VersionsOverrider};
 use node_semver::Range;
 use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_lockfile::{
@@ -74,11 +74,11 @@ pub(crate) struct OverriddenDeclarations<'a> {
     pub importer_manifests: &'a BTreeMap<String, &'a PackageManifest>,
 }
 
-impl OverriddenDeclarations<'_> {
-    fn governs(&self, importer_id: &str, alias: &str, declared: &str) -> bool {
-        self.importer_manifests.get(importer_id).is_some_and(|manifest| {
-            self.overrider.overrides_dependency(manifest.value(), alias, declared)
-        })
+impl<'a> OverriddenDeclarations<'a> {
+    fn matcher_for(&self, importer_id: &str) -> Option<OverriddenDependencyMatcher<'a>> {
+        self.importer_manifests
+            .get(importer_id)
+            .map(|manifest| self.overrider.dependency_matcher(manifest.value()))
     }
 }
 
@@ -101,6 +101,8 @@ pub(crate) fn apply_manifest_spec_bumps(
 
     for (importer_id, targets) in &bumps.targets {
         let Some(importer) = lockfile.importers.get(importer_id) else { continue };
+        let override_matcher =
+            overridden.and_then(|overridden| overridden.matcher_for(importer_id));
         for (alias, (manifest_group, manifest_specifier)) in targets {
             // An override — or another manifest hook — governs this entry, so
             // the version the run resolved answers the override rather than
@@ -110,9 +112,10 @@ pub(crate) fn apply_manifest_spec_bumps(
             // that repeats the declaration verbatim rewrites nothing, which
             // is why the text comparison below cannot stand in for this
             // (pnpm/pnpm#14224).
-            if overridden.is_some_and(|overridden| {
-                overridden.governs(importer_id, alias, manifest_specifier)
-            }) {
+            if override_matcher
+                .as_ref()
+                .is_some_and(|matcher| matcher.matches(alias, manifest_specifier))
+            {
                 continue;
             }
             let Ok(alias) = PkgName::parse(alias.as_str()) else { continue };

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -140,7 +140,7 @@ importers:
     );
 
     let bumps = bumps(&[("foo", DependencyGroup::Dev, "^2.0.0")]);
-    apply_manifest_spec_bumps(&mut lockfile, &bumps);
+    apply_manifest_spec_bumps(&mut lockfile, &bumps, None);
 
     let importer = &lockfile.importers["."];
     assert_eq!(specifier_of(importer.dev_dependencies.as_ref(), "foo"), "^2.1.0");
@@ -168,7 +168,7 @@ importers:
     );
 
     let bumps = bumps(&[("foo", DependencyGroup::Prod, "catalog:")]);
-    apply_manifest_spec_bumps(&mut lockfile, &bumps);
+    apply_manifest_spec_bumps(&mut lockfile, &bumps, None);
 
     assert_eq!(specifier_of(lockfile.importers["."].dependencies.as_ref(), "foo"), "^1.0.0");
     assert!(bumps.applied.into_inner().expect("never poisoned").is_empty());

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps/tests.rs
@@ -1,8 +1,18 @@
-use super::{ManifestSpecBumps, apply_manifest_spec_bumps, bumped_range, split_npm_alias};
+use super::{
+    ManifestSpecBumps, OverriddenDeclarations, apply_manifest_spec_bumps, bumped_range,
+    split_npm_alias,
+};
+use crate::VersionsOverrider;
+use pnpm_catalogs_types::Catalogs;
+use pnpm_config_parse_overrides::parse_overrides;
 use pnpm_lockfile::{ImporterDepVersion, Lockfile, PkgName, ResolvedDependencyMap};
-use pnpm_package_manifest::DependencyGroup;
+use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_registry::RangeSpecStyle;
-use std::collections::{BTreeMap, HashMap};
+use serde_json::json;
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::{Path, PathBuf},
+};
 
 fn lockfile(source: &str) -> Lockfile {
     serde_saphyr::from_str(source).expect("parse lockfile")
@@ -172,4 +182,56 @@ importers:
 
     assert_eq!(specifier_of(lockfile.importers["."].dependencies.as_ref(), "foo"), "^1.0.0");
     assert!(bumps.applied.into_inner().expect("never poisoned").is_empty());
+}
+
+/// Mirrors `update moves a declaration a range-scoped override does not claim`
+/// on the TypeScript side. A range-scoped override claims one declaration of
+/// an alias and not another, so ownership is decided per declared range: the
+/// `devDependencies` entry the override matches stands, and the
+/// `dependencies` entry it does not match is still the update's to move.
+#[test]
+fn a_range_scoped_override_claims_only_the_declaration_it_matches() {
+    let overrides = parse_overrides(
+        &HashMap::from([("foo@^1.0.0".to_string(), "1.0.0".to_string())]),
+        &Catalogs::new(),
+    )
+    .expect("parse the overrides");
+    let overrider = VersionsOverrider::new(&overrides, Path::new("/workspace"));
+    let manifest = PackageManifest::from_value(
+        PathBuf::from("package.json"),
+        json!({
+            "name": "my-app",
+            "version": "1.0.0",
+            "dependencies": { "foo": "^100.0.0" },
+            "devDependencies": { "foo": "^1.0.0" },
+        }),
+    );
+    let importer_manifests = BTreeMap::from([(".".to_string(), &manifest)]);
+    let overridden =
+        OverriddenDeclarations { overrider: &overrider, importer_manifests: &importer_manifests };
+
+    let mut lockfile = lockfile(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      foo:
+        specifier: ^100.0.0
+        version: 100.1.0
+    devDependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+",
+    );
+
+    let unclaimed = bumps(&[("foo", DependencyGroup::Prod, "^100.0.0")]);
+    apply_manifest_spec_bumps(&mut lockfile, &unclaimed, Some(&overridden));
+    assert_eq!(specifier_of(lockfile.importers["."].dependencies.as_ref(), "foo"), "^100.1.0");
+
+    let claimed = bumps(&[("foo", DependencyGroup::Dev, "^1.0.0")]);
+    apply_manifest_spec_bumps(&mut lockfile, &claimed, Some(&overridden));
+    assert_eq!(specifier_of(lockfile.importers["."].dev_dependencies.as_ref(), "foo"), "^1.0.0");
+    assert!(claimed.applied.into_inner().expect("never poisoned").is_empty());
 }

--- a/pnpm/crates/package-manager/src/overrides.rs
+++ b/pnpm/crates/package-manager/src/overrides.rs
@@ -89,6 +89,26 @@ struct LocalTarget {
     specified_via_relative_path: bool,
 }
 
+/// Answers whether an override governs a dependency declared as a given
+/// specifier — whether or not it rewrites the text. An override that repeats
+/// the declaration verbatim still governs it, and a range-scoped override
+/// (`foo@^2`) governs one declaration of `foo` and not another, so the
+/// declared specifier is part of the question.
+///
+/// Built by [`VersionsOverrider::dependency_matcher`] for one manifest.
+pub struct OverriddenDependencyMatcher<'a> {
+    overrider: &'a VersionsOverrider,
+    applicable_parent_scoped: Vec<&'a ResolvedOverride>,
+}
+
+impl OverriddenDependencyMatcher<'_> {
+    #[must_use]
+    pub fn matches(&self, dep_name: &str, dep_spec: &str) -> bool {
+        self.overrider.choose_override(&self.applicable_parent_scoped, dep_name, dep_spec).is_some()
+            || self.overrider.converge_applies(dep_name, dep_spec)
+    }
+}
+
 impl VersionsOverrider {
     /// Build the hook from the parsed overrides set produced by
     /// [`pnpm_config_parse_overrides::parse_overrides`].
@@ -399,14 +419,15 @@ impl VersionsOverrider {
             .then(|| self.converge[dep_name].new_bare_specifier.clone())
     }
 
-    /// `true` when an override governs `dep_name` declared as `dep_spec` in
-    /// `manifest` — whether or not it rewrites the specifier text. An
-    /// override that repeats the declaration verbatim still governs it.
+    /// An [`OverriddenDependencyMatcher`] bound to `manifest`, so the
+    /// parent-scoped overrides that manifest answers to are selected once
+    /// rather than once per dependency asked about.
     #[must_use]
-    pub fn overrides_dependency(&self, manifest: &Value, dep_name: &str, dep_spec: &str) -> bool {
-        let applicable_parent_scoped = self.applicable_parent_scoped(manifest);
-        self.choose_override(&applicable_parent_scoped, dep_name, dep_spec).is_some()
-            || self.converge_applies(dep_name, dep_spec)
+    pub fn dependency_matcher<'a>(&'a self, manifest: &Value) -> OverriddenDependencyMatcher<'a> {
+        OverriddenDependencyMatcher {
+            overrider: self,
+            applicable_parent_scoped: self.applicable_parent_scoped(manifest),
+        }
     }
 
     fn choose_override<'b>(

--- a/pnpm/crates/package-manager/src/overrides.rs
+++ b/pnpm/crates/package-manager/src/overrides.rs
@@ -399,6 +399,16 @@ impl VersionsOverrider {
             .then(|| self.converge[dep_name].new_bare_specifier.clone())
     }
 
+    /// `true` when an override governs `dep_name` declared as `dep_spec` in
+    /// `manifest` — whether or not it rewrites the specifier text. An
+    /// override that repeats the declaration verbatim still governs it.
+    #[must_use]
+    pub fn overrides_dependency(&self, manifest: &Value, dep_name: &str, dep_spec: &str) -> bool {
+        let applicable_parent_scoped = self.applicable_parent_scoped(manifest);
+        self.choose_override(&applicable_parent_scoped, dep_name, dep_spec).is_some()
+            || self.converge_applies(dep_name, dep_spec)
+    }
+
     fn choose_override<'b>(
         &'b self,
         applicable_parent_scoped: &[&'b ResolvedOverride],

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -63,16 +63,25 @@ export function createDependencyOverrider (
 export type OverridableManifest = Pick<ProjectManifest, 'name' | 'version' | DependenciesOrPeersField>
 
 /**
- * The names of a manifest's declared dependencies that an override claims —
- * whether or not it rewrites their specifier text.
+ * Whether an override claims a dependency declared as `bareSpecifier` —
+ * whether or not it rewrites the text. The specifier is part of the question:
+ * a range-scoped override (`foo@^2`) claims one declaration of `foo` and not
+ * another, so an alias alone cannot answer it.
+ */
+export type OverriddenDependencyMatcher = (alias: string, bareSpecifier: string) => boolean
+
+/**
+ * Builds an {@link OverriddenDependencyMatcher} for a manifest, so the
+ * parent-scoped overrides that manifest answers to are selected once rather
+ * than per dependency.
  *
  * `undefined` when no override could claim anything, so a caller with no
- * overrides configured skips the walk.
+ * overrides configured skips the work.
  */
-export function createOverriddenDependencyFinder (
+export function createOverriddenDependencyMatcher (
   overrides: VersionOverrideWithoutRawSelector[],
   rootDir: string
-): ((manifest: OverridableManifest) => Set<string>) | undefined {
+): ((manifest: OverridableManifest) => OverriddenDependencyMatcher) | undefined {
   const { versionOverrides, genericVersionOverrides, convergeVersions } = splitOverrides(overrides, rootDir)
   if (versionOverrides.length === 0 && genericVersionOverrides.length === 0 && convergeVersions.size === 0) {
     return undefined
@@ -82,18 +91,9 @@ export function createOverriddenDependencyFinder (
       versionOverrides: pickOverridesOfParent(versionOverrides, manifest),
       genericVersionOverrides,
     }
-    const overridden = new Set<string>()
-    for (const depsField of DEPENDENCIES_OR_PEER_FIELDS) {
-      for (const [name, bareSpecifier] of Object.entries(manifest[depsField] ?? {})) {
-        if (
-          pickVersionOverride(overridesForManifest, name, bareSpecifier) != null ||
-          convergeBareSpecifier(convergeVersions, name, bareSpecifier) != null
-        ) {
-          overridden.add(name)
-        }
-      }
-    }
-    return overridden
+    return (alias, bareSpecifier) =>
+      pickVersionOverride(overridesForManifest, alias, bareSpecifier) != null ||
+      convergeBareSpecifier(convergeVersions, alias, bareSpecifier) != null
   }
 }
 

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import type { PackageSelector, VersionOverride as VersionOverrideBase } from '@pnpm/config.parse-overrides'
 import { isValidPeerRange } from '@pnpm/deps.peer-range'
-import { type Dependencies, DEPENDENCIES_OR_PEER_FIELDS, type PackageManifest, type ReadPackageHook } from '@pnpm/types'
+import { type Dependencies, DEPENDENCIES_OR_PEER_FIELDS, type DependenciesOrPeersField, type PackageManifest, type ProjectManifest, type ReadPackageHook } from '@pnpm/types'
 import normalizePath from 'normalize-path'
 import { partition } from 'ramda'
 import semver from 'semver'
@@ -54,6 +54,49 @@ export function createDependencyOverrider (
   }
 }
 
+/**
+ * What an override needs to read to decide whether it claims a dependency: the
+ * parent half of a `parent>child` key is matched against the manifest's own
+ * name and version. Workspace projects may declare neither, so this is wider
+ * than {@link PackageManifest}.
+ */
+export type OverridableManifest = Pick<ProjectManifest, 'name' | 'version' | DependenciesOrPeersField>
+
+/**
+ * The names of a manifest's declared dependencies that an override claims —
+ * whether or not it rewrites their specifier text.
+ *
+ * `undefined` when no override could claim anything, so a caller with no
+ * overrides configured skips the walk.
+ */
+export function createOverriddenDependencyFinder (
+  overrides: VersionOverrideWithoutRawSelector[],
+  rootDir: string
+): ((manifest: OverridableManifest) => Set<string>) | undefined {
+  const { versionOverrides, genericVersionOverrides, convergeVersions } = splitOverrides(overrides, rootDir)
+  if (versionOverrides.length === 0 && genericVersionOverrides.length === 0 && convergeVersions.size === 0) {
+    return undefined
+  }
+  return (manifest) => {
+    const overridesForManifest = {
+      versionOverrides: pickOverridesOfParent(versionOverrides, manifest),
+      genericVersionOverrides,
+    }
+    const overridden = new Set<string>()
+    for (const depsField of DEPENDENCIES_OR_PEER_FIELDS) {
+      for (const [name, bareSpecifier] of Object.entries(manifest[depsField] ?? {})) {
+        if (
+          pickVersionOverride(overridesForManifest, name, bareSpecifier) != null ||
+          convergeBareSpecifier(convergeVersions, name, bareSpecifier) != null
+        ) {
+          overridden.add(name)
+        }
+      }
+    }
+    return overridden
+  }
+}
+
 export function createVersionsOverrider (
   overrides: VersionOverrideWithoutRawSelector[],
   rootDir: string,
@@ -61,12 +104,7 @@ export function createVersionsOverrider (
 ): ReadPackageHook {
   const { versionOverrides, genericVersionOverrides, convergeVersions } = splitOverrides(overrides, rootDir)
   return ((manifest: PackageManifest, dir?: string) => {
-    const versionOverridesWithParent = versionOverrides.filter(({ parentPkg }) => {
-      return (
-        parentPkg.name === manifest.name &&
-        (!parentPkg.bareSpecifier || semver.satisfies(manifest.version, parentPkg.bareSpecifier))
-      )
-    })
+    const versionOverridesWithParent = pickOverridesOfParent(versionOverrides, manifest)
     // The manifest may come from a shared cache, so the fields the overrides
     // rewrite are cloned instead of mutated in place.
     const clonedManifest = { ...manifest }
@@ -82,6 +120,20 @@ export function createVersionsOverrider (
 
     return clonedManifest
   }) as ReadPackageHook
+}
+
+/**
+ * The parent-scoped overrides (`parent>child`) whose parent half this manifest
+ * answers to. The rest never govern its dependencies.
+ */
+function pickOverridesOfParent (
+  versionOverrides: VersionOverrideWithParent[],
+  manifest: OverridableManifest
+): VersionOverrideWithParent[] {
+  return versionOverrides.filter(({ parentPkg }) => (
+    parentPkg.name === manifest.name &&
+    (!parentPkg.bareSpecifier || (manifest.version != null && semver.satisfies(manifest.version, parentPkg.bareSpecifier)))
+  ))
 }
 
 function splitOverrides (overrides: VersionOverrideWithoutRawSelector[], rootDir: string): {

--- a/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
+++ b/pnpm11/hooks/read-package-hook/src/createVersionsOverrider.ts
@@ -71,12 +71,14 @@ export type OverridableManifest = Pick<ProjectManifest, 'name' | 'version' | Dep
 export type OverriddenDependencyMatcher = (alias: string, bareSpecifier: string) => boolean
 
 /**
- * Builds an {@link OverriddenDependencyMatcher} for a manifest, so the
- * parent-scoped overrides that manifest answers to are selected once rather
- * than per dependency.
+ * Builds an {@link OverriddenDependencyMatcher} for one manifest: a
+ * `parent>child` override key is matched against that manifest's own name and
+ * version, so a project asks only about the overrides that govern its own
+ * declarations. Binding to the manifest also selects those once, rather than
+ * once per dependency asked about.
  *
- * `undefined` when no override could claim anything, so a caller with no
- * overrides configured skips the work.
+ * `undefined` when no override in the set could claim anything, so a caller
+ * with none configured skips the work entirely.
  */
 export function createOverriddenDependencyMatcher (
   overrides: VersionOverrideWithoutRawSelector[],

--- a/pnpm11/hooks/read-package-hook/src/index.ts
+++ b/pnpm11/hooks/read-package-hook/src/index.ts
@@ -1,2 +1,2 @@
 export { createReadPackageHook, getEffectivePackageExtensions } from './createReadPackageHook.js'
-export { createDependencyOverrider, type DependencyOverrider } from './createVersionsOverrider.js'
+export { createDependencyOverrider, createOverriddenDependencyFinder, type DependencyOverrider } from './createVersionsOverrider.js'

--- a/pnpm11/hooks/read-package-hook/src/index.ts
+++ b/pnpm11/hooks/read-package-hook/src/index.ts
@@ -1,2 +1,2 @@
 export { createReadPackageHook, getEffectivePackageExtensions } from './createReadPackageHook.js'
-export { createDependencyOverrider, createOverriddenDependencyFinder, type DependencyOverrider } from './createVersionsOverrider.js'
+export { createDependencyOverrider, createOverriddenDependencyMatcher, type DependencyOverrider, type OverriddenDependencyMatcher } from './createVersionsOverrider.js'

--- a/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { describe, expect, test } from '@jest/globals'
 import { parseOverrides } from '@pnpm/config.parse-overrides'
 
-import { createDependencyOverrider, createOverriddenDependencyFinder, createVersionsOverrider } from '../src/createVersionsOverrider.js'
+import { createDependencyOverrider, createOverriddenDependencyMatcher, createVersionsOverrider } from '../src/createVersionsOverrider.js'
 
 test('createVersionsOverrider() matches sub-ranges', () => {
   const overrider = createVersionsOverrider([
@@ -978,56 +978,45 @@ describe('createDependencyOverrider()', () => {
   })
 })
 
-describe('createOverriddenDependencyFinder()', () => {
-  test('reports a dependency an override repeats verbatim', () => {
-    const findOverriddenDependencies = createOverriddenDependencyFinder(
+describe('createOverriddenDependencyMatcher()', () => {
+  test('claims a dependency an override repeats verbatim, and no other', () => {
+    const isOverridden = createOverriddenDependencyMatcher(
       parseOverrides({ foo: '^1.0.0' }, {}),
       process.cwd()
-    )!
-    expect(findOverriddenDependencies({
-      dependencies: { foo: '^1.0.0', bar: '^1.0.0' },
-    })).toStrictEqual(new Set(['foo']))
+    )!({})
+    expect(isOverridden('foo', '^1.0.0')).toBe(true)
+    expect(isOverridden('bar', '^1.0.0')).toBe(false)
   })
 
-  test('skips an override whose selector cannot claim the declared range', () => {
-    const findOverriddenDependencies = createOverriddenDependencyFinder(
+  test('answers per declared range, so a range-scoped override claims only the declaration it matches', () => {
+    const isOverridden = createOverriddenDependencyMatcher(
       parseOverrides({ 'foo@^2.0.0': '2.1.0' }, {}),
       process.cwd()
-    )!
-    expect(findOverriddenDependencies({ dependencies: { foo: '^1.0.0' } })).toStrictEqual(new Set())
-    expect(findOverriddenDependencies({ dependencies: { foo: '^2.0.0' } })).toStrictEqual(new Set(['foo']))
+    )!({})
+    expect(isOverridden('foo', '^1.0.0')).toBe(false)
+    expect(isOverridden('foo', '^2.0.0')).toBe(true)
   })
 
   test('scopes a parent-qualified override to the project it names', () => {
-    const findOverriddenDependencies = createOverriddenDependencyFinder(
+    const matcherFor = createOverriddenDependencyMatcher(
       parseOverrides({ 'parent>foo': '1.0.0' }, {}),
       process.cwd()
     )!
-    expect(findOverriddenDependencies({
-      name: 'parent',
-      version: '1.0.0',
-      devDependencies: { foo: '^1.0.0' },
-    })).toStrictEqual(new Set(['foo']))
-    expect(findOverriddenDependencies({
-      name: 'other',
-      version: '1.0.0',
-      devDependencies: { foo: '^1.0.0' },
-    })).toStrictEqual(new Set())
+    expect(matcherFor({ name: 'parent', version: '1.0.0' })('foo', '^1.0.0')).toBe(true)
+    expect(matcherFor({ name: 'other', version: '1.0.0' })('foo', '^1.0.0')).toBe(false)
   })
 
-  test('reports a dependency a convergence override can move, and no others', () => {
-    const findOverriddenDependencies = createOverriddenDependencyFinder(
+  test('claims a dependency a convergence override can move, and no others', () => {
+    const isOverridden = createOverriddenDependencyMatcher(
       parseOverrides({ 'foo@': '1.5.0' }, {}),
       process.cwd()
-    )!
-    expect(findOverriddenDependencies({
-      dependencies: { foo: '^1.0.0' },
-      peerDependencies: { bar: '^1.0.0' },
-    })).toStrictEqual(new Set(['foo']))
-    expect(findOverriddenDependencies({ dependencies: { foo: '^2.0.0' } })).toStrictEqual(new Set())
+    )!({})
+    expect(isOverridden('foo', '^1.0.0')).toBe(true)
+    expect(isOverridden('foo', '^2.0.0')).toBe(false)
+    expect(isOverridden('bar', '^1.0.0')).toBe(false)
   })
 
   test('is undefined when no override could claim anything', () => {
-    expect(createOverriddenDependencyFinder([], process.cwd())).toBeUndefined()
+    expect(createOverriddenDependencyMatcher([], process.cwd())).toBeUndefined()
   })
 })

--- a/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
+++ b/pnpm11/hooks/read-package-hook/test/createVersionOverrider.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import { describe, expect, test } from '@jest/globals'
 import { parseOverrides } from '@pnpm/config.parse-overrides'
 
-import { createDependencyOverrider, createVersionsOverrider } from '../src/createVersionsOverrider.js'
+import { createDependencyOverrider, createOverriddenDependencyFinder, createVersionsOverrider } from '../src/createVersionsOverrider.js'
 
 test('createVersionsOverrider() matches sub-ranges', () => {
   const overrider = createVersionsOverrider([
@@ -975,5 +975,59 @@ describe('createDependencyOverrider()', () => {
     }), process.cwd())!
     expect(overrideDependency('react', '^18.0.0')).toBe('18.3.1')
     expect(overrideDependency('react', '^19.0.0')).toBeUndefined()
+  })
+})
+
+describe('createOverriddenDependencyFinder()', () => {
+  test('reports a dependency an override repeats verbatim', () => {
+    const findOverriddenDependencies = createOverriddenDependencyFinder(
+      parseOverrides({ foo: '^1.0.0' }, {}),
+      process.cwd()
+    )!
+    expect(findOverriddenDependencies({
+      dependencies: { foo: '^1.0.0', bar: '^1.0.0' },
+    })).toStrictEqual(new Set(['foo']))
+  })
+
+  test('skips an override whose selector cannot claim the declared range', () => {
+    const findOverriddenDependencies = createOverriddenDependencyFinder(
+      parseOverrides({ 'foo@^2.0.0': '2.1.0' }, {}),
+      process.cwd()
+    )!
+    expect(findOverriddenDependencies({ dependencies: { foo: '^1.0.0' } })).toStrictEqual(new Set())
+    expect(findOverriddenDependencies({ dependencies: { foo: '^2.0.0' } })).toStrictEqual(new Set(['foo']))
+  })
+
+  test('scopes a parent-qualified override to the project it names', () => {
+    const findOverriddenDependencies = createOverriddenDependencyFinder(
+      parseOverrides({ 'parent>foo': '1.0.0' }, {}),
+      process.cwd()
+    )!
+    expect(findOverriddenDependencies({
+      name: 'parent',
+      version: '1.0.0',
+      devDependencies: { foo: '^1.0.0' },
+    })).toStrictEqual(new Set(['foo']))
+    expect(findOverriddenDependencies({
+      name: 'other',
+      version: '1.0.0',
+      devDependencies: { foo: '^1.0.0' },
+    })).toStrictEqual(new Set())
+  })
+
+  test('reports a dependency a convergence override can move, and no others', () => {
+    const findOverriddenDependencies = createOverriddenDependencyFinder(
+      parseOverrides({ 'foo@': '1.5.0' }, {}),
+      process.cwd()
+    )!
+    expect(findOverriddenDependencies({
+      dependencies: { foo: '^1.0.0' },
+      peerDependencies: { bar: '^1.0.0' },
+    })).toStrictEqual(new Set(['foo']))
+    expect(findOverriddenDependencies({ dependencies: { foo: '^2.0.0' } })).toStrictEqual(new Set())
+  })
+
+  test('is undefined when no override could claim anything', () => {
+    expect(createOverriddenDependencyFinder([], process.cwd())).toBeUndefined()
   })
 })

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -33,7 +33,7 @@ import {
   runLifecycleHooksConcurrently,
   type RunLifecycleHooksConcurrentlyOptions,
 } from '@pnpm/exec.lifecycle'
-import { createDependencyOverrider } from '@pnpm/hooks.read-package-hook'
+import { createDependencyOverrider, createOverriddenDependencyFinder } from '@pnpm/hooks.read-package-hook'
 import { getContext, type PnpmContext } from '@pnpm/installing.context'
 import {
   type DependenciesGraph,
@@ -1764,6 +1764,7 @@ export type ImporterToUpdate = {
   id: ProjectId
   manifest: ProjectManifest
   originalManifest?: ProjectManifest
+  overriddenDependencyNames?: Set<string>
   modulesDir: string
   rootDir: ProjectRootDir
   pruneDirectDependencies: boolean
@@ -1870,6 +1871,16 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
         }
       })
   )
+
+  // Only the projects whose manifest this run writes need the answer, and only
+  // the manifest on disk — the one the overrides hook read — can give it.
+  const findOverriddenDependencies = createOverriddenDependencyFinder(opts.parsedOverrides, opts.lockfileDir)
+  if (findOverriddenDependencies != null) {
+    for (const project of projects) {
+      if (!project.updatePackageManifest) continue
+      project.overriddenDependencyNames = findOverriddenDependencies(project.originalManifest ?? project.manifest)
+    }
+  }
 
   stageLogger.debug({
     prefix: ctx.lockfileDir,

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -33,7 +33,7 @@ import {
   runLifecycleHooksConcurrently,
   type RunLifecycleHooksConcurrentlyOptions,
 } from '@pnpm/exec.lifecycle'
-import { createDependencyOverrider, createOverriddenDependencyFinder } from '@pnpm/hooks.read-package-hook'
+import { createDependencyOverrider, createOverriddenDependencyMatcher, type OverriddenDependencyMatcher } from '@pnpm/hooks.read-package-hook'
 import { getContext, type PnpmContext } from '@pnpm/installing.context'
 import {
   type DependenciesGraph,
@@ -1764,7 +1764,7 @@ export type ImporterToUpdate = {
   id: ProjectId
   manifest: ProjectManifest
   originalManifest?: ProjectManifest
-  overriddenDependencyNames?: Set<string>
+  isOverriddenDependency?: OverriddenDependencyMatcher
   modulesDir: string
   rootDir: ProjectRootDir
   pruneDirectDependencies: boolean
@@ -1874,11 +1874,11 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
 
   // Only the projects whose manifest this run writes need the answer, and only
   // the manifest on disk — the one the overrides hook read — can give it.
-  const findOverriddenDependencies = createOverriddenDependencyFinder(opts.parsedOverrides, opts.lockfileDir)
-  if (findOverriddenDependencies != null) {
+  const overriddenDependencyMatcherFor = createOverriddenDependencyMatcher(opts.parsedOverrides, opts.lockfileDir)
+  if (overriddenDependencyMatcherFor != null) {
     for (const project of projects) {
       if (!project.updatePackageManifest) continue
-      project.overriddenDependencyNames = findOverriddenDependencies(project.originalManifest ?? project.manifest)
+      project.isOverriddenDependency = overriddenDependencyMatcherFor(project.originalManifest ?? project.manifest)
     }
   }
 

--- a/pnpm11/installing/deps-installer/test/install/overrides.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrides.ts
@@ -669,3 +669,38 @@ test('overrides remove dependencies', async () => {
   const currentLockfile = project.readCurrentLockfile()
   expect(lockfile.overrides).toStrictEqual(currentLockfile.overrides)
 })
+
+// Regression test for https://github.com/pnpm/pnpm/issues/14224
+// An override claims the dependency even when it repeats the range the project
+// declares, so the declared range is not the update's to move: the overrides
+// hook rewrites it back before the resolver reads it, and the lockfile would
+// then record a specifier the manifest never shows.
+test('update keeps the declared range of a dependency an override repeats', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+  }
+  const options = testDefaults({
+    overrides: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const { updatedProject } = await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, { ...options, update: true, updatePackageManifest: true })
+
+  expect(updatedProject.manifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '^100.0.0' })
+  expect(project.readLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].specifier).toBe('^100.0.0')
+})

--- a/pnpm11/installing/deps-installer/test/install/overrides.ts
+++ b/pnpm11/installing/deps-installer/test/install/overrides.ts
@@ -704,3 +704,40 @@ test('update keeps the declared range of a dependency an override repeats', asyn
   expect(updatedProject.manifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '^100.0.0' })
   expect(project.readLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].specifier).toBe('^100.0.0')
 })
+
+// A range-scoped override claims one declaration of an alias and not another,
+// so ownership is decided per declared range rather than per name. Here the
+// override matches only the `devDependencies` entry; the `dependencies` one
+// the manifest writer reaches is still the update's to move.
+test('update moves a declaration a range-scoped override does not claim', async () => {
+  await addDistTag({ package: '@pnpm.e2e/foo', version: '100.1.0', distTag: 'latest' })
+  const project = prepareEmpty()
+  const manifest: ProjectManifest = {
+    dependencies: {
+      '@pnpm.e2e/foo': '^100.0.0',
+    },
+    devDependencies: {
+      '@pnpm.e2e/foo': '^1.0.0',
+    },
+  }
+  const options = testDefaults({
+    overrides: {
+      '@pnpm.e2e/foo@^1.0.0': '1.0.0',
+    },
+  })
+
+  await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, options)
+
+  const { updatedProject } = await mutateModulesInSingleProject({
+    manifest,
+    mutation: 'install',
+    rootDir: process.cwd() as ProjectRootDir,
+  }, { ...options, update: true, updatePackageManifest: true })
+
+  expect(updatedProject.manifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '^100.1.0' })
+  expect(project.readLockfile().importers['.'].dependencies?.['@pnpm.e2e/foo'].specifier).toBe('^100.1.0')
+})

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -102,10 +102,11 @@ export interface ImporterToResolve extends Importer<{
   manifest: ProjectManifest
   originalManifest?: ProjectManifest
   /**
-   * The direct dependencies an override claims, so `updateProjectManifest`
-   * can tell a declared range the update owns from one the override governs.
+   * Tells a declared range the update owns from one an override governs, so
+   * `updateProjectManifest` leaves the latter where the project wrote it.
+   * Built per project by `@pnpm/hooks.read-package-hook`.
    */
-  overriddenDependencyNames?: Set<string>
+  isOverriddenDependency?: (alias: string, bareSpecifier: string) => boolean
   update?: boolean
   updateMatching?: UpdateMatchingFunction
   updatePackageManifest: boolean

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -101,6 +101,11 @@ export interface ImporterToResolve extends Importer<{
   binsDir: string
   manifest: ProjectManifest
   originalManifest?: ProjectManifest
+  /**
+   * The direct dependencies an override claims, so `updateProjectManifest`
+   * can tell a declared range the update owns from one the override governs.
+   */
+  overriddenDependencyNames?: Set<string>
   update?: boolean
   updateMatching?: UpdateMatchingFunction
   updatePackageManifest: boolean

--- a/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
@@ -24,7 +24,7 @@ export async function updateProjectManifest (
   for (const rdd of opts.directDependencies) {
     const wantedDep = rdd.wantedDependency
     if (wantedDep?.updateSpec !== true) continue
-    const declaredSpecifier = getDeclaredSpecifierReplacedByHook(importer, rdd)
+    const declaredSpecifier = getDeclaredSpecifierOwnedByHook(importer, rdd)
     if (declaredSpecifier != null) {
       declaredSpecifiers.set(rdd.alias, declaredSpecifier)
     }
@@ -72,21 +72,26 @@ export async function updateProjectManifest (
 }
 
 /**
- * The specifier the project declares on disk for a direct dependency whose
- * entry a `readPackage` hook — a version override, most often — replaced in
- * the manifest handed to the resolver. `undefined` when the declaration is
- * what resolution followed, and the update owns it.
+ * The specifier the project declares on disk for a direct dependency an
+ * override — or another `readPackage` hook — governs in the manifest handed to
+ * the resolver. `undefined` when the declaration is what resolution followed,
+ * and the update owns it.
  *
- * The version resolution settled on answers the hook, not the declaration, so
- * neither manifest's entry is the update's to move: writing the resolved range
- * over them bakes the override into every project that declares the package —
- * replacing a `catalog:` reference with a version (pnpm/pnpm#12115) — and
- * contradicts the override on the next install.
+ * The version resolution settled on answers the override, not the declaration,
+ * so neither manifest's entry is the update's to move: writing the resolved
+ * range over them bakes the override into every project that declares the
+ * package — replacing a `catalog:` reference with a version (pnpm/pnpm#12115)
+ * — and leaves a specifier the hook rewrites away on the next install, which
+ * `--frozen-lockfile` then rejects (pnpm/pnpm#14224).
+ *
+ * An override that repeats the declared range verbatim governs it just the
+ * same, so a hook that rewrote nothing is recognized through
+ * `overriddenDependencyNames` rather than by comparing the two manifests.
  *
  * A dependency this run names with a specifier of its own (`pnpm add foo@2`)
  * is exempt: that request is the manifest's new specifier.
  */
-function getDeclaredSpecifierReplacedByHook (
+function getDeclaredSpecifierOwnedByHook (
   importer: ImporterToResolve,
   rdd: ResolvedDirectDependency
 ): string | undefined {
@@ -94,7 +99,10 @@ function getDeclaredSpecifierReplacedByHook (
   const hookedSpecifier = getSpecFromPackageManifest(importer.manifest, rdd.alias)
   if (hookedSpecifier === '' || hookedSpecifier !== rdd.wantedDependency?.bareSpecifier) return undefined
   const declaredSpecifier = getSpecFromPackageManifest(importer.originalManifest, rdd.alias)
-  return declaredSpecifier !== '' && declaredSpecifier !== hookedSpecifier ? declaredSpecifier : undefined
+  if (declaredSpecifier === '') return undefined
+  return declaredSpecifier !== hookedSpecifier || importer.overriddenDependencyNames?.has(rdd.alias) === true
+    ? declaredSpecifier
+    : undefined
 }
 
 function getBareSpecifierToSave (

--- a/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
@@ -86,7 +86,7 @@ export async function updateProjectManifest (
  *
  * An override that repeats the declared range verbatim governs it just the
  * same, so a hook that rewrote nothing is recognized through
- * `overriddenDependencyNames` rather than by comparing the two manifests.
+ * `isOverriddenDependency` rather than by comparing the two manifests.
  *
  * A dependency this run names with a specifier of its own (`pnpm add foo@2`)
  * is exempt: that request is the manifest's new specifier.
@@ -100,7 +100,7 @@ function getDeclaredSpecifierOwnedByHook (
   if (hookedSpecifier === '' || hookedSpecifier !== rdd.wantedDependency?.bareSpecifier) return undefined
   const declaredSpecifier = getSpecFromPackageManifest(importer.originalManifest, rdd.alias)
   if (declaredSpecifier === '') return undefined
-  return declaredSpecifier !== hookedSpecifier || importer.overriddenDependencyNames?.has(rdd.alias) === true
+  return declaredSpecifier !== hookedSpecifier || importer.isOverriddenDependency?.(rdd.alias, declaredSpecifier) === true
     ? declaredSpecifier
     : undefined
 }


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14223, which fixed the half of this family where the override's text *differs* from the declaration.

An override governs a direct dependency's specifier whether or not it rewrites the text. When it repeats the declared range verbatim — `"foo": "^1.0.0"` with `overrides: { foo: '^1.0.0' }` — the overrides hook leaves the manifest byte-identical, so comparing the hooked manifest against the one on disk (the test pnpm/pnpm#14223 introduced) sees nothing. `pnpm update` then moved the declaration onto the version it resolved while the override held the resolver's view at the old range:

```
specifiers in the lockfile don't match specifiers in package.json:
* in importers["."]:
  - @pnpm.e2e/foo (lockfile: ^100.1.0, manifest: ^100.0.0)
```

`package.json` got `^100.1.0`, the hook rewrote that back to `^100.0.0` before the next resolve read it, and the lockfile kept a specifier the manifest never shows — so the next `pnpm install --frozen-lockfile` failed.

**TypeScript** — `@pnpm/hooks.read-package-hook` now also exports `createOverriddenDependencyMatcher`, which binds to one manifest and answers whether an override claims a dependency at a given declared specifier (parent-scoped `parent>child` keys, range-scoped `foo@^2` keys, and `foo@` convergence overrides included), reusing the same selection the hook itself runs. The install builds one matcher per manifest-writing project from the on-disk manifest; `updateProjectManifest` asks it with the declaration it is about to move, so a declaration an override governs is recognised even where no text changed.

The specifier is part of the question by design: a range-scoped override claims one declaration of an alias and not another, so an alias alone cannot answer it.

**pacquet** — `apply_manifest_spec_bumps` consults the run's own `VersionsOverrider` (already built for the resolve) before moving a range, matching each target's alias and declared specifier against it. `VersionsOverrider::dependency_matcher` returns the same per-manifest `OverriddenDependencyMatcher` shape, so the parent-scoped filter runs once per importer rather than once per target.

Closes pnpm/pnpm#14224

## Squash Commit Body

```text
An override governs a direct dependency's specifier whether or not it
rewrites the text. When it repeats the declared range, the overrides hook
leaves the manifest byte-identical, so comparing the hooked manifest with
the one on disk — the test the previous fix used — sees nothing. `pnpm
update` then moved the declaration onto the version it resolved while the
override held the resolver's view at the old range, and the lockfile
recorded a specifier the manifest never shows. The next
`--frozen-lockfile` install rejected the pair.

The overrides hook now also answers which of a manifest's dependencies it
claims, so the manifest writer can recognise a declaration it does not
own even where no text changed. pacquet reaches the same entries through
`ManifestSpecBumps`, whose apply step consults the run's own
`VersionsOverrider` before moving a range.

Closes pnpm/pnpm#14224
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm update` now preserves dependency ranges when matching entries are also declared in `overrides`.
  * Prevented manifest and lockfile specifier mismatches that could cause subsequent frozen-lockfile installs to fail.
  * Ensured range-scoped overrides only affect the intended dependency entries.

* **Tests**
  * Added coverage for repeated override ranges and successful frozen-lockfile installation.
  * Added tests for verbatim, range-based, parent-scoped, and convergence override matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->