### PR TITLE
fix(cli): accept `--shamefully-hoist` option

### DIFF
--- a/.changeset/shamefully-hoist-cli-option.md
+++ b/.changeset/shamefully-hoist-cli-option.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed the `--shamefully-hoist` CLI option being rejected [pnpm/pnpm#14235](https://github.com/pnpm/pnpm/issues/14235).

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -468,6 +468,9 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
         if key.is_empty() {
             return ConfigToken::Malformed;
         }
+        if key == "shamefully-hoist" && parse_bool(value).is_none() {
+            return ConfigToken::NotOurs;
+        }
         return ConfigToken::WellFormed { key, value };
     }
     match arg {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -480,6 +480,7 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
         _ => {}
     }
     match arg.strip_prefix("--").and_then(|flag| flag.split_once('=')) {
+        Some(("shamefully-hoist", value)) if parse_bool(value).is_none() => ConfigToken::NotOurs,
         Some((key, value)) if BARE_SETTING_FLAGS.contains(&key) => {
             ConfigToken::WellFormed { key, value }
         }

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -108,6 +108,7 @@ pub struct ConfigOverrides {
     pending: Option<bool>,
     recursive_install: Option<bool>,
     reverse: Option<bool>,
+    shamefully_hoist: Option<bool>,
     shell_emulator: Option<bool>,
     skip_manifest_obfuscation: Option<bool>,
     sort: Option<bool>,
@@ -188,6 +189,7 @@ impl ConfigOverrides {
             "pending" => self.pending = parse_bool(value),
             "recursive-install" => self.recursive_install = parse_bool(value),
             "reverse" => self.reverse = parse_bool(value),
+            "shamefully-hoist" => self.shamefully_hoist = parse_bool(value),
             "shell-emulator" => self.shell_emulator = parse_bool(value),
             "skip-manifest-obfuscation" => {
                 self.skip_manifest_obfuscation = parse_bool(value);
@@ -329,6 +331,11 @@ impl ConfigOverrides {
         if let Some(value) = self.reverse {
             config.reverse = value;
         }
+        if let Some(value) = self.shamefully_hoist {
+            config.shamefully_hoist = value;
+            config.explicit_settings.insert("shamefullyHoist".to_string(), value.into());
+            config.apply_shamefully_hoist_derivation();
+        }
         if let Some(value) = self.shell_emulator {
             config.shell_emulator = value;
         }
@@ -462,6 +469,15 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
         }
         return ConfigToken::WellFormed { key, value };
     }
+    match arg {
+        "--shamefully-hoist" => {
+            return ConfigToken::WellFormed { key: "shamefully-hoist", value: "true" };
+        }
+        "--no-shamefully-hoist" => {
+            return ConfigToken::WellFormed { key: "shamefully-hoist", value: "false" };
+        }
+        _ => {}
+    }
     match arg.strip_prefix("--").and_then(|flag| flag.split_once('=')) {
         Some((key, value)) if BARE_SETTING_FLAGS.contains(&key) => {
             ConfigToken::WellFormed { key, value }
@@ -474,7 +490,7 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
 /// `--<setting>=<value>` flag. pnpm accepts every setting that way; pacquet
 /// only declares a clap flag for a subset, so these are recognized here to
 /// keep the hints they appear in actionable.
-const BARE_SETTING_FLAGS: [&str; 2] = ["pm-on-fail", "runtime-on-fail"];
+const BARE_SETTING_FLAGS: [&str; 3] = ["pm-on-fail", "runtime-on-fail", "shamefully-hoist"];
 
 fn scoped_registry_key(key: &str) -> Option<&str> {
     key.strip_suffix(":registry")

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -335,6 +335,7 @@ impl ConfigOverrides {
             config.shamefully_hoist = value;
             config.explicit_settings.insert("shamefullyHoist".to_string(), value.into());
             config.apply_shamefully_hoist_derivation();
+            config.apply_virtual_store_only_derivation();
         }
         if let Some(value) = self.shell_emulator {
             config.shell_emulator = value;

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -67,6 +67,12 @@ fn extract_accepts_shamefully_hoist_cli_spellings() {
         ("--shamefully-hoist", true),
         ("--shamefully-hoist=true", true),
         ("--shamefully-hoist=false", false),
+        ("--shamefully-hoist=1", true),
+        ("--shamefully-hoist=0", false),
+        ("--config.shamefully-hoist=true", true),
+        ("--config.shamefully-hoist=false", false),
+        ("--config.shamefully-hoist=1", true),
+        ("--config.shamefully-hoist=0", false),
         ("--no-shamefully-hoist", false),
     ] {
         let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "--version"]));
@@ -82,6 +88,23 @@ fn extract_accepts_shamefully_hoist_cli_spellings() {
             Some(&serde_json::Value::Bool(expected)),
         );
     }
+}
+
+#[test]
+fn shamefully_hoist_override_preserves_virtual_store_only_precedence() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "--shamefully-hoist=true", "install"]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config {
+        virtual_store_only: true,
+        hoist_pattern: Some(vec!["*".to_string()]),
+        ..Config::default()
+    };
+    overrides.apply(&mut config);
+
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
+    assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -109,7 +109,12 @@ fn shamefully_hoist_override_preserves_virtual_store_only_precedence() {
 
 #[test]
 fn extract_leaves_invalid_shamefully_hoist_values_for_clap() {
-    for flag in ["--shamefully-hoist=yes", "--shamefully-hoist="] {
+    for flag in [
+        "--shamefully-hoist=yes",
+        "--shamefully-hoist=",
+        "--config.shamefully-hoist=yes",
+        "--config.shamefully-hoist=",
+    ] {
         let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "--version"]));
         assert_eq!(remaining, argv(["pacquet", flag, "--version"]));
 

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -62,6 +62,29 @@ fn extract_accepts_the_on_fail_settings_as_bare_flags() {
 }
 
 #[test]
+fn extract_accepts_shamefully_hoist_cli_spellings() {
+    for (flag, expected) in [
+        ("--shamefully-hoist", true),
+        ("--shamefully-hoist=true", true),
+        ("--shamefully-hoist=false", false),
+        ("--no-shamefully-hoist", false),
+    ] {
+        let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "--version"]));
+        assert_eq!(remaining, argv(["pacquet", "--version"]));
+
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert_eq!(config.shamefully_hoist, expected);
+        let expected_public_hoist_pattern = expected.then(|| vec!["*".to_string()]);
+        assert_eq!(config.public_hoist_pattern, expected_public_hoist_pattern);
+        assert_eq!(
+            config.explicit_settings.get("shamefullyHoist"),
+            Some(&serde_json::Value::Bool(expected)),
+        );
+    }
+}
+
+#[test]
 fn extract_leaves_config_tokens_after_the_separator_for_the_child() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -108,6 +108,18 @@ fn shamefully_hoist_override_preserves_virtual_store_only_precedence() {
 }
 
 #[test]
+fn extract_leaves_invalid_shamefully_hoist_values_for_clap() {
+    for flag in ["--shamefully-hoist=yes", "--shamefully-hoist="] {
+        let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "--version"]));
+        assert_eq!(remaining, argv(["pacquet", flag, "--version"]));
+
+        let mut config = Config::default();
+        overrides.apply(&mut config);
+        assert!(!config.explicit_settings.contains_key("shamefullyHoist"));
+    }
+}
+
+#[test]
 fn extract_leaves_config_tokens_after_the_separator_for_the_child() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",

--- a/pnpm/crates/cli/tests/suite/hoist.rs
+++ b/pnpm/crates/cli/tests/suite/hoist.rs
@@ -272,6 +272,32 @@ fn shamefully_hoist_legacy_publicly_hoists_everything() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn shamefully_hoist_cli_option_publicly_hoists_everything() {
+    let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(
+        &workspace,
+        serde_json::json!({ "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" }),
+    );
+    generate_lockfile(pnpm);
+
+    pacquet
+        .with_args(["--shamefully-hoist=true", "install", "--frozen-lockfile"])
+        .assert()
+        .success();
+
+    let public_hoist = workspace.join("node_modules/@pnpm.e2e/hello-world-js-bin");
+    assert!(
+        is_symlink_or_junction(&public_hoist).unwrap(),
+        "--shamefully-hoist should publicly hoist everything at {public_hoist:?}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// `.modules.yaml` records `hoistedDependencies` when the hoist pass
 /// runs.
 #[test]

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -38,17 +38,17 @@ fn version_flag_accepts_shamefully_hoist() {
 
 #[test]
 fn version_flag_rejects_invalid_shamefully_hoist_value() {
-    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
-
-    let output = pacquet
-        .with_args(["--shamefully-hoist=yes", "--version"])
-        .output()
-        .expect("run pacquet with an invalid shamefully-hoist value");
-    dbg!(&output);
-    assert!(!output.status.success(), "pacquet should reject an invalid shamefully-hoist value");
-    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument"));
-
-    drop(root);
+    for flag in ["--shamefully-hoist=yes", "--config.shamefully-hoist=yes"] {
+        let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+        let output = pacquet
+            .with_args([flag, "--version"])
+            .output()
+            .expect("run pacquet with an invalid shamefully-hoist value");
+        dbg!(&output);
+        assert!(!output.status.success(), "pacquet should reject {flag}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument"));
+        drop(root);
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -37,6 +37,21 @@ fn version_flag_accepts_shamefully_hoist() {
 }
 
 #[test]
+fn version_flag_rejects_invalid_shamefully_hoist_value() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet
+        .with_args(["--shamefully-hoist=yes", "--version"])
+        .output()
+        .expect("run pacquet with an invalid shamefully-hoist value");
+    dbg!(&output);
+    assert!(!output.status.success(), "pacquet should reject an invalid shamefully-hoist value");
+    assert!(String::from_utf8_lossy(&output.stderr).contains("unexpected argument"));
+
+    drop(root);
+}
+
+#[test]
 fn short_version_flag_prints_the_bare_version() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -22,6 +22,21 @@ fn version_flag_prints_the_bare_version() {
 }
 
 #[test]
+fn version_flag_accepts_shamefully_hoist() {
+    let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
+
+    let output = pacquet
+        .with_args(["--shamefully-hoist=true", "--version"])
+        .output()
+        .expect("run pacquet --shamefully-hoist=true --version");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet should accept --shamefully-hoist");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), format!("{}\n", pnpm_config::PNPM_VERSION));
+
+    drop(root);
+}
+
+#[test]
 fn short_version_flag_prints_the_bare_version() {
     let CommandTempCwd { pacquet, root, .. } = CommandTempCwd::init();
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3029,7 +3029,7 @@ impl Config {
     /// This runs after all config sources have been merged because an explicit
     /// `shamefullyHoist` value takes precedence over `publicHoistPattern`
     /// regardless of which source supplied either setting.
-    fn apply_shamefully_hoist_derivation(&mut self) {
+    pub fn apply_shamefully_hoist_derivation(&mut self) {
         match self.explicit_settings.get("shamefullyHoist").and_then(serde_json::Value::as_bool) {
             Some(true) => self.public_hoist_pattern = Some(vec!["*".to_string()]),
             Some(false) => self.public_hoist_pattern = None,


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14235.

Accept `--shamefully-hoist`, `--no-shamefully-hoist`, and explicit boolean values in the Rust pnpm 12 CLI, then apply the existing public-hoist derivation. Invalid bare values remain errors, and `virtualStoreOnly` continues to suppress hoisting when the settings are combined. The TypeScript CLI already supports this option, so this restores CLI parity.

The regression coverage includes the reported `--version` invocation, supported and invalid boolean spellings, configuration precedence, and an installation test proving that transitive dependencies are publicly hoisted.

## Squash Commit Body

```text
pnpm 12's Rust CLI knew how to read shamefullyHoist from configuration files, but let argument parsing reject the equivalent CLI option before configuration was loaded. Extract the boolean CLI spellings as configuration overrides, record them as explicit settings, and reuse the existing public-hoist derivation while preserving virtualStoreOnly precedence. Leave invalid bare values for clap to reject instead of silently consuming them.

Add parser and end-to-end regressions for the reported version command, boolean spellings, configuration precedence, and actual public hoisting.

Fixes pnpm/pnpm#14235.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the `--shamefully-hoist` CLI option so it is accepted and correctly enables public hoisting.
  - Added support for common boolean forms, including `true`, `false`, `1`, `0`, and `--no-shamefully-hoist`.
  - Invalid values are now rejected with a clear command-line error.
  - Preserved correct precedence when virtual-store-only settings are enabled.

- **Tests**
  - Added coverage for supported option formats, invalid values, version commands, and dependency hoisting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->