### PR TITLE
fix(engine-pm): record a satisfied range pin the same way in both stacks

### DIFF
--- a/.changeset/sync-satisfied-range-pin.md
+++ b/.changeset/sync-satisfied-range-pin.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/installing.env-installer": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-A `devEngines.packageManager` range pin on pnpm is now recorded in `pnpm-lock.yaml`'s `packageManagerDependencies` when the running pnpm already satisfies it, using the running version. Previously only an exact pin — or a range resolved on the way through a version switch — reached the lockfile, so a range pin written by hand (or by any tool other than `pnpm add` / `pnpm self-update`) left the project without the shared resolution the pin exists to provide.
+A `devEngines.packageManager` range pin on pnpm is now recorded in `pnpm-lock.yaml`'s `packageManagerDependencies` when the running pnpm already satisfies it, using the running version and keeping the range as the recorded specifier. Previously only an exact pin — or a range resolved on the way through a version switch — reached the lockfile, so a range pin written by hand (or by any tool other than `pnpm add` / `pnpm self-update`) left the project without the shared resolution the pin exists to provide.

--- a/.changeset/sync-satisfied-range-pin.md
+++ b/.changeset/sync-satisfied-range-pin.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/installing.env-installer": minor
+"@pnpm/installing.env-installer": patch
 "pacquet": patch
 "pnpm": patch
 ---

--- a/.changeset/sync-satisfied-range-pin.md
+++ b/.changeset/sync-satisfied-range-pin.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/installing.env-installer": patch
+"@pnpm/installing.env-installer": minor
 "pacquet": patch
 "pnpm": patch
 ---

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -45,10 +45,17 @@ export interface ResolvePackageManagerIntegritiesOpts {
 
 /**
  * Checks if the wanted pnpm version integrities are already fully resolved in the env lockfile.
+ *
+ * `specifier` is what the project asked for, which a range pin records
+ * alongside the version it resolved to. Pass it to also require that the entry
+ * records the pin the project asks for now: one written under a pin that has
+ * since changed still has to be rewritten, even though its version stands.
+ * Omit it to accept the entry on its version alone.
  */
 export function isPackageManagerResolved (
   envLockfile: EnvLockfile | undefined,
-  pnpmVersion: string
+  pnpmVersion: string,
+  specifier?: string
 ): boolean {
   if (!envLockfile) return false
 
@@ -56,7 +63,10 @@ export function isPackageManagerResolved (
   if (pmDeps == null) return false
   const wantedDeps = packageManagerDeps(pnpmVersion)
   return Object.keys(pmDeps).length === wantedDeps.length &&
-    wantedDeps.every((name) => pmDeps[name]?.version === pnpmVersion)
+    wantedDeps.every((name) =>
+      pmDeps[name]?.version === pnpmVersion &&
+      (specifier == null || pmDeps[name]?.specifier === specifier)
+    )
 }
 
 /**
@@ -130,7 +140,9 @@ export async function resolvePackageManagerIntegrities (
   const save = opts.save ?? true
   const envLockfile = opts.envLockfile ?? (save ? await readEnvLockfile(opts.rootDir) : undefined) ?? createEnvLockfile()
 
-  if (isPackageManagerResolved(envLockfile, pnpmVersion)) {
+  // A frozen lockfile is not rewritten to refresh a stale specifier: refusing
+  // the entry over one would fail the install rather than update it.
+  if (isPackageManagerResolved(envLockfile, pnpmVersion, opts.frozenLockfile ? undefined : opts.specifier)) {
     return envLockfile
   }
 

--- a/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
+++ b/pnpm11/installing/env-installer/src/resolvePackageManagerIntegrities.ts
@@ -29,6 +29,13 @@ export interface ResolvePackageManagerIntegritiesOpts {
    */
   save?: boolean
   /**
+   * The specifier to record for each entry, when it differs from the version
+   * being resolved. A range pin names no exact version, so its entries resolve
+   * to a concrete version while still recording the range the project asked
+   * for. Defaults to the resolved spec, which is what an exact pin wants.
+   */
+  specifier?: string
+  /**
    * Refuse to record entries that are missing or out of date, failing the
    * command instead. Only meaningful together with `save`: an in-memory
    * resolution changes no lockfile, so nothing can fall out of sync with it.
@@ -211,7 +218,7 @@ async function resolveWantedPnpmPackages (
     storeDir: opts.storeDir,
   }
   if (semver.valid(spec) != null) {
-    return resolveManifestDependencies({ dependencies: wantedDependencies(spec, spec) }, resolveOpts)
+    return resolveManifestDependencies({ dependencies: wantedDependencies(spec, opts.specifier ?? spec) }, resolveOpts)
   }
   const lockfile = await resolveManifestDependencies({ dependencies: { pnpm: spec } }, resolveOpts)
   const ref = lockfile.importers['.' as ProjectId]?.dependencies?.['pnpm']

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -34,6 +34,15 @@ test('an env lockfile pinning another pnpm version is not resolved', () => {
 // or Artifactory-style mirror) must still yield integrity-only
 // package-manager entries, or the bootstrap validation rejects them.
 // See https://github.com/pnpm/pnpm/issues/13619.
+test('an entry recording the wanted version under a stale specifier is not resolved', () => {
+  // Changing an exact pin to a range that still includes the recorded version
+  // leaves the version alone but not the specifier, so the entry still has to
+  // be rewritten.
+  const lockfile = envLockfile({ pnpm: '12.0.0' })
+  expect(isPackageManagerResolved(lockfile, '12.0.0')).toBe(true)
+  expect(isPackageManagerResolved(lockfile, '12.0.0', '^12.0.0')).toBe(false)
+})
+
 test('registry tarball URLs are dropped from package-manager resolutions; file:, git-hosted, and subdir tarballs are kept', async () => {
   resolveManifestDependencies.mockResolvedValueOnce({
     lockfileVersion: '9.0',

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -208,6 +208,38 @@ test('an in-memory resolution is performed under frozenLockfile', async () => {
   })
 })
 
+test('a range pin records the range it asked for, not the version it resolved to', async () => {
+  resolveManifestDependencies.mockResolvedValueOnce({
+    lockfileVersion: '9.0',
+    importers: {
+      '.': {
+        specifiers: { pnpm: '^12.0.0' },
+        dependencies: { pnpm: '12.0.0' },
+      },
+    },
+    packages: {
+      'pnpm@12.0.0': { resolution: { integrity: 'sha512-pnpm' } },
+    },
+  } as unknown as LockfileObject)
+
+  const result = await resolvePackageManagerIntegrities('12.0.0', {
+    registriesByScope: { default: 'https://mirror.example.com/' },
+    rootDir: '/repo',
+    storeController: {} as never,
+    storeDir: '/store',
+    save: false,
+    specifier: '^12.0.0',
+  })
+
+  expect(resolveManifestDependencies).toHaveBeenCalledWith(
+    { dependencies: { pnpm: '^12.0.0' } },
+    expect.anything()
+  )
+  expect(result.importers['.'].packageManagerDependencies).toEqual({
+    pnpm: { specifier: '^12.0.0', version: '12.0.0' },
+  })
+})
+
 function envLockfile (packageManagerDependencies: Record<string, string>): EnvLockfile {
   const pinned = Object.entries(packageManagerDependencies)
   return {

--- a/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
+++ b/pnpm11/installing/env-installer/test/resolvePackageManagerIntegrities.test.ts
@@ -1,8 +1,10 @@
 import { expect, jest, test } from '@jest/globals'
 import { isPackageManagerResolved } from '@pnpm/installing.env-installer'
 import type { EnvLockfile, LockfileObject } from '@pnpm/lockfile.types'
+import type { ProjectManifest } from '@pnpm/types'
 
-const resolveManifestDependencies = jest.fn<() => Promise<LockfileObject>>()
+const resolveManifestDependencies =
+  jest.fn<(manifest: ProjectManifest, opts: unknown) => Promise<LockfileObject>>()
 jest.unstable_mockModule('../src/resolveManifestDependencies.js', () => ({
   resolveManifestDependencies,
 }))

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -34,13 +34,26 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
   let storeToUse: Awaited<ReturnType<typeof createStoreController>> | undefined
   const packageManagerConfig = getPackageManagerBootstrapConfig(config)
 
+  const wantedVersion = pm.version
+  const satisfiesPin = (version: string): boolean =>
+    semver.satisfies(version, wantedVersion, { includePrerelease: true })
+
   // Check if the env lockfile already has a resolved version that satisfies the wanted version/range.
   let pmVersion = envLockfile?.importers['.'].packageManagerDependencies?.['pnpm']?.version
+  if (pmVersion != null && !satisfiesPin(pmVersion)) {
+    pmVersion = undefined
+  }
+  // A range pin names no exact version, so the running pnpm's version is the
+  // one the project actually uses. Asking the registry instead would pin a
+  // version nobody is running and switch away from a satisfying one.
+  if (pmVersion == null && satisfiesPin(packageManager.version)) {
+    pmVersion = packageManager.version
+  }
   let freshlyResolved = false
-  if (!pmVersion || !semver.satisfies(pmVersion, pm.version, { includePrerelease: true })) {
+  if (pmVersion == null) {
     // Resolve to an exact version from the registry.
     storeToUse = await createStoreController({ ...config, ...context, ...packageManagerConfig })
-    envLockfile = await resolvePackageManagerIntegrities(pm.version, {
+    envLockfile = await resolvePackageManagerIntegrities(wantedVersion, {
       envLockfile,
       registriesByScope: packageManagerConfig.registriesByScope,
       rootDir: context.rootProjectManifestDir,
@@ -52,7 +65,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
     freshlyResolved = true
     pmVersion = envLockfile.importers['.'].packageManagerDependencies?.['pnpm']?.version
     if (!pmVersion) {
-      globalWarn(`Cannot resolve pnpm version for "${pm.version}"`)
+      globalWarn(`Cannot resolve pnpm version for "${wantedVersion}"`)
       await storeToUse.ctrl.close()
       return
     }
@@ -66,6 +79,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       storeDir: storeToUse.dir,
       save: persistLockfile,
       frozenLockfile: config.frozenLockfile,
+      specifier: wantedVersion,
     })
     freshlyResolved = true
   }

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -69,7 +69,7 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
       await storeToUse.ctrl.close()
       return
     }
-  } else if (!isPackageManagerResolved(envLockfile, pmVersion)) {
+  } else if (!isPackageManagerResolved(envLockfile, pmVersion, config.frozenLockfile ? undefined : wantedVersion)) {
     storeToUse = await createStoreController({ ...config, ...context, ...packageManagerConfig })
     envLockfile = await resolvePackageManagerIntegrities(pmVersion, {
       envLockfile,


### PR DESCRIPTION
## Summary

Ports the behaviour that landed for the Rust CLI in pnpm/pnpm#13932 to the TypeScript CLI, so both stacks record a satisfied range pin the same way. Related to pnpm/pnpm#13932.

That PR made `package_manager_to_sync` record the running pnpm's version when it satisfies a `devEngines.packageManager` range pin. The TypeScript side still did two things differently:

- **It asked the registry to resolve the range even when the running pnpm already satisfied it.** `switchCliVersion` only consulted the version recorded in the env lockfile, so a project with no recorded version resolved the range against the registry and pinned whatever that returned — a version nobody was running, and one it would then switch to.
- **It recorded the resolved version as the specifier.** `resolveWantedPnpmPackages` derives the specifier from the spec it is given, so passing an exact version made `specifier` and `version` identical and overwrote the range the project had asked for.

The Rust side never had the second problem because `resolve_package_manager_integrities` takes `wanted_specifier` separately from `version`. This gives the TypeScript function the same seam.

## Squash Commit Body

```text
The TypeScript side asked the registry to resolve a range pin even when the
running pnpm already satisfied it, so it recorded a version nobody was running
and switched away from a satisfying one. It also passed the resolved version as
the specifier, overwriting the range the project had asked for with an exact
version.

It now prefers the running version when that satisfies the pin, matching
package_manager_to_sync, and records the range as the specifier the way
resolve_package_manager_integrities already does through its wanted_specifier
argument.

Related to pnpm/pnpm#13932, which made the Rust CLI record a satisfied range pin
this way.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790442459&installation_model_id=426870&pr_number=14245&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14245&signature=12063ce50b6612c15c2b219cd5c3b51ef3b454b9fdaef26c27092d467cf85bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compatible pnpm version ranges are now recorded in `pnpm-lock.yaml` alongside the running version and original range.
  * pnpm reuses the current CLI version when it satisfies the configured version range, reducing unnecessary version lookups.

* **Bug Fixes**
  * Improved handling of missing or incompatible locked pnpm versions.
  * Preserved the requested version range when resolving package manager versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->