### PR TITLE
fix(cli): validate filtered pnpr repairs

### DIFF
--- a/.changeset/repair-pacquet-lockfiles.md
+++ b/.changeset/repair-pacquet-lockfiles.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Recognize `pnpm install --fix-lockfile`, including filtered installs delegated to pnpr, and regenerate broken lockfile metadata while preserving compatible locked versions [pnpm/pnpm#14250](https://github.com/pnpm/pnpm/issues/14250).
+Recognize `pnpm install --fix-lockfile`, including filtered installs, and regenerate broken lockfile metadata while preserving compatible locked versions [pnpm/pnpm#14250](https://github.com/pnpm/pnpm/issues/14250).

--- a/.changeset/repair-pacquet-lockfiles.md
+++ b/.changeset/repair-pacquet-lockfiles.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Recognize `pnpm install --fix-lockfile` and regenerate broken lockfile metadata while preserving compatible locked versions [pnpm/pnpm#14250](https://github.com/pnpm/pnpm/issues/14250).
+Recognize `pnpm install --fix-lockfile`, including filtered installs delegated to pnpr, and regenerate broken lockfile metadata while preserving compatible locked versions [pnpm/pnpm#14250](https://github.com/pnpm/pnpm/issues/14250).

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -15,7 +15,10 @@ use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::NodeLinker;
 use pnpm_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
-use pnpm_lockfile_verification::{lockfile_verification_is_cached, record_lockfile_verified};
+use pnpm_lockfile_verification::{
+    VerifyLockfileResolutionsOptions, lockfile_verification_is_cached, record_lockfile_verified,
+    verify_lockfile_resolutions,
+};
 use pnpm_modules_yaml::IncludedDependencies;
 use pnpm_package_manager::{
     Install, InstallFrozenLockfileError, LockfileVerificationOverride, ProjectMutation,
@@ -927,7 +930,7 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         None
     };
     let merge_wanted = if link.fix_lockfile && link.use_state_lockfile {
-        state.lockfile.get().or_else(|_| state.lockfile.get_for_fix()).map_err(|err| {
+        MaybeLazyLockfile::Repair(&state.lockfile).get_for_merge().map_err(|err| {
             miette::Report::new(err).wrap_err("load the lockfile for filtered merge")
         })?
     } else {
@@ -1331,22 +1334,11 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         )
         .map_err(miette::Report::new)?;
     }
-
-    if state.config.lockfile {
-        outcome
-            .lockfile
-            .save_to_path(&lockfile_path)
-            .map_err(|err| miette::miette!("{err}"))
-            .wrap_err("writing the pnpr-resolved lockfile")?;
-        // Recording is sound here because every entry in the saved
-        // lockfile passed the server's gates under the client's own
-        // forwarded policy: freshly-resolved entries through the
-        // pick-time gate, and entries carried over by the filtered-
-        // install merge as part of the input lockfile the server
-        // verified before resolving (pnpm's
-        // `writeWantedLockfileAndRecordVerified`).
-        if !link.trust_lockfile
-            && let Ok(verifiers) = build_resolution_verifiers(
+    let merged_repair_verifiers = if link.fix_lockfile && partial_selection {
+        let verifiers = if link.trust_lockfile {
+            Vec::new()
+        } else {
+            build_resolution_verifiers(
                 state.config,
                 std::sync::Arc::clone(&state.http_client),
                 None,
@@ -1354,13 +1346,49 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
                 None,
                 None,
             )
-        {
-            record_lockfile_verified(
-                Some(&state.config.cache_dir),
-                &lockfile_path,
-                &outcome.lockfile,
-                &verifiers,
-            );
+            .map_err(miette::Report::new)?
+        };
+        verify_lockfile_resolutions::<Reporter>(
+            &outcome.lockfile,
+            &verifiers,
+            &VerifyLockfileResolutionsOptions::default(),
+        )
+        .await
+        .map_err(miette::Report::new)?;
+        Some(verifiers)
+    } else {
+        None
+    };
+
+    if state.config.lockfile {
+        outcome
+            .lockfile
+            .save_to_path(&lockfile_path)
+            .map_err(|err| miette::miette!("{err}"))
+            .wrap_err("writing the pnpr-resolved lockfile")?;
+        if !link.trust_lockfile {
+            if let Some(verifiers) = merged_repair_verifiers.as_ref() {
+                record_lockfile_verified(
+                    Some(&state.config.cache_dir),
+                    &lockfile_path,
+                    &outcome.lockfile,
+                    verifiers,
+                );
+            } else if let Ok(verifiers) = build_resolution_verifiers(
+                state.config,
+                std::sync::Arc::clone(&state.http_client),
+                None,
+                None,
+                None,
+                None,
+            ) {
+                record_lockfile_verified(
+                    Some(&state.config.cache_dir),
+                    &lockfile_path,
+                    &outcome.lockfile,
+                    &verifiers,
+                );
+            }
         }
     }
 

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -16,7 +16,8 @@ use pnpm_catalogs_types::Catalogs;
 use pnpm_config::NodeLinker;
 use pnpm_lockfile::{Lockfile, LockfileResolution, MaybeLazyLockfile};
 use pnpm_lockfile_verification::{
-    VerifyLockfileResolutionsOptions, lockfile_verification_is_cached, record_lockfile_verified,
+    VerifyLockfileResolutionsOptions, lockfile_verification_is_cached,
+    lockfile_verification_is_cached_by_content, record_lockfile_verified,
     verify_lockfile_resolutions,
 };
 use pnpm_modules_yaml::IncludedDependencies;
@@ -1348,13 +1349,19 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
             )
             .map_err(miette::Report::new)?
         };
-        verify_lockfile_resolutions::<Reporter>(
+        if !lockfile_verification_is_cached_by_content(
+            &state.config.cache_dir,
             &outcome.lockfile,
             &verifiers,
-            &VerifyLockfileResolutionsOptions::default(),
-        )
-        .await
-        .map_err(miette::Report::new)?;
+        ) {
+            verify_lockfile_resolutions::<Reporter>(
+                &outcome.lockfile,
+                &verifiers,
+                &VerifyLockfileResolutionsOptions::default(),
+            )
+            .await
+            .map_err(miette::Report::new)?;
+        }
         Some(verifiers)
     } else {
         None

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -1206,6 +1206,54 @@ fn assert_filtered_workspace_pnpr(lockfile_only: bool) {
     drop((root, mock_instance));
 }
 
+fn seed_filtered_repair_workspace(workspace: &Path, registry_url: &str) {
+    configure_workspace(workspace);
+    write_workspace_project(workspace, "selected", "selected", (WORKSPACE_HELLO, "0.0.0"));
+    write_workspace_project(workspace, "unselected", "unselected", (WORKSPACE_PARENT, "100.0.0"));
+    pacquet_at(workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", registry_url)
+        .with_args(["install", "--lockfile-only"])
+        .assert()
+        .success();
+}
+
+fn selected_only_pnpr_lockfile(mut lockfile: Lockfile) -> Lockfile {
+    lockfile.importers.retain(|id, _| id == "packages/selected");
+    if let Some(packages) = lockfile.packages.as_mut() {
+        packages.retain(|key, _| key.to_string().contains(WORKSPACE_HELLO));
+    }
+    if let Some(snapshots) = lockfile.snapshots.as_mut() {
+        snapshots.retain(|key, _| key.to_string().contains(WORKSPACE_HELLO));
+    }
+    lockfile
+}
+
+fn mock_filtered_repair_response(
+    server: &mut mockito::Server,
+    lockfile: &Lockfile,
+) -> (mockito::Mock, mockito::Mock) {
+    let handshake = server
+        .mock("GET", "/-/pnpr")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"pnpr":{"versions":[0],"fixLockfile":[0]}}"#)
+        .expect(1)
+        .create();
+    let response = serde_json::json!({
+        "type": "done",
+        "lockfile": lockfile,
+        "stats": { "totalPackages": 0 },
+    });
+    let resolve = server
+        .mock("POST", "/-/pnpr/v0/resolve")
+        .with_status(200)
+        .with_header("content-type", "application/x-ndjson")
+        .with_body(format!("{response}\n"))
+        .expect(1)
+        .create();
+    (handshake, resolve)
+}
+
 #[test]
 fn filtered_workspace_install_via_pnpr_materializes_the_root_and_selected_closure() {
     assert_filtered_workspace_pnpr(false);
@@ -1214,6 +1262,146 @@ fn filtered_workspace_install_via_pnpr_materializes_the_root_and_selected_closur
 #[test]
 fn filtered_workspace_pnpr_lockfile_only_merges_the_root_and_selected_importers() {
     assert_filtered_workspace_pnpr(true);
+}
+
+#[test]
+fn filtered_pnpr_repair_preserves_unselected_metadata() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    seed_filtered_repair_workspace(&workspace, &mock_instance.url());
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let mut previous = read_workspace_lockfile(&workspace);
+    let mut preserved_package_count = 0;
+    for (key, metadata) in previous.packages.as_mut().expect("packages") {
+        let key = key.to_string();
+        if key.contains(WORKSPACE_PARENT) || key.contains(WORKSPACE_DEP) {
+            metadata.deprecated = Some("preserve this metadata".to_string());
+            preserved_package_count += 1;
+        }
+    }
+    assert!(preserved_package_count > 0);
+    let mut preserved_snapshot_count = 0;
+    for (key, snapshot) in previous.snapshots.as_mut().expect("snapshots") {
+        let key = key.to_string();
+        if key.contains(WORKSPACE_PARENT) || key.contains(WORKSPACE_DEP) {
+            snapshot.optional = true;
+            snapshot.transitive_peer_dependencies = Some(vec!["preserved-peer".to_string()]);
+            preserved_snapshot_count += 1;
+        }
+    }
+    assert!(preserved_snapshot_count > 0);
+    let fresh = selected_only_pnpr_lockfile(previous.clone());
+    let mut broken: serde_json::Value =
+        serde_saphyr::from_str(&serde_saphyr::to_string(&previous).expect("serialize lockfile"))
+            .expect("parse lockfile value");
+    broken["time"] = serde_json::json!("invalid");
+    fs::write(&lockfile_path, serde_saphyr::to_string(&broken).expect("serialize lockfile"))
+        .expect("write broken lockfile");
+    let mut server = mockito::Server::new();
+    let (handshake_mock, resolve_mock) = mock_filtered_repair_response(&mut server, &fresh);
+
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args([
+            "--filter",
+            "selected",
+            "install",
+            "--fix-lockfile",
+            "--lockfile-only",
+            "--pnpr-server",
+            &server.url(),
+        ])
+        .assert()
+        .success();
+
+    let repaired = read_workspace_lockfile(&workspace);
+    let preserved_packages = repaired
+        .packages
+        .as_ref()
+        .expect("repaired packages")
+        .iter()
+        .filter(|(key, _)| {
+            let key = key.to_string();
+            key.contains(WORKSPACE_PARENT) || key.contains(WORKSPACE_DEP)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(preserved_packages.len(), preserved_package_count);
+    assert!(
+        preserved_packages.iter().all(|(_, metadata)| {
+            metadata.deprecated.as_deref() == Some("preserve this metadata")
+        }),
+    );
+    let preserved_snapshots = repaired
+        .snapshots
+        .as_ref()
+        .expect("repaired snapshots")
+        .iter()
+        .filter(|(key, _)| {
+            let key = key.to_string();
+            key.contains(WORKSPACE_PARENT) || key.contains(WORKSPACE_DEP)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(preserved_snapshots.len(), preserved_snapshot_count);
+    assert!(preserved_snapshots.iter().all(|(_, snapshot)| {
+        snapshot.optional
+            && snapshot
+                .transitive_peer_dependencies
+                .as_ref()
+                .is_some_and(|peers| peers.len() == 1 && peers[0] == "preserved-peer")
+    }));
+    handshake_mock.assert();
+    resolve_mock.assert();
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn filtered_pnpr_repair_verifies_the_merged_lockfile_before_writing() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    seed_filtered_repair_workspace(&workspace, &mock_instance.url());
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let previous = read_workspace_lockfile(&workspace);
+    let fresh = selected_only_pnpr_lockfile(previous.clone());
+    let mut broken: serde_json::Value =
+        serde_saphyr::from_str(&serde_saphyr::to_string(&previous).expect("serialize lockfile"))
+            .expect("parse lockfile value");
+    broken["time"] = serde_json::json!("invalid");
+    broken["importers"]["packages/unselected"]["dependencies"]["../../../escape"] =
+        serde_json::json!({ "specifier": "link:local", "version": "link:local" });
+    let before = serde_saphyr::to_string(&broken).expect("serialize lockfile");
+    fs::write(&lockfile_path, &before).expect("write broken lockfile");
+    let mut server = mockito::Server::new();
+    let (handshake_mock, resolve_mock) = mock_filtered_repair_response(&mut server, &fresh);
+
+    let output = pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args([
+            "--filter",
+            "selected",
+            "install",
+            "--fix-lockfile",
+            "--lockfile-only",
+            "--trust-lockfile",
+            "--pnpr-server",
+            &server.url(),
+        ])
+        .output()
+        .expect("run filtered repair");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_INVALID_DEPENDENCY_NAME"),
+        "merged repair must reject the traversal alias; got:\n{stderr}",
+    );
+    assert_eq!(fs::read_to_string(&lockfile_path).expect("read lockfile after failure"), before);
+    handshake_mock.assert();
+    resolve_mock.assert();
+
+    drop((root, mock_instance));
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -1272,6 +1272,7 @@ fn filtered_pnpr_repair_preserves_unselected_metadata() {
     seed_filtered_repair_workspace(&workspace, &mock_instance.url());
     let lockfile_path = workspace.join("pnpm-lock.yaml");
     let mut previous = read_workspace_lockfile(&workspace);
+    let previous_unselected = workspace_importer(&previous, "packages/unselected").clone();
     let mut preserved_package_count = 0;
     for (key, metadata) in previous.packages.as_mut().expect("packages") {
         let key = key.to_string();
@@ -1316,6 +1317,7 @@ fn filtered_pnpr_repair_preserves_unselected_metadata() {
         .success();
 
     let repaired = read_workspace_lockfile(&workspace);
+    assert_eq!(workspace_importer(&repaired, "packages/unselected"), &previous_unselected);
     let preserved_packages = repaired
         .packages
         .as_ref()

--- a/pnpm/crates/lockfile-verification/src/cache.rs
+++ b/pnpm/crates/lockfile-verification/src/cache.rs
@@ -171,20 +171,13 @@ pub fn try_lockfile_verification_cache(
     }
 
     let hash = hash_lockfile();
-    let Some(record) = indexes.by_hash.get(&hash) else {
+    let Some(record) = trusted_record_by_hash(&indexes, &hash, verifiers) else {
         return CacheLookupResult {
             hit: false,
             verified_at: None,
             precomputed: CachePrecomputed { stat: Some(stat), hash: Some(hash) },
         };
     };
-    if !every_verifier_trusts_cached_run(record, verifiers) {
-        return CacheLookupResult {
-            hit: false,
-            verified_at: None,
-            precomputed: CachePrecomputed { stat: Some(stat), hash: Some(hash) },
-        };
-    }
 
     // Refresh the byPath slot so the next install at this path takes
     // the stat shortcut. Failure here is best-effort: even if the
@@ -208,6 +201,17 @@ pub fn try_lockfile_verification_cache(
         verified_at: (!refreshed.verified_at.is_empty()).then(|| refreshed.verified_at.clone()),
         precomputed: CachePrecomputed { stat: Some(stat), hash: Some(hash) },
     }
+}
+
+/// Look up a verification by content hash without consulting any
+/// lockfile path or filesystem metadata.
+pub(crate) fn lockfile_verification_is_cached_by_hash(
+    cache_dir: &Path,
+    hash: &str,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+) -> bool {
+    let Ok(indexes) = read_cache(cache_dir) else { return false };
+    trusted_record_by_hash(&indexes, hash, verifiers).is_some()
 }
 
 /// Persist a successful verification.
@@ -250,6 +254,15 @@ struct CacheIndexes {
     by_hash: HashMap<String, CacheRecord>,
     /// Latest record per absolute path — same-machine stat fast path.
     by_path: HashMap<String, CacheRecord>,
+}
+
+fn trusted_record_by_hash<'a>(
+    indexes: &'a CacheIndexes,
+    hash: &str,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+) -> Option<&'a CacheRecord> {
+    let record = indexes.by_hash.get(hash)?;
+    every_verifier_trusts_cached_run(record, verifiers).then_some(record)
 }
 
 /// Read the cache file, building both indexes in one pass. Records

--- a/pnpm/crates/lockfile-verification/src/cache/tests.rs
+++ b/pnpm/crates/lockfile-verification/src/cache/tests.rs
@@ -13,7 +13,7 @@ use tempfile::TempDir;
 
 use super::{
     CACHE_FILE_NAME, CacheLockfile, CachePrecomputed, CacheRecord, MAX_CACHE_ENTRIES,
-    record_verification, try_lockfile_verification_cache,
+    lockfile_verification_is_cached_by_hash, record_verification, try_lockfile_verification_cache,
 };
 
 /// Trivial verifier that records what policy it advertises and
@@ -97,6 +97,39 @@ fn stat_shortcut_hits_same_path_same_stat() {
         try_lockfile_verification_cache(dir.path(), &lockfile, &verifiers, &mut hash_lockfile);
     assert!(result.hit, "same path + same stat → hit");
     assert_eq!(calls, 0, "stat shortcut skipped the hash call");
+}
+
+#[test]
+fn content_hash_only_lookup_ignores_a_matching_path_record() {
+    let dir = TempDir::new().expect("tempdir");
+    let lockfile = touch_lockfile(&dir.path().join("current"), "old content");
+    let verifiers: Vec<Arc<dyn ResolutionVerifier>> =
+        vec![Stub::new(true) as Arc<dyn ResolutionVerifier>];
+    record_verification(
+        dir.path(),
+        &lockfile,
+        &verifiers,
+        || "old-hash".to_string(),
+        CachePrecomputed::default(),
+    );
+
+    assert!(
+        !lockfile_verification_is_cached_by_hash(dir.path(), "merged-hash", &verifiers),
+        "the current file stat must not cover different in-memory content",
+    );
+
+    let merged = touch_lockfile(&dir.path().join("merged"), "merged content");
+    record_verification(
+        dir.path(),
+        &merged,
+        &verifiers,
+        || "merged-hash".to_string(),
+        CachePrecomputed::default(),
+    );
+    assert!(
+        lockfile_verification_is_cached_by_hash(dir.path(), "merged-hash", &verifiers),
+        "the exact in-memory content hash should reuse its cached verdict",
+    );
 }
 
 #[test]

--- a/pnpm/crates/lockfile-verification/src/lib.rs
+++ b/pnpm/crates/lockfile-verification/src/lib.rs
@@ -12,6 +12,7 @@
 //!
 //! Public surface today: [`verify_lockfile_resolutions()`],
 //! [`lockfile_verification_is_cached()`],
+//! [`lockfile_verification_is_cached_by_content()`],
 //! [`verify_lockfile_dependency_names()`],
 //! [`collect_resolution_policy_violations()`], [`hash_lockfile()`],
 //! [`VerifyError`], and [`RenderedViolation`] — the last lets a caller
@@ -38,5 +39,6 @@ pub use record_lockfile_verified::record_lockfile_verified;
 pub use verify_lockfile_resolutions::{
     RESOLUTION_SHAPE_MISMATCH_VIOLATION_CODE, VerifyLockfileResolutionsOptions,
     collect_resolution_policy_violations, lockfile_verification_is_cached,
-    verify_lockfile_dependency_names, verify_lockfile_resolutions,
+    lockfile_verification_is_cached_by_content, verify_lockfile_dependency_names,
+    verify_lockfile_resolutions,
 };

--- a/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
+++ b/pnpm/crates/lockfile-verification/src/verify_lockfile_resolutions.rs
@@ -27,7 +27,10 @@ use pnpm_resolving_resolver_base::{
 use tokio::sync::Semaphore;
 
 use crate::{
-    cache::{CachePrecomputed, record_verification, try_lockfile_verification_cache},
+    cache::{
+        CachePrecomputed, lockfile_verification_is_cached_by_hash, record_verification,
+        try_lockfile_verification_cache,
+    },
     errors::{RenderedViolation, VerifyError},
     hash_lockfile,
 };
@@ -86,6 +89,28 @@ pub fn lockfile_verification_is_cached(
         || hash_lockfile(lockfile),
     )
     .hit
+}
+
+/// Whether a recorded verification covers the exact in-memory
+/// `lockfile` content under the currently active policy. Unlike
+/// [`lockfile_verification_is_cached`], this never consults path or
+/// filesystem metadata.
+pub fn lockfile_verification_is_cached_by_content(
+    cache_dir: &Path,
+    lockfile: &Lockfile,
+    verifiers: &[Arc<dyn ResolutionVerifier>],
+) -> bool {
+    if verify_lockfile_dependency_names(lockfile).is_err() {
+        return false;
+    }
+    if lockfile.packages.is_none() {
+        return true;
+    }
+    lockfile_verification_is_cached_by_hash(
+        cache_dir,
+        &hash_lockfile(lockfile),
+        &with_offline_check_cache_identities(verifiers),
+    )
 }
 
 /// Run every active [`ResolutionVerifier`] against every entry in


### PR DESCRIPTION
## Summary

- Follow up on pnpm/pnpm#14253 by loading filtered repair merge input through the repair-aware merge view, preserving unselected importer and package metadata.
- Verify the exact client-merged lockfile before writing it or materializing dependencies, including structural checks when `--trust-lockfile` disables policy verification.
- Reuse verification safely by the merged lockfile content hash, without allowing the pre-merge file stat to cover different in-memory content.
- Add regressions for preserved unselected metadata, rejection of an unselected traversal alias before the lockfile is changed, and content-only cache lookup.

This is specific to the Rust CLI pnpr delegation path; the TypeScript CLI does not use this merge path. Related to pnpm/pnpm#14250.

## Squash Commit Body

```text
Filtered pnpr repairs merge server output with unselected data from the client lockfile. Load that data through the repair-aware merge view so repairable corruption is sanitized without discarding valid metadata, then verify the exact merged result before any write or materialization. Reuse a cached verdict only when the merged content hash and active policy match, and reuse the resulting verifier set when recording the post-write verification cache.

Add regressions covering preservation of unselected importer, package, and snapshot metadata; rejection of an unselected traversal alias before the lockfile is written; and content-only cache lookup that cannot trust stale path metadata.

Related to pnpm/pnpm#14250. Follow-up to pnpm/pnpm#14253.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm install --fix-lockfile` support for filtered workspace installs.
  * Repairs broken lockfile metadata while preserving compatible locked versions and metadata outside the selected project.
  * Added validation for merged lockfile resolutions during repairs.
  * Invalid dependency names are now detected safely, leaving the existing lockfile unchanged when repair fails.

* **Documentation**
  * Documented `--fix-lockfile` support for filtered installs without requiring explicit delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->