### PR TITLE
fix(run): treat empty regexp scripts as missing

### DIFF
--- a/.changeset/empty-regexp-scripts.md
+++ b/.changeset/empty-regexp-scripts.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Treat empty scripts selected by a regular expression as missing before running dependent tasks.

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -566,7 +566,13 @@ impl<'a> ScriptSelector<'a> {
         let (Some(pattern), Some(scripts)) = (self.pattern.as_ref(), scripts) else {
             return Vec::new();
         };
-        scripts.keys().filter(|script| pattern.is_match(script)).cloned().collect()
+        scripts
+            .iter()
+            .filter(|(script, body)| {
+                body.as_str().is_some_and(|body| !body.is_empty()) && pattern.is_match(script)
+            })
+            .map(|(script, _)| script.clone())
+            .collect()
     }
 
     /// [`Self::select`] plus single-project `run`'s `start` fallback:

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -2105,11 +2105,8 @@ fn recursive_run_keeps_a_failure_when_a_later_selected_script_passes() {
     drop(root);
 }
 
-/// A selector can match a script with an empty body alongside a real
-/// one. The no-op says nothing about the script that did run, so it must
-/// not overwrite the project's recorded status.
 #[test]
-fn recursive_run_keeps_a_pass_when_a_later_selected_script_is_a_no_op() {
+fn recursive_run_keeps_a_pass_when_a_later_matching_script_is_empty() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_workspace(
         &workspace,
@@ -2120,8 +2117,6 @@ fn recursive_run_keeps_a_pass_when_a_later_selected_script_is_a_no_op() {
                 "version": "1.0.0",
                 "scripts": {
                     "check:a": "true",
-                    // Sorts after `check:a`, so a regression reports the
-                    // project as skipped rather than passed.
                     "check:b": "",
                 },
             }),
@@ -2936,6 +2931,40 @@ fn missing_requested_script_errors_before_upstream_tasks_run() {
     assert!(!output.status.success(), "a script nothing declares must fail the run");
     assert!(String::from_utf8_lossy(&output.stderr).contains("RECURSIVE_RUN_NO_SCRIPT"));
     assert!(!workspace.join("order.log").exists(), "the pulled-in task must not have run");
+
+    drop(root);
+}
+
+#[test]
+fn regexp_selected_empty_script_errors_before_upstream_tasks_run() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[(
+            "project-a",
+            json!({
+                "name": "project-a",
+                "version": "1.0.0",
+                "scripts": { "build:empty": "", "codegen": "echo codegen >> ../order.log" },
+            }),
+        )],
+    );
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - project-a\ntasks:\n  '/^build:/':\n    dependsOn: ['codegen']\n",
+    )
+    .expect("write workspace settings");
+
+    let output =
+        pacquet.with_args(["-r", "run", "/^build:/"]).output().expect("run recursive script");
+    eprintln!("STATUS: {}", output.status);
+    assert!(!output.status.success(), "an empty selected script must fail the run");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(stderr.contains("RECURSIVE_RUN_NO_SCRIPT"));
+    let order_log_exists = workspace.join("order.log").exists();
+    eprintln!("ORDER LOG EXISTS: {order_log_exists}");
+    assert!(!order_log_exists, "the pulled-in task must not have run");
 
     drop(root);
 }

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -364,7 +364,7 @@ export function getSpecifiedScripts (scripts: PackageScripts, scriptName: string
 
   // if scriptName which a user passes is RegExp (like /build:.*/), multiple scripts to execute will be selected with RegExp
   if (scriptSelector) {
-    return Object.keys(scripts).filter(script => script.match(scriptSelector))
+    return Object.keys(scripts).filter(script => Boolean(scripts[script]) && scriptSelector.test(script))
   }
 
   return []

--- a/pnpm11/exec/commands/test/runTasks.e2e.ts
+++ b/pnpm11/exec/commands/test/runTasks.e2e.ts
@@ -577,6 +577,40 @@ test('a missing requested script errors before upstream tasks run', async () => 
   expect(server.getLines()).toStrictEqual([])
 })
 
+test('an empty requested script matched by a RegExp errors before upstream tasks run', async () => {
+  await using server = await createTestIpcServer()
+
+  preparePackages([
+    {
+      name: 'project-a',
+      version: '1.0.0',
+      scripts: {
+        'build:empty': '',
+        codegen: server.sendLineScript('codegen'),
+      },
+    },
+  ])
+
+  let err!: PnpmError
+  try {
+    await run.handler({
+      ...DEFAULT_OPTS,
+      ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+      dir: process.cwd(),
+      recursive: true,
+      tasks: {
+        '/^build:/': { dependsOn: ['codegen'] },
+      },
+      workspaceDir: process.cwd(),
+    }, ['/^build:/'])
+  } catch (_err: any) { // eslint-disable-line
+    err = _err
+  }
+
+  expect(err.code).toBe('ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT')
+  expect(server.getLines()).toStrictEqual([])
+})
+
 test('a failed upstream task is reported as the failure, not as a missing script', async () => {
   preparePackages([
     {

--- a/pnpm11/exec/commands/test/runTasks.e2e.ts
+++ b/pnpm11/exec/commands/test/runTasks.e2e.ts
@@ -591,23 +591,18 @@ test('an empty requested script matched by a RegExp errors before upstream tasks
     },
   ])
 
-  let err!: PnpmError
-  try {
-    await run.handler({
-      ...DEFAULT_OPTS,
-      ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
-      dir: process.cwd(),
-      recursive: true,
-      tasks: {
-        '/^build:/': { dependsOn: ['codegen'] },
-      },
-      workspaceDir: process.cwd(),
-    }, ['/^build:/'])
-  } catch (_err: any) { // eslint-disable-line
-    err = _err
-  }
-
-  expect(err.code).toBe('ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT')
+  await expect(run.handler({
+    ...DEFAULT_OPTS,
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    dir: process.cwd(),
+    recursive: true,
+    tasks: {
+      '/^build:/': { dependsOn: ['codegen'] },
+    },
+    workspaceDir: process.cwd(),
+  }, ['/^build:/'])).rejects.toMatchObject({
+    code: 'ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT',
+  })
   expect(server.getLines()).toStrictEqual([])
 })
 


### PR DESCRIPTION
## Summary

- treat empty script bodies matched by a RegExp selector as missing during task selection
- reject a recursive run before any `dependsOn`-pulled task executes when every match is empty
- keep the TypeScript CLI and pacquet behavior in sync

Related to pnpm/pnpm#14211.

## Squash Commit Body

```text
RegExp script selectors included matching names even when their script bodies
were empty, unlike exact-name selection. Recursive task orchestration could
therefore dispatch tasks pulled in through dependsOn before eventually
reporting that the requested script did not exist.

Filter empty bodies at the shared script-selection boundary in both the
TypeScript CLI and pacquet, so pre-dispatch validation observes the same
missing-script semantics for exact and RegExp selectors.

Related to pnpm/pnpm#14211.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790436316&installation_model_id=426870&pr_number=14237&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14237&signature=7102638fc5cbdcfc4dd8cb497e3ac3970496a7b41eb56e37b4a4e90e7d567c17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Regular-expression script selection now ignores empty scripts, treating them as unavailable.
  - Recursive task execution reports the appropriate missing-script error before running dependent tasks.

- **Tests**
  - Added coverage confirming consistent behavior across supported execution paths.
  - Updated recursive execution tests for empty scripts selected by regular expressions.

- **Documentation**
  - Recorded a patch release for the affected packages reflecting this behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->