### PR TITLE
refactor: give the artifact blob digest one name and one guard

### DIFF
--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -208,24 +208,24 @@ pub(crate) async fn apply_shared_side_effects(
                 if let Some(path) = stored.get(&storage_key) {
                     return Ok(path.clone());
                 }
-                // A built package's files are mostly its own, and artifacts
-                // share files with each other. The store addresses content by
-                // the digest this manifest entry already carries, so anything
-                // it holds is the same bytes and needs no transfer.
-                //
-                // Both this lookup and the write below address the store by
-                // `is_executable`, so they cannot disagree about where a mode
-                // belongs. The manifest only carries 0o644 and 0o755 today,
-                // but the agreement must not rest on that.
-                if !downloaded.contains_key(&file.integrity)
-                    && let Ok(digest) = blob_id(&file.integrity)
-                    && let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
-                    && store_holds(&path, &digest).await?
-                {
-                    stored.insert(storage_key, path.clone());
-                    return Ok(path);
-                }
                 if !downloaded.contains_key(&file.integrity) {
+                    // A built package's files are mostly its own, and
+                    // artifacts share files with each other. The store
+                    // addresses content by the digest this manifest entry
+                    // already carries, so anything it holds is the same bytes
+                    // and needs no transfer.
+                    //
+                    // Both this lookup and the write below address the store
+                    // by `is_executable`, so they cannot disagree about where
+                    // a mode belongs. The manifest only carries 0o644 and
+                    // 0o755 today, but the agreement must not rest on that.
+                    let digest = blob_id(&file.integrity).map_err(|error| error.to_string())?;
+                    if let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
+                        && store_holds(&path, &digest).await?
+                    {
+                        stored.insert(storage_key, path.clone());
+                        return Ok(path);
+                    }
                     let bytes = client
                         .download_artifact_blob(
                             &ArtifactBlobRequest {

--- a/pnpr/client/src/sharedSideEffects.ts
+++ b/pnpr/client/src/sharedSideEffects.ts
@@ -313,7 +313,7 @@ export async function downloadSharedArtifactBlob (
   }
 ): Promise<Buffer> {
   validateOwner(opts.request.owner)
-  blobId(opts.request.integrity)
+  artifactBlobDigest(opts.request.integrity)
   const response = await request({
     registryUrl: opts.registryUrl,
     path: '-/pnpr/v0/artifacts/blob',
@@ -347,7 +347,7 @@ function serializePublishRequest (opts: PublishSharedSideEffectsOptions): Buffer
     Buffer.byteLength(opts.envelope.signature)
   for (const blob of opts.blobs) {
     if (blob == null || typeof blob !== 'object') throw new Error('Shared artifact blob upload is malformed')
-    blobId(blob.integrity)
+    artifactBlobDigest(blob.integrity)
     if (uploads.has(blob.integrity)) {
       throw new Error(`Duplicate shared artifact blob upload ${JSON.stringify(blob.integrity)}`)
     }
@@ -525,7 +525,7 @@ function validateManifest (manifest: ArtifactManifest): void {
     }
     totalSize += file.size
     if (totalSize > MAX_ARTIFACT_SIZE) throw new Error(`Shared artifact exceeds ${MAX_ARTIFACT_SIZE} bytes`)
-    blobId(file.integrity)
+    artifactBlobDigest(file.integrity)
     const previousSize = integritySizes.get(file.integrity)
     if (previousSize != null && previousSize !== file.size) {
       throw new Error(`Shared artifact blob integrity ${JSON.stringify(file.integrity)} is declared with inconsistent sizes`)
@@ -676,15 +676,12 @@ function ownersEqual (left: OwnerScope, right: OwnerScope): boolean {
  * Hex digest identifying an artifact blob's content, from its `sha512-` value.
  *
  * The same identity the store addresses its content by, so a caller holding a
- * manifest entry can ask the store whether it already has the bytes.
+ * manifest entry can ask the store whether it already has the bytes. Callers
+ * that only need the integrity checked can discard the result.
  *
  * @throws if `integrity` is not a `sha512-` value carrying a 64-byte digest.
  */
 export function artifactBlobDigest (integrity: string): string {
-  return blobId(integrity)
-}
-
-function blobId (integrity: string): string {
   if (typeof integrity !== 'string' || !integrity.startsWith('sha512-')) {
     throw new Error('Shared artifact blobs require sha512 integrity')
   }
@@ -694,7 +691,7 @@ function blobId (integrity: string): string {
 }
 
 function verifyBlob (integrity: string, bytes: Buffer): void {
-  const expected = blobId(integrity)
+  const expected = artifactBlobDigest(integrity)
   const actual = createHash('sha512').update(bytes).digest('hex')
   if (expected !== actual) throw new Error('Downloaded shared artifact blob does not match its declared digest')
 }


### PR DESCRIPTION
## Summary

Two leftovers from pnpm/pnpm#14189. Both are behaviour-neutral; no published API moves.

- **One name for the artifact blob digest.** `artifactBlobDigest` was a pass-through around a private `blobId` that did the work, so the digest had two names and the doc comment sat on the wrapper rather than on the definition. There is now one exported function. The three call sites that only want the integrity validated call it and discard the result, exactly as they did under the other name.
- **One guard for the store lookup.** The restore's store lookup tested `!downloaded.contains_key(&file.integrity)` and the download right below tested it again, so a reader had to hold both conditions in mind to see that the lookup only runs when the bytes are not already in memory. The lookup now sits inside the download's own branch. `blob_id`'s error is propagated with `?` rather than swallowed by `if let Ok(..)`: the manifest validator rejects a malformed integrity long before hydration, so this is unreachable either way, and a silent fall-through to downloading is a poorer way to say so.

## Squash Commit Body

```text
Two leftovers from pnpm/pnpm#14189, both behaviour-neutral.

`artifactBlobDigest` was a pass-through around a private `blobId` that did
the actual work, so the digest had two names and the doc comment sat on
neither the definition nor every call site. There is now one exported
function; the three call sites that only wanted the integrity validated
call it and discard the result, as they did before under the other name.

The restore's store lookup tested `!downloaded.contains_key` and then the
download below tested it again, so a reader had to hold both in mind to see
that the lookup only runs when the bytes are not already in memory. Folding
the lookup into the download's own branch says it once. `blob_id`'s error is
propagated rather than swallowed by `if let Ok(..)`: the manifest validator
rejects a malformed integrity long before hydration, so this is unreachable,
and a silent fall-through to downloading is a worse way to express that than
a `?`.

Follow-up to pnpm/pnpm#14189.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <sub>Each half lands where it applies: the wrapper only existed in the TypeScript client, and the doubled guard only in pacquet. The Rust client already exported `blob_id` directly.</sub>
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
  <sub>Not added: a pure refactor with no user-visible effect has no release note to write, matching the recent `refactor(pnpr):` PRs.</sub>
- [x] Added or updated tests.
  <sub>No new tests: the behaviour is unchanged, and the existing `shared_side_effects` and `@pnpm/pnpr.client` suites already cover both paths.</sub>

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790439919&installation_model_id=426870&pr_number=14241&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14241&signature=9ac683180fdcf0e38ba4ba0152115e5fc6b479639923b96df4e4f0a828c1cd14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved artifact integrity validation across downloads, uploads, manifests, and stored blobs.
  - Artifact processing now reports invalid or unavailable blob identifiers as errors instead of silently attempting an alternate download.
  - Added more consistent digest verification to help prevent corrupted or mismatched artifacts from being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->