### PR TITLE
fix(run): filter hidden regexp script matches

### DIFF
--- a/.changeset/filter-hidden-regexp-scripts.md
+++ b/.changeset/filter-hidden-regexp-scripts.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/exec.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Filter hidden scripts matched by a regular expression during recursive runs when a visible script also matches.

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -12,7 +12,10 @@
 //! concurrently. The main-dispatch auto-exclusion of the workspace root is
 //! applied via [`AutoExcludeRoot::Enabled`].
 
-use super::{RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages};
+use super::{
+    RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages,
+    throw_or_filter_hidden_scripts,
+};
 use crate::cli_args::recursive::{
     AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
     filtered_projects_dependencies, find_resume_root, select_recursive_projects,
@@ -177,10 +180,9 @@ pub fn run_recursive(
     // named: a `dependsOn` declaration naming a hidden script is a
     // deliberate reference, like a call from another script.
     if env::var_os("npm_lifecycle_event").is_none() {
-        for node in task_graph.values().filter(|node| node.requested) {
-            if let Some(script) = node.scripts.iter().find(|script| script.starts_with('.')) {
-                return Err(super::RunError::HiddenScript { script: script.clone() }.into());
-            }
+        for node in task_graph.values_mut().filter(|node| node.requested) {
+            node.scripts =
+                throw_or_filter_hidden_scripts(std::mem::take(&mut node.scripts), script_name)?;
         }
     }
 

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -2066,6 +2066,32 @@ fn recursive_run_executes_every_script_matching_a_regexp_selector() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_filters_hidden_regexp_matches_when_a_visible_script_matches() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[(
+            "project",
+            json!({
+                "name": "project",
+                "version": "1.0.0",
+                "scripts": {
+                    "build:visible": "touch visible.txt",
+                    ".build:hidden": "touch hidden.txt",
+                },
+            }),
+        )],
+    );
+
+    pacquet.with_args(["-r", "run", "/build/"]).assert().success();
+
+    assert!(workspace.join("project").join("visible.txt").exists());
+    assert!(!workspace.join("project").join("hidden.txt").exists());
+
+    drop(root);
+}
+
 /// A `/pattern/` selector can match several scripts in one project, but
 /// the summary carries a single status per project and the exit code is
 /// derived from it. Under `--no-bail` a later script's success must not

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -102,9 +102,7 @@ export async function runRecursive (
   if (!process.env.npm_lifecycle_event) {
     for (const node of taskGraph.values()) {
       if (!node.requested) continue
-      for (const script of node.scripts) {
-        throwOrFilterHiddenScripts([script], script)
-      }
+      node.scripts = throwOrFilterHiddenScripts(node.scripts, scriptName)
     }
   }
 

--- a/pnpm11/exec/commands/test/runTasks.e2e.ts
+++ b/pnpm11/exec/commands/test/runTasks.e2e.ts
@@ -606,6 +606,31 @@ test('an empty requested script matched by a RegExp errors before upstream tasks
   expect(server.getLines()).toStrictEqual([])
 })
 
+test('a RegExp selector filters hidden scripts when a visible script also matches', async () => {
+  await using server = await createTestIpcServer()
+
+  preparePackages([
+    {
+      name: 'project-a',
+      version: '1.0.0',
+      scripts: {
+        'build:visible': server.sendLineScript('visible'),
+        '.build:hidden': server.sendLineScript('hidden'),
+      },
+    },
+  ])
+
+  await run.handler({
+    ...DEFAULT_OPTS,
+    ...await filterProjectsBySelectorObjectsFromDir(process.cwd(), []),
+    dir: process.cwd(),
+    recursive: true,
+    workspaceDir: process.cwd(),
+  }, ['/build/'])
+
+  expect(server.getLines()).toStrictEqual(['visible'])
+})
+
 test('a failed upstream task is reported as the failure, not as a missing script', async () => {
   preparePackages([
     {


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790438552&installation_model_id=426870&pr_number=14238&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14238&signature=086242cfecc862ece40a95959c71e13062795fcebd8f616e210fe91f85dec8d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Recursive regular-expression script runs now execute matching visible scripts while skipping hidden scripts.
  - Hidden matching scripts no longer cause recursive runs to fail when a visible script also matches.

- **Tests**
  - Added coverage for hidden-script filtering in both native and end-to-end recursive run scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->