### PR TITLE
fix(cli): resolve the modules dir per project in clean

### DIFF
--- a/.changeset/clean-resolves-modules-dir-per-project.md
+++ b/.changeset/clean-resolves-modules-dir-per-project.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm clean` / `pnpm purge` run from a workspace subdirectory now remove each project's own `node_modules` instead of emptying the workspace root's for every project [#14239](https://github.com/pnpm/pnpm/issues/14239). A custom `modulesDir` is resolved against each project directory too.

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -109,10 +109,17 @@ fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> mi
     // Windows the raw `current_dir()` can differ (casing, 8.3 short names,
     // junctions) and defeat the relative-path computation.
     let cwd = std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_default();
-    // `pnpm clean` resolves the modules dir relative to each project
-    // directory, not against a single absolute prefix, so strip the
-    // config anchor back to the leaf and rejoin per project.
-    let modules_leaf = config.modules_dir.strip_prefix(ctx.dir).unwrap_or(&config.modules_dir);
+    // `pnpm clean` resolves `modulesDir` against every project directory it
+    // cleans. `config.modules_dir` is already anchored — at the workspace
+    // root, or at a configured `lockfileDir` — so rejoining it per project
+    // would send every project back to that one directory. Take the
+    // configured leaf instead; an absolute setting survives `join`, as it
+    // does pnpm's `pathAbsolute`.
+    let modules_leaf = config
+        .explicit_settings
+        .get("modulesDir")
+        .and_then(Value::as_str)
+        .map_or(Path::new("node_modules"), Path::new);
     let root_dir = config.workspace_dir.as_deref().unwrap_or(ctx.dir);
     let dirs: Vec<PathBuf> = if let Some(workspace_dir) = config.workspace_dir.as_deref() {
         let (projects, _patterns) = discover_workspace_projects(workspace_dir, config)?;

--- a/pnpm/crates/cli/src/cli_args/clean.rs
+++ b/pnpm/crates/cli/src/cli_args/clean.rs
@@ -119,7 +119,7 @@ fn clean_builtin(ctx: &RunCtx<'_>, config: &Config, remove_lockfile: bool) -> mi
         .explicit_settings
         .get("modulesDir")
         .and_then(Value::as_str)
-        .map_or(Path::new("node_modules"), Path::new);
+        .map_or_else(|| Path::new("node_modules"), Path::new);
     let root_dir = config.workspace_dir.as_deref().unwrap_or(ctx.dir);
     let dirs: Vec<PathBuf> = if let Some(workspace_dir) = config.workspace_dir.as_deref() {
         let (projects, _patterns) = discover_workspace_projects(workspace_dir, config)?;

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -121,9 +121,7 @@ fn clean_lockfile_removes_lockfile() {
     drop(root);
 }
 
-/// A two-project workspace with `node_modules` seeded in the root and in
-/// `pkg1`, plus a `pnpm-workspace.yaml` carrying `settings`.
-fn seed_workspace(workspace: &Path, settings: &str) {
+fn write_workspace(workspace: &Path, settings: &str) {
     fs::write(workspace.join("pnpm-workspace.yaml"), format!("packages:\n  - pkg1\n{settings}"))
         .expect("write pnpm-workspace.yaml");
     let pkg1 = workspace.join("pkg1");
@@ -139,7 +137,7 @@ fn seed_workspace(workspace: &Path, settings: &str) {
 fn clean_from_a_workspace_subdirectory_cleans_every_project() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
-    seed_workspace(&workspace, "");
+    write_workspace(&workspace, "");
     seed_package(&workspace.join("node_modules"), "a");
     seed_package(&workspace.join("pkg1").join("node_modules"), "b");
 
@@ -161,7 +159,7 @@ fn clean_from_a_workspace_subdirectory_cleans_every_project() {
 fn clean_from_a_workspace_subdirectory_honors_a_custom_modules_dir() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
-    seed_workspace(&workspace, "modulesDir: custom_nm\n");
+    write_workspace(&workspace, "modulesDir: custom_nm\n");
     seed_package(&workspace.join("custom_nm"), "a");
     seed_package(&workspace.join("pkg1").join("custom_nm"), "b");
 

--- a/pnpm/crates/cli/tests/suite/clean.rs
+++ b/pnpm/crates/cli/tests/suite/clean.rs
@@ -121,6 +121,60 @@ fn clean_lockfile_removes_lockfile() {
     drop(root);
 }
 
+/// A two-project workspace with `node_modules` seeded in the root and in
+/// `pkg1`, plus a `pnpm-workspace.yaml` carrying `settings`.
+fn seed_workspace(workspace: &Path, settings: &str) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), format!("packages:\n  - pkg1\n{settings}"))
+        .expect("write pnpm-workspace.yaml");
+    let pkg1 = workspace.join("pkg1");
+    fs::create_dir_all(&pkg1).expect("create pkg1");
+    fs::write(pkg1.join("package.json"), "{}").expect("write pkg1 manifest");
+    fs::write(workspace.join("package.json"), "{}").expect("write root manifest");
+}
+
+/// Every project's own modules dir is cleaned no matter which directory
+/// the command runs from
+/// ([pnpm/pnpm#14239](https://github.com/pnpm/pnpm/issues/14239)).
+#[test]
+fn clean_from_a_workspace_subdirectory_cleans_every_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    seed_workspace(&workspace, "");
+    seed_package(&workspace.join("node_modules"), "a");
+    seed_package(&workspace.join("pkg1").join("node_modules"), "b");
+
+    let output = pacquet.with_args(["clean", "--dir", "pkg1"]).output().expect("run pacquet clean");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "pacquet clean should succeed: {stderr}");
+
+    assert!(!workspace.join("node_modules").join("a").exists(), "root package removed");
+    assert!(
+        !workspace.join("pkg1").join("node_modules").join("b").exists(),
+        "pkg1 package removed",
+    );
+
+    drop(root);
+}
+
+/// A custom `modulesDir` is resolved against each project directory too.
+#[test]
+fn clean_from_a_workspace_subdirectory_honors_a_custom_modules_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    seed_workspace(&workspace, "modulesDir: custom_nm\n");
+    seed_package(&workspace.join("custom_nm"), "a");
+    seed_package(&workspace.join("pkg1").join("custom_nm"), "b");
+
+    let output = pacquet.with_args(["clean", "--dir", "pkg1"]).output().expect("run pacquet clean");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(output.status.success(), "pacquet clean should succeed: {stderr}");
+
+    assert!(!workspace.join("custom_nm").join("a").exists(), "root package removed");
+    assert!(!workspace.join("pkg1").join("custom_nm").join("b").exists(), "pkg1 package removed");
+
+    drop(root);
+}
+
 #[test]
 fn clean_works_in_a_workspace() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();


### PR DESCRIPTION
## Summary

`pnpm clean` / `pnpm purge` run from a workspace member emptied the **workspace root's** `node_modules` for every discovered project and left the members' in place:

```
$ pnpm clean --dir packages/a
Removing node_modules          # the root's — packages/a/node_modules untouched
```

`clean_builtin` derived its per-project modules leaf with `config.modules_dir.strip_prefix(ctx.dir)`. `config.modules_dir` is anchored at the workspace root (or at a configured `lockfileDir`), so the strip only succeeds when `--dir` *is* that anchor. From a member it fails, the leaf stays absolute, and `dir.join(leaf)` resolves back to the anchor for every project — hence one directory cleaned repeatedly.

The fix takes the configured `modulesDir` leaf (defaulting to `node_modules`) instead, so it resolves against each project directory the way pnpm's `clean.ts` does with `pathAbsolute(modulesDir, dir)`. An absolute `modulesDir` still wins, since `join` leaves an absolute path absolute — the same property `pathAbsolute` has.

After:

```
$ pnpm clean --dir packages/a
Removing node_modules
Removing packages/a/node_modules
```

Closes pnpm/pnpm#14239.

**Parity:** the TypeScript CLI resolves `modulesDir` per project already and is not affected, so this is a Rust-only fix.

**Tests:** two regression tests — the default `node_modules` case and a custom `modulesDir: custom_nm` — both run `clean --dir pkg1` and assert the root's *and* the member's own modules dir are cleaned. Verified they fail against the old leaf computation.

## Squash Commit Body

```text
`clean` derived its per-project modules leaf by stripping `ctx.dir` off
`config.modules_dir`. That path is anchored at the workspace root (or at a
configured `lockfileDir`), so from a workspace member the strip failed, the
leaf stayed absolute, and `dir.join(leaf)` sent every discovered project
back to the anchor: `pnpm clean --dir packages/a` emptied the workspace
root's `node_modules` and left the members' in place.

Take the configured `modulesDir` leaf instead — defaulting to
`node_modules`, as pnpm's `clean` does — so it resolves against each
project directory the way `pathAbsolute(modulesDir, dir)` does upstream. An
absolute setting still wins, since `join` leaves it absolute.

Closes pnpm/pnpm#14239.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439329&installation_model_id=426870&pr_number=14240&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14240&signature=feee29b3f5111ee447ef8cc4d95337d737bd1bfc61e60b63de3fe34bda23da8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm clean` and `pnpm purge` when run from a workspace subdirectory.
  - Each project’s own dependency directory is now removed instead of repeatedly targeting the workspace root.
  - Custom `modulesDir` settings are correctly resolved for every project, including workspace-level configurations.

- **Documentation**
  - Added release notes describing the corrected cleanup behavior and improved project-level handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->