### PR TITLE
fix(run): clean up lifecycle process trees on failure

### DIFF
--- a/.changeset/tidy-lifecycle-children.md
+++ b/.changeset/tidy-lifecycle-children.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/exec.lifecycle": patch
+"pnpm": patch
+---
+
+Fixed recursive `run` cleanup on Windows when a lifecycle script fails while another script's process tree is still running.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ catalogs:
       specifier: ^0.3.1
       version: 0.3.1
     '@pnpm/npm-lifecycle':
-      specifier: ^1100.0.0
-      version: 1100.0.0
+      specifier: ^1100.1.0
+      version: 1100.1.0
     '@pnpm/npm-package-arg':
       specifier: ^2.0.0
       version: 2.0.0
@@ -4387,7 +4387,7 @@ importers:
         version: link:../../fetching/directory-fetcher
       '@pnpm/npm-lifecycle':
         specifier: 'catalog:'
-        version: 1100.0.0(supports-color@10.2.2)(typanion@3.14.0)
+        version: 1100.1.0(supports-color@10.2.2)(typanion@3.14.0)
       '@pnpm/pkg-manifest.reader':
         specifier: workspace:*
         version: link:../../pkg-manifest/reader
@@ -11896,8 +11896,8 @@ packages:
     resolution: {integrity: sha512-5jW/GNLdZMiw+PJ8FYSvOghoApSjsORNIro2fj8j6NHAqJxJjcHekC5/NsKaawoI5LAkU/XDDVjNC71Yz+uS1w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/npm-lifecycle@1100.0.0':
-    resolution: {integrity: sha512-igdq1MDnShKMFLdA9uBkMZ8lI/65FUMeh7mjgd1x710qjk9JtF8bV2iYOs/hbBz6IFo98adyQvg1Trx1n5dwIw==}
+  '@pnpm/npm-lifecycle@1100.1.0':
+    resolution: {integrity: sha512-CL1iRrlTlsghpglS+IkgJu6J6FDEDA8ShqgSib55eq2c/Vha+/mYBp3Ob6epYndB25JPF2B/NYlbrBt4Cn7QCw==}
     engines: {node: '>=22.13'}
 
   '@pnpm/npm-package-arg@2.0.0':
@@ -19206,7 +19206,7 @@ snapshots:
       - supports-color
       - typanion
 
-  '@pnpm/npm-lifecycle@1100.0.0(supports-color@10.2.2)(typanion@3.14.0)':
+  '@pnpm/npm-lifecycle@1100.1.0(supports-color@10.2.2)(typanion@3.14.0)':
     dependencies:
       '@pnpm/byline': 1.0.0
       '@pnpm/error': 1000.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -117,7 +117,7 @@ catalog:
   '@pnpm/logger': '^1100.0.0'
   '@pnpm/meta-updater': 2.0.6
   '@pnpm/nopt': ^0.3.1
-  '@pnpm/npm-lifecycle': ^1100.0.0
+  '@pnpm/npm-lifecycle': ^1100.1.0
   '@pnpm/npm-package-arg': ^2.0.0
   '@pnpm/os.env.path-extender': ^3.0.1
   '@pnpm/patch-package': 0.0.1

--- a/pnpm11/__fixtures__/exec-error-exit/project-a/package.json
+++ b/pnpm11/__fixtures__/exec-error-exit/project-a/package.json
@@ -2,5 +2,8 @@
   "name": "project-a",
   "private": true,
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "start": "node script.js"
+  }
 }

--- a/pnpm11/__fixtures__/exec-error-exit/project-b/package.json
+++ b/pnpm11/__fixtures__/exec-error-exit/project-b/package.json
@@ -2,5 +2,8 @@
   "name": "project-b",
   "private": true,
   "version": "1.0.0",
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "start": "node script.js"
+  }
 }

--- a/pnpm11/exec/lifecycle/src/runLifecycleHook.ts
+++ b/pnpm11/exec/lifecycle/src/runLifecycleHook.ts
@@ -10,6 +10,8 @@ import chalk from 'chalk'
 import isWindows from 'is-windows'
 import { join as shellQuote } from 'shlex'
 
+import { trackChildProcess } from './trackChildProcess.js'
+
 function noop () {} // eslint-disable-line:no-empty
 
 export interface RunLifecycleHookOptions {
@@ -135,6 +137,7 @@ Please unset the scriptShell option, or configure it to a .exe instead.
         globalWarn(msg.join(' '))
       },
     },
+    onSpawn: trackChildProcess,
     runConcurrently: true,
     scriptsPrependNodePath: opts.scriptsPrependNodePath,
     scriptShell: opts.scriptShell,

--- a/pnpm11/pnpm/test/errorHandler.test.ts
+++ b/pnpm11/pnpm/test/errorHandler.test.ts
@@ -204,7 +204,10 @@ function getWindowsCleanupTestEnv (): NodeJS.ProcessEnv {
   const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
   const pathWithoutProcessEnumerators = (process.env[pathKey] ?? '')
     .split(path.delimiter)
-    .filter((dir) => !/wbem|windowspowershell/i.test(dir))
+    .filter((dir) => {
+      const lowerDir = dir.toLowerCase()
+      return !lowerDir.includes('wbem') && !lowerDir.includes('windowspowershell')
+    })
     .join(path.delimiter)
   return { [pathKey]: pathWithoutProcessEnumerators }
 }

--- a/pnpm11/pnpm/test/errorHandler.test.ts
+++ b/pnpm11/pnpm/test/errorHandler.test.ts
@@ -23,7 +23,7 @@ test('should print json format error when publish --json failed', async () => {
     version: undefined,
   })
 
-  const { status, stdout } = execPnpmSync(['publish', '--dry-run', '--json'])
+  const { status, stdout } = execPnpmSync(['publish', '--dry-run', '--json', '--no-git-checks'])
 
   expect(status).toBe(1)
   const { error } = JSON.parse(stdout.toString())
@@ -113,27 +113,35 @@ test('should clean up the process trees of running commands when a recursive exe
   const cwdBefore = process.cwd()
   process.chdir(execErrorExit)
   try {
-    // Remove the wmic and powershell directories from PATH to emulate a
-    // Windows installation where enumerating descendant processes is not
-    // possible (wmic is removed on modern Windows, and the PowerShell
-    // fallback regularly exceeds its 500 ms budget on real machines - the
-    // scenario of https://github.com/pnpm/pnpm/issues/12406). The cleanup
-    // then has to go through the tracked child PIDs instead. taskkill lives
-    // in System32 itself and stays reachable.
-    const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
-    const pathWithoutProcessEnumerators = (process.env[pathKey] ?? '')
-      .split(path.delimiter)
-      .filter((dir) => !/wbem|windowspowershell/i.test(dir))
-      .join(path.delimiter)
     const { status, stdout } = execPnpmSync(['--recursive', 'exec', 'node', 'script.js'], {
       stdio: 'pipe',
       env: {
         FOO_PORT: fooPort.toString(),
-        ...(isWindows() ? { [pathKey]: pathWithoutProcessEnumerators } : {}),
+        ...getWindowsCleanupTestEnv(),
       },
     })
     expect(status).toBe(1)
     expect(stdout.toString()).toContain('ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL')
+    expect(await isPortInUse(fooPort)).toBe(false)
+  } finally {
+    process.chdir(cwdBefore)
+  }
+})
+
+test('should clean up the process trees of running scripts when a recursive run fails', async () => {
+  const fooPort = await getPort()
+  const cwdBefore = process.cwd()
+  process.chdir(execErrorExit)
+  try {
+    const { status, stdout } = execPnpmSync(['--recursive', 'run', 'start'], {
+      stdio: 'pipe',
+      env: {
+        FOO_PORT: fooPort.toString(),
+        ...getWindowsCleanupTestEnv(),
+      },
+    })
+    expect(status).toBe(1)
+    expect(stdout.toString()).toContain('ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL')
     expect(await isPortInUse(fooPort)).toBe(false)
   } finally {
     process.chdir(cwdBefore)
@@ -188,3 +196,15 @@ test('should print error summary when some packages fail with --no-bail', async 
   expect(output).toContain('Summary: 1 fails, 2 passes')
   expect(output).toContain('[ERROR] project-2@1.0.0 build: `exit 1`')
 })
+
+function getWindowsCleanupTestEnv (): NodeJS.ProcessEnv {
+  if (!isWindows()) return {}
+  // Modern Windows may lack wmic, while the PowerShell fallback can exceed
+  // the error handler's budget. Removing both verifies cleanup by tracked PID.
+  const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH'
+  const pathWithoutProcessEnumerators = (process.env[pathKey] ?? '')
+    .split(path.delimiter)
+    .filter((dir) => !/wbem|windowspowershell/i.test(dir))
+    .join(path.delimiter)
+  return { [pathKey]: pathWithoutProcessEnumerators }
+}


### PR DESCRIPTION
## Summary

- Upgrade `@pnpm/npm-lifecycle` to 1100.1.0 and register every native lifecycle child with pnpm's existing process tracker.
- Add an end-to-end regression test proving a bailed recursive `run` cleans up an in-flight script process tree when Windows process enumeration is unavailable.
- Make the existing publish error-handler test independent of the worktree's Git status.

Related to pnpm/pnpm#14211.

Pacquet does not need a matching change: its recursive scheduler waits for all started tasks before surfacing the first failure, so it does not enter an early error-exit path while lifecycle children are still running.

## Squash Commit Body

```text
On Windows, pnpm's error handler cannot rely on descendant enumeration because modern systems may lack wmic and the PowerShell fallback can exceed its time budget. Recursive exec children already register their PIDs for the taskkill fallback, but lifecycle children spawned by recursive run did not.

Use the spawn observer added in `@pnpm/npm-lifecycle` 1100.1.0 to register lifecycle children with the existing tracker. Reuse the process-tree fixture to verify recursive run cleanup with the process-enumeration paths removed from PATH.

Also disable Git checks in the publish error test so a dirty contributor worktree cannot mask the missing-version error that test exercises.

Related to pnpm/pnpm#14211.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790442049&installation_model_id=426870&pr_number=14244&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14244&signature=0c5aab4e08d3faa60f7672d37c56805e64c94bf62b270936761c339e98c3503d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed recursive `run` cleanup on Windows when a lifecycle script fails while another process tree is still running.
  * Ensured spawned lifecycle processes are tracked and terminated correctly.
  * Prevented failed recursive runs from leaving ports occupied or child processes running.
  * Improved reliability when stopping related processes after a failed recursive command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->