### PR TITLE
fix(config): decode and re-encode `_auth` credentials

### DIFF
--- a/.changeset/wild-buttons-repeat.md
+++ b/.changeset/wild-buttons-repeat.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`_auth` credentials in an `.npmrc` are now decoded and re-encoded before they are sent, so a value written without its `=` padding (or with redundant padding or embedded whitespace) authenticates instead of failing with a 401. An `_auth` that is not base64, or whose decoded form has no `:` separating the username from the password, now fails with `ERR_PNPM_AUTH_INVALID_BASE64` / `ERR_PNPM_AUTH_MISSING_SEPARATOR` instead of being sent as an unusable header [#14257](https://github.com/pnpm/pnpm/issues/14257).

--- a/.changeset/wild-buttons-repeat.md
+++ b/.changeset/wild-buttons-repeat.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`_auth` credentials in an `.npmrc` are now decoded and re-encoded before they are sent, so a value written without its `=` padding (or with redundant padding or embedded whitespace) authenticates instead of failing with a 401. An `_auth` that is not base64, or whose decoded form has no `:` separating the username from the password, now fails with `ERR_PNPM_AUTH_INVALID_BASE64` / `ERR_PNPM_AUTH_MISSING_SEPARATOR` instead of being sent as an unusable header [#14257](https://github.com/pnpm/pnpm/issues/14257).
+An `_auth` credential in an `.npmrc` now authenticates even when its base64 is written without the trailing `=` padding (or with extra padding, or with whitespace inside it), instead of failing with a 401. An `_auth` that is not valid base64, or that carries no `:` between the username and the password, now fails with `ERR_PNPM_AUTH_INVALID_BASE64` / `ERR_PNPM_AUTH_MISSING_SEPARATOR` [#14257](https://github.com/pnpm/pnpm/issues/14257).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4516,6 +4516,7 @@ dependencies = [
 name = "pnpm-config"
 version = "0.0.1"
 dependencies = [
+ "base64 0.23.1",
  "derive_more",
  "dunce",
  "home",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm/crates/cli/tests/suite/auth.rs
+++ b/pnpm/crates/cli/tests/suite/auth.rs
@@ -126,6 +126,19 @@ fn legacy_basic_auth_authenticates_install() {
     );
 }
 
+/// An `_auth` written without its `=` padding authenticates the same as
+/// the canonical spelling: the header carries the credential the value
+/// decodes to, not the value as written (pnpm/pnpm#14257).
+#[test]
+fn unpadded_legacy_basic_auth_authenticates_install() {
+    assert_authenticated_install(
+        "private-pkg",
+        |authority| format!("//{authority}/:_auth=Zm9vOmJhcg\n"),
+        "Basic Zm9vOmJhcg==",
+        false,
+    );
+}
+
 #[test]
 fn package_scope_bearer_auth_wins_for_scoped_install() {
     assert_authenticated_install(

--- a/pnpm/crates/config/Cargo.toml
+++ b/pnpm/crates/config/Cargo.toml
@@ -26,6 +26,7 @@ pnpm-store-dir              = { workspace = true }
 pnpm-versioning             = { workspace = true }
 pnpm-workspace-state        = { workspace = true }
 
+base64        = { workspace = true }
 derive_more   = { workspace = true }
 dunce         = { workspace = true }
 home          = { workspace = true }

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -956,7 +956,9 @@ fn creds_to_header(creds: &RawCreds) -> Result<Option<String>, LoadWorkspaceYaml
     if let Some(token) = &creds.auth_token {
         return Ok(Some(format!("Bearer {token}")));
     }
-    if let Some(pair) = &creds.auth_pair_base64 {
+    // An empty `_auth` names no credential — the shape an unresolved
+    // `${VAR}` leaves behind — and pnpm skips it rather than failing.
+    if let Some(pair) = creds.auth_pair_base64.as_deref().filter(|pair| !pair.is_empty()) {
         let decoded = base64_decode_bytes(pair)
             .ok_or(LoadWorkspaceYamlError::AuthInvalidBase64 { key: "_auth" })?;
         if !decoded.contains(&b':') {
@@ -1066,9 +1068,12 @@ const CREDENTIAL_BASE64: base64::engine::GeneralPurpose = base64::engine::Genera
 /// not base64 at all.
 fn base64_decode_bytes(input: &str) -> Option<Vec<u8>> {
     let cleaned: Vec<u8> = input.bytes().filter(|byte| !byte.is_ascii_whitespace()).collect();
-    let payload =
-        cleaned.iter().rposition(|byte| *byte != b'=').map_or(&[][..], |last| &cleaned[..=last]);
-    base64::Engine::decode(&CREDENTIAL_BASE64, payload).ok()
+    let Some(last) = cleaned.iter().rposition(|byte| *byte != b'=') else {
+        // Padding with nothing to pad is not base64; `atob` rejects it,
+        // and only an empty value decodes to nothing.
+        return cleaned.is_empty().then(Vec::new);
+    };
+    base64::Engine::decode(&CREDENTIAL_BASE64, &cleaned[..=last]).ok()
 }
 
 /// [`base64_decode_bytes`] for the `_password` field, whose decoded form

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -1046,41 +1046,29 @@ fn parse_token_helper_field(
     Ok((!command.is_empty()).then_some(command))
 }
 
-/// Decode a standard base64 credential to the bytes it carries, ignoring
-/// whitespace and accepting padding that is redundant (`aGk===`) or
-/// missing (`aGk`) — the spellings that reach a `.npmrc` by hand or from
-/// a shell pipeline. `None` when the value is not base64 at all.
+/// The decoder pnpm reads credentials with: `atob`'s forgiving-base64,
+/// which ignores whitespace anywhere and keeps the low bits of a
+/// truncated final group rather than rejecting the value. Padding is
+/// stripped before the value reaches this engine, so `=` left anywhere
+/// else is an invalid byte — as it is for `atob`.
+const CREDENTIAL_BASE64: base64::engine::GeneralPurpose = base64::engine::GeneralPurpose::new(
+    &base64::alphabet::STANDARD,
+    base64::engine::GeneralPurposeConfig::new()
+        .with_decode_allow_trailing_bits(true)
+        .with_decode_padding_mode(base64::engine::DecodePaddingMode::RequireNone),
+);
+
+/// Decode a standard base64 credential to the bytes it carries, matching
+/// `decodeBase64Credential` in the TypeScript stack: whitespace is
+/// ignored, and trailing `=` padding may be redundant (`aGk===`),
+/// short (`Zm9vOmJhcg=`), or missing (`aGk`) — the spellings that reach
+/// a `.npmrc` by hand or from a shell pipeline. `None` when the value is
+/// not base64 at all.
 fn base64_decode_bytes(input: &str) -> Option<Vec<u8>> {
     let cleaned: Vec<u8> = input.bytes().filter(|byte| !byte.is_ascii_whitespace()).collect();
-    let payload = match cleaned.iter().position(|byte| *byte == b'=') {
-        Some(padding_start) => &cleaned[..padding_start],
-        None => &cleaned[..],
-    };
-    // A trailing group of a single base64 character encodes no whole
-    // byte, so the value is truncated rather than merely unpadded.
-    if payload.len() % 4 == 1 {
-        return None;
-    }
-    let mut bytes = Vec::with_capacity(payload.len() / 4 * 3);
-    let mut buffer = 0u32;
-    let mut bits = 0u32;
-    for byte in payload.iter().copied() {
-        let value = match byte {
-            b'A'..=b'Z' => byte - b'A',
-            b'a'..=b'z' => byte - b'a' + 26,
-            b'0'..=b'9' => byte - b'0' + 52,
-            b'+' => 62,
-            b'/' => 63,
-            _ => return None,
-        };
-        buffer = (buffer << 6) | u32::from(value);
-        bits += 6;
-        if bits >= 8 {
-            bits -= 8;
-            bytes.push(((buffer >> bits) & 0xff) as u8);
-        }
-    }
-    Some(bytes)
+    let payload =
+        cleaned.iter().rposition(|byte| *byte != b'=').map_or(&[][..], |last| &cleaned[..=last]);
+    base64::Engine::decode(&CREDENTIAL_BASE64, payload).ok()
 }
 
 /// [`base64_decode_bytes`] for the `_password` field, whose decoded form

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use pnpm_env_replace::env_replace_lossy;
 use pnpm_network::{
     AuthHeaders, DEFAULT_REGISTRY_SCOPE, NoProxySetting, PerRegistryTls, RegistryTls,
-    base64_encode, nerf_dart,
+    base64_encode, base64_encode_bytes, nerf_dart,
 };
 use std::{
     collections::{BTreeMap, HashMap},
@@ -619,7 +619,7 @@ impl NpmrcAuth {
                             .or_default()
                             .insert(scope, command);
                     }
-                } else if let Some(header) = creds_to_header(&raw) {
+                } else if let Some(header) = creds_to_header(&raw)? {
                     if scope == DEFAULT_REGISTRY_SCOPE {
                         auth_header_by_uri.insert(uri.clone(), header);
                     } else {
@@ -811,7 +811,7 @@ impl NpmrcAuth {
         self.apply_registry_and_warn(config);
         self.apply_proxy_cascade::<Sys>(config);
         self.apply_tls_and_local_address(config);
-        self.build_auth_headers(config).expect("valid tokenHelper in test .npmrc");
+        self.build_auth_headers(config).expect("valid credentials in test .npmrc");
     }
 
     fn creds_entry_mut(&mut self, uri: &str) -> &mut RawCreds {
@@ -947,21 +947,31 @@ pub(crate) fn parse_no_proxy(raw: &str) -> NoProxySetting {
 
 /// Convert raw .npmrc credentials into an `Authorization` header
 /// value. Returns `None` if no usable credential shape is present.
-fn creds_to_header(creds: &RawCreds) -> Option<String> {
+///
+/// `_auth` is decoded and re-encoded rather than forwarded: an `.npmrc`
+/// carries spellings the wire format does not (embedded whitespace,
+/// redundant or missing `=` padding), and only the canonical encoding of
+/// the credential it names is a header a registry can read.
+fn creds_to_header(creds: &RawCreds) -> Result<Option<String>, LoadWorkspaceYamlError> {
     if let Some(token) = &creds.auth_token {
-        return Some(format!("Bearer {token}"));
+        return Ok(Some(format!("Bearer {token}")));
     }
     if let Some(pair) = &creds.auth_pair_base64 {
-        return Some(format!("Basic {pair}"));
+        let decoded = base64_decode_bytes(pair)
+            .ok_or(LoadWorkspaceYamlError::AuthInvalidBase64 { key: "_auth" })?;
+        if !decoded.contains(&b':') {
+            return Err(LoadWorkspaceYamlError::AuthMissingSeparator);
+        }
+        return Ok(Some(format!("Basic {}", base64_encode_bytes(&decoded))));
     }
     if let (Some(user), Some(pass_b64)) = (&creds.username, &creds.password) {
         // npm encodes `_password` as base64 of the raw password. The
         // header itself is `Basic base64(user:password)`, so we decode
         // the password back and re-encode the pair.
         let password = base64_decode(pass_b64).unwrap_or_else(|| pass_b64.clone());
-        return Some(format!("Basic {}", base64_encode(&format!("{user}:{password}"))));
+        return Ok(Some(format!("Basic {}", base64_encode(&format!("{user}:{password}")))));
     }
-    None
+    Ok(None)
 }
 
 /// Reject a `tokenHelper` that a workspace or project `.npmrc` contributed.
@@ -1036,23 +1046,31 @@ fn parse_token_helper_field(
     Ok((!command.is_empty()).then_some(command))
 }
 
-/// Decode a standard base64 string. Used for the `_password` field
-/// where npm stores the raw password base64-encoded; falls back to
-/// returning `None` so the caller can keep the raw value verbatim
-/// when the input is not valid base64.
-fn base64_decode(input: &str) -> Option<String> {
+/// Decode a standard base64 credential to the bytes it carries, ignoring
+/// whitespace and accepting padding that is redundant (`aGk===`) or
+/// missing (`aGk`) — the spellings that reach a `.npmrc` by hand or from
+/// a shell pipeline. `None` when the value is not base64 at all.
+fn base64_decode_bytes(input: &str) -> Option<Vec<u8>> {
     let cleaned: Vec<u8> = input.bytes().filter(|byte| !byte.is_ascii_whitespace()).collect();
-    let mut bytes = Vec::with_capacity(cleaned.len() / 4 * 3);
+    let payload = match cleaned.iter().position(|byte| *byte == b'=') {
+        Some(padding_start) => &cleaned[..padding_start],
+        None => &cleaned[..],
+    };
+    // A trailing group of a single base64 character encodes no whole
+    // byte, so the value is truncated rather than merely unpadded.
+    if payload.len() % 4 == 1 {
+        return None;
+    }
+    let mut bytes = Vec::with_capacity(payload.len() / 4 * 3);
     let mut buffer = 0u32;
     let mut bits = 0u32;
-    for byte in cleaned {
+    for byte in payload.iter().copied() {
         let value = match byte {
             b'A'..=b'Z' => byte - b'A',
             b'a'..=b'z' => byte - b'a' + 26,
             b'0'..=b'9' => byte - b'0' + 52,
             b'+' => 62,
             b'/' => 63,
-            b'=' => break,
             _ => return None,
         };
         buffer = (buffer << 6) | u32::from(value);
@@ -1062,7 +1080,14 @@ fn base64_decode(input: &str) -> Option<String> {
             bytes.push(((buffer >> bits) & 0xff) as u8);
         }
     }
-    String::from_utf8(bytes).ok()
+    Some(bytes)
+}
+
+/// [`base64_decode_bytes`] for the `_password` field, whose decoded form
+/// is read as text. `None` — so the caller can keep the raw value
+/// verbatim — when the input is not base64 or not UTF-8.
+fn base64_decode(input: &str) -> Option<String> {
+    String::from_utf8(base64_decode_bytes(input)?).ok()
 }
 
 /// Auth-suffix keys recognised on a `//host[:port]/path/:` prefix in

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use pnpm_network::{DEFAULT_REGISTRY_SCOPE, NoProxySetting};
 use pretty_assertions::assert_eq;
 
-use crate::Config;
+use crate::{Config, workspace_yaml::LoadWorkspaceYamlError};
 
 use super::{EnvVar, NpmrcAuth, RawCreds, base64_decode, base64_encode};
 
@@ -431,7 +431,7 @@ fn basic_auth_built_from_username_and_password() {
 }
 
 #[test]
-fn auth_pair_base64_passes_through_to_basic_header() {
+fn auth_pair_base64_keys_to_basic_header() {
     let pair = base64_encode("alice:p@ss");
     let ini = format!("//reg.com/:_auth={pair}\n");
     let mut config = Config::new();
@@ -440,6 +440,46 @@ fn auth_pair_base64_passes_through_to_basic_header() {
         config.auth_headers.for_url("https://reg.com/").as_deref(),
         Some(format!("Basic {pair}").as_str()),
     );
+}
+
+/// An `_auth` spelled without its `=` padding — as a shell pipeline or a
+/// hand-written `.npmrc` leaves it — reaches the registry canonically
+/// encoded, not verbatim (pnpm/pnpm#14257).
+#[test]
+fn unpadded_auth_pair_base64_is_canonically_re_encoded() {
+    let padded = base64_encode("alice:pass1");
+    let unpadded = padded.trim_end_matches('=');
+    assert_ne!(unpadded, padded, "the fixture must exercise the padding branch");
+    let ini = format!("//reg.com/:_auth={unpadded}\n");
+    let mut config = Config::new();
+    NpmrcAuth::from_ini::<NoEnv>(&ini, Path::new("")).apply_to::<NoEnv>(&mut config);
+    assert_eq!(
+        config.auth_headers.for_url("https://reg.com/").as_deref(),
+        Some(format!("Basic {padded}").as_str()),
+    );
+}
+
+#[test]
+fn auth_pair_base64_that_does_not_decode_is_rejected() {
+    let ini = "//reg.com/:_auth=not*base64\n";
+    let mut config = Config::new();
+    let error = NpmrcAuth::from_ini::<NoEnv>(ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect_err("invalid base64 in _auth must fail the load");
+    assert!(
+        matches!(error, LoadWorkspaceYamlError::AuthInvalidBase64 { key: "_auth" }),
+        "got: {error:?}",
+    );
+}
+
+#[test]
+fn auth_pair_base64_without_a_colon_is_rejected() {
+    let ini = format!("//reg.com/:_auth={}\n", base64_encode("alice"));
+    let mut config = Config::new();
+    let error = NpmrcAuth::from_ini::<NoEnv>(&ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect_err("a passwordless _auth must fail the load");
+    assert!(matches!(error, LoadWorkspaceYamlError::AuthMissingSeparator), "got: {error:?}");
 }
 
 /// `[section]`-style headers are not legal `.npmrc` syntax (npm's
@@ -549,6 +589,10 @@ fn base64_decode_covers_every_alphabet_branch() {
     assert_eq!(base64_decode("fn5+").as_deref(), Some("~~~"));
     assert_eq!(base64_decode("aGk=").as_deref(), Some("hi"));
     assert_eq!(base64_decode("aGk===").as_deref(), Some("hi"));
+    // Padding may also be missing entirely.
+    assert_eq!(base64_decode("aGk").as_deref(), Some("hi"));
+    // A lone trailing character carries no whole byte of its own.
+    assert_eq!(base64_decode("aGkyM"), None);
     assert_eq!(base64_decode("not*base64"), None);
 }
 

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -474,9 +474,9 @@ fn auth_pair_base64_with_a_suffix_after_its_padding_is_rejected() {
     );
 }
 
-/// A value that is all padding decodes to nothing, so it is rejected as
-/// invalid base64 rather than as a credential missing its separator —
-/// the answer `atob` gives it.
+/// Padding with nothing to pad is not base64 — the answer `atob` gives
+/// it — so it fails as an undecodable value rather than as a credential
+/// that decoded but carries no separator.
 #[test]
 fn auth_pair_base64_of_only_padding_is_rejected_as_invalid_base64() {
     let ini = "//reg.com/:_auth=====\n";

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -474,6 +474,32 @@ fn auth_pair_base64_with_a_suffix_after_its_padding_is_rejected() {
     );
 }
 
+/// A value that is all padding decodes to nothing, so it is rejected as
+/// invalid base64 rather than as a credential missing its separator —
+/// the answer `atob` gives it.
+#[test]
+fn auth_pair_base64_of_only_padding_is_rejected_as_invalid_base64() {
+    let ini = "//reg.com/:_auth=====\n";
+    let mut config = Config::new();
+    let error = NpmrcAuth::from_ini::<NoEnv>(ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect_err("an all-padding _auth must fail the load");
+    assert!(
+        matches!(error, LoadWorkspaceYamlError::AuthInvalidBase64 { key: "_auth" }),
+        "got: {error:?}",
+    );
+}
+
+/// An `_auth` left empty — the shape an unresolved `${VAR}` leaves —
+/// names no credential, so it is skipped instead of failing the load.
+#[test]
+fn empty_auth_pair_base64_supplies_no_header() {
+    let ini = "//reg.com/:_auth=\n";
+    let mut config = Config::new();
+    NpmrcAuth::from_ini::<NoEnv>(ini, Path::new("")).apply_to::<NoEnv>(&mut config);
+    assert_eq!(config.auth_headers.for_url("https://reg.com/"), None);
+}
+
 #[test]
 fn auth_pair_base64_that_does_not_decode_is_rejected() {
     let ini = "//reg.com/:_auth=not*base64\n";
@@ -616,10 +642,15 @@ fn base64_decode_matches_atob() {
     assert_eq!(base64_decode("aH").as_deref(), Some("h"));
     // A lone trailing character carries no whole byte of its own.
     assert_eq!(base64_decode("aGkyM"), None);
-    // `=` is padding, so anything after it is not base64.
+    // `=` is padding, so anything after it is not base64, and padding
+    // with nothing to pad is not base64 either.
     assert_eq!(base64_decode("Zm9vOmJhcg==garbage"), None);
     assert_eq!(base64_decode("aGk=x"), None);
+    assert_eq!(base64_decode("===="), None);
     assert_eq!(base64_decode("not*base64"), None);
+    // Only an empty value decodes to nothing.
+    assert_eq!(base64_decode("").as_deref(), Some(""));
+    assert_eq!(base64_decode("  ").as_deref(), Some(""));
 }
 
 // --- Proxy parsing and cascade tests ---

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -459,6 +459,21 @@ fn unpadded_auth_pair_base64_is_canonically_re_encoded() {
     );
 }
 
+/// A value that decodes only once its trailing garbage is thrown away is
+/// not a credential — pnpm's `atob` rejects it, so pacquet must too.
+#[test]
+fn auth_pair_base64_with_a_suffix_after_its_padding_is_rejected() {
+    let ini = format!("//reg.com/:_auth={}garbage\n", base64_encode("alice:p@ss"));
+    let mut config = Config::new();
+    let error = NpmrcAuth::from_ini::<NoEnv>(&ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect_err("trailing garbage after the padding must fail the load");
+    assert!(
+        matches!(error, LoadWorkspaceYamlError::AuthInvalidBase64 { key: "_auth" }),
+        "got: {error:?}",
+    );
+}
+
 #[test]
 fn auth_pair_base64_that_does_not_decode_is_rejected() {
     let ini = "//reg.com/:_auth=not*base64\n";
@@ -582,17 +597,28 @@ fn invalid_base64_password_falls_back_to_raw_value() {
 /// Without these assertions the password-decode fallback
 /// (`unwrap_or_else(... pass_b64.clone())`) path stays unreachable
 /// from the parser tests.
+///
+/// Every case here is an `atob` result: the decoder answers what pnpm's
+/// `decodeBase64Credential` answers for the same value.
 #[test]
-fn base64_decode_covers_every_alphabet_branch() {
+fn base64_decode_matches_atob() {
     assert_eq!(base64_decode(&base64_encode("alice:hunter2")).as_deref(), Some("alice:hunter2"));
     assert_eq!(base64_decode("Pz8/").as_deref(), Some("???"));
     assert_eq!(base64_decode("fn5+").as_deref(), Some("~~~"));
     assert_eq!(base64_decode("aGk=").as_deref(), Some("hi"));
+    // Padding may be redundant, short of what the value needs, or
+    // missing entirely, and whitespace may appear anywhere.
     assert_eq!(base64_decode("aGk===").as_deref(), Some("hi"));
-    // Padding may also be missing entirely.
+    assert_eq!(base64_decode("Zm9vOmJhcg=").as_deref(), Some("foo:bar"));
     assert_eq!(base64_decode("aGk").as_deref(), Some("hi"));
+    assert_eq!(base64_decode("aG k=").as_deref(), Some("hi"));
+    // A truncated final group keeps the whole bytes it does carry.
+    assert_eq!(base64_decode("aH").as_deref(), Some("h"));
     // A lone trailing character carries no whole byte of its own.
     assert_eq!(base64_decode("aGkyM"), None);
+    // `=` is padding, so anything after it is not base64.
+    assert_eq!(base64_decode("Zm9vOmJhcg==garbage"), None);
+    assert_eq!(base64_decode("aGk=x"), None);
     assert_eq!(base64_decode("not*base64"), None);
 }
 

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -419,6 +419,38 @@ pub fn npmrc_auth_file_override_supplies_auth() {
     );
 }
 
+/// The `.npmrc` an `npmrcAuthFile` points at is trusted, so its `_auth`
+/// authenticates the package-manager bootstrap too — the path a
+/// `devEngines` pin resolves `@pnpm/exe` through (pnpm/pnpm#14257).
+#[test]
+pub fn npmrc_auth_file_override_supplies_basic_auth_to_bootstrap() {
+    let project = tempdir().expect("project tempdir");
+    let auth = tempdir().expect("auth tempdir");
+    let auth_file = auth.path().join("custom-npmrc");
+    let pair = pnpm_network::base64_encode("alice:p@ss");
+    fs::write(
+        &auth_file,
+        format!(
+            "registry=https://registry.example.com/\n\
+             //registry.example.com/:_auth={pair}\n"
+        ),
+    )
+    .expect("write auth file");
+
+    let config = Config { npmrc_auth_file: Some(auth_file), ..Config::default() }
+        .current::<HostNoHome>(project.path())
+        .expect("load config");
+
+    assert_eq!(
+        config
+            .package_manager_bootstrap
+            .auth_headers
+            .for_url_with_package("https://registry.example.com/@pnpm%2Fexe", Some("@pnpm/exe"))
+            .as_deref(),
+        Some(format!("Basic {pair}").as_str()),
+    );
+}
+
 /// Write a `.npmrc` that declares its own registry plus an unscoped
 /// `_authToken`, so the token pins to that registry — the shape the
 /// precedence assertions check the winning file by.

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -432,7 +432,7 @@ pub fn npmrc_auth_file_override_supplies_basic_auth_to_bootstrap() {
         &auth_file,
         format!(
             "registry=https://registry.example.com/\n\
-             //registry.example.com/:_auth={pair}\n"
+             //registry.example.com/:_auth={pair}\n",
         ),
     )
     .expect("write auth file");

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1220,6 +1220,25 @@ pub enum LoadWorkspaceYamlError {
         )
     )]
     TokenHelperInProjectConfig { key: String },
+    /// An `_auth` credential did not decode as base64. Its whole point is
+    /// to carry `<username>:<password>` base64-encoded, so a value that
+    /// cannot be decoded would otherwise reach the registry as a header
+    /// no server can read — a silent 401 instead of a fixable error.
+    #[display("Failed to decode {key} as base64")]
+    #[diagnostic(
+        code(ERR_PNPM_AUTH_INVALID_BASE64),
+        help("{key} must hold the base64 encoding of <username>:<password>.")
+    )]
+    AuthInvalidBase64 { key: &'static str },
+    /// A decoded `_auth` credential held no `:`, so it names no password.
+    #[display("No separator found in the decoded form of _auth")]
+    #[diagnostic(
+        code(ERR_PNPM_AUTH_MISSING_SEPARATOR),
+        help(
+            "_auth is a base64 encoded form of <username>:<password> where the colon (:) serves as the separator"
+        )
+    )]
+    AuthMissingSeparator,
     /// A honored `tokenHelper` value contained a character pnpm reserves
     /// for future quoting / interpolation support.
     #[display("Unexpected character {character:?} in tokenHelper")]

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -725,8 +725,14 @@ fn is_default_port(scheme: &str, port: &str) -> bool {
 /// 4 lines. Standard alphabet, with padding.
 #[must_use]
 pub fn base64_encode(input: &str) -> String {
+    base64_encode_bytes(input.as_bytes())
+}
+
+/// [`base64_encode`] for credentials that are not required to be UTF-8,
+/// so a re-encoded `.npmrc` credential reproduces its bytes exactly.
+#[must_use]
+pub fn base64_encode_bytes(bytes: &[u8]) -> String {
     const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let bytes = input.as_bytes();
     let mut out = String::with_capacity(bytes.len().div_ceil(3) * 4);
     let mut chunks = bytes.chunks_exact(3);
     for chunk in &mut chunks {

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -10,8 +10,9 @@ mod token_helper;
 
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
-    base64_encode, hide_auth_information, nerf_dart, normalize_auth_key, redact_and_sanitize,
-    redact_and_sanitize_multiline, redact_url_credentials, redact_url_for_display,
+    base64_encode, base64_encode_bytes, hide_auth_information, nerf_dart, normalize_auth_key,
+    redact_and_sanitize, redact_and_sanitize_multiline, redact_url_credentials,
+    redact_url_for_display,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
 pub use token_helper::{TokenHelperOutput, TokenHelperRunner};

--- a/pnpm11/config/reader/test/parseCreds.test.ts
+++ b/pnpm11/config/reader/test/parseCreds.test.ts
@@ -75,6 +75,10 @@ describe('parseCreds', () => {
     } as Creds)
   })
 
+  test('an empty authPairBase64 supplies no credentials', () => {
+    expect(parseCreds({ authPairBase64: '' })).toBeUndefined()
+  })
+
   test('authPairBase64 must be base64', () => {
     expect(() => parseCreds({
       authPairBase64: 'foo*bar',

--- a/pnpm11/config/reader/test/parseCreds.test.ts
+++ b/pnpm11/config/reader/test/parseCreds.test.ts
@@ -75,6 +75,12 @@ describe('parseCreds', () => {
     } as Creds)
   })
 
+  test('authPairBase64 of only padding is not base64', () => {
+    expect(() => parseCreds({
+      authPairBase64: '====',
+    })).toThrow(new AuthBase64DecodeError('_auth'))
+  })
+
   test('an empty authPairBase64 supplies no credentials', () => {
     expect(parseCreds({ authPairBase64: '' })).toBeUndefined()
   })

--- a/pnpm11/config/reader/test/parseCreds.test.ts
+++ b/pnpm11/config/reader/test/parseCreds.test.ts
@@ -64,6 +64,17 @@ describe('parseCreds', () => {
     } as Creds)
   })
 
+  test('authPairBase64 allows missing trailing padding', () => {
+    expect(parseCreds({
+      authPairBase64: btoa('foo:bar').replaceAll('=', ''),
+    })).toStrictEqual({
+      basicAuth: {
+        username: 'foo',
+        password: 'bar',
+      },
+    } as Creds)
+  })
+
   test('authPairBase64 must be base64', () => {
     expect(() => parseCreds({
       authPairBase64: 'foo*bar',


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14257.

pnpm 12 forwarded an `.npmrc` `_auth` value verbatim as the `Basic` header. That
is only correct when the value is canonical base64: a credential written without
its `=` padding (or with redundant padding, or with embedded whitespace) reached
the registry as a header no server can decode, and the request came back `401`.
Swapping the same credential for an `_authToken` "fixed" it, because a token is
passed through in both stacks — which is what the reporter observed.

The TypeScript CLI has never had this bug: `parseBasicAuth` decodes `_auth`
(normalizing padding since pnpm/pnpm#11694), splits it on the first `:`, and
re-encodes canonically. The Rust port mirrored the `username` + `_password`
branch of that function — it decodes and re-encodes, and the original commit
even cites `parseBasicAuth` in a comment — but shortcut the `_auth` branch. So
this is a port oversight, not a deliberate divergence.

This PR gives pacquet the same handling:

- `_auth` is decoded (whitespace ignored, padding optional or redundant) and
  re-encoded canonically. For a canonically encoded value the header is
  **byte-identical** to what pnpm 12 sends today — the decode/re-encode works on
  raw bytes, not UTF-8 text, so no working configuration changes on the wire.
- An `_auth` that is not base64, or whose decoded form has no `:`, now fails the
  config load with `ERR_PNPM_AUTH_INVALID_BASE64` / `ERR_PNPM_AUTH_MISSING_SEPARATOR`
  — the codes and messages the TypeScript stack raises — instead of silently
  producing an unusable header.

Not changed: the `_password` decoder keeps its raw-value fallback. That
tolerance is a deliberate, documented divergence from the TypeScript stack
(`invalid_base64_password_falls_back_to_raw_value`), so flipping it to an error
belongs in its own change if we want it.

Also worth stating, since the issue frames it as a bug: the package-manager
bootstrap ignoring the project `.npmrc` is correct and stays that way
(GHSA-j2hc-m6cf-6jm8). The reporter's `PNPM_CONFIG_NPMRC_AUTH_FILE` is the
supported opt-in, and with it set, Basic credentials now work through that path.

Verified end to end against a mock registry: with `_auth=<unpadded base64>` and
a `devEngines` pin, `Basic <canonical>` is now sent on the `pnpm` packument, the
`@pnpm/exe` packument, and the tarball; with a canonical `_auth` the bytes are
unchanged.

TypeScript side: implementation already correct, so it only gains the matching
test for an `_auth` written without padding.

## Squash Commit Body

```text
pacquet forwarded an `.npmrc` `_auth` value verbatim as the `Basic` header, so a
value written without its `=` padding (or with redundant padding or embedded
whitespace) reached the registry as an unusable header and the request failed
with a 401. Decode it, require the `:` that separates the username from the
password, and re-encode canonically — matching `parseBasicAuth` in the
TypeScript stack, which has decoded `_auth` since the setting was added. The
decode/re-encode is byte-exact for a canonically encoded value, so a working
configuration sends the same header as before.

An `_auth` that is not base64 at all, or whose decoded form has no separator,
now fails the config load with ERR_PNPM_AUTH_INVALID_BASE64 /
ERR_PNPM_AUTH_MISSING_SEPARATOR, the codes the TypeScript stack raises, instead
of silently producing a header no server can read.

The `_password` decoder keeps its raw-value fallback: that tolerance is a
deliberate divergence from the TypeScript stack, and this change is about the
`_auth` path.

Closes pnpm/pnpm#14257
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790464754&installation_model_id=426870&pr_number=14261&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14261&signature=3f5b6df59a25ac35278e23b74c6978fd1f1a61793348b7b56ef2cc71568d34ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `.npmrc` `_auth` handling for credentials with missing, redundant, or embedded Base64 padding and whitespace.
  - Valid credentials are now normalized before authentication, preventing avoidable authorization failures.
  - Empty credentials are ignored, while invalid Base64 values and credentials missing the username/password separator now produce clear diagnostic errors.

- **Tests**
  - Added coverage for credential normalization, validation errors, empty credentials, and authentication during package-manager bootstrap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->