### PR TITLE
feat(run): persist recursive task state

### DIFF
--- a/.changeset/persist-task-run-state.md
+++ b/.changeset/persist-task-run-state.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/workspace.task-scheduler": minor
+"@pnpm/exec.commands": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Persist completed recursive tasks so `--resume-from` skips exactly the work that passed during a matching interrupted or failed `pnpm -r run` / `pnpm -r exec` invocation. When no compatible state exists, pnpm retains its graph-based resume behavior.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4337,6 +4337,9 @@ importers:
       which:
         specifier: 'catalog:'
         version: '@pnpm/which@3.0.1'
+      write-file-atomic:
+        specifier: 'catalog:'
+        version: 7.0.1
       write-json-file:
         specifier: 'catalog:'
         version: 7.0.0
@@ -4374,6 +4377,9 @@ importers:
       '@types/which':
         specifier: 'catalog:'
         version: 3.0.4
+      '@types/write-file-atomic':
+        specifier: 'catalog:'
+        version: 4.0.3
       is-windows:
         specifier: 'catalog:'
         version: 1.0.2

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -85,6 +85,7 @@ pub mod stars;
 pub mod store;
 pub mod sudo_guard;
 pub mod supported_architectures;
+mod task_run_state;
 pub mod team;
 pub mod undeprecate;
 pub mod unlink;

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -12,10 +12,13 @@
 //! project concurrently.
 
 use super::{ExecArgs, ExecError, prepare_command, read_package_name, spawn_in_dir};
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
-    filtered_projects_dependencies, find_resume_root, select_recursive_projects,
-    write_recursive_summary,
+use crate::cli_args::{
+    recursive::{
+        AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
+        filtered_projects_dependencies, find_resume_root, select_recursive_projects,
+        write_recursive_summary,
+    },
+    task_run_state::TaskRunStateContext,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -28,6 +31,7 @@ use pnpm_workspace_task_scheduler::{
     resume_task_graph_from, reverse_task_graph, schedule_tasks, sequence_tasks,
 };
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Mutex,
     time::Instant,
@@ -135,10 +139,37 @@ pub async fn exec_recursive(
     if args.reverse {
         task_graph = reverse_task_graph(&task_graph);
     }
-    if let Some(resume_from) = &args.resume_from {
-        let anchor = find_resume_root(resume_from, graph)?;
-        task_graph = resume_task_graph_from(task_graph, &anchor, command_name);
-    }
+    let full_task_graph = task_graph;
+    let mut state_params = args.command.clone();
+    state_params.push(format!("shell-mode={}", args.shell_mode));
+    let task_run_state_context = TaskRunStateContext::new(
+        "exec",
+        &state_params,
+        &[],
+        &full_task_graph,
+        workspace_root,
+        |_, _| Vec::new(),
+    );
+    let resume_anchor = args
+        .resume_from
+        .as_ref()
+        .map(|resume_from| find_resume_root(resume_from, graph))
+        .transpose()?;
+    let completed_tasks = resume_anchor
+        .as_ref()
+        .map(|_| task_run_state_context.read_completed_tasks())
+        .transpose()?
+        .flatten();
+    task_graph = if let Some(anchor) = resume_anchor {
+        resume_task_graph_from(
+            full_task_graph.clone(),
+            &anchor,
+            command_name,
+            completed_tasks.as_ref(),
+        )
+    } else {
+        full_task_graph.clone()
+    };
     // Also the cycle check: a cyclic graph cannot be scheduled, and
     // sequenced into an arbitrary order it would succeed or fail by luck.
     sequence_tasks(
@@ -149,6 +180,10 @@ pub async fn exec_recursive(
             emit,
         },
     )?;
+
+    let initially_completed: HashSet<TaskKey> =
+        full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect();
+    let task_run_state = task_run_state_context.start(&initially_completed)?;
 
     let bail = !args.no_bail;
     let concurrency = if args.parallel {
@@ -163,6 +198,7 @@ pub async fn exec_recursive(
             .collect(),
     );
     let first_failure: Mutex<Option<String>> = Mutex::new(None);
+    let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
     let process_tracker = bail.then(ProcessTracker::default);
 
     let run_task = |node: &TaskNode| -> TaskCompletion {
@@ -186,7 +222,22 @@ pub async fn exec_recursive(
         match execution.message {
             None => {
                 entry.status = Status::Passed;
-                TaskCompletion::Passed
+                drop(result);
+                let key =
+                    TaskKey { project: node.project.clone(), task_name: node.task_name.clone() };
+                match task_run_state.record_passed(&key, node, workspace_root) {
+                    Ok(()) => TaskCompletion::Passed,
+                    Err(error) => {
+                        let mut abort = abort.lock().expect("abort slot lock is not poisoned");
+                        if abort.is_none() {
+                            *abort = Some(error);
+                        }
+                        if let Some(process_tracker) = &process_tracker {
+                            process_tracker.cancel();
+                        }
+                        TaskCompletion::Aborted
+                    }
+                }
             }
             Some(message) => {
                 if process_tracker.as_ref().is_some_and(|tracker| !tracker.cancel()) {
@@ -220,6 +271,10 @@ pub async fn exec_recursive(
         },
     );
 
+    if let Some(error) = abort.into_inner().expect("abort slot lock is not poisoned") {
+        return Err(error);
+    }
+
     let result = result.into_inner().expect("summary lock is not poisoned");
     if bail
         && let Some(prefix) =
@@ -239,6 +294,7 @@ pub async fn exec_recursive(
     if failures > 0 {
         return Err(RecursiveExecError::RecursiveFail { count: failures }.into());
     }
+    task_run_state.finish()?;
     Ok(())
 }
 

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -18,7 +18,7 @@ use crate::cli_args::{
         filtered_projects_dependencies, find_resume_root, select_recursive_projects,
         write_recursive_summary,
     },
-    task_run_state::TaskRunStateContext,
+    task_run_state::{TaskRunExecutionSettings, TaskRunStateContext, task_run_execution_settings},
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -142,10 +142,19 @@ pub async fn exec_recursive(
     let full_task_graph = task_graph;
     let mut state_params = args.command.clone();
     state_params.push(format!("shell-mode={}", args.shell_mode));
+    let state_extra_env = config.extra_env_with_node_options();
+    let state_settings = task_run_execution_settings(&TaskRunExecutionSettings {
+        extra_bin_paths: &config.extra_bin_paths,
+        extra_env: &state_extra_env,
+        modules_dir: &config.modules_dir,
+        node_experimental_package_map: config.node_experimental_package_map,
+        node_options: config.node_options.as_deref(),
+        user_agent: &config.user_agent,
+    });
     let task_run_state_context = TaskRunStateContext::new(
         "exec",
         &state_params,
-        &[],
+        &state_settings,
         &full_task_graph,
         workspace_root,
         |_, _| Vec::new(),

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -402,49 +402,23 @@ pub(super) fn run_stages(
     main_body: &str,
     args: &[String],
 ) -> miette::Result<ScriptExit> {
-    let get_script = |key: &str| -> Option<String> {
-        ctx.manifest
-            .value()
-            .get("scripts")
-            .and_then(|scripts| scripts.as_object())
-            .and_then(|scripts| scripts.get(key))
-            .and_then(|script| script.as_str())
-            .map(str::to_string)
-    };
-
-    if ctx.config.enable_pre_post_scripts {
-        let pre = format!("pre{name}");
-        if let Some(script) = get_script(&pre)
-            && !main_body.contains(&pre)
-            && let Some(status) = run_stage(ctx, &pre, &script, &[])?
-            && !status.success()
-        {
-            return Ok(status);
+    let mut main_status = None;
+    for (stage, script) in
+        get_run_script_stages(ctx.manifest, name, main_body, ctx.config.enable_pre_post_scripts)
+    {
+        let is_main = stage == name;
+        if let Some(status) = run_stage(ctx, &stage, &script, if is_main { args } else { &[] })? {
+            if !status.success() {
+                return Ok(status);
+            }
+            if is_main {
+                main_status = Some(status);
+            }
         }
     }
-
-    // The caller's contract rules out both no-op paths in `run_stage`
-    // for the main stage (empty body, args-less `npx only-allow pnpm`),
-    // so `run_stage` here is guaranteed to surface a real [`ScriptExit`].
-    // The `expect` documents the invariant.
-    let main_status = run_stage(ctx, name, main_body, args)?.expect(
+    let main_status = main_status.expect(
         "caller validated main_body is neither empty nor the args-less `npx only-allow pnpm` no-op",
     );
-
-    if !main_status.success() {
-        return Ok(main_status);
-    }
-
-    if ctx.config.enable_pre_post_scripts {
-        let post = format!("post{name}");
-        if let Some(script) = get_script(&post)
-            && !main_body.contains(&post)
-            && let Some(status) = run_stage(ctx, &post, &script, &[])?
-            && !status.success()
-        {
-            return Ok(status);
-        }
-    }
 
     if ctx.config.sync_injected_deps_after_scripts.iter().any(|script| script == name) {
         sync_injected_deps(&SyncInjectedDeps {
@@ -457,6 +431,48 @@ pub(super) fn run_stages(
     }
 
     Ok(main_status)
+}
+
+pub(super) fn get_run_script_commands(
+    manifest: &PackageManifest,
+    name: &str,
+    main_body: &str,
+    enable_pre_post_scripts: bool,
+) -> Vec<String> {
+    get_run_script_stages(manifest, name, main_body, enable_pre_post_scripts)
+        .into_iter()
+        .map(|(_, script)| script)
+        .collect()
+}
+
+fn get_run_script_stages(
+    manifest: &PackageManifest,
+    name: &str,
+    main_body: &str,
+    enable_pre_post_scripts: bool,
+) -> Vec<(String, String)> {
+    let scripts = manifest.value().get("scripts").and_then(Value::as_object);
+    let mut stages = vec![(name.to_string(), main_body.to_string())];
+    if !enable_pre_post_scripts {
+        return stages;
+    }
+    let pre = format!("pre{name}");
+    if let Some(script) = scripts
+        .and_then(|scripts| scripts.get(&pre))
+        .and_then(Value::as_str)
+        .filter(|script| !script.is_empty() && !main_body.contains(&pre))
+    {
+        stages.insert(0, (pre, script.to_string()));
+    }
+    let post = format!("post{name}");
+    if let Some(script) = scripts
+        .and_then(|scripts| scripts.get(&post))
+        .and_then(Value::as_str)
+        .filter(|script| !script.is_empty() && !main_body.contains(&post))
+    {
+        stages.push((post, script.to_string()));
+    }
+    stages
 }
 
 /// Run one lifecycle stage. Returns `Ok(None)` when pnpm's per-stage

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -13,8 +13,8 @@
 //! applied via [`AutoExcludeRoot::Enabled`].
 
 use super::{
-    RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages,
-    throw_or_filter_hidden_scripts,
+    RunArgs, RunContext, ScriptSelector, get_run_script_commands, render_project_commands,
+    run_stages, throw_or_filter_hidden_scripts,
 };
 use crate::cli_args::{
     recursive::{
@@ -22,7 +22,7 @@ use crate::cli_args::{
         filtered_projects_dependencies, find_resume_root, select_recursive_projects,
         write_recursive_summary,
     },
-    task_run_state::TaskRunStateContext,
+    task_run_state::{TaskRunExecutionSettings, TaskRunStateContext, task_run_execution_settings},
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -160,16 +160,25 @@ pub fn run_recursive(
         pnpm_config::ScriptsPrependNodePath::Never => "false",
         pnpm_config::ScriptsPrependNodePath::WarnOnly => "warn-only",
     };
-    let state_settings = vec![
+    let extra_env: HashMap<String, String> = config.extra_env_with_node_options();
+    let mut state_settings = task_run_execution_settings(&TaskRunExecutionSettings {
+        extra_bin_paths: &config.extra_bin_paths,
+        extra_env: &extra_env,
+        modules_dir: &config.modules_dir,
+        node_experimental_package_map: config.node_experimental_package_map,
+        node_options: config.node_options.as_deref(),
+        user_agent: &config.user_agent,
+    });
+    state_settings.extend([
         format!("enable-pre-post-scripts={}", config.enable_pre_post_scripts),
         format!("script-shell={}", config.script_shell.as_deref().unwrap_or_default()),
         format!("scripts-prepend-node-path={scripts_prepend_node_path}"),
         format!("shell-emulator={}", config.shell_emulator),
         format!(
             "sync-injected-deps-after-scripts={}",
-            serde_json::to_string(&sync_injected).expect("script names serialize")
+            serde_json::to_string(&sync_injected).expect("script names serialize"),
         ),
-    ];
+    ]);
     let task_run_state_context = TaskRunStateContext::new(
         "run",
         &args.script,
@@ -177,31 +186,11 @@ pub fn run_recursive(
         &full_task_graph,
         workspace_root,
         |node, script| {
-            let scripts = graph[&node.project]
-                .package
-                .project
-                .manifest
-                .value()
-                .get("scripts")
-                .and_then(serde_json::Value::as_object);
-            let Some(main) =
-                scripts.and_then(|scripts| scripts.get(script)).and_then(serde_json::Value::as_str)
-            else {
+            let manifest = &graph[&node.project].package.project.manifest;
+            let Some(main) = manifest.script(script, true).ok().flatten() else {
                 return Vec::new();
             };
-            if !config.enable_pre_post_scripts {
-                return vec![main.to_string()];
-            }
-            [format!("pre{script}"), script.to_string(), format!("post{script}")]
-                .into_iter()
-                .filter(|stage| stage == script || !main.contains(stage.as_str()))
-                .filter_map(|stage| {
-                    scripts
-                        .and_then(|scripts| scripts.get(&stage))
-                        .and_then(serde_json::Value::as_str)
-                        .map(str::to_string)
-                })
-                .collect()
+            get_run_script_commands(manifest, script, main, config.enable_pre_post_scripts)
         },
     );
     let resume_anchor = args
@@ -299,11 +288,7 @@ pub fn run_recursive(
     let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
     let process_tracker = bail.then(ProcessTracker::default);
 
-    // Compute the shared lifecycle env once. Each project adds loader
-    // options for its own root before reusing that environment across
-    // the selected pre/main/post stages.
     let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
-    let extra_env: HashMap<String, String> = config.extra_env_with_node_options();
 
     let run_task = |node: &TaskNode| -> TaskCompletion {
         let summary_key = task_summary_key(node);

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -187,7 +187,9 @@ pub fn run_recursive(
         workspace_root,
         |node, script| {
             let manifest = &graph[&node.project].package.project.manifest;
-            let Some(main) = manifest.script(script, true).ok().flatten() else {
+            let Some(main) =
+                manifest.script(script, true).expect("if-present script lookup cannot fail")
+            else {
                 return Vec::new();
             };
             get_run_script_commands(manifest, script, main, config.enable_pre_post_scripts)
@@ -327,6 +329,7 @@ pub fn run_recursive(
         }
         let failed = execution.status.status == Status::Failure;
         let cancelled = execution.cancelled;
+        let recursion_guarded = execution.recursion_guarded;
         result.lock().expect("summary lock is not poisoned")[&summary_key] = execution.status;
         if cancelled {
             return TaskCompletion::Cancelled;
@@ -338,6 +341,8 @@ pub fn run_recursive(
                 *first_failure = Some(node.project.to_string_lossy().into_owned());
             }
             TaskCompletion::Failed
+        } else if recursion_guarded {
+            TaskCompletion::Passed
         } else if let Err(error) = task_run_state.record_passed(
             &TaskKey { project: node.project.clone(), task_name: node.task_name.clone() },
             node,
@@ -485,6 +490,7 @@ struct ProjectExecution {
     status: ExecutionStatus,
     has_command: usize,
     cancelled: bool,
+    recursion_guarded: bool,
 }
 
 #[derive(Clone, Copy)]
@@ -538,8 +544,12 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
     // run's lifecycle events; the reporter renders `wd` and only groups
     // by this.
     let root_str = root.to_string_lossy().into_owned();
-    let mut execution =
-        ProjectExecution { status: ExecutionStatus::queued(), has_command: 0, cancelled: false };
+    let mut execution = ProjectExecution {
+        status: ExecutionStatus::queued(),
+        has_command: 0,
+        cancelled: false,
+        recursion_guarded: false,
+    };
     let mut project_failed = false;
     for selected in &node.scripts {
         let Some(script) = manifest.script(selected, true)? else {
@@ -551,6 +561,7 @@ fn run_project(options: RunProjectOptions<'_, '_>) -> miette::Result<ProjectExec
         if env::var_os("npm_lifecycle_event").is_some_and(|event| event == **selected)
             && env::var_os("PNPM_SCRIPT_SRC_DIR").is_some_and(|src_dir| Path::new(&src_dir) == root)
         {
+            execution.recursion_guarded = true;
             continue;
         }
 

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -16,10 +16,13 @@ use super::{
     RunArgs, RunContext, ScriptSelector, render_project_commands, run_stages,
     throw_or_filter_hidden_scripts,
 };
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
-    filtered_projects_dependencies, find_resume_root, select_recursive_projects,
-    write_recursive_summary,
+use crate::cli_args::{
+    recursive::{
+        AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
+        filtered_projects_dependencies, find_resume_root, select_recursive_projects,
+        write_recursive_summary,
+    },
+    task_run_state::TaskRunStateContext,
 };
 use derive_more::{Display, Error};
 use indexmap::IndexMap;
@@ -35,12 +38,12 @@ use pnpm_workspace::GraphPkg;
 use pnpm_workspace_projects_graph::ProjectGraph;
 use pnpm_workspace_task_scheduler::{
     BuildTaskGraphOptions, ScheduleTasksOptions, SequenceTasksOptions, TaskCompletion, TaskGraph,
-    TaskNode, build_task_graph, is_serial_task_graph, render_task_graph_dry_run,
+    TaskKey, TaskNode, build_task_graph, is_serial_task_graph, render_task_graph_dry_run,
     resume_task_graph_from, reverse_task_graph, schedule_tasks, sequence_tasks, task_graph_to_json,
     task_summary_key,
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     path::{Path, PathBuf},
     sync::{
@@ -148,8 +151,79 @@ pub fn run_recursive(
 
     // Compiled once for the whole run, not per project or task.
     let selector = ScriptSelector::new(script_name)?;
-    let mut task_graph =
+    let full_task_graph =
         build_run_task_graph(script_name, &selector, args, config, graph, &selection, emit)?;
+    let mut sync_injected = config.sync_injected_deps_after_scripts.clone();
+    sync_injected.sort();
+    let scripts_prepend_node_path = match config.scripts_prepend_node_path {
+        pnpm_config::ScriptsPrependNodePath::Always => "true",
+        pnpm_config::ScriptsPrependNodePath::Never => "false",
+        pnpm_config::ScriptsPrependNodePath::WarnOnly => "warn-only",
+    };
+    let state_settings = vec![
+        format!("enable-pre-post-scripts={}", config.enable_pre_post_scripts),
+        format!("script-shell={}", config.script_shell.as_deref().unwrap_or_default()),
+        format!("scripts-prepend-node-path={scripts_prepend_node_path}"),
+        format!("shell-emulator={}", config.shell_emulator),
+        format!(
+            "sync-injected-deps-after-scripts={}",
+            serde_json::to_string(&sync_injected).expect("script names serialize")
+        ),
+    ];
+    let task_run_state_context = TaskRunStateContext::new(
+        "run",
+        &args.script,
+        &state_settings,
+        &full_task_graph,
+        workspace_root,
+        |node, script| {
+            let scripts = graph[&node.project]
+                .package
+                .project
+                .manifest
+                .value()
+                .get("scripts")
+                .and_then(serde_json::Value::as_object);
+            let Some(main) =
+                scripts.and_then(|scripts| scripts.get(script)).and_then(serde_json::Value::as_str)
+            else {
+                return Vec::new();
+            };
+            if !config.enable_pre_post_scripts {
+                return vec![main.to_string()];
+            }
+            [format!("pre{script}"), script.to_string(), format!("post{script}")]
+                .into_iter()
+                .filter(|stage| stage == script || !main.contains(stage.as_str()))
+                .filter_map(|stage| {
+                    scripts
+                        .and_then(|scripts| scripts.get(&stage))
+                        .and_then(serde_json::Value::as_str)
+                        .map(str::to_string)
+                })
+                .collect()
+        },
+    );
+    let resume_anchor = args
+        .resume_from
+        .as_ref()
+        .map(|resume_from| find_resume_root(resume_from, graph))
+        .transpose()?;
+    let completed_tasks = resume_anchor
+        .as_ref()
+        .map(|_| task_run_state_context.read_completed_tasks())
+        .transpose()?
+        .flatten();
+    let mut task_graph = if let Some(anchor) = resume_anchor {
+        resume_task_graph_from(
+            full_task_graph.clone(),
+            &anchor,
+            script_name,
+            completed_tasks.as_ref(),
+        )
+    } else {
+        full_task_graph.clone()
+    };
     // Also the cycle check: a cyclic graph cannot be scheduled, and
     // sequenced into an arbitrary order it would succeed or fail by luck.
     let sequenced_tasks = sequence_tasks(
@@ -195,6 +269,10 @@ pub fn run_recursive(
     {
         return Err(no_requested_script_error(script_name, graph.len() == projects.len()).into());
     }
+
+    let initially_completed: HashSet<TaskKey> =
+        full_task_graph.keys().filter(|key| !task_graph.contains_key(*key)).cloned().collect();
+    let task_run_state = task_run_state_context.start(&initially_completed)?;
 
     let bail = !args.no_bail;
     let concurrency = if args.parallel {
@@ -275,6 +353,19 @@ pub fn run_recursive(
                 *first_failure = Some(node.project.to_string_lossy().into_owned());
             }
             TaskCompletion::Failed
+        } else if let Err(error) = task_run_state.record_passed(
+            &TaskKey { project: node.project.clone(), task_name: node.task_name.clone() },
+            node,
+            workspace_root,
+        ) {
+            let mut abort = abort.lock().expect("abort slot lock is not poisoned");
+            if abort.is_none() {
+                *abort = Some(error);
+            }
+            if let Some(process_tracker) = &process_tracker {
+                process_tracker.cancel();
+            }
+            TaskCompletion::Aborted
         } else {
             TaskCompletion::Passed
         }
@@ -320,6 +411,7 @@ pub fn run_recursive(
         && failures == 0
         && !args.if_present
     {
+        task_run_state.finish()?;
         return Err(no_requested_script_error(script_name, graph.len() == projects.len()).into());
     }
 
@@ -330,12 +422,13 @@ pub fn run_recursive(
     if failures > 0 {
         return Err(RecursiveRunError::RecursiveFail { count: failures }.into());
     }
+    task_run_state.finish()?;
     Ok(())
 }
 
 /// The task graph of this invocation: `script_name` in every selected
 /// project plus what the `tasks` declarations pull in, with `--reverse`
-/// and `--resume-from` already applied.
+/// applied.
 ///
 /// `--no-sort` keeps its meaning of disregarding ordering entirely: tasks
 /// get no edges, and the `tasks` declarations do not apply.
@@ -399,10 +492,6 @@ fn build_run_task_graph(
     });
     if args.reverse {
         task_graph = reverse_task_graph(&task_graph);
-    }
-    if let Some(resume_from) = &args.resume_from {
-        let anchor = find_resume_root(resume_from, graph)?;
-        task_graph = resume_task_graph_from(task_graph, &anchor, script_name);
     }
     Ok(task_graph)
 }

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -281,7 +281,7 @@ impl TaskRunStateContext {
     ) -> Result<Option<File>, StateStorageError> {
         self.validate_state_directory(true)?;
         let lock_path = self.state_dir.join(START_LOCK_DIR);
-        let Some(_lock) =
+        let Some(lock) =
             pnpm_fs::DirLock::acquire(lock_path.clone(), LOCK_WAIT, LOCK_ABANDONED_AFTER)
                 .map_err(|error| StateStorageError::io(error, "locking", &lock_path))?
         else {
@@ -296,6 +296,19 @@ impl TaskRunStateContext {
                 return Err(StateStorageError::io(error, "opening", file_path));
             }
         };
+        match lock.is_owner() {
+            Ok(true) => {}
+            Ok(false) => {
+                drop(file);
+                let _ = fs::remove_file(file_path);
+                return Ok(None);
+            }
+            Err(error) => {
+                drop(file);
+                let _ = fs::remove_file(file_path);
+                return Err(StateStorageError::io(error, "checking", &lock_path));
+            }
+        }
         let latest_write = pnpm_fs::write_atomic(
             &self.latest_state_path,
             serde_json::to_string(header).expect("latest task state serializes").as_bytes(),

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -16,6 +16,7 @@ use std::{
 
 const STATE_VERSION: u8 = 1;
 const STATE_DIR: &str = ".pnpm-task-run-state-v1";
+const LATEST_STATE_FILE: &str = "latest.json";
 static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -61,8 +62,39 @@ struct TaskRecord {
     task: String,
 }
 
+pub struct TaskRunExecutionSettings<'a> {
+    pub extra_bin_paths: &'a [PathBuf],
+    pub extra_env: &'a HashMap<String, String>,
+    pub modules_dir: &'a Path,
+    pub node_experimental_package_map: bool,
+    pub node_options: Option<&'a str>,
+    pub user_agent: &'a str,
+}
+
+pub fn task_run_execution_settings(opts: &TaskRunExecutionSettings<'_>) -> Vec<String> {
+    let extra_bin_paths: Vec<String> =
+        opts.extra_bin_paths.iter().map(|path| path.to_string_lossy().into_owned()).collect();
+    let mut extra_env: Vec<(&String, &String)> = opts.extra_env.iter().collect();
+    extra_env.sort_by_key(|(key, _)| *key);
+    vec![
+        format!(
+            "extra-bin-paths={}",
+            serde_json::to_string(&extra_bin_paths).expect("extra bin paths serialize")
+        ),
+        format!(
+            "extra-env={}",
+            serde_json::to_string(&extra_env).expect("extra environment serializes")
+        ),
+        format!("modules-dir={}", opts.modules_dir.to_string_lossy()),
+        format!("node-experimental-package-map={}", opts.node_experimental_package_map),
+        format!("node-options={}", opts.node_options.unwrap_or_default()),
+        format!("user-agent={}", opts.user_agent),
+    ]
+}
+
 pub struct TaskRunStateContext {
-    file_path: PathBuf,
+    state_dir: PathBuf,
+    latest_state_path: PathBuf,
     invocation: String,
     keys_by_id: HashMap<TaskId, TaskKey>,
     ids_by_key: HashMap<TaskKey, TaskId>,
@@ -122,19 +154,41 @@ impl TaskRunStateContext {
         })
         .expect("task invocation identity serializes");
         let invocation = create_hex_hash(&identity);
-        let file_path =
-            workspace_dir.join("node_modules").join(STATE_DIR).join(format!("{invocation}.jsonl"));
-        Self { file_path, invocation, keys_by_id, ids_by_key }
+        let state_dir = workspace_dir.join("node_modules").join(STATE_DIR);
+        let latest_state_path = state_dir.join(LATEST_STATE_FILE);
+        Self { state_dir, latest_state_path, invocation, keys_by_id, ids_by_key }
     }
 
     pub fn read_completed_tasks(&self) -> miette::Result<Option<HashSet<TaskKey>>> {
-        let contents = match fs::read(&self.file_path) {
+        if !self.validate_state_directory(false)? {
+            return Ok(None);
+        }
+        let latest = match fs::read_to_string(&self.latest_state_path) {
+            Ok(contents) => match serde_json::from_str::<StateHeader>(&contents) {
+                Ok(header) => header,
+                Err(_) => return Ok(None),
+            },
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("reading {}", self.latest_state_path.display()));
+            }
+        };
+        if latest.version != STATE_VERSION
+            || latest.invocation != self.invocation
+            || !is_run_id(&latest.run)
+        {
+            return Ok(None);
+        }
+        let file_path = self.journal_path(&latest.run);
+        let contents = match fs::read(&file_path) {
             Ok(contents) => contents,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
                 return Err(error)
                     .into_diagnostic()
-                    .wrap_err_with(|| format!("reading {}", self.file_path.display()));
+                    .wrap_err_with(|| format!("reading {}", file_path.display()));
             }
         };
         // A record is committed by its newline; a process killed during
@@ -148,7 +202,10 @@ impl TaskRunStateContext {
         let mut lines = complete.lines();
         let Some(header) = lines.next() else { return Ok(None) };
         let Ok(header) = serde_json::from_str::<StateHeader>(header) else { return Ok(None) };
-        if header.version != STATE_VERSION || header.invocation != self.invocation {
+        if header.version != STATE_VERSION
+            || header.invocation != self.invocation
+            || header.run != latest.run
+        {
             return Ok(None);
         }
         let mut completed = HashSet::new();
@@ -182,53 +239,47 @@ impl TaskRunStateContext {
             contents.push_str(&serde_json::to_string(&record).expect("task record serializes"));
             contents.push('\n');
         }
-        let state_dir = self.file_path.parent().expect("task state file has a parent");
-        fs::create_dir_all(state_dir)
+        let file_path = self.journal_path(&run);
+        self.validate_state_directory(true)?;
+        pnpm_fs::write_atomic(&file_path, contents.as_bytes())
             .into_diagnostic()
-            .wrap_err_with(|| format!("creating {}", state_dir.display()))?;
-        pnpm_fs::write_atomic(&self.file_path, contents.as_bytes())
-            .into_diagnostic()
-            .wrap_err_with(|| format!("writing {}", self.file_path.display()))?;
-        // Only the latest recursive invocation is resumable. Otherwise an
-        // old compatible journal could become active after intervening work.
-        for entry in fs::read_dir(state_dir)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("reading {}", state_dir.display()))?
-        {
-            let entry = entry
-                .into_diagnostic()
-                .wrap_err_with(|| format!("reading {}", state_dir.display()))?;
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            let file_type = entry
-                .file_type()
-                .into_diagnostic()
-                .wrap_err_with(|| format!("reading stale task state {name}"))?;
-            if entry.path() != self.file_path && is_state_file_name(&name) && !file_type.is_dir() {
-                match fs::remove_file(entry.path()) {
-                    Ok(()) => {}
-                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-                    Err(error) => {
-                        return Err(error)
-                            .into_diagnostic()
-                            .wrap_err_with(|| format!("removing stale task state {name}"));
-                    }
-                }
-            }
-        }
+            .wrap_err_with(|| format!("writing {}", file_path.display()))?;
         let file = OpenOptions::new()
             .append(true)
-            .open(&self.file_path)
+            .open(&file_path)
             .into_diagnostic()
-            .wrap_err_with(|| format!("opening {}", self.file_path.display()))?;
+            .wrap_err_with(|| format!("opening {}", file_path.display()))?;
+        let latest_write = pnpm_fs::write_atomic(
+            &self.latest_state_path,
+            serde_json::to_string(&header).expect("latest task state serializes").as_bytes(),
+        )
+        .into_diagnostic()
+        .wrap_err_with(|| format!("writing {}", self.latest_state_path.display()));
+        if let Err(error) = latest_write {
+            drop(file);
+            let _ = fs::remove_file(&file_path);
+            return Err(error);
+        }
         Ok(TaskRunState {
-            file_path: self.file_path.clone(),
+            file_path,
             writer: Mutex::new(TaskRunStateWriter {
                 file: Some(file),
                 run,
                 completed: completed_tasks.clone(),
             }),
         })
+    }
+
+    fn journal_path(&self, run: &str) -> PathBuf {
+        self.state_dir.join(format!("{}.{run}.jsonl", self.invocation))
+    }
+
+    fn validate_state_directory(&self, create: bool) -> miette::Result<bool> {
+        let node_modules_dir = self.state_dir.parent().expect("task state directory has a parent");
+        if !validate_real_directory(node_modules_dir, create)? {
+            return Ok(false);
+        }
+        validate_real_directory(&self.state_dir, create)
     }
 }
 
@@ -286,11 +337,50 @@ fn task_id(node: &TaskNode, workspace_dir: &Path) -> TaskId {
     TaskId { project, task: node.task_name.clone() }
 }
 
-fn is_state_file_name(name: &str) -> bool {
-    let bytes = name.as_bytes();
-    bytes.len() == 70
-        && &bytes[64..] == b".jsonl"
-        && bytes[..64].iter().all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+fn is_run_id(run: &str) -> bool {
+    !run.is_empty()
+        && run.len() <= 128
+        && run
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte) || byte == b'-')
+}
+
+fn validate_real_directory(path: &Path, create: bool) -> miette::Result<bool> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound && !create => return Ok(false),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            match fs::create_dir(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error)
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("creating {}", path.display()));
+                }
+            }
+            fs::symlink_metadata(path)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("inspecting {}", path.display()))?
+        }
+        Err(error) => {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("inspecting {}", path.display()));
+        }
+    };
+    if metadata.file_type().is_symlink()
+        || pnpm_fs::read_symlink_dir(path).is_ok()
+        || !metadata.is_dir()
+    {
+        let path = path.display();
+        return Err(miette::miette!(
+            code = "ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH",
+            "Refusing to use task run state directory at {} because it is a symbolic link or not a directory",
+            path,
+        ));
+    }
+    Ok(true)
 }
 
 fn run_id() -> String {

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -11,12 +11,15 @@ use std::{
         Mutex,
         atomic::{AtomicU64, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 const STATE_VERSION: u8 = 1;
 const STATE_DIR: &str = ".pnpm-task-run-state-v1";
 const LATEST_STATE_FILE: &str = "latest.json";
+const START_LOCK_DIR: &str = "start.lock";
+const LOCK_WAIT: Duration = Duration::from_secs(2);
+const LOCK_ABANDONED_AFTER: Duration = Duration::from_secs(30);
 static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -160,7 +163,12 @@ impl TaskRunStateContext {
     }
 
     pub fn read_completed_tasks(&self) -> miette::Result<Option<HashSet<TaskKey>>> {
-        if !self.validate_state_directory(false)? {
+        let state_directory_exists = match self.validate_state_directory(false) {
+            Ok(exists) => exists,
+            Err(error) if error.is_unavailable() => return Ok(None),
+            Err(error) => return Err(error.into_report()),
+        };
+        if !state_directory_exists {
             return Ok(None);
         }
         let latest = match fs::read_to_string(&self.latest_state_path) {
@@ -168,7 +176,12 @@ impl TaskRunStateContext {
                 Ok(header) => header,
                 Err(_) => return Ok(None),
             },
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound
+                    || is_state_unavailable_error(&error) =>
+            {
+                return Ok(None);
+            }
             Err(error) => {
                 return Err(error)
                     .into_diagnostic()
@@ -184,7 +197,12 @@ impl TaskRunStateContext {
         let file_path = self.journal_path(&latest.run);
         let contents = match fs::read(&file_path) {
             Ok(contents) => contents,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error)
+                if error.kind() == io::ErrorKind::NotFound
+                    || is_state_unavailable_error(&error) =>
+            {
+                return Ok(None);
+            }
             Err(error) => {
                 return Err(error)
                     .into_diagnostic()
@@ -240,41 +258,61 @@ impl TaskRunStateContext {
             contents.push('\n');
         }
         let file_path = self.journal_path(&run);
-        self.validate_state_directory(true)?;
-        pnpm_fs::write_atomic(&file_path, contents.as_bytes())
-            .into_diagnostic()
-            .wrap_err_with(|| format!("writing {}", file_path.display()))?;
-        let file = OpenOptions::new()
-            .append(true)
-            .open(&file_path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("opening {}", file_path.display()))?;
-        let latest_write = pnpm_fs::write_atomic(
-            &self.latest_state_path,
-            serde_json::to_string(&header).expect("latest task state serializes").as_bytes(),
-        )
-        .into_diagnostic()
-        .wrap_err_with(|| format!("writing {}", self.latest_state_path.display()));
-        if let Err(error) = latest_write {
-            drop(file);
-            let _ = fs::remove_file(&file_path);
-            return Err(error);
-        }
+        let file = match self.start_file(&file_path, &contents, &header) {
+            Ok(file) => file,
+            Err(error) if error.is_unavailable() => None,
+            Err(error) => return Err(error.into_report()),
+        };
         Ok(TaskRunState {
             file_path,
             writer: Mutex::new(TaskRunStateWriter {
-                file: Some(file),
+                file,
                 run,
                 completed: completed_tasks.clone(),
             }),
         })
     }
 
+    fn start_file(
+        &self,
+        file_path: &Path,
+        contents: &str,
+        header: &StateHeader,
+    ) -> Result<Option<File>, StateStorageError> {
+        self.validate_state_directory(true)?;
+        let lock_path = self.state_dir.join(START_LOCK_DIR);
+        let Some(_lock) =
+            pnpm_fs::DirLock::acquire(lock_path.clone(), LOCK_WAIT, LOCK_ABANDONED_AFTER)
+                .map_err(|error| StateStorageError::io(error, "locking", &lock_path))?
+        else {
+            return Ok(None);
+        };
+        pnpm_fs::write_atomic(file_path, contents.as_bytes())
+            .map_err(|error| StateStorageError::io(error, "writing", file_path))?;
+        let file = match OpenOptions::new().append(true).open(file_path) {
+            Ok(file) => file,
+            Err(error) => {
+                let _ = fs::remove_file(file_path);
+                return Err(StateStorageError::io(error, "opening", file_path));
+            }
+        };
+        let latest_write = pnpm_fs::write_atomic(
+            &self.latest_state_path,
+            serde_json::to_string(header).expect("latest task state serializes").as_bytes(),
+        );
+        if let Err(error) = latest_write {
+            drop(file);
+            let _ = fs::remove_file(file_path);
+            return Err(StateStorageError::io(error, "writing", &self.latest_state_path));
+        }
+        Ok(Some(file))
+    }
+
     fn journal_path(&self, run: &str) -> PathBuf {
         self.state_dir.join(format!("{}.{run}.jsonl", self.invocation))
     }
 
-    fn validate_state_directory(&self, create: bool) -> miette::Result<bool> {
+    fn validate_state_directory(&self, create: bool) -> Result<bool, StateStorageError> {
         let node_modules_dir = self.state_dir.parent().expect("task state directory has a parent");
         if !validate_real_directory(node_modules_dir, create)? {
             return Ok(false);
@@ -302,24 +340,44 @@ impl TaskRunState {
         workspace_dir: &Path,
     ) -> miette::Result<()> {
         let mut writer = self.writer.lock().expect("task state lock is not poisoned");
+        if writer.file.is_none() {
+            return Ok(());
+        }
         if !writer.completed.insert(key.clone()) {
             return Ok(());
         }
         let id = task_id(node, workspace_dir);
         let record = TaskRecord { run: writer.run.clone(), project: id.project, task: id.task };
         let line = serde_json::to_string(&record).expect("task record serializes");
-        let file = writer.file.as_mut().expect("unfinished task state has an open file");
-        writeln!(file, "{line}")
-            .into_diagnostic()
-            .wrap_err_with(|| format!("writing {}", self.file_path.display()))
+        let result = writeln!(
+            writer.file.as_mut().expect("unfinished task state has an open file"),
+            "{line}",
+        );
+        if let Err(error) = result {
+            if is_state_unavailable_error(&error) {
+                writer.file.take();
+                drop(writer);
+                let _ = fs::remove_file(&self.file_path);
+                return Ok(());
+            }
+            writer.completed.remove(key);
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("writing {}", self.file_path.display()));
+        }
+        Ok(())
     }
 
     pub fn finish(&self) -> miette::Result<()> {
         let file = self.writer.lock().expect("task state lock is not poisoned").file.take();
+        if file.is_none() {
+            return Ok(());
+        }
         drop(file);
         match fs::remove_file(&self.file_path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) if is_state_unavailable_error(&error) => Ok(()),
             Err(error) => Err(error)
                 .into_diagnostic()
                 .wrap_err_with(|| format!("removing {}", self.file_path.display())),
@@ -345,7 +403,7 @@ fn is_run_id(run: &str) -> bool {
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte) || byte == b'-')
 }
 
-fn validate_real_directory(path: &Path, create: bool) -> miette::Result<bool> {
+fn validate_real_directory(path: &Path, create: bool) -> Result<bool, StateStorageError> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound && !create => return Ok(false),
@@ -354,33 +412,61 @@ fn validate_real_directory(path: &Path, create: bool) -> miette::Result<bool> {
                 Ok(()) => {}
                 Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
                 Err(error) => {
-                    return Err(error)
-                        .into_diagnostic()
-                        .wrap_err_with(|| format!("creating {}", path.display()));
+                    return Err(StateStorageError::io(error, "creating", path));
                 }
             }
             fs::symlink_metadata(path)
-                .into_diagnostic()
-                .wrap_err_with(|| format!("inspecting {}", path.display()))?
+                .map_err(|error| StateStorageError::io(error, "inspecting", path))?
         }
         Err(error) => {
-            return Err(error)
-                .into_diagnostic()
-                .wrap_err_with(|| format!("inspecting {}", path.display()));
+            return Err(StateStorageError::io(error, "inspecting", path));
         }
     };
     if metadata.file_type().is_symlink()
         || pnpm_fs::read_symlink_dir(path).is_ok()
         || !metadata.is_dir()
     {
-        let path = path.display();
-        return Err(miette::miette!(
-            code = "ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH",
-            "Refusing to use task run state directory at {} because it is a symbolic link or not a directory",
-            path,
-        ));
+        return Err(StateStorageError::UnsafePath(path.to_path_buf()));
     }
     Ok(true)
+}
+
+enum StateStorageError {
+    Io { error: io::Error, operation: &'static str, path: PathBuf },
+    UnsafePath(PathBuf),
+}
+
+impl StateStorageError {
+    fn io(error: io::Error, operation: &'static str, path: &Path) -> Self {
+        Self::Io { error, operation, path: path.to_path_buf() }
+    }
+
+    fn is_unavailable(&self) -> bool {
+        matches!(self, Self::Io { error, .. } if is_state_unavailable_error(error))
+    }
+
+    fn into_report(self) -> miette::Report {
+        match self {
+            Self::Io { error, operation, path } => {
+                let result: miette::Result<()> = Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("{operation} {}", path.display()));
+                result.expect_err("task state storage error cannot succeed")
+            }
+            Self::UnsafePath(path) => {
+                let path = path.display();
+                miette::miette!(
+                    code = "ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH",
+                    "Refusing to use task run state directory at {} because it is a symbolic link or not a directory",
+                    path,
+                )
+            }
+        }
+    }
+}
+
+fn is_state_unavailable_error(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ReadOnlyFilesystem)
 }
 
 fn run_id() -> String {

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -68,6 +68,19 @@ struct TaskRecord {
     task: String,
 }
 
+#[derive(Serialize, Deserialize)]
+struct FinishRecord {
+    run: String,
+    finished: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum JournalRecord {
+    Task(TaskRecord),
+    Finish(FinishRecord),
+}
+
 pub struct TaskRunExecutionSettings<'a> {
     pub extra_bin_paths: &'a [PathBuf],
     pub extra_env: &'a HashMap<String, String>,
@@ -236,13 +249,18 @@ impl TaskRunStateContext {
         }
         let mut completed = HashSet::new();
         for line in lines {
-            let Ok(record) = serde_json::from_str::<TaskRecord>(line) else { return Ok(None) };
-            if record.run != header.run {
-                continue;
+            let Ok(record) = serde_json::from_str::<JournalRecord>(line) else { return Ok(None) };
+            match record {
+                JournalRecord::Task(record) if record.run == header.run => {
+                    let id = TaskId { project: record.project, task: record.task };
+                    let Some(key) = self.keys_by_id.get(&id) else { return Ok(None) };
+                    completed.insert(key.clone());
+                }
+                JournalRecord::Finish(record) if record.run == header.run && record.finished => {
+                    return Ok(None);
+                }
+                _ => {}
             }
-            let id = TaskId { project: record.project, task: record.task };
-            let Some(key) = self.keys_by_id.get(&id) else { return Ok(None) };
-            completed.insert(key.clone());
         }
         Ok(Some(completed))
     }
@@ -458,26 +476,36 @@ impl TaskRunState {
     }
 
     pub fn finish(&self) -> miette::Result<()> {
-        let file = self.writer.lock().expect("task state lock is not poisoned").file.take();
-        if file.is_none() {
+        let mut writer = self.writer.lock().expect("task state lock is not poisoned");
+        let Some(mut file) = writer.file.take() else {
             return Ok(());
+        };
+        let finish_record = FinishRecord { run: writer.run.clone(), finished: true };
+        let line = serde_json::to_string(&finish_record).expect("finish record serializes");
+        if let Err(error) = writeln!(file, "{line}")
+            && !is_state_unavailable_error(&error)
+        {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("writing {}", self.file_path.display()));
         }
         drop(file);
-        match fs::remove_file(&self.file_path) {
+        drop(writer);
+        match fs::remove_file(&self.published_path) {
             Ok(()) => {}
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}
             Err(error) if is_state_unavailable_error(&error) => return Ok(()),
             Err(error) => Err(error)
                 .into_diagnostic()
-                .wrap_err_with(|| format!("removing {}", self.file_path.display()))?,
+                .wrap_err_with(|| format!("removing {}", self.published_path.display()))?,
         }
-        match fs::remove_file(&self.published_path) {
+        match fs::remove_file(&self.file_path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) if is_state_unavailable_error(&error) => Ok(()),
             Err(error) => Err(error)
                 .into_diagnostic()
-                .wrap_err_with(|| format!("removing {}", self.published_path.display())),
+                .wrap_err_with(|| format!("removing {}", self.file_path.display())),
         }
     }
 }

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -19,6 +19,7 @@ const STATE_VERSION: u8 = 1;
 const STATE_DIR: &str = ".pnpm-task-run-state-v1";
 const LATEST_STATE_FILE: &str = "latest.json";
 const PUBLISHED_SUFFIX: &str = ".published";
+const FINISHED_SUFFIX: &str = ".finished";
 const START_LOCK_DIR: &str = "start.lock";
 const LOCK_WAIT: Duration = Duration::from_secs(2);
 const LOCK_ABANDONED_AFTER: Duration = Duration::from_secs(30);
@@ -210,11 +211,14 @@ impl TaskRunStateContext {
         {
             return Ok(None);
         }
-        let run = match self.newest_journal_run(&latest.run) {
-            Ok(run) => run,
+        let (run, finished) = match self.newest_state(&latest.run) {
+            Ok(state) => state,
             Err(error) if error.is_unavailable() => return Ok(None),
             Err(error) => return Err(error.into_report()),
         };
+        if finished {
+            return Ok(None);
+        }
         let file_path = self.journal_path(&run);
         let contents = match fs::read(&file_path) {
             Ok(contents) => contents,
@@ -280,6 +284,7 @@ impl TaskRunStateContext {
         Ok(TaskRunState {
             file_path,
             published_path: self.published_path(&run),
+            finished_path: self.finished_path(&run),
             writer: Mutex::new(TaskRunStateWriter {
                 file,
                 run,
@@ -354,6 +359,7 @@ impl TaskRunStateContext {
             let _ = fs::remove_file(&published_path);
             return Err(StateStorageError::io(error, "writing", &published_path));
         }
+        self.cleanup_older_finished_state(&run);
         Ok((file_path, run, Some(file)))
     }
 
@@ -365,7 +371,11 @@ impl TaskRunStateContext {
         self.state_dir.join(format!("{}.{run}{PUBLISHED_SUFFIX}", self.invocation))
     }
 
-    fn newest_journal_run(&self, latest_run: &str) -> Result<String, StateStorageError> {
+    fn finished_path(&self, run: &str) -> PathBuf {
+        self.state_dir.join(format!("{}.{run}{FINISHED_SUFFIX}", self.invocation))
+    }
+
+    fn newest_state(&self, latest_run: &str) -> Result<(String, bool), StateStorageError> {
         let mut newest_run = latest_run.to_string();
         let prefix = format!("{}.", self.invocation);
         let entries = fs::read_dir(&self.state_dir)
@@ -376,21 +386,33 @@ impl TaskRunStateContext {
                 entry.map_err(|error| StateStorageError::io(error, "reading", &self.state_dir))?;
             names.insert(entry.file_name());
         }
+        let mut finished =
+            names.contains(OsStr::new(&format!("{prefix}{latest_run}{FINISHED_SUFFIX}")));
         for name in &names {
             let Some(name) = name.to_str() else { continue };
-            let Some(run) = name.strip_prefix(&prefix).and_then(|name| name.strip_suffix(".jsonl"))
-            else {
+            let Some(name) = name.strip_prefix(&prefix) else { continue };
+            let (run, candidate_finished) = if let Some(run) = name.strip_suffix(FINISHED_SUFFIX) {
+                (run, true)
+            } else if let Some(run) = name.strip_suffix(".jsonl") {
+                let published_name = format!("{prefix}{run}{PUBLISHED_SUFFIX}");
+                if !names.contains(OsStr::new(&published_name)) {
+                    continue;
+                }
+                (run, false)
+            } else {
                 continue;
             };
-            let published_name = format!("{prefix}{run}{PUBLISHED_SUFFIX}");
-            if is_run_id(run)
-                && names.contains(OsStr::new(&published_name))
-                && run_generation(run) > run_generation(&newest_run)
-            {
+            if !is_run_id(run) {
+                continue;
+            }
+            if run_generation(run) > run_generation(&newest_run) {
                 newest_run = run.to_string();
+                finished = candidate_finished;
+            } else if run == newest_run && candidate_finished {
+                finished = true;
             }
         }
-        Ok(newest_run)
+        Ok((newest_run, finished))
     }
 
     fn next_run_id(&self) -> Result<String, StateStorageError> {
@@ -410,11 +432,27 @@ impl TaskRunStateContext {
                 return Err(StateStorageError::io(error, "reading", &self.latest_state_path));
             }
         }
-        newest_run = self.newest_journal_run(&newest_run)?;
+        newest_run = self.newest_state(&newest_run)?.0;
         let generation = u64::from_str_radix(run_generation(&newest_run), 16)
             .expect("validated run generation")
             .saturating_add(1);
         Ok(run_id(generation))
+    }
+
+    fn cleanup_older_finished_state(&self, run: &str) {
+        let Ok(entries) = fs::read_dir(&self.state_dir) else { return };
+        let prefix = format!("{}.", self.invocation);
+        let generation = run_generation(run);
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            let Some(name) = name.strip_prefix(&prefix) else { continue };
+            let Some(older_run) = name.strip_suffix(FINISHED_SUFFIX) else { continue };
+            if !is_run_id(older_run) || run_generation(older_run) >= generation {
+                continue;
+            }
+            let _ = fs::remove_file(entry.path());
+        }
     }
 
     fn validate_state_directory(&self, create: bool) -> Result<bool, StateStorageError> {
@@ -429,6 +467,7 @@ impl TaskRunStateContext {
 pub struct TaskRunState {
     file_path: PathBuf,
     published_path: PathBuf,
+    finished_path: PathBuf,
     writer: Mutex<TaskRunStateWriter>,
 }
 
@@ -491,6 +530,14 @@ impl TaskRunState {
         }
         drop(file);
         drop(writer);
+        if let Err(error) = pnpm_fs::write_atomic(&self.finished_path, &[]) {
+            if is_state_unavailable_error(&error) {
+                return Ok(());
+            }
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("writing {}", self.finished_path.display()));
+        }
         match fs::remove_file(&self.published_path) {
             Ok(()) => {}
             Err(error) if error.kind() == io::ErrorKind::NotFound => {}

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -1,0 +1,304 @@
+use miette::{IntoDiagnostic, WrapErr as _};
+use pnpm_crypto_hash::create_hex_hash;
+use pnpm_workspace_task_scheduler::{TaskGraph, TaskKey, TaskNode};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{self, File, OpenOptions},
+    io::{self, Write as _},
+    path::{Path, PathBuf},
+    sync::{
+        Mutex,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+const STATE_VERSION: u8 = 1;
+const STATE_DIR: &str = ".pnpm-task-run-state-v1";
+static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+struct TaskId {
+    project: String,
+    task: String,
+}
+
+#[derive(Serialize)]
+struct ScriptIdentity {
+    name: String,
+    commands: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct TaskIdentity {
+    project: String,
+    task: String,
+    scripts: Vec<ScriptIdentity>,
+    requested: bool,
+    dependencies: Vec<TaskId>,
+}
+
+#[derive(Serialize)]
+struct InvocationIdentity<'a> {
+    command: &'a str,
+    params: &'a [String],
+    settings: &'a [String],
+    tasks: Vec<TaskIdentity>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct StateHeader {
+    version: u8,
+    invocation: String,
+    run: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct TaskRecord {
+    run: String,
+    project: String,
+    task: String,
+}
+
+pub struct TaskRunStateContext {
+    file_path: PathBuf,
+    invocation: String,
+    keys_by_id: HashMap<TaskId, TaskKey>,
+    ids_by_key: HashMap<TaskKey, TaskId>,
+}
+
+impl TaskRunStateContext {
+    pub fn new(
+        command: &str,
+        params: &[String],
+        settings: &[String],
+        graph: &TaskGraph,
+        workspace_dir: &Path,
+        script_commands: impl Fn(&TaskNode, &str) -> Vec<String>,
+    ) -> Self {
+        let mut keys_by_id = HashMap::with_capacity(graph.len());
+        let mut ids_by_key = HashMap::with_capacity(graph.len());
+        let mut tasks: Vec<TaskIdentity> = graph
+            .iter()
+            .map(|(key, node)| {
+                let id = task_id(node, workspace_dir);
+                keys_by_id.insert(id.clone(), key.clone());
+                ids_by_key.insert(key.clone(), id.clone());
+                let mut scripts: Vec<ScriptIdentity> = node
+                    .scripts
+                    .iter()
+                    .map(|name| ScriptIdentity {
+                        name: name.clone(),
+                        commands: script_commands(node, name),
+                    })
+                    .collect();
+                scripts.sort_by(|left, right| left.name.cmp(&right.name));
+                let mut dependencies: Vec<TaskId> = node
+                    .dependencies
+                    .iter()
+                    .map(|dependency| task_id(&graph[dependency], workspace_dir))
+                    .collect();
+                dependencies.sort();
+                TaskIdentity {
+                    project: id.project,
+                    task: id.task,
+                    scripts,
+                    requested: node.requested,
+                    dependencies,
+                }
+            })
+            .collect();
+        tasks.sort_by(|left, right| {
+            left.project.cmp(&right.project).then_with(|| left.task.cmp(&right.task))
+        });
+        let mut settings = settings.to_vec();
+        settings.sort();
+        let identity = serde_json::to_string(&InvocationIdentity {
+            command,
+            params,
+            settings: &settings,
+            tasks,
+        })
+        .expect("task invocation identity serializes");
+        let invocation = create_hex_hash(&identity);
+        let file_path =
+            workspace_dir.join("node_modules").join(STATE_DIR).join(format!("{invocation}.jsonl"));
+        Self { file_path, invocation, keys_by_id, ids_by_key }
+    }
+
+    pub fn read_completed_tasks(&self) -> miette::Result<Option<HashSet<TaskKey>>> {
+        let contents = match fs::read(&self.file_path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("reading {}", self.file_path.display()));
+            }
+        };
+        // A record is committed by its newline; a process killed during
+        // append can leave only the final record torn.
+        let Some(last_newline) = contents.iter().rposition(|byte| *byte == b'\n') else {
+            return Ok(None);
+        };
+        let Ok(complete) = std::str::from_utf8(&contents[..last_newline]) else {
+            return Ok(None);
+        };
+        let mut lines = complete.lines();
+        let Some(header) = lines.next() else { return Ok(None) };
+        let Ok(header) = serde_json::from_str::<StateHeader>(header) else { return Ok(None) };
+        if header.version != STATE_VERSION || header.invocation != self.invocation {
+            return Ok(None);
+        }
+        let mut completed = HashSet::new();
+        for line in lines {
+            let Ok(record) = serde_json::from_str::<TaskRecord>(line) else { return Ok(None) };
+            if record.run != header.run {
+                continue;
+            }
+            let id = TaskId { project: record.project, task: record.task };
+            let Some(key) = self.keys_by_id.get(&id) else { return Ok(None) };
+            completed.insert(key.clone());
+        }
+        Ok(Some(completed))
+    }
+
+    pub fn start(&self, completed_tasks: &HashSet<TaskKey>) -> miette::Result<TaskRunState> {
+        let run = run_id();
+        let header = StateHeader {
+            version: STATE_VERSION,
+            invocation: self.invocation.clone(),
+            run: run.clone(),
+        };
+        let mut completed: Vec<&TaskId> =
+            completed_tasks.iter().map(|key| &self.ids_by_key[key]).collect();
+        completed.sort();
+        let mut contents = serde_json::to_string(&header).expect("task state header serializes");
+        contents.push('\n');
+        for id in &completed {
+            let record =
+                TaskRecord { run: run.clone(), project: id.project.clone(), task: id.task.clone() };
+            contents.push_str(&serde_json::to_string(&record).expect("task record serializes"));
+            contents.push('\n');
+        }
+        let state_dir = self.file_path.parent().expect("task state file has a parent");
+        fs::create_dir_all(state_dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("creating {}", state_dir.display()))?;
+        pnpm_fs::write_atomic(&self.file_path, contents.as_bytes())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("writing {}", self.file_path.display()))?;
+        // Only the latest recursive invocation is resumable. Otherwise an
+        // old compatible journal could become active after intervening work.
+        for entry in fs::read_dir(state_dir)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("reading {}", state_dir.display()))?
+        {
+            let entry = entry
+                .into_diagnostic()
+                .wrap_err_with(|| format!("reading {}", state_dir.display()))?;
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            let file_type = entry
+                .file_type()
+                .into_diagnostic()
+                .wrap_err_with(|| format!("reading stale task state {name}"))?;
+            if entry.path() != self.file_path && is_state_file_name(&name) && !file_type.is_dir() {
+                match fs::remove_file(entry.path()) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+                    Err(error) => {
+                        return Err(error)
+                            .into_diagnostic()
+                            .wrap_err_with(|| format!("removing stale task state {name}"));
+                    }
+                }
+            }
+        }
+        let file = OpenOptions::new()
+            .append(true)
+            .open(&self.file_path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("opening {}", self.file_path.display()))?;
+        Ok(TaskRunState {
+            file_path: self.file_path.clone(),
+            writer: Mutex::new(TaskRunStateWriter {
+                file: Some(file),
+                run,
+                completed: completed_tasks.clone(),
+            }),
+        })
+    }
+}
+
+pub struct TaskRunState {
+    file_path: PathBuf,
+    writer: Mutex<TaskRunStateWriter>,
+}
+
+struct TaskRunStateWriter {
+    file: Option<File>,
+    run: String,
+    completed: HashSet<TaskKey>,
+}
+
+impl TaskRunState {
+    pub fn record_passed(
+        &self,
+        key: &TaskKey,
+        node: &TaskNode,
+        workspace_dir: &Path,
+    ) -> miette::Result<()> {
+        let mut writer = self.writer.lock().expect("task state lock is not poisoned");
+        if !writer.completed.insert(key.clone()) {
+            return Ok(());
+        }
+        let id = task_id(node, workspace_dir);
+        let record = TaskRecord { run: writer.run.clone(), project: id.project, task: id.task };
+        let line = serde_json::to_string(&record).expect("task record serializes");
+        let file = writer.file.as_mut().expect("unfinished task state has an open file");
+        writeln!(file, "{line}")
+            .into_diagnostic()
+            .wrap_err_with(|| format!("writing {}", self.file_path.display()))
+    }
+
+    pub fn finish(&self) -> miette::Result<()> {
+        let file = self.writer.lock().expect("task state lock is not poisoned").file.take();
+        drop(file);
+        match fs::remove_file(&self.file_path) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("removing {}", self.file_path.display())),
+        }
+    }
+}
+
+fn task_id(node: &TaskNode, workspace_dir: &Path) -> TaskId {
+    let relative = pnpm_fs::relative_path(workspace_dir, &node.project);
+    let project = if relative.as_os_str().is_empty() {
+        ".".to_string()
+    } else {
+        relative.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/")
+    };
+    TaskId { project, task: node.task_name.clone() }
+}
+
+fn is_state_file_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    bytes.len() == 70
+        && &bytes[64..] == b".jsonl"
+        && bytes[..64].iter().all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+}
+
+fn run_id() -> String {
+    let timestamp =
+        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_nanos());
+    let sequence = RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    format!("{}-{timestamp}-{sequence}", std::process::id())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/task_run_state.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state.rs
@@ -4,6 +4,7 @@ use pnpm_workspace_task_scheduler::{TaskGraph, TaskKey, TaskNode};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsStr,
     fs::{self, File, OpenOptions},
     io::{self, Write as _},
     path::{Path, PathBuf},
@@ -17,9 +18,11 @@ use std::{
 const STATE_VERSION: u8 = 1;
 const STATE_DIR: &str = ".pnpm-task-run-state-v1";
 const LATEST_STATE_FILE: &str = "latest.json";
+const PUBLISHED_SUFFIX: &str = ".published";
 const START_LOCK_DIR: &str = "start.lock";
 const LOCK_WAIT: Duration = Duration::from_secs(2);
 const LOCK_ABANDONED_AFTER: Duration = Duration::from_secs(30);
+const RUN_GENERATION_LENGTH: usize = 12;
 static RUN_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -194,7 +197,12 @@ impl TaskRunStateContext {
         {
             return Ok(None);
         }
-        let file_path = self.journal_path(&latest.run);
+        let run = match self.newest_journal_run(&latest.run) {
+            Ok(run) => run,
+            Err(error) if error.is_unavailable() => return Ok(None),
+            Err(error) => return Err(error.into_report()),
+        };
+        let file_path = self.journal_path(&run);
         let contents = match fs::read(&file_path) {
             Ok(contents) => contents,
             Err(error)
@@ -222,7 +230,7 @@ impl TaskRunStateContext {
         let Ok(header) = serde_json::from_str::<StateHeader>(header) else { return Ok(None) };
         if header.version != STATE_VERSION
             || header.invocation != self.invocation
-            || header.run != latest.run
+            || header.run != run
         {
             return Ok(None);
         }
@@ -240,31 +248,20 @@ impl TaskRunStateContext {
     }
 
     pub fn start(&self, completed_tasks: &HashSet<TaskKey>) -> miette::Result<TaskRunState> {
-        let run = run_id();
-        let header = StateHeader {
-            version: STATE_VERSION,
-            invocation: self.invocation.clone(),
-            run: run.clone(),
-        };
         let mut completed: Vec<&TaskId> =
             completed_tasks.iter().map(|key| &self.ids_by_key[key]).collect();
         completed.sort();
-        let mut contents = serde_json::to_string(&header).expect("task state header serializes");
-        contents.push('\n');
-        for id in &completed {
-            let record =
-                TaskRecord { run: run.clone(), project: id.project.clone(), task: id.task.clone() };
-            contents.push_str(&serde_json::to_string(&record).expect("task record serializes"));
-            contents.push('\n');
-        }
-        let file_path = self.journal_path(&run);
-        let file = match self.start_file(&file_path, &contents, &header) {
-            Ok(file) => file,
-            Err(error) if error.is_unavailable() => None,
+        let (file_path, run, file) = match self.start_file(&completed) {
+            Ok(state) => state,
+            Err(error) if error.is_unavailable() => {
+                let run = run_id(current_generation());
+                (self.journal_path(&run), run, None)
+            }
             Err(error) => return Err(error.into_report()),
         };
         Ok(TaskRunState {
             file_path,
+            published_path: self.published_path(&run),
             writer: Mutex::new(TaskRunStateWriter {
                 file,
                 run,
@@ -275,54 +272,131 @@ impl TaskRunStateContext {
 
     fn start_file(
         &self,
-        file_path: &Path,
-        contents: &str,
-        header: &StateHeader,
-    ) -> Result<Option<File>, StateStorageError> {
+        completed: &[&TaskId],
+    ) -> Result<(PathBuf, String, Option<File>), StateStorageError> {
         self.validate_state_directory(true)?;
         let lock_path = self.state_dir.join(START_LOCK_DIR);
         let Some(lock) =
             pnpm_fs::DirLock::acquire(lock_path.clone(), LOCK_WAIT, LOCK_ABANDONED_AFTER)
                 .map_err(|error| StateStorageError::io(error, "locking", &lock_path))?
         else {
-            return Ok(None);
+            let run = run_id(current_generation());
+            return Ok((self.journal_path(&run), run, None));
         };
-        pnpm_fs::write_atomic(file_path, contents.as_bytes())
-            .map_err(|error| StateStorageError::io(error, "writing", file_path))?;
-        let file = match OpenOptions::new().append(true).open(file_path) {
+        let run = self.next_run_id()?;
+        let header = StateHeader {
+            version: STATE_VERSION,
+            invocation: self.invocation.clone(),
+            run: run.clone(),
+        };
+        let mut contents = serde_json::to_string(&header).expect("task state header serializes");
+        contents.push('\n');
+        for id in completed {
+            let record =
+                TaskRecord { run: run.clone(), project: id.project.clone(), task: id.task.clone() };
+            contents.push_str(&serde_json::to_string(&record).expect("task record serializes"));
+            contents.push('\n');
+        }
+        let file_path = self.journal_path(&run);
+        pnpm_fs::write_atomic(&file_path, contents.as_bytes())
+            .map_err(|error| StateStorageError::io(error, "writing", &file_path))?;
+        let file = match OpenOptions::new().append(true).open(&file_path) {
             Ok(file) => file,
             Err(error) => {
-                let _ = fs::remove_file(file_path);
-                return Err(StateStorageError::io(error, "opening", file_path));
+                let _ = fs::remove_file(&file_path);
+                return Err(StateStorageError::io(error, "opening", &file_path));
             }
         };
         match lock.is_owner() {
             Ok(true) => {}
             Ok(false) => {
                 drop(file);
-                let _ = fs::remove_file(file_path);
-                return Ok(None);
+                let _ = fs::remove_file(&file_path);
+                return Ok((file_path, run, None));
             }
             Err(error) => {
                 drop(file);
-                let _ = fs::remove_file(file_path);
+                let _ = fs::remove_file(&file_path);
                 return Err(StateStorageError::io(error, "checking", &lock_path));
             }
         }
         let latest_write = pnpm_fs::write_atomic(
             &self.latest_state_path,
-            serde_json::to_string(header).expect("latest task state serializes").as_bytes(),
+            serde_json::to_string(&header).expect("latest task state serializes").as_bytes(),
         );
         if let Err(error) = latest_write {
             drop(file);
-            let _ = fs::remove_file(file_path);
+            let _ = fs::remove_file(&file_path);
             return Err(StateStorageError::io(error, "writing", &self.latest_state_path));
         }
-        Ok(Some(file))
+        let published_path = self.published_path(&run);
+        if let Err(error) = pnpm_fs::write_atomic(&published_path, &[]) {
+            drop(file);
+            let _ = fs::remove_file(&file_path);
+            let _ = fs::remove_file(&published_path);
+            return Err(StateStorageError::io(error, "writing", &published_path));
+        }
+        Ok((file_path, run, Some(file)))
     }
 
     fn journal_path(&self, run: &str) -> PathBuf {
         self.state_dir.join(format!("{}.{run}.jsonl", self.invocation))
+    }
+
+    fn published_path(&self, run: &str) -> PathBuf {
+        self.state_dir.join(format!("{}.{run}{PUBLISHED_SUFFIX}", self.invocation))
+    }
+
+    fn newest_journal_run(&self, latest_run: &str) -> Result<String, StateStorageError> {
+        let mut newest_run = latest_run.to_string();
+        let prefix = format!("{}.", self.invocation);
+        let entries = fs::read_dir(&self.state_dir)
+            .map_err(|error| StateStorageError::io(error, "reading", &self.state_dir))?;
+        let mut names = HashSet::new();
+        for entry in entries {
+            let entry =
+                entry.map_err(|error| StateStorageError::io(error, "reading", &self.state_dir))?;
+            names.insert(entry.file_name());
+        }
+        for name in &names {
+            let Some(name) = name.to_str() else { continue };
+            let Some(run) = name.strip_prefix(&prefix).and_then(|name| name.strip_suffix(".jsonl"))
+            else {
+                continue;
+            };
+            let published_name = format!("{prefix}{run}{PUBLISHED_SUFFIX}");
+            if is_run_id(run)
+                && names.contains(OsStr::new(&published_name))
+                && run_generation(run) > run_generation(&newest_run)
+            {
+                newest_run = run.to_string();
+            }
+        }
+        Ok(newest_run)
+    }
+
+    fn next_run_id(&self) -> Result<String, StateStorageError> {
+        let mut newest_run = run_id(current_generation());
+        match fs::read_to_string(&self.latest_state_path) {
+            Ok(contents) => {
+                if let Ok(latest) = serde_json::from_str::<StateHeader>(&contents)
+                    && latest.invocation == self.invocation
+                    && is_run_id(&latest.run)
+                    && run_generation(&latest.run) > run_generation(&newest_run)
+                {
+                    newest_run = latest.run;
+                }
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(StateStorageError::io(error, "reading", &self.latest_state_path));
+            }
+        }
+        newest_run = self.newest_journal_run(&newest_run)?;
+        let generation = u64::from_str_radix(run_generation(&newest_run), 16)
+            .expect("validated run generation")
+            .saturating_add(1);
+        Ok(run_id(generation))
     }
 
     fn validate_state_directory(&self, create: bool) -> Result<bool, StateStorageError> {
@@ -336,6 +410,7 @@ impl TaskRunStateContext {
 
 pub struct TaskRunState {
     file_path: PathBuf,
+    published_path: PathBuf,
     writer: Mutex<TaskRunStateWriter>,
 }
 
@@ -371,6 +446,7 @@ impl TaskRunState {
                 writer.file.take();
                 drop(writer);
                 let _ = fs::remove_file(&self.file_path);
+                let _ = fs::remove_file(&self.published_path);
                 return Ok(());
             }
             writer.completed.remove(key);
@@ -388,12 +464,20 @@ impl TaskRunState {
         }
         drop(file);
         match fs::remove_file(&self.file_path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) if is_state_unavailable_error(&error) => return Ok(()),
+            Err(error) => Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("removing {}", self.file_path.display()))?,
+        }
+        match fs::remove_file(&self.published_path) {
             Ok(()) => Ok(()),
             Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
             Err(error) if is_state_unavailable_error(&error) => Ok(()),
             Err(error) => Err(error)
                 .into_diagnostic()
-                .wrap_err_with(|| format!("removing {}", self.file_path.display())),
+                .wrap_err_with(|| format!("removing {}", self.published_path.display())),
         }
     }
 }
@@ -409,11 +493,19 @@ fn task_id(node: &TaskNode, workspace_dir: &Path) -> TaskId {
 }
 
 fn is_run_id(run: &str) -> bool {
-    !run.is_empty()
+    run.len() > RUN_GENERATION_LENGTH + 1
         && run.len() <= 128
-        && run
+        && run.as_bytes()[RUN_GENERATION_LENGTH] == b'-'
+        && run[..RUN_GENERATION_LENGTH]
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        && run[RUN_GENERATION_LENGTH + 1..]
             .bytes()
             .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte) || byte == b'-')
+}
+
+fn run_generation(run: &str) -> &str {
+    &run[..RUN_GENERATION_LENGTH]
 }
 
 fn validate_real_directory(path: &Path, create: bool) -> Result<bool, StateStorageError> {
@@ -482,11 +574,15 @@ fn is_state_unavailable_error(error: &io::Error) -> bool {
     matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ReadOnlyFilesystem)
 }
 
-fn run_id() -> String {
-    let timestamp =
-        SystemTime::now().duration_since(UNIX_EPOCH).map_or(0, |duration| duration.as_nanos());
+fn current_generation() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |duration| duration.as_millis().try_into().unwrap_or(u64::MAX))
+}
+
+fn run_id(generation: u64) -> String {
     let sequence = RUN_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-    format!("{}-{timestamp}-{sequence}", std::process::id())
+    format!("{generation:012x}-{}-{sequence}", std::process::id())
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -1,0 +1,80 @@
+use super::TaskRunStateContext;
+use indexmap::IndexMap;
+use pnpm_workspace_task_scheduler::{TaskGraph, TaskKey, TaskNode};
+use std::{collections::HashSet, fs, io::Write as _};
+
+#[test]
+fn ignores_a_torn_trailing_record_and_removes_a_completed_journal() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let first = workspace.path().join("first");
+    let second = workspace.path().join("second");
+    let first_key = TaskKey { project: first.clone(), task_name: "build".to_string() };
+    let second_key = TaskKey { project: second.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([
+        (
+            first_key.clone(),
+            TaskNode {
+                project: first,
+                task_name: "build".to_string(),
+                concurrency: None,
+                scripts: vec!["build".to_string()],
+                requested: true,
+                dependencies: Vec::new(),
+            },
+        ),
+        (
+            second_key.clone(),
+            TaskNode {
+                project: second,
+                task_name: "build".to_string(),
+                concurrency: None,
+                scripts: vec!["build".to_string()],
+                requested: true,
+                dependencies: vec![first_key.clone()],
+            },
+        ),
+    ]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    assert_eq!(
+        context.invocation,
+        "76a575bfcc3b67becd98b5ec661be54567b53954a723da167603dad119fab140",
+    );
+    let stale_state = context
+        .file_path
+        .parent()
+        .expect("state file has a parent")
+        .join(format!("{}.jsonl", "a".repeat(64)));
+    fs::create_dir_all(stale_state.parent().expect("stale state has a parent"))
+        .expect("create state directory");
+    fs::write(&stale_state, "stale").expect("write stale state");
+    let state = context.start(&HashSet::from([first_key.clone()])).expect("start state");
+    assert!(!stale_state.exists());
+    state
+        .record_passed(&second_key, &graph[&second_key], workspace.path())
+        .expect("record passed task");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&context.file_path)
+        .expect("open state")
+        .write_all(b"{\"run\":\"superseded\",\"project\":\"unknown\",\"task\":\"build\"}\n")
+        .expect("write superseded record");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&context.file_path)
+        .expect("open state")
+        .write_all(br#"{"project":"torn"#)
+        .expect("write torn record");
+
+    let completed =
+        context.read_completed_tasks().expect("read state").expect("state is compatible");
+    assert_eq!(completed, HashSet::from([first_key, second_key]));
+    state.finish().expect("finish state");
+    assert!(!context.file_path.exists());
+}

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -227,6 +227,49 @@ fn rejects_a_symlinked_state_directory() {
     assert!(!outside.path().join("latest.json").exists());
 }
 
+#[cfg(unix)]
+#[test]
+fn disables_state_when_node_modules_is_read_only() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key.clone(),
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let node_modules = workspace.path().join("node_modules");
+    fs::create_dir(&node_modules).expect("create node_modules");
+    fs::set_permissions(&node_modules, fs::Permissions::from_mode(0o555))
+        .expect("make node_modules read-only");
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+
+    let result = context.start(&HashSet::new()).and_then(|state| {
+        state.record_passed(&key, &graph[&key], workspace.path())?;
+        state.finish()
+    });
+    fs::set_permissions(&node_modules, fs::Permissions::from_mode(0o755))
+        .expect("restore node_modules permissions");
+
+    result.expect("read-only state storage is optional");
+    assert!(!context.latest_state_path.exists());
+}
+
 #[test]
 fn finishing_an_older_invocation_preserves_the_newer_invocation_journal() {
     let workspace = tempfile::tempdir().expect("create workspace");

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -1,7 +1,86 @@
-use super::TaskRunStateContext;
+use super::{TaskRunExecutionSettings, TaskRunStateContext, task_run_execution_settings};
 use indexmap::IndexMap;
 use pnpm_workspace_task_scheduler::{TaskGraph, TaskKey, TaskNode};
-use std::{collections::HashSet, fs, io::Write as _};
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    io::Write as _,
+    path::{Path, PathBuf},
+};
+
+#[test]
+fn task_execution_settings_have_a_stable_canonical_encoding() {
+    let extra_bin_paths = vec![PathBuf::from("tools"), PathBuf::from("other-tools")];
+    let extra_env = HashMap::from([
+        ("ZED".to_string(), "last".to_string()),
+        ("ALPHA".to_string(), "first".to_string()),
+    ]);
+    assert_eq!(
+        task_run_execution_settings(&TaskRunExecutionSettings {
+            extra_bin_paths: &extra_bin_paths,
+            extra_env: &extra_env,
+            modules_dir: Path::new("vendor"),
+            node_experimental_package_map: true,
+            node_options: Some("--conditions=development"),
+            user_agent: "pnpm/test",
+        }),
+        [
+            r#"extra-bin-paths=["tools","other-tools"]"#,
+            r#"extra-env=[["ALPHA","first"],["ZED","last"]]"#,
+            "modules-dir=vendor",
+            "node-experimental-package-map=true",
+            "node-options=--conditions=development",
+            "user-agent=pnpm/test",
+        ],
+    );
+}
+
+#[test]
+fn a_changed_execution_setting_produces_a_different_invocation_identity() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key,
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let settings = |mode: &str| {
+        let extra_env = HashMap::from([("MODE".to_string(), mode.to_string())]);
+        task_run_execution_settings(&TaskRunExecutionSettings {
+            extra_bin_paths: &[],
+            extra_env: &extra_env,
+            modules_dir: Path::new("node_modules"),
+            node_experimental_package_map: false,
+            node_options: None,
+            user_agent: "",
+        })
+    };
+    let first = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &settings("first"),
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let second = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &settings("second"),
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+
+    assert_ne!(first.invocation, second.invocation);
+}
 
 #[test]
 fn ignores_a_torn_trailing_record_and_removes_a_completed_journal() {
@@ -46,28 +125,19 @@ fn ignores_a_torn_trailing_record_and_removes_a_completed_journal() {
         context.invocation,
         "76a575bfcc3b67becd98b5ec661be54567b53954a723da167603dad119fab140",
     );
-    let stale_state = context
-        .file_path
-        .parent()
-        .expect("state file has a parent")
-        .join(format!("{}.jsonl", "a".repeat(64)));
-    fs::create_dir_all(stale_state.parent().expect("stale state has a parent"))
-        .expect("create state directory");
-    fs::write(&stale_state, "stale").expect("write stale state");
     let state = context.start(&HashSet::from([first_key.clone()])).expect("start state");
-    assert!(!stale_state.exists());
     state
         .record_passed(&second_key, &graph[&second_key], workspace.path())
         .expect("record passed task");
     fs::OpenOptions::new()
         .append(true)
-        .open(&context.file_path)
+        .open(&state.file_path)
         .expect("open state")
         .write_all(b"{\"run\":\"superseded\",\"project\":\"unknown\",\"task\":\"build\"}\n")
         .expect("write superseded record");
     fs::OpenOptions::new()
         .append(true)
-        .open(&context.file_path)
+        .open(&state.file_path)
         .expect("open state")
         .write_all(br#"{"project":"torn"#)
         .expect("write torn record");
@@ -76,5 +146,118 @@ fn ignores_a_torn_trailing_record_and_removes_a_completed_journal() {
         context.read_completed_tasks().expect("read state").expect("state is compatible");
     assert_eq!(completed, HashSet::from([first_key, second_key]));
     state.finish().expect("finish state");
-    assert!(!context.file_path.exists());
+    assert!(context.read_completed_tasks().expect("read finished state").is_none());
+}
+
+#[test]
+fn rejects_a_malformed_complete_record() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key,
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let state = context.start(&HashSet::new()).expect("start state");
+    fs::OpenOptions::new()
+        .append(true)
+        .open(&state.file_path)
+        .expect("open state")
+        .write_all(b"not-json\n")
+        .expect("write malformed record");
+
+    assert!(context.read_completed_tasks().expect("read malformed state").is_none());
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_a_symlinked_state_directory() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let outside = tempfile::tempdir().expect("create outside directory");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key,
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let node_modules = workspace.path().join("node_modules");
+    fs::create_dir(&node_modules).expect("create node_modules");
+    symlink(outside.path(), node_modules.join(".pnpm-task-run-state-v1"))
+        .expect("symlink state directory");
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+
+    let Err(error) = context.start(&HashSet::new()) else {
+        panic!("symlinked state directory must be rejected");
+    };
+    assert!(error.to_string().contains("symbolic link or not a directory"));
+    assert!(!outside.path().join("latest.json").exists());
+}
+
+#[test]
+fn finishing_an_older_invocation_preserves_the_newer_invocation_journal() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key.clone(),
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let older = context.start(&HashSet::new()).expect("start older state");
+    let newer = context.start(&HashSet::from([key.clone()])).expect("start newer state");
+
+    older.finish().expect("finish older state");
+
+    let completed = context
+        .read_completed_tasks()
+        .expect("read newer state")
+        .expect("newer state remains compatible");
+    assert_eq!(completed, HashSet::from([key]));
+    newer.finish().expect("finish newer state");
+    assert!(context.read_completed_tasks().expect("read finished state").is_none());
 }

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -307,3 +307,55 @@ fn finishing_an_older_invocation_preserves_the_newer_invocation_journal() {
     newer.finish().expect("finish newer state");
     assert!(context.read_completed_tasks().expect("read finished state").is_none());
 }
+
+#[test]
+fn a_stale_pointer_does_not_hide_a_newer_published_invocation_journal() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key.clone(),
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let older = context.start(&HashSet::new()).expect("start older state");
+    let older_contents = fs::read_to_string(&older.file_path).expect("read older state");
+    let older_header = older_contents.lines().next().expect("older state has a header");
+    let newer = context.start(&HashSet::from([key.clone()])).expect("start newer state");
+
+    fs::remove_file(&newer.published_path).expect("remove publication marker");
+    fs::write(&context.latest_state_path, older_header).expect("write stale pointer");
+    let completed = context
+        .read_completed_tasks()
+        .expect("read older state")
+        .expect("older state remains compatible");
+    assert!(completed.is_empty());
+    fs::write(&newer.published_path, []).expect("write publication marker");
+
+    let completed = context
+        .read_completed_tasks()
+        .expect("read newer state")
+        .expect("newer state remains compatible");
+    assert_eq!(completed, HashSet::from([key.clone()]));
+    older.finish().expect("finish older state");
+    let completed = context
+        .read_completed_tasks()
+        .expect("read newer state")
+        .expect("newer state remains compatible");
+    assert_eq!(completed, HashSet::from([key]));
+    newer.finish().expect("finish newer state");
+}

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -308,6 +308,45 @@ fn finishing_an_older_invocation_preserves_the_newer_invocation_journal() {
     assert!(context.read_completed_tasks().expect("read finished state").is_none());
 }
 
+#[cfg(unix)]
+#[test]
+fn a_finished_journal_is_not_resumable_when_cleanup_is_unavailable() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key.clone(),
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let state = context.start(&HashSet::from([key])).expect("start state");
+    fs::set_permissions(&context.state_dir, fs::Permissions::from_mode(0o555))
+        .expect("make state directory read-only");
+
+    let result = state.finish();
+    fs::set_permissions(&context.state_dir, fs::Permissions::from_mode(0o755))
+        .expect("restore state directory permissions");
+
+    result.expect("unavailable cleanup is optional");
+    assert!(context.read_completed_tasks().expect("read finished state").is_none());
+}
+
 #[test]
 fn a_stale_pointer_does_not_hide_a_newer_published_invocation_journal() {
     let workspace = tempfile::tempdir().expect("create workspace");

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -220,7 +220,10 @@ fn rejects_a_symlinked_state_directory() {
     let Err(error) = context.start(&HashSet::new()) else {
         panic!("symlinked state directory must be rejected");
     };
-    assert!(error.to_string().contains("symbolic link or not a directory"));
+    assert!(
+        error.to_string().contains("symbolic link or not a directory"),
+        "unexpected error: {error:?}",
+    );
     assert!(!outside.path().join("latest.json").exists());
 }
 

--- a/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/task_run_state/tests.rs
@@ -398,3 +398,44 @@ fn a_stale_pointer_does_not_hide_a_newer_published_invocation_journal() {
     assert_eq!(completed, HashSet::from([key]));
     newer.finish().expect("finish newer state");
 }
+
+#[test]
+fn a_stale_start_cannot_revive_state_after_a_newer_invocation_finishes() {
+    let workspace = tempfile::tempdir().expect("create workspace");
+    let project = workspace.path().join("project");
+    let key = TaskKey { project: project.clone(), task_name: "build".to_string() };
+    let graph: TaskGraph = IndexMap::from([(
+        key.clone(),
+        TaskNode {
+            project,
+            task_name: "build".to_string(),
+            concurrency: None,
+            scripts: vec!["build".to_string()],
+            requested: true,
+            dependencies: Vec::new(),
+        },
+    )]);
+    let context = TaskRunStateContext::new(
+        "run",
+        &["build".to_string()],
+        &[],
+        &graph,
+        workspace.path(),
+        |_, _| vec!["build-command".to_string()],
+    );
+    let older = context.start(&HashSet::new()).expect("start older state");
+    let older_contents = fs::read(&older.file_path).expect("read older state");
+    let older_header = older_contents
+        .split(|byte| *byte == b'\n')
+        .next()
+        .expect("older state has a header")
+        .to_vec();
+    let newer = context.start(&HashSet::from([key])).expect("start newer state");
+
+    newer.finish().expect("finish newer state");
+    fs::write(&older.file_path, older_contents).expect("republish older journal");
+    fs::write(&older.published_path, []).expect("republish older marker");
+    fs::write(&context.latest_state_path, older_header).expect("write stale pointer");
+
+    assert!(context.read_completed_tasks().expect("read finished state").is_none());
+}

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -777,3 +777,56 @@ fn recursive_exec_resume_from_skips_only_the_anchors_dependencies() {
 
     drop(root);
 }
+
+#[test]
+fn recursive_exec_resumes_from_exactly_the_projects_that_passed_before_a_failure() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace_manifests(
+        &workspace,
+        &[
+            ("dependency", json!({ "name": "dependency", "version": "1.0.0" })),
+            (
+                "anchor",
+                json!({
+                    "name": "anchor",
+                    "version": "1.0.0",
+                    "dependencies": { "dependency": "workspace:*" },
+                }),
+            ),
+            ("completed", json!({ "name": "completed", "version": "1.0.0" })),
+        ],
+    );
+    fs::write(workspace.join("fail"), "").expect("write failure marker");
+    let command = r#"name=$(basename "$PWD"); echo "$name" >> ../order.log; [ "$name" != dependency ] || [ ! -e ../fail ]"#;
+
+    pacquet
+        .with_args(["--no-bail", "--workspace-concurrency=1", "-r", "exec", "sh", "-c", command])
+        .assert()
+        .failure();
+    let first_run = fs::read_to_string(workspace.join("order.log")).expect("read first run");
+    let mut first_projects: Vec<&str> = first_run.lines().collect();
+    first_projects.sort_unstable();
+    assert_eq!(first_projects, ["completed", "dependency"]);
+
+    fs::remove_file(workspace.join("fail")).expect("remove failure marker");
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args([
+            "--workspace-concurrency=1",
+            "--resume-from=anchor",
+            "-r",
+            "exec",
+            "sh",
+            "-c",
+            command,
+        ])
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read resumed run");
+    assert!(order.ends_with("dependency\nanchor\n"), "unfinished dependency must rerun: {order}");
+    assert_eq!(order.lines().filter(|project| *project == "completed").count(), 1);
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1409,10 +1409,17 @@ fn recursive_run_resumes_from_exactly_the_tasks_that_passed_before_a_failure() {
     let order = fs::read_to_string(workspace.join("order.log")).expect("read resumed run");
     assert!(order.ends_with("dependency\nanchor\n"), "unfinished dependency must rerun: {order}");
     assert_eq!(order.lines().filter(|task| *task == "completed").count(), 1);
-    let state_files = fs::read_dir(workspace.join("node_modules").join(".pnpm-task-run-state-v1"))
-        .expect("read state directory")
-        .count();
-    assert_eq!(state_files, 0, "successful resume removes its checkpoint");
+    let state_dir = workspace.join("node_modules").join(".pnpm-task-run-state-v1");
+    let latest: Value = serde_json::from_str(
+        &fs::read_to_string(state_dir.join("latest.json")).expect("read latest state pointer"),
+    )
+    .expect("parse latest state pointer");
+    let latest_journal = state_dir.join(format!(
+        "{}.{}.jsonl",
+        latest["invocation"].as_str().expect("latest invocation"),
+        latest["run"].as_str().expect("latest run"),
+    ));
+    assert!(!latest_journal.exists(), "successful resume removes its current checkpoint");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1354,6 +1354,69 @@ fn recursive_run_resume_from_starts_at_the_given_package() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_resumes_from_exactly_the_tasks_that_passed_before_a_failure() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "dependency",
+                json!({
+                    "name": "dependency",
+                    "version": "1.0.0",
+                    "scripts": { "build": "echo dependency >> ../order.log; [ ! -e ../fail ]" },
+                }),
+            ),
+            (
+                "anchor",
+                json!({
+                    "name": "anchor",
+                    "version": "1.0.0",
+                    "dependencies": { "dependency": "workspace:*" },
+                    "scripts": { "build": "echo anchor >> ../order.log" },
+                }),
+            ),
+            (
+                "completed",
+                json!({
+                    "name": "completed",
+                    "version": "1.0.0",
+                    "scripts": { "build": "echo completed >> ../order.log" },
+                }),
+            ),
+        ],
+    );
+    fs::write(workspace.join("fail"), "").expect("write failure marker");
+
+    pacquet
+        .with_args(["--no-bail", "--workspace-concurrency=1", "-r", "run", "build"])
+        .assert()
+        .failure();
+    let first_run = fs::read_to_string(workspace.join("order.log")).expect("read first run");
+    let mut first_tasks: Vec<&str> = first_run.lines().collect();
+    first_tasks.sort_unstable();
+    assert_eq!(first_tasks, ["completed", "dependency"]);
+
+    fs::remove_file(workspace.join("fail")).expect("remove failure marker");
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["--workspace-concurrency=1", "--resume-from=anchor", "-r", "run", "build"])
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read resumed run");
+    assert!(order.ends_with("dependency\nanchor\n"), "unfinished dependency must rerun: {order}");
+    assert_eq!(order.lines().filter(|task| *task == "completed").count(), 1);
+    let state_files = fs::read_dir(workspace.join("node_modules").join(".pnpm-task-run-state-v1"))
+        .expect("read state directory")
+        .count();
+    assert_eq!(state_files, 0, "successful resume removes its checkpoint");
+
+    drop(root);
+}
+
 /// An unknown `--resume-from` package fails with
 /// `ERR_PNPM_RESUME_FROM_NOT_FOUND`.
 #[test]

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -1424,6 +1424,71 @@ fn recursive_run_resumes_from_exactly_the_tasks_that_passed_before_a_failure() {
     drop(root);
 }
 
+#[test]
+fn recursive_run_does_not_persist_a_task_skipped_by_the_recursion_guard() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "origin",
+                json!({
+                    "name": "origin",
+                    "version": "1.0.0",
+                    "scripts": {
+                        "build": r#"node -e "require('fs').appendFileSync('../order.log', 'origin\n')""#,
+                    },
+                }),
+            ),
+            (
+                "anchor",
+                json!({
+                    "name": "anchor",
+                    "version": "1.0.0",
+                    "dependencies": { "origin": "workspace:*" },
+                    "scripts": {
+                        "build": r#"node -e "require('fs').appendFileSync('../order.log', 'anchor\n')""#,
+                    },
+                }),
+            ),
+            (
+                "failure",
+                json!({
+                    "name": "failure",
+                    "version": "1.0.0",
+                    "scripts": {
+                        "build": r#"node -e "const fs=require('fs');fs.appendFileSync('../order.log','failure\n');if(fs.existsSync('../fail'))process.exit(1)""#,
+                    },
+                }),
+            ),
+        ],
+    );
+    fs::write(workspace.join("fail"), "").expect("write failure marker");
+    let origin = fs::canonicalize(workspace.join("origin")).expect("canonicalize origin");
+
+    pacquet
+        .with_env("npm_lifecycle_event", "build")
+        .with_env("PNPM_SCRIPT_SRC_DIR", origin.to_string_lossy().as_ref())
+        .with_args(["--no-bail", "--workspace-concurrency=1", "-r", "run", "build"])
+        .assert()
+        .failure();
+    let first_run = fs::read_to_string(workspace.join("order.log")).expect("read first run");
+    assert!(!first_run.lines().any(|task| task == "origin"), "origin must be recursion-guarded");
+
+    fs::remove_file(workspace.join("fail")).expect("remove failure marker");
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["--workspace-concurrency=1", "--resume-from=anchor", "-r", "run", "build"])
+        .assert()
+        .success();
+
+    let order = fs::read_to_string(workspace.join("order.log")).expect("read resumed run");
+    assert_eq!(order.lines().filter(|task| *task == "origin").count(), 1, "{order}");
+
+    drop(root);
+}
+
 /// An unknown `--resume-from` package fails with
 /// `ERR_PNPM_RESUME_FROM_NOT_FOUND`.
 #[test]

--- a/pnpm/crates/fs/src/dir_lock.rs
+++ b/pnpm/crates/fs/src/dir_lock.rs
@@ -92,6 +92,15 @@ impl DirLock {
             sleep(POLL_INTERVAL);
         }
     }
+
+    /// Reports whether this acquisition still owns the lock after a possible takeover.
+    pub fn is_owner(&self) -> io::Result<bool> {
+        match fs::read_to_string(self.path.join(OWNER_FILE)) {
+            Ok(owner) => Ok(owner == self.token),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
 }
 
 fn is_transient_release_error(

--- a/pnpm/crates/fs/src/dir_lock/tests.rs
+++ b/pnpm/crates/fs/src/dir_lock/tests.rs
@@ -81,6 +81,8 @@ fn a_stale_holder_does_not_release_its_successors_lock() {
         .expect("acquire")
         .expect("an abandoned lock is taken over");
 
+    assert!(!stale.is_owner().expect("inspect stale owner"));
+    assert!(successor.is_owner().expect("inspect successor owner"));
     drop(stale);
     assert!(path.is_dir(), "the successor still holds the lock");
 

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -277,6 +277,7 @@ pub fn resume_task_graph_from(
     graph: TaskGraph,
     anchor_project: &Path,
     task_name: &str,
+    completed_tasks: Option<&HashSet<TaskKey>>,
 ) -> TaskGraph {
     let anchor =
         TaskKey { project: anchor_project.to_path_buf(), task_name: task_name.to_string() };
@@ -285,14 +286,16 @@ pub fn resume_task_graph_from(
         // nothing to skip.
         return graph;
     };
-    let mut dropped: HashSet<TaskKey> = HashSet::new();
-    let mut stack: Vec<TaskKey> = anchor_node.dependencies.clone();
-    while let Some(key) = stack.pop() {
-        if !dropped.insert(key.clone()) {
-            continue;
-        }
-        stack.extend(graph[&key].dependencies.iter().cloned());
-    }
+    let dropped = completed_tasks.map_or_else(
+        || transitive_dependencies(&graph, anchor_node),
+        |completed| {
+            completed
+                .iter()
+                .filter(|key| **key != anchor && graph.contains_key(*key))
+                .cloned()
+                .collect()
+        },
+    );
     graph
         .into_iter()
         .filter(|(key, _)| !dropped.contains(key))
@@ -301,6 +304,18 @@ pub fn resume_task_graph_from(
             (key, node)
         })
         .collect()
+}
+
+fn transitive_dependencies(graph: &TaskGraph, anchor: &TaskNode) -> HashSet<TaskKey> {
+    let mut dependencies: HashSet<TaskKey> = HashSet::new();
+    let mut stack: Vec<TaskKey> = anchor.dependencies.clone();
+    while let Some(key) = stack.pop() {
+        if !dependencies.insert(key.clone()) {
+            continue;
+        }
+        stack.extend(graph[&key].dependencies.iter().cloned());
+    }
+    dependencies
 }
 
 /// Whether at most one script can ever be in flight, which is when output

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -9,7 +9,7 @@ use indexmap::IndexMap;
 use pnpm_config::TaskSettings;
 use pnpm_reporter::LogEvent;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         Condvar, Mutex,
@@ -210,7 +210,7 @@ fn resume_drops_only_the_anchors_transitive_dependencies() {
         None,
     );
 
-    let resumed = resume_task_graph_from(graph, &dir("b"), "build");
+    let resumed = resume_task_graph_from(graph, &dir("b"), "build", None);
 
     assert_eq!(resumed.len(), 3);
     assert!(!resumed.contains_key(&key("a", "build")));
@@ -218,6 +218,28 @@ fn resume_drops_only_the_anchors_transitive_dependencies() {
     assert!(resumed[&key("b", "build")].dependencies.is_empty());
     assert_eq!(resumed[&key("c", "build")].dependencies, vec![key("b", "build")]);
     assert!(resumed.contains_key(&key("unrelated", "build")));
+}
+
+#[test]
+fn resume_drops_exact_completed_tasks_when_state_is_available() {
+    let graph = build_graph(
+        &[
+            ("dependency", project(&[], &["build"])),
+            ("anchor", project(&["dependency"], &["build"])),
+            ("completed", project(&[], &["build"])),
+        ],
+        "build",
+        None,
+    );
+    let completed = HashSet::from([key("anchor", "build"), key("completed", "build")]);
+
+    let resumed = resume_task_graph_from(graph, &dir("anchor"), "build", Some(&completed));
+
+    assert_eq!(resumed.len(), 2);
+    assert!(resumed.contains_key(&key("anchor", "build")));
+    assert!(resumed.contains_key(&key("dependency", "build")));
+    assert!(!resumed.contains_key(&key("completed", "build")));
+    assert_eq!(resumed[&key("anchor", "build")].dependencies, vec![key("dependency", "build")]);
 }
 
 #[test]

--- a/pnpm11/exec/commands/package.json
+++ b/pnpm11/exec/commands/package.json
@@ -72,6 +72,7 @@
     "render-help": "catalog:",
     "symlink-dir": "catalog:",
     "which": "catalog:",
+    "write-file-atomic": "catalog:",
     "write-json-file": "catalog:"
   },
   "peerDependencies": {
@@ -89,6 +90,7 @@
     "@types/is-windows": "catalog:",
     "@types/ramda": "catalog:",
     "@types/which": "catalog:",
+    "@types/write-file-atomic": "catalog:",
     "is-windows": "catalog:",
     "write-yaml-file": "catalog:"
   },

--- a/pnpm11/exec/commands/src/exec.ts
+++ b/pnpm11/exec/commands/src/exec.ts
@@ -41,7 +41,7 @@ import {
   shorthands as runShorthands,
 } from './run.js'
 import { runDepsStatusCheck } from './runDepsStatusCheck.js'
-import { type TaskRunState, TaskRunStateContext } from './taskRunState.js'
+import { taskRunExecutionSettings, type TaskRunState, TaskRunStateContext } from './taskRunState.js'
 import { trackedExeca } from './trackedExeca.js'
 
 export const shorthands: Record<string, string | string[]> = {
@@ -221,11 +221,16 @@ export async function handler (
   }
 
   const fullTaskGraph = taskGraph
+  const baseExtraEnv: Record<string, string | undefined> = {
+    ...opts.extraEnv,
+    ...(opts.nodeOptions ? { NODE_OPTIONS: keepEsmNodePathLoaderOption(opts.nodeOptions, opts.extraEnv?.NODE_OPTIONS) } : {}),
+  }
   let taskRunStateContext: TaskRunStateContext | undefined
   if (opts.recursive) {
     taskRunStateContext = new TaskRunStateContext({
       command: 'exec',
       params: [...params, `shell-mode=${Boolean(opts.shellMode)}`],
+      settings: taskRunExecutionSettings({ ...opts, extraEnv: baseExtraEnv }),
       graph: fullTaskGraph,
       workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
       scriptCommands: () => [],
@@ -303,10 +308,7 @@ export async function handler (
       try {
         const pnpPath = workspacePnpPath ?? existsPnp(prefix)
         const packageMapPath = workspacePackageMapPath || (opts.nodeExperimentalPackageMap && existsPackageMap(prefix))
-        const extraEnv: Record<string, string | undefined> = {
-          ...opts.extraEnv,
-          ...(opts.nodeOptions ? { NODE_OPTIONS: keepEsmNodePathLoaderOption(opts.nodeOptions, opts.extraEnv?.NODE_OPTIONS) } : {}),
-        }
+        const extraEnv = { ...baseExtraEnv }
         if (pnpPath) {
           Object.assign(extraEnv, makeNodeRequireOption(pnpPath, extraEnv))
         }
@@ -438,36 +440,41 @@ export async function handler (
       return 'passed'
     })
 
-  await scheduleTasks(taskGraph, {
-    bail: Boolean(opts.bail),
-    runTask,
-    onTaskSkipped: (node) => {
-      result[node.project].status = 'skipped'
-    },
-  })
+  try {
+    await scheduleTasks(taskGraph, {
+      bail: Boolean(opts.bail),
+      runTask,
+      onTaskSkipped: (node) => {
+        result[node.project].status = 'skipped'
+      },
+    })
 
-  if (abortError !== undefined) {
-    throw abortError
-  }
-  if (firstError != null) {
+    if (abortError !== undefined) {
+      throw abortError
+    }
+    if (firstError != null) {
+      if (opts.reportSummary) {
+        await writeRecursiveSummary({
+          dir: opts.lockfileDir ?? opts.dir,
+          summary: result,
+        })
+      }
+      throw firstError
+    }
+
     if (opts.reportSummary) {
       await writeRecursiveSummary({
         dir: opts.lockfileDir ?? opts.dir,
         summary: result,
       })
     }
-    throw firstError
+    throwOnCommandFail('pnpm recursive exec', result)
+    await taskRunState?.finish()
+    return { exitCode }
+  } catch (err: unknown) {
+    await taskRunState?.close()
+    throw err
   }
-
-  if (opts.reportSummary) {
-    await writeRecursiveSummary({
-      dir: opts.lockfileDir ?? opts.dir,
-      summary: result,
-    })
-  }
-  throwOnCommandFail('pnpm recursive exec', result)
-  await taskRunState?.finish()
-  return { exitCode }
 }
 
 async function createExecCommandNotFoundHint (

--- a/pnpm11/exec/commands/src/exec.ts
+++ b/pnpm11/exec/commands/src/exec.ts
@@ -21,6 +21,7 @@ import {
   sequenceTasks,
   type TaskCompletion,
   type TaskGraph,
+  type TaskKey,
   taskKey,
   type TaskNode,
 } from '@pnpm/workspace.task-scheduler'
@@ -40,6 +41,7 @@ import {
   shorthands as runShorthands,
 } from './run.js'
 import { runDepsStatusCheck } from './runDepsStatusCheck.js'
+import { type TaskRunState, TaskRunStateContext } from './taskRunState.js'
 import { trackedExeca } from './trackedExeca.js'
 
 export const shorthands: Record<string, string | string[]> = {
@@ -218,12 +220,28 @@ export async function handler (
     throw new PnpmError('RECURSIVE_EXEC_NO_PACKAGE', 'No package found in this workspace')
   }
 
+  const fullTaskGraph = taskGraph
+  let taskRunStateContext: TaskRunStateContext | undefined
+  if (opts.recursive) {
+    taskRunStateContext = new TaskRunStateContext({
+      command: 'exec',
+      params: [...params, `shell-mode=${Boolean(opts.shellMode)}`],
+      graph: fullTaskGraph,
+      workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
+      scriptCommands: () => [],
+    })
+  }
   if (opts.resumeFrom) {
-    taskGraph = resumeTaskGraphFrom(taskGraph, {
+    const resumeOptions = {
       resumeFrom: opts.resumeFrom,
       selectedProjectsGraph: opts.selectedProjectsGraph,
       taskName: commandName,
-    })
+    }
+    taskGraph = resumeTaskGraphFrom(fullTaskGraph, resumeOptions)
+    const completedTasks = await taskRunStateContext?.readCompletedTasks()
+    if (completedTasks != null) {
+      taskGraph = resumeTaskGraphFrom(fullTaskGraph, { ...resumeOptions, completedTasks })
+    }
   }
 
   // Also the cycle check: a cyclic graph cannot be scheduled, and sequenced
@@ -232,6 +250,15 @@ export async function handler (
     workspaceDir: opts.workspaceDir ?? opts.dir,
     ignoreCycles: opts.ignoreWorkspaceCycles,
   })
+
+  let taskRunState: TaskRunState | undefined
+  if (taskRunStateContext != null) {
+    const initiallyCompleted = new Set<TaskKey>()
+    for (const key of fullTaskGraph.keys()) {
+      if (!taskGraph.has(key)) initiallyCompleted.add(key)
+    }
+    taskRunState = await taskRunStateContext.start(initiallyCompleted)
+  }
 
   const result: RecursiveSummary = {}
   for (const node of taskGraph.values()) {
@@ -251,9 +278,9 @@ export async function handler (
   ]
   const reporterShowPrefix = opts.recursive && opts.reporterHidePrefix === false
 
-  const runTask = async (node: TaskNode): Promise<TaskCompletion> => {
+  const runTask = async (node: TaskNode, key: TaskKey): Promise<TaskCompletion> => {
     try {
-      return await runCommandTask(node)
+      return await runCommandTask(node, key)
     } catch (err: unknown) {
       // An error the per-project handling could not absorb is an
       // infrastructure failure: hold it for rethrow and stop the run.
@@ -262,7 +289,7 @@ export async function handler (
     }
   }
 
-  const runCommandTask = async (node: TaskNode): Promise<TaskCompletion> =>
+  const runCommandTask = async (node: TaskNode, key: TaskKey): Promise<TaskCompletion> =>
     limitRun(async (): Promise<TaskCompletion> => {
       // Under --bail a failure stops dispatch, but a task already queued
       // behind the concurrency limit has been dispatched in name only —
@@ -375,7 +402,6 @@ export async function handler (
         }
         result[prefix].status = 'passed'
         result[prefix].duration = getExecutionDuration(startTime)
-        return 'passed'
       } catch (err: any) { // eslint-disable-line
         if (isErrorCommandNotFound(params[0], err, prefix, prependPaths)) {
           err.message = `Command "${params[0]}" not found`
@@ -408,6 +434,8 @@ export async function handler (
         }
         return 'failed'
       }
+      await taskRunState?.recordPassed(key, node)
+      return 'passed'
     })
 
   await scheduleTasks(taskGraph, {
@@ -438,6 +466,7 @@ export async function handler (
     })
   }
   throwOnCommandFail('pnpm recursive exec', result)
+  await taskRunState?.finish()
   return { exitCode }
 }
 

--- a/pnpm11/exec/commands/src/run.ts
+++ b/pnpm11/exec/commands/src/run.ts
@@ -455,21 +455,14 @@ export async function runScript (opts: {
   runScriptOptions: RunScriptOptions
   passedThruArgs: string[]
 }, scriptName: string): Promise<void> {
-  if (
-    opts.runScriptOptions.enablePrePostScripts &&
-    opts.manifest.scripts?.[`pre${scriptName}`] &&
-    !opts.manifest.scripts[scriptName].includes(`pre${scriptName}`)
-  ) {
-    await runLifecycleHook(`pre${scriptName}`, opts.manifest, opts.lifecycleOpts)
-  }
-  await runLifecycleHook(scriptName, opts.manifest, { ...opts.lifecycleOpts, args: opts.passedThruArgs })
-  if (
-    opts.runScriptOptions.enablePrePostScripts &&
-    opts.manifest.scripts?.[`post${scriptName}`] &&
-    !opts.manifest.scripts[scriptName].includes(`post${scriptName}`)
-  ) {
-    await runLifecycleHook(`post${scriptName}`, opts.manifest, opts.lifecycleOpts)
-  }
+  const stages = getRunScriptStages(opts.manifest, scriptName, opts.runScriptOptions.enablePrePostScripts)
+  if (stages.length === 0) throw new Error(`Missing script: ${scriptName}`)
+  await stages.reduce(async (previous, stage) => {
+    await previous
+    await runLifecycleHook(stage.name, opts.manifest, stage.name === scriptName
+      ? { ...opts.lifecycleOpts, args: opts.passedThruArgs }
+      : opts.lifecycleOpts)
+  }, Promise.resolve())
   if (opts.runScriptOptions.syncInjectedDepsAfterScripts?.includes(scriptName)) {
     await syncInjectedDeps({
       pkgName: opts.manifest.name,
@@ -479,6 +472,31 @@ export async function runScript (opts: {
       manifestBeforeScripts: opts.manifest as DependencyManifest,
     })
   }
+}
+
+export function getRunScriptCommands (
+  manifest: ProjectManifest,
+  scriptName: string,
+  enablePrePostScripts: boolean
+): string[] {
+  return getRunScriptStages(manifest, scriptName, enablePrePostScripts).map(({ command }) => command)
+}
+
+function getRunScriptStages (
+  manifest: ProjectManifest,
+  scriptName: string,
+  enablePrePostScripts: boolean
+): Array<{ name: string, command: string }> {
+  const scripts = manifest.scripts ?? {}
+  const main = scripts[scriptName]
+  if (main == null) return []
+  const stages = [{ name: scriptName, command: main }]
+  if (!enablePrePostScripts) return stages
+  const pre = `pre${scriptName}`
+  const post = `post${scriptName}`
+  if (scripts[pre] && !main.includes(pre)) stages.unshift({ name: pre, command: scripts[pre] })
+  if (scripts[post] && !main.includes(post)) stages.push({ name: post, command: scripts[post] })
+  return stages
 }
 
 function renderCommands (commands: string[][]): string {

--- a/pnpm11/exec/commands/src/run.ts
+++ b/pnpm11/exec/commands/src/run.ts
@@ -456,13 +456,16 @@ export async function runScript (opts: {
   passedThruArgs: string[]
 }, scriptName: string): Promise<void> {
   const stages = getRunScriptStages(opts.manifest, scriptName, opts.runScriptOptions.enablePrePostScripts)
-  if (stages.length === 0) throw new Error(`Missing script: ${scriptName}`)
-  await stages.reduce(async (previous, stage) => {
-    await previous
-    await runLifecycleHook(stage.name, opts.manifest, stage.name === scriptName
-      ? { ...opts.lifecycleOpts, args: opts.passedThruArgs }
-      : opts.lifecycleOpts)
-  }, Promise.resolve())
+  if (stages.length === 0) {
+    await runLifecycleHook(scriptName, opts.manifest, { ...opts.lifecycleOpts, args: opts.passedThruArgs })
+  } else {
+    await stages.reduce(async (previous, stage) => {
+      await previous
+      await runLifecycleHook(stage.name, opts.manifest, stage.name === scriptName
+        ? { ...opts.lifecycleOpts, args: opts.passedThruArgs }
+        : opts.lifecycleOpts)
+    }, Promise.resolve())
+  }
   if (opts.runScriptOptions.syncInjectedDepsAfterScripts?.includes(scriptName)) {
     await syncInjectedDeps({
       pkgName: opts.manifest.name,

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -196,6 +196,7 @@ export async function runRecursive (
     // would race (and TypeScript narrows it to 'running' regardless).
     let taskFailed = false
     let taskCancelled = false
+    let taskSkippedForCurrentLifecycle = false
     await Promise.all(node.scripts.map(async (script) =>
       limitRun(async () => {
         // Under --bail a failure stops dispatch, but a script already queued
@@ -205,11 +206,14 @@ export async function runRecursive (
           taskCancelled = true
           return
         }
+        if (!pkg.package.manifest.scripts?.[script]) {
+          return
+        }
         if (
-          !pkg.package.manifest.scripts?.[script] ||
           process.env.npm_lifecycle_event === script &&
           process.env.PNPM_SCRIPT_SRC_DIR === node.project
         ) {
+          taskSkippedForCurrentLifecycle = true
           return
         }
         if (!taskFailed) {
@@ -289,7 +293,9 @@ export async function runRecursive (
         }
       })))
     if (taskFailed || taskCancelled) return 'failed'
-    await taskRunState.recordPassed(key, node)
+    if (!taskSkippedForCurrentLifecycle) {
+      await taskRunState.recordPassed(key, node)
+    }
     return 'passed'
   }
 

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -35,8 +35,8 @@ import { getExecutionDuration, writeRecursiveSummary } from './exec.js'
 import { existsInDir } from './existsInDir.js'
 import { throwOrFilterHiddenScripts } from './hiddenScripts.js'
 import { tryBuildRegExpFromCommand } from './regexpCommand.js'
-import { runScript, type RunScriptOptions } from './run.js'
-import { TaskRunStateContext } from './taskRunState.js'
+import { getRunScriptCommands, runScript, type RunScriptOptions } from './run.js'
+import { taskRunExecutionSettings, TaskRunStateContext } from './taskRunState.js'
 export type RecursiveRunOpts = Pick<Config,
 | 'bin'
 | 'enablePrePostScripts'
@@ -51,6 +51,7 @@ export type RecursiveRunOpts = Pick<Config,
 | 'syncInjectedDepsAfterScripts'
 | 'workspaceDir'
 | 'nodeExperimentalPackageMap'
+| 'nodeOptions'
 | 'modulesDir'
 > & Pick<ConfigContext, 'rootProjectManifest' | 'allProjectsGraph' | 'prodAllProjectsGraph' | 'prodOnlySelectedProjectDirs'> & Required<Pick<ConfigContext, 'allProjects' | 'selectedProjectsGraph'> & Pick<Config, 'workspaceDir' | 'dir'>> &
 Partial<Pick<Config, 'extraBinPaths' | 'extraEnv' | 'bail' | 'dryRun' | 'ignoreWorkspaceCycles' | 'reporter' | 'reverse' | 'sort' | 'tasks' | 'workspaceConcurrency'>> &
@@ -79,6 +80,7 @@ export async function runRecursive (
     command: 'run',
     params,
     settings: [
+      ...taskRunExecutionSettings(opts),
       `enable-pre-post-scripts=${Boolean(opts.enablePrePostScripts)}`,
       `script-shell=${opts.scriptShell ?? ''}`,
       `scripts-prepend-node-path=${String(opts.scriptsPrependNodePath ?? false)}`,
@@ -87,15 +89,11 @@ export async function runRecursive (
     ],
     graph: fullTaskGraph,
     workspaceDir: opts.workspaceDir,
-    scriptCommands: (node, script) => {
-      const scripts = opts.selectedProjectsGraph[node.project].package.manifest.scripts ?? {}
-      const main = scripts[script]
-      if (main == null) return []
-      if (!opts.enablePrePostScripts) return [main]
-      return [`pre${script}`, script, `post${script}`]
-        .filter((stage) => scripts[stage] != null && (stage === script || !main.includes(stage)))
-        .map((stage) => scripts[stage]!)
-    },
+    scriptCommands: (node, script) => getRunScriptCommands(
+      opts.selectedProjectsGraph[node.project].package.manifest,
+      script,
+      Boolean(opts.enablePrePostScripts)
+    ),
   })
   let taskGraph = fullTaskGraph
   if (opts.resumeFrom != null) {
@@ -295,44 +293,49 @@ export async function runRecursive (
     return 'passed'
   }
 
-  await scheduleTasks(taskGraph, {
-    bail: Boolean(opts.bail),
-    runTask,
-    onTaskSkipped: (node) => {
-      result[taskSummaryKey(node)].status = 'skipped'
-    },
-  })
+  try {
+    await scheduleTasks(taskGraph, {
+      bail: Boolean(opts.bail),
+      runTask,
+      onTaskSkipped: (node) => {
+        result[taskSummaryKey(node)].status = 'skipped'
+      },
+    })
 
-  if (abortError !== undefined) {
-    throw abortError
-  }
-  if (firstError != null) {
+    if (abortError !== undefined) {
+      throw abortError
+    }
+    if (firstError != null) {
+      if (opts.reportSummary) {
+        await writeRecursiveSummary({
+          dir: opts.workspaceDir ?? opts.dir,
+          summary: result,
+        })
+      }
+      throw firstError
+    }
+
+    // The no-script error is only for a run that had nothing to do. A run
+    // where a `dependsOn`-pulled task failed and skipped every requested task
+    // must report that failure, not claim the script does not exist.
+    const hasFailures = Object.values(result).some(({ status }) => status === 'failure')
+    if (scriptName !== 'test' && !hasCommand && !hasFailures && !opts.ifPresent) {
+      await taskRunState.finish()
+      throw noRequestedScriptError(scriptName, opts)
+    }
     if (opts.reportSummary) {
       await writeRecursiveSummary({
         dir: opts.workspaceDir ?? opts.dir,
         summary: result,
       })
     }
-    throw firstError
-  }
-
-  // The no-script error is only for a run that had nothing to do. A run
-  // where a `dependsOn`-pulled task failed and skipped every requested task
-  // must report that failure, not claim the script does not exist.
-  const hasFailures = Object.values(result).some(({ status }) => status === 'failure')
-  if (scriptName !== 'test' && !hasCommand && !hasFailures && !opts.ifPresent) {
+    throwOnCommandFail('pnpm recursive run', result)
     await taskRunState.finish()
-    throw noRequestedScriptError(scriptName, opts)
+    return undefined
+  } catch (err: unknown) {
+    await taskRunState.close()
+    throw err
   }
-  if (opts.reportSummary) {
-    await writeRecursiveSummary({
-      dir: opts.workspaceDir ?? opts.dir,
-      summary: result,
-    })
-  }
-  throwOnCommandFail('pnpm recursive run', result)
-  await taskRunState.finish()
-  return undefined
 }
 
 /**

--- a/pnpm11/exec/commands/src/runRecursive.ts
+++ b/pnpm11/exec/commands/src/runRecursive.ts
@@ -25,6 +25,7 @@ import {
   type TaskCompletion,
   type TaskGraph,
   taskGraphToJson,
+  type TaskKey,
   type TaskNode,
 } from '@pnpm/workspace.task-scheduler'
 import pLimit from 'p-limit'
@@ -35,6 +36,7 @@ import { existsInDir } from './existsInDir.js'
 import { throwOrFilterHiddenScripts } from './hiddenScripts.js'
 import { tryBuildRegExpFromCommand } from './regexpCommand.js'
 import { runScript, type RunScriptOptions } from './run.js'
+import { TaskRunStateContext } from './taskRunState.js'
 export type RecursiveRunOpts = Pick<Config,
 | 'bin'
 | 'enablePrePostScripts'
@@ -72,7 +74,42 @@ export async function runRecursive (
     throw new PnpmError('SCRIPT_NAME_IS_REQUIRED', 'You must specify the script you want to run')
   }
 
-  const taskGraph = buildRunTaskGraph(scriptName, opts)
+  const fullTaskGraph = buildRunTaskGraph(scriptName, opts)
+  const taskRunStateContext = new TaskRunStateContext({
+    command: 'run',
+    params,
+    settings: [
+      `enable-pre-post-scripts=${Boolean(opts.enablePrePostScripts)}`,
+      `script-shell=${opts.scriptShell ?? ''}`,
+      `scripts-prepend-node-path=${String(opts.scriptsPrependNodePath ?? false)}`,
+      `shell-emulator=${Boolean(opts.shellEmulator)}`,
+      `sync-injected-deps-after-scripts=${JSON.stringify([...(opts.syncInjectedDepsAfterScripts ?? [])].sort())}`,
+    ],
+    graph: fullTaskGraph,
+    workspaceDir: opts.workspaceDir,
+    scriptCommands: (node, script) => {
+      const scripts = opts.selectedProjectsGraph[node.project].package.manifest.scripts ?? {}
+      const main = scripts[script]
+      if (main == null) return []
+      if (!opts.enablePrePostScripts) return [main]
+      return [`pre${script}`, script, `post${script}`]
+        .filter((stage) => scripts[stage] != null && (stage === script || !main.includes(stage)))
+        .map((stage) => scripts[stage]!)
+    },
+  })
+  let taskGraph = fullTaskGraph
+  if (opts.resumeFrom != null) {
+    const resumeOptions = {
+      resumeFrom: opts.resumeFrom,
+      selectedProjectsGraph: opts.selectedProjectsGraph,
+      taskName: scriptName,
+    }
+    taskGraph = resumeTaskGraphFrom(fullTaskGraph, resumeOptions)
+    const completedTasks = await taskRunStateContext.readCompletedTasks()
+    if (completedTasks != null) {
+      taskGraph = resumeTaskGraphFrom(fullTaskGraph, { ...resumeOptions, completedTasks })
+    }
+  }
   // Also the cycle check: a cyclic graph cannot be scheduled, and sequenced
   // into an arbitrary order it would succeed or fail by luck.
   const sequencedTasks = sequenceTasks(taskGraph, {
@@ -113,6 +150,12 @@ export async function runRecursive (
     throw noRequestedScriptError(scriptName, opts)
   }
 
+  const initiallyCompleted = new Set<TaskKey>()
+  for (const key of fullTaskGraph.keys()) {
+    if (!taskGraph.has(key)) initiallyCompleted.add(key)
+  }
+  const taskRunState = await taskRunStateContext.start(initiallyCompleted)
+
   const limitRun = pLimit(getWorkspaceConcurrency(opts.workspaceConcurrency))
   const stdio =
     !opts.stream &&
@@ -132,9 +175,9 @@ export async function runRecursive (
   let firstError: Error | undefined
   let abortError: unknown
 
-  const runTask = async (node: TaskNode): Promise<TaskCompletion> => {
+  const runTask = async (node: TaskNode, key: TaskKey): Promise<TaskCompletion> => {
     try {
-      return await runTaskScripts(node)
+      return await runTaskScripts(node, key)
     } catch (err: unknown) {
       // An error the per-script handling could not absorb is an
       // infrastructure failure: hold it for rethrow and stop the run.
@@ -143,7 +186,7 @@ export async function runRecursive (
     }
   }
 
-  const runTaskScripts = async (node: TaskNode): Promise<TaskCompletion> => {
+  const runTaskScripts = async (node: TaskNode, key: TaskKey): Promise<TaskCompletion> => {
     const pkg = opts.selectedProjectsGraph[node.project]
     const summaryKey = taskSummaryKey(node)
     // A RegExp selector can match several scripts in one task, but the
@@ -154,12 +197,14 @@ export async function runRecursive (
     // scripts settle concurrently, so reading back the recorded status
     // would race (and TypeScript narrows it to 'running' regardless).
     let taskFailed = false
+    let taskCancelled = false
     await Promise.all(node.scripts.map(async (script) =>
       limitRun(async () => {
         // Under --bail a failure stops dispatch, but a script already queued
         // behind the concurrency limit has been dispatched in name only —
         // starting it now would grow the failed run. It stays 'queued'.
         if (opts.bail && firstError != null) {
+          taskCancelled = true
           return
         }
         if (
@@ -245,7 +290,9 @@ export async function runRecursive (
           }
         }
       })))
-    return taskFailed ? 'failed' : 'passed'
+    if (taskFailed || taskCancelled) return 'failed'
+    await taskRunState.recordPassed(key, node)
+    return 'passed'
   }
 
   await scheduleTasks(taskGraph, {
@@ -274,6 +321,7 @@ export async function runRecursive (
   // must report that failure, not claim the script does not exist.
   const hasFailures = Object.values(result).some(({ status }) => status === 'failure')
   if (scriptName !== 'test' && !hasCommand && !hasFailures && !opts.ifPresent) {
+    await taskRunState.finish()
     throw noRequestedScriptError(scriptName, opts)
   }
   if (opts.reportSummary) {
@@ -283,13 +331,13 @@ export async function runRecursive (
     })
   }
   throwOnCommandFail('pnpm recursive run', result)
+  await taskRunState.finish()
   return undefined
 }
 
 /**
  * The task graph of one `pnpm -r run` invocation: `scriptName` in every
- * selected project plus what `dependsOn` pulls in, with `--reverse` and
- * `--resume-from` already applied.
+ * selected project plus what `dependsOn` pulls in, with `--reverse` applied.
  *
  * `--no-sort` keeps its meaning of disregarding ordering entirely: tasks get
  * no edges, and the `tasks` declarations do not apply.
@@ -310,13 +358,6 @@ function buildRunTaskGraph (scriptName: string, opts: RecursiveRunOpts): TaskGra
   })
   if (opts.reverse) {
     taskGraph = reverseTaskGraph(taskGraph)
-  }
-  if (opts.resumeFrom) {
-    taskGraph = resumeTaskGraphFrom(taskGraph, {
-      resumeFrom: opts.resumeFrom,
-      selectedProjectsGraph: opts.selectedProjectsGraph,
-      taskName: scriptName,
-    })
   }
   return taskGraph
 }

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -1,15 +1,17 @@
 import crypto from 'node:crypto'
-import fs from 'node:fs/promises'
+import fs, { type FileHandle } from 'node:fs/promises'
 import path from 'node:path'
 import util from 'node:util'
 
 import { createHexHash } from '@pnpm/crypto.hash'
+import { PnpmError } from '@pnpm/error'
 import type { TaskGraph, TaskKey, TaskNode } from '@pnpm/workspace.task-scheduler'
 import writeFileAtomic from 'write-file-atomic'
 
 const STATE_VERSION = 1
 const STATE_DIR = '.pnpm-task-run-state-v1'
-const STATE_FILE_NAME = /^[0-9a-f]{64}\.jsonl$/
+const LATEST_STATE_FILE = 'latest.json'
+const RUN_ID = /^[0-9a-f-]{1,128}$/
 
 interface TaskId {
   project: string
@@ -48,10 +50,35 @@ export interface TaskRunStateContextOptions {
   scriptCommands: (node: TaskNode, script: string) => string[]
 }
 
+export interface TaskRunExecutionSettings {
+  extraBinPaths?: string[]
+  extraEnv?: Record<string, string | undefined>
+  modulesDir?: string
+  nodeExperimentalPackageMap?: boolean
+  nodeOptions?: string
+  userAgent?: string
+}
+
+export function taskRunExecutionSettings (opts: TaskRunExecutionSettings): string[] {
+  const extraEnv = Object.entries(opts.extraEnv ?? {})
+    .sort(([left], [right]) => compareStrings(left, right))
+    .map(([key, value]) => [key, value ?? null])
+  return [
+    `extra-bin-paths=${JSON.stringify(opts.extraBinPaths ?? [])}`,
+    `extra-env=${JSON.stringify(extraEnv)}`,
+    `modules-dir=${opts.modulesDir ?? 'node_modules'}`,
+    `node-experimental-package-map=${Boolean(opts.nodeExperimentalPackageMap)}`,
+    `node-options=${opts.nodeOptions ?? ''}`,
+    `user-agent=${opts.userAgent ?? ''}`,
+  ]
+}
+
 export class TaskRunStateContext {
-  readonly filePath: string
   readonly invocation: string
+  readonly latestStatePath: string
   private readonly opts: TaskRunStateContextOptions
+  private readonly nodeModulesDir: string
+  private readonly stateDir: string
   private readonly keysById = new Map<string, TaskKey>()
 
   constructor (opts: TaskRunStateContextOptions) {
@@ -76,13 +103,25 @@ export class TaskRunStateContext {
       }).sort(compareTaskIds),
     }
     this.invocation = createHexHash(JSON.stringify(identity))
-    this.filePath = path.join(opts.workspaceDir, 'node_modules', STATE_DIR, `${this.invocation}.jsonl`)
+    this.nodeModulesDir = path.join(opts.workspaceDir, 'node_modules')
+    this.stateDir = path.join(this.nodeModulesDir, STATE_DIR)
+    this.latestStatePath = path.join(this.stateDir, LATEST_STATE_FILE)
   }
 
   async readCompletedTasks (): Promise<Set<TaskKey> | undefined> {
+    if (!await this.validateStateDirectory(false)) return undefined
+    let latest: StateHeader
+    try {
+      latest = JSON.parse(await fs.readFile(this.latestStatePath, 'utf8')) as StateHeader
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code !== 'ENOENT') throw err
+      return undefined
+    }
+    if (latest.version !== STATE_VERSION || latest.invocation !== this.invocation || !RUN_ID.test(latest.run)) return undefined
+    const filePath = this.journalPath(latest.run)
     let contents: string
     try {
-      contents = await fs.readFile(this.filePath, 'utf8')
+      contents = await fs.readFile(filePath, 'utf8')
     } catch (err: unknown) {
       if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return undefined
       throw err
@@ -98,7 +137,7 @@ export class TaskRunStateContext {
     } catch {
       return undefined
     }
-    if (header.version !== STATE_VERSION || header.invocation !== this.invocation) return undefined
+    if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== latest.run) return undefined
     const completed = new Set<TaskKey>()
     for (const line of lines.slice(1)) {
       let record: TaskRecord
@@ -122,33 +161,48 @@ export class TaskRunStateContext {
       .map((key): TaskRecord => ({ run, ...taskId(this.opts.graph.get(key)!, this.opts.workspaceDir) }))
       .sort(compareTaskIds)
     const contents = [header, ...completed].map((record) => JSON.stringify(record)).join('\n') + '\n'
-    const stateDir = path.dirname(this.filePath)
-    await fs.mkdir(stateDir, { recursive: true })
-    await writeFileAtomic(this.filePath, contents, { mode: 0o600 })
-    // Only the latest recursive invocation is resumable. Otherwise an old
-    // compatible journal could become active again after intervening work.
-    const entries = await fs.readdir(stateDir, { withFileTypes: true })
-    await Promise.all(entries
-      .filter((entry) => entry.name !== path.basename(this.filePath) && !entry.isDirectory() && STATE_FILE_NAME.test(entry.name))
-      .map(async (entry) => unlinkIfExists(path.join(stateDir, entry.name))))
-    return new TaskRunState(this.filePath, this.opts.workspaceDir, run, completedTasks)
+    const filePath = this.journalPath(run)
+    await this.validateStateDirectory(true)
+    await writeFileAtomic(filePath, contents, { mode: 0o600 })
+    const file = await fs.open(filePath, 'a')
+    try {
+      await writeFileAtomic(this.latestStatePath, JSON.stringify(header), { mode: 0o600 })
+    } catch (err: unknown) {
+      await file.close()
+      await unlinkIfExists(filePath)
+      throw err
+    }
+    return new TaskRunState(filePath, file, this.opts.workspaceDir, run, completedTasks)
+  }
+
+  private journalPath (run: string): string {
+    return path.join(this.stateDir, `${this.invocation}.${run}.jsonl`)
+  }
+
+  private async validateStateDirectory (create: boolean): Promise<boolean> {
+    if (!await validateRealDirectory(this.nodeModulesDir, create)) return false
+    return validateRealDirectory(this.stateDir, create)
   }
 }
 
 export class TaskRunState {
-  private readonly filePath: string
+  readonly filePath: string
+  private readonly file: FileHandle
   private readonly workspaceDir: string
   private readonly run: string
   private readonly completedTasks: Set<TaskKey>
   private pendingWrite: Promise<void> = Promise.resolve()
+  private closePromise: Promise<void> | undefined
 
   constructor (
     filePath: string,
+    file: FileHandle,
     workspaceDir: string,
     run: string,
     completedTasks: ReadonlySet<TaskKey>
   ) {
     this.filePath = filePath
+    this.file = file
     this.workspaceDir = workspaceDir
     this.run = run
     this.completedTasks = new Set(completedTasks)
@@ -159,16 +213,47 @@ export class TaskRunState {
     this.completedTasks.add(key)
     const record: TaskRecord = { run: this.run, ...taskId(node, this.workspaceDir) }
     const line = `${JSON.stringify(record)}\n`
-    this.pendingWrite = this.pendingWrite.then(async () => {
-      await fs.appendFile(this.filePath, line)
+    const write = this.pendingWrite.then(async () => {
+      await this.file.appendFile(line)
     })
-    await this.pendingWrite
+    this.pendingWrite = write.catch(() => {})
+    try {
+      await write
+    } catch (err: unknown) {
+      this.completedTasks.delete(key)
+      throw err
+    }
   }
 
   async finish (): Promise<void> {
-    await this.pendingWrite
+    await this.close()
     await unlinkIfExists(this.filePath)
   }
+
+  async close (): Promise<void> {
+    this.closePromise ??= this.pendingWrite.then(async () => this.file.close())
+    await this.closePromise
+  }
+}
+
+async function validateRealDirectory (dir: string, create: boolean): Promise<boolean> {
+  let stats
+  try {
+    stats = await fs.lstat(dir)
+  } catch (err: unknown) {
+    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) throw err
+    if (!create) return false
+    try {
+      await fs.mkdir(dir)
+    } catch (mkdirErr: unknown) {
+      if (!(util.types.isNativeError(mkdirErr) && 'code' in mkdirErr && mkdirErr.code === 'EEXIST')) throw mkdirErr
+    }
+    stats = await fs.lstat(dir)
+  }
+  if (stats.isSymbolicLink() || !stats.isDirectory()) {
+    throw new PnpmError('UNSAFE_TASK_RUN_STATE_PATH', `Refusing to use task run state directory at "${dir}" because it is a symbolic link or not a directory`)
+  }
+  return true
 }
 
 function taskId (node: TaskNode, workspaceDir: string): TaskId {

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -1,0 +1,204 @@
+import crypto from 'node:crypto'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import util from 'node:util'
+
+import { createHexHash } from '@pnpm/crypto.hash'
+import type { TaskGraph, TaskKey, TaskNode } from '@pnpm/workspace.task-scheduler'
+import writeFileAtomic from 'write-file-atomic'
+
+const STATE_VERSION = 1
+const STATE_DIR = '.pnpm-task-run-state-v1'
+const STATE_FILE_NAME = /^[0-9a-f]{64}\.jsonl$/
+
+interface TaskId {
+  project: string
+  task: string
+}
+
+interface TaskIdentity extends TaskId {
+  scripts: Array<{ name: string, commands: string[] }>
+  requested: boolean
+  dependencies: TaskId[]
+}
+
+interface InvocationIdentity {
+  command: 'run' | 'exec'
+  params: string[]
+  settings: string[]
+  tasks: TaskIdentity[]
+}
+
+interface StateHeader {
+  version: number
+  invocation: string
+  run: string
+}
+
+interface TaskRecord extends TaskId {
+  run: string
+}
+
+export interface TaskRunStateContextOptions {
+  command: InvocationIdentity['command']
+  params: string[]
+  settings?: string[]
+  graph: TaskGraph
+  workspaceDir: string
+  scriptCommands: (node: TaskNode, script: string) => string[]
+}
+
+export class TaskRunStateContext {
+  readonly filePath: string
+  readonly invocation: string
+  private readonly opts: TaskRunStateContextOptions
+  private readonly keysById = new Map<string, TaskKey>()
+
+  constructor (opts: TaskRunStateContextOptions) {
+    this.opts = opts
+    const identity: InvocationIdentity = {
+      command: opts.command,
+      params: opts.params,
+      settings: [...(opts.settings ?? [])].sort(compareStrings),
+      tasks: [...opts.graph].map(([key, node]) => {
+        const id = taskId(node, opts.workspaceDir)
+        this.keysById.set(taskIdKey(id), key)
+        return {
+          ...id,
+          scripts: node.scripts
+            .map((name) => ({ name, commands: opts.scriptCommands(node, name) }))
+            .sort(compareScripts),
+          requested: node.requested,
+          dependencies: node.dependencies
+            .map((dependency) => taskId(opts.graph.get(dependency)!, opts.workspaceDir))
+            .sort(compareTaskIds),
+        }
+      }).sort(compareTaskIds),
+    }
+    this.invocation = createHexHash(JSON.stringify(identity))
+    this.filePath = path.join(opts.workspaceDir, 'node_modules', STATE_DIR, `${this.invocation}.jsonl`)
+  }
+
+  async readCompletedTasks (): Promise<Set<TaskKey> | undefined> {
+    let contents: string
+    try {
+      contents = await fs.readFile(this.filePath, 'utf8')
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return undefined
+      throw err
+    }
+    // A record is committed by its newline; a process killed during append
+    // can leave only the final record torn.
+    const lines = contents.split('\n')
+    lines.pop()
+    if (lines.length === 0) return undefined
+    let header: StateHeader
+    try {
+      header = JSON.parse(lines[0]) as StateHeader
+    } catch {
+      return undefined
+    }
+    if (header.version !== STATE_VERSION || header.invocation !== this.invocation) return undefined
+    const completed = new Set<TaskKey>()
+    for (const line of lines.slice(1)) {
+      let record: TaskRecord
+      try {
+        record = JSON.parse(line) as TaskRecord
+      } catch {
+        return undefined
+      }
+      if (record.run !== header.run) continue
+      const key = this.keysById.get(taskIdKey(record))
+      if (key == null) return undefined
+      completed.add(key)
+    }
+    return completed
+  }
+
+  async start (completedTasks: ReadonlySet<TaskKey>): Promise<TaskRunState> {
+    const run = crypto.randomUUID()
+    const header: StateHeader = { version: STATE_VERSION, invocation: this.invocation, run }
+    const completed = [...completedTasks]
+      .map((key): TaskRecord => ({ run, ...taskId(this.opts.graph.get(key)!, this.opts.workspaceDir) }))
+      .sort(compareTaskIds)
+    const contents = [header, ...completed].map((record) => JSON.stringify(record)).join('\n') + '\n'
+    const stateDir = path.dirname(this.filePath)
+    await fs.mkdir(stateDir, { recursive: true })
+    await writeFileAtomic(this.filePath, contents, { mode: 0o600 })
+    // Only the latest recursive invocation is resumable. Otherwise an old
+    // compatible journal could become active again after intervening work.
+    const entries = await fs.readdir(stateDir, { withFileTypes: true })
+    await Promise.all(entries
+      .filter((entry) => entry.name !== path.basename(this.filePath) && !entry.isDirectory() && STATE_FILE_NAME.test(entry.name))
+      .map(async (entry) => unlinkIfExists(path.join(stateDir, entry.name))))
+    return new TaskRunState(this.filePath, this.opts.workspaceDir, run, completedTasks)
+  }
+}
+
+export class TaskRunState {
+  private readonly filePath: string
+  private readonly workspaceDir: string
+  private readonly run: string
+  private readonly completedTasks: Set<TaskKey>
+  private pendingWrite: Promise<void> = Promise.resolve()
+
+  constructor (
+    filePath: string,
+    workspaceDir: string,
+    run: string,
+    completedTasks: ReadonlySet<TaskKey>
+  ) {
+    this.filePath = filePath
+    this.workspaceDir = workspaceDir
+    this.run = run
+    this.completedTasks = new Set(completedTasks)
+  }
+
+  async recordPassed (key: TaskKey, node: TaskNode): Promise<void> {
+    if (this.completedTasks.has(key)) return
+    this.completedTasks.add(key)
+    const record: TaskRecord = { run: this.run, ...taskId(node, this.workspaceDir) }
+    const line = `${JSON.stringify(record)}\n`
+    this.pendingWrite = this.pendingWrite.then(async () => {
+      await fs.appendFile(this.filePath, line)
+    })
+    await this.pendingWrite
+  }
+
+  async finish (): Promise<void> {
+    await this.pendingWrite
+    await unlinkIfExists(this.filePath)
+  }
+}
+
+function taskId (node: TaskNode, workspaceDir: string): TaskId {
+  const relative = path.relative(workspaceDir, node.project)
+  return {
+    project: relative === '' ? '.' : relative.replaceAll(path.sep, '/'),
+    task: node.taskName,
+  }
+}
+
+function taskIdKey (id: TaskId): string {
+  return `${id.project}\0${id.task}`
+}
+
+function compareTaskIds (left: TaskId, right: TaskId): number {
+  return compareStrings(left.project, right.project) || compareStrings(left.task, right.task)
+}
+
+function compareScripts (left: { name: string }, right: { name: string }): number {
+  return compareStrings(left.name, right.name)
+}
+
+function compareStrings (left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+async function unlinkIfExists (filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath)
+  } catch (err: unknown) {
+    if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) throw err
+  }
+}

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -11,12 +11,14 @@ import writeFileAtomic from 'write-file-atomic'
 const STATE_VERSION = 1
 const STATE_DIR = '.pnpm-task-run-state-v1'
 const LATEST_STATE_FILE = 'latest.json'
+const PUBLISHED_SUFFIX = '.published'
 const START_LOCK_DIR = 'start.lock'
 const LOCK_OWNER_FILE = 'owner'
 const LOCK_POLL_INTERVAL_MS = 50
 const LOCK_WAIT_MS = 2_000
 const LOCK_ABANDONED_MS = 30_000
-const RUN_ID = /^[0-9a-f-]{1,128}$/
+const RUN_GENERATION_LENGTH = 12
+const RUN_ID = /^[0-9a-f]{12}-[0-9a-f-]{1,115}$/
 
 interface TaskId {
   project: string
@@ -128,7 +130,14 @@ export class TaskRunStateContext {
       return undefined
     }
     if (latest.version !== STATE_VERSION || latest.invocation !== this.invocation || !RUN_ID.test(latest.run)) return undefined
-    const filePath = this.journalPath(latest.run)
+    let run: string
+    try {
+      run = await this.newestJournalRun(latest.run)
+    } catch (err: unknown) {
+      if (isStateUnavailableError(err)) return undefined
+      throw err
+    }
+    const filePath = this.journalPath(run)
     let contents: string
     try {
       contents = await fs.readFile(filePath, 'utf8')
@@ -147,7 +156,7 @@ export class TaskRunStateContext {
     } catch {
       return undefined
     }
-    if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== latest.run) return undefined
+    if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== run) return undefined
     const completed = new Set<TaskKey>()
     for (const line of lines.slice(1)) {
       let record: TaskRecord
@@ -165,13 +174,8 @@ export class TaskRunStateContext {
   }
 
   async start (completedTasks: ReadonlySet<TaskKey>): Promise<TaskRunState> {
-    const run = crypto.randomUUID()
-    const header: StateHeader = { version: STATE_VERSION, invocation: this.invocation, run }
-    const completed = [...completedTasks]
-      .map((key): TaskRecord => ({ run, ...taskId(this.opts.graph.get(key)!, this.opts.workspaceDir) }))
-      .sort(compareTaskIds)
-    const contents = [header, ...completed].map((record) => JSON.stringify(record)).join('\n') + '\n'
-    const filePath = this.journalPath(run)
+    let run = createRunId(Date.now())
+    let filePath = this.journalPath(run)
     let file: FileHandle | undefined
     let journalCreated = false
     let lock: StateStartLock | undefined
@@ -179,8 +183,15 @@ export class TaskRunStateContext {
       await this.validateStateDirectory(true)
       lock = await StateStartLock.acquire(path.join(this.stateDir, START_LOCK_DIR))
       if (lock == null) {
-        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
+      run = await this.nextRunId()
+      filePath = this.journalPath(run)
+      const header: StateHeader = { version: STATE_VERSION, invocation: this.invocation, run }
+      const completed = [...completedTasks]
+        .map((key): TaskRecord => ({ run, ...taskId(this.opts.graph.get(key)!, this.opts.workspaceDir) }))
+        .sort(compareTaskIds)
+      const contents = [header, ...completed].map((record) => JSON.stringify(record)).join('\n') + '\n'
       await writeFileAtomic(filePath, contents, { mode: 0o600 })
       journalCreated = true
       file = await fs.open(filePath, 'a')
@@ -189,24 +200,61 @@ export class TaskRunStateContext {
         file = undefined
         await unlinkIfExists(filePath)
         journalCreated = false
-        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
       await writeFileAtomic(this.latestStatePath, JSON.stringify(header), { mode: 0o600 })
+      await writeFileAtomic(this.publishedPath(run), '', { mode: 0o600 })
     } catch (err: unknown) {
       await file?.close().catch(() => {})
       if (journalCreated) await unlinkIfExists(filePath).catch(() => {})
+      await unlinkIfExists(this.publishedPath(run)).catch(() => {})
       if (isStateUnavailableError(err)) {
-        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
       throw err
     } finally {
       await lock?.release()
     }
-    return new TaskRunState(filePath, file, this.opts.workspaceDir, run, completedTasks)
+    return new TaskRunState(filePath, this.publishedPath(run), file, this.opts.workspaceDir, run, completedTasks)
   }
 
   private journalPath (run: string): string {
     return path.join(this.stateDir, `${this.invocation}.${run}.jsonl`)
+  }
+
+  private publishedPath (run: string): string {
+    return path.join(this.stateDir, `${this.invocation}.${run}${PUBLISHED_SUFFIX}`)
+  }
+
+  private async newestJournalRun (latestRun: string): Promise<string> {
+    let newestRun = latestRun
+    const prefix = `${this.invocation}.`
+    const names = new Set(await fs.readdir(this.stateDir))
+    for (const name of names) {
+      if (!name.startsWith(prefix) || !name.endsWith('.jsonl')) continue
+      const run = name.slice(prefix.length, -'.jsonl'.length)
+      if (RUN_ID.test(run) && names.has(`${prefix}${run}${PUBLISHED_SUFFIX}`) && runGeneration(run) > runGeneration(newestRun)) newestRun = run
+    }
+    return newestRun
+  }
+
+  private async nextRunId (): Promise<string> {
+    let newestGeneration = Date.now().toString(16).padStart(RUN_GENERATION_LENGTH, '0')
+    try {
+      const latest = JSON.parse(await fs.readFile(this.latestStatePath, 'utf8')) as StateHeader
+      if (latest.invocation === this.invocation && RUN_ID.test(latest.run)) {
+        newestGeneration = maxString(newestGeneration, runGeneration(latest.run))
+      }
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code !== 'ENOENT') throw err
+    }
+    const prefix = `${this.invocation}.`
+    for (const name of await fs.readdir(this.stateDir)) {
+      if (!name.startsWith(prefix) || !name.endsWith('.jsonl')) continue
+      const run = name.slice(prefix.length, -'.jsonl'.length)
+      if (RUN_ID.test(run)) newestGeneration = maxString(newestGeneration, runGeneration(run))
+    }
+    return createRunId(Number.parseInt(newestGeneration, 16) + 1)
   }
 
   private async validateStateDirectory (create: boolean): Promise<boolean> {
@@ -215,8 +263,21 @@ export class TaskRunStateContext {
   }
 }
 
+function createRunId (generation: number): string {
+  return `${generation.toString(16).padStart(RUN_GENERATION_LENGTH, '0')}-${crypto.randomUUID()}`
+}
+
+function runGeneration (run: string): string {
+  return run.slice(0, RUN_GENERATION_LENGTH)
+}
+
+function maxString (left: string, right: string): string {
+  return left > right ? left : right
+}
+
 export class TaskRunState {
   readonly filePath: string
+  private readonly publishedPath: string
   private readonly file: FileHandle | undefined
   private readonly workspaceDir: string
   private readonly run: string
@@ -227,12 +288,14 @@ export class TaskRunState {
 
   constructor (
     filePath: string,
+    publishedPath: string,
     file: FileHandle | undefined,
     workspaceDir: string,
     run: string,
     completedTasks: ReadonlySet<TaskKey>
   ) {
     this.filePath = filePath
+    this.publishedPath = publishedPath
     this.file = file
     this.workspaceDir = workspaceDir
     this.run = run
@@ -267,6 +330,7 @@ export class TaskRunState {
     if (unavailable) {
       await this.close().catch(() => {})
       await unlinkIfExists(this.filePath).catch(() => {})
+      await unlinkIfExists(this.publishedPath).catch(() => {})
     }
   }
 
@@ -275,6 +339,7 @@ export class TaskRunState {
     await this.close()
     try {
       await unlinkIfExists(this.filePath)
+      await unlinkIfExists(this.publishedPath)
     } catch (err: unknown) {
       if (!isStateUnavailableError(err)) throw err
     }

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -239,6 +239,7 @@ export class TaskRunState {
     this.completedTasks.add(key)
     const record: TaskRecord = { run: this.run, ...taskId(node, this.workspaceDir) }
     const line = `${JSON.stringify(record)}\n`
+    let unavailable = false
     const write = this.pendingWrite.then(async () => {
       if (this.disabled) return
       try {
@@ -246,6 +247,7 @@ export class TaskRunState {
       } catch (err: unknown) {
         if (!isStateUnavailableError(err)) throw err
         this.disabled = true
+        unavailable = true
       }
     })
     this.pendingWrite = write.catch(() => {})
@@ -255,10 +257,14 @@ export class TaskRunState {
       this.completedTasks.delete(key)
       throw err
     }
+    if (unavailable) {
+      await this.close().catch(() => {})
+      await unlinkIfExists(this.filePath).catch(() => {})
+    }
   }
 
   async finish (): Promise<void> {
-    if (this.file == null) return
+    if (this.file == null || this.disabled) return
     await this.close()
     try {
       await unlinkIfExists(this.filePath)
@@ -308,8 +314,8 @@ class StateStartLock {
     const stats = await fs.lstat(lockPath).catch(() => undefined)
     if (stats == null || stats.isSymbolicLink() || !stats.isDirectory()) return undefined
     if (Date.now() - stats.mtimeMs > LOCK_ABANDONED_MS) {
-      await fs.rm(lockPath, { force: true, recursive: true }).catch(() => {})
-      return StateStartLock.acquireUntil(lockPath, deadline)
+      const removed = await fs.rm(lockPath, { force: true, recursive: true }).then(() => true, () => false)
+      if (removed) return StateStartLock.acquireUntil(lockPath, deadline)
     }
     if (Date.now() >= deadline) return undefined
     await new Promise(resolve => setTimeout(resolve, LOCK_POLL_INTERVAL_MS))

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -48,6 +48,11 @@ interface TaskRecord extends TaskId {
   run: string
 }
 
+interface FinishRecord {
+  run: string
+  finished: true
+}
+
 export interface TaskRunStateContextOptions {
   command: InvocationIdentity['command']
   params: string[]
@@ -159,13 +164,14 @@ export class TaskRunStateContext {
     if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== run) return undefined
     const completed = new Set<TaskKey>()
     for (const line of lines.slice(1)) {
-      let record: TaskRecord
+      let record: TaskRecord | FinishRecord
       try {
-        record = JSON.parse(line) as TaskRecord
+        record = JSON.parse(line) as TaskRecord | FinishRecord
       } catch {
         return undefined
       }
       if (record.run !== header.run) continue
+      if (isFinishRecord(record)) return undefined
       const key = this.keysById.get(taskIdKey(record))
       if (key == null) return undefined
       completed.add(key)
@@ -275,6 +281,10 @@ function maxString (left: string, right: string): string {
   return left > right ? left : right
 }
 
+function isFinishRecord (record: TaskRecord | FinishRecord): record is FinishRecord {
+  return 'finished' in record && record.finished
+}
+
 export class TaskRunState {
   readonly filePath: string
   private readonly publishedPath: string
@@ -336,10 +346,20 @@ export class TaskRunState {
 
   async finish (): Promise<void> {
     if (this.file == null || this.disabled) return
+    if (this.closePromise == null) {
+      const finishRecord: FinishRecord = { run: this.run, finished: true }
+      const write = this.pendingWrite.then(async () => this.file!.appendFile(`${JSON.stringify(finishRecord)}\n`))
+      this.pendingWrite = write.catch(() => {})
+      try {
+        await write
+      } catch (err: unknown) {
+        if (!isStateUnavailableError(err)) throw err
+      }
+    }
     await this.close()
     try {
-      await unlinkIfExists(this.filePath)
       await unlinkIfExists(this.publishedPath)
+      await unlinkIfExists(this.filePath)
     } catch (err: unknown) {
       if (!isStateUnavailableError(err)) throw err
     }

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -12,6 +12,7 @@ const STATE_VERSION = 1
 const STATE_DIR = '.pnpm-task-run-state-v1'
 const LATEST_STATE_FILE = 'latest.json'
 const PUBLISHED_SUFFIX = '.published'
+const FINISHED_SUFFIX = '.finished'
 const START_LOCK_DIR = 'start.lock'
 const LOCK_OWNER_FILE = 'owner'
 const LOCK_POLL_INTERVAL_MS = 50
@@ -135,14 +136,15 @@ export class TaskRunStateContext {
       return undefined
     }
     if (latest.version !== STATE_VERSION || latest.invocation !== this.invocation || !RUN_ID.test(latest.run)) return undefined
-    let run: string
+    let state: { run: string, finished: boolean }
     try {
-      run = await this.newestJournalRun(latest.run)
+      state = await this.newestState(latest.run)
     } catch (err: unknown) {
       if (isStateUnavailableError(err)) return undefined
       throw err
     }
-    const filePath = this.journalPath(run)
+    if (state.finished) return undefined
+    const filePath = this.journalPath(state.run)
     let contents: string
     try {
       contents = await fs.readFile(filePath, 'utf8')
@@ -161,7 +163,7 @@ export class TaskRunStateContext {
     } catch {
       return undefined
     }
-    if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== run) return undefined
+    if (header.version !== STATE_VERSION || header.invocation !== this.invocation || header.run !== state.run) return undefined
     const completed = new Set<TaskKey>()
     for (const line of lines.slice(1)) {
       let record: TaskRecord | FinishRecord
@@ -189,7 +191,7 @@ export class TaskRunStateContext {
       await this.validateStateDirectory(true)
       lock = await StateStartLock.acquire(path.join(this.stateDir, START_LOCK_DIR))
       if (lock == null) {
-        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), this.finishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
       run = await this.nextRunId()
       filePath = this.journalPath(run)
@@ -206,22 +208,23 @@ export class TaskRunStateContext {
         file = undefined
         await unlinkIfExists(filePath)
         journalCreated = false
-        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), this.finishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
       await writeFileAtomic(this.latestStatePath, JSON.stringify(header), { mode: 0o600 })
       await writeFileAtomic(this.publishedPath(run), '', { mode: 0o600 })
+      await this.cleanupOlderFinishedState(run).catch(() => {})
     } catch (err: unknown) {
       await file?.close().catch(() => {})
       if (journalCreated) await unlinkIfExists(filePath).catch(() => {})
       await unlinkIfExists(this.publishedPath(run)).catch(() => {})
       if (isStateUnavailableError(err)) {
-        return new TaskRunState(filePath, this.publishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
+        return new TaskRunState(filePath, this.publishedPath(run), this.finishedPath(run), undefined, this.opts.workspaceDir, run, completedTasks)
       }
       throw err
     } finally {
       await lock?.release()
     }
-    return new TaskRunState(filePath, this.publishedPath(run), file, this.opts.workspaceDir, run, completedTasks)
+    return new TaskRunState(filePath, this.publishedPath(run), this.finishedPath(run), file, this.opts.workspaceDir, run, completedTasks)
   }
 
   private journalPath (run: string): string {
@@ -232,16 +235,38 @@ export class TaskRunStateContext {
     return path.join(this.stateDir, `${this.invocation}.${run}${PUBLISHED_SUFFIX}`)
   }
 
-  private async newestJournalRun (latestRun: string): Promise<string> {
+  private finishedPath (run: string): string {
+    return path.join(this.stateDir, `${this.invocation}.${run}${FINISHED_SUFFIX}`)
+  }
+
+  private async newestState (latestRun: string): Promise<{ run: string, finished: boolean }> {
     let newestRun = latestRun
     const prefix = `${this.invocation}.`
     const names = new Set(await fs.readdir(this.stateDir))
+    let finished = names.has(`${prefix}${latestRun}${FINISHED_SUFFIX}`)
     for (const name of names) {
-      if (!name.startsWith(prefix) || !name.endsWith('.jsonl')) continue
-      const run = name.slice(prefix.length, -'.jsonl'.length)
-      if (RUN_ID.test(run) && names.has(`${prefix}${run}${PUBLISHED_SUFFIX}`) && runGeneration(run) > runGeneration(newestRun)) newestRun = run
+      if (!name.startsWith(prefix)) continue
+      let run: string
+      let candidateFinished: boolean
+      if (name.endsWith(FINISHED_SUFFIX)) {
+        run = name.slice(prefix.length, -FINISHED_SUFFIX.length)
+        candidateFinished = true
+      } else if (name.endsWith('.jsonl')) {
+        run = name.slice(prefix.length, -'.jsonl'.length)
+        if (!names.has(`${prefix}${run}${PUBLISHED_SUFFIX}`)) continue
+        candidateFinished = false
+      } else {
+        continue
+      }
+      if (!RUN_ID.test(run)) continue
+      if (runGeneration(run) > runGeneration(newestRun)) {
+        newestRun = run
+        finished = candidateFinished
+      } else if (run === newestRun && candidateFinished) {
+        finished = true
+      }
     }
-    return newestRun
+    return { run: newestRun, finished }
   }
 
   private async nextRunId (): Promise<string> {
@@ -256,11 +281,27 @@ export class TaskRunStateContext {
     }
     const prefix = `${this.invocation}.`
     for (const name of await fs.readdir(this.stateDir)) {
-      if (!name.startsWith(prefix) || !name.endsWith('.jsonl')) continue
-      const run = name.slice(prefix.length, -'.jsonl'.length)
+      if (!name.startsWith(prefix)) continue
+      const suffix = name.endsWith('.jsonl') ? '.jsonl' : name.endsWith(FINISHED_SUFFIX) ? FINISHED_SUFFIX : undefined
+      if (suffix == null) continue
+      const run = name.slice(prefix.length, -suffix.length)
       if (RUN_ID.test(run)) newestGeneration = maxString(newestGeneration, runGeneration(run))
     }
     return createRunId(Number.parseInt(newestGeneration, 16) + 1)
+  }
+
+  private async cleanupOlderFinishedState (run: string): Promise<void> {
+    const prefix = `${this.invocation}.`
+    const generation = runGeneration(run)
+    const removals: Array<Promise<void>> = []
+    for (const name of await fs.readdir(this.stateDir)) {
+      if (!name.startsWith(prefix)) continue
+      if (!name.endsWith(FINISHED_SUFFIX)) continue
+      const olderRun = name.slice(prefix.length, -FINISHED_SUFFIX.length)
+      if (!RUN_ID.test(olderRun) || runGeneration(olderRun) >= generation) continue
+      removals.push(unlinkIfExists(path.join(this.stateDir, name)).catch(() => {}))
+    }
+    await Promise.all(removals)
   }
 
   private async validateStateDirectory (create: boolean): Promise<boolean> {
@@ -288,6 +329,7 @@ function isFinishRecord (record: TaskRecord | FinishRecord): record is FinishRec
 export class TaskRunState {
   readonly filePath: string
   private readonly publishedPath: string
+  private readonly finishedPath: string
   private readonly file: FileHandle | undefined
   private readonly workspaceDir: string
   private readonly run: string
@@ -299,6 +341,7 @@ export class TaskRunState {
   constructor (
     filePath: string,
     publishedPath: string,
+    finishedPath: string,
     file: FileHandle | undefined,
     workspaceDir: string,
     run: string,
@@ -306,6 +349,7 @@ export class TaskRunState {
   ) {
     this.filePath = filePath
     this.publishedPath = publishedPath
+    this.finishedPath = finishedPath
     this.file = file
     this.workspaceDir = workspaceDir
     this.run = run
@@ -357,6 +401,12 @@ export class TaskRunState {
       }
     }
     await this.close()
+    try {
+      await writeFileAtomic(this.finishedPath, '', { mode: 0o600 })
+    } catch (err: unknown) {
+      if (isStateUnavailableError(err)) return
+      throw err
+    }
     try {
       await unlinkIfExists(this.publishedPath)
       await unlinkIfExists(this.filePath)

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -184,6 +184,13 @@ export class TaskRunStateContext {
       await writeFileAtomic(filePath, contents, { mode: 0o600 })
       journalCreated = true
       file = await fs.open(filePath, 'a')
+      if (!await lock.isOwner()) {
+        await file.close()
+        file = undefined
+        await unlinkIfExists(filePath)
+        journalCreated = false
+        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+      }
       await writeFileAtomic(this.latestStatePath, JSON.stringify(header), { mode: 0o600 })
     } catch (err: unknown) {
       await file?.close().catch(() => {})
@@ -322,9 +329,17 @@ class StateStartLock {
     return StateStartLock.acquireUntil(lockPath, deadline)
   }
 
+  async isOwner (): Promise<boolean> {
+    try {
+      return await fs.readFile(path.join(this.lockPath, LOCK_OWNER_FILE), 'utf8') === this.token
+    } catch (err: unknown) {
+      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return false
+      throw err
+    }
+  }
+
   async release (): Promise<void> {
-    const owner = await fs.readFile(path.join(this.lockPath, LOCK_OWNER_FILE), 'utf8').catch(() => undefined)
-    if (owner !== this.token) return
+    if (!await this.isOwner().catch(() => false)) return
     await fs.rm(this.lockPath, { force: true, recursive: true }).catch(() => {})
   }
 }

--- a/pnpm11/exec/commands/src/taskRunState.ts
+++ b/pnpm11/exec/commands/src/taskRunState.ts
@@ -11,6 +11,11 @@ import writeFileAtomic from 'write-file-atomic'
 const STATE_VERSION = 1
 const STATE_DIR = '.pnpm-task-run-state-v1'
 const LATEST_STATE_FILE = 'latest.json'
+const START_LOCK_DIR = 'start.lock'
+const LOCK_OWNER_FILE = 'owner'
+const LOCK_POLL_INTERVAL_MS = 50
+const LOCK_WAIT_MS = 2_000
+const LOCK_ABANDONED_MS = 30_000
 const RUN_ID = /^[0-9a-f-]{1,128}$/
 
 interface TaskId {
@@ -109,12 +114,17 @@ export class TaskRunStateContext {
   }
 
   async readCompletedTasks (): Promise<Set<TaskKey> | undefined> {
-    if (!await this.validateStateDirectory(false)) return undefined
+    try {
+      if (!await this.validateStateDirectory(false)) return undefined
+    } catch (err: unknown) {
+      if (isStateUnavailableError(err)) return undefined
+      throw err
+    }
     let latest: StateHeader
     try {
       latest = JSON.parse(await fs.readFile(this.latestStatePath, 'utf8')) as StateHeader
     } catch (err: unknown) {
-      if (util.types.isNativeError(err) && 'code' in err && err.code !== 'ENOENT') throw err
+      if (util.types.isNativeError(err) && 'code' in err && err.code !== 'ENOENT' && !isStateUnavailableError(err)) throw err
       return undefined
     }
     if (latest.version !== STATE_VERSION || latest.invocation !== this.invocation || !RUN_ID.test(latest.run)) return undefined
@@ -123,7 +133,7 @@ export class TaskRunStateContext {
     try {
       contents = await fs.readFile(filePath, 'utf8')
     } catch (err: unknown) {
-      if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') return undefined
+      if (util.types.isNativeError(err) && 'code' in err && (err.code === 'ENOENT' || isStateUnavailableError(err))) return undefined
       throw err
     }
     // A record is committed by its newline; a process killed during append
@@ -162,15 +172,28 @@ export class TaskRunStateContext {
       .sort(compareTaskIds)
     const contents = [header, ...completed].map((record) => JSON.stringify(record)).join('\n') + '\n'
     const filePath = this.journalPath(run)
-    await this.validateStateDirectory(true)
-    await writeFileAtomic(filePath, contents, { mode: 0o600 })
-    const file = await fs.open(filePath, 'a')
+    let file: FileHandle | undefined
+    let journalCreated = false
+    let lock: StateStartLock | undefined
     try {
+      await this.validateStateDirectory(true)
+      lock = await StateStartLock.acquire(path.join(this.stateDir, START_LOCK_DIR))
+      if (lock == null) {
+        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+      }
+      await writeFileAtomic(filePath, contents, { mode: 0o600 })
+      journalCreated = true
+      file = await fs.open(filePath, 'a')
       await writeFileAtomic(this.latestStatePath, JSON.stringify(header), { mode: 0o600 })
     } catch (err: unknown) {
-      await file.close()
-      await unlinkIfExists(filePath)
+      await file?.close().catch(() => {})
+      if (journalCreated) await unlinkIfExists(filePath).catch(() => {})
+      if (isStateUnavailableError(err)) {
+        return new TaskRunState(filePath, undefined, this.opts.workspaceDir, run, completedTasks)
+      }
       throw err
+    } finally {
+      await lock?.release()
     }
     return new TaskRunState(filePath, file, this.opts.workspaceDir, run, completedTasks)
   }
@@ -187,16 +210,17 @@ export class TaskRunStateContext {
 
 export class TaskRunState {
   readonly filePath: string
-  private readonly file: FileHandle
+  private readonly file: FileHandle | undefined
   private readonly workspaceDir: string
   private readonly run: string
   private readonly completedTasks: Set<TaskKey>
   private pendingWrite: Promise<void> = Promise.resolve()
   private closePromise: Promise<void> | undefined
+  private disabled: boolean
 
   constructor (
     filePath: string,
-    file: FileHandle,
+    file: FileHandle | undefined,
     workspaceDir: string,
     run: string,
     completedTasks: ReadonlySet<TaskKey>
@@ -206,15 +230,23 @@ export class TaskRunState {
     this.workspaceDir = workspaceDir
     this.run = run
     this.completedTasks = new Set(completedTasks)
+    this.disabled = file == null
   }
 
   async recordPassed (key: TaskKey, node: TaskNode): Promise<void> {
-    if (this.completedTasks.has(key)) return
+    const file = this.file
+    if (this.disabled || file == null || this.completedTasks.has(key)) return
     this.completedTasks.add(key)
     const record: TaskRecord = { run: this.run, ...taskId(node, this.workspaceDir) }
     const line = `${JSON.stringify(record)}\n`
     const write = this.pendingWrite.then(async () => {
-      await this.file.appendFile(line)
+      if (this.disabled) return
+      try {
+        await file.appendFile(line)
+      } catch (err: unknown) {
+        if (!isStateUnavailableError(err)) throw err
+        this.disabled = true
+      }
     })
     this.pendingWrite = write.catch(() => {})
     try {
@@ -226,13 +258,68 @@ export class TaskRunState {
   }
 
   async finish (): Promise<void> {
+    if (this.file == null) return
     await this.close()
-    await unlinkIfExists(this.filePath)
+    try {
+      await unlinkIfExists(this.filePath)
+    } catch (err: unknown) {
+      if (!isStateUnavailableError(err)) throw err
+    }
   }
 
   async close (): Promise<void> {
-    this.closePromise ??= this.pendingWrite.then(async () => this.file.close())
+    const file = this.file
+    if (file == null) return
+    this.closePromise ??= this.pendingWrite.then(async () => file.close())
     await this.closePromise
+  }
+}
+
+class StateStartLock {
+  private readonly lockPath: string
+  private readonly token: string
+
+  private constructor (
+    lockPath: string,
+    token: string
+  ) {
+    this.lockPath = lockPath
+    this.token = token
+  }
+
+  static async acquire (lockPath: string): Promise<StateStartLock | undefined> {
+    return StateStartLock.acquireUntil(lockPath, Date.now() + LOCK_WAIT_MS)
+  }
+
+  private static async acquireUntil (lockPath: string, deadline: number): Promise<StateStartLock | undefined> {
+    try {
+      await fs.mkdir(lockPath)
+      const token = `${process.pid}-${Date.now()}-${crypto.randomUUID()}`
+      try {
+        await fs.writeFile(path.join(lockPath, LOCK_OWNER_FILE), token, { mode: 0o600 })
+      } catch (err: unknown) {
+        await fs.rm(lockPath, { force: true, recursive: true }).catch(() => {})
+        throw err
+      }
+      return new StateStartLock(lockPath, token)
+    } catch (err: unknown) {
+      if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'EEXIST')) throw err
+    }
+    const stats = await fs.lstat(lockPath).catch(() => undefined)
+    if (stats == null || stats.isSymbolicLink() || !stats.isDirectory()) return undefined
+    if (Date.now() - stats.mtimeMs > LOCK_ABANDONED_MS) {
+      await fs.rm(lockPath, { force: true, recursive: true }).catch(() => {})
+      return StateStartLock.acquireUntil(lockPath, deadline)
+    }
+    if (Date.now() >= deadline) return undefined
+    await new Promise(resolve => setTimeout(resolve, LOCK_POLL_INTERVAL_MS))
+    return StateStartLock.acquireUntil(lockPath, deadline)
+  }
+
+  async release (): Promise<void> {
+    const owner = await fs.readFile(path.join(this.lockPath, LOCK_OWNER_FILE), 'utf8').catch(() => undefined)
+    if (owner !== this.token) return
+    await fs.rm(this.lockPath, { force: true, recursive: true }).catch(() => {})
   }
 }
 
@@ -286,4 +373,9 @@ async function unlinkIfExists (filePath: string): Promise<void> {
   } catch (err: unknown) {
     if (!(util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT')) throw err
   }
+}
+
+function isStateUnavailableError (err: unknown): boolean {
+  return util.types.isNativeError(err) && 'code' in err &&
+    (err.code === 'EACCES' || err.code === 'EPERM' || err.code === 'EROFS')
 }

--- a/pnpm11/exec/commands/test/exec.e2e.ts
+++ b/pnpm11/exec/commands/test/exec.e2e.ts
@@ -651,6 +651,56 @@ test('pnpm recursive exec --resume-from should work', async () => {
   expect(server.getLines().sort()).toEqual(['project-2', 'project-3', 'project-4'])
 })
 
+test('recursive exec resumes from exactly the projects that passed before a failure', async () => {
+  preparePackages([
+    {
+      name: 'dependency',
+      version: '1.0.0',
+    },
+    {
+      name: 'anchor',
+      version: '1.0.0',
+      dependencies: {
+        dependency: '1',
+      },
+    },
+    {
+      name: 'completed',
+      version: '1.0.0',
+    },
+  ])
+  await fs.promises.writeFile('fail', '')
+  const { selectedProjectsGraph } = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  const command = [
+    'node',
+    '-e',
+    "const fs = require('fs'); const name = require('path').basename(process.cwd()); fs.appendFileSync('../order.log', `${name}\\n`); if (name === 'dependency' && fs.existsSync('../fail')) process.exit(1)",
+  ]
+  const opts = {
+    ...DEFAULT_OPTS,
+    bail: false,
+    dir: process.cwd(),
+    recursive: true,
+    selectedProjectsGraph,
+    sort: true,
+    workspaceConcurrency: 1,
+    workspaceDir: process.cwd(),
+  }
+
+  await expect(exec.handler(opts, command)).rejects.toMatchObject({ code: 'ERR_PNPM_RECURSIVE_FAIL' })
+  const firstRun = (await fs.promises.readFile('order.log', 'utf8')).trim().split('\n')
+  expect([...firstRun].sort()).toStrictEqual(['completed', 'dependency'])
+
+  await fs.promises.rm('fail')
+  await exec.handler({ ...opts, bail: true, resumeFrom: 'anchor' }, command)
+
+  expect((await fs.promises.readFile('order.log', 'utf8')).trim().split('\n')).toStrictEqual([
+    ...firstRun,
+    'dependency',
+    'anchor',
+  ])
+})
+
 test('should throw error when the package specified by resume-from does not exist', async () => {
   preparePackages([
     {

--- a/pnpm11/exec/commands/test/runRecursive.ts
+++ b/pnpm11/exec/commands/test/runRecursive.ts
@@ -1141,6 +1141,66 @@ test('recursive run resumes from exactly the tasks that passed before a failure'
   await expect(fs.promises.access(path.join(stateDir, `${latest.invocation}.${latest.run}.jsonl`))).rejects.toMatchObject({ code: 'ENOENT' })
 })
 
+test('recursive run does not persist a task skipped by the lifecycle recursion guard', async () => {
+  preparePackages([
+    {
+      name: 'origin',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "require(\'fs\').appendFileSync(\'../order.log\', \'origin\\n\')"',
+      },
+    },
+    {
+      name: 'anchor',
+      version: '1.0.0',
+      dependencies: {
+        origin: '1',
+      },
+      scripts: {
+        build: 'node -e "require(\'fs\').appendFileSync(\'../order.log\', \'anchor\\n\')"',
+      },
+    },
+    {
+      name: 'failure',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "const fs = require(\'fs\'); fs.appendFileSync(\'../order.log\', \'failure\\n\'); if (fs.existsSync(\'../fail\')) process.exit(1)"',
+      },
+    },
+  ])
+  await fs.promises.writeFile('fail', '')
+  const selection = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  const opts = {
+    ...DEFAULT_OPTS,
+    ...selection,
+    bail: false,
+    dir: process.cwd(),
+    recursive: true,
+    workspaceConcurrency: 1,
+    workspaceDir: process.cwd(),
+  }
+  const previousLifecycleEvent = process.env.npm_lifecycle_event
+  const previousScriptSrcDir = process.env.PNPM_SCRIPT_SRC_DIR
+  try {
+    process.env.npm_lifecycle_event = 'build'
+    process.env.PNPM_SCRIPT_SRC_DIR = path.join(process.cwd(), 'origin')
+    await expect(run.handler(opts, ['build'])).rejects.toMatchObject({ code: 'ERR_PNPM_RECURSIVE_FAIL' })
+  } finally {
+    restoreEnv('npm_lifecycle_event', previousLifecycleEvent)
+    restoreEnv('PNPM_SCRIPT_SRC_DIR', previousScriptSrcDir)
+  }
+  expect((await fs.promises.readFile('order.log', 'utf8')).split('\n')).not.toContain('origin')
+
+  await fs.promises.rm('fail')
+  await run.handler({ ...opts, bail: true, resumeFrom: 'anchor' }, ['build'])
+
+  const order = (await fs.promises.readFile('order.log', 'utf8')).trim().split('\n')
+  expect(order.filter((task) => task === 'origin')).toHaveLength(1)
+  const stateDir = path.join('node_modules', '.pnpm-task-run-state-v1')
+  const latest = JSON.parse(await fs.promises.readFile(path.join(stateDir, 'latest.json'), 'utf8')) as { invocation: string, run: string }
+  await expect(fs.promises.access(path.join(stateDir, `${latest.invocation}.${latest.run}.jsonl`))).rejects.toMatchObject({ code: 'ENOENT' })
+})
+
 test('pnpm run with RegExp script selector should work on recursive', async () => {
   preparePackages([
     {
@@ -1415,3 +1475,11 @@ test('pnpm recursive run with a regex selector keeps a failure when a later matc
 
   expect(err?.code).toBe('ERR_PNPM_RECURSIVE_FAIL')
 })
+
+function restoreEnv (name: string, value: string | undefined): void {
+  if (value == null) {
+    delete process.env[name]
+  } else {
+    process.env[name] = value
+  }
+}

--- a/pnpm11/exec/commands/test/runRecursive.ts
+++ b/pnpm11/exec/commands/test/runRecursive.ts
@@ -1136,7 +1136,9 @@ test('recursive run resumes from exactly the tasks that passed before a failure'
     'dependency',
     'anchor',
   ])
-  await expect(fs.promises.readdir(path.join('node_modules', '.pnpm-task-run-state-v1'))).resolves.toStrictEqual([])
+  const stateDir = path.join('node_modules', '.pnpm-task-run-state-v1')
+  const latest = JSON.parse(await fs.promises.readFile(path.join(stateDir, 'latest.json'), 'utf8')) as { invocation: string, run: string }
+  await expect(fs.promises.access(path.join(stateDir, `${latest.invocation}.${latest.run}.jsonl`))).rejects.toMatchObject({ code: 'ENOENT' })
 })
 
 test('pnpm run with RegExp script selector should work on recursive', async () => {

--- a/pnpm11/exec/commands/test/runRecursive.ts
+++ b/pnpm11/exec/commands/test/runRecursive.ts
@@ -1085,6 +1085,60 @@ test('`pnpm -r --resume-from run` should executed from given package', async () 
   expect(server.getLines().sort()).toEqual(['project-2', 'project-3'])
 })
 
+test('recursive run resumes from exactly the tasks that passed before a failure', async () => {
+  preparePackages([
+    {
+      name: 'dependency',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "const fs = require(\'fs\'); fs.appendFileSync(\'../order.log\', \'dependency\\n\'); if (fs.existsSync(\'../fail\')) process.exit(1)"',
+      },
+    },
+    {
+      name: 'anchor',
+      version: '1.0.0',
+      dependencies: {
+        dependency: '1',
+      },
+      scripts: {
+        build: 'node -e "require(\'fs\').appendFileSync(\'../order.log\', \'anchor\\n\')"',
+      },
+    },
+    {
+      name: 'completed',
+      version: '1.0.0',
+      scripts: {
+        build: 'node -e "require(\'fs\').appendFileSync(\'../order.log\', \'completed\\n\')"',
+      },
+    },
+  ])
+  await fs.promises.writeFile('fail', '')
+  const selection = await filterProjectsBySelectorObjectsFromDir(process.cwd(), [])
+  const opts = {
+    ...DEFAULT_OPTS,
+    ...selection,
+    bail: false,
+    dir: process.cwd(),
+    recursive: true,
+    workspaceConcurrency: 1,
+    workspaceDir: process.cwd(),
+  }
+
+  await expect(run.handler(opts, ['build'])).rejects.toMatchObject({ code: 'ERR_PNPM_RECURSIVE_FAIL' })
+  const firstRun = (await fs.promises.readFile('order.log', 'utf8')).trim().split('\n')
+  expect([...firstRun].sort()).toStrictEqual(['completed', 'dependency'])
+
+  await fs.promises.rm('fail')
+  await run.handler({ ...opts, bail: true, resumeFrom: 'anchor' }, ['build'])
+
+  expect((await fs.promises.readFile('order.log', 'utf8')).trim().split('\n')).toStrictEqual([
+    ...firstRun,
+    'dependency',
+    'anchor',
+  ])
+  await expect(fs.promises.readdir(path.join('node_modules', '.pnpm-task-run-state-v1'))).resolves.toStrictEqual([])
+})
+
 test('pnpm run with RegExp script selector should work on recursive', async () => {
   preparePackages([
     {

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -459,3 +459,36 @@ test('a stale start does not overwrite a newer invocation', async () => {
     open.mockRestore()
   }
 })
+
+test('a stale start cannot revive state after a newer invocation finishes', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const older = await context.start(new Set())
+  const olderContents = await fs.readFile(older.filePath, 'utf8')
+  const olderPublishedPath = older.filePath.replace(/\.jsonl$/, '.published')
+  const newer = await context.start(new Set([key]))
+
+  await newer.finish()
+  await fs.writeFile(older.filePath, olderContents)
+  await fs.writeFile(olderPublishedPath, '')
+  await fs.writeFile(context.latestStatePath, olderContents.split('\n')[0])
+
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
+  await older.close()
+})

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -9,6 +9,7 @@ import { type TaskGraph, taskKey } from '@pnpm/workspace.task-scheduler'
 import { taskRunExecutionSettings, TaskRunStateContext } from '../src/taskRunState.js'
 
 const temporaryDirectories: string[] = []
+const testOnPosix = process.platform === 'win32' ? test.skip : test
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
@@ -161,6 +162,47 @@ test('task run state recovers its write queue after an append failure', async ()
   await state.finish()
 })
 
+test('task run state is disabled after an append permission error', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const secondKey = taskKey(project, 'test')
+  const graph: TaskGraph = new Map([
+    [key, {
+      project,
+      taskName: 'build',
+      scripts: ['build'],
+      requested: true,
+      dependencies: [],
+    }],
+    [secondKey, {
+      project,
+      taskName: 'test',
+      scripts: ['test'],
+      requested: true,
+      dependencies: [],
+    }],
+  ])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const state = await context.start(new Set())
+  const file = (state as unknown as { file: { appendFile: (data: string) => Promise<void> } }).file
+  const appendFile = jest.spyOn(file, 'appendFile').mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+
+  await state.recordPassed(key, graph.get(key)!)
+  await state.recordPassed(secondKey, graph.get(secondKey)!)
+
+  expect(appendFile).toHaveBeenCalledTimes(1)
+  appendFile.mockRestore()
+  await state.finish()
+})
+
 test('task run state rejects a symlinked state directory', async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
   const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-outside-'))
@@ -187,6 +229,39 @@ test('task run state rejects a symlinked state directory', async () => {
 
   await expect(context.start(new Set())).rejects.toMatchObject({ code: 'ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH' })
   await expect(fs.access(path.join(outsideDir, 'latest.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+})
+
+testOnPosix('task run state is disabled when node_modules is read-only', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const nodeModulesDir = path.join(workspaceDir, 'node_modules')
+  await fs.mkdir(nodeModulesDir)
+  await fs.chmod(nodeModulesDir, 0o555)
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+
+  try {
+    const state = await context.start(new Set())
+    await state.recordPassed(key, graph.get(key)!)
+    await state.finish()
+    await expect(fs.access(context.latestStatePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  } finally {
+    await fs.chmod(nodeModulesDir, 0o755)
+  }
 })
 
 test('finishing an older invocation preserves the newer invocation journal', async () => {
@@ -216,4 +291,59 @@ test('finishing an older invocation preserves the newer invocation journal', asy
   await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
   await newer.finish()
   await expect(context.readCompletedTasks()).resolves.toBeUndefined()
+})
+
+test('overlapping starts publish the newer invocation last', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const originalOpen = fs.open.bind(fs)
+  let markOlderBlocked!: () => void
+  let unblockOlder!: () => void
+  const olderBlocked = new Promise<void>(resolve => {
+    markOlderBlocked = resolve
+  })
+  const olderGate = new Promise<void>(resolve => {
+    unblockOlder = resolve
+  })
+  let blockNextJournal = true
+  const open = jest.spyOn(fs, 'open').mockImplementation(async (...args) => {
+    if (blockNextJournal && String(args[0]).endsWith('.jsonl')) {
+      blockNextJournal = false
+      markOlderBlocked()
+      await olderGate
+    }
+    return originalOpen(...args)
+  })
+
+  try {
+    const olderPromise = context.start(new Set())
+    await olderBlocked
+    const newerPromise = context.start(new Set([key]))
+    await new Promise(resolve => setTimeout(resolve, 100))
+    unblockOlder()
+    const [older, newer] = await Promise.all([olderPromise, newerPromise])
+
+    await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
+    await older.close()
+    await newer.close()
+  } finally {
+    unblockOlder()
+    open.mockRestore()
+  }
 })

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -199,8 +199,52 @@ test('task run state is disabled after an append permission error', async () => 
   await state.recordPassed(secondKey, graph.get(secondKey)!)
 
   expect(appendFile).toHaveBeenCalledTimes(1)
+  await expect(fs.access(state.filePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
   appendFile.mockRestore()
   await state.finish()
+})
+
+test('task run state stops waiting when an abandoned lock cannot be removed', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const lockPath = path.join(workspaceDir, 'node_modules', '.pnpm-task-run-state-v1', 'start.lock')
+  await fs.mkdir(lockPath, { recursive: true })
+  const now = Date.now()
+  const staleTime = new Date(now - 60_000)
+  await fs.utimes(lockPath, staleTime, staleTime)
+  const rm = jest.spyOn(fs, 'rm').mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+  const dateNow = jest.spyOn(Date, 'now')
+    .mockReturnValueOnce(now)
+    .mockReturnValueOnce(now)
+    .mockReturnValue(now + 2_000)
+
+  try {
+    const state = await context.start(new Set())
+
+    expect(rm).toHaveBeenCalledTimes(1)
+    await expect(fs.access(context.latestStatePath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await state.finish()
+  } finally {
+    dateNow.mockRestore()
+    rm.mockRestore()
+  }
 })
 
 test('task run state rejects a symlinked state directory', async () => {

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -337,7 +337,7 @@ test('finishing an older invocation preserves the newer invocation journal', asy
   await expect(context.readCompletedTasks()).resolves.toBeUndefined()
 })
 
-test('overlapping starts publish the newer invocation last', async () => {
+test('a stale start does not overwrite a newer invocation', async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
   temporaryDirectories.push(workspaceDir)
   const project = path.join(workspaceDir, 'project') as ProjectRootDir
@@ -357,15 +357,10 @@ test('overlapping starts publish the newer invocation last', async () => {
     scriptCommands: () => ['build-command'],
   })
   const originalOpen = fs.open.bind(fs)
-  const originalMkdir = fs.mkdir.bind(fs)
   let markOlderBlocked!: () => void
-  let markNewerWaiting!: () => void
   let unblockOlder!: () => void
   const olderBlocked = new Promise<void>(resolve => {
     markOlderBlocked = resolve
-  })
-  const newerWaiting = new Promise<void>(resolve => {
-    markNewerWaiting = resolve
   })
   const olderGate = new Promise<void>(resolve => {
     unblockOlder = resolve
@@ -379,26 +374,22 @@ test('overlapping starts publish the newer invocation last', async () => {
     }
     return originalOpen(...args)
   })
-  let lockAttempts = 0
-  const mkdir = jest.spyOn(fs, 'mkdir').mockImplementation(async (...args) => {
-    if (String(args[0]).endsWith('start.lock') && ++lockAttempts === 2) markNewerWaiting()
-    return originalMkdir(...args)
-  })
 
   try {
     const olderPromise = context.start(new Set())
     await olderBlocked
-    const newerPromise = context.start(new Set([key]))
-    await newerWaiting
+    const lockPath = path.join(workspaceDir, 'node_modules', '.pnpm-task-run-state-v1', 'start.lock')
+    const staleTime = new Date(Date.now() - 60_000)
+    await fs.utimes(lockPath, staleTime, staleTime)
+    const newer = await context.start(new Set([key]))
     unblockOlder()
-    const [older, newer] = await Promise.all([olderPromise, newerPromise])
+    const older = await olderPromise
 
     await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
     await older.close()
     await newer.close()
   } finally {
     unblockOlder()
-    mkdir.mockRestore()
     open.mockRestore()
   }
 })

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -337,6 +337,41 @@ test('finishing an older invocation preserves the newer invocation journal', asy
   await expect(context.readCompletedTasks()).resolves.toBeUndefined()
 })
 
+test('a stale pointer does not hide a newer published invocation journal', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const older = await context.start(new Set())
+  const olderHeader = (await fs.readFile(older.filePath, 'utf8')).split('\n')[0]
+  const newer = await context.start(new Set([key]))
+  const newerPublishedPath = newer.filePath.replace(/\.jsonl$/, '.published')
+
+  await fs.unlink(newerPublishedPath)
+  await fs.writeFile(context.latestStatePath, olderHeader)
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set())
+  await fs.writeFile(newerPublishedPath, '')
+
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
+  await older.finish()
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
+  await newer.finish()
+})
+
 test('a stale start does not overwrite a newer invocation', async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
   temporaryDirectories.push(workspaceDir)

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -2,16 +2,65 @@ import fs from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 
-import { afterEach, expect, test } from '@jest/globals'
+import { afterEach, expect, jest, test } from '@jest/globals'
 import type { ProjectRootDir } from '@pnpm/types'
 import { type TaskGraph, taskKey } from '@pnpm/workspace.task-scheduler'
 
-import { TaskRunStateContext } from '../src/taskRunState.js'
+import { taskRunExecutionSettings, TaskRunStateContext } from '../src/taskRunState.js'
 
 const temporaryDirectories: string[] = []
 
 afterEach(async () => {
   await Promise.all(temporaryDirectories.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
+})
+
+test('task execution settings have a stable canonical encoding', () => {
+  expect(taskRunExecutionSettings({
+    extraBinPaths: ['tools', 'other-tools'],
+    extraEnv: { ZED: 'last', ALPHA: 'first' },
+    modulesDir: 'vendor',
+    nodeExperimentalPackageMap: true,
+    nodeOptions: '--conditions=development',
+    userAgent: 'pnpm/test',
+  })).toStrictEqual([
+    'extra-bin-paths=["tools","other-tools"]',
+    'extra-env=[["ALPHA","first"],["ZED","last"]]',
+    'modules-dir=vendor',
+    'node-experimental-package-map=true',
+    'node-options=--conditions=development',
+    'user-agent=pnpm/test',
+  ])
+})
+
+test('a changed execution setting produces a different invocation identity', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const contextOptions = {
+    command: 'run' as const,
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  }
+  const first = new TaskRunStateContext({
+    ...contextOptions,
+    settings: taskRunExecutionSettings({ extraEnv: { MODE: 'first' } }),
+  })
+  const second = new TaskRunStateContext({
+    ...contextOptions,
+    settings: taskRunExecutionSettings({ extraEnv: { MODE: 'second' } }),
+  })
+
+  expect(first.invocation).not.toBe(second.invocation)
 })
 
 test('task run state ignores a torn trailing record and removes a completed journal', async () => {
@@ -45,18 +94,14 @@ test('task run state ignores a torn trailing record and removes a completed jour
     scriptCommands: () => ['build-command'],
   })
   expect(context.invocation).toBe('76a575bfcc3b67becd98b5ec661be54567b53954a723da167603dad119fab140')
-  const staleState = path.join(path.dirname(context.filePath), `${'a'.repeat(64)}.jsonl`)
-  await fs.mkdir(path.dirname(staleState), { recursive: true })
-  await fs.writeFile(staleState, 'stale')
   const state = await context.start(new Set([firstKey]))
-  await expect(fs.stat(staleState)).rejects.toMatchObject({ code: 'ENOENT' })
   await state.recordPassed(secondKey, graph.get(secondKey)!)
-  await fs.appendFile(context.filePath, '{"run":"superseded","project":"unknown","task":"build"}\n')
-  await fs.appendFile(context.filePath, '{"project":"torn')
+  await fs.appendFile(state.filePath, '{"run":"superseded","project":"unknown","task":"build"}\n')
+  await fs.appendFile(state.filePath, '{"project":"torn')
 
   await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([firstKey, secondKey]))
   await state.finish()
-  await expect(fs.stat(context.filePath)).rejects.toMatchObject({ code: 'ENOENT' })
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
 })
 
 test('task run state rejects a malformed complete record', async () => {
@@ -78,8 +123,97 @@ test('task run state rejects a malformed complete record', async () => {
     workspaceDir,
     scriptCommands: () => ['build-command'],
   })
-  await context.start(new Set())
-  await fs.appendFile(context.filePath, 'not-json\n')
+  const state = await context.start(new Set())
+  await fs.appendFile(state.filePath, 'not-json\n')
 
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
+  await state.close()
+})
+
+test('task run state recovers its write queue after an append failure', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const state = await context.start(new Set())
+  const file = (state as unknown as { file: { appendFile: (data: string) => Promise<void> } }).file
+  const appendFile = jest.spyOn(file, 'appendFile').mockRejectedValueOnce(new Error('append failed'))
+
+  await expect(state.recordPassed(key, graph.get(key)!)).rejects.toThrow()
+
+  await state.recordPassed(key, graph.get(key)!)
+  appendFile.mockRestore()
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
+  await state.finish()
+})
+
+test('task run state rejects a symlinked state directory', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  const outsideDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-outside-'))
+  temporaryDirectories.push(workspaceDir, outsideDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const nodeModulesDir = path.join(workspaceDir, 'node_modules')
+  await fs.mkdir(nodeModulesDir)
+  await fs.symlink(outsideDir, path.join(nodeModulesDir, '.pnpm-task-run-state-v1'), process.platform === 'win32' ? 'junction' : 'dir')
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+
+  await expect(context.start(new Set())).rejects.toMatchObject({ code: 'ERR_PNPM_UNSAFE_TASK_RUN_STATE_PATH' })
+  await expect(fs.access(path.join(outsideDir, 'latest.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+})
+
+test('finishing an older invocation preserves the newer invocation journal', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const older = await context.start(new Set())
+  const newer = await context.start(new Set([key]))
+
+  await older.finish()
+
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([key]))
+  await newer.finish()
   await expect(context.readCompletedTasks()).resolves.toBeUndefined()
 })

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -337,6 +337,37 @@ test('finishing an older invocation preserves the newer invocation journal', asy
   await expect(context.readCompletedTasks()).resolves.toBeUndefined()
 })
 
+test('a finished journal is not resumable when cleanup is unavailable', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  const state = await context.start(new Set([key]))
+  const unlink = jest.spyOn(fs, 'unlink').mockRejectedValue(Object.assign(new Error('permission denied'), { code: 'EACCES' }))
+
+  try {
+    await state.finish()
+  } finally {
+    unlink.mockRestore()
+  }
+
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
+})
+
 test('a stale pointer does not hide a newer published invocation journal', async () => {
   const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
   temporaryDirectories.push(workspaceDir)

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, expect, test } from '@jest/globals'
+import type { ProjectRootDir } from '@pnpm/types'
+import { type TaskGraph, taskKey } from '@pnpm/workspace.task-scheduler'
+
+import { TaskRunStateContext } from '../src/taskRunState.js'
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(async (dir) => fs.rm(dir, { force: true, recursive: true })))
+})
+
+test('task run state ignores a torn trailing record and removes a completed journal', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const firstProject = path.join(workspaceDir, 'first') as ProjectRootDir
+  const secondProject = path.join(workspaceDir, 'second') as ProjectRootDir
+  const firstKey = taskKey(firstProject, 'build')
+  const secondKey = taskKey(secondProject, 'build')
+  const graph: TaskGraph = new Map([
+    [firstKey, {
+      project: firstProject,
+      taskName: 'build',
+      scripts: ['build'],
+      requested: true,
+      dependencies: [],
+    }],
+    [secondKey, {
+      project: secondProject,
+      taskName: 'build',
+      scripts: ['build'],
+      requested: true,
+      dependencies: [firstKey],
+    }],
+  ])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  expect(context.invocation).toBe('76a575bfcc3b67becd98b5ec661be54567b53954a723da167603dad119fab140')
+  const staleState = path.join(path.dirname(context.filePath), `${'a'.repeat(64)}.jsonl`)
+  await fs.mkdir(path.dirname(staleState), { recursive: true })
+  await fs.writeFile(staleState, 'stale')
+  const state = await context.start(new Set([firstKey]))
+  await expect(fs.stat(staleState)).rejects.toMatchObject({ code: 'ENOENT' })
+  await state.recordPassed(secondKey, graph.get(secondKey)!)
+  await fs.appendFile(context.filePath, '{"run":"superseded","project":"unknown","task":"build"}\n')
+  await fs.appendFile(context.filePath, '{"project":"torn')
+
+  await expect(context.readCompletedTasks()).resolves.toStrictEqual(new Set([firstKey, secondKey]))
+  await state.finish()
+  await expect(fs.stat(context.filePath)).rejects.toMatchObject({ code: 'ENOENT' })
+})
+
+test('task run state rejects a malformed complete record', async () => {
+  const workspaceDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-task-state-'))
+  temporaryDirectories.push(workspaceDir)
+  const project = path.join(workspaceDir, 'project') as ProjectRootDir
+  const key = taskKey(project, 'build')
+  const graph: TaskGraph = new Map([[key, {
+    project,
+    taskName: 'build',
+    scripts: ['build'],
+    requested: true,
+    dependencies: [],
+  }]])
+  const context = new TaskRunStateContext({
+    command: 'run',
+    params: ['build'],
+    graph,
+    workspaceDir,
+    scriptCommands: () => ['build-command'],
+  })
+  await context.start(new Set())
+  await fs.appendFile(context.filePath, 'not-json\n')
+
+  await expect(context.readCompletedTasks()).resolves.toBeUndefined()
+})

--- a/pnpm11/exec/commands/test/taskRunState.test.ts
+++ b/pnpm11/exec/commands/test/taskRunState.test.ts
@@ -357,10 +357,15 @@ test('overlapping starts publish the newer invocation last', async () => {
     scriptCommands: () => ['build-command'],
   })
   const originalOpen = fs.open.bind(fs)
+  const originalMkdir = fs.mkdir.bind(fs)
   let markOlderBlocked!: () => void
+  let markNewerWaiting!: () => void
   let unblockOlder!: () => void
   const olderBlocked = new Promise<void>(resolve => {
     markOlderBlocked = resolve
+  })
+  const newerWaiting = new Promise<void>(resolve => {
+    markNewerWaiting = resolve
   })
   const olderGate = new Promise<void>(resolve => {
     unblockOlder = resolve
@@ -374,12 +379,17 @@ test('overlapping starts publish the newer invocation last', async () => {
     }
     return originalOpen(...args)
   })
+  let lockAttempts = 0
+  const mkdir = jest.spyOn(fs, 'mkdir').mockImplementation(async (...args) => {
+    if (String(args[0]).endsWith('start.lock') && ++lockAttempts === 2) markNewerWaiting()
+    return originalMkdir(...args)
+  })
 
   try {
     const olderPromise = context.start(new Set())
     await olderBlocked
     const newerPromise = context.start(new Set([key]))
-    await new Promise(resolve => setTimeout(resolve, 100))
+    await newerWaiting
     unblockOlder()
     const [older, newer] = await Promise.all([olderPromise, newerPromise])
 
@@ -388,6 +398,7 @@ test('overlapping starts publish the newer invocation last', async () => {
     await newer.close()
   } finally {
     unblockOlder()
+    mkdir.mockRestore()
     open.mockRestore()
   }
 })

--- a/pnpm11/workspace/task-scheduler/src/taskGraph.ts
+++ b/pnpm11/workspace/task-scheduler/src/taskGraph.ts
@@ -197,13 +197,16 @@ export interface ResumeTaskGraphOptions {
   selectedProjectsGraph: ProjectsGraph
   /** The task of the anchor project the invocation resolves to. */
   taskName: string
+  /** Tasks durably completed by the matching previous invocation. */
+  completedTasks?: ReadonlySet<TaskKey>
 }
 
 /**
- * The graph without the anchor's transitive dependencies — the tasks known to
- * have finished before a run would reach the anchor. Everything else stays,
- * including work unrelated to the anchor, and edges into the dropped set are
- * treated as satisfied.
+ * When durable state is available, the graph without exactly those completed
+ * tasks. Otherwise, the graph without the anchor's transitive dependencies —
+ * the tasks inferred to have finished before a run would reach the anchor.
+ * The anchor itself and unfinished work stay, and edges into the dropped set
+ * are treated as satisfied.
  */
 export function resumeTaskGraphFrom (graph: TaskGraph, opts: ResumeTaskGraphOptions): TaskGraph {
   const anchorProject = (Object.keys(opts.selectedProjectsGraph) as ProjectRootDir[])
@@ -217,20 +220,28 @@ export function resumeTaskGraphFrom (graph: TaskGraph, opts: ResumeTaskGraphOpti
     // non-recursive invocation): there is nothing to skip.
     return graph
   }
-  const dropped = new Set<TaskKey>()
-  const stack = [...anchor.dependencies]
-  while (stack.length > 0) {
-    const key = stack.pop()!
-    if (dropped.has(key)) continue
-    dropped.add(key)
-    stack.push(...graph.get(key)!.dependencies)
-  }
+  const anchorKey = taskKey(anchorProject, opts.taskName)
+  const dropped = opts.completedTasks == null
+    ? transitiveDependencies(graph, anchor)
+    : new Set([...opts.completedTasks].filter((key) => key !== anchorKey && graph.has(key)))
   const resumed: TaskGraph = new Map()
   for (const [key, node] of graph) {
     if (dropped.has(key)) continue
     resumed.set(key, { ...node, dependencies: node.dependencies.filter((dependency) => !dropped.has(dependency)) })
   }
   return resumed
+}
+
+function transitiveDependencies (graph: TaskGraph, anchor: TaskNode): Set<TaskKey> {
+  const dependencies = new Set<TaskKey>()
+  const stack = [...anchor.dependencies]
+  while (stack.length > 0) {
+    const key = stack.pop()!
+    if (dependencies.has(key)) continue
+    dependencies.add(key)
+    stack.push(...graph.get(key)!.dependencies)
+  }
+  return dependencies
 }
 
 /**

--- a/pnpm11/workspace/task-scheduler/test/taskGraph.test.ts
+++ b/pnpm11/workspace/task-scheduler/test/taskGraph.test.ts
@@ -179,6 +179,33 @@ test('resumeTaskGraphFrom drops only the anchor\'s transitive dependencies', () 
   expect(resumed.get(taskKey(dir('c'), 'build'))!.dependencies).toStrictEqual([taskKey(dir('b'), 'build')])
 })
 
+test('resumeTaskGraphFrom drops exact completed tasks when state is available', () => {
+  const graph = buildGraph({
+    dependency: { scripts: ['build'] },
+    anchor: { dependencies: ['dependency'], scripts: ['build'] },
+    completed: { scripts: ['build'] },
+  }, 'build')
+
+  const resumed = resumeTaskGraphFrom(graph, {
+    resumeFrom: 'anchor',
+    selectedProjectsGraph: Object.fromEntries(['dependency', 'anchor', 'completed'].map((name) => [
+      dir(name),
+      { dependencies: [], package: { manifest: { name } } },
+    ])) as never,
+    taskName: 'build',
+    completedTasks: new Set([
+      taskKey(dir('anchor'), 'build'),
+      taskKey(dir('completed'), 'build'),
+    ]),
+  })
+
+  expect([...resumed.keys()].sort()).toStrictEqual([
+    taskKey(dir('anchor'), 'build'),
+    taskKey(dir('dependency'), 'build'),
+  ].sort())
+  expect(resumed.get(taskKey(dir('anchor'), 'build'))!.dependencies).toStrictEqual([taskKey(dir('dependency'), 'build')])
+})
+
 test('resumeTaskGraphFrom throws when the package is not selected', () => {
   const graph = buildGraph({ a: { scripts: ['build'] } }, 'build')
   expect(() => resumeTaskGraphFrom(graph, {


### PR DESCRIPTION
## Summary

Persist completed recursive tasks in a versioned, append-only journal so `--resume-from` can skip exactly the tasks that passed during a matching interrupted or failed invocation. Invocation identities cover the selected graph, script bodies, arguments, environment, and execution settings.

The implementation covers both the TypeScript CLI and the Rust pnpm port for recursive `run` and `exec`. Each invocation owns a unique journal behind an atomically published latest-run pointer, preventing overlapping runs from replacing or deleting one another’s state. Unsafe symlinked state paths, stale pointers, superseded runs, malformed records, and torn writes are rejected or ignored safely. Pointer publication is serialized across processes, while read-only or permission-denied state storage disables persistence without blocking task execution. When no compatible state exists, the existing graph-based resume behavior remains the fallback; a successful invocation removes its own journal.

Related to pnpm/pnpm#14211.

Verified with the complete `@pnpm/exec.commands` TypeScript suite (171 passing, 2 skipped), TypeScript compilation and repository linting, targeted recursive integration tests, the full Rust workspace suite (9,441 passing, 5 skipped), Clippy with warnings denied, dylint, rustdoc, metadata linting, spelling, and the repository pre-push checks.

## Squash Commit Body

```text
Persist passed recursive tasks incrementally in a versioned journal under the workspace's node_modules directory. Hash the invocation's task graph, script commands, arguments, environment, and execution settings so only compatible state is reused.

Use unique per-run journals, cross-process serialization around the atomically published latest-run pointer, open file handles, and newline-committed records to reject stale, superseded, malformed, torn, or unsafe state. Remove each journal after its invocation succeeds and preserve the existing dependency-pruning fallback when no compatible state is available.

Implement the same state format and resume semantics in the TypeScript CLI and Rust pnpm port, with shared identity fixtures guarding cross-implementation compatibility.

Related to pnpm/pnpm#14211.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recursive `run` and `exec` commands now persist completed task progress.
  * `--resume-from` skips tasks that already passed while rerunning unfinished dependencies.
  * Resume checkpoints account for matching commands and execution settings.
  * Checkpoints are automatically cleaned up after successful runs.

* **Bug Fixes**
  * Improved resume accuracy after failures and interruptions.
  * Tasks skipped by recursion safeguards are not incorrectly saved as completed.
  * Invalid, incomplete, read-only, or unsafe checkpoint locations are safely handled.
  * Checkpoint locking prevents conflicting runs from corrupting saved progress.
  * Unavailable checkpoint storage no longer prevents commands from running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->