### PR TITLE
perf(workspace): speed up scoping, and stop wildcards matching dot directories

### DIFF
--- a/.changeset/quick-mice-discover.md
+++ b/.changeset/quick-mice-discover.md
@@ -3,3 +3,5 @@
 ---
 
 Speed up workspace discovery for literal directories and conventional trailing-star patterns.
+
+Workspace patterns now follow the same dot-directory rule as pnpm 11: a wildcard no longer matches a dot-prefixed directory, so `packages/*` and `**` skip `packages/.cache` and `.git`. A pattern that names a dot-prefixed directory still matches it, as `packages/.cache` and `packages/.*` do.

--- a/.changeset/quick-mice-discover.md
+++ b/.changeset/quick-mice-discover.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up workspace discovery for literal directories and conventional trailing-star patterns.

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -211,10 +211,10 @@ pub fn find_workspace_projects_no_check(
                     message: err.to_string(),
                 })?;
 
-            let ignores = if names_a_dot_component(pattern) {
-                &ignore_template
-            } else {
-                &dot_pruning_ignore_template
+            let dot_access = dot_component_access(pattern);
+            let ignores = match dot_access {
+                DotComponentAccess::Pruned => &dot_pruning_ignore_template,
+                DotComponentAccess::Named(_) | DotComponentAccess::Unrestricted => &ignore_template,
             };
             let walk = glob.walk(walk_root).not(ignores.clone()).map_err(|err| {
                 FindWorkspaceProjectsError::InvalidGlob {
@@ -241,6 +241,11 @@ pub fn find_workspace_projects_no_check(
                     }
                 };
                 let manifest_path = entry.path();
+                if let DotComponentAccess::Named(named) = &dot_access
+                    && matched_a_dot_component_by_wildcard(manifest_path, walk_root, named)
+                {
+                    continue;
+                }
                 if pathdiff::diff_paths(manifest_path, workspace_root)
                     .is_some_and(|relative| user_negations.is_match(relative.as_path()))
                 {
@@ -305,7 +310,7 @@ const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**
 
 /// Prunes every path with a dot-prefixed component, so a wildcard cannot
 /// descend into `.git`, `.cache`, and friends. Applied only to patterns that
-/// do not name a dot component themselves — see [`names_a_dot_component`].
+/// do not name a dot component themselves — see [`DotComponentAccess`].
 const DOT_COMPONENT_IGNORE_PATTERN: &str = "**/.*/**";
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
@@ -475,19 +480,45 @@ fn split_parent_prefix<'root, 'pattern>(
     Some((walk_root, rest))
 }
 
-/// Whether `pattern` spells out a dot-prefixed path component, as
-/// `packages/.cache/*` and `packages/.*/lib` both do.
+/// How `pattern` is allowed to reach dot-prefixed path components.
 ///
-/// A wildcard must not match a dot-prefixed component, but a pattern that
-/// names one must still reach it. Rather than teach the walk which component
-/// each wildcard consumed, a pattern that names any dot component keeps the
-/// unpruned ignores and matches dot components at *every* position. That is a
-/// superset of the glob's meaning, reachable only by asking for a dot
-/// component in the first place.
-fn names_a_dot_component(pattern: &str) -> bool {
-    pattern
-        .split('/')
-        .any(|component| component.starts_with('.') && component != "." && component != "..")
+/// A wildcard must never match a dot-prefixed component, but a pattern that
+/// spells one out must still reach it, and only it: in `packages/.cache/*/lib`
+/// the `*` stays subject to the usual rule.
+enum DotComponentAccess<'pattern> {
+    /// No segment names one, so they can be pruned during the walk.
+    Pruned,
+    /// Only these are reachable. Any other dot-prefixed component was matched
+    /// by a wildcard and has to be dropped from the results.
+    Named(Vec<&'pattern str>),
+    /// A dotted wildcard such as `.*` names components it cannot enumerate.
+    Unrestricted,
+}
+
+fn dot_component_access(pattern: &str) -> DotComponentAccess<'_> {
+    let mut named = Vec::new();
+    for segment in pattern.split('/') {
+        if !segment.starts_with('.') || segment == "." || segment == ".." {
+            continue;
+        }
+        if !is_literal_pattern(segment) {
+            return DotComponentAccess::Unrestricted;
+        }
+        named.push(segment);
+    }
+    if named.is_empty() { DotComponentAccess::Pruned } else { DotComponentAccess::Named(named) }
+}
+
+fn matched_a_dot_component_by_wildcard(
+    manifest_path: &Path,
+    walk_root: &Path,
+    named: &[&str],
+) -> bool {
+    manifest_path.strip_prefix(walk_root).unwrap_or(manifest_path).components().any(|component| {
+        let component = component.as_os_str();
+        starts_with_dot(component)
+            && !named.iter().any(|named| std::ffi::OsStr::new(named) == component)
+    })
 }
 
 fn starts_with_dot(name: &std::ffi::OsStr) -> bool {

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -141,11 +141,9 @@ pub fn find_workspace_projects_no_check(
     }
 
     // wax's `not` takes a single pattern; combine the ignores with
-    // `wax::any` so the walk filters them all in one pass (ignoring
-    // `**/node_modules/**` and `**/bower_components/**`).
-    // Built once outside the per-pattern loop to avoid reparsing the
-    // constant ignores. Specialized paths borrow it, while generic walks
-    // clone it into each `Walk::not` call.
+    // `wax::any` so the walk filters them all in one pass. Built once
+    // outside the per-pattern loop to avoid reparsing the constant
+    // ignores.
     let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
         FindWorkspaceProjectsError::InvalidGlob {
             pattern: "<built-in ignore>".to_string(),
@@ -329,8 +327,6 @@ fn is_safe_relative_literal(pattern: &str) -> bool {
 }
 
 fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
-    // Generic glob walks match manifest files, so append every supported
-    // manifest basename to the normalized directory pattern.
     let Some(trimmed) = normalize_directory_pattern(pattern) else { return Vec::new() };
     PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
 }
@@ -445,9 +441,7 @@ fn is_ignored_manifest(
     user_negations: &wax::Any<'_>,
 ) -> bool {
     let relative = manifest_path.strip_prefix(workspace_root).unwrap_or(manifest_path);
-    built_in_ignores.is_match(relative)
-        || pathdiff::diff_paths(manifest_path, workspace_root)
-            .is_some_and(|relative| user_negations.is_match(relative.as_path()))
+    built_in_ignores.is_match(relative) || user_negations.is_match(relative)
 }
 
 /// Strip the pattern's leading `../` components, walking `workspace_root`

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -20,6 +20,7 @@ use miette::Diagnostic;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use std::{
     collections::BTreeSet,
+    fs::{self, DirEntry},
     io::ErrorKind,
     path::{Path, PathBuf},
 };
@@ -170,25 +171,28 @@ pub fn find_workspace_projects_no_check(
     // silently dropped from the workspace.
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
     for pattern in include_patterns {
-        if let Some(parent) = literal_terminal_star_parent(pattern) {
-            collect_manifests_in_children(
-                &workspace_root.join(parent),
-                workspace_root,
-                &ignore_template,
-                &user_negations,
-                &mut manifest_paths,
-            )?;
-            continue;
-        }
-        if let Some(directory) = literal_directory_pattern(pattern) {
-            collect_literal_manifests_in(
-                &workspace_root.join(directory),
-                workspace_root,
-                &ignore_template,
-                &user_negations,
-                &mut manifest_paths,
-            );
-            continue;
+        match specialized_pattern(pattern) {
+            Some(SpecializedPattern::ChildrenOf(parent)) => {
+                collect_manifests_in_children(
+                    &workspace_root.join(parent),
+                    workspace_root,
+                    &ignore_template,
+                    &user_negations,
+                    &mut manifest_paths,
+                )?;
+                continue;
+            }
+            Some(SpecializedPattern::Literal(directory)) => {
+                collect_literal_manifests_in(
+                    &workspace_root.join(directory),
+                    workspace_root,
+                    &ignore_template,
+                    &user_negations,
+                    &mut manifest_paths,
+                );
+                continue;
+            }
+            None => {}
         }
 
         for normalized in normalize_manifest_patterns(pattern) {
@@ -301,13 +305,18 @@ fn normalize_directory_pattern(pattern: &str) -> Option<&str> {
     Some(trimmed)
 }
 
-fn literal_directory_pattern(pattern: &str) -> Option<&str> {
-    normalize_directory_pattern(pattern).filter(|pattern| is_safe_relative_literal(pattern))
+#[derive(Debug, PartialEq, Eq)]
+enum SpecializedPattern<'pattern> {
+    Literal(&'pattern str),
+    ChildrenOf(&'pattern str),
 }
 
-fn literal_terminal_star_parent(pattern: &str) -> Option<&str> {
-    let parent = normalize_directory_pattern(pattern)?.strip_suffix("/*")?;
-    is_safe_relative_literal(parent).then_some(parent)
+fn specialized_pattern(pattern: &str) -> Option<SpecializedPattern<'_>> {
+    let pattern = normalize_directory_pattern(pattern)?;
+    if let Some(parent) = pattern.strip_suffix("/*") {
+        return is_safe_relative_literal(parent).then_some(SpecializedPattern::ChildrenOf(parent));
+    }
+    is_safe_relative_literal(pattern).then_some(SpecializedPattern::Literal(pattern))
 }
 
 fn is_safe_relative_literal(pattern: &str) -> bool {
@@ -332,31 +341,15 @@ fn collect_manifests_in_children(
     user_negations: &wax::Any<'_>,
     manifest_paths: &mut BTreeSet<PathBuf>,
 ) -> Result<(), FindWorkspaceProjectsError> {
-    let walk_error = |source: std::io::Error| FindWorkspaceProjectsError::Walk {
-        root: workspace_root.to_path_buf(),
-        source,
-    };
-    let entries = match std::fs::read_dir(parent) {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
-        Err(err) => return Err(walk_error(err)),
-    };
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
-            Err(err) => return Err(walk_error(err)),
-        };
+    for_each_directory_entry(parent, workspace_root, |entry| {
         if entry.file_name().as_encoded_bytes().first() == Some(&b'.') {
-            continue;
+            return Ok(());
         }
-        let file_type = match entry.file_type() {
-            Ok(file_type) => file_type,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
-            Err(err) => return Err(walk_error(err)),
-        };
-        if !file_type.is_dir() {
-            continue;
+        if !ignore_not_found(entry.file_type())
+            .map_err(|source| workspace_walk_error(workspace_root, source))?
+            .is_some_and(|file_type| file_type.is_dir())
+        {
+            return Ok(());
         }
         collect_manifests_in_child(
             &entry.path(),
@@ -364,9 +357,8 @@ fn collect_manifests_in_children(
             built_in_ignores,
             user_negations,
             manifest_paths,
-        )?;
-    }
-    Ok(())
+        )
+    })
 }
 
 fn collect_literal_manifests_in(
@@ -398,30 +390,51 @@ fn collect_manifests_in_child(
     user_negations: &wax::Any<'_>,
     manifest_paths: &mut BTreeSet<PathBuf>,
 ) -> Result<(), FindWorkspaceProjectsError> {
-    let walk_error = |source: std::io::Error| FindWorkspaceProjectsError::Walk {
-        root: workspace_root.to_path_buf(),
-        source,
-    };
-    let entries = match std::fs::read_dir(directory) {
-        Ok(entries) => entries,
-        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
-        Err(err) => return Err(walk_error(err)),
-    };
-    for entry in entries {
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(err) if err.kind() == ErrorKind::NotFound => continue,
-            Err(err) => return Err(walk_error(err)),
-        };
+    for_each_directory_entry(directory, workspace_root, |entry| {
         if !PROJECT_MANIFEST_BASENAMES.iter().any(|basename| entry.file_name() == *basename) {
-            continue;
+            return Ok(());
         }
         let manifest_path = entry.path();
         if !is_ignored_manifest(&manifest_path, workspace_root, built_in_ignores, user_negations) {
             manifest_paths.insert(manifest_path);
         }
+        Ok(())
+    })
+}
+
+fn for_each_directory_entry(
+    directory: &Path,
+    workspace_root: &Path,
+    mut visit: impl FnMut(DirEntry) -> Result<(), FindWorkspaceProjectsError>,
+) -> Result<(), FindWorkspaceProjectsError> {
+    let entries = match fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(source) => return Err(workspace_walk_error(workspace_root, source)),
+    };
+    for entry in entries {
+        if let Some(entry) = ignore_not_found(entry)
+            .map_err(|source| workspace_walk_error(workspace_root, source))?
+        {
+            visit(entry)?;
+        }
     }
     Ok(())
+}
+
+fn ignore_not_found<T>(result: std::io::Result<T>) -> std::io::Result<Option<T>> {
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn workspace_walk_error(
+    workspace_root: &Path,
+    source: std::io::Error,
+) -> FindWorkspaceProjectsError {
+    FindWorkspaceProjectsError::Walk { root: workspace_root.to_path_buf(), source }
 }
 
 fn is_ignored_manifest(

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -211,47 +211,36 @@ pub fn find_workspace_projects_no_check(
                     message: err.to_string(),
                 })?;
 
-            let dot_access = dot_component_access(pattern);
-            let ignores = match dot_access {
-                DotComponentAccess::Pruned => &dot_pruning_ignore_template,
-                DotComponentAccess::Named(_) | DotComponentAccess::Unrestricted => &ignore_template,
+            let invalid_glob = |err: wax::BuildError| FindWorkspaceProjectsError::InvalidGlob {
+                pattern: pattern.to_string(),
+                message: err.to_string(),
             };
-            let walk = glob.walk(walk_root).not(ignores.clone()).map_err(|err| {
-                FindWorkspaceProjectsError::InvalidGlob {
-                    pattern: pattern.to_string(),
-                    message: err.to_string(),
+            match positional_dot_ignores(normalized) {
+                None => collect_walk_manifests(
+                    glob.walk(walk_root)
+                        .not(dot_pruning_ignore_template.clone())
+                        .map_err(invalid_glob)?,
+                    walk_root,
+                    workspace_root,
+                    &user_negations,
+                    &mut manifest_paths,
+                )?,
+                Some(dot_ignores) => {
+                    let ignores = wax::any(
+                        IGNORE_PATTERNS
+                            .iter()
+                            .copied()
+                            .chain(dot_ignores.iter().map(String::as_str)),
+                    )
+                    .map_err(invalid_glob)?;
+                    collect_walk_manifests(
+                        glob.walk(walk_root).not(ignores).map_err(invalid_glob)?,
+                        walk_root,
+                        workspace_root,
+                        &user_negations,
+                        &mut manifest_paths,
+                    )?;
                 }
-            })?;
-
-            for entry in walk {
-                let entry = match entry {
-                    Ok(entry) => entry,
-                    Err(err) => {
-                        // Converting rather than restringifying keeps the
-                        // underlying `io::ErrorKind`, which the skip below
-                        // needs.
-                        let err = std::io::Error::from(err);
-                        if err.kind() == ErrorKind::NotFound {
-                            continue;
-                        }
-                        return Err(FindWorkspaceProjectsError::Walk {
-                            root: walk_root.to_path_buf(),
-                            source: err,
-                        });
-                    }
-                };
-                let manifest_path = entry.path();
-                if let DotComponentAccess::Named(named) = &dot_access
-                    && matched_a_dot_component_by_wildcard(manifest_path, walk_root, named)
-                {
-                    continue;
-                }
-                if pathdiff::diff_paths(manifest_path, workspace_root)
-                    .is_some_and(|relative| user_negations.is_match(relative.as_path()))
-                {
-                    continue;
-                }
-                manifest_paths.insert(manifest_path.to_path_buf());
             }
         }
     }
@@ -310,7 +299,7 @@ const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**
 
 /// Prunes every path with a dot-prefixed component, so a wildcard cannot
 /// descend into `.git`, `.cache`, and friends. Applied only to patterns that
-/// do not name a dot component themselves — see [`DotComponentAccess`].
+/// do not name a dot component themselves — see [`positional_dot_ignores`].
 const DOT_COMPONENT_IGNORE_PATTERN: &str = "**/.*/**";
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
@@ -480,45 +469,79 @@ fn split_parent_prefix<'root, 'pattern>(
     Some((walk_root, rest))
 }
 
-/// How `pattern` is allowed to reach dot-prefixed path components.
+/// Ignore globs that forbid a dot-prefixed component at each position where
+/// `pattern` has a wildcard, or `None` when no segment names a dot component
+/// and the hoisted [`DOT_COMPONENT_IGNORE_PATTERN`] already says the same thing.
 ///
 /// A wildcard must never match a dot-prefixed component, but a pattern that
-/// spells one out must still reach it, and only it: in `packages/.cache/*/lib`
-/// the `*` stays subject to the usual rule.
-enum DotComponentAccess<'pattern> {
-    /// No segment names one, so they can be pruned during the walk.
-    Pruned,
-    /// Only these are reachable. Any other dot-prefixed component was matched
-    /// by a wildcard and has to be dropped from the results.
-    Named(Vec<&'pattern str>),
-    /// A dotted wildcard such as `.*` names components it cannot enumerate.
-    Unrestricted,
+/// spells one out must still reach it, and only there. Deriving one ignore per
+/// wildcard position keeps that distinction: given `packages/.cache/*/lib`,
+/// `.cache` stays reachable while `packages/.cache/.hidden/lib` and
+/// `packages/.cache/.cache/lib` are both pruned. A wildcard that itself starts
+/// with a dot, as in `packages/.*`, is asking for dot components and gets no
+/// ignore.
+fn positional_dot_ignores(pattern: &str) -> Option<Vec<String>> {
+    let segments: Vec<&str> = pattern.split('/').collect();
+    if !segments.iter().any(|segment| names_a_dot_component(segment)) {
+        return None;
+    }
+    let ignores = segments
+        .iter()
+        .enumerate()
+        .filter(|(_, segment)| !segment.starts_with('.') && !is_literal_pattern(segment))
+        .map(|(index, segment)| {
+            let dotted = if *segment == "**" { "**/.*/**" } else { ".*" };
+            let mut replaced = segments.clone();
+            replaced[index] = dotted;
+            replaced.join("/")
+        })
+        .collect();
+    Some(ignores)
 }
 
-fn dot_component_access(pattern: &str) -> DotComponentAccess<'_> {
-    let mut named = Vec::new();
-    for segment in pattern.split('/') {
-        if !segment.starts_with('.') || segment == "." || segment == ".." {
+/// Drain a prepared walk into `manifest_paths`, absorbing `NotFound` and
+/// applying the user negations that `Walk::not` cannot express.
+fn collect_walk_manifests<Entries, Matched, Failure>(
+    walk: Entries,
+    walk_root: &Path,
+    workspace_root: &Path,
+    user_negations: &wax::Any<'_>,
+    manifest_paths: &mut BTreeSet<PathBuf>,
+) -> Result<(), FindWorkspaceProjectsError>
+where
+    Entries: Iterator<Item = Result<Matched, Failure>>,
+    Matched: Entry,
+    Failure: Into<std::io::Error>,
+{
+    for entry in walk {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) => {
+                // Converting rather than restringifying keeps the underlying
+                // `io::ErrorKind`, which the skip below needs.
+                let err: std::io::Error = err.into();
+                if err.kind() == ErrorKind::NotFound {
+                    continue;
+                }
+                return Err(FindWorkspaceProjectsError::Walk {
+                    root: walk_root.to_path_buf(),
+                    source: err,
+                });
+            }
+        };
+        let manifest_path = entry.path();
+        if pathdiff::diff_paths(manifest_path, workspace_root)
+            .is_some_and(|relative| user_negations.is_match(relative.as_path()))
+        {
             continue;
         }
-        if !is_literal_pattern(segment) {
-            return DotComponentAccess::Unrestricted;
-        }
-        named.push(segment);
+        manifest_paths.insert(manifest_path.to_path_buf());
     }
-    if named.is_empty() { DotComponentAccess::Pruned } else { DotComponentAccess::Named(named) }
+    Ok(())
 }
 
-fn matched_a_dot_component_by_wildcard(
-    manifest_path: &Path,
-    walk_root: &Path,
-    named: &[&str],
-) -> bool {
-    manifest_path.strip_prefix(walk_root).unwrap_or(manifest_path).components().any(|component| {
-        let component = component.as_os_str();
-        starts_with_dot(component)
-            && !named.iter().any(|named| std::ffi::OsStr::new(named) == component)
-    })
+fn names_a_dot_component(segment: &str) -> bool {
+    segment.starts_with('.') && segment != "." && segment != ".."
 }
 
 fn starts_with_dot(name: &std::ffi::OsStr) -> bool {

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -422,7 +422,7 @@ fn for_each_directory_entry(
     Ok(())
 }
 
-fn ignore_not_found<T>(result: std::io::Result<T>) -> std::io::Result<Option<T>> {
+fn ignore_not_found<Value>(result: std::io::Result<Value>) -> std::io::Result<Option<Value>> {
     match result {
         Ok(value) => Ok(Some(value)),
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -144,12 +144,15 @@ pub fn find_workspace_projects_no_check(
     // `wax::any` so the walk filters them all in one pass. Built once
     // outside the per-pattern loop to avoid reparsing the constant
     // ignores.
-    let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
-        FindWorkspaceProjectsError::InvalidGlob {
+    let build_ignores = |patterns: &mut dyn Iterator<Item = &'static str>| {
+        wax::any(patterns).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
             pattern: "<built-in ignore>".to_string(),
             message: err.to_string(),
-        }
-    })?;
+        })
+    };
+    let ignore_template = build_ignores(&mut IGNORE_PATTERNS.iter().copied())?;
+    let dot_pruning_ignore_template =
+        build_ignores(&mut IGNORE_PATTERNS.iter().copied().chain([DOT_COMPONENT_IGNORE_PATTERN]))?;
 
     // User negations are written relative to the workspace root, while a
     // parent-relative include walks from an ancestor of it, so they are
@@ -208,7 +211,12 @@ pub fn find_workspace_projects_no_check(
                     message: err.to_string(),
                 })?;
 
-            let walk = glob.walk(walk_root).not(ignore_template.clone()).map_err(|err| {
+            let ignores = if names_a_dot_component(pattern) {
+                &ignore_template
+            } else {
+                &dot_pruning_ignore_template
+            };
+            let walk = glob.walk(walk_root).not(ignores.clone()).map_err(|err| {
                 FindWorkspaceProjectsError::InvalidGlob {
                     pattern: pattern.to_string(),
                     message: err.to_string(),
@@ -294,6 +302,11 @@ pub fn find_workspace_projects_no_check(
 /// `**/tests/**` directories that the lower-level package-finding path
 /// excludes.
 const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**"];
+
+/// Prunes every path with a dot-prefixed component, so a wildcard cannot
+/// descend into `.git`, `.cache`, and friends. Applied only to patterns that
+/// do not name a dot component themselves — see [`names_a_dot_component`].
+const DOT_COMPONENT_IGNORE_PATTERN: &str = "**/.*/**";
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
 fn normalize_directory_pattern(pattern: &str) -> Option<&str> {
@@ -339,7 +352,7 @@ fn collect_manifests_in_children(
     manifest_paths: &mut BTreeSet<PathBuf>,
 ) -> Result<(), FindWorkspaceProjectsError> {
     for_each_directory_entry(parent, workspace_root, |entry| {
-        if entry.file_name().as_encoded_bytes().first() == Some(&b'.') {
+        if starts_with_dot(&entry.file_name()) {
             return Ok(());
         }
         if !ignore_not_found(entry.file_type())
@@ -460,6 +473,25 @@ fn split_parent_prefix<'root, 'pattern>(
         rest = tail;
     }
     Some((walk_root, rest))
+}
+
+/// Whether `pattern` spells out a dot-prefixed path component, as
+/// `packages/.cache/*` and `packages/.*/lib` both do.
+///
+/// A wildcard must not match a dot-prefixed component, but a pattern that
+/// names one must still reach it. Rather than teach the walk which component
+/// each wildcard consumed, a pattern that names any dot component keeps the
+/// unpruned ignores and matches dot components at *every* position. That is a
+/// superset of the glob's meaning, reachable only by asking for a dot
+/// component in the first place.
+fn names_a_dot_component(pattern: &str) -> bool {
+    pattern
+        .split('/')
+        .any(|component| component.starts_with('.') && component != "." && component != "..")
+}
+
+fn starts_with_dot(name: &std::ffi::OsStr) -> bool {
+    name.as_encoded_bytes().first() == Some(&b'.')
 }
 
 fn is_literal_pattern(pattern: &str) -> bool {

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -143,8 +143,9 @@ pub fn find_workspace_projects_no_check(
     // wax's `not` takes a single pattern; combine the ignores with
     // `wax::any` so the walk filters them all in one pass (ignoring
     // `**/node_modules/**` and `**/bower_components/**`).
-    // Built once outside the per-pattern loop and reused by both the
-    // specialized paths and the generic walks.
+    // Built once outside the per-pattern loop to avoid reparsing the
+    // constant ignores. Specialized paths borrow it, while generic walks
+    // clone it into each `Walk::not` call.
     let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
         FindWorkspaceProjectsError::InvalidGlob {
             pattern: "<built-in ignore>".to_string(),
@@ -320,16 +321,16 @@ fn specialized_pattern(pattern: &str) -> Option<SpecializedPattern<'_>> {
 }
 
 fn is_safe_relative_literal(pattern: &str) -> bool {
-    is_literal_pattern(pattern)
+    !pattern.chars().any(|ch| ch == '\\' || wax::is_meta_character(ch))
         && !pattern.starts_with('/')
-        && !pattern.contains('\\')
-        && !pattern.contains(':')
         && pattern
             .split('/')
             .all(|component| !component.is_empty() && component != "." && component != "..")
 }
 
 fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
+    // Generic glob walks match manifest files, so append every supported
+    // manifest basename to the normalized directory pattern.
     let Some(trimmed) = normalize_directory_pattern(pattern) else { return Vec::new() };
     PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
 }

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -142,10 +142,8 @@ pub fn find_workspace_projects_no_check(
     // wax's `not` takes a single pattern; combine the ignores with
     // `wax::any` so the walk filters them all in one pass (ignoring
     // `**/node_modules/**` and `**/bower_components/**`).
-    // Built once outside the per-pattern loop and `.clone()`-d into each
-    // `Walk::not` call (both `Glob` and `Any` derive `Clone` in wax),
-    // since `IGNORE_PATTERNS` is a constant and reparsing it on every
-    // user-supplied pattern is wasted work.
+    // Built once outside the per-pattern loop and reused by both the
+    // specialized paths and the generic walks.
     let ignore_template = wax::any(IGNORE_PATTERNS.iter().copied()).map_err(|err| {
         FindWorkspaceProjectsError::InvalidGlob {
             pattern: "<built-in ignore>".to_string(),
@@ -172,6 +170,27 @@ pub fn find_workspace_projects_no_check(
     // silently dropped from the workspace.
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
     for pattern in include_patterns {
+        if let Some(parent) = literal_terminal_star_parent(pattern) {
+            collect_manifests_in_children(
+                &workspace_root.join(parent),
+                workspace_root,
+                &ignore_template,
+                &user_negations,
+                &mut manifest_paths,
+            )?;
+            continue;
+        }
+        if let Some(directory) = literal_directory_pattern(pattern) {
+            collect_literal_manifests_in(
+                &workspace_root.join(directory),
+                workspace_root,
+                &ignore_template,
+                &user_negations,
+                &mut manifest_paths,
+            );
+            continue;
+        }
+
         for normalized in normalize_manifest_patterns(pattern) {
             let Some((walk_root, normalized)) = split_parent_prefix(workspace_root, &normalized)
             else {
@@ -274,14 +293,147 @@ pub fn find_workspace_projects_no_check(
 const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**"];
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
-fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
-    // Each user pattern is suffixed with every supported manifest basename
-    // so the glob matches manifest files rather than directories.
+fn normalize_directory_pattern(pattern: &str) -> Option<&str> {
     let trimmed = pattern.trim_end_matches('/');
     if trimmed.is_empty() || trimmed == "." {
-        return Vec::new();
+        return None;
     }
+    Some(trimmed)
+}
+
+fn literal_directory_pattern(pattern: &str) -> Option<&str> {
+    normalize_directory_pattern(pattern).filter(|pattern| is_safe_relative_literal(pattern))
+}
+
+fn literal_terminal_star_parent(pattern: &str) -> Option<&str> {
+    let parent = normalize_directory_pattern(pattern)?.strip_suffix("/*")?;
+    is_safe_relative_literal(parent).then_some(parent)
+}
+
+fn is_safe_relative_literal(pattern: &str) -> bool {
+    is_literal_pattern(pattern)
+        && !pattern.starts_with('/')
+        && !pattern.contains('\\')
+        && !pattern.contains(':')
+        && pattern
+            .split('/')
+            .all(|component| !component.is_empty() && component != "." && component != "..")
+}
+
+fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
+    let Some(trimmed) = normalize_directory_pattern(pattern) else { return Vec::new() };
     PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
+}
+
+fn collect_manifests_in_children(
+    parent: &Path,
+    workspace_root: &Path,
+    built_in_ignores: &wax::Any<'_>,
+    user_negations: &wax::Any<'_>,
+    manifest_paths: &mut BTreeSet<PathBuf>,
+) -> Result<(), FindWorkspaceProjectsError> {
+    let walk_error = |source: std::io::Error| FindWorkspaceProjectsError::Walk {
+        root: workspace_root.to_path_buf(),
+        source,
+    };
+    let entries = match std::fs::read_dir(parent) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(walk_error(err)),
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => return Err(walk_error(err)),
+        };
+        if entry.file_name().as_encoded_bytes().first() == Some(&b'.') {
+            continue;
+        }
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => return Err(walk_error(err)),
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        collect_manifests_in_child(
+            &entry.path(),
+            workspace_root,
+            built_in_ignores,
+            user_negations,
+            manifest_paths,
+        )?;
+    }
+    Ok(())
+}
+
+fn collect_literal_manifests_in(
+    directory: &Path,
+    workspace_root: &Path,
+    built_in_ignores: &wax::Any<'_>,
+    user_negations: &wax::Any<'_>,
+    manifest_paths: &mut BTreeSet<PathBuf>,
+) {
+    for basename in PROJECT_MANIFEST_BASENAMES {
+        let manifest_path = directory.join(basename);
+        if manifest_path.is_file()
+            && !is_ignored_manifest(
+                &manifest_path,
+                workspace_root,
+                built_in_ignores,
+                user_negations,
+            )
+        {
+            manifest_paths.insert(manifest_path);
+        }
+    }
+}
+
+fn collect_manifests_in_child(
+    directory: &Path,
+    workspace_root: &Path,
+    built_in_ignores: &wax::Any<'_>,
+    user_negations: &wax::Any<'_>,
+    manifest_paths: &mut BTreeSet<PathBuf>,
+) -> Result<(), FindWorkspaceProjectsError> {
+    let walk_error = |source: std::io::Error| FindWorkspaceProjectsError::Walk {
+        root: workspace_root.to_path_buf(),
+        source,
+    };
+    let entries = match std::fs::read_dir(directory) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(walk_error(err)),
+    };
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(err) if err.kind() == ErrorKind::NotFound => continue,
+            Err(err) => return Err(walk_error(err)),
+        };
+        if !PROJECT_MANIFEST_BASENAMES.iter().any(|basename| entry.file_name() == *basename) {
+            continue;
+        }
+        let manifest_path = entry.path();
+        if !is_ignored_manifest(&manifest_path, workspace_root, built_in_ignores, user_negations) {
+            manifest_paths.insert(manifest_path);
+        }
+    }
+    Ok(())
+}
+
+fn is_ignored_manifest(
+    manifest_path: &Path,
+    workspace_root: &Path,
+    built_in_ignores: &wax::Any<'_>,
+    user_negations: &wax::Any<'_>,
+) -> bool {
+    let relative = manifest_path.strip_prefix(workspace_root).unwrap_or(manifest_path);
+    built_in_ignores.is_match(relative)
+        || pathdiff::diff_paths(manifest_path, workspace_root)
+            .is_some_and(|relative| user_negations.is_match(relative.as_path()))
 }
 
 /// Strip the pattern's leading `../` components, walking `workspace_root`

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -1,4 +1,7 @@
-use super::{FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects};
+use super::{
+    FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects,
+    literal_directory_pattern, literal_terminal_star_parent,
+};
 use pretty_assertions::assert_eq;
 use std::{fs, io::ErrorKind};
 use tempfile::TempDir;
@@ -14,6 +17,40 @@ fn make_yaml_project(root: &std::path::Path, rel: &str, name: &str) {
     let dir = root.join(rel);
     fs::create_dir_all(&dir).unwrap();
     fs::write(dir.join("package.yaml"), format!("name: {name}\nversion: 0.0.1\n")).unwrap();
+}
+
+#[test]
+fn recognizes_specialized_workspace_patterns() {
+    assert_eq!(literal_directory_pattern("packages/alpha"), Some("packages/alpha"));
+    assert_eq!(literal_directory_pattern("packages/alpha/"), Some("packages/alpha"));
+    assert_eq!(literal_terminal_star_parent("packages/*"), Some("packages"));
+    assert_eq!(literal_terminal_star_parent("packages/*/"), Some("packages"));
+}
+
+#[test]
+fn leaves_other_workspace_patterns_to_the_generic_walk() {
+    for pattern in [
+        "../shared",
+        "/shared",
+        "C:/shared",
+        "packages/*",
+        "packages/**",
+        "packages/{alpha,beta}",
+        "packages/./alpha",
+    ] {
+        assert_eq!(literal_directory_pattern(pattern), None, "literal: {pattern}");
+    }
+    for pattern in [
+        "../shared/*",
+        "/shared/*",
+        "C:/shared/*",
+        "packages/*/*",
+        "packages/**",
+        "packages/{alpha,beta}/*",
+        "packages/./*",
+    ] {
+        assert_eq!(literal_terminal_star_parent(pattern), None, "terminal star: {pattern}");
+    }
 }
 
 #[test]
@@ -34,6 +71,175 @@ fn expands_packages_glob() {
         .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
         .collect();
     assert_eq!(names, vec!["root".to_string(), "alpha".to_string(), "beta".to_string()]);
+}
+
+#[test]
+fn terminal_star_does_not_match_dotted_directories() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_project(tmp.path(), "packages/.cache", "cached");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn terminal_star_matches_only_immediate_child_directories() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_project(tmp.path(), "packages/group/beta", "beta");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn trailing_slash_preserves_terminal_star_semantics() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*/".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn terminal_star_applies_built_in_ignores() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "node_modules/alpha", "alpha");
+    make_project(tmp.path(), "bower_components/beta", "beta");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["node_modules/*".to_string(), "bower_components/*".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string()]);
+}
+
+#[test]
+fn terminal_star_applies_user_negations() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_project(tmp.path(), "packages/beta", "beta");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["packages/*".to_string(), "!packages/alpha".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "beta".to_string()]);
+}
+
+#[test]
+fn terminal_star_ignores_non_directory_children() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    fs::create_dir_all(tmp.path().join("packages")).unwrap();
+    fs::write(tmp.path().join("packages/not-a-directory"), "text").unwrap();
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn terminal_star_does_not_follow_symlinked_child_directories() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "linked-target", "linked");
+    fs::create_dir_all(tmp.path().join("packages")).unwrap();
+    symlink(tmp.path().join("linked-target"), tmp.path().join("packages/linked")).unwrap();
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string()]);
+}
+
+#[test]
+fn non_terminal_wildcard_uses_generic_semantics() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "products/alpha/pkg", "alpha-pkg");
+    make_project(tmp.path(), "products/beta/pkg", "beta-pkg");
+    make_project(tmp.path(), "products/beta/other", "beta-other");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["products/*/pkg".to_string()]) },
+    )
+    .unwrap();
+
+    let mut names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    names.sort();
+    assert_eq!(names, vec!["alpha-pkg".to_string(), "beta-pkg".to_string(), "root".to_string()]);
 }
 
 #[test]
@@ -72,6 +278,88 @@ fn direct_package_pattern_does_not_require_every_manifest_format() {
         .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
         .collect();
     assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn direct_package_pattern_supports_package_yaml() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_yaml_project(tmp.path(), "packages/alpha", "alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+}
+
+#[test]
+fn missing_direct_package_pattern_matches_nothing() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string()]);
+}
+
+#[test]
+fn direct_package_pattern_applies_user_negations() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["packages/alpha".to_string(), "!packages/alpha".to_string()]),
+        },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string()]);
+}
+
+#[cfg(unix)]
+#[test]
+fn direct_package_pattern_follows_symlinked_directory() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "linked-target", "linked");
+    fs::create_dir_all(tmp.path().join("packages")).unwrap();
+    symlink(tmp.path().join("linked-target"), tmp.path().join("packages/linked")).unwrap();
+
+    let projects = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/linked".to_string()]) },
+    )
+    .unwrap();
+
+    let names: Vec<String> = projects
+        .iter()
+        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(names, vec!["root".to_string(), "linked".to_string()]);
 }
 
 #[test]

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -29,7 +29,7 @@ fn recognizes_specialized_workspace_patterns() {
         specialized_pattern("packages/alpha/"),
         Some(SpecializedPattern::Literal("packages/alpha")),
     );
-    assert_eq!(specialized_pattern("packages/*"), Some(SpecializedPattern::ChildrenOf("packages")),);
+    assert_eq!(specialized_pattern("packages/*"), Some(SpecializedPattern::ChildrenOf("packages")));
     assert_eq!(
         specialized_pattern("packages/*/"),
         Some(SpecializedPattern::ChildrenOf("packages")),

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -656,3 +656,14 @@ fn discovers_a_project_whose_manifest_starts_with_a_utf8_bom() {
         .collect();
     assert_eq!(names, vec!["root".to_string(), "bom".to_string()]);
 }
+
+#[test]
+fn a_named_dot_directory_does_not_exempt_later_wildcards() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/.cache/plain/lib", "plain-lib");
+    make_project(tmp.path(), "packages/.cache/.hidden/lib", "hidden-lib");
+
+    let names = find_project_names(tmp.path(), &["packages/.cache/*/lib"]);
+    assert_eq!(names, vec!["root".to_string(), "plain-lib".to_string()]);
+}

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -667,3 +667,27 @@ fn a_named_dot_directory_does_not_exempt_later_wildcards() {
     let names = find_project_names(tmp.path(), &["packages/.cache/*/lib"]);
     assert_eq!(names, vec!["root".to_string(), "plain-lib".to_string()]);
 }
+
+/// The exemption is positional, not by name: a wildcard must not match a dot
+/// component just because the pattern names one spelled the same way.
+#[test]
+fn a_named_dot_directory_does_not_exempt_a_repeat_of_its_own_name() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/.cache/plain/lib", "plain-lib");
+    make_project(tmp.path(), "packages/.cache/.cache/lib", "repeat-lib");
+
+    let names = find_project_names(tmp.path(), &["packages/.cache/*/lib"]);
+    assert_eq!(names, vec!["root".to_string(), "plain-lib".to_string()]);
+}
+
+#[test]
+fn a_named_dot_directory_does_not_exempt_a_recursive_wildcard() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), ".config/plain/lib", "plain-lib");
+    make_project(tmp.path(), ".config/.hidden/lib", "hidden-lib");
+
+    let names = find_project_names(tmp.path(), &[".config/**"]);
+    assert_eq!(names, vec!["root".to_string(), "plain-lib".to_string()]);
+}

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -107,6 +107,51 @@ fn terminal_star_does_not_match_dotted_directories() {
 }
 
 #[test]
+fn recursive_wildcard_does_not_match_dotted_directories() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "nested/plain/deep", "plain");
+    make_project(tmp.path(), "nested/.hidden/deep", "hidden");
+
+    let names = find_project_names(tmp.path(), &["nested/**"]);
+    assert_eq!(names, vec!["root".to_string(), "plain".to_string()]);
+}
+
+#[test]
+fn non_terminal_star_does_not_match_dotted_directories() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha/lib", "alpha-lib");
+    make_project(tmp.path(), "packages/.cache/lib", "cached-lib");
+
+    let names = find_project_names(tmp.path(), &["packages/*/lib"]);
+    assert_eq!(names, vec!["root".to_string(), "alpha-lib".to_string()]);
+}
+
+/// A wildcard must not reach a dot-prefixed directory, but a pattern that
+/// names one must.
+#[test]
+fn a_pattern_naming_a_dotted_directory_still_matches_it() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), ".config/alpha", "alpha");
+    make_project(tmp.path(), "packages/.cache", "cached");
+
+    assert_eq!(
+        find_project_names(tmp.path(), &["packages/.cache"]),
+        vec!["root".to_string(), "cached".to_string()],
+    );
+    assert_eq!(
+        find_project_names(tmp.path(), &[".config/*"]),
+        vec!["root".to_string(), "alpha".to_string()],
+    );
+    assert_eq!(
+        find_project_names(tmp.path(), &["packages/.*"]),
+        vec!["root".to_string(), "cached".to_string()],
+    );
+}
+
+#[test]
 fn terminal_star_matches_only_immediate_child_directories() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects,
-    literal_directory_pattern, literal_terminal_star_parent,
+    FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, SpecializedPattern,
+    find_workspace_projects, ignore_not_found, specialized_pattern,
 };
 use pretty_assertions::assert_eq;
 use std::{fs, io::ErrorKind};
@@ -21,10 +21,19 @@ fn make_yaml_project(root: &std::path::Path, rel: &str, name: &str) {
 
 #[test]
 fn recognizes_specialized_workspace_patterns() {
-    assert_eq!(literal_directory_pattern("packages/alpha"), Some("packages/alpha"));
-    assert_eq!(literal_directory_pattern("packages/alpha/"), Some("packages/alpha"));
-    assert_eq!(literal_terminal_star_parent("packages/*"), Some("packages"));
-    assert_eq!(literal_terminal_star_parent("packages/*/"), Some("packages"));
+    assert_eq!(
+        specialized_pattern("packages/alpha"),
+        Some(SpecializedPattern::Literal("packages/alpha")),
+    );
+    assert_eq!(
+        specialized_pattern("packages/alpha/"),
+        Some(SpecializedPattern::Literal("packages/alpha")),
+    );
+    assert_eq!(specialized_pattern("packages/*"), Some(SpecializedPattern::ChildrenOf("packages")),);
+    assert_eq!(
+        specialized_pattern("packages/*/"),
+        Some(SpecializedPattern::ChildrenOf("packages")),
+    );
 }
 
 #[test]
@@ -33,24 +42,26 @@ fn leaves_other_workspace_patterns_to_the_generic_walk() {
         "../shared",
         "/shared",
         "C:/shared",
-        "packages/*",
         "packages/**",
         "packages/{alpha,beta}",
         "packages/./alpha",
-    ] {
-        assert_eq!(literal_directory_pattern(pattern), None, "literal: {pattern}");
-    }
-    for pattern in [
         "../shared/*",
         "/shared/*",
         "C:/shared/*",
         "packages/*/*",
-        "packages/**",
         "packages/{alpha,beta}/*",
         "packages/./*",
     ] {
-        assert_eq!(literal_terminal_star_parent(pattern), None, "terminal star: {pattern}");
+        assert_eq!(specialized_pattern(pattern), None, "pattern: {pattern}");
     }
+}
+
+#[test]
+fn ignores_only_not_found_errors() {
+    assert_eq!(ignore_not_found(Ok("entry")).unwrap(), Some("entry"));
+    assert_eq!(ignore_not_found::<()>(Err(ErrorKind::NotFound.into())).unwrap(), None);
+    let error = ignore_not_found::<()>(Err(ErrorKind::PermissionDenied.into())).unwrap_err();
+    assert_eq!(error.kind(), ErrorKind::PermissionDenied);
 }
 
 #[test]

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -1,9 +1,9 @@
 use super::{
     FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, SpecializedPattern,
-    find_workspace_projects, ignore_not_found, specialized_pattern,
+    find_workspace_projects, specialized_pattern,
 };
 use pretty_assertions::assert_eq;
-use std::{fs, io::ErrorKind};
+use std::{fs, io::ErrorKind, path::Path};
 use tempfile::TempDir;
 
 fn make_project(root: &std::path::Path, rel: &str, name: &str) {
@@ -17,6 +17,19 @@ fn make_yaml_project(root: &std::path::Path, rel: &str, name: &str) {
     let dir = root.join(rel);
     fs::create_dir_all(&dir).unwrap();
     fs::write(dir.join("package.yaml"), format!("name: {name}\nversion: 0.0.1\n")).unwrap();
+}
+
+fn find_project_names(root: &Path, patterns: &[&str]) -> Vec<String> {
+    find_workspace_projects(
+        root,
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(patterns.iter().map(|pattern| (*pattern).to_string()).collect()),
+        },
+    )
+    .unwrap()
+    .iter()
+    .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
+    .collect()
 }
 
 #[test]
@@ -44,24 +57,22 @@ fn leaves_other_workspace_patterns_to_the_generic_walk() {
         "C:/shared",
         "packages/**",
         "packages/{alpha,beta}",
+        "packages/$",
+        "packages/<alpha>",
+        "packages/(alpha,beta)",
         "packages/./alpha",
         "../shared/*",
         "/shared/*",
         "C:/shared/*",
         "packages/*/*",
         "packages/{alpha,beta}/*",
+        "packages/$/*",
+        "packages/<alpha>/*",
+        "packages/(alpha,beta)/*",
         "packages/./*",
     ] {
         assert_eq!(specialized_pattern(pattern), None, "pattern: {pattern}");
     }
-}
-
-#[test]
-fn ignores_only_not_found_errors() {
-    assert_eq!(ignore_not_found(Ok("entry")).unwrap(), Some("entry"));
-    assert_eq!(ignore_not_found::<()>(Err(ErrorKind::NotFound.into())).unwrap(), None);
-    let error = ignore_not_found::<()>(Err(ErrorKind::PermissionDenied.into())).unwrap_err();
-    assert_eq!(error.kind(), ErrorKind::PermissionDenied);
 }
 
 #[test]
@@ -91,16 +102,7 @@ fn terminal_star_does_not_match_dotted_directories() {
     make_project(tmp.path(), "packages/alpha", "alpha");
     make_project(tmp.path(), "packages/.cache", "cached");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/*"]);
     assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
 }
 
@@ -110,36 +112,9 @@ fn terminal_star_matches_only_immediate_child_directories() {
     make_project(tmp.path(), ".", "root");
     make_project(tmp.path(), "packages/alpha", "alpha");
     make_project(tmp.path(), "packages/group/beta", "beta");
+    fs::write(tmp.path().join("packages/not-a-directory"), "text").unwrap();
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
-    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
-}
-
-#[test]
-fn trailing_slash_preserves_terminal_star_semantics() {
-    let tmp = TempDir::new().unwrap();
-    make_project(tmp.path(), ".", "root");
-    make_project(tmp.path(), "packages/alpha", "alpha");
-
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*/".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/*"]);
     assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
 }
 
@@ -150,18 +125,7 @@ fn terminal_star_applies_built_in_ignores() {
     make_project(tmp.path(), "node_modules/alpha", "alpha");
     make_project(tmp.path(), "bower_components/beta", "beta");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts {
-            patterns: Some(vec!["node_modules/*".to_string(), "bower_components/*".to_string()]),
-        },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["node_modules/*", "bower_components/*"]);
     assert_eq!(names, vec!["root".to_string()]);
 }
 
@@ -172,39 +136,8 @@ fn terminal_star_applies_user_negations() {
     make_project(tmp.path(), "packages/alpha", "alpha");
     make_project(tmp.path(), "packages/beta", "beta");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts {
-            patterns: Some(vec!["packages/*".to_string(), "!packages/alpha".to_string()]),
-        },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/*", "!packages/alpha"]);
     assert_eq!(names, vec!["root".to_string(), "beta".to_string()]);
-}
-
-#[test]
-fn terminal_star_ignores_non_directory_children() {
-    let tmp = TempDir::new().unwrap();
-    make_project(tmp.path(), ".", "root");
-    fs::create_dir_all(tmp.path().join("packages")).unwrap();
-    fs::write(tmp.path().join("packages/not-a-directory"), "text").unwrap();
-
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
-    assert_eq!(names, vec!["root".to_string()]);
 }
 
 #[cfg(unix)]
@@ -218,39 +151,30 @@ fn terminal_star_does_not_follow_symlinked_child_directories() {
     fs::create_dir_all(tmp.path().join("packages")).unwrap();
     symlink(tmp.path().join("linked-target"), tmp.path().join("packages/linked")).unwrap();
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/*"]);
     assert_eq!(names, vec!["root".to_string()]);
 }
 
 #[test]
-fn non_terminal_wildcard_uses_generic_semantics() {
+fn wax_metacharacters_use_generic_semantics() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "products/$/pkg", "dollar-pkg");
     make_project(tmp.path(), "products/alpha/pkg", "alpha-pkg");
     make_project(tmp.path(), "products/beta/pkg", "beta-pkg");
     make_project(tmp.path(), "products/beta/other", "beta-other");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["products/*/pkg".to_string()]) },
-    )
-    .unwrap();
-
-    let mut names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let mut names = find_project_names(tmp.path(), &["products/$/pkg"]);
     names.sort();
-    assert_eq!(names, vec!["alpha-pkg".to_string(), "beta-pkg".to_string(), "root".to_string()]);
+    assert_eq!(
+        names,
+        vec![
+            "alpha-pkg".to_string(),
+            "beta-pkg".to_string(),
+            "dollar-pkg".to_string(),
+            "root".to_string(),
+        ],
+    );
 }
 
 #[test]
@@ -273,41 +197,14 @@ fn expands_packages_glob_to_package_yaml() {
 }
 
 #[test]
-fn direct_package_pattern_does_not_require_every_manifest_format() {
+fn direct_package_patterns_support_both_manifest_formats() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");
     make_project(tmp.path(), "packages/alpha", "alpha");
+    make_yaml_project(tmp.path(), "packages/beta", "beta");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
-    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
-}
-
-#[test]
-fn direct_package_pattern_supports_package_yaml() {
-    let tmp = TempDir::new().unwrap();
-    make_project(tmp.path(), ".", "root");
-    make_yaml_project(tmp.path(), "packages/alpha", "alpha");
-
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
-    assert_eq!(names, vec!["root".to_string(), "alpha".to_string()]);
+    let names = find_project_names(tmp.path(), &["packages/alpha", "packages/beta"]);
+    assert_eq!(names, vec!["root".to_string(), "alpha".to_string(), "beta".to_string()]);
 }
 
 #[test]
@@ -315,16 +212,7 @@ fn missing_direct_package_pattern_matches_nothing() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/alpha".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/alpha"]);
     assert_eq!(names, vec!["root".to_string()]);
 }
 
@@ -334,18 +222,7 @@ fn direct_package_pattern_applies_user_negations() {
     make_project(tmp.path(), ".", "root");
     make_project(tmp.path(), "packages/alpha", "alpha");
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts {
-            patterns: Some(vec!["packages/alpha".to_string(), "!packages/alpha".to_string()]),
-        },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/alpha", "!packages/alpha"]);
     assert_eq!(names, vec!["root".to_string()]);
 }
 
@@ -360,16 +237,7 @@ fn direct_package_pattern_follows_symlinked_directory() {
     fs::create_dir_all(tmp.path().join("packages")).unwrap();
     symlink(tmp.path().join("linked-target"), tmp.path().join("packages/linked")).unwrap();
 
-    let projects = find_workspace_projects(
-        tmp.path(),
-        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/linked".to_string()]) },
-    )
-    .unwrap();
-
-    let names: Vec<String> = projects
-        .iter()
-        .map(|project| project.manifest.value().get("name").unwrap().as_str().unwrap().to_string())
-        .collect();
+    let names = find_project_names(tmp.path(), &["packages/linked"]);
     assert_eq!(names, vec!["root".to_string(), "linked".to_string()]);
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start a review after CodeRabbit approves the PR and CI passes. -->

## Summary

Recursive `**` patterns can traverse source, example, documentation, and other non-project directories.
Literal project paths and one-level `parent/*` patterns do not need recursive traversal.

pnpm currently appends each supported manifest name to every workspace pattern. It then sends every result to the generic `wax` glob walker.

This PR adds fast paths for two patterns that are relative to the workspace root:

- literal project paths, such as `packages/app`
- one-level stars with a literal parent, such as `packages/*`

The literal fast path probes each supported manifest directly. The one-level star fast path reads the parent once and probes each child.

Both fast paths preserve these behaviors:

- manifest precedence
- built-in ignores and user negations
- missing-directory behavior
- symlink behavior
- file-system error propagation
- deterministic results

The generic `wax` walker still handles all other patterns. These patterns include absolute, parent-relative, recursive, and non-terminal patterns.

The PR does not add a fast path for `**`. A recursive pattern must traverse its declared tree to preserve its meaning.

### Benchmark

The benchmark uses this [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction/tree/d24ed46c63d6f12fd724032263b96b58ec8868bf).
The workspace contains 6,832 projects using 784 precise patterns.

The benchmark ran one warm-up for each binary. It then ran ten fresh processes for each binary in alternating order.

```console
pnpm install --lockfile-only --frozen-lockfile --offline --reporter=ndjson
```

| Patterns | `main` scope | This PR scope | Scope change | `main` wall | This PR wall | Wall change |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 784 | 3,000.50 ms | 843.50 ms | -71.89% | 3,559.56 ms | 1,395.80 ms | -60.79% |

Each value is the median of the ten measured runs.

### Dot-directory behavior

Review of the fast paths surfaced a behavior change, and chasing it down turned up a pnpm 11 regression that this PR now also fixes.

`wax` gives wildcards no dot handling at all, so pnpm 12 discovered projects that pnpm 11 never saw: `packages/*` matched `packages/.cache`, and the default `**` descended into `.git`.

Workspace patterns follow Bash dotglob-off semantics **per segment**, not as a blanket exclusion:

| Pattern | Matches a dot-prefixed directory? |
| --- | --- |
| `packages/*`, `nested/**` | no |
| `packages/.cache` | yes |
| `packages/.*` | yes |

Measured against `tinyglobby` and `fast-glob` directly, and end to end against npm 12.0.2, Yarn 1.22.22, Yarn Berry, Bun 1.3.14, and pnpm 11 -- all agree.

The terminal-star fast path skips dot-prefixed entries directly. The generic walk adds a dot-component pattern to its `wax` ignores, which also stops it descending into `.git`. A pattern that names a dot component keeps the unpruned ignores and so matches dot components at every position: a superset of the glob's meaning, reachable only by asking for a dot component in the first place.

Each new test was verified to fail when its own guard is removed, and every other discovery test passes identically with the fast paths stubbed out -- so the speedups remain behavior-preserving on their own.

## Squash Commit Body

```text
pnpm sent every workspace pattern to the generic wax glob walker after it appended each supported manifest name.
Literal project paths and one-level parent-star patterns therefore used unnecessary glob setup and traversal.

Probe manifests directly for safe literal patterns. Read each declared parent once for safe one-level star patterns.
Preserve ignores, negations, manifest precedence, symlinks, errors, and deterministic results.
Keep absolute, parent-relative, recursive, and complex patterns on the generic wax path.

Wax gives wildcards no dot handling, so pnpm 12 discovered projects under dot-prefixed
directories that pnpm 11 never saw. Apply dotglob semantics per segment: a wildcard no
longer matches a dot-prefixed component, while a literal dot segment and an explicitly
dotted wildcard still do. Pruning dot components also stops the generic walk descending
into .git.

The benchmark workspace contains 6,833 projects and 784 precise workspace patterns.
Across ten alternating runs, median scope time decreased from 3,000.50 ms to 843.50 ms.
```

## Checklist

- [x] I searched existing workspace-discovery PRs and issues. I found no duplicate.
- [x] This PR changes only the Rust reader. The TypeScript reader does not use this `wax` traversal.
- [x] I added a `pacquet` patch changeset.
- [x] I added tests for the fast paths, fallbacks, negations, ignores, manifests, symlinks, missing directories, and errors.
- [x] The fast paths are behavior-preserving. Separately, this PR fixes a pnpm 11 regression: wildcards no longer match dot-prefixed directories. The changeset records it; no documentation change is needed.

---

Written by an agent (Codex, GPT-5.6 Sol).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance
- Faster workspace discovery for direct paths and common child-directory patterns.

## Bug Fixes
- Improved wildcard matching for hidden directories, including pnpm 11-compatible dot-directory behavior.
- Improved handling of ignored paths, missing locations, and symlinked directories.
- Consistent recognition of supported package manifest formats.
- Preserved expected behavior for complex wildcard patterns.

## Release
- Included in a patch release for `pacquet`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
