### PR TITLE
feat: persist verified remote build artifacts

### DIFF
--- a/.changeset/persist-remote-build-artifacts.md
+++ b/.changeset/persist-remote-build-artifacts.md
@@ -1,0 +1,15 @@
+---
+"@pnpm/store.cafs-types": minor
+"@pnpm/store.cafs": minor
+"@pnpm/store.controller-types": minor
+"@pnpm/store.controller": patch
+"@pnpm/store.index": minor
+"@pnpm/worker": patch
+"@pnpm/pnpr.client": minor
+"@pnpm/installing.deps-restorer": minor
+"@pnpm/installing.deps-installer": minor
+"pnpm": minor
+"pacquet": minor
+---
+
+Verified remote build artifacts are persisted in the shared store with their signed origin metadata. Later installs reverify the artifact against current trust, policy, platform, source, and lockfile pins before reuse, while invalid remote variants are quarantined per channel ([pnpm/pnpm#13771](https://github.com/pnpm/pnpm/issues/13771)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5791,6 +5791,7 @@ dependencies = [
  "pnpm-deps-path",
  "pnpm-fs",
  "pnpm-resolving-parse-wanted-dependency",
+ "pnpm-shared-artifact-protocol",
  "pretty_assertions",
  "rmp-serde",
  "rusqlite",

--- a/pnpm/crates/deps-restorer/Cargo.toml
+++ b/pnpm/crates/deps-restorer/Cargo.toml
@@ -30,6 +30,7 @@ pnpm-package-is-installable   = { workspace = true }
 pnpm-package-manifest         = { workspace = true }
 pnpm-patching                 = { workspace = true }
 pnpm-pnpr-client              = { workspace = true }
+pnpm-shared-artifact-protocol = { workspace = true }
 pnpm-real-hoist               = { workspace = true }
 pnpm-reporter                 = { workspace = true }
 pnpm-resolving-npm-resolver   = { workspace = true }
@@ -59,8 +60,7 @@ tokio        = { workspace = true }
 tracing      = { workspace = true }
 
 [dev-dependencies]
-pnpm-shared-artifact-protocol = { workspace = true }
-pnpm-testing-utils            = { workspace = true }
+pnpm-testing-utils = { workspace = true }
 
 async-trait       = { workspace = true }
 dunce             = { workspace = true }

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -1776,6 +1776,7 @@ async fn write_path_populates_side_effects_row() {
         algo: HASH_ALGORITHM.to_string(),
         files: base_files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     {
         let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
@@ -1920,6 +1921,7 @@ async fn write_path_disabled_skips_upload() {
         algo: HASH_ALGORITHM.to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     {
         let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
@@ -2165,6 +2167,7 @@ async fn upload_error_does_not_interrupt_install() {
         algo: HASH_ALGORITHM.to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     {
         let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");
@@ -2378,6 +2381,7 @@ async fn write_path_cache_key_includes_patch_hash() {
         algo: HASH_ALGORITHM.to_string(),
         files: base_files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     {
         let mut index = StoreIndex::open_in(&store_dir).expect("open index for seed");

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -72,6 +72,14 @@ pub type PackageManifests = HashMap<PkgNameVerPeer, std::sync::Arc<serde_json::V
 pub type SideEffectsMapsBySnapshot =
     HashMap<PackageKey, std::sync::Arc<HashMap<String, HashMap<String, PathBuf>>>>;
 
+pub type SideEffectsBySnapshot =
+    HashMap<PackageKey, std::sync::Arc<HashMap<String, pnpm_store_dir::SideEffectsDiff>>>;
+
+pub type RemoteSideEffectsQuarantineBySnapshot =
+    HashMap<PackageKey, std::sync::Arc<HashMap<String, Vec<String>>>>;
+
+pub type StoreIndexKeysBySnapshot = HashMap<PackageKey, String>;
+
 /// Per-snapshot `requiresBuild` flags recovered from the store index
 /// during the warm-cache prefetch. `BuildModules` consumes this to
 /// avoid re-inspecting every package directory after materialization.
@@ -498,6 +506,9 @@ impl CreateVirtualStore<'_> {
             cold,
             package_manifests,
             mut side_effects_maps_by_snapshot,
+            side_effects_by_snapshot,
+            remote_side_effects_quarantine_by_snapshot,
+            store_index_keys_by_snapshot,
             mut requires_build_by_snapshot,
         } = partition::partition_snapshots(
             &snapshot_entries,
@@ -506,9 +517,6 @@ impl CreateVirtualStore<'_> {
             &marker_rebuilds,
             node_linker,
         );
-        if !config.side_effects_cache_read() {
-            side_effects_maps_by_snapshot.clear();
-        }
         let shared_packages = config
             .remote_side_effects_cache
             .as_ref()
@@ -868,13 +876,20 @@ impl CreateVirtualStore<'_> {
         }
 
         let artifact_pin_records = crate::shared_side_effects::apply_shared_side_effects(
-            config,
-            snapshots,
-            packages,
-            &requires_build_by_snapshot,
-            allow_build_policy,
-            &shared_base_cas_paths,
-            &mut side_effects_maps_by_snapshot,
+            crate::shared_side_effects::ApplySharedSideEffectsOptions {
+                config,
+                snapshots,
+                packages,
+                requires_build_by_snapshot: &requires_build_by_snapshot,
+                allow_build_policy,
+                base_cas_paths: &shared_base_cas_paths,
+                side_effects_maps_by_snapshot: &mut side_effects_maps_by_snapshot,
+                side_effects_by_snapshot: &side_effects_by_snapshot,
+                remote_side_effects_quarantine_by_snapshot:
+                    &remote_side_effects_quarantine_by_snapshot,
+                store_index_keys_by_snapshot: &store_index_keys_by_snapshot,
+                store_index_writer,
+            },
         )
         .await;
 

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/partition.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/partition.rs
@@ -6,8 +6,9 @@
 //! Runs immediately after the prefetch, whose results it consumes.
 
 use super::{
-    PackageManifests, RequiresBuildBySnapshot, SideEffectsMapsBySnapshot, SnapshotWithCacheKey,
-    snapshot_needs_build_marker,
+    PackageManifests, RemoteSideEffectsQuarantineBySnapshot, RequiresBuildBySnapshot,
+    SideEffectsBySnapshot, SideEffectsMapsBySnapshot, SnapshotWithCacheKey,
+    StoreIndexKeysBySnapshot, snapshot_needs_build_marker,
 };
 use pnpm_config::NodeLinker;
 use pnpm_lockfile::{PackageKey, SnapshotEntry};
@@ -31,6 +32,9 @@ pub(super) struct Partition<'a> {
     /// linker need not re-read each child's `package.json`.
     pub package_manifests: PackageManifests,
     pub side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot,
+    pub side_effects_by_snapshot: SideEffectsBySnapshot,
+    pub remote_side_effects_quarantine_by_snapshot: RemoteSideEffectsQuarantineBySnapshot,
+    pub store_index_keys_by_snapshot: StoreIndexKeysBySnapshot,
     pub requires_build_by_snapshot: RequiresBuildBySnapshot,
 }
 
@@ -108,13 +112,22 @@ pub(super) fn partition_snapshots<'a>(
         node_linker = ?node_linker,
         "phase complete",
     );
-    let IndexRows { package_manifests, side_effects_maps_by_snapshot, requires_build_by_snapshot } =
-        rows;
+    let IndexRows {
+        package_manifests,
+        side_effects_maps_by_snapshot,
+        side_effects_by_snapshot,
+        remote_side_effects_quarantine_by_snapshot,
+        store_index_keys_by_snapshot,
+        requires_build_by_snapshot,
+    } = rows;
     Partition {
         warm,
         cold,
         package_manifests,
         side_effects_maps_by_snapshot,
+        side_effects_by_snapshot,
+        remote_side_effects_quarantine_by_snapshot,
+        store_index_keys_by_snapshot,
         requires_build_by_snapshot,
     }
 }
@@ -124,6 +137,9 @@ pub(super) fn partition_snapshots<'a>(
 struct IndexRows {
     package_manifests: PackageManifests,
     side_effects_maps_by_snapshot: SideEffectsMapsBySnapshot,
+    side_effects_by_snapshot: SideEffectsBySnapshot,
+    remote_side_effects_quarantine_by_snapshot: RemoteSideEffectsQuarantineBySnapshot,
+    store_index_keys_by_snapshot: StoreIndexKeysBySnapshot,
     requires_build_by_snapshot: RequiresBuildBySnapshot,
 }
 
@@ -132,6 +148,11 @@ impl IndexRows {
         IndexRows {
             package_manifests: HashMap::with_capacity(prefetch.manifests.len()),
             side_effects_maps_by_snapshot: HashMap::with_capacity(prefetch.side_effects_maps.len()),
+            side_effects_by_snapshot: HashMap::with_capacity(prefetch.side_effects.len()),
+            remote_side_effects_quarantine_by_snapshot: HashMap::with_capacity(
+                prefetch.remote_side_effects_quarantine.len(),
+            ),
+            store_index_keys_by_snapshot: HashMap::with_capacity(prefetch.cas_paths.len()),
             requires_build_by_snapshot: HashMap::with_capacity(prefetch.requires_build.len()),
         }
     }
@@ -148,6 +169,7 @@ impl IndexRows {
         marker_rebuilds: &HashSet<PackageKey>,
     ) {
         let Some(cache_key) = cache_key else { return };
+        self.store_index_keys_by_snapshot.insert(snapshot_key.clone(), cache_key.to_string());
         if let Some(manifest) = prefetch.manifests.get(cache_key) {
             self.package_manifests
                 .entry(snapshot_key.without_peer())
@@ -160,6 +182,14 @@ impl IndexRows {
         {
             self.side_effects_maps_by_snapshot
                 .insert(snapshot_key.clone(), std::sync::Arc::clone(maps));
+        }
+        if let Some(diffs) = prefetch.side_effects.get(cache_key) {
+            self.side_effects_by_snapshot
+                .insert(snapshot_key.clone(), std::sync::Arc::clone(diffs));
+        }
+        if let Some(quarantine) = prefetch.remote_side_effects_quarantine.get(cache_key) {
+            self.remote_side_effects_quarantine_by_snapshot
+                .insert(snapshot_key.clone(), std::sync::Arc::clone(quarantine));
         }
         if let Some(&requires_build) = prefetch.requires_build.get(cache_key) {
             self.requires_build_by_snapshot.insert(snapshot_key.clone(), requires_build);

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -278,6 +278,7 @@ async fn shared_store_context_materializes_a_warm_package() {
                 algo: "sha512".to_string(),
                 files,
                 side_effects: None,
+                remote_side_effects_quarantine: None,
             },
         )
         .expect("seed context store index");

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -189,22 +189,35 @@ pub(crate) async fn apply_shared_side_effects(
                 &supported_tags,
                 &trusted_keys,
             )
-            && stored_remote_side_effects_blobs_are_valid(diff, &overlay).await
         {
-            insert_side_effects_map(
-                side_effects_maps_by_snapshot,
-                snapshot_key.clone(),
-                local_cache_key,
-                overlay,
-            );
-            artifact_pin_records.push(ArtifactPinRecord {
-                snapshot_key,
-                input_key,
-                owner: owner_namespace.clone(),
-                platform_fingerprint: fingerprint.clone(),
-                envelope_digest,
-            });
-            continue;
+            match stored_remote_side_effects_blobs_are_valid(diff, &overlay).await {
+                Ok(true) => {
+                    insert_side_effects_map(
+                        side_effects_maps_by_snapshot,
+                        snapshot_key.clone(),
+                        local_cache_key,
+                        overlay,
+                    );
+                    artifact_pin_records.push(ArtifactPinRecord {
+                        snapshot_key,
+                        input_key,
+                        owner: owner_namespace.clone(),
+                        platform_fingerprint: fingerprint.clone(),
+                        envelope_digest,
+                    });
+                    continue;
+                }
+                Ok(false) => {}
+                Err(error) => {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        package = %candidate.package.name,
+                        %error,
+                        "persisted remote side-effects artifact could not be checked",
+                    );
+                    continue;
+                }
+            }
         }
         if config.side_effects_cache_read()
             && side_effects_maps_by_snapshot
@@ -598,18 +611,20 @@ fn manifest_matches_diff(manifest: &ArtifactManifest, diff: &SideEffectsDiff) ->
 async fn stored_remote_side_effects_blobs_are_valid(
     diff: &SideEffectsDiff,
     overlay: &HashMap<String, PathBuf>,
-) -> bool {
+) -> Result<bool, String> {
     for (file_path, info) in diff.added.iter().flatten() {
-        let Some(path) = overlay.get(file_path) else { return false };
-        match store_holds(path, &info.digest).await {
-            Ok(true) => {}
-            Ok(false) | Err(_) => return false,
+        let Some(path) = overlay.get(file_path) else { return Ok(false) };
+        if !store_holds(path, &info.digest).await? {
+            return Ok(false);
         }
-        if !tokio::fs::metadata(path).await.is_ok_and(|metadata| metadata.len() == info.size) {
-            return false;
+        let metadata = tokio::fs::metadata(path)
+            .await
+            .map_err(|error| format!("failed to inspect {}: {error}", path.display()))?;
+        if metadata.len() != info.size {
+            return Ok(false);
         }
     }
-    true
+    Ok(true)
 }
 
 fn quarantine_remote_side_effects(

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -1,6 +1,7 @@
 use crate::{
-    AllowBuildPolicy, ArtifactPinRecord, RequiresBuildBySnapshot, SideEffectsMapsBySnapshot,
-    build_deps_subgraph, deps_graph::in_lockfile_order,
+    AllowBuildPolicy, ArtifactPinRecord, RemoteSideEffectsQuarantineBySnapshot,
+    RequiresBuildBySnapshot, SideEffectsBySnapshot, SideEffectsMapsBySnapshot,
+    StoreIndexKeysBySnapshot, build_deps_subgraph, deps_graph::in_lockfile_order,
     install_frozen_lockfile::find_runtime_node_major,
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
@@ -9,10 +10,12 @@ use pnpm_lockfile::{PackageKey, PackageMetadata, SnapshotEntry};
 use pnpm_pnpr_client::{
     ARTIFACT_KIND, ArtifactBlobRequest, ArtifactBlobUpload, ArtifactCandidate, ArtifactFile,
     ArtifactManifest, ArtifactPayload, BuilderProfile, CompatibilityConstraints,
-    LinuxGlibcPlatform, OwnerScope, PackageIdentity, PnprClient, PublishArtifactRequest,
-    ResolveArtifactsOptions, SignedArtifactEnvelope, blob_id, linux_glibc_supported_tags,
-    linux_glibc_tag, platform_fingerprint,
+    LinuxGlibcPlatform, OwnerScope, PackageIdentity, PnprClient, PnprClientError,
+    PublishArtifactRequest, RejectedArtifact, ResolveArtifactsOptions, SignedArtifactEnvelope,
+    blob_id, linux_glibc_supported_tags, linux_glibc_tag, platform_fingerprint,
 };
+use pnpm_shared_artifact_protocol::compatibility_rank;
+use pnpm_store_dir::{CafsFileInfo, RemoteSideEffectsOrigin, SideEffectsDiff, StoreIndexWriter};
 use sha2::{Digest as _, Sha512};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -38,26 +41,48 @@ pub struct SharedSideEffectsPublisher {
 struct CandidateGroup {
     candidate: ArtifactCandidate,
     pinned_envelope_digest: Option<String>,
-    snapshots: Vec<(PackageKey, String)>,
+    snapshots: Vec<(PackageKey, String, String)>,
+}
+
+pub(crate) struct ApplySharedSideEffectsOptions<'a> {
+    pub config: &'a Config,
+    pub snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+    pub packages: &'a HashMap<PackageKey, PackageMetadata>,
+    pub requires_build_by_snapshot: &'a RequiresBuildBySnapshot,
+    pub allow_build_policy: &'a AllowBuildPolicy,
+    pub base_cas_paths: &'a BaseCasPaths,
+    pub side_effects_maps_by_snapshot: &'a mut SideEffectsMapsBySnapshot,
+    pub side_effects_by_snapshot: &'a SideEffectsBySnapshot,
+    pub remote_side_effects_quarantine_by_snapshot: &'a RemoteSideEffectsQuarantineBySnapshot,
+    pub store_index_keys_by_snapshot: &'a StoreIndexKeysBySnapshot,
+    pub store_index_writer: &'a Arc<StoreIndexWriter>,
 }
 
 pub(crate) async fn apply_shared_side_effects(
-    config: &Config,
-    snapshots: &HashMap<PackageKey, SnapshotEntry>,
-    packages: &HashMap<PackageKey, PackageMetadata>,
-    requires_build_by_snapshot: &RequiresBuildBySnapshot,
-    allow_build_policy: &AllowBuildPolicy,
-    base_cas_paths: &BaseCasPaths,
-    side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
+    options: ApplySharedSideEffectsOptions<'_>,
 ) -> Vec<ArtifactPinRecord> {
-    if config.ignore_scripts || config.frozen_store {
+    let ApplySharedSideEffectsOptions {
+        config,
+        snapshots,
+        packages,
+        requires_build_by_snapshot,
+        allow_build_policy,
+        base_cas_paths,
+        side_effects_maps_by_snapshot,
+        side_effects_by_snapshot,
+        remote_side_effects_quarantine_by_snapshot,
+        store_index_keys_by_snapshot,
+        store_index_writer,
+    } = options;
+    let mut persisted_remote =
+        take_persisted_remote_side_effects(side_effects_maps_by_snapshot, side_effects_by_snapshot);
+    if !config.side_effects_cache_read() {
+        side_effects_maps_by_snapshot.clear();
+    }
+    if config.ignore_scripts {
         return Vec::new();
     }
-    let (Some(server), Some(settings)) =
-        (config.pnpr_server.as_deref(), config.remote_side_effects_cache.as_ref())
-    else {
-        return Vec::new();
-    };
+    let Some(settings) = config.remote_side_effects_cache.as_ref() else { return Vec::new() };
     let Some(platform) = linux_glibc_platform(snapshots) else { return Vec::new() };
     let supported_tags = match linux_glibc_supported_tags(platform) {
         Ok(tags) => tags,
@@ -107,6 +132,7 @@ pub(crate) async fn apply_shared_side_effects(
     let engine_name = pnpm_graph_hasher::engine_name(platform.node_major, None, None);
     let mut groups = BTreeMap::<String, CandidateGroup>::new();
     let mut collisions = HashSet::new();
+    let mut artifact_pin_records = Vec::new();
     for snapshot_key in roots {
         let metadata_key = snapshot_key.without_peer();
         let Some(metadata) = packages.get(&metadata_key) else { continue };
@@ -134,13 +160,6 @@ pub(crate) async fn apply_shared_side_effects(
                 include_dep_graph_hash: true,
             },
         );
-        if config.side_effects_cache_read()
-            && side_effects_maps_by_snapshot
-                .get(&snapshot_key)
-                .is_some_and(|maps| maps.contains_key(&local_cache_key))
-        {
-            continue;
-        }
         let candidate = ArtifactCandidate {
             key: input_key.clone(),
             package: PackageIdentity {
@@ -157,6 +176,45 @@ pub(crate) async fn apply_shared_side_effects(
             .and_then(|owners| owners.get(&owner_namespace))
             .and_then(|platforms| platforms.get(&fingerprint))
             .cloned();
+        if let Some(overlay) =
+            persisted_remote.remove(&(snapshot_key.clone(), local_cache_key.clone()))
+            && let Some(diff) = side_effects_by_snapshot
+                .get(&snapshot_key)
+                .and_then(|diffs| diffs.get(&local_cache_key))
+            && let Some(envelope_digest) = stored_remote_side_effects_envelope_digest(
+                diff,
+                &candidate,
+                pinned_envelope_digest.as_deref(),
+                &supported_tags,
+                &trusted_keys,
+            )
+            && stored_remote_side_effects_blobs_are_valid(diff, &overlay).await
+        {
+            insert_side_effects_map(
+                side_effects_maps_by_snapshot,
+                snapshot_key.clone(),
+                local_cache_key,
+                overlay,
+            );
+            artifact_pin_records.push(ArtifactPinRecord {
+                snapshot_key,
+                input_key,
+                owner: owner_namespace.clone(),
+                platform_fingerprint: fingerprint.clone(),
+                envelope_digest,
+            });
+            continue;
+        }
+        if config.side_effects_cache_read()
+            && side_effects_maps_by_snapshot
+                .get(&snapshot_key)
+                .is_some_and(|maps| maps.contains_key(&local_cache_key))
+        {
+            continue;
+        }
+        let Some(store_index_key) = store_index_keys_by_snapshot.get(&snapshot_key).cloned() else {
+            continue;
+        };
         if let Some(group) = groups.get_mut(&input_key) {
             if group.candidate.package != candidate.package
                 || group.candidate.source_integrity != candidate.source_integrity
@@ -175,21 +233,22 @@ pub(crate) async fn apply_shared_side_effects(
             }
             group.pinned_envelope_digest =
                 group.pinned_envelope_digest.take().or(pinned_envelope_digest);
-            group.snapshots.push((snapshot_key, local_cache_key));
+            group.snapshots.push((snapshot_key, local_cache_key, store_index_key));
         } else {
             groups.insert(
                 input_key,
                 CandidateGroup {
                     candidate,
                     pinned_envelope_digest,
-                    snapshots: vec![(snapshot_key, local_cache_key)],
+                    snapshots: vec![(snapshot_key, local_cache_key, store_index_key)],
                 },
             );
         }
     }
-    if groups.is_empty() {
-        return Vec::new();
+    if groups.is_empty() || config.frozen_store {
+        return artifact_pin_records;
     }
+    let Some(server) = config.pnpr_server.as_deref() else { return artifact_pin_records };
     tracing::debug!(
         target: "pacquet::install",
         candidates = groups.len(),
@@ -199,7 +258,7 @@ pub(crate) async fn apply_shared_side_effects(
     let client = PnprClient::new(server);
     if let Err(error) = client.handshake_artifacts().await {
         tracing::warn!(target: "pacquet::install", %error, "remote side-effects cache handshake failed");
-        return Vec::new();
+        return artifact_pin_records;
     }
     let authorization = config.auth_headers.for_url(server);
     let allowed_builds =
@@ -210,15 +269,38 @@ pub(crate) async fn apply_shared_side_effects(
             group.pinned_envelope_digest.as_ref().map(|digest| (input_key.clone(), digest.clone()))
         })
         .collect();
+    let quarantined_envelope_digests = groups
+        .iter()
+        .map(|(input_key, group)| {
+            let digests = group
+                .snapshots
+                .iter()
+                .filter_map(|(snapshot_key, _, _)| {
+                    remote_side_effects_quarantine_by_snapshot
+                        .get(snapshot_key)
+                        .and_then(|channels| channels.get(server))
+                })
+                .flatten()
+                .cloned()
+                .collect();
+            (input_key.clone(), digests)
+        })
+        .collect();
+    let rejected_artifacts = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let rejected_artifacts_for_callback = Arc::clone(&rejected_artifacts);
     let resolved = match client
         .resolve_artifacts(ResolveArtifactsOptions {
             candidates: groups.values().map(|group| group.candidate.clone()).collect(),
-            supported_tags,
+            supported_tags: supported_tags.clone(),
             eligible_packages,
             allowed_builds,
             ignore_scripts: false,
-            trusted_keys,
+            trusted_keys: trusted_keys.clone(),
             pinned_envelope_digests,
+            quarantined_envelope_digests,
+            on_rejected_artifact: Some(Arc::new(move |rejected| {
+                rejected_artifacts_for_callback.lock().unwrap().push(rejected);
+            })),
             authorization: authorization.clone(),
         })
         .await
@@ -226,9 +308,13 @@ pub(crate) async fn apply_shared_side_effects(
         Ok(resolved) => resolved,
         Err(error) => {
             tracing::warn!(target: "pacquet::install", %error, "remote side-effects cache lookup failed");
-            return Vec::new();
+            return artifact_pin_records;
         }
     };
+    let rejected_artifacts = std::mem::take(&mut *rejected_artifacts.lock().unwrap());
+    for rejected in rejected_artifacts {
+        quarantine_remote_side_effects(&rejected, &groups, server, store_index_writer);
+    }
 
     for (input_key, group) in &groups {
         if group.pinned_envelope_digest.is_some() && !resolved.contains_key(input_key) {
@@ -239,23 +325,32 @@ pub(crate) async fn apply_shared_side_effects(
             );
         }
     }
-    let mut artifact_pin_records = Vec::new();
     for (input_key, artifact) in resolved {
         let Some(group) = groups.get(&input_key) else { continue };
-        let Some((first_snapshot, _)) = group.snapshots.first() else { continue };
+        let Some((first_snapshot, _, _)) = group.snapshots.first() else { continue };
         let Some(base) = base_cas_paths.get(first_snapshot) else { continue };
         let mut overlay = base.clone();
         let mut downloaded = HashMap::<String, Vec<u8>>::new();
         let mut stored = HashMap::<(String, u32), PathBuf>::new();
+        let mut added = HashMap::<String, CafsFileInfo>::new();
         for deleted in &artifact.payload.manifest.deleted {
             overlay.remove(deleted);
         }
         let mut rejected = None;
         for file in &artifact.payload.manifest.added {
-            let result: Result<PathBuf, String> = async {
+            let result: Result<(PathBuf, CafsFileInfo), (String, bool)> = async {
                 let storage_key = (file.integrity.clone(), file.mode);
                 if let Some(path) = stored.get(&storage_key) {
-                    return Ok(path.clone());
+                    return Ok((
+                        path.clone(),
+                        CafsFileInfo {
+                            digest: blob_id(&file.integrity)
+                                .map_err(|error| (error.to_string(), true))?,
+                            mode: file.mode,
+                            size: file.size,
+                            checked_at: None,
+                        },
+                    ));
                 }
                 if !downloaded.contains_key(&file.integrity) {
                     // A built package's files are mostly its own, and
@@ -268,12 +363,31 @@ pub(crate) async fn apply_shared_side_effects(
                     // by `is_executable`, so they cannot disagree about where
                     // a mode belongs. The manifest only carries 0o644 and
                     // 0o755 today, but the agreement must not rest on that.
-                    let digest = blob_id(&file.integrity).map_err(|error| error.to_string())?;
+                    let digest =
+                        blob_id(&file.integrity).map_err(|error| (error.to_string(), true))?;
                     if let Some(path) = config.store_dir.cas_file_path_by_mode(&digest, file.mode)
-                        && store_holds(&path, &digest).await?
+                        && store_holds(&path, &digest).await.map_err(|error| (error, false))?
                     {
+                        if !tokio::fs::metadata(&path)
+                            .await
+                            .is_ok_and(|metadata| metadata.len() == file.size)
+                        {
+                            return Err((
+                                "stored shared artifact blob does not match its declared size"
+                                    .to_string(),
+                                true,
+                            ));
+                        }
                         stored.insert(storage_key, path.clone());
-                        return Ok(path);
+                        return Ok((
+                            path,
+                            CafsFileInfo {
+                                digest,
+                                mode: file.mode,
+                                size: file.size,
+                                checked_at: None,
+                            },
+                        ));
                     }
                     let bytes = client
                         .download_artifact_blob(
@@ -284,7 +398,16 @@ pub(crate) async fn apply_shared_side_effects(
                             authorization.as_deref(),
                         )
                         .await
-                        .map_err(|error| error.to_string())?;
+                        .map_err(|error| {
+                            let quarantine = matches!(error, PnprClientError::Protocol(_));
+                            (error.to_string(), quarantine)
+                        })?;
+                    if bytes.len() as u64 != file.size {
+                        return Err((
+                            "shared artifact blob does not match its declared size".to_string(),
+                            true,
+                        ));
+                    }
                     downloaded.insert(file.integrity.clone(), bytes);
                 }
                 let (path, _) = config
@@ -293,22 +416,44 @@ pub(crate) async fn apply_shared_side_effects(
                         &downloaded[&file.integrity],
                         pnpm_fs::file_mode::is_executable(file.mode),
                     )
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|error| (error.to_string(), false))?;
                 stored.insert(storage_key, path.clone());
-                Ok(path)
+                Ok((
+                    path,
+                    CafsFileInfo {
+                        digest: blob_id(&file.integrity)
+                            .map_err(|error| (error.to_string(), true))?,
+                        mode: file.mode,
+                        size: file.size,
+                        checked_at: None,
+                    },
+                ))
             }
             .await;
             match result {
-                Ok(path) => {
+                Ok((path, info)) => {
                     overlay.insert(file.path.clone(), path);
+                    added.insert(file.path.clone(), info);
                 }
-                Err(error) => {
-                    rejected = Some(error);
+                Err((error, quarantine)) => {
+                    rejected = Some((error, quarantine));
                     break;
                 }
             }
         }
-        if let Some(error) = rejected {
+        if let Some((error, quarantine)) = rejected {
+            if quarantine {
+                quarantine_remote_side_effects(
+                    &RejectedArtifact {
+                        input_key: input_key.clone(),
+                        envelope_digest: artifact.envelope_digest.clone(),
+                        reason: error.clone(),
+                    },
+                    &groups,
+                    server,
+                    store_index_writer,
+                );
+            }
             tracing::warn!(
                 target: "pacquet::install",
                 package = %group.candidate.package.name,
@@ -317,12 +462,30 @@ pub(crate) async fn apply_shared_side_effects(
             );
             continue;
         }
-        for (snapshot_key, local_cache_key) in &group.snapshots {
-            let mut maps = side_effects_maps_by_snapshot
-                .get(snapshot_key)
-                .map_or_else(HashMap::new, |maps| (**maps).clone());
-            maps.insert(local_cache_key.clone(), overlay.clone());
-            side_effects_maps_by_snapshot.insert(snapshot_key.clone(), Arc::new(maps));
+        let diff = SideEffectsDiff {
+            added: Some(added),
+            deleted: Some(artifact.payload.manifest.deleted.clone()),
+            remote_origin: Some(RemoteSideEffectsOrigin {
+                channel: server.to_string(),
+                owner: artifact.payload.owner.clone(),
+                signer_key_id: artifact.envelope.key_id.clone(),
+                builder_profile: artifact.payload.builder_profile.clone(),
+                envelope: artifact.envelope.clone(),
+                verification: "verified".to_string(),
+            }),
+        };
+        for (snapshot_key, local_cache_key, store_index_key) in &group.snapshots {
+            insert_side_effects_map(
+                side_effects_maps_by_snapshot,
+                snapshot_key.clone(),
+                local_cache_key.clone(),
+                overlay.clone(),
+            );
+            store_index_writer.queue_remote_side_effects(
+                store_index_key.clone(),
+                local_cache_key.clone(),
+                diff.clone(),
+            );
             artifact_pin_records.push(ArtifactPinRecord {
                 snapshot_key: snapshot_key.clone(),
                 input_key: input_key.clone(),
@@ -333,6 +496,139 @@ pub(crate) async fn apply_shared_side_effects(
         }
     }
     artifact_pin_records
+}
+
+fn take_persisted_remote_side_effects(
+    side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
+    side_effects_by_snapshot: &SideEffectsBySnapshot,
+) -> HashMap<(PackageKey, String), HashMap<String, PathBuf>> {
+    let mut persisted = HashMap::new();
+    for (snapshot_key, diffs) in side_effects_by_snapshot {
+        let remote_keys: Vec<&String> = diffs
+            .iter()
+            .filter_map(|(cache_key, diff)| diff.remote_origin.as_ref().map(|_| cache_key))
+            .collect();
+        if remote_keys.is_empty() {
+            continue;
+        }
+        let Some(existing) = side_effects_maps_by_snapshot.get(snapshot_key) else { continue };
+        let mut maps = (**existing).clone();
+        for cache_key in remote_keys {
+            if let Some(overlay) = maps.remove(cache_key) {
+                persisted.insert((snapshot_key.clone(), cache_key.clone()), overlay);
+            }
+        }
+        if maps.is_empty() {
+            side_effects_maps_by_snapshot.remove(snapshot_key);
+        } else {
+            side_effects_maps_by_snapshot.insert(snapshot_key.clone(), Arc::new(maps));
+        }
+    }
+    persisted
+}
+
+fn insert_side_effects_map(
+    side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
+    snapshot_key: PackageKey,
+    cache_key: String,
+    overlay: HashMap<String, PathBuf>,
+) {
+    let mut maps = side_effects_maps_by_snapshot
+        .get(&snapshot_key)
+        .map_or_else(HashMap::new, |maps| (**maps).clone());
+    maps.insert(cache_key, overlay);
+    side_effects_maps_by_snapshot.insert(snapshot_key, Arc::new(maps));
+}
+
+fn stored_remote_side_effects_envelope_digest(
+    diff: &SideEffectsDiff,
+    candidate: &ArtifactCandidate,
+    pinned_envelope_digest: Option<&str>,
+    supported_tags: &[String],
+    trusted_keys: &BTreeMap<String, Vec<u8>>,
+) -> Option<String> {
+    let Some(origin) = &diff.remote_origin else { return None };
+    if origin.verification != "verified" || origin.signer_key_id != origin.envelope.key_id {
+        return None;
+    }
+    let public_key = trusted_keys.get(&origin.signer_key_id)?;
+    let Ok(payload) = origin.envelope.verify(public_key) else { return None };
+    let Ok(envelope_digest) = origin.envelope.digest() else { return None };
+    if pinned_envelope_digest.is_some_and(|pinned| pinned != envelope_digest) {
+        return None;
+    }
+    if payload.input_key != candidate.key {
+        return None;
+    }
+    (payload.package == candidate.package
+        && payload.source_integrity == candidate.source_integrity
+        && payload.owner == candidate.owner
+        && payload.owner == origin.owner
+        && payload.builder_profile == origin.builder_profile
+        && compatibility_rank(&payload.compatibility, supported_tags).is_some()
+        && manifest_matches_diff(&payload.manifest, diff))
+    .then_some(envelope_digest)
+}
+
+fn manifest_matches_diff(manifest: &ArtifactManifest, diff: &SideEffectsDiff) -> bool {
+    let empty = HashMap::new();
+    let added = diff.added.as_ref().unwrap_or(&empty);
+    if added.len() != manifest.added.len() {
+        return false;
+    }
+    for file in &manifest.added {
+        let Ok(digest) = blob_id(&file.integrity) else { return false };
+        if !added.get(&file.path).is_some_and(|stored| {
+            stored.digest == digest && stored.mode == file.mode && stored.size == file.size
+        }) {
+            return false;
+        }
+    }
+    let deleted = diff.deleted.as_deref().unwrap_or_default();
+    deleted.len() == manifest.deleted.len()
+        && deleted.iter().collect::<HashSet<_>>().len() == deleted.len()
+        && deleted.iter().all(|path| manifest.deleted.contains(path))
+}
+
+async fn stored_remote_side_effects_blobs_are_valid(
+    diff: &SideEffectsDiff,
+    overlay: &HashMap<String, PathBuf>,
+) -> bool {
+    for (file_path, info) in diff.added.iter().flatten() {
+        let Some(path) = overlay.get(file_path) else { return false };
+        match store_holds(path, &info.digest).await {
+            Ok(true) => {}
+            Ok(false) | Err(_) => return false,
+        }
+        if !tokio::fs::metadata(path).await.is_ok_and(|metadata| metadata.len() == info.size) {
+            return false;
+        }
+    }
+    true
+}
+
+fn quarantine_remote_side_effects(
+    rejected: &RejectedArtifact,
+    groups: &BTreeMap<String, CandidateGroup>,
+    channel: &str,
+    store_index_writer: &StoreIndexWriter,
+) {
+    let Some(group) = groups.get(&rejected.input_key) else { return };
+    let mut rows = HashSet::new();
+    for (_, _, store_index_key) in &group.snapshots {
+        if rows.insert(store_index_key) {
+            store_index_writer.queue_remote_side_effects_quarantine(
+                store_index_key.clone(),
+                channel.to_string(),
+                rejected.envelope_digest.clone(),
+            );
+        }
+    }
+    tracing::warn!(
+        target: "pacquet::install",
+        reason = %rejected.reason,
+        "remote side-effects artifact was quarantined",
+    );
 }
 
 /// Decode the configured trust root, or `None` when it is absent or unusable.

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -185,6 +185,7 @@ pub(crate) async fn apply_shared_side_effects(
                 diff,
                 &candidate,
                 pinned_envelope_digest.as_deref(),
+                config.pnpr_server.as_deref(),
                 &supported_tags,
                 &trusted_keys,
             )
@@ -544,11 +545,15 @@ fn stored_remote_side_effects_envelope_digest(
     diff: &SideEffectsDiff,
     candidate: &ArtifactCandidate,
     pinned_envelope_digest: Option<&str>,
+    configured_channel: Option<&str>,
     supported_tags: &[String],
     trusted_keys: &BTreeMap<String, Vec<u8>>,
 ) -> Option<String> {
     let Some(origin) = &diff.remote_origin else { return None };
-    if origin.verification != "verified" || origin.signer_key_id != origin.envelope.key_id {
+    if origin.verification != "verified"
+        || origin.signer_key_id != origin.envelope.key_id
+        || configured_channel.is_some_and(|channel| origin.channel != channel)
+    {
         return None;
     }
     let public_key = trusted_keys.get(&origin.signer_key_id)?;

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -138,7 +138,7 @@ mod restore {
     use pnpm_shared_artifact_protocol::{
         ArtifactVariant, ResolveArtifactsResponse, ResolvedArtifact,
     };
-    use pnpm_store_dir::StoreDir;
+    use pnpm_store_dir::{CafsFileInfo, RemoteSideEffectsOrigin, SideEffectsDiff, StoreDir};
     use sha2::{Digest as _, Sha512};
     use std::{
         collections::{BTreeMap, HashMap, HashSet},
@@ -267,6 +267,91 @@ mod restore {
         serde_json::to_string(&response).expect("serialize response")
     }
 
+    #[test]
+    fn persisted_remote_side_effects_are_reverified_against_current_trust() {
+        let supported_tags = vec!["pnpm:v1:linux-x64-node22-glibc2.17".to_string()];
+        let candidate = pnpm_pnpr_client::ArtifactCandidate {
+            key: "dependency-side-effects:v1:fixture".to_string(),
+            package: pnpm_pnpr_client::PackageIdentity {
+                name: PACKAGE.to_string(),
+                version: "1.0.0".to_string(),
+            },
+            source_integrity: integrity_of(b"the source tarball"),
+            owner: OwnerScope::organization(ORGANIZATION),
+        };
+        let payload = ArtifactPayload {
+            kind: ARTIFACT_KIND.to_string(),
+            package: candidate.package.clone(),
+            source_integrity: candidate.source_integrity.clone(),
+            input_key: candidate.key.clone(),
+            owner: candidate.owner.clone(),
+            builder_id: "ci/main/1".to_string(),
+            builder_profile: BuilderProfile {
+                image_digest: None,
+                architecture_baseline: "x86-64-v2".to_string(),
+                environment: BTreeMap::new(),
+            },
+            compatibility: CompatibilityConstraints::Tagged { tags: supported_tags.clone() },
+            manifest: ArtifactManifest {
+                added: vec![ArtifactFile {
+                    path: BUILT_FILE.to_string(),
+                    integrity: integrity_of(built_bytes()),
+                    mode: BUILT_MODE,
+                    size: built_bytes().len() as u64,
+                }],
+                deleted: Vec::new(),
+            },
+        };
+        let envelope = SignedArtifactEnvelope::sign(
+            &payload,
+            KEY_ID,
+            secret_key().to_pkcs8_der().unwrap().as_bytes(),
+        )
+        .unwrap();
+        let diff = SideEffectsDiff {
+            added: Some(HashMap::from([(
+                BUILT_FILE.to_string(),
+                CafsFileInfo {
+                    checked_at: None,
+                    digest: pnpm_pnpr_client::blob_id(&integrity_of(built_bytes())).unwrap(),
+                    mode: BUILT_MODE,
+                    size: built_bytes().len() as u64,
+                },
+            )])),
+            deleted: Some(Vec::new()),
+            remote_origin: Some(RemoteSideEffectsOrigin {
+                channel: "https://pnpr.example/".to_string(),
+                owner: payload.owner.clone(),
+                signer_key_id: KEY_ID.to_string(),
+                builder_profile: payload.builder_profile,
+                envelope,
+                verification: "verified".to_string(),
+            }),
+        };
+        let trusted_keys =
+            BTreeMap::from([(KEY_ID.to_string(), BASE64.decode(public_key()).unwrap())]);
+        assert!(
+            super::super::stored_remote_side_effects_envelope_digest(
+                &diff,
+                &candidate,
+                None,
+                &supported_tags,
+                &trusted_keys,
+            )
+            .is_some(),
+        );
+        assert!(
+            super::super::stored_remote_side_effects_envelope_digest(
+                &diff,
+                &candidate,
+                None,
+                &supported_tags,
+                &BTreeMap::new(),
+            )
+            .is_none(),
+        );
+    }
+
     /// Restore against a server that offers the artifact, asserting that the
     /// blob endpoint was hit exactly `expected_downloads` times, and return
     /// the path the resulting overlay maps the built file to.
@@ -312,16 +397,34 @@ mod restore {
 
         let snapshot_key: PackageKey = SNAPSHOT.parse().expect("snapshot key");
         let mut side_effects = SideEffectsMapsBySnapshot::new();
-        super::super::apply_shared_side_effects(
-            &config(&server.url(), store_dir),
-            &snapshots,
-            &packages,
-            &RequiresBuildBySnapshot::from([(snapshot_key.clone(), true)]),
-            &AllowBuildPolicy::new(HashSet::from([PACKAGE.to_string()]), HashSet::new(), false),
-            &HashMap::from([(snapshot_key.clone(), HashMap::new())]),
-            &mut side_effects,
-        )
+        let (store_index_writer, store_index_writer_task) =
+            pnpm_store_dir::StoreIndexWriter::spawn_disabled();
+        super::super::apply_shared_side_effects(super::super::ApplySharedSideEffectsOptions {
+            config: &config(&server.url(), store_dir),
+            snapshots: &snapshots,
+            packages: &packages,
+            requires_build_by_snapshot: &RequiresBuildBySnapshot::from([(
+                snapshot_key.clone(),
+                true,
+            )]),
+            allow_build_policy: &AllowBuildPolicy::new(
+                HashSet::from([PACKAGE.to_string()]),
+                HashSet::new(),
+                false,
+            ),
+            base_cas_paths: &HashMap::from([(snapshot_key.clone(), HashMap::new())]),
+            side_effects_maps_by_snapshot: &mut side_effects,
+            side_effects_by_snapshot: &HashMap::new(),
+            remote_side_effects_quarantine_by_snapshot: &HashMap::new(),
+            store_index_keys_by_snapshot: &HashMap::from([(
+                snapshot_key.clone(),
+                "row".to_string(),
+            )]),
+            store_index_writer: &store_index_writer,
+        })
         .await;
+        drop(store_index_writer);
+        store_index_writer_task.await.unwrap().unwrap();
 
         handshake.assert_async().await;
         resolve.assert_async().await;

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -335,6 +335,7 @@ mod restore {
                 &diff,
                 &candidate,
                 None,
+                Some("https://pnpr.example/"),
                 &supported_tags,
                 &trusted_keys,
             )
@@ -345,8 +346,20 @@ mod restore {
                 &diff,
                 &candidate,
                 None,
+                Some("https://pnpr.example/"),
                 &supported_tags,
                 &BTreeMap::new(),
+            )
+            .is_none(),
+        );
+        assert!(
+            super::super::stored_remote_side_effects_envelope_digest(
+                &diff,
+                &candidate,
+                None,
+                Some("https://other-pnpr.example/"),
+                &supported_tags,
+                &trusted_keys,
             )
             .is_none(),
         );

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -191,6 +191,7 @@ impl GitFetcher<'_> {
                     algo: "sha512".to_string(),
                     files: files_index,
                     side_effects: None,
+                    remote_side_effects_quarantine: None,
                 },
             );
         }

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher.rs
@@ -177,6 +177,7 @@ impl GitHostedTarballFetcher<'_> {
                         algo: "sha512".to_string(),
                         files: files_index,
                         side_effects: None,
+                        remote_side_effects_quarantine: None,
                     },
                 );
             }
@@ -212,6 +213,7 @@ impl GitHostedTarballFetcher<'_> {
                     algo: "sha512".to_string(),
                     files: files_index,
                     side_effects: None,
+                    remote_side_effects_quarantine: None,
                 },
             );
         }

--- a/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch/tests.rs
@@ -26,6 +26,7 @@ fn sample_index() -> PackageFilesIndex {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     }
 }
 

--- a/pnpm/crates/pnpr-client/src/lib.rs
+++ b/pnpm/crates/pnpr-client/src/lib.rs
@@ -337,7 +337,16 @@ pub struct ResolveArtifactsOptions {
     /// P-256 `SubjectPublicKeyInfo` DER bytes keyed by the envelope's key id.
     pub trusted_keys: BTreeMap<String, Vec<u8>>,
     pub pinned_envelope_digests: BTreeMap<String, String>,
+    pub quarantined_envelope_digests: BTreeMap<String, HashSet<String>>,
+    pub on_rejected_artifact: Option<std::sync::Arc<dyn Fn(RejectedArtifact) + Send + Sync>>,
     pub authorization: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct RejectedArtifact {
+    pub input_key: String,
+    pub envelope_digest: String,
+    pub reason: String,
 }
 
 /// A variant whose signature, owner, input key, source integrity, manifest,
@@ -566,7 +575,43 @@ impl PnprClient {
                 let Some(public_key) = opts.trusted_keys.get(&variant.envelope.key_id) else {
                     continue;
                 };
-                let Ok(payload) = variant.envelope.verify(public_key) else { continue };
+                let Ok(payload_bytes) = variant.envelope.verify_signature_bytes(public_key) else {
+                    continue;
+                };
+                let envelope_digest = variant
+                    .envelope
+                    .digest()
+                    .map_err(|err| PnprClientError::Protocol(err.to_string()))?;
+                if opts
+                    .quarantined_envelope_digests
+                    .get(candidate.key.as_str())
+                    .is_some_and(|digests| digests.contains(&envelope_digest))
+                {
+                    continue;
+                }
+                let payload: ArtifactPayload = match serde_json::from_slice(&payload_bytes) {
+                    Ok(payload) => payload,
+                    Err(error) => {
+                        if let Some(on_rejected_artifact) = &opts.on_rejected_artifact {
+                            on_rejected_artifact(RejectedArtifact {
+                                input_key: candidate.key.clone(),
+                                envelope_digest,
+                                reason: format!("payload is not valid JSON: {error}"),
+                            });
+                        }
+                        continue;
+                    }
+                };
+                if let Err(error) = payload.validate() {
+                    if let Some(on_rejected_artifact) = &opts.on_rejected_artifact {
+                        on_rejected_artifact(RejectedArtifact {
+                            input_key: candidate.key.clone(),
+                            envelope_digest,
+                            reason: error.to_string(),
+                        });
+                    }
+                    continue;
+                }
                 if !artifact_matches_candidate(&payload, candidate) {
                     continue;
                 }
@@ -574,10 +619,6 @@ impl PnprClient {
                 else {
                     continue;
                 };
-                let envelope_digest = variant
-                    .envelope
-                    .digest()
-                    .map_err(|err| PnprClientError::Protocol(err.to_string()))?;
                 if opts
                     .pinned_envelope_digests
                     .get(candidate.key.as_str())

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -897,6 +897,8 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
             ignore_scripts: false,
             trusted_keys: BTreeMap::from([("acme-2026".to_string(), untrusted_public_key)]),
             pinned_envelope_digests: BTreeMap::new(),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth.clone()),
         })
         .await
@@ -914,6 +916,8 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
             ignore_scripts: false,
             trusted_keys: BTreeMap::from([("acme-2026".to_string(), public_key.clone())]),
             pinned_envelope_digests: BTreeMap::new(),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth.clone()),
         })
         .await
@@ -929,6 +933,8 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
             ignore_scripts: false,
             trusted_keys: BTreeMap::from([("acme-2026".to_string(), public_key.clone())]),
             pinned_envelope_digests: BTreeMap::new(),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth.clone()),
         })
         .await
@@ -937,6 +943,25 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
     assert_eq!(artifact.payload.owner, OwnerScope::organization("pnpr-client"));
     assert_eq!(artifact.envelope_digest.len(), 64);
     let pinned_digest = artifact.envelope_digest.clone();
+    let quarantined = client
+        .resolve_artifacts(ResolveArtifactsOptions {
+            candidates: vec![candidate.clone()],
+            supported_tags: vec!["pnpm:v1:linux-x64-node22-glibc2.17".to_string()],
+            eligible_packages: HashSet::from([candidate.package.name.clone()]),
+            allowed_builds: HashSet::from([candidate.package.name.clone()]),
+            ignore_scripts: false,
+            trusted_keys: BTreeMap::from([("acme-2026".to_string(), public_key.clone())]),
+            pinned_envelope_digests: BTreeMap::new(),
+            quarantined_envelope_digests: BTreeMap::from([(
+                candidate.key.clone(),
+                HashSet::from([pinned_digest.clone()]),
+            )]),
+            on_rejected_artifact: None,
+            authorization: Some(pnpr_auth.clone()),
+        })
+        .await
+        .expect("a quarantined variant is a cache miss");
+    assert!(quarantined.is_empty());
     let pinned = client
         .resolve_artifacts(ResolveArtifactsOptions {
             candidates: vec![candidate.clone()],
@@ -949,6 +974,8 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
                 candidate.key.clone(),
                 pinned_digest.clone(),
             )]),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth.clone()),
         })
         .await
@@ -966,6 +993,8 @@ async fn publishes_resolves_and_verifies_an_organization_artifact() {
             ignore_scripts: false,
             trusted_keys: BTreeMap::from([("acme-2026".to_string(), public_key)]),
             pinned_envelope_digests: BTreeMap::from([(candidate.key.clone(), "0".repeat(64))]),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth.clone()),
         })
         .await
@@ -1016,6 +1045,8 @@ async fn artifact_lookup_preserves_script_eligibility_and_allow_build_policy() {
                 ignore_scripts,
                 trusted_keys: trusted_keys.clone(),
                 pinned_envelope_digests: BTreeMap::new(),
+                quarantined_envelope_digests: BTreeMap::new(),
+                on_rejected_artifact: None,
                 authorization: None,
             })
             .await
@@ -1131,6 +1162,8 @@ async fn organization_artifact_existence_is_not_exposed_to_another_owner() {
             ignore_scripts: false,
             trusted_keys: BTreeMap::from([("acme-2026".to_string(), public_key)]),
             pinned_envelope_digests: BTreeMap::new(),
+            quarantined_envelope_digests: BTreeMap::new(),
+            on_rejected_artifact: None,
             authorization: Some(pnpr_auth),
         })
         .await

--- a/pnpm/crates/shared-artifact-protocol/src/lib.rs
+++ b/pnpm/crates/shared-artifact-protocol/src/lib.rs
@@ -234,6 +234,13 @@ impl SignedArtifactEnvelope {
     }
 
     pub fn decode_payload(&self) -> Result<(ArtifactPayload, Vec<u8>), ArtifactProtocolError> {
+        let payload_bytes = self.decode_payload_bytes()?;
+        let payload = decode_payload_json(&payload_bytes)?;
+        payload.validate()?;
+        Ok((payload, payload_bytes))
+    }
+
+    fn decode_payload_bytes(&self) -> Result<Vec<u8>, ArtifactProtocolError> {
         validate_scalar("signature algorithm", &self.algorithm, 64)?;
         if self.algorithm != SIGNATURE_ALGORITHM {
             return Err(ArtifactProtocolError::InvalidEnvelope(format!(
@@ -260,26 +267,39 @@ impl SignedArtifactEnvelope {
                 "signed payload exceeds {MAX_SIGNED_PAYLOAD_SIZE} bytes",
             )));
         }
-        let payload: ArtifactPayload = serde_json::from_slice(&payload_bytes).map_err(|err| {
-            ArtifactProtocolError::InvalidEnvelope(format!("payload is not valid JSON: {err}"))
-        })?;
-        payload.validate()?;
-        Ok((payload, payload_bytes))
+        Ok(payload_bytes)
     }
 
     pub fn verify(&self, public_key_spki: &[u8]) -> Result<ArtifactPayload, ArtifactProtocolError> {
-        let (payload, payload_bytes) = self.decode_payload()?;
+        let payload = self.verify_signature(public_key_spki)?;
+        payload.validate()?;
+        Ok(payload)
+    }
+
+    pub fn verify_signature(
+        &self,
+        public_key_spki: &[u8],
+    ) -> Result<ArtifactPayload, ArtifactProtocolError> {
+        let payload_bytes = self.verify_signature_bytes(public_key_spki)?;
+        decode_payload_json(&payload_bytes)
+    }
+
+    pub fn verify_signature_bytes(
+        &self,
+        public_key_spki: &[u8],
+    ) -> Result<Vec<u8>, ArtifactProtocolError> {
+        let payload_bytes = self.decode_payload_bytes()?;
         let (signature, _) = self.decode_signature()?;
         let public_key = VerifyingKey::from_public_key_der(public_key_spki)
             .map_err(|_| ArtifactProtocolError::InvalidSignature)?;
         public_key
             .verify(&payload_bytes, &signature)
             .map_err(|_| ArtifactProtocolError::InvalidSignature)?;
-        Ok(payload)
+        Ok(payload_bytes)
     }
 
     pub fn digest(&self) -> Result<String, ArtifactProtocolError> {
-        let (_, payload_bytes) = self.decode_payload()?;
+        let payload_bytes = self.decode_payload_bytes()?;
         let (_, signature_bytes) = self.decode_signature()?;
         let mut hasher = Sha256::new();
         hasher.update(b"pnpm-shared-artifact-envelope-v1\0");
@@ -319,6 +339,12 @@ impl SignedArtifactEnvelope {
         }
         Ok((signature, signature_bytes))
     }
+}
+
+fn decode_payload_json(payload_bytes: &[u8]) -> Result<ArtifactPayload, ArtifactProtocolError> {
+    serde_json::from_slice(payload_bytes).map_err(|error| {
+        ArtifactProtocolError::InvalidEnvelope(format!("payload is not valid JSON: {error}"))
+    })
 }
 
 impl PublishArtifactRequest {

--- a/pnpm/crates/shared-artifact-protocol/src/tests.rs
+++ b/pnpm/crates/shared-artifact-protocol/src/tests.rs
@@ -77,6 +77,46 @@ fn verifies_the_exact_signed_payload_bytes() {
     assert!(envelope.verify(other_public_key.as_bytes()).is_err());
 }
 
+#[test]
+fn verifies_signature_before_rejecting_a_trusted_invalid_payload() {
+    let mut invalid = payload(integrity(b"addon"));
+    invalid.manifest.added[0].path = "../escape".to_string();
+    let payload_bytes = serde_json::to_vec(&invalid).unwrap();
+    let private_key = SigningKey::from_slice(&[7; 32]).unwrap();
+    let signature: p256::ecdsa::Signature = private_key.sign(&payload_bytes);
+    let envelope = SignedArtifactEnvelope {
+        algorithm: SIGNATURE_ALGORITHM.to_string(),
+        key_id: "acme-2026".to_string(),
+        payload: BASE64.encode(&payload_bytes),
+        signature: BASE64.encode(signature.to_der().as_bytes()),
+    };
+    let public_key =
+        p256::PublicKey::from(private_key.verifying_key()).to_public_key_der().unwrap();
+
+    assert_eq!(envelope.verify_signature(public_key.as_bytes()).unwrap(), invalid);
+    assert!(envelope.verify(public_key.as_bytes()).is_err());
+    assert_eq!(envelope.digest().unwrap().len(), 64);
+}
+
+#[test]
+fn verifies_signature_before_deserializing_a_trusted_malformed_payload() {
+    let payload_bytes = b"{";
+    let private_key = SigningKey::from_slice(&[7; 32]).unwrap();
+    let signature: p256::ecdsa::Signature = private_key.sign(payload_bytes);
+    let envelope = SignedArtifactEnvelope {
+        algorithm: SIGNATURE_ALGORITHM.to_string(),
+        key_id: "acme-2026".to_string(),
+        payload: BASE64.encode(payload_bytes),
+        signature: BASE64.encode(signature.to_der().as_bytes()),
+    };
+    let public_key =
+        p256::PublicKey::from(private_key.verifying_key()).to_public_key_der().unwrap();
+
+    assert_eq!(envelope.verify_signature_bytes(public_key.as_bytes()).unwrap(), payload_bytes);
+    assert!(envelope.verify_signature(public_key.as_bytes()).is_err());
+    assert_eq!(envelope.digest().unwrap().len(), 64);
+}
+
 /// An oversized envelope must be refused from its encoded length, before the
 /// decoder allocates the bytes it describes.
 #[test]

--- a/pnpm/crates/store-dir/Cargo.toml
+++ b/pnpm/crates/store-dir/Cargo.toml
@@ -15,6 +15,7 @@ pnpm-crypto-hash                       = { workspace = true }
 pnpm-deps-path                         = { workspace = true }
 pnpm-fs                                = { workspace = true }
 pnpm-resolving-parse-wanted-dependency = { workspace = true }
+pnpm-shared-artifact-protocol          = { workspace = true }
 
 dashmap       = { workspace = true }
 derive_more   = { workspace = true }

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -155,6 +155,8 @@ pub struct VerifyResult {
     pub passed: bool,
     pub files_map: FilesMap,
     pub side_effects_maps: Option<HashMap<String, FilesMap>>,
+    pub side_effects: Option<HashMap<String, SideEffectsDiff>>,
+    pub remote_side_effects_quarantine: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Fast path used when `verify-store-integrity` is `false`.
@@ -162,7 +164,7 @@ pub struct VerifyResult {
 /// No stat syscalls — the caller trusts the index, and any missing /
 /// corrupt CAFS file surfaces lazily at import time.
 pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex) -> VerifyResult {
-    let PackageFilesIndex { files, side_effects, .. } = entry;
+    let PackageFilesIndex { files, side_effects, remote_side_effects_quarantine, .. } = entry;
     let mut files_map = HashMap::with_capacity(files.len());
     let mut passed = true;
     // Consume `entry.files` so the owned `String` filenames move into
@@ -184,8 +186,14 @@ pub fn build_file_maps_from_index(store_dir: &StoreDir, entry: PackageFilesIndex
         };
         files_map.insert(filename, path);
     }
-    let side_effects_maps = build_side_effects_maps(store_dir, side_effects, &files_map);
-    VerifyResult { passed, files_map, side_effects_maps }
+    let side_effects_maps = build_side_effects_maps(store_dir, side_effects.as_ref(), &files_map);
+    VerifyResult {
+        passed,
+        files_map,
+        side_effects_maps,
+        side_effects,
+        remote_side_effects_quarantine,
+    }
 }
 
 /// Careful path used when `verify-store-integrity` is `true` (the
@@ -204,7 +212,7 @@ pub fn check_pkg_files_integrity(
     // Destructure so the owned `files` HashMap and `algo` String can be
     // consumed below, moving the filenames into `files_map` without a
     // per-file clone on the hot path.
-    let PackageFilesIndex { files, algo, side_effects, .. } = entry;
+    let PackageFilesIndex { files, algo, side_effects, remote_side_effects_quarantine, .. } = entry;
     let mut all_verified = true;
     let mut files_map = HashMap::with_capacity(files.len());
     for (filename, info) in files {
@@ -233,8 +241,14 @@ pub fn check_pkg_files_integrity(
         }
         files_map.insert(filename, path);
     }
-    let side_effects_maps = build_side_effects_maps(store_dir, side_effects, &files_map);
-    VerifyResult { passed: all_verified, files_map, side_effects_maps }
+    let side_effects_maps = build_side_effects_maps(store_dir, side_effects.as_ref(), &files_map);
+    VerifyResult {
+        passed: all_verified,
+        files_map,
+        side_effects_maps,
+        side_effects,
+        remote_side_effects_quarantine,
+    }
 }
 
 /// Materialize the per-cache-key overlaid [`FilesMap`]s from a
@@ -244,13 +258,13 @@ pub fn check_pkg_files_integrity(
 /// as a missing CAS blob.
 fn build_side_effects_maps(
     store_dir: &StoreDir,
-    side_effects: Option<HashMap<String, SideEffectsDiff>>,
+    side_effects: Option<&HashMap<String, SideEffectsDiff>>,
     base_files: &FilesMap,
 ) -> Option<HashMap<String, FilesMap>> {
     let raw = side_effects?;
     let mut out: HashMap<String, FilesMap> = HashMap::with_capacity(raw.len());
     'next_key: for (cache_key, diff) in raw {
-        let SideEffectsDiff { added, deleted } = diff;
+        let SideEffectsDiff { added, deleted, .. } = diff;
         let mut overlay: FilesMap = HashMap::with_capacity(base_files.len());
         if let Some(added) = added {
             for (filename, info) in added {
@@ -259,7 +273,7 @@ fn build_side_effects_maps(
                 // corrupted index row (store integrity is explicitly not
                 // a tamper boundary — see `verify_file`) could otherwise
                 // escape the slot via a `..` or absolute `added` key.
-                if !is_safe_overlay_path(&filename) {
+                if !is_safe_overlay_path(filename) {
                     tracing::debug!(
                         target: "pacquet::store_index",
                         ?filename,
@@ -282,20 +296,20 @@ fn build_side_effects_maps(
                     );
                     continue 'next_key;
                 };
-                overlay.insert(filename, path);
+                overlay.insert(filename.clone(), path);
             }
         }
         // Promote `deleted` to a `HashSet` once per cache key so
         // the `base_files` walk stays linear in `|base|` instead of
         // `O(|base| * |deleted|)`.
         let deleted_set: std::collections::HashSet<String> =
-            deleted.unwrap_or_default().into_iter().collect();
+            deleted.iter().flatten().cloned().collect();
         for (filename, path) in base_files {
             if !deleted_set.contains(filename) && !overlay.contains_key(filename) {
                 overlay.insert(filename.clone(), path.clone());
             }
         }
-        out.insert(cache_key, overlay);
+        out.insert(cache_key.clone(), overlay);
     }
     Some(out)
 }

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -42,6 +42,7 @@ fn index_with(algo: &str, info: Vec<(&str, CafsFileInfo)>) -> PackageFilesIndex 
         algo: algo.to_string(),
         files: info.into_iter().map(|(k, v)| (k.to_string(), v)).collect(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     }
 }
 
@@ -386,7 +387,11 @@ fn side_effects_overlay_adds_and_drops_correctly() {
     added.insert("c.js".to_string(), info(&added_digest, 5, 0o644, None));
     side_effects.insert(
         "darwin;arm64;node20;deps=fake".to_string(),
-        SideEffectsDiff { added: Some(added), deleted: Some(vec!["b.js".to_string()]) },
+        SideEffectsDiff {
+            added: Some(added),
+            deleted: Some(vec!["b.js".to_string()]),
+            remote_origin: None,
+        },
     );
     let entry = PackageFilesIndex {
         manifest: None,
@@ -398,6 +403,7 @@ fn side_effects_overlay_adds_and_drops_correctly() {
             ("b.js".to_string(), info(&base_digest, 4, 0o644, None)),
         ]),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let result = build_file_maps_from_index(&store_dir, entry);
     let maps = result.side_effects_maps.expect("populated");
@@ -417,7 +423,10 @@ fn side_effects_overlay_added_shadows_base_on_collision() {
     let mut added = HashMap::new();
     added.insert("collide.js".to_string(), info(&overlay_digest, 16, 0o644, None));
     let mut side_effects = HashMap::new();
-    side_effects.insert("k1".to_string(), SideEffectsDiff { added: Some(added), deleted: None });
+    side_effects.insert(
+        "k1".to_string(),
+        SideEffectsDiff { added: Some(added), deleted: None, remote_origin: None },
+    );
     let entry = PackageFilesIndex {
         manifest: None,
         requires_build: None,
@@ -425,6 +434,7 @@ fn side_effects_overlay_added_shadows_base_on_collision() {
         algo: "sha512".into(),
         files: HashMap::from([("collide.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let result = build_file_maps_from_index(&store_dir, entry);
     let overlay = result.side_effects_maps.unwrap().remove("k1").unwrap();
@@ -463,10 +473,14 @@ fn side_effects_overlay_malformed_added_digest_drops_cache_key_entry() {
     k_good_added.insert("ok.js".to_string(), info(&good_digest, 4, 0o644, None));
 
     let mut side_effects = HashMap::new();
-    side_effects
-        .insert("k-bad".to_string(), SideEffectsDiff { added: Some(k_bad_added), deleted: None });
-    side_effects
-        .insert("k-good".to_string(), SideEffectsDiff { added: Some(k_good_added), deleted: None });
+    side_effects.insert(
+        "k-bad".to_string(),
+        SideEffectsDiff { added: Some(k_bad_added), deleted: None, remote_origin: None },
+    );
+    side_effects.insert(
+        "k-good".to_string(),
+        SideEffectsDiff { added: Some(k_good_added), deleted: None, remote_origin: None },
+    );
 
     let entry = PackageFilesIndex {
         manifest: None,
@@ -475,6 +489,7 @@ fn side_effects_overlay_malformed_added_digest_drops_cache_key_entry() {
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let result = build_file_maps_from_index(&store_dir, entry);
     let maps = result.side_effects_maps.expect("populated");
@@ -504,6 +519,7 @@ fn side_effects_overlay_unsafe_added_path_drops_cache_key_entry() {
                     (unsafe_name.to_string(), info(&good_digest, 4, 0o644, None)),
                 ])),
                 deleted: None,
+                remote_origin: None,
             },
         );
     }
@@ -515,6 +531,7 @@ fn side_effects_overlay_unsafe_added_path_drops_cache_key_entry() {
                 info(&good_digest, 4, 0o644, None),
             )])),
             deleted: None,
+            remote_origin: None,
         },
     );
 
@@ -525,6 +542,7 @@ fn side_effects_overlay_unsafe_added_path_drops_cache_key_entry() {
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let result = build_file_maps_from_index(&store_dir, entry);
     let maps = result.side_effects_maps.expect("populated");
@@ -547,6 +565,7 @@ fn side_effects_overlay_keys_are_independent() {
         SideEffectsDiff {
             added: Some(HashMap::from([("a.js".to_string(), info(&added_k1, 1, 0o644, None))])),
             deleted: None,
+            remote_origin: None,
         },
     );
     side_effects.insert(
@@ -554,6 +573,7 @@ fn side_effects_overlay_keys_are_independent() {
         SideEffectsDiff {
             added: Some(HashMap::from([("b.js".to_string(), info(&added_k2, 1, 0o644, None))])),
             deleted: None,
+            remote_origin: None,
         },
     );
     let entry = PackageFilesIndex {
@@ -563,6 +583,7 @@ fn side_effects_overlay_keys_are_independent() {
         algo: "sha512".into(),
         files: HashMap::from([("base.js".to_string(), info(&base_digest, 4, 0o644, None))]),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let result = build_file_maps_from_index(&store_dir, entry);
     let maps = result.side_effects_maps.unwrap();
@@ -591,6 +612,7 @@ fn index_with_one_file(path: &str, content: &[u8]) -> PackageFilesIndex {
             },
         )]),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     }
 }
 

--- a/pnpm/crates/store-dir/src/msgpackr_records.rs
+++ b/pnpm/crates/store-dir/src/msgpackr_records.rs
@@ -629,10 +629,8 @@ fn write_str(writer: &mut Vec<u8>, text: &str) {
 ///   the slot. When `Some`, it's written as `float 64` (see
 ///   [`CafsFileInfo::checked_at`] for why — msgpackr reads `uint 64`
 ///   as `BigInt`, which crashes pnpm's `mtimeMs - (checkedAt ?? 0)`).
-/// - **`SideEffectsDiff`**: `added` and `deleted` are both optional;
-///   each is included in the schema only when `Some`. The four
-///   possible shapes (`{added}`, `{deleted}`, `{added, deleted}`,
-///   `{}`) each get their own slot on first use.
+/// - **`SideEffectsDiff`**: `added`, `deleted`, and `remoteOrigin` are
+///   optional; each field set gets its own slot on first use.
 pub fn encode_package_files_index(index: &PackageFilesIndex) -> Result<Vec<u8>, EncodeError> {
     let mut state = EncodeState::default();
     let mut out = Vec::with_capacity(256);
@@ -648,7 +646,7 @@ pub enum EncodeError {
         "Ran out of msgpackr record slots: encountered more than \
          {max} distinct record shapes (slot range is 0x41..=0x7f). \
          `CafsFileInfo` contributes at most 2 shapes and \
-         `SideEffectsDiff` at most 4; the rest are allocated lazily \
+         `SideEffectsDiff` at most 8; the rest are allocated lazily \
          from `PackageFilesIndex.manifest`'s nested object shapes, \
          which in practice fit comfortably inside the remaining \
          range for a single tarball's manifest. Reaching this error \
@@ -677,7 +675,7 @@ const FIRST_INNER_SLOT: u8 = SLOT_LO + 1; // 0x41
 ///
 /// Shape keys are small bitmasks over the optional fields of each
 /// record type, see [`cafs_shape`] / [`side_effects_shape`]. Each type has
-/// at most a handful of possible shapes (2 for `CafsFileInfo`, 4 for
+/// at most a handful of possible shapes (2 for `CafsFileInfo`, 8 for
 /// `SideEffectsDiff`), so the 0x40..=0x7f slot range is vastly
 /// over-provisioned for realistic workloads.
 #[derive(SmartDefault)]
@@ -688,8 +686,8 @@ struct EncodeState {
     /// in this stream.
     cafs_slots: [Option<u8>; 2],
     /// Same for `SideEffectsDiff`, indexed by [`side_effects_shape`]
-    /// (4 possible values).
-    side_effects_slots: [Option<u8>; 4],
+    /// (8 possible values).
+    side_effects_slots: [Option<u8>; 8],
     /// Field-name vector → slot for every JSON-object shape seen so
     /// far inside a manifest value. Shape keys are owned `Vec<String>`
     /// because the field names are read from a borrowed
@@ -729,9 +727,11 @@ fn cafs_shape(info: &CafsFileInfo) -> u8 {
 }
 
 /// Bitmask describing which optional fields a [`SideEffectsDiff`]
-/// carries. Bit 0 = `added`, bit 1 = `deleted`.
+/// carries. Bit 0 = `added`, bit 1 = `deleted`, bit 2 = `remoteOrigin`.
 fn side_effects_shape(diff: &SideEffectsDiff) -> u8 {
-    u8::from(diff.added.is_some()) | (u8::from(diff.deleted.is_some()) << 1)
+    u8::from(diff.added.is_some())
+        | (u8::from(diff.deleted.is_some()) << 1)
+        | (u8::from(diff.remote_origin.is_some()) << 2)
 }
 
 fn encode_pkg_files_index_value(
@@ -743,7 +743,7 @@ fn encode_pkg_files_index_value(
     // Optional fields are omitted from the schema when `None`, matching
     // msgpackr's field-omit-when-absent shape so a pnpm reader sees the
     // same JS object regardless of whether pacquet or pnpm wrote the row.
-    let mut fields: Vec<&str> = Vec::with_capacity(6);
+    let mut fields: Vec<&str> = Vec::with_capacity(7);
     fields.push("algo");
     if idx.requires_build.is_some() {
         fields.push("requiresBuild");
@@ -757,6 +757,9 @@ fn encode_pkg_files_index_value(
     fields.push("files");
     if idx.side_effects.is_some() {
         fields.push("sideEffects");
+    }
+    if idx.remote_side_effects_quarantine.is_some() {
+        fields.push("remoteSideEffectsQuarantine");
     }
 
     write_record_def_header(writer, PKG_FILES_INDEX_SLOT, &fields);
@@ -790,6 +793,16 @@ fn encode_pkg_files_index_value(
         for (platform, diff) in sorted_by_key(se) {
             write_str(writer, platform);
             encode_side_effects_diff(writer, state, diff)?;
+        }
+    }
+    if let Some(quarantine) = &idx.remote_side_effects_quarantine {
+        write_map_header(writer, quarantine.len());
+        for (channel, digests) in sorted_by_key(quarantine) {
+            write_str(writer, channel);
+            write_array_header(writer, digests.len());
+            for digest in digests {
+                write_str(writer, digest);
+            }
         }
     }
 
@@ -942,13 +955,17 @@ fn encode_side_effects_diff(
     } else {
         let slot = state.allocate_slot()?;
         state.side_effects_slots[shape as usize] = Some(slot);
-        let fields: &[&str] = match (diff.added.is_some(), diff.deleted.is_some()) {
-            (true, true) => &["added", "deleted"],
-            (true, false) => &["added"],
-            (false, true) => &["deleted"],
-            (false, false) => &[],
-        };
-        write_record_def_header(writer, slot, fields);
+        let mut fields = Vec::with_capacity(3);
+        if diff.added.is_some() {
+            fields.push("added");
+        }
+        if diff.deleted.is_some() {
+            fields.push("deleted");
+        }
+        if diff.remote_origin.is_some() {
+            fields.push("remoteOrigin");
+        }
+        write_record_def_header(writer, slot, &fields);
     }
 
     if let Some(added) = &diff.added {
@@ -963,6 +980,11 @@ fn encode_side_effects_diff(
         for name in deleted {
             write_str(writer, name);
         }
+    }
+    if let Some(origin) = &diff.remote_origin {
+        let value = serde_json::to_value(origin)
+            .expect("RemoteSideEffectsOrigin serialization cannot fail");
+        encode_json_value(writer, state, &value)?;
     }
     Ok(())
 }

--- a/pnpm/crates/store-dir/src/msgpackr_records/tests.rs
+++ b/pnpm/crates/store-dir/src/msgpackr_records/tests.rs
@@ -2,9 +2,10 @@ use super::{
     DecodeError, EncodeError, EncodeState, FIRST_INNER_SLOT, PKG_FILES_INDEX_SLOT,
     RECORD_DEF_EXT_TYPE, SLOT_HI, encode_package_files_index, transcode_to_plain_msgpack,
 };
-use crate::{CafsFileInfo, PackageFilesIndex, SideEffectsDiff};
+use crate::{CafsFileInfo, PackageFilesIndex, RemoteSideEffectsOrigin, SideEffectsDiff};
+use pnpm_shared_artifact_protocol::{BuilderProfile, OwnerScope, SignedArtifactEnvelope};
 use pretty_assertions::assert_eq;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 fn decode(bytes: &[u8]) -> PackageFilesIndex {
     let plain = transcode_to_plain_msgpack(bytes).expect("transcode succeeds");
@@ -144,6 +145,7 @@ fn round_trips_plain_msgpack_through_transcoder() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = rmp_serde::to_vec_named(&original).unwrap();
     let transcoded = transcode_to_plain_msgpack(&bytes).unwrap();
@@ -280,6 +282,7 @@ fn encode_emits_record_header_for_top_level_struct() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&idx).unwrap();
     assert_eq!(&bytes[0..3], &[0xd4, RECORD_DEF_EXT_TYPE, PKG_FILES_INDEX_SLOT]);
@@ -296,6 +299,7 @@ fn encode_roundtrips_single_file() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     assert_eq!(roundtrip(&original), original);
 }
@@ -313,6 +317,7 @@ fn encode_roundtrips_many_files_sharing_one_slot() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&original).unwrap();
     let record_def_headers =
@@ -342,6 +347,7 @@ fn encode_handles_fixint_in_slot_range_safely() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     assert_eq!(roundtrip(&original).files.get("f").unwrap().size, 0x7b);
 }
@@ -357,6 +363,7 @@ fn encode_omits_checked_at_when_none() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&original).unwrap();
     let needle = b"checkedAt";
@@ -380,6 +387,7 @@ fn encode_allocates_separate_slots_for_distinct_cafs_shapes() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&original).unwrap();
     let record_def_headers =
@@ -400,6 +408,7 @@ fn encode_requires_build_when_set() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let roundtripped = roundtrip(&original);
     assert_eq!(roundtripped.requires_build, Some(true));
@@ -414,6 +423,7 @@ fn encode_requires_prepare_when_set() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let roundtripped = roundtrip(&original);
     assert_eq!(roundtripped.requires_prepare, Some(true));
@@ -438,6 +448,7 @@ fn encode_outer_field_order_matches_msgpackr() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&idx).unwrap();
     // Find the outer schema bytes: after `d4 72 40` (fixext1 +
@@ -467,6 +478,7 @@ fn encode_omits_requires_build_when_none() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&idx).unwrap();
     let needle = b"requiresBuild";
@@ -483,7 +495,11 @@ fn encode_side_effects_roundtrip() {
     let mut side_effects = HashMap::new();
     side_effects.insert(
         "linux".to_string(),
-        SideEffectsDiff { added: Some(added), deleted: Some(vec!["bar.o".to_string()]) },
+        SideEffectsDiff {
+            added: Some(added),
+            deleted: Some(vec!["bar.o".to_string()]),
+            remote_origin: None,
+        },
     );
     let mut files = HashMap::new();
     files.insert("main.js".to_string(), sample_cafs(10, true));
@@ -494,6 +510,46 @@ fn encode_side_effects_roundtrip() {
         algo: "sha512".to_string(),
         files,
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
+    };
+    assert_eq!(roundtrip(&original), original);
+}
+
+#[test]
+fn encode_remote_side_effects_origin_and_quarantine_roundtrip() {
+    let origin = RemoteSideEffectsOrigin {
+        channel: "https://pnpr.example/".to_string(),
+        owner: OwnerScope::organization("acme"),
+        signer_key_id: "acme-2026".to_string(),
+        builder_profile: BuilderProfile {
+            image_digest: Some("sha256:builder".to_string()),
+            architecture_baseline: "x64-v2".to_string(),
+            environment: BTreeMap::from([("CC".to_string(), "clang".to_string())]),
+        },
+        envelope: SignedArtifactEnvelope {
+            algorithm: "ecdsa-p256-sha256".to_string(),
+            key_id: "acme-2026".to_string(),
+            payload: "payload".to_string(),
+            signature: "signature".to_string(),
+        },
+        verification: "verified".to_string(),
+    };
+    let original = PackageFilesIndex {
+        algo: "sha512".to_string(),
+        files: HashMap::new(),
+        side_effects: Some(HashMap::from([(
+            "linux".to_string(),
+            SideEffectsDiff {
+                added: Some(HashMap::new()),
+                deleted: Some(Vec::new()),
+                remote_origin: Some(origin),
+            },
+        )])),
+        remote_side_effects_quarantine: Some(HashMap::from([(
+            "https://pnpr.example/".to_string(),
+            vec!["a".repeat(64), "b".repeat(64)],
+        )])),
+        ..Default::default()
     };
     assert_eq!(roundtrip(&original), original);
 }
@@ -503,7 +559,10 @@ fn encode_side_effects_with_only_added_omits_deleted_field() {
     let mut added = HashMap::new();
     added.insert("foo.so".to_string(), sample_cafs(42, true));
     let mut side_effects = HashMap::new();
-    side_effects.insert("linux".to_string(), SideEffectsDiff { added: Some(added), deleted: None });
+    side_effects.insert(
+        "linux".to_string(),
+        SideEffectsDiff { added: Some(added), deleted: None, remote_origin: None },
+    );
     let original = PackageFilesIndex {
         manifest: None,
         requires_build: None,
@@ -511,6 +570,7 @@ fn encode_side_effects_with_only_added_omits_deleted_field() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&original).unwrap();
     assert!(
@@ -525,11 +585,17 @@ fn encode_allocates_separate_slots_for_distinct_side_effects_shapes() {
     let mut linux_added = HashMap::new();
     linux_added.insert("foo.so".to_string(), sample_cafs(42, true));
     let mut side_effects = HashMap::new();
-    side_effects
-        .insert("linux".to_string(), SideEffectsDiff { added: Some(linux_added), deleted: None });
+    side_effects.insert(
+        "linux".to_string(),
+        SideEffectsDiff { added: Some(linux_added), deleted: None, remote_origin: None },
+    );
     side_effects.insert(
         "darwin".to_string(),
-        SideEffectsDiff { added: None, deleted: Some(vec!["bar.o".to_string()]) },
+        SideEffectsDiff {
+            added: None,
+            deleted: Some(vec!["bar.o".to_string()]),
+            remote_origin: None,
+        },
     );
     let original = PackageFilesIndex {
         manifest: None,
@@ -538,6 +604,7 @@ fn encode_allocates_separate_slots_for_distinct_side_effects_shapes() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: Some(side_effects),
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&original).unwrap();
     let record_def_headers =
@@ -582,6 +649,7 @@ fn encode_roundtrips_simple_manifest() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     assert_eq!(roundtrip(&original), original);
 }
@@ -608,6 +676,7 @@ fn encode_record_encodes_nested_objects_in_manifest() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&idx).unwrap();
 
@@ -640,6 +709,7 @@ fn encode_shares_slot_for_same_shaped_nested_objects() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let bytes = encode_package_files_index(&idx).unwrap();
     let record_defs =
@@ -678,6 +748,7 @@ fn encode_roundtrips_all_json_value_kinds() {
         algo: "sha512".to_string(),
         files: HashMap::new(),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     assert_eq!(roundtrip(&idx), idx);
 }
@@ -696,6 +767,7 @@ fn encode_roundtrips_manifest_with_other_fields() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     assert_eq!(roundtrip(&original), original);
 }

--- a/pnpm/crates/store-dir/src/store_index.rs
+++ b/pnpm/crates/store-dir/src/store_index.rs
@@ -66,7 +66,10 @@ enum WriteMsg {
     /// Wholesale replace the row at `key`. Used by the prefetch /
     /// download path that already has the full [`PackageFilesIndex`]
     /// in hand.
-    Replace { key: String, value: PackageFilesIndex },
+    Replace {
+        key: String,
+        value: PackageFilesIndex,
+    },
     /// Read-modify-write the row at `key`: load the existing row
     /// (from the same writer task's pending state or, on a miss,
     /// from `SQLite`), compute the diff between `current_files` and
@@ -88,7 +91,19 @@ enum WriteMsg {
         current_files: HashMap<String, CafsFileInfo>,
         response: Option<std::sync::mpsc::SyncSender<Option<SideEffectsDiff>>>,
     },
+    RemoteSideEffects {
+        key: String,
+        cache_key: String,
+        diff: SideEffectsDiff,
+    },
+    QuarantineRemoteSideEffects {
+        key: String,
+        channel: String,
+        envelope_digest: String,
+    },
 }
+
+const MAX_QUARANTINED_REMOTE_SIDE_EFFECTS: usize = 64;
 
 /// Batch cap for [`StoreIndexWriter`]. Big enough that a 1352-snapshot
 /// install flushes in a handful of transactions (so the fsync cost is
@@ -278,6 +293,26 @@ fn apply_write_msg(
                 let _ = response.send(diff);
             }
         }
+        WriteMsg::RemoteSideEffects { key, cache_key, diff } => {
+            if let Some(row) = load_pending_row(index, pending, &key) {
+                row.side_effects.get_or_insert_with(HashMap::new).insert(cache_key, diff);
+            }
+        }
+        WriteMsg::QuarantineRemoteSideEffects { key, channel, envelope_digest } => {
+            if let Some(row) = load_pending_row(index, pending, &key) {
+                let digests = row
+                    .remote_side_effects_quarantine
+                    .get_or_insert_with(HashMap::new)
+                    .entry(channel)
+                    .or_default();
+                if !digests.contains(&envelope_digest) {
+                    digests.push(envelope_digest);
+                }
+                if digests.len() > MAX_QUARANTINED_REMOTE_SIDE_EFFECTS {
+                    digests.drain(..digests.len() - MAX_QUARANTINED_REMOTE_SIDE_EFFECTS);
+                }
+            }
+        }
     }
 }
 
@@ -371,6 +406,19 @@ impl StoreIndexWriter {
             response: Some(response),
         });
         result.recv().ok().flatten()
+    }
+
+    pub fn queue_remote_side_effects(&self, key: String, cache_key: String, diff: SideEffectsDiff) {
+        self.send_msg(WriteMsg::RemoteSideEffects { key, cache_key, diff });
+    }
+
+    pub fn queue_remote_side_effects_quarantine(
+        &self,
+        key: String,
+        channel: String,
+        envelope_digest: String,
+    ) {
+        self.send_msg(WriteMsg::QuarantineRemoteSideEffects { key, channel, envelope_digest });
     }
 
     fn send_msg(&self, msg: WriteMsg) {
@@ -1058,6 +1106,9 @@ pub struct PackageFilesIndex {
     /// round-trip through `rmp_serde::from_slice`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub side_effects: Option<HashMap<String, SideEffectsDiff>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_side_effects_quarantine: Option<HashMap<String, Vec<String>>>,
 }
 
 /// Value of [`PackageFilesIndex::files`]. Matches pnpm v11's per-file
@@ -1116,6 +1167,19 @@ pub struct SideEffectsDiff {
     pub added: Option<HashMap<String, CafsFileInfo>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deleted: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_origin: Option<RemoteSideEffectsOrigin>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteSideEffectsOrigin {
+    pub channel: String,
+    pub owner: pnpm_shared_artifact_protocol::OwnerScope,
+    pub signer_key_id: String,
+    pub builder_profile: pnpm_shared_artifact_protocol::BuilderProfile,
+    pub envelope: pnpm_shared_artifact_protocol::SignedArtifactEnvelope,
+    pub verification: String,
 }
 
 /// Build the `file://…?immutable=1` URI used to open `index.db` read-only (see

--- a/pnpm/crates/store-dir/src/store_index/tests.rs
+++ b/pnpm/crates/store-dir/src/store_index/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    CafsFileInfo, GET_MANY_CHUNK, PackageFilesIndex, StoreIndex, StoreIndexError,
+    CafsFileInfo, GET_MANY_CHUNK, PackageFilesIndex, SideEffectsDiff, StoreIndex, StoreIndexError,
     git_hosted_store_index_key, immutable_sqlite_uri, pick_store_index_key, store_index_key,
 };
 use crate::StoreDir;
@@ -52,6 +52,7 @@ fn sample_index() -> PackageFilesIndex {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     }
 }
 
@@ -89,6 +90,42 @@ fn pick_store_index_key_uses_git_hosted_for_flagged_tarball() {
 
     let key = pick_store_index_key(Some("sha512-abc"), true, "github.com/foo/bar/abc1234", false);
     assert_eq!(key, "github.com/foo/bar/abc1234\tnot-built");
+}
+
+#[tokio::test]
+async fn writer_persists_remote_side_effects_and_bounded_quarantine() {
+    let dir = tempdir().unwrap();
+    let store_dir = StoreDir::new(dir.path());
+    let key = store_index_key("sha512-remote", "native-addon@1.0.0");
+    StoreIndex::open(store_dir.root()).unwrap().set(&key, &sample_index()).unwrap();
+
+    let (writer, task) = super::StoreIndexWriter::spawn(&store_dir);
+    writer.queue_remote_side_effects(
+        key.clone(),
+        "linux".to_string(),
+        SideEffectsDiff {
+            added: Some(HashMap::new()),
+            deleted: Some(Vec::new()),
+            remote_origin: None,
+        },
+    );
+    for index in 0..70 {
+        writer.queue_remote_side_effects_quarantine(
+            key.clone(),
+            "https://pnpr.example/".to_string(),
+            format!("{index:064}"),
+        );
+    }
+    drop(writer);
+    task.await.unwrap().unwrap();
+
+    let row = StoreIndex::open(store_dir.root()).unwrap().get(&key).unwrap().unwrap();
+    assert!(row.side_effects.unwrap().contains_key("linux"));
+    let quarantine = row.remote_side_effects_quarantine.unwrap();
+    assert_eq!(
+        quarantine["https://pnpr.example/"],
+        (6..70).map(|index| format!("{index:064}")).collect::<Vec<_>>(),
+    );
 }
 
 #[test]

--- a/pnpm/crates/store-dir/src/upload.rs
+++ b/pnpm/crates/store-dir/src/upload.rs
@@ -115,6 +115,7 @@ pub fn calculate_diff(
     SideEffectsDiff {
         added: (!added.is_empty()).then_some(added),
         deleted: (!deleted.is_empty()).then_some(deleted),
+        remote_origin: None,
     }
 }
 

--- a/pnpm/crates/store-dir/tests/verify_writer_race.rs
+++ b/pnpm/crates/store-dir/tests/verify_writer_race.rs
@@ -80,6 +80,7 @@ fn make_index(filename: &str, content: &[u8]) -> PackageFilesIndex {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     }
 }
 

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -655,6 +655,7 @@ fn assemble_extract_output(
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     (cas_paths, pkg_files_idx)
 }

--- a/pnpm/crates/tarball/src/prefetch.rs
+++ b/pnpm/crates/tarball/src/prefetch.rs
@@ -54,6 +54,11 @@ pub type PrefetchedManifests = HashMap<String, Arc<serde_json::Value>>;
 pub type PrefetchedSideEffectsMaps =
     HashMap<String, Arc<HashMap<String, HashMap<String, PathBuf>>>>;
 
+pub type PrefetchedSideEffects =
+    HashMap<String, Arc<HashMap<String, pnpm_store_dir::SideEffectsDiff>>>;
+
+pub type PrefetchedRemoteSideEffectsQuarantine = HashMap<String, Arc<HashMap<String, Vec<String>>>>;
+
 /// `requiresBuild` flags recovered from the same `index.db` rows as
 /// [`PrefetchedCasPaths`]. Missing values in old rows are recomputed
 /// from the bundled manifest plus verified file keys, mirroring
@@ -82,6 +87,8 @@ pub struct PrefetchResult {
     pub cas_paths: PrefetchedCasPaths,
     pub manifests: PrefetchedManifests,
     pub side_effects_maps: PrefetchedSideEffectsMaps,
+    pub side_effects: PrefetchedSideEffects,
+    pub remote_side_effects_quarantine: PrefetchedRemoteSideEffectsQuarantine,
     pub requires_build: PrefetchedRequiresBuild,
     pub requires_prepare: PrefetchedRequiresPrepare,
 }
@@ -184,6 +191,8 @@ pub async fn prefetch_cas_paths(
         let mut cas_paths = HashMap::with_capacity(decoded.len());
         let mut manifests = HashMap::new();
         let mut side_effects_maps = HashMap::new();
+        let mut side_effects = HashMap::new();
+        let mut remote_side_effects_quarantine = HashMap::new();
         let mut requires_build = HashMap::with_capacity(decoded.len());
         let mut requires_prepare = HashMap::new();
         for (cache_key, manifest, stored_requires_build, stored_requires_prepare, verify_result) in
@@ -202,6 +211,17 @@ pub async fn prefetch_cas_paths(
                 {
                     side_effects_maps.insert(cache_key.clone(), Arc::new(maps));
                 }
+                if let Some(diffs) = verify_result.side_effects
+                    && !diffs.is_empty()
+                {
+                    side_effects.insert(cache_key.clone(), Arc::new(diffs));
+                }
+                if let Some(quarantine) = verify_result.remote_side_effects_quarantine
+                    && !quarantine.is_empty()
+                {
+                    remote_side_effects_quarantine
+                        .insert(cache_key.clone(), Arc::new(quarantine));
+                }
                 requires_build.insert(cache_key.clone(), calculated_requires_build);
                 if let Some(requires_prepare_value) = stored_requires_prepare {
                     requires_prepare.insert(cache_key.clone(), requires_prepare_value);
@@ -213,6 +233,8 @@ pub async fn prefetch_cas_paths(
             cas_paths,
             manifests,
             side_effects_maps,
+            side_effects,
+            remote_side_effects_quarantine,
             requires_build,
             requires_prepare,
         }

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -432,6 +432,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
 
     let index = StoreIndex::open_in(store_path).unwrap();
@@ -586,6 +587,7 @@ async fn prefetch_cas_paths_returns_hits_for_live_index_rows() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -637,6 +639,7 @@ async fn prefetch_cas_paths_recomputes_requires_build_for_legacy_rows() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -691,6 +694,7 @@ async fn prefetch_cas_paths_omits_failed_integrity_entries() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -752,6 +756,7 @@ async fn prefetch_cas_paths_skips_filesystem_checks_when_verify_disabled() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -805,6 +810,7 @@ async fn falls_through_when_cafs_file_missing() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -858,6 +864,7 @@ fn seed_row_holding_another_package(store_path: &StoreDir, index_key: &str) {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(index_key, &entry).unwrap();
@@ -1015,6 +1022,7 @@ async fn falls_through_when_digest_is_malformed() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -1084,6 +1092,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();
@@ -1163,6 +1172,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         algo: "sha512".to_string(),
         files,
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
     let index = StoreIndex::open_in(store_path).unwrap();
     index.set(&index_key, &entry).unwrap();

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -54,6 +54,7 @@ pub(crate) fn extract_zip_entries(
         algo: "sha512".to_string(),
         files: HashMap::with_capacity(entry_count),
         side_effects: None,
+        remote_side_effects_quarantine: None,
     };
 
     // Build the `{prefix}/` slice once. Treat `Some("")` as `None`,

--- a/pnpm11/installing/deps-installer/src/install/link.ts
+++ b/pnpm11/installing/deps-installer/src/install/link.ts
@@ -568,6 +568,7 @@ async function linkAllPkgs (
         graphKey: depNode.depPath,
         depPath: depNode.depPath,
         files,
+        filesIndexFile: depNode.filesIndexFile,
         name: depNode.name,
         patchFileHash: depNode.patch?.hash,
         resolution: depNode.resolution,
@@ -575,12 +576,15 @@ async function linkAllPkgs (
       })
       if (sideEffectsCacheKey == null && opts.sideEffectsCacheRead && files.sideEffectsMaps && !isEmpty(files.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
-          sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, {
+          const localCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.depPath, {
             includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild === true,
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,
           })
+          if (files.sideEffectsDiffs?.get(localCacheKey)?.remoteOrigin == null) {
+            sideEffectsCacheKey = localCacheKey
+          }
         }
       }
       const { importMethod, isBuilt } = await storeController.importPackage(depNode.dir, {

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -1101,6 +1101,7 @@ async function linkAllPkgs (
         graphKey: depNode.dir,
         depPath: depNode.depPath,
         files: filesResponse,
+        filesIndexFile: depNode.filesIndexFile,
         name: depNode.name,
         patchFileHash: depNode.patch?.hash,
         resolution: depNode.resolution,
@@ -1108,12 +1109,15 @@ async function linkAllPkgs (
       })
       if (sideEffectsCacheKey == null && opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
         if (opts.allowBuild?.(depNode.depPath) === true) {
-          sideEffectsCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, {
+          const localCacheKey = calcDepState(opts.depGraph, opts.depsStateCache, depNode.dir, {
             includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild === true,
             patchFileHash: depNode.patch?.hash,
             supportedArchitectures: opts.supportedArchitectures,
             nodeVersion,
           })
+          if (filesResponse.sideEffectsDiffs?.get(localCacheKey)?.remoteOrigin == null) {
+            sideEffectsCacheKey = localCacheKey
+          }
         }
       }
       // For GVS packages that need building, add a .pnpm-needs-build marker to the

--- a/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
+++ b/pnpm11/installing/deps-restorer/src/linkHoistedModules.ts
@@ -164,6 +164,7 @@ async function linkAllPkgsInOrder (
           graphKey: dir,
           depPath: depNode.depPath,
           files: filesResponse,
+          filesIndexFile: depNode.filesIndexFile,
           name: depNode.name,
           patchFileHash: depNode.patch?.hash,
           resolution: depNode.resolution,
@@ -171,12 +172,15 @@ async function linkAllPkgsInOrder (
         })
         if (sideEffectsCacheKey == null && opts.sideEffectsCacheRead && filesResponse.sideEffectsMaps && !isEmpty(filesResponse.sideEffectsMaps)) {
           if (opts.allowBuild?.(depNode.depPath) === true) {
-            sideEffectsCacheKey = calcDepState(graph, opts.depsStateCache, dir, {
+            const localCacheKey = calcDepState(graph, opts.depsStateCache, dir, {
               includeDepGraphHash: !opts.ignoreScripts && depNode.requiresBuild === true,
               patchFileHash: depNode.patch?.hash,
               supportedArchitectures: opts.supportedArchitectures,
               nodeVersion: opts.nodeVersion,
             })
+            if (filesResponse.sideEffectsDiffs?.get(localCacheKey)?.remoteOrigin == null) {
+              sideEffectsCacheKey = localCacheKey
+            }
           }
         }
         // Limiting the concurrency here fixes an out of memory error.

--- a/pnpm11/store/cafs-types/src/index.ts
+++ b/pnpm11/store/cafs-types/src/index.ts
@@ -14,7 +14,36 @@ export type SideEffects = Map<string, SideEffectsDiff>
 export interface SideEffectsDiff {
   deleted?: string[]
   added?: PackageFiles
+  remoteOrigin?: RemoteSideEffectsOrigin
 }
+
+export type RemoteSideEffectsOwner =
+  | { type: 'organization', name: string }
+  | { type: 'publisher', package: string }
+
+export interface RemoteSideEffectsBuilderProfile {
+  imageDigest?: string
+  architectureBaseline: string
+  environment: Record<string, string>
+}
+
+export interface RemoteSideEffectsEnvelope {
+  algorithm: string
+  keyId: string
+  payload: string
+  signature: string
+}
+
+export interface RemoteSideEffectsOrigin {
+  channel: string
+  owner: RemoteSideEffectsOwner
+  signerKeyId: string
+  builderProfile: RemoteSideEffectsBuilderProfile
+  envelope: RemoteSideEffectsEnvelope
+  verification: 'verified'
+}
+
+export type RemoteSideEffectsQuarantine = Map<string, string[]>
 
 export type ResolvedFrom = 'store' | 'local-dir' | 'remote'
 
@@ -26,6 +55,8 @@ export interface PackageFilesResponse {
   packageImportMethod?: 'auto' | 'hardlink' | 'copy' | 'clone' | 'clone-or-copy'
   // Pre-calculated file location maps for side effects, avoiding recalculation during import
   sideEffectsMaps?: Map<string, { added?: FilesMap, deleted?: string[] }>
+  sideEffectsDiffs?: SideEffects
+  remoteSideEffectsQuarantine?: RemoteSideEffectsQuarantine
   requiresBuild: boolean
   /** Whether preparing a git package required lifecycle scripts before these files were stored. */
   requiresPrepare?: boolean

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -4,7 +4,7 @@ import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import gfs from '@pnpm/fs.graceful-fs'
-import type { FilesMap, PackageFileInfo, PackageFiles, SideEffects } from '@pnpm/store.cafs-types'
+import type { FilesMap, PackageFileInfo, PackageFiles, RemoteSideEffectsQuarantine, SideEffects } from '@pnpm/store.cafs-types'
 import type { BundledManifest } from '@pnpm/types'
 import { rimrafSync } from '@zkochan/rimraf'
 
@@ -54,6 +54,8 @@ export interface VerifyResult {
   passed: boolean
   filesMap: FilesMap
   sideEffectsMaps?: Map<string, { added?: FilesMap, deleted?: string[] }>
+  sideEffectsDiffs?: SideEffects
+  remoteSideEffectsQuarantine?: RemoteSideEffectsQuarantine
 }
 
 export interface PackageFilesIndex {
@@ -64,6 +66,7 @@ export interface PackageFilesIndex {
   algo: string
   files: PackageFiles
   sideEffects?: SideEffects
+  remoteSideEffectsQuarantine?: RemoteSideEffectsQuarantine
 }
 
 export function checkPkgFilesIntegrity (
@@ -101,6 +104,8 @@ export function checkPkgFilesIntegrity (
   return {
     ...verified,
     sideEffectsMaps: sideEffectsMaps.size > 0 ? sideEffectsMaps : undefined,
+    sideEffectsDiffs: sideEffectsMaps.size > 0 ? matchingSideEffects(pkgIndex.sideEffects, sideEffectsMaps) : undefined,
+    remoteSideEffectsQuarantine: pkgIndex.remoteSideEffectsQuarantine,
   }
 }
 
@@ -145,7 +150,17 @@ export function buildFileMapsFromIndex (
     passed: true,
     filesMap,
     sideEffectsMaps: sideEffectsMaps.size > 0 ? sideEffectsMaps : undefined,
+    sideEffectsDiffs: sideEffectsMaps.size > 0 ? matchingSideEffects(pkgIndex.sideEffects, sideEffectsMaps) : undefined,
+    remoteSideEffectsQuarantine: pkgIndex.remoteSideEffectsQuarantine,
   }
+}
+
+function matchingSideEffects (
+  sideEffects: SideEffects | undefined,
+  sideEffectsMaps: Map<string, unknown>
+): SideEffects | undefined {
+  if (sideEffects == null) return undefined
+  return new Map(Array.from(sideEffects).filter(([cacheKey]) => sideEffectsMaps.has(cacheKey)))
 }
 
 function checkFilesIntegrity (

--- a/pnpm11/store/controller-types/src/index.ts
+++ b/pnpm11/store/controller-types/src/index.ts
@@ -20,6 +20,7 @@ import type {
   ImportPackageFunctionAsync,
   PackageFileInfo,
   PackageFilesResponse,
+  RemoteSideEffectsOrigin,
   ResolvedFrom,
   SideEffectsDiff,
 } from '@pnpm/store.cafs-types'
@@ -33,7 +34,7 @@ import type {
   TrustPolicy,
 } from '@pnpm/types'
 
-export type { FilesMap, ImportPackageFunction, ImportPackageFunctionAsync, PackageFileInfo, PackageFilesResponse, ResolvedFrom, SideEffectsDiff }
+export type { FilesMap, ImportPackageFunction, ImportPackageFunctionAsync, PackageFileInfo, PackageFilesResponse, RemoteSideEffectsOrigin, ResolvedFrom, SideEffectsDiff }
 
 export * from '@pnpm/resolving.resolver-base'
 export type { BundledManifest }
@@ -69,6 +70,16 @@ export interface StoreController {
    * the store keeps executable and non-executable content apart.
    */
   locateFileInStore?: (hexDigest: string, mode: number) => Promise<string | undefined>
+  persistRemoteSideEffects?: (opts: {
+    filesIndexFile: string
+    sideEffectsCacheKey: string
+    sideEffects: SideEffectsDiff
+  }) => boolean
+  quarantineRemoteSideEffects?: (opts: {
+    channel: string
+    envelopeDigest: string
+    filesIndexFile: string
+  }) => boolean
   clearResolutionCache: () => void
 }
 

--- a/pnpm11/store/controller/src/storeController/index.ts
+++ b/pnpm11/store/controller/src/storeController/index.ts
@@ -6,9 +6,10 @@ import type { Fetchers } from '@pnpm/fetching.fetcher-base'
 import type { CustomFetcher } from '@pnpm/hooks.types'
 import { createPackageRequester } from '@pnpm/installing.package-requester'
 import type { ResolveFunction } from '@pnpm/resolving.resolver-base'
-import { verifyFileIntegrityAsync } from '@pnpm/store.cafs'
+import { type PackageFilesIndex, verifyFileIntegrityAsync } from '@pnpm/store.cafs'
 import type {
   ImportIndexedPackageAsync,
+  SideEffectsDiff,
   StoreController,
 } from '@pnpm/store.controller-types'
 import { type CafsLocker, createCafsStore, createPackageImporterAsync } from '@pnpm/store.create-cafs-store'
@@ -16,6 +17,8 @@ import type { StoreIndex } from '@pnpm/store.index'
 import { addFilesFromDir, importPackage, initStoreDir } from '@pnpm/worker'
 
 import { prune } from './prune.js'
+
+const MAX_QUARANTINED_REMOTE_SIDE_EFFECTS = 64
 
 export { type CafsLocker }
 
@@ -100,6 +103,8 @@ export function createPackageStore (
     // direct write capability that remote side-effects hydration requires.
     addFileToStore: initOpts.frozenStore ? undefined : cafs.addFile,
     locateFileInStore,
+    persistRemoteSideEffects: initOpts.frozenStore ? undefined : persistRemoteSideEffects,
+    quarantineRemoteSideEffects: initOpts.frozenStore ? undefined : quarantineRemoteSideEffects,
     clearResolutionCache: initOpts.clearResolutionCache,
   }
 
@@ -112,6 +117,35 @@ export function createPackageStore (
     return await verifyFileIntegrityAsync(filePath, { algorithm: 'sha512', digest: hexDigest })
       ? filePath
       : undefined
+  }
+
+  function persistRemoteSideEffects (opts: {
+    filesIndexFile: string
+    sideEffectsCacheKey: string
+    sideEffects: SideEffectsDiff
+  }): boolean {
+    return initOpts.storeIndex.update(opts.filesIndexFile, (value) => {
+      const index = value as PackageFilesIndex
+      index.sideEffects ??= new Map()
+      index.sideEffects.set(opts.sideEffectsCacheKey, opts.sideEffects)
+      return index
+    })
+  }
+
+  function quarantineRemoteSideEffects (opts: {
+    channel: string
+    envelopeDigest: string
+    filesIndexFile: string
+  }): boolean {
+    return initOpts.storeIndex.update(opts.filesIndexFile, (value) => {
+      const index = value as PackageFilesIndex
+      index.remoteSideEffectsQuarantine ??= new Map()
+      const quarantined = index.remoteSideEffectsQuarantine.get(opts.channel) ?? []
+      const bounded = Array.from(new Set([...quarantined, opts.envelopeDigest]))
+        .slice(-MAX_QUARANTINED_REMOTE_SIDE_EFFECTS)
+      index.remoteSideEffectsQuarantine.set(opts.channel, bounded)
+      return index
+    })
   }
 
   async function upload (builtPkgLocation: string, opts: { filesIndexFile: string, sideEffectsCacheKey: string }) {

--- a/pnpm11/store/controller/test/index.ts
+++ b/pnpm11/store/controller/test/index.ts
@@ -170,3 +170,43 @@ describe('store.locateFileInStore', () => {
     }
   )
 })
+
+describe('remote side-effects metadata', () => {
+  it('persists diffs and bounds quarantine entries', () => {
+    const tmp = temporaryDirectory()
+    const storeDir = path.join(tmp, 'store')
+    const storeIndex = new StoreIndex(storeDir)
+    fs.mkdirSync(path.join(storeDir, 'files'), { recursive: true })
+    const store = createPackageStore({} as never, {} as never, {
+      storeDir,
+      cacheDir: path.join(tmp, 'cache'),
+      verifyStoreIntegrity: true,
+      virtualStoreDirMaxLength: 120,
+      clearResolutionCache: () => {},
+      storeIndex,
+    })
+    storeIndex.set('row', { algo: 'sha512', files: new Map() })
+
+    expect(store.persistRemoteSideEffects?.({
+      filesIndexFile: 'row',
+      sideEffectsCacheKey: 'linux',
+      sideEffects: { added: new Map(), deleted: [] },
+    })).toBe(true)
+    for (let index = 0; index < 70; index++) {
+      store.quarantineRemoteSideEffects?.({
+        channel: 'https://pnpr.example/',
+        envelopeDigest: String(index).padStart(64, '0'),
+        filesIndexFile: 'row',
+      })
+    }
+
+    const row = storeIndex.get('row') as {
+      sideEffects: Map<string, unknown>
+      remoteSideEffectsQuarantine: Map<string, string[]>
+    }
+    expect(row.sideEffects.has('linux')).toBe(true)
+    expect(row.remoteSideEffectsQuarantine.get('https://pnpr.example/')).toEqual(
+      Array.from({ length: 64 }, (_, index) => String(index + 6).padStart(64, '0'))
+    )
+  })
+})

--- a/pnpm11/store/index/src/index.ts
+++ b/pnpm11/store/index/src/index.ts
@@ -197,6 +197,32 @@ export class StoreIndex {
     })
   }
 
+  update (key: string, updateValue: (value: unknown) => unknown): boolean {
+    this.flush()
+    return sqliteRetry(() => {
+      this.db.exec('BEGIN IMMEDIATE')
+      let committed = false
+      try {
+        const row = this.stmtGet.get(key) as { data: Uint8Array } | undefined
+        if (row == null) {
+          this.db.exec('COMMIT')
+          committed = true
+          return false
+        }
+        this.stmtSet.run(key, packr.pack(updateValue(packr.unpack(row.data))))
+        this.db.exec('COMMIT')
+        committed = true
+        return true
+      } finally {
+        if (!committed) {
+          try {
+            this.db.exec('ROLLBACK')
+          } catch {}
+        }
+      }
+    })
+  }
+
   delete (key: string): boolean {
     let result!: { changes: number | bigint }
     sqliteRetry(() => {
@@ -384,6 +410,10 @@ export class ReadOnlyStoreIndex extends StoreIndex {
   }
 
   override delete (_key: string): boolean {
+    this.throwReadOnly()
+  }
+
+  override update (_key: string, _updateValue: (value: unknown) => unknown): boolean {
     this.throwReadOnly()
   }
 

--- a/pnpm11/store/index/src/index.ts
+++ b/pnpm11/store/index/src/index.ts
@@ -201,24 +201,26 @@ export class StoreIndex {
     this.flush()
     return sqliteRetry(() => {
       this.db.exec('BEGIN IMMEDIATE')
-      let committed = false
       try {
         const row = this.stmtGet.get(key) as { data: Uint8Array } | undefined
         if (row == null) {
           this.db.exec('COMMIT')
-          committed = true
           return false
         }
         this.stmtSet.run(key, packr.pack(updateValue(packr.unpack(row.data))))
         this.db.exec('COMMIT')
-        committed = true
         return true
-      } finally {
-        if (!committed) {
-          try {
-            this.db.exec('ROLLBACK')
-          } catch {}
+      } catch (updateError: unknown) {
+        try {
+          this.db.exec('ROLLBACK')
+        } catch (rollbackError: unknown) {
+          throw new AggregateError(
+            [updateError, rollbackError],
+            `Failed to roll back store index update for ${key}`,
+            { cause: rollbackError }
+          )
         }
+        throw updateError
       }
     })
   }

--- a/pnpm11/store/index/test/index.ts
+++ b/pnpm11/store/index/test/index.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { expect, test } from '@jest/globals'
 import { ReadOnlyStoreIndex, StoreIndex, storeIndexKey } from '@pnpm/store.index'
@@ -64,6 +65,28 @@ test('StoreIndex update mutates an existing row without creating a missing row',
   } finally {
     idx.close()
   }
+})
+
+test('StoreIndex update reports a rollback failure without hiding the update error', () => {
+  const storeDir = path.join(temporaryDirectory(), 'store', 'v11')
+  const idx = new StoreIndex(storeDir)
+  idx.set('present', { value: 1 })
+  let thrown: unknown
+  try {
+    idx.update('present', (value) => {
+      idx.close()
+      return value
+    })
+  } catch (err: unknown) {
+    thrown = err
+  }
+  expect(util.types.isNativeError(thrown)).toBe(true)
+  if (!util.types.isNativeError(thrown) || !('errors' in thrown) || !Array.isArray(thrown.errors)) {
+    throw new Error('Expected update and rollback errors to be aggregated')
+  }
+  expect(thrown.name).toBe('AggregateError')
+  expect(thrown.message).toContain('present')
+  expect(thrown.errors).toHaveLength(2)
 })
 
 // The immutable open only works on a runtime that honors the immutable URI;

--- a/pnpm11/store/index/test/index.ts
+++ b/pnpm11/store/index/test/index.ts
@@ -48,6 +48,24 @@ test('StoreIndex entries() iterates all SQLite entries', () => {
   }
 })
 
+test('StoreIndex update mutates an existing row without creating a missing row', () => {
+  const storeDir = path.join(temporaryDirectory(), 'store', 'v11')
+  const idx = new StoreIndex(storeDir)
+  try {
+    idx.set('present', { values: new Map([['one', 1]]) })
+    expect(idx.update('present', (value) => {
+      const row = value as { values: Map<string, number> }
+      row.values.set('two', 2)
+      return row
+    })).toBe(true)
+    expect(idx.get('present')).toEqual({ values: new Map([['one', 1], ['two', 2]]) })
+    expect(idx.update('missing', () => ({ created: true }))).toBe(false)
+    expect(idx.get('missing')).toBeUndefined()
+  } finally {
+    idx.close()
+  }
+})
+
 // The immutable open only works on a runtime that honors the immutable URI;
 // this is purely a Node-version property, independent of platform.
 const supportsImmutableUri = nodeSupportsImmutableSqliteUri()
@@ -85,6 +103,9 @@ testFrozenOpen('StoreIndex frozen mode reads a WAL db on a read-only directory a
       }).toThrow(expect.objectContaining({ code: 'ERR_PNPM_FROZEN_STORE_WRITE' }))
       expect(() => {
         idx.delete(key)
+      }).toThrow(expect.objectContaining({ code: 'ERR_PNPM_FROZEN_STORE_WRITE' }))
+      expect(() => {
+        idx.update(key, value => value)
       }).toThrow(expect.objectContaining({ code: 'ERR_PNPM_FROZEN_STORE_WRITE' }))
 
       // The immutable open must not create any sidecar under the

--- a/pnpm11/worker/src/start.ts
+++ b/pnpm11/worker/src/start.ts
@@ -160,6 +160,8 @@ async function handleMessage (
             files: {
               filesMap: verifyResult.filesMap,
               sideEffectsMaps: verifyResult.sideEffectsMaps,
+              sideEffectsDiffs: verifyResult.sideEffectsDiffs,
+              remoteSideEffectsQuarantine: verifyResult.remoteSideEffectsQuarantine,
               resolvedFrom: 'store',
               requiresBuild,
               requiresPrepare: pkgFilesIndex.requiresPrepare,

--- a/pnpr/client/src/index.ts
+++ b/pnpr/client/src/index.ts
@@ -34,9 +34,12 @@ export {
   pnprSupportsSharedSideEffects,
   publishSharedSideEffects,
   resolveSharedSideEffects,
+  SharedArtifactBlobIntegrityError,
   SIGNATURE_ALGORITHM,
   type SignedArtifactEnvelope,
   signedArtifactEnvelopeDigest,
   type VerifiedArtifact,
   verifySignedArtifactEnvelope,
+  verifyStoredSharedSideEffects,
+  type VerifyStoredSharedSideEffectsOptions,
 } from './sharedSideEffects.js'

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -5,7 +5,7 @@ import util from 'node:util'
 import { calcDepState, calcDepStateInputKey, type DepsGraph, type DepsStateCache } from '@pnpm/deps.graph-hasher'
 import type { ArtifactPins, LockfileObject, LockfileResolution } from '@pnpm/lockfile.types'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
-import type { PackageFilesResponse, StoreController, UploadPkgToStoreResult } from '@pnpm/store.controller-types'
+import type { PackageFilesResponse, RemoteSideEffectsOrigin, SideEffectsDiff, StoreController, UploadPkgToStoreResult } from '@pnpm/store.controller-types'
 import type { AllowBuild, DepPath, RegistryConfig, RemoteSideEffectsCacheSettings, SupportedArchitectures } from '@pnpm/types'
 import pLimit from 'p-limit'
 
@@ -24,13 +24,17 @@ import {
   pnprSupportsSharedSideEffects,
   publishSharedSideEffects,
   resolveSharedSideEffects,
+  SharedArtifactBlobIntegrityError,
+  type SignedArtifactEnvelope,
   type VerifiedArtifact,
+  verifyStoredSharedSideEffects,
 } from './sharedSideEffects.js'
 
 export interface RemoteSideEffectsInstallNode<T extends string> {
   graphKey: T
   depPath: DepPath
   files: PackageFilesResponse
+  filesIndexFile?: string
   name: string
   patchFileHash?: string
   resolution: LockfileResolution
@@ -90,6 +94,7 @@ interface RestoredArtifact {
   added: Map<string, string>
   deleted: string[]
   envelopeDigest: string
+  sideEffects: SideEffectsDiff
 }
 
 interface QueuedLookup {
@@ -98,14 +103,12 @@ interface QueuedLookup {
 }
 
 export function canRestoreRemoteSideEffects (opts: RemoteSideEffectsPrerequisites): boolean {
-  return opts.pnprServer != null &&
-    opts.settings != null &&
+  return opts.settings != null &&
     opts.settings.organization != null &&
     (opts.settings.packages?.length ?? 0) > 0 &&
     Object.keys(opts.settings.trustedKeys ?? {}).length > 0 &&
     !opts.ignoreScripts &&
-    currentLinuxGlibcPlatform(opts.nodeVersion) != null &&
-    opts.storeController.addFileToStore != null
+    currentLinuxGlibcPlatform(opts.nodeVersion) != null
 }
 
 export function createRemoteSideEffectsRestorer<T extends string> (
@@ -115,7 +118,7 @@ export function createRemoteSideEffectsRestorer<T extends string> (
   const platform = currentLinuxGlibcPlatform(opts.nodeVersion)
   const { pnprServer, settings } = opts
   const organization = settings?.organization
-  if (platform == null || pnprServer == null || settings == null || organization == null) return undefined
+  if (platform == null || settings == null || organization == null) return undefined
   const registryUrl = pnprServer
   const ownerName = organization
   const owner = { type: 'organization', name: ownerName } as const
@@ -132,7 +135,7 @@ export function createRemoteSideEffectsRestorer<T extends string> (
   const pinnedEnvelopeDigests = new Map<string, string>()
   const pinCollisions = new Set<string>()
   const eligiblePackages = new Set(settings.packages)
-  const authorization = createGetAuthHeaderByURI(opts.configByUri)(registryUrl)
+  const authorization = registryUrl == null ? undefined : createGetAuthHeaderByURI(opts.configByUri)(registryUrl)
   const artifactLimit = pLimit(4)
   const downloadLimit = pLimit(16)
   // A store probe reads and hashes the candidate, so it holds a descriptor for
@@ -142,10 +145,12 @@ export function createRemoteSideEffectsRestorer<T extends string> (
   const storeLookupLimit = pLimit(16)
   // Restorer-lifetime, so one blob shared by several artifacts is fetched and
   // stored once however the batches happen to fall.
-  const storedBlobs = new Map<string, Promise<string>>()
+  const storedBlobs = new Map<string, Promise<{ filePath: string, fileInfo: { checkedAt?: number, digest: string, mode: number, size: number } }>>()
   const identityByInputKey = new Map<string, string>()
   const collisions = new Set<string>()
   const lookups = new Map<string, Promise<RestoredArtifact | undefined>>()
+  const filesIndexFilesByInputKey = new Map<string, Set<string>>()
+  const quarantinedEnvelopeDigests = new Map<string, Set<string>>()
   let queued: QueuedLookup[] = []
   let flushTimer: NodeJS.Timeout | undefined
   let supported: Promise<boolean> | undefined
@@ -198,16 +203,50 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       supportedArchitectures: opts.supportedArchitectures,
       nodeVersion: opts.nodeVersion,
     })
-    if (opts.sideEffectsCacheRead && node.files.sideEffectsMaps?.has(localCacheKey) === true) return undefined
+    const candidate: ArtifactCandidate = {
+      key: inputKey,
+      package: { name: node.name, version: node.version },
+      sourceIntegrity,
+      owner,
+    }
+    const localSideEffects = node.files.sideEffectsMaps?.get(localCacheKey)
+    const storedDiff = node.files.sideEffectsDiffs?.get(localCacheKey)
+    if (localSideEffects != null) {
+      if (storedDiff?.remoteOrigin == null) {
+        if (opts.sideEffectsCacheRead) return undefined
+      } else {
+        const envelopeDigest = await storedArtifactEnvelopeDigest(storedDiff, localSideEffects, candidate, pinnedEnvelopeDigest)
+        if (envelopeDigest != null) {
+          recordArtifactPin(node.depPath, inputKey, envelopeDigest)
+          return localCacheKey
+        }
+        node.files.sideEffectsMaps?.delete(localCacheKey)
+        node.files.sideEffectsDiffs?.delete(localCacheKey)
+      }
+    }
+    if (registryUrl == null || opts.storeController.addFileToStore == null) return undefined
+
+    if (node.filesIndexFile != null) {
+      let filesIndexFiles = filesIndexFilesByInputKey.get(inputKey)
+      if (filesIndexFiles == null) {
+        filesIndexFiles = new Set()
+        filesIndexFilesByInputKey.set(inputKey, filesIndexFiles)
+      }
+      filesIndexFiles.add(node.filesIndexFile)
+    }
+    const storedQuarantine = node.files.remoteSideEffectsQuarantine?.get(registryUrl)
+    if (storedQuarantine != null) {
+      let quarantined = quarantinedEnvelopeDigests.get(inputKey)
+      if (quarantined == null) {
+        quarantined = new Set()
+        quarantinedEnvelopeDigests.set(inputKey, quarantined)
+      }
+      for (const digest of storedQuarantine) quarantined.add(digest)
+    }
 
     let lookup = lookups.get(inputKey)
     if (lookup == null) {
-      lookup = enqueue({
-        key: inputKey,
-        package: { name: node.name, version: node.version },
-        sourceIntegrity,
-        owner,
-      })
+      lookup = enqueue(candidate)
       lookups.set(inputKey, lookup)
     }
     const artifact = await lookup
@@ -220,6 +259,19 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     recordArtifactPin(node.depPath, inputKey, artifact.envelopeDigest)
     node.files.sideEffectsMaps ??= new Map()
     node.files.sideEffectsMaps.set(localCacheKey, { added: artifact.added, deleted: artifact.deleted })
+    node.files.sideEffectsDiffs ??= new Map()
+    node.files.sideEffectsDiffs.set(localCacheKey, artifact.sideEffects)
+    if (node.filesIndexFile != null) {
+      try {
+        opts.storeController.persistRemoteSideEffects?.({
+          filesIndexFile: node.filesIndexFile,
+          sideEffectsCacheKey: localCacheKey,
+          sideEffects: artifact.sideEffects,
+        })
+      } catch (err: unknown) {
+        opts.warn?.(`Remote side-effects artifact for ${node.name}@${node.version} could not be persisted: ${errorMessage(err)}`)
+      }
+    }
     return localCacheKey
   }
 
@@ -255,6 +307,10 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       return false
     })
     if (eligibleBatch.length === 0) return
+    if (registryUrl == null) {
+      for (const { resolve } of eligibleBatch) resolve(undefined)
+      return
+    }
     const batchPinnedEnvelopeDigests = new Map(pinnedEnvelopeDigests)
     supported ??= (async () => {
       try {
@@ -282,6 +338,10 @@ export function createRemoteSideEffectsRestorer<T extends string> (
         },
         trustedKeys,
         pinnedEnvelopeDigests: batchPinnedEnvelopeDigests,
+        quarantinedEnvelopeDigests,
+        onRejectedArtifact: ({ inputKey, envelopeDigest, reason }) => {
+          quarantine(inputKey, envelopeDigest, reason)
+        },
       })
     } catch (err: unknown) {
       opts.warn?.(`Remote side-effects cache lookup failed: ${errorMessage(err)}`)
@@ -306,8 +366,9 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     artifact: VerifiedArtifact,
     candidate: ArtifactCandidate
   ): Promise<RestoredArtifact | undefined> {
+    if (registryUrl == null) return undefined
     try {
-      const added = new Map(await Promise.all(artifact.payload.manifest.added.map(async (file) => {
+      const hydrated = await Promise.all(artifact.payload.manifest.added.map(async (file) => {
         const storedKey = `${file.integrity}\0${file.mode}`
         let stored = storedBlobs.get(storedKey)
         if (stored == null) {
@@ -320,7 +381,20 @@ export function createRemoteSideEffectsRestorer<T extends string> (
               artifactBlobDigest(file.integrity),
               file.mode
             ))
-            if (present != null) return present
+            if (present != null) {
+              const stat = await fs.stat(present)
+              if (stat.size !== file.size) {
+                throw new SharedArtifactBlobIntegrityError('Stored shared artifact blob does not match its declared size')
+              }
+              return {
+                filePath: present,
+                fileInfo: {
+                  digest: artifactBlobDigest(file.integrity),
+                  mode: file.mode,
+                  size: file.size,
+                },
+              }
+            }
             const bytes = await downloadLimit(async () => downloadSharedArtifactBlob({
               registryUrl,
               authorization,
@@ -329,22 +403,123 @@ export function createRemoteSideEffectsRestorer<T extends string> (
                 integrity: file.integrity,
               },
             }))
-            return opts.storeController.addFileToStore!(bytes, file.mode).filePath
+            if (bytes.byteLength !== file.size) {
+              throw new SharedArtifactBlobIntegrityError('Downloaded shared artifact blob does not match its declared size')
+            }
+            const storedFile = opts.storeController.addFileToStore!(bytes, file.mode)
+            return {
+              filePath: storedFile.filePath,
+              fileInfo: {
+                checkedAt: storedFile.checkedAt,
+                digest: storedFile.digest,
+                mode: file.mode,
+                size: file.size,
+              },
+            }
           })()
           storedBlobs.set(storedKey, stored)
         }
         try {
-          return [file.path, await stored] as const
+          const result = await stored
+          if (result.fileInfo.size !== file.size) {
+            throw new SharedArtifactBlobIntegrityError('Shared artifact blob is declared with inconsistent sizes')
+          }
+          return [file.path, result] as const
         } catch (err: unknown) {
           if (storedBlobs.get(storedKey) === stored) storedBlobs.delete(storedKey)
           throw err
         }
-      })))
-      return { added, deleted: artifact.payload.manifest.deleted, envelopeDigest: artifact.envelopeDigest }
+      }))
+      const added = new Map(hydrated.map(([filePath, stored]) => [filePath, stored.filePath]))
+      const remoteOrigin: RemoteSideEffectsOrigin = {
+        channel: registryUrl,
+        owner: artifact.payload.owner,
+        signerKeyId: artifact.envelope.keyId,
+        builderProfile: artifact.payload.builderProfile,
+        envelope: artifact.envelope,
+        verification: 'verified',
+      }
+      const sideEffects: SideEffectsDiff = {
+        added: new Map(hydrated.map(([filePath, stored]) => [filePath, stored.fileInfo])),
+        deleted: artifact.payload.manifest.deleted,
+        remoteOrigin,
+      }
+      return {
+        added,
+        deleted: artifact.payload.manifest.deleted,
+        envelopeDigest: artifact.envelopeDigest,
+        sideEffects,
+      }
     } catch (err: unknown) {
+      if (isBlobIntegrityError(err)) {
+        quarantine(candidate.key, artifact.envelopeDigest, errorMessage(err))
+        return undefined
+      }
       opts.warn?.(`Remote side-effects artifact for ${candidate.package.name}@${candidate.package.version} was rejected: ${errorMessage(err)}`)
       return undefined
     }
+  }
+
+  async function storedArtifactEnvelopeDigest (
+    diff: SideEffectsDiff,
+    files: { added?: Map<string, string>, deleted?: string[] },
+    candidate: ArtifactCandidate,
+    pinnedEnvelopeDigest: string | undefined
+  ): Promise<string | undefined> {
+    const origin = diff.remoteOrigin
+    if (
+      origin == null ||
+      origin.verification !== 'verified' ||
+      origin.signerKeyId !== origin.envelope.keyId
+    ) return undefined
+    const publicKey = trustedKeys[origin.signerKeyId]
+    if (publicKey == null) return undefined
+    try {
+      const artifact = verifyStoredSharedSideEffects({
+        candidate,
+        envelope: origin.envelope as SignedArtifactEnvelope,
+        pinnedEnvelopeDigest,
+        publicKey,
+        supportedTags,
+      })
+      if (!ownersMatch(origin.owner, artifact.payload.owner) ||
+        !builderProfilesMatch(origin.builderProfile, artifact.payload.builderProfile) ||
+        !manifestMatchesDiff(artifact.payload.manifest, diff)) return undefined
+      const validFiles = await Promise.all(Array.from(diff.added ?? [], async ([filePath, info]) => {
+        return storeLookupLimit(async () => {
+          const located = await opts.storeController.locateFileInStore?.(info.digest, info.mode)
+          return located != null &&
+            files.added?.get(filePath) === located &&
+            (await fs.stat(located)).size === info.size
+        })
+      }))
+      return validFiles.every(Boolean) ? artifact.envelopeDigest : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  function quarantine (inputKey: string, envelopeDigest: string, reason: string): void {
+    if (registryUrl == null) return
+    let quarantined = quarantinedEnvelopeDigests.get(inputKey)
+    if (quarantined == null) {
+      quarantined = new Set()
+      quarantinedEnvelopeDigests.set(inputKey, quarantined)
+    }
+    if (quarantined.has(envelopeDigest)) return
+    quarantined.add(envelopeDigest)
+    for (const filesIndexFile of filesIndexFilesByInputKey.get(inputKey) ?? []) {
+      try {
+        opts.storeController.quarantineRemoteSideEffects?.({
+          channel: registryUrl,
+          envelopeDigest,
+          filesIndexFile,
+        })
+      } catch (err: unknown) {
+        opts.warn?.(`Remote side-effects quarantine could not be persisted: ${errorMessage(err)}`)
+      }
+    }
+    opts.warn?.(`Remote side-effects artifact was quarantined: ${reason}`)
   }
 
   function recordArtifactPin (depPath: DepPath, inputKey: string, envelopeDigest: string): void {
@@ -500,4 +675,52 @@ function verifiedIntegrity (resolution: LockfileResolution): string | undefined 
 
 function errorMessage (err: unknown): string {
   return util.types.isNativeError(err) ? err.message : String(err)
+}
+
+function isBlobIntegrityError (err: unknown): boolean {
+  return util.types.isNativeError(err) &&
+    'code' in err &&
+    err.code === 'ERR_PNPM_SHARED_ARTIFACT_BLOB_INTEGRITY'
+}
+
+function ownersMatch (
+  left: RemoteSideEffectsOrigin['owner'],
+  right: ArtifactPayload['owner']
+): boolean {
+  if (left.type !== right.type) return false
+  return left.type === 'organization'
+    ? left.name === (right as { type: 'organization', name: string }).name
+    : left.package === (right as { type: 'publisher', package: string }).package
+}
+
+function builderProfilesMatch (
+  left: RemoteSideEffectsOrigin['builderProfile'],
+  right: ArtifactPayload['builderProfile']
+): boolean {
+  if (
+    left.imageDigest !== right.imageDigest ||
+    left.architectureBaseline !== right.architectureBaseline
+  ) return false
+  const leftEnvironment = Object.entries(left.environment)
+  const rightEnvironment = Object.entries(right.environment)
+  return leftEnvironment.length === rightEnvironment.length &&
+    leftEnvironment.every(([name, value]) => right.environment[name] === value)
+}
+
+function manifestMatchesDiff (manifest: ArtifactManifest, diff: SideEffectsDiff): boolean {
+  const added = diff.added ?? new Map()
+  if (added.size !== manifest.added.length) return false
+  for (const file of manifest.added) {
+    const stored = added.get(file.path)
+    if (
+      stored == null ||
+      stored.digest !== artifactBlobDigest(file.integrity) ||
+      stored.mode !== file.mode ||
+      stored.size !== file.size
+    ) return false
+  }
+  const deleted = diff.deleted ?? []
+  return deleted.length === manifest.deleted.length &&
+    new Set(deleted).size === deleted.length &&
+    deleted.every(path => manifest.deleted.includes(path))
 }

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -215,12 +215,18 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       if (storedDiff?.remoteOrigin == null) {
         if (opts.sideEffectsCacheRead) return undefined
       } else {
-        const envelopeDigest = await storedArtifactEnvelopeDigest({
-          candidate,
-          diff: storedDiff,
-          files: localSideEffects,
-          pinnedEnvelopeDigest,
-        })
+        let envelopeDigest: string | undefined
+        try {
+          envelopeDigest = await storedArtifactEnvelopeDigest({
+            candidate,
+            diff: storedDiff,
+            files: localSideEffects,
+            pinnedEnvelopeDigest,
+          })
+        } catch (err: unknown) {
+          opts.warn?.(`Persisted remote side-effects artifact for ${node.name}@${node.version} could not be checked: ${errorMessage(err)}`)
+          return undefined
+        }
         if (envelopeDigest != null) {
           recordArtifactPin(node.depPath, inputKey, envelopeDigest)
           return localCacheKey
@@ -252,7 +258,13 @@ export function createRemoteSideEffectsRestorer<T extends string> (
         quarantined = new Set()
         quarantinedEnvelopeDigests.set(inputKey, quarantined)
       }
-      for (const digest of storedQuarantine) quarantined.add(digest)
+      for (const digest of storedQuarantine) {
+        if (quarantined.has(digest)) continue
+        quarantined.add(digest)
+        for (const filesIndexFile of filesIndexFilesByInputKey.get(inputKey) ?? []) {
+          if (filesIndexFile !== node.filesIndexFile) persistQuarantine(filesIndexFile, digest)
+        }
+      }
     }
 
     let lookup = lookups.get(inputKey)
@@ -271,6 +283,7 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       opts.warn?.(`Pinned remote side-effects artifact for ${node.name}@${node.version} is unavailable; building locally`)
       return undefined
     }
+    if (quarantinedEnvelopeDigests.get(inputKey)?.has(resolvedArtifact.envelopeDigest) === true) return undefined
     const artifact = await artifactLimit(async () => hydrate(resolvedArtifact, candidate))
     if (artifact == null) return undefined
     recordArtifactPin(node.depPath, inputKey, artifact.envelopeDigest)
@@ -493,29 +506,30 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     ) return undefined
     const publicKey = trustedKeys[origin.signerKeyId]
     if (publicKey == null) return undefined
+    let artifact: VerifiedArtifact
     try {
-      const artifact = verifyStoredSharedSideEffects({
+      artifact = verifyStoredSharedSideEffects({
         candidate,
         envelope: origin.envelope as SignedArtifactEnvelope,
         pinnedEnvelopeDigest,
         publicKey,
         supportedTags,
       })
-      if (!ownersMatch(origin.owner, artifact.payload.owner) ||
-        !builderProfilesMatch(origin.builderProfile, artifact.payload.builderProfile) ||
-        !manifestMatchesDiff(artifact.payload.manifest, diff)) return undefined
-      const validFiles = await Promise.all(Array.from(diff.added ?? [], async ([filePath, info]) => {
-        return storeLookupLimit(async () => {
-          const located = await opts.storeController.locateFileInStore?.(info.digest, info.mode)
-          return located != null &&
-            files.added?.get(filePath) === located &&
-            (await fs.stat(located)).size === info.size
-        })
-      }))
-      return validFiles.every(Boolean) ? artifact.envelopeDigest : undefined
     } catch {
       return undefined
     }
+    if (!ownersMatch(origin.owner, artifact.payload.owner) ||
+      !builderProfilesMatch(origin.builderProfile, artifact.payload.builderProfile) ||
+      !manifestMatchesDiff(artifact.payload.manifest, diff)) return undefined
+    const validFiles = await Promise.all(Array.from(diff.added ?? [], async ([filePath, info]) => {
+      return storeLookupLimit(async () => {
+        const located = await opts.storeController.locateFileInStore?.(info.digest, info.mode)
+        return located != null &&
+          files.added?.get(filePath) === located &&
+          (await fs.stat(located)).size === info.size
+      })
+    }))
+    return validFiles.every(Boolean) ? artifact.envelopeDigest : undefined
   }
 
   function quarantine (inputKey: string, envelopeDigest: string, reason: string): void {

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -470,7 +470,8 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     if (
       origin == null ||
       origin.verification !== 'verified' ||
-      origin.signerKeyId !== origin.envelope.keyId
+      origin.signerKeyId !== origin.envelope.keyId ||
+      (registryUrl != null && origin.channel !== registryUrl)
     ) return undefined
     const publicKey = trustedKeys[origin.signerKeyId]
     if (publicKey == null) return undefined

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -215,7 +215,12 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       if (storedDiff?.remoteOrigin == null) {
         if (opts.sideEffectsCacheRead) return undefined
       } else {
-        const envelopeDigest = await storedArtifactEnvelopeDigest(storedDiff, localSideEffects, candidate, pinnedEnvelopeDigest)
+        const envelopeDigest = await storedArtifactEnvelopeDigest({
+          candidate,
+          diff: storedDiff,
+          files: localSideEffects,
+          pinnedEnvelopeDigest,
+        })
         if (envelopeDigest != null) {
           recordArtifactPin(node.depPath, inputKey, envelopeDigest)
           return localCacheKey
@@ -466,12 +471,13 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     }
   }
 
-  async function storedArtifactEnvelopeDigest (
-    diff: SideEffectsDiff,
-    files: { added?: Map<string, string>, deleted?: string[] },
-    candidate: ArtifactCandidate,
-    pinnedEnvelopeDigest: string | undefined
-  ): Promise<string | undefined> {
+  async function storedArtifactEnvelopeDigest (params: {
+    candidate: ArtifactCandidate
+    diff: SideEffectsDiff
+    files: { added?: Map<string, string>, deleted?: string[] }
+    pinnedEnvelopeDigest?: string
+  }): Promise<string | undefined> {
+    const { candidate, diff, files, pinnedEnvelopeDigest } = params
     const origin = diff.remoteOrigin
     if (
       origin == null ||

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -99,7 +99,7 @@ interface RestoredArtifact {
 
 interface QueuedLookup {
   candidate: ArtifactCandidate
-  resolve: (artifact: RestoredArtifact | undefined) => void
+  resolve: (artifact: VerifiedArtifact | undefined) => void
 }
 
 export function canRestoreRemoteSideEffects (opts: RemoteSideEffectsPrerequisites): boolean {
@@ -148,7 +148,7 @@ export function createRemoteSideEffectsRestorer<T extends string> (
   const storedBlobs = new Map<string, Promise<{ filePath: string, fileInfo: { checkedAt?: number, digest: string, mode: number, size: number } }>>()
   const identityByInputKey = new Map<string, string>()
   const collisions = new Set<string>()
-  const lookups = new Map<string, Promise<RestoredArtifact | undefined>>()
+  const lookups = new Map<string, Promise<VerifiedArtifact | undefined>>()
   const filesIndexFilesByInputKey = new Map<string, Set<string>>()
   const quarantinedEnvelopeDigests = new Map<string, Set<string>>()
   let queued: QueuedLookup[] = []
@@ -249,13 +249,19 @@ export function createRemoteSideEffectsRestorer<T extends string> (
       lookup = enqueue(candidate)
       lookups.set(inputKey, lookup)
     }
-    const artifact = await lookup
-    if (artifact == null) {
+    const resolvedArtifact = await lookup
+    if (resolvedArtifact == null) {
       if (pinnedEnvelopeDigests.has(inputKey)) {
         opts.warn?.(`Pinned remote side-effects artifact for ${node.name}@${node.version} is unavailable; building locally`)
       }
       return undefined
     }
+    if (pinnedEnvelopeDigest != null && resolvedArtifact.envelopeDigest !== pinnedEnvelopeDigest) {
+      opts.warn?.(`Pinned remote side-effects artifact for ${node.name}@${node.version} is unavailable; building locally`)
+      return undefined
+    }
+    const artifact = await artifactLimit(async () => hydrate(resolvedArtifact, candidate))
+    if (artifact == null) return undefined
     recordArtifactPin(node.depPath, inputKey, artifact.envelopeDigest)
     node.files.sideEffectsMaps ??= new Map()
     node.files.sideEffectsMaps.set(localCacheKey, { added: artifact.added, deleted: artifact.deleted })
@@ -275,9 +281,9 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     return localCacheKey
   }
 
-  async function enqueue (candidate: ArtifactCandidate): Promise<RestoredArtifact | undefined> {
-    let resolve!: (artifact: RestoredArtifact | undefined) => void
-    const promise = new Promise<RestoredArtifact | undefined>((settle) => {
+  async function enqueue (candidate: ArtifactCandidate): Promise<VerifiedArtifact | undefined> {
+    let resolve!: (artifact: VerifiedArtifact | undefined) => void
+    const promise = new Promise<VerifiedArtifact | undefined>((settle) => {
       resolve = settle
     })
     queued.push({ candidate, resolve })
@@ -358,7 +364,7 @@ export function createRemoteSideEffectsRestorer<T extends string> (
         resolve(undefined)
         return
       }
-      resolve(await artifactLimit(async () => hydrate(artifact, candidate)))
+      resolve(artifact)
     }))
   }
 

--- a/pnpr/client/src/installSharedSideEffects.ts
+++ b/pnpr/client/src/installSharedSideEffects.ts
@@ -237,7 +237,13 @@ export function createRemoteSideEffectsRestorer<T extends string> (
         filesIndexFiles = new Set()
         filesIndexFilesByInputKey.set(inputKey, filesIndexFiles)
       }
+      const isNewFilesIndexFile = !filesIndexFiles.has(node.filesIndexFile)
       filesIndexFiles.add(node.filesIndexFile)
+      if (isNewFilesIndexFile) {
+        for (const digest of quarantinedEnvelopeDigests.get(inputKey) ?? []) {
+          persistQuarantine(node.filesIndexFile, digest)
+        }
+      }
     }
     const storedQuarantine = node.files.remoteSideEffectsQuarantine?.get(registryUrl)
     if (storedQuarantine != null) {
@@ -522,17 +528,22 @@ export function createRemoteSideEffectsRestorer<T extends string> (
     if (quarantined.has(envelopeDigest)) return
     quarantined.add(envelopeDigest)
     for (const filesIndexFile of filesIndexFilesByInputKey.get(inputKey) ?? []) {
-      try {
-        opts.storeController.quarantineRemoteSideEffects?.({
-          channel: registryUrl,
-          envelopeDigest,
-          filesIndexFile,
-        })
-      } catch (err: unknown) {
-        opts.warn?.(`Remote side-effects quarantine could not be persisted: ${errorMessage(err)}`)
-      }
+      persistQuarantine(filesIndexFile, envelopeDigest)
     }
     opts.warn?.(`Remote side-effects artifact was quarantined: ${reason}`)
+  }
+
+  function persistQuarantine (filesIndexFile: string, envelopeDigest: string): void {
+    if (registryUrl == null) return
+    try {
+      opts.storeController.quarantineRemoteSideEffects?.({
+        channel: registryUrl,
+        envelopeDigest,
+        filesIndexFile,
+      })
+    } catch (err: unknown) {
+      opts.warn?.(`Remote side-effects quarantine could not be persisted: ${errorMessage(err)}`)
+    }
   }
 
   function recordArtifactPin (depPath: DepPath, inputKey: string, envelopeDigest: string): void {

--- a/pnpr/client/src/sharedSideEffects.ts
+++ b/pnpr/client/src/sharedSideEffects.ts
@@ -2,7 +2,7 @@ import { createHash, createPrivateKey, createPublicKey, KeyObject, sign as crypt
 import http from 'node:http'
 import https from 'node:https'
 import { URL } from 'node:url'
-import { TextDecoder } from 'node:util'
+import util, { TextDecoder } from 'node:util'
 
 export const ARTIFACT_KIND = 'dependency-side-effects:v1'
 export const INPUT_KEY_PREFIX = 'dependency-side-effects:v1:'
@@ -105,6 +105,14 @@ export interface VerifiedArtifact {
   envelopeDigest: string
 }
 
+export interface VerifyStoredSharedSideEffectsOptions {
+  candidate: ArtifactCandidate
+  envelope: SignedArtifactEnvelope
+  pinnedEnvelopeDigest?: string
+  publicKey: string
+  supportedTags: string[]
+}
+
 export interface CreateSignedArtifactEnvelopeOptions {
   keyId: string
   privateKey: string | Buffer | KeyObject
@@ -131,6 +139,12 @@ export interface ResolveSharedSideEffectsOptions {
   /** Base64-encoded P-256 SubjectPublicKeyInfo DER, keyed by key id. */
   trustedKeys: Record<string, string>
   pinnedEnvelopeDigests?: ReadonlyMap<string, string>
+  quarantinedEnvelopeDigests?: ReadonlyMap<string, ReadonlySet<string>>
+  onRejectedArtifact?: (rejection: {
+    inputKey: string
+    envelopeDigest: string
+    reason: string
+  }) => void
 }
 
 interface ArtifactVariant {
@@ -251,10 +265,25 @@ export async function resolveSharedSideEffects (
     for (const variant of artifact.variants) {
       const publicKey = opts.trustedKeys[variant.envelope.keyId]
       if (publicKey == null) continue
+      let decoded: DecodedEnvelopeFields
+      try {
+        decoded = decodeEnvelopeFields(variant.envelope)
+        verifyEnvelopeSignature(decoded, publicKey)
+      } catch {
+        continue
+      }
+      const digest = digestDecodedEnvelope(variant.envelope, decoded)
+      if (opts.quarantinedEnvelopeDigests?.get(candidate.key)?.has(digest) === true) continue
       let payload: ArtifactPayload
       try {
-        payload = verifySignedArtifactEnvelope(variant.envelope, publicKey)
-      } catch {
+        payload = decodeArtifactPayload(decoded.payloadBytes)
+        validatePayload(payload)
+      } catch (err: unknown) {
+        opts.onRejectedArtifact?.({
+          inputKey: candidate.key,
+          envelopeDigest: digest,
+          reason: errorMessage(err),
+        })
         continue
       }
       if (
@@ -266,7 +295,6 @@ export async function resolveSharedSideEffects (
       ) continue
       const rank = compatibilityRank(payload.compatibility, opts.supportedTags)
       if (rank == null) continue
-      const digest = signedArtifactEnvelopeDigest(variant.envelope)
       const pinnedDigest = opts.pinnedEnvelopeDigests?.get(candidate.key)
       if (pinnedDigest != null && digest !== pinnedDigest) continue
       if (
@@ -295,11 +323,42 @@ export function ownerNamespace (owner: OwnerScope): string {
     : `publisher:${owner.package}`
 }
 
+export function verifyStoredSharedSideEffects (
+  opts: VerifyStoredSharedSideEffectsOptions
+): VerifiedArtifact {
+  const payload = verifySignedArtifactEnvelope(opts.envelope, opts.publicKey)
+  if (
+    payload.inputKey !== opts.candidate.key ||
+    payload.package.name !== opts.candidate.package.name ||
+    payload.package.version !== opts.candidate.package.version ||
+    payload.sourceIntegrity !== opts.candidate.sourceIntegrity ||
+    !ownersEqual(payload.owner, opts.candidate.owner) ||
+    compatibilityRank(payload.compatibility, opts.supportedTags) == null
+  ) {
+    throw new Error('Stored shared artifact no longer matches the package or consumer')
+  }
+  const envelopeDigest = signedArtifactEnvelopeDigest(opts.envelope)
+  if (opts.pinnedEnvelopeDigest != null && envelopeDigest !== opts.pinnedEnvelopeDigest) {
+    throw new Error('Stored shared artifact does not match the lockfile pin')
+  }
+  return { payload, envelope: opts.envelope, envelopeDigest }
+}
+
 export function verifySignedArtifactEnvelope (
   envelope: SignedArtifactEnvelope,
   publicKeySpki: string
 ): ArtifactPayload {
-  const { payload, payloadBytes, signatureBytes } = decodeEnvelope(envelope)
+  const decoded = decodeEnvelopeFields(envelope)
+  verifyEnvelopeSignature(decoded, publicKeySpki)
+  const payload = decodeArtifactPayload(decoded.payloadBytes)
+  validatePayload(payload)
+  return payload
+}
+
+function verifyEnvelopeSignature (
+  { payloadBytes, signatureBytes }: DecodedEnvelopeFields,
+  publicKeySpki: string
+): void {
   const publicKey = createPublicKey({
     key: Buffer.from(publicKeySpki, 'base64'),
     format: 'der',
@@ -311,7 +370,6 @@ export function verifySignedArtifactEnvelope (
   if (!cryptoVerify('sha256', payloadBytes, publicKey, signatureBytes)) {
     throw new Error('Shared artifact signature verification failed')
   }
-  return payload
 }
 
 export async function downloadSharedArtifactBlob (
@@ -332,8 +390,16 @@ export async function downloadSharedArtifactBlob (
     maxResponseSize: MAX_FILE_SIZE,
   })
   assertSuccess(response, '/-/pnpr/v0/artifacts/blob')
-  verifyBlob(opts.request.integrity, response.body)
+  try {
+    verifyBlob(opts.request.integrity, response.body)
+  } catch (err: unknown) {
+    throw new SharedArtifactBlobIntegrityError(errorMessage(err))
+  }
   return response.body
+}
+
+export class SharedArtifactBlobIntegrityError extends Error {
+  public readonly code = 'ERR_PNPM_SHARED_ARTIFACT_BLOB_INTEGRITY'
 }
 
 function serializePublishRequest (opts: PublishSharedSideEffectsOptions): Buffer {
@@ -390,11 +456,12 @@ function serializePublishRequest (opts: PublishSharedSideEffectsOptions): Buffer
   return body
 }
 
-function decodeEnvelope (envelope: SignedArtifactEnvelope): {
-  payload: ArtifactPayload
+interface DecodedEnvelopeFields {
   payloadBytes: Buffer
   signatureBytes: Buffer
-} {
+}
+
+function decodeEnvelopeFields (envelope: SignedArtifactEnvelope): DecodedEnvelopeFields {
   if (envelope.algorithm !== SIGNATURE_ALGORITHM) {
     throw new Error(`Unsupported shared artifact signature algorithm ${JSON.stringify(envelope.algorithm)}`)
   }
@@ -411,13 +478,28 @@ function decodeEnvelope (envelope: SignedArtifactEnvelope): {
   }
   const signatureBytes = decodeBase64('signature', envelope.signature)
   validateP256DerSignature(signatureBytes)
-  const payload = JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(payloadBytes)) as ArtifactPayload
+  return { payloadBytes, signatureBytes }
+}
+
+function decodeEnvelope (envelope: SignedArtifactEnvelope): DecodedEnvelopeFields & { payload: ArtifactPayload } {
+  const decoded = decodeEnvelopeFields(envelope)
+  const payload = decodeArtifactPayload(decoded.payloadBytes)
   validatePayload(payload)
-  return { payload, payloadBytes, signatureBytes }
+  return { ...decoded, payload }
+}
+
+function decodeArtifactPayload (payloadBytes: Buffer): ArtifactPayload {
+  return JSON.parse(new TextDecoder('utf-8', { fatal: true }).decode(payloadBytes)) as ArtifactPayload
 }
 
 export function signedArtifactEnvelopeDigest (envelope: SignedArtifactEnvelope): string {
-  const { payloadBytes, signatureBytes } = decodeEnvelope(envelope)
+  return digestDecodedEnvelope(envelope, decodeEnvelopeFields(envelope))
+}
+
+function digestDecodedEnvelope (
+  envelope: SignedArtifactEnvelope,
+  { payloadBytes, signatureBytes }: DecodedEnvelopeFields
+): string {
   return createHash('sha256')
     .update('pnpm-shared-artifact-envelope-v1\0')
     .update(envelope.algorithm)
@@ -428,6 +510,10 @@ export function signedArtifactEnvelopeDigest (envelope: SignedArtifactEnvelope):
     .update('\0')
     .update(signatureBytes)
     .digest('hex')
+}
+
+function errorMessage (err: unknown): string {
+  return util.types.isNativeError(err) ? err.message : String(err)
 }
 
 function validatePayload (payload: ArtifactPayload): void {

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -18,7 +18,7 @@ import {
   type SignedArtifactEnvelope,
   verifySignedArtifactEnvelope,
 } from '@pnpm/pnpr.client'
-import type { PackageFilesResponse, StoreController } from '@pnpm/store.controller-types'
+import type { PackageFilesResponse, SideEffectsDiff, StoreController } from '@pnpm/store.controller-types'
 import type { DepPath } from '@pnpm/types'
 
 const packageName = 'native-addon'
@@ -38,6 +38,8 @@ describe('install remote side-effects', () => {
       'acme-2026': publicKey.export({ format: 'der', type: 'spki' }).toString('base64'),
     }
     const requestedPaths: string[] = []
+    const serverState = { corruptBlob: false }
+    const envelopesByKey = new Map<string, SignedArtifactEnvelope>()
     let heldResolve: { wait: Promise<void>, notifyStarted: () => void } | undefined
     const server = createServer((request, response) => {
       const chunks: Buffer[] = []
@@ -87,14 +89,17 @@ describe('install remote side-effects', () => {
                 deleted: ['src/intermediate.o'],
               },
             }
+            let envelope = envelopesByKey.get(candidate.key)
+            if (envelope == null) {
+              envelope = createSignedArtifactEnvelope(payload, {
+                keyId: 'acme-2026',
+                privateKey,
+              })
+              envelopesByKey.set(candidate.key, envelope)
+            }
             return {
               key: candidate.key,
-              variants: [{
-                envelope: createSignedArtifactEnvelope(payload, {
-                  keyId: 'acme-2026',
-                  privateKey,
-                }),
-              }],
+              variants: [{ envelope }],
             }
           })
           const sendResponse = (): void => {
@@ -112,7 +117,8 @@ describe('install remote side-effects', () => {
           return
         }
         if (request.url === '/-/pnpr/v0/artifacts/blob') {
-          response.writeHead(200, { 'content-type': 'application/octet-stream' }).end(builtFile)
+          response.writeHead(200, { 'content-type': 'application/octet-stream' })
+            .end(serverState.corruptBlob ? Buffer.from('corrupt') : builtFile)
           return
         }
         response.writeHead(404).end()
@@ -125,7 +131,14 @@ describe('install remote side-effects', () => {
       resolvedFrom: 'remote',
     }
     const storedFiles: Array<{ bytes: Buffer, mode: number }> = []
+    const persisted: Array<{ filesIndexFile: string, sideEffectsCacheKey: string, sideEffects: SideEffectsDiff }> = []
+    const quarantined: Array<{ channel: string, envelopeDigest: string, filesIndexFile: string }> = []
     const alreadyInStore = new Map<string, string>()
+    const alreadyStoredFile = path.join(
+      await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-shared-side-effects-store-')),
+      'addon.node'
+    )
+    await fs.writeFile(alreadyStoredFile, builtFile)
     const storeController = {
       addFileToStore: (bytes: Buffer, mode: number) => {
         storedFiles.push({ bytes, mode })
@@ -136,6 +149,14 @@ describe('install remote side-effects', () => {
         }
       },
       locateFileInStore: async (hexDigest: string, mode: number) => alreadyInStore.get(`${hexDigest}\0${mode}`),
+      persistRemoteSideEffects: (entry: typeof persisted[number]) => {
+        persisted.push(entry)
+        return true
+      },
+      quarantineRemoteSideEffects: (entry: typeof quarantined[number]) => {
+        quarantined.push(entry)
+        return true
+      },
     } as unknown as StoreController
     const depsGraph: DepsGraph<typeof graphKey> = {
       [graphKey]: {
@@ -184,6 +205,7 @@ describe('install remote side-effects', () => {
         graphKey,
         depPath,
         files,
+        filesIndexFile: 'package-index-row',
         name: packageName,
         resolution: { integrity: sourceIntegrity } as LockfileResolution,
         version: packageVersion,
@@ -209,6 +231,18 @@ describe('install remote side-effects', () => {
       expect(Object.keys(ownerPins ?? {})[0]).toMatch(/^[a-f0-9]{64}$/)
       expect(Object.values(ownerPins ?? {})[0]).toMatch(/^[a-f0-9]{64}$/)
       expect(artifactPinsChanged).toBe(1)
+      expect(persisted).toHaveLength(1)
+      expect(persisted[0]).toMatchObject({
+        filesIndexFile: 'package-index-row',
+        sideEffectsCacheKey: cacheKey,
+        sideEffects: {
+          remoteOrigin: {
+            channel: pnprServer,
+            signerKeyId: 'acme-2026',
+            verification: 'verified',
+          },
+        },
+      })
       expect(requestedPaths).toEqual([
         '/-/pnpr',
         '/-/pnpr/v0/artifacts/resolve',
@@ -219,7 +253,7 @@ describe('install remote side-effects', () => {
       // digest the manifest carries, so a second restore transfers nothing.
       alreadyInStore.set(
         `${createHash('sha512').update(builtFile).digest('hex')}\0${0o755}`,
-        '/store/cafs/already-there'
+        alreadyStoredFile
       )
       storedFiles.length = 0
       requestedPaths.length = 0
@@ -248,9 +282,68 @@ describe('install remote side-effects', () => {
         version: packageVersion,
       })
       expect(reusedFiles.sideEffectsMaps?.get(reusedKey!)?.added?.get('build/addon.node'))
-        .toBe('/store/cafs/already-there')
+        .toBe(alreadyStoredFile)
       expect(storedFiles).toEqual([])
       expect(requestedPaths).not.toContain('/-/pnpr/v0/artifacts/blob')
+
+      requestedPaths.length = 0
+      const persistedFiles: PackageFilesResponse = {
+        filesMap: new Map(),
+        requiresBuild: true,
+        resolvedFrom: 'store',
+        sideEffectsMaps: new Map([[cacheKey!, {
+          added: new Map([
+            ['build/addon.node', alreadyStoredFile],
+            ['build/addon-copy.node', alreadyStoredFile],
+          ]),
+          deleted: ['src/intermediate.o'],
+        }]]),
+        sideEffectsDiffs: new Map([[cacheKey!, persisted[0].sideEffects]]),
+      }
+      const offlineReuse = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })
+      await expect(offlineReuse?.restore({
+        graphKey,
+        depPath,
+        files: persistedFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBe(cacheKey)
+      expect(requestedPaths).toEqual([])
+
+      const rejectedPersistedFiles: PackageFilesResponse = {
+        ...persistedFiles,
+        sideEffectsMaps: new Map(persistedFiles.sideEffectsMaps),
+        sideEffectsDiffs: new Map(persistedFiles.sideEffectsDiffs),
+      }
+      const changedTrust = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys: { replacement: trustedKeys['acme-2026'] } },
+        sideEffectsCacheRead: true,
+        storeController,
+      })
+      await expect(changedTrust?.restore({
+        graphKey,
+        depPath,
+        files: rejectedPersistedFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(rejectedPersistedFiles.sideEffectsMaps?.has(cacheKey!)).toBe(false)
 
       const platformFingerprint = Object.keys(owners['organization:acme'])[0]
       const unrelatedPinLockfile: LockfileObject = {
@@ -420,6 +513,63 @@ describe('install remote side-effects', () => {
       const restored = await Promise.all([first, second])
       expect(restored.every((key) => key != null)).toBe(true)
       expect(requestedPaths.filter((path) => path === '/-/pnpr/v0/artifacts/resolve')).toHaveLength(1)
+
+      alreadyInStore.clear()
+      serverState.corruptBlob = true
+      requestedPaths.length = 0
+      const corruptRestorer = createRemoteSideEffectsRestorer({
+        allowBuild: () => true,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })!
+      await expect(corruptRestorer.restore({
+        graphKey,
+        depPath,
+        files: { filesMap: new Map(), requiresBuild: true, resolvedFrom: 'remote' },
+        filesIndexFile: 'corrupt-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(quarantined).toEqual([{
+        channel: pnprServer,
+        envelopeDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+        filesIndexFile: 'corrupt-row',
+      }])
+
+      requestedPaths.length = 0
+      const quarantinedRestorer = createRemoteSideEffectsRestorer({
+        allowBuild: () => true,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })!
+      await expect(quarantinedRestorer.restore({
+        graphKey,
+        depPath,
+        files: {
+          filesMap: new Map(),
+          requiresBuild: true,
+          remoteSideEffectsQuarantine: new Map([[pnprServer, [quarantined[0].envelopeDigest]]]),
+          resolvedFrom: 'store',
+        },
+        filesIndexFile: 'corrupt-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(requestedPaths).not.toContain('/-/pnpr/v0/artifacts/blob')
     } finally {
       await new Promise<void>((resolve, reject) => server.close(error => error == null ? resolve() : reject(error)))
     }

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -320,6 +320,34 @@ describe('install remote side-effects', () => {
       })).resolves.toBe(cacheKey)
       expect(requestedPaths).toEqual([])
 
+      requestedPaths.length = 0
+      const changedChannelFiles: PackageFilesResponse = {
+        ...persistedFiles,
+        sideEffectsMaps: new Map(persistedFiles.sideEffectsMaps),
+        sideEffectsDiffs: new Map(persistedFiles.sideEffectsDiffs),
+      }
+      const changedChannel = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer: `${pnprServer}/other`,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: true,
+        storeController,
+      })
+      await expect(changedChannel?.restore({
+        graphKey,
+        depPath,
+        files: changedChannelFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(changedChannelFiles.sideEffectsMaps?.has(cacheKey!)).toBe(false)
+      expect(requestedPaths).toEqual(['/other/-/pnpr'])
+
       const rejectedPersistedFiles: PackageFilesResponse = {
         ...persistedFiles,
         sideEffectsMaps: new Map(persistedFiles.sideEffectsMaps),

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -642,6 +642,28 @@ describe('install remote side-effects', () => {
         filesIndexFile: 'corrupt-row',
       }])
 
+      await expect(corruptRestorer.restore({
+        graphKey,
+        depPath,
+        files: { filesMap: new Map(), requiresBuild: true, resolvedFrom: 'remote' },
+        filesIndexFile: 'late-corrupt-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(quarantined).toEqual([
+        {
+          channel: pnprServer,
+          envelopeDigest: expect.stringMatching(/^[a-f0-9]{64}$/),
+          filesIndexFile: 'corrupt-row',
+        },
+        {
+          channel: pnprServer,
+          envelopeDigest: quarantined[0].envelopeDigest,
+          filesIndexFile: 'late-corrupt-row',
+        },
+      ])
+
       requestedPaths.length = 0
       const quarantinedRestorer = createRemoteSideEffectsRestorer({
         allowBuild: () => true,

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -320,6 +320,42 @@ describe('install remote side-effects', () => {
       })).resolves.toBe(cacheKey)
       expect(requestedPaths).toEqual([])
 
+      const storeProbeWarnings: string[] = []
+      const storeProbeFailureFiles: PackageFilesResponse = {
+        ...persistedFiles,
+        sideEffectsMaps: new Map(persistedFiles.sideEffectsMaps),
+        sideEffectsDiffs: new Map(persistedFiles.sideEffectsDiffs),
+      }
+      const storeProbeFailure = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController: {
+          ...storeController,
+          locateFileInStore: async () => {
+            throw new Error('store unavailable')
+          },
+        } as unknown as StoreController,
+        warn: warning => storeProbeWarnings.push(warning),
+      })
+      await expect(storeProbeFailure?.restore({
+        graphKey,
+        depPath,
+        files: storeProbeFailureFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })).resolves.toBeUndefined()
+      expect(storeProbeFailureFiles.sideEffectsMaps?.has(cacheKey!)).toBe(true)
+      expect(storeProbeFailureFiles.sideEffectsDiffs?.has(cacheKey!)).toBe(true)
+      expect(storeProbeWarnings).toEqual([
+        `Persisted remote side-effects artifact for ${packageName}@${packageVersion} could not be checked: store unavailable`,
+      ])
+
       requestedPaths.length = 0
       const changedChannelFiles: PackageFilesResponse = {
         ...persistedFiles,
@@ -642,6 +678,7 @@ describe('install remote side-effects', () => {
         filesIndexFile: 'corrupt-row',
       }])
 
+      requestedPaths.length = 0
       await expect(corruptRestorer.restore({
         graphKey,
         depPath,
@@ -663,6 +700,7 @@ describe('install remote side-effects', () => {
           filesIndexFile: 'late-corrupt-row',
         },
       ])
+      expect(requestedPaths).not.toContain('/-/pnpr/v0/artifacts/blob')
 
       requestedPaths.length = 0
       const quarantinedRestorer = createRemoteSideEffectsRestorer({
@@ -691,6 +729,58 @@ describe('install remote side-effects', () => {
         version: packageVersion,
       })).resolves.toBeUndefined()
       expect(requestedPaths).not.toContain('/-/pnpr/v0/artifacts/blob')
+
+      let releaseQuarantineImport!: () => void
+      const waitForQuarantineImport = new Promise<void>((resolve) => {
+        releaseQuarantineImport = resolve
+      })
+      let notifyQuarantineResolveStarted!: () => void
+      const quarantineResolveStarted = new Promise<void>((resolve) => {
+        notifyQuarantineResolveStarted = resolve
+      })
+      heldResolve = { wait: waitForQuarantineImport, notifyStarted: notifyQuarantineResolveStarted }
+      const quarantineImportRestorer = createRemoteSideEffectsRestorer({
+        allowBuild: () => true,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })!
+      const quarantineRecipient = quarantineImportRestorer.restore({
+        graphKey,
+        depPath,
+        files: { filesMap: new Map(), requiresBuild: true, resolvedFrom: 'remote' },
+        filesIndexFile: 'quarantine-recipient-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })
+      await quarantineResolveStarted
+      const quarantineSource = quarantineImportRestorer.restore({
+        graphKey,
+        depPath,
+        files: {
+          filesMap: new Map(),
+          requiresBuild: true,
+          remoteSideEffectsQuarantine: new Map([[pnprServer, [quarantined[0].envelopeDigest]]]),
+          resolvedFrom: 'store',
+        },
+        filesIndexFile: 'quarantine-source-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })
+      releaseQuarantineImport()
+      await expect(Promise.all([quarantineRecipient, quarantineSource])).resolves.toEqual([undefined, undefined])
+      expect(quarantined).toContainEqual({
+        channel: pnprServer,
+        envelopeDigest: quarantined[0].envelopeDigest,
+        filesIndexFile: 'quarantine-recipient-row',
+      })
     } finally {
       await new Promise<void>((resolve, reject) => server.close(error => error == null ? resolve() : reject(error)))
     }

--- a/pnpr/client/test/installSharedSideEffects.test.ts
+++ b/pnpr/client/test/installSharedSideEffects.test.ts
@@ -416,6 +416,77 @@ describe('install remote side-effects', () => {
       })
       expect(snapshotScopedKey).toBeDefined()
 
+      let releaseLatePinResolve!: () => void
+      const waitForLatePinRelease = new Promise<void>((resolve) => {
+        releaseLatePinResolve = resolve
+      })
+      let notifyLatePinResolveStarted!: () => void
+      const latePinResolveStarted = new Promise<void>((resolve) => {
+        notifyLatePinResolveStarted = resolve
+      })
+      heldResolve = { wait: waitForLatePinRelease, notifyStarted: notifyLatePinResolveStarted }
+      const latePinnedDepPath = `${depPath}(peer@2.0.0)` as DepPath
+      const latePinsLockfile: LockfileObject = {
+        lockfileVersion: '9.0',
+        importers: {},
+        packages: {
+          [depPath]: { resolution: { integrity: sourceIntegrity } },
+          [latePinnedDepPath]: {
+            artifactPins: {
+              [inputKey]: {
+                'organization:acme': { [platformFingerprint]: '0'.repeat(64) },
+              },
+            },
+            resolution: { integrity: sourceIntegrity },
+          },
+        },
+      }
+      const latePinRestorer = createRemoteSideEffectsRestorer({
+        allowBuild: candidate => candidate === depPath || candidate === latePinnedDepPath,
+        artifactPinsLockfile: latePinsLockfile,
+        configByUri: {},
+        depsGraph,
+        depsStateCache: {},
+        ignoreScripts: false,
+        pnprServer,
+        settings: { organization: 'acme', packages: [packageName], trustedKeys },
+        sideEffectsCacheRead: false,
+        storeController,
+      })!
+      const unpinnedFiles: PackageFilesResponse = {
+        filesMap: new Map(),
+        requiresBuild: true,
+        resolvedFrom: 'remote',
+      }
+      const unpinnedRestore = latePinRestorer.restore({
+        graphKey,
+        depPath,
+        files: unpinnedFiles,
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })
+      await latePinResolveStarted
+      const latePinnedFiles: PackageFilesResponse = {
+        filesMap: new Map(),
+        requiresBuild: true,
+        resolvedFrom: 'remote',
+      }
+      const latePinnedRestore = latePinRestorer.restore({
+        graphKey,
+        depPath: latePinnedDepPath,
+        files: latePinnedFiles,
+        filesIndexFile: 'late-pin-row',
+        name: packageName,
+        resolution: { integrity: sourceIntegrity } as LockfileResolution,
+        version: packageVersion,
+      })
+      releaseLatePinResolve()
+      await expect(unpinnedRestore).resolves.toBeDefined()
+      await expect(latePinnedRestore).resolves.toBeUndefined()
+      expect(latePinnedFiles.sideEffectsMaps).toBeUndefined()
+      expect(persisted.some(({ filesIndexFile }) => filesIndexFile === 'late-pin-row')).toBe(false)
+
       let releaseResolve!: () => void
       const waitForRelease = new Promise<void>((resolve) => {
         releaseResolve = resolve

--- a/pnpr/client/test/sharedSideEffects.test.ts
+++ b/pnpr/client/test/sharedSideEffects.test.ts
@@ -1,4 +1,4 @@
-import { createHash, generateKeyPairSync } from 'node:crypto'
+import { createHash, generateKeyPairSync, sign } from 'node:crypto'
 import { createServer } from 'node:http'
 
 import { describe, expect, test } from '@jest/globals'
@@ -256,6 +256,13 @@ describe('signed shared artifacts', () => {
       keyId: 'acme-2026',
       privateKey: privateKey.export({ format: 'pem', type: 'pkcs8' }),
     })
+    const malformedPayload = Buffer.from('{')
+    const malformedEnvelope = {
+      algorithm: 'ecdsa-p256-sha256' as const,
+      keyId: 'acme-2026',
+      payload: malformedPayload.toString('base64'),
+      signature: sign('sha256', malformedPayload, privateKey).toString('base64'),
+    }
     const variants = [envelope, alternateEnvelope]
       .sort((left, right) => signedArtifactEnvelopeDigest(right).localeCompare(signedArtifactEnvelopeDigest(left)))
     const requests: Array<{ url: string | undefined, authorization: string | undefined, body: Buffer }> = []
@@ -274,7 +281,7 @@ describe('signed shared artifacts', () => {
           const body = JSON.stringify({
             artifacts: [{
               key: payload().inputKey,
-              variants: variants.map(envelope => ({ envelope })),
+              variants: [...variants, malformedEnvelope].map(envelope => ({ envelope })),
             }],
           })
           response.writeHead(200, { 'content-type': 'application/json' }).end(body)
@@ -340,6 +347,26 @@ describe('signed shared artifacts', () => {
           .map(signedArtifactEnvelopeDigest)
           .sort()[0]
       )
+      const selectedDigest = selected.get(payload().inputKey)!.envelopeDigest
+      const rejected: Array<{ inputKey: string, envelopeDigest: string, reason: string }> = []
+      await resolveSharedSideEffects({
+        ...resolveOptions,
+        onRejectedArtifact: rejection => rejected.push(rejection),
+      })
+      expect(rejected).toHaveLength(1)
+      expect(rejected[0]).toMatchObject({
+        inputKey: payload().inputKey,
+        envelopeDigest: signedArtifactEnvelopeDigest(malformedEnvelope),
+      })
+      const afterQuarantine = await resolveSharedSideEffects({
+        ...resolveOptions,
+        quarantinedEnvelopeDigests: new Map([[payload().inputKey, new Set([selectedDigest])]]),
+      })
+      expect(afterQuarantine.get(payload().inputKey)?.envelopeDigest).toBe(
+        [envelope, alternateEnvelope]
+          .map(signedArtifactEnvelopeDigest)
+          .find(digest => digest !== selectedDigest)
+      )
       const pinnedDigest = signedArtifactEnvelopeDigest(alternateEnvelope)
       const pinned = await resolveSharedSideEffects({
         ...resolveOptions,
@@ -357,6 +384,8 @@ describe('signed shared artifacts', () => {
       })).resolves.toEqual(contents)
       expect(requests.map(request => request.url)).toEqual([
         '/-/pnpr/v0/artifacts',
+        '/-/pnpr/v0/artifacts/resolve',
+        '/-/pnpr/v0/artifacts/resolve',
         '/-/pnpr/v0/artifacts/resolve',
         '/-/pnpr/v0/artifacts/resolve',
         '/-/pnpr/v0/artifacts/resolve',


### PR DESCRIPTION
## Summary

- Persist verified remote build-artifact diffs in the shared store together with their signed envelope, owner, signer, builder profile, and channel metadata.
- Reverify persisted artifacts against current trust, package identity, source integrity, compatibility, lockfile pins, manifest contents, and actual CAS blobs before every reuse, including offline and frozen-store installs.
- Quarantine trusted malformed artifacts and corrupt blob responses per channel, retaining the newest 64 envelope digests, while network and local I/O failures continue to fall back without poisoning the channel.
- Implement the same store format and reuse policy in the TypeScript CLI and pacquet.

Related to pnpm/pnpm#13771.

## Squash Commit Body

```text
Persist the signed origin metadata for hydrated remote build artifacts in each package's store-index row. This lets later installs reuse a verified artifact without contacting pnpr, while preserving enough evidence to reevaluate the artifact under the consumer's current trust configuration.

Before reuse, verify the envelope signature, signer, owner, package identity, source integrity, input key, compatibility constraints, lockfile pin, builder profile, manifest-to-diff mapping, and the digest and size of every stored CAS blob. Remote entries do not pass through the ordinary local side-effects-cache path when this verification is unavailable or fails.

Track trusted invalid manifests and corrupt remote blobs in a bounded per-channel quarantine stored alongside the package index. Keep transient network, server, and local filesystem failures out of quarantine so they can recover normally. Frozen stores may reuse valid persisted artifacts but do not hydrate, persist, or quarantine.

Apply the same behavior and serialized metadata shape to the TypeScript CLI and pacquet.

Related to pnpm/pnpm#13771.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790461307&installation_model_id=426870&pr_number=14259&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14259&signature=de09ac4868389648b646fe8a418e66976ef5ba7776fa8b43d476f6775404838d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote build artifacts are persisted with signed origin metadata.
  * Stored artifacts are reverified against trust, policy, platform, source, and lockfile requirements.
  * Verified artifacts can be reused offline.
  * Rejected or corrupted artifacts are quarantined by channel.
  * Added atomic store-index updates with rollback handling.
* **Bug Fixes**
  * Improved malformed artifact and blob-integrity handling.
  * Prevented incompatible local cache fallback for remote-origin artifacts.
* **Tests**
  * Expanded coverage for persistence, verification, offline reuse, rejection, and quarantine.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->