### PR TITLE
fix(pacquet): match npm tarball path stripping

### DIFF
--- a/.changeset/dot-prefixed-tarball-entries.md
+++ b/.changeset/dot-prefixed-tarball-entries.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Pacquet now strips exactly one leading path component from `./`-prefixed tarball entries, matching pnpm and npm's tar extraction semantics and keeping shared store keys consistent.

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -959,6 +959,9 @@ pub(crate) fn tar_entry_payload<'a, Reader: std::io::Read>(
 /// both implementations share to a reader that *does* treat them as
 /// separators.
 ///
+/// A leading `.` is preserved because npm's `tar` counts it as the
+/// component removed by `strip: 1`. Other `.` components are ignored.
+///
 /// `None` for an absolute path or one climbing past the root.
 pub(crate) fn archive_entry_segments(raw: &str) -> Option<Vec<String>> {
     let normalized = raw.replace('\\', "/");
@@ -966,9 +969,11 @@ pub(crate) fn archive_entry_segments(raw: &str) -> Option<Vec<String>> {
         return None;
     }
     let mut segments = Vec::new();
-    for segment in normalized.split('/') {
+    for (index, segment) in normalized.split('/').enumerate() {
         match segment {
-            "" | "." => {}
+            "" => {}
+            "." if index == 0 => segments.push(segment.to_string()),
+            "." => {}
             ".." => return None,
             other => segments.push(other.to_string()),
         }

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5312,6 +5312,21 @@ fn tar_with_raw_entry_name(name: &[u8]) -> Vec<u8> {
     tar_bytes
 }
 
+#[test]
+fn extract_strips_only_one_component_from_a_dot_prefixed_entry_path() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_raw_entry_name(b"./package/package.json");
+    let (cas_paths, pkg_files_idx) =
+        extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
+
+    assert_eq!(cas_paths.keys().collect::<Vec<_>>(), vec!["package/package.json"]);
+    assert_eq!(pkg_files_idx.files.keys().collect::<Vec<_>>(), vec!["package/package.json"]);
+    assert!(pkg_files_idx.manifest.is_none());
+
+    drop(tempdir);
+}
+
 /// A backslash is an ordinary filename character on Unix but a
 /// separator on Windows, and these keys travel between the two through
 /// the shared `index.db`. pnpm folds `\` to `/` before validating

--- a/pnpm11/store/cafs/test/index.ts
+++ b/pnpm11/store/cafs/test/index.ts
@@ -251,7 +251,7 @@ test('unpack a tarball that contains hard links', () => {
 // A malicious tarball entry like "foo\..\..\..\.npmrc" should have its path normalized
 test('path traversal with backslashes is blocked (Windows security fix)', () => {
   // Create a minimal valid tarball with a malicious filename
-  const tarBuffer = createTarballWithEntry('foo\\..\\..\\..\\malicious.txt', 'evil content')
+  const tarBuffer = createTarballWithEntry('package/foo\\..\\..\\..\\malicious.txt', 'evil content')
 
   const result = parseTarball(tarBuffer)
   const fileNames = Array.from(result.files.keys())
@@ -263,16 +263,21 @@ test('path traversal with backslashes is blocked (Windows security fix)', () => 
   }
 })
 
+test('only one segment is stripped from a dot-prefixed tarball entry', () => {
+  const result = parseTarball(createTarballWithEntry('./package/package.json', '{}'))
+
+  expect(Array.from(result.files.keys())).toStrictEqual(['package/package.json'])
+})
+
 // Helper to create a minimal tarball buffer with a single entry
-function createTarballWithEntry (fileName: string, content: string): Buffer {
+function createTarballWithEntry (entryPath: string, content: string): Buffer {
   const contentBytes = Buffer.from(content, 'utf8')
 
   // Create a 512-byte header
   const header = Buffer.alloc(512, 0)
 
   // File name at offset 0 (max 100 chars)
-  const nameToWrite = `package/${fileName}`
-  header.write(nameToWrite, 0, Math.min(nameToWrite.length, 100), 'utf8')
+  header.write(entryPath, 0, Math.min(entryPath.length, 100), 'utf8')
 
   // File mode at offset 100 (octal, 8 bytes) - 0644
   header.write('0000644\0', 100, 8, 'utf8')


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#14165.

- Match npm 12.0.2's `pacote`/`tar` behavior by treating a leading `.` as the single component stripped from a `./`-prefixed tar entry.
- Align pacquet's CAFS keys with the TypeScript CLI, whose existing behavior is now covered by a matching regression test.
- Preserve rejection of absolute paths and parent-directory traversal.

Current npm uses `tar.x({ strip: 1 })`, which counts the leading `.` as the stripped path component. Therefore `./package/package.json` is stored as `package/package.json`; it does not strip both `.` and `package`.

## Squash Commit Body

```text
Pacquet normalized away a leading dot component before dropping the archive's top-level path segment. As a result, `./package/package.json` became `package.json`, while pnpm and npm's `tar.x({ strip: 1 })` count `.` as the stripped component and retain `package/package.json`.

Preserve a leading dot in shared archive segmentation long enough for the tar extractor to remove exactly one component. Absolute paths and parent traversal remain rejected. Add matching Rust and TypeScript regression coverage.

Closes pnpm/pnpm#14165
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790444199&installation_model_id=426870&pr_number=14247&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14247&signature=3d33f2513f9e547c6a4f41f6da45987f2461f4745e468c632ca0f27ff4606b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->