### PR TITLE
perf(deps-restorer): overlap the node version probe with the warm-cache prefetch

### DIFF
--- a/.changeset/overlap-engine-probe.md
+++ b/.changeset/overlap-engine-probe.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Rebuilding `node_modules` from an up-to-date lockfile is up to ~200 ms faster: the `node --version` probe that installability checks and store keying need now runs concurrently with the store's warm-cache reads instead of before them.

--- a/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_dir_by_snapshot.rs
@@ -95,7 +95,7 @@ pub struct CreateVirtualDirBySnapshot<'a> {
     /// eligible ([`DirCloneCache::eligible`]) or when the caller's
     /// per-slot qualification says this slot must take the per-file
     /// import.
-    pub dir_clone_cache: Option<&'a DirCloneCache>,
+    pub dir_clone_cache: Option<&'a DirCloneCache<'a>>,
     #[cfg(test)]
     pub link_concurrency_probe: Option<&'a tests::LinkConcurrencyProbe>,
 }

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -125,10 +125,19 @@ impl CasPrefetch {
         store_context: Option<&CreateVirtualStoreStoreContext<'_>>,
     ) -> Self {
         let store_dir: &'static _ = &config.store_dir;
-        // See the comment on [`CreateVirtualStore::run`]'s former open
-        // site (now here): one read-only SQLite handle for the whole
-        // run, opened on the blocking pool, `None` for a store with no
-        // `index.db` yet.
+        // Open the read-only SQLite index once for the whole run instead
+        // of per snapshot. Every `InstallPackageBySnapshot` performs a
+        // cache lookup against this index before falling through to the
+        // network; on a 1352-package lockfile the per-snapshot reopen
+        // accounted for ~1.3 s of wall time even with a fully populated
+        // store (see <https://github.com/pnpm/pacquet/issues/260>). A
+        // `None` here means the store has no `index.db` yet (first
+        // install against an empty store), in which case every lookup
+        // would miss — so the handle stays `Option`al and lookups
+        // short-circuit. The open itself is synchronous SQLite I/O
+        // parked on the blocking pool; `open_shared` degrades a
+        // blocking-task failure to `None` so the install still makes
+        // progress with cache misses.
         let store_index = match store_context.and_then(|context| context.index) {
             Some(index) => Some(Arc::clone(index)),
             None => StoreIndex::open_shared(store_dir, config.frozen_store).await,
@@ -425,27 +434,11 @@ impl CreateVirtualStore<'_> {
         };
         let packages = packages.ok_or(CreateVirtualStoreError::MissingPackagesSection)?;
 
-        // Open the read-only SQLite index once for the whole run instead of
-        // per snapshot. Every `InstallPackageBySnapshot` performs a cache
-        // lookup against this index before falling through to the network;
-        // on a 1352-package lockfile the per-snapshot reopen accounted for
-        // ~1.3 s of wall time even with a fully populated store (see <https://github.com/pnpm/pacquet/issues/260>).
-        // A `None` here means the store has no `index.db` yet (first install
-        // against an empty store), in which case every lookup would miss —
-        // so we keep the handle `Option`al and short-circuit.
-        //
-        // The open itself is synchronous SQLite I/O (`Connection::open_with_flags`
-        // + a `PRAGMA busy_timeout`), so park it on the blocking pool instead
-        // of stalling the reactor thread, even for the sub-millisecond it
-        // usually takes.
-        //
-        // A `JoinError` here (blocking-task panic, or cancellation during
-        // runtime shutdown) is degraded into `None` so the install still
-        // makes progress — cache lookups just miss. `shared_readonly_in`
-        // already yields `None` for a first-time install against an empty
-        // store, and downstream callers handle that shape correctly. We
-        // surface the error at `warn!` so a silent task panic or
-        // cancellation is still diagnosable in the log.
+        // The prefetch carries the run's store handles — the shared
+        // read-only index and the install-scoped `verifiedFilesCache`
+        // (one `Arc<DashSet>` per install, so a CAFS path verified for
+        // one snapshot is not re-stat'd for another) — plus the derived
+        // cache keys and the in-flight lookup task.
         let CasPrefetch {
             store_index,
             verified_files_cache,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -83,6 +83,106 @@ pub struct CreateVirtualStoreStoreContext<'a> {
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
 }
 
+/// The store-side half of [`CreateVirtualStore::run`]'s planning,
+/// started ahead of the rest: the store-index open, the per-snapshot
+/// cache-key derivation, and the warm-cache prefetch task those keys
+/// feed.
+///
+/// [`CreateVirtualStore::run`] starts one itself when the caller passes
+/// none. A caller that has independent async work to do between
+/// planning and materialization — the frozen install path's
+/// installability host detection, whose `node --version` costs more
+/// than the entire prefetch — starts it early via [`Self::start`] and
+/// hands it over through [`CreateVirtualStore::cas_prefetch`], so the
+/// prefetch's store reads run under that work instead of after it.
+pub struct CasPrefetch {
+    store_index: Option<SharedReadonlyStoreIndex>,
+    verified_files_cache: SharedVerifiedFilesCache,
+    /// One entry per lockfile snapshot. Values keep the derivation
+    /// `Result` so [`snapshot_plan::plan_snapshots`] can preserve the
+    /// strict/lenient asymmetry documented there: a survivor propagates
+    /// its error, a skipped snapshot swallows it.
+    cache_keys: HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+    task: tokio::task::JoinHandle<PrefetchResult>,
+}
+
+impl CasPrefetch {
+    /// Derive every snapshot's store-index cache key and spawn the
+    /// warm-cache prefetch over the keys that exist. Read-only against
+    /// the store apart from the `SQLite` open, so it is safe to run
+    /// concurrently with anything that does not write store rows —
+    /// but, like the rest of the store planning, only after the
+    /// offline lockfile checks.
+    ///
+    /// `snapshots` and `packages` must be the same maps later given to
+    /// [`CreateVirtualStore::run`]: the plan pass consumes one derived
+    /// key per snapshot.
+    pub async fn start(
+        config: &'static Config,
+        snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+        packages: Option<&HashMap<PackageKey, PackageMetadata>>,
+        supported_architectures: Option<&pnpm_package_is_installable::SupportedArchitectures>,
+        store_context: Option<&CreateVirtualStoreStoreContext<'_>>,
+    ) -> Self {
+        let store_dir: &'static _ = &config.store_dir;
+        // See the comment on [`CreateVirtualStore::run`]'s former open
+        // site (now here): one read-only SQLite handle for the whole
+        // run, opened on the blocking pool, `None` for a store with no
+        // `index.db` yet.
+        let store_index = match store_context.and_then(|context| context.index) {
+            Some(index) => Some(Arc::clone(index)),
+            None => StoreIndex::open_shared(store_dir, config.frozen_store).await,
+        };
+        // Install-scoped `verifiedFilesCache`: one `Arc<DashSet>` for
+        // the duration of the install, so a CAFS path verified for one
+        // snapshot is not re-stat'd for another.
+        let verified_files_cache = store_context
+            .map_or_else(SharedVerifiedFilesCache::default, |context| {
+                Arc::clone(context.verified_files_cache)
+            });
+        let cache_keys: HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>> =
+            match (snapshots, packages) {
+                (Some(snapshots), Some(packages)) => {
+                    let selector = runtime_platform_selector(supported_architectures);
+                    snapshots
+                        .keys()
+                        .map(|snapshot_key| {
+                            let cache_key = snapshot_cache_key(
+                                snapshot_key,
+                                packages,
+                                config.ignore_scripts,
+                                &selector,
+                            );
+                            (snapshot_key.clone(), cache_key)
+                        })
+                        .collect()
+                }
+                _ => HashMap::new(),
+            };
+        // Sorted + deduplicated so `prefetch_cas_paths` doesn't redo
+        // identical SELECT + integrity-check work for peer variants of
+        // one package. Derived leniently over the whole lockfile — the
+        // superset over what the plan pass will keep merely prefetches
+        // a few rows nothing reads.
+        let mut cache_key_refs: Vec<&str> = cache_keys
+            .values()
+            .filter_map(|cache_key| cache_key.as_ref().ok())
+            .filter_map(|cache_key| cache_key.value.as_deref())
+            .collect();
+        cache_key_refs.sort_unstable();
+        cache_key_refs.dedup();
+        let prefetch_keys: Vec<String> = cache_key_refs.into_iter().map(String::from).collect();
+        let task = tokio::spawn(prefetch_cas_paths(
+            store_index.clone(),
+            store_dir,
+            prefetch_keys,
+            config.verify_store_integrity,
+            SharedVerifiedFilesCache::clone(&verified_files_cache),
+        ));
+        CasPrefetch { store_index, verified_files_cache, cache_keys, task }
+    }
+}
+
 /// A snapshot paired with the store-index cache key it is looked up
 /// by. `None` for a resolution that never goes through the CAFS
 /// (directory and git), which therefore has no row to prefetch.
@@ -162,6 +262,11 @@ pub struct CreateVirtualStore<'a> {
     /// `BuildModules` for the side-effects-cache WRITE path.
     pub store_index_writer: &'a std::sync::Arc<StoreIndexWriter>,
     pub store_context: Option<CreateVirtualStoreStoreContext<'a>>,
+    /// A [`CasPrefetch`] the caller started early so its store reads
+    /// overlap caller-side async work; `None` makes [`Self::run`] start
+    /// one itself. Must have been started with this run's `snapshots` /
+    /// `packages`.
+    pub cas_prefetch: Option<CasPrefetch>,
     /// `allowBuilds` gate, shared with `BuildModules`. The cold-batch
     /// path threads this into the git fetcher so `preparePackage` can
     /// reject `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` for packages that aren't
@@ -200,7 +305,7 @@ pub struct CreateVirtualStore<'a> {
     /// ([`crate::dir_clone_cache`]), built by the install entry points
     /// when [`crate::DirCloneCache::eligible`] holds. Threaded into
     /// every slot link that passes `dir_clone_cacheable`.
-    pub dir_clone_cache: Option<&'a crate::DirCloneCache>,
+    pub dir_clone_cache: Option<&'a crate::DirCloneCache<'a>>,
     /// Cache keys whose package status (`fetched` or `found_in_store`)
     /// has already been emitted earlier in this install. The warm batch
     /// still emits `resolved` for those packages, but skips the second
@@ -285,6 +390,7 @@ impl CreateVirtualStore<'_> {
             requester,
             store_index_writer,
             store_context,
+            cas_prefetch,
             allow_build_policy,
             skipped,
             include_optional_dependencies,
@@ -340,6 +446,24 @@ impl CreateVirtualStore<'_> {
         // store, and downstream callers handle that shape correctly. We
         // surface the error at `warn!` so a silent task panic or
         // cancellation is still diagnosable in the log.
+        let CasPrefetch {
+            store_index,
+            verified_files_cache,
+            cache_keys: mut snapshot_cache_keys,
+            task: prefetch_task,
+        } = match cas_prefetch {
+            Some(cas_prefetch) => cas_prefetch,
+            None => {
+                CasPrefetch::start(
+                    config,
+                    Some(snapshots),
+                    Some(packages),
+                    supported_architectures,
+                    store_context.as_ref(),
+                )
+                .await
+            }
+        };
         let store_dir: &'static _ = &config.store_dir;
 
         // Eagerly create `files/00..ff` under the v11 store root so per-
@@ -365,10 +489,6 @@ impl CreateVirtualStore<'_> {
                 None
             };
 
-        let store_index = match store_context.as_ref().and_then(|context| context.index) {
-            Some(index) => Some(Arc::clone(index)),
-            None => StoreIndex::open_shared(store_dir, config.frozen_store).await,
-        };
         let store_index_ref = store_index.as_ref();
 
         // The batched store-index writer is owned by the caller
@@ -381,56 +501,19 @@ impl CreateVirtualStore<'_> {
         // `InstallPackageBySnapshot.store_index_writer`.
         let store_index_writer_ref = Some(store_index_writer);
 
-        // Install-scoped `verifiedFilesCache`. One `Arc<DashSet>` lives
-        // for the duration of the install; every per-snapshot fetch
-        // gets the same handle. A CAFS path verified on snapshot A
-        // populates the set so snapshot B's verify pass skips the stat
-        // / re-hash cost.
-        let verified_files_cache = store_context
-            .map_or_else(SharedVerifiedFilesCache::default, |context| {
-                Arc::clone(context.verified_files_cache)
-            });
-
-        // Batch every cache lookup the per-snapshot futures would otherwise
-        // each fan into `tokio::task::spawn_blocking`. With 1352 snapshots
-        // hitting the default 512-thread blocking pool, each task's actual
-        // work (≈40 µs SELECT + per-file integrity stats) gets dwarfed by
-        // OS context-switching among hundreds of competing threads
-        // (sample-profiling: 20-60 ms wall per call, sum 26-82 s). Doing
-        // the same `SELECT`s and integrity checks on one thread holding the
-        // index mutex once is dramatically faster — and turns each
-        // per-snapshot future's cache lookup into a synchronous
-        // `HashMap::get`.
-        //
-        // Compute the cache keys upfront from `(integrity, pkg_id)` for
-        // every snapshot whose metadata has a tarball-style resolution.
-        // Tarball-and-Registry resolutions both ship an `Integrity`;
-        // Directory and Git resolutions don't go through CAFS at all,
-        // so skipping them here matches the per-snapshot path's check.
-        // [`snapshot_cache_key`] is the shared key-derivation helper —
-        // a future change to the resolution-type handling or key
-        // shape stays in one place (Copilot review on <https://github.com/pnpm/pacquet/pull/292>).
-        //
-        // Walk `snapshots` once, stash the per-snapshot cache key
-        // alongside its `(snapshot_key, snapshot)` tuple, and reuse
-        // the stashed key for both the prefetch input and the
-        // warm/cold partition below. A separate pass to recompute
-        // each key would re-allocate two strings per snapshot for
-        // nothing (Copilot follow-up review on <https://github.com/pnpm/pacquet/pull/292>).
-        //
-        // Lockfiles with peer-dependency variants of the same package
-        // (e.g. `react-dom@17.0.2(react@17.0.2)` plus
-        // `react-dom@17.0.2(react@18.2.0)`) collapse to one cache key
-        // because the key is built from `metadata_key.without_peer()`.
-        // Sort + dedup the prefetch input so `prefetch_cas_paths`
-        // doesn't redo identical SELECT + integrity-check work for
-        // every peer variant.
+        // The plan pass consumes the keys [`CasPrefetch::start`]
+        // derived (one per snapshot, kept as `Result`s so the
+        // strict/lenient asymmetry documented on `plan_snapshots`
+        // survives the early derivation), stashing each survivor's key
+        // alongside its `(snapshot_key, snapshot)` tuple for the
+        // warm/cold partition below. Its slot probes run while the
+        // prefetch task reads the store index.
         let snapshot_plan::SnapshotPlan {
             survivors: mut snapshot_entries,
             skipped_entries,
             marker_rebuilds,
             has_git_hosted_survivor,
-        } = snapshot_plan::plan_snapshots::<Reporter>(&snapshot_plan::SnapshotPlanInputs {
+        } = snapshot_plan::plan_snapshots::<Reporter>(snapshot_plan::SnapshotPlanInputs {
             snapshots,
             packages,
             current_snapshots,
@@ -441,8 +524,7 @@ impl CreateVirtualStore<'_> {
             link_dependencies: !is_hoisted && config.symlink,
             is_hoisted,
             include_optional_dependencies,
-            ignore_scripts: config.ignore_scripts,
-            runtime_platform_selector: &runtime_platform_selector,
+            cache_keys: &mut snapshot_cache_keys,
         })?;
         let materialized_snapshots =
             snapshot_entries.iter().map(|(snapshot_key, _, _)| (*snapshot_key).clone()).collect();
@@ -465,26 +547,17 @@ impl CreateVirtualStore<'_> {
             },
         }));
 
-        // Union the cache keys from survivors and skipped snapshots
-        // so the prefetch covers everyone the build phase might need
-        // to gate on. Sorted + deduplicated to avoid redundant SQL
-        // queries in `prefetch_cas_paths`.
-        let mut cache_key_refs: Vec<&str> = snapshot_entries
-            .iter()
-            .chain(skipped_entries.iter())
-            .filter_map(|(_, _, k)| k.as_deref())
-            .collect();
-        cache_key_refs.sort_unstable();
-        cache_key_refs.dedup();
-        let cache_keys: Vec<String> = cache_key_refs.into_iter().map(String::from).collect();
-        let prefetch = prefetch_cas_paths(
-            store_index.clone(),
-            store_dir,
-            cache_keys,
-            config.verify_store_integrity,
-            SharedVerifiedFilesCache::clone(&verified_files_cache),
-        )
-        .await;
+        // A joined-task failure degrades to an empty result: every
+        // lookup misses and the snapshots fall through to their
+        // per-snapshot path, the same shape as a store with no index.
+        let prefetch = prefetch_task.await.unwrap_or_else(|error| {
+            tracing::warn!(
+                target: "pacquet::install",
+                ?error,
+                "warm-cache prefetch task failed; treating every lookup as a miss",
+            );
+            PrefetchResult::default()
+        });
         enforce_cached_git_prepare_policy(
             &mut snapshot_entries,
             packages,
@@ -1228,7 +1301,7 @@ struct LinkSlotsParallel<'a> {
     batch: &'static str,
     slots: &'a [SlotLink<'a>],
     layout: &'a crate::VirtualStoreLayout,
-    dir_clone_cache: Option<&'a crate::DirCloneCache>,
+    dir_clone_cache: Option<&'a crate::DirCloneCache<'a>>,
     symlink: bool,
     import_method: PackageImportMethod,
     logged_methods: &'a AtomicU8,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -1,17 +1,13 @@
-//! Decide which snapshots this install must materialize, and derive the
-//! store-index cache key each one is looked up by.
-//!
-//! Runs before the prefetch, whose input is the cache keys produced
-//! here.
+//! Decide which snapshots this install must materialize, pairing each
+//! with the store-index cache key [`super::CasPrefetch::start`]
+//! derived for it.
 
 use super::{
-    CreateVirtualStoreError, SnapshotWithCacheKey, gvs_slot_needs_rebuild, integrity_equal,
-    snapshot_cache_key, snapshot_deps_equal,
+    CreateVirtualStoreError, SnapshotCacheKey, SnapshotWithCacheKey, gvs_slot_needs_rebuild,
+    integrity_equal, snapshot_deps_equal,
 };
 use crate::{SkippedSnapshots, VirtualStoreLayout};
-use pnpm_lockfile::{
-    LockfileResolution, PackageKey, PackageMetadata, PlatformSelector, SnapshotEntry,
-};
+use pnpm_lockfile::{LockfileResolution, PackageKey, PackageMetadata, SnapshotEntry};
 use pnpm_reporter::{BrokenModulesLog, LogEvent, LogLevel, Reporter};
 use std::{
     collections::{HashMap, HashSet},
@@ -33,8 +29,10 @@ pub(super) struct SnapshotPlanInputs<'a> {
     pub link_dependencies: bool,
     pub is_hoisted: bool,
     pub include_optional_dependencies: bool,
-    pub ignore_scripts: bool,
-    pub runtime_platform_selector: &'a PlatformSelector,
+    /// One derivation `Result` per lockfile snapshot, taken by the
+    /// entry that keeps it. See [`super::CasPrefetch::start`], which
+    /// guarantees the every-snapshot coverage.
+    pub cache_keys: &'a mut HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
 }
 
 /// The snapshots to install, the ones deliberately left alone, and the
@@ -54,16 +52,16 @@ pub(super) struct SnapshotPlan<'a> {
 /// Partition the lockfile's snapshots into what this install must do
 /// and what it may leave alone.
 ///
-/// Validation is deliberately asymmetric: survivors go through the
-/// strict cache-key derivation, because the install will actually fetch
-/// and link them, so a malformed resolution must fail before the warm
-/// batch starts rather than several seconds into it. Skipped snapshots
-/// get a lenient pass — they are not being installed, and swallowing a
-/// per-snapshot error there costs only a prefetch row.
-pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
-    inputs: &SnapshotPlanInputs<'a>,
-) -> Result<SnapshotPlan<'a>, CreateVirtualStoreError> {
-    let &SnapshotPlanInputs {
+/// Validation is deliberately asymmetric: survivors keep the strict
+/// cache-key derivation `Result`, because the install will actually
+/// fetch and link them, so a malformed resolution must fail before the
+/// warm batch starts rather than several seconds into it. Skipped
+/// snapshots get a lenient pass — they are not being installed, and
+/// swallowing a per-snapshot error there costs only a prefetch row.
+pub(super) fn plan_snapshots<Reporter: self::Reporter>(
+    inputs: SnapshotPlanInputs<'_>,
+) -> Result<SnapshotPlan<'_>, CreateVirtualStoreError> {
+    let SnapshotPlanInputs {
         snapshots,
         packages,
         current_snapshots,
@@ -74,8 +72,7 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         link_dependencies,
         is_hoisted,
         include_optional_dependencies,
-        ignore_scripts,
-        runtime_platform_selector,
+        cache_keys,
     } = inputs;
 
     // The slot probe goes through `layout.slot_dir` because under GVS
@@ -152,12 +149,9 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 Ok(!needs_rebuild)
             })()?;
             if !current_slot_matches {
-                let cache_key = snapshot_cache_key(
-                    snapshot_key,
-                    packages,
-                    ignore_scripts,
-                    runtime_platform_selector,
-                )?;
+                let cache_key = cache_keys
+                    .remove(snapshot_key)
+                    .expect("CasPrefetch::start derived a cache key for every lockfile snapshot")?;
                 has_git_hosted_survivor |= cache_key.is_git_hosted;
                 entries.push((snapshot_key, snapshot, cache_key.value));
             }
@@ -191,14 +185,10 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         // here.
         .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
         .map(|(snapshot_key, snapshot)| {
-            let cache_key = snapshot_cache_key(
-                snapshot_key,
-                packages,
-                ignore_scripts,
-                runtime_platform_selector,
-            )
-            .ok()
-            .and_then(|cache_key| cache_key.value);
+            let cache_key = cache_keys
+                .remove(snapshot_key)
+                .and_then(Result::ok)
+                .and_then(|cache_key| cache_key.value);
             (snapshot_key, snapshot, cache_key)
         })
         .collect();

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/tests.rs
@@ -182,6 +182,7 @@ async fn cold_batch_links_slots_in_parallel() {
         requester: &requester,
         store_index_writer: &store_index_writer,
         store_context: None,
+        cas_prefetch: None,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
         include_optional_dependencies: true,
@@ -314,6 +315,7 @@ async fn shared_store_context_materializes_a_warm_package() {
         logged_methods: &logged_methods,
         requester: &requester,
         store_index_writer: &store_index_writer,
+        cas_prefetch: None,
         store_context: Some(CreateVirtualStoreStoreContext {
             index: Some(&shared_index),
             verified_files_cache: &verified_files_cache,
@@ -441,6 +443,7 @@ async fn gvs_link_pass_materializes_shared_slot_once() {
         requester: &requester,
         store_index_writer: &store_index_writer,
         store_context: None,
+        cas_prefetch: None,
         allow_build_policy: &allow_build_policy,
         skipped: &skipped,
         include_optional_dependencies: true,

--- a/pnpm/crates/deps-restorer/src/dir_clone_cache.rs
+++ b/pnpm/crates/deps-restorer/src/dir_clone_cache.rs
@@ -52,17 +52,44 @@ use std::{
     collections::HashMap,
     fs, io,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, AtomicU8, Ordering},
+    },
 };
+
+/// The engine name that keys the cache's canonical slots — the same
+/// value a GVS-enabled install computes (see
+/// [`crate::materialization_plan::resolve_engine_name`]), so the slot
+/// hashes agree between the two modes.
+pub enum EngineNameSource {
+    /// Known when the cache is built: a lockfile `node@runtime:` pin or
+    /// an already-detected host.
+    Ready(Option<String>),
+    /// A `node --version` probe still in flight (see
+    /// [`crate::materialization_plan::DeferredEngineName::shared`]).
+    /// Keeping the probe unresolved here is what lets it overlap the
+    /// virtual-store partition and warm-batch I/O instead of
+    /// serializing before them.
+    Pending(Arc<OnceLock<Option<String>>>),
+}
 
 /// See the [module documentation](self) for what the cache is and when
 /// it applies.
-pub struct DirCloneCache {
+pub struct DirCloneCache<'install> {
     /// GVS-shaped layout rooted at `Config::global_virtual_store_dir`
     /// (`<store_dir>/links` unless pinned), built via
     /// [`VirtualStoreLayout::global`] so canonical slots coincide with
-    /// the slots a GVS-enabled install materializes.
-    layout: VirtualStoreLayout,
+    /// the slots a GVS-enabled install materializes. Built on first
+    /// use — see [`Self::layout`].
+    layout: OnceLock<VirtualStoreLayout>,
+    global_virtual_store_dir: PathBuf,
+    virtual_store_dir_max_length: usize,
+    engine: EngineNameSource,
+    snapshots: Option<&'install HashMap<PackageKey, SnapshotEntry>>,
+    packages: Option<&'install HashMap<PackageKey, PackageMetadata>>,
+    allow_build_policy: Option<&'install AllowBuildPolicy>,
+    lockfile_dir: Option<&'install Path>,
     /// Under `frozenStore` the store is read-only: the cache may serve
     /// canonical slots that already exist but must not populate new
     /// ones.
@@ -70,11 +97,10 @@ pub struct DirCloneCache {
     disabled: AtomicBool,
 }
 
-impl DirCloneCache {
+impl<'install> DirCloneCache<'install> {
     /// Whether this install's configuration can use the cache at all.
-    /// Split from [`Self::build`] so the install entry points can know
-    /// up front that the layout below will need the engine name
-    /// synchronously.
+    /// Checked by [`Self::build`]; public so tests can pin the gate on
+    /// its own.
     #[must_use]
     pub fn eligible(config: &Config, node_linker: NodeLinker) -> bool {
         cfg!(target_os = "macos")
@@ -90,19 +116,15 @@ impl DirCloneCache {
 
     /// Build the cache for one install, or `None` when
     /// [`Self::eligible`] says the configuration can't use it.
-    ///
-    /// `engine` must be the same value a GVS-enabled install would
-    /// compute (see `resolve_engine_name`), so the canonical slot
-    /// hashes agree between the two modes.
     #[must_use]
     pub fn build(
         config: &Config,
         node_linker: NodeLinker,
-        engine: Option<&str>,
-        snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
-        packages: Option<&HashMap<PackageKey, PackageMetadata>>,
-        allow_build_policy: Option<&AllowBuildPolicy>,
-        lockfile_dir: Option<&Path>,
+        engine: EngineNameSource,
+        snapshots: Option<&'install HashMap<PackageKey, SnapshotEntry>>,
+        packages: Option<&'install HashMap<PackageKey, PackageMetadata>>,
+        allow_build_policy: Option<&'install AllowBuildPolicy>,
+        lockfile_dir: Option<&'install Path>,
     ) -> Option<Self> {
         if !Self::eligible(config, node_linker) {
             return None;
@@ -122,17 +144,40 @@ impl DirCloneCache {
             return None;
         }
         Some(DirCloneCache {
-            layout: VirtualStoreLayout::global(
-                config.global_virtual_store_dir.clone(),
-                config.virtual_store_dir_max_length as usize,
-                engine,
-                snapshots,
-                packages,
-                allow_build_policy,
-                lockfile_dir,
-            ),
+            layout: OnceLock::new(),
+            global_virtual_store_dir: config.global_virtual_store_dir.clone(),
+            virtual_store_dir_max_length: config.virtual_store_dir_max_length as usize,
+            engine,
+            snapshots,
+            packages,
+            allow_build_policy,
+            lockfile_dir,
             frozen_store: config.frozen_store,
             disabled: AtomicBool::new(false),
+        })
+    }
+
+    /// The canonical-slot layout, built on the first call. Deferred to
+    /// here so a still-running `node --version` probe overlaps the
+    /// virtual-store partition and warm-batch I/O that run between
+    /// [`Self::build`] and the first [`Self::try_import`]. May block on
+    /// that probe, so it must only run on a worker thread — which
+    /// [`Self::try_import`]'s calling convention already guarantees.
+    fn layout(&self) -> &VirtualStoreLayout {
+        self.layout.get_or_init(|| {
+            let engine = match &self.engine {
+                EngineNameSource::Ready(name) => name.clone(),
+                EngineNameSource::Pending(slot) => slot.wait().clone(),
+            };
+            VirtualStoreLayout::global(
+                self.global_virtual_store_dir.clone(),
+                self.virtual_store_dir_max_length,
+                engine.as_deref(),
+                self.snapshots,
+                self.packages,
+                self.allow_build_policy,
+                self.lockfile_dir,
+            )
         })
     }
 
@@ -143,6 +188,11 @@ impl DirCloneCache {
     /// import instead. Never fails the install: the per-file path can
     /// succeed where the cache cannot (and reports its own errors when
     /// it can't).
+    ///
+    /// Must be called from a worker thread (the link pass runs on
+    /// rayon, under `block_in_place` on the multi-thread runtime): the
+    /// first call may block on the deferred engine probe while it
+    /// builds the layout — see `Self::layout`.
     pub fn try_import<Reporter: self::Reporter>(
         &self,
         logged_methods: &AtomicU8,
@@ -165,7 +215,7 @@ impl DirCloneCache {
         // Only a hash-suffixed canonical slot is content-addressed;
         // a snapshot the layout has no precomputed suffix for goes
         // through the per-file import.
-        let Some(slot_dir) = self.layout.hashed_slot_dir(package_key) else {
+        let Some(slot_dir) = self.layout().hashed_slot_dir(package_key) else {
             return false;
         };
         let canonical_node_modules = slot_dir.join("node_modules");

--- a/pnpm/crates/deps-restorer/src/dir_clone_cache/tests.rs
+++ b/pnpm/crates/deps-restorer/src/dir_clone_cache/tests.rs
@@ -137,6 +137,21 @@ mod macos {
             .filter(|path| path.ends_with("node_modules/foo/package.json"))
             .count();
         assert_eq!(canonical_manifests, 1, "one canonical slot for the one snapshot");
+        let expected_slot = crate::VirtualStoreLayout::global(
+            links_root.clone(),
+            Config::default().virtual_store_dir_max_length as usize,
+            Some("node-22"),
+            Some(&snapshots),
+            None,
+            None,
+            None,
+        )
+        .hashed_slot_dir(&key)
+        .expect("hashed slot for the one snapshot");
+        assert!(
+            expected_slot.join("node_modules/foo/package.json").is_file(),
+            "the canonical slot must be the one the delivered engine name selects: {expected_slot:?}",
+        );
 
         fs::remove_file(&lib_blob).expect("remove CAS blob");
         let second_target = dir.path().join("second/node_modules/foo");

--- a/pnpm/crates/deps-restorer/src/dir_clone_cache/tests.rs
+++ b/pnpm/crates/deps-restorer/src/dir_clone_cache/tests.rs
@@ -33,6 +33,7 @@ fn eligible_only_for_isolated_clone_capable_local_virtual_store() {
 #[cfg(target_os = "macos")]
 mod macos {
     use super::{Config, DirCloneCache, NodeLinker, PackageImportMethod};
+    use crate::dir_clone_cache::EngineNameSource;
     use pnpm_lockfile::{PackageKey, SnapshotEntry};
     use pnpm_reporter::{LogEvent, Reporter};
     use std::{collections::HashMap, fs, path::PathBuf, sync::atomic::AtomicU8};
@@ -43,13 +44,21 @@ mod macos {
         fn emit(_: &LogEvent) {}
     }
 
-    /// Build a cache whose canonical root is `links_root`, with one
-    /// snapshot so the layout precomputes its hashed slot. The
+    fn one_snapshot(key: &PackageKey) -> HashMap<PackageKey, SnapshotEntry> {
+        HashMap::from([(key.clone(), SnapshotEntry::default())])
+    }
+
+    /// Build a cache whose canonical root is `links_root`, with
+    /// `snapshots` so the layout precomputes their hashed slots. The
     /// virtual-store dir is pinned next to the links root so the
     /// capability probe in `build` clones within one volume — the
     /// default would point at the crate's working directory, which may
     /// live on another volume than the temp root.
-    fn cache_for_one_snapshot(links_root: &std::path::Path, key: &PackageKey) -> DirCloneCache {
+    fn cache_for_snapshots<'a>(
+        links_root: &std::path::Path,
+        snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
+        engine: EngineNameSource,
+    ) -> DirCloneCache<'a> {
         let config = Config {
             enable_global_virtual_store: false,
             package_import_method: PackageImportMethod::Clone,
@@ -57,13 +66,11 @@ mod macos {
             virtual_store_dir: links_root.with_file_name("probe-virtual-store"),
             ..Config::default()
         };
-        let snapshots: HashMap<PackageKey, SnapshotEntry> =
-            HashMap::from([(key.clone(), SnapshotEntry::default())]);
         DirCloneCache::build(
             &config,
             NodeLinker::Isolated,
-            None,
-            Some(&snapshots),
+            engine,
+            Some(snapshots),
             None,
             None,
             None,
@@ -72,7 +79,10 @@ mod macos {
     }
 
     /// Deleting the CAS blob between the two imports is what proves
-    /// the second one reads only the canonical slot.
+    /// the second one reads only the canonical slot. The engine name
+    /// arrives through a pending slot filled from another thread, so
+    /// the first import also proves the lazy layout blocks until the
+    /// deferred probe delivers.
     #[test]
     fn try_import_populates_canonical_slot_and_clones_it() {
         let dir = tempdir().expect("tempdir");
@@ -89,7 +99,20 @@ mod macos {
 
         let key: PackageKey = "foo@1.0.0".parse().expect("valid snapshot key");
         let links_root = dir.path().join("links");
-        let cache = cache_for_one_snapshot(&links_root, &key);
+        let snapshots = one_snapshot(&key);
+        let engine_slot = std::sync::Arc::new(std::sync::OnceLock::new());
+        let probe = std::thread::spawn({
+            let engine_slot = std::sync::Arc::clone(&engine_slot);
+            move || {
+                std::thread::sleep(std::time::Duration::from_millis(30));
+                let _ = engine_slot.set(Some("node-22".to_string()));
+            }
+        });
+        let cache = cache_for_snapshots(
+            &links_root,
+            &snapshots,
+            EngineNameSource::Pending(std::sync::Arc::clone(&engine_slot)),
+        );
         let logged = AtomicU8::new(0);
 
         let first_target = dir.path().join("first/node_modules/foo");
@@ -132,6 +155,7 @@ mod macos {
             fs::read(second_target.join("lib/index.js")).expect("cloned file"),
             b"module.exports = 1",
         );
+        probe.join().expect("probe thread");
     }
 
     /// An existing dirent at the target belongs to the marker/repair
@@ -140,7 +164,12 @@ mod macos {
     fn try_import_declines_an_occupied_target() {
         let dir = tempdir().expect("tempdir");
         let key: PackageKey = "foo@1.0.0".parse().expect("valid snapshot key");
-        let cache = cache_for_one_snapshot(&dir.path().join("links"), &key);
+        let snapshots = one_snapshot(&key);
+        let cache = cache_for_snapshots(
+            &dir.path().join("links"),
+            &snapshots,
+            EngineNameSource::Ready(None),
+        );
         let logged = AtomicU8::new(0);
         let target = dir.path().join("slot/node_modules/foo");
         fs::create_dir_all(&target).expect("pre-create target");
@@ -160,7 +189,12 @@ mod macos {
         let dir = tempdir().expect("tempdir");
         let key: PackageKey = "foo@1.0.0".parse().expect("valid snapshot key");
         let other: PackageKey = "bar@2.0.0".parse().expect("valid snapshot key");
-        let cache = cache_for_one_snapshot(&dir.path().join("links"), &key);
+        let snapshots = one_snapshot(&key);
+        let cache = cache_for_snapshots(
+            &dir.path().join("links"),
+            &snapshots,
+            EngineNameSource::Ready(None),
+        );
         let logged = AtomicU8::new(0);
         let target = dir.path().join("slot/node_modules/bar");
         fs::create_dir_all(target.parent().unwrap()).expect("create slot node_modules");

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -458,42 +458,38 @@ where
                 }
                 _ => false,
             };
-        let installability_host = crate::materialization_plan::detect_installability_host(
-            needs_installability_check,
-            config.engine_strict,
-            node_version,
-            supported_architectures,
-        )
-        .await;
-        let host_node =
-            installability_host.as_ref().map(crate::materialization_plan::HostNode::from);
-
-        let closure_importer_ids: std::collections::HashSet<String> =
-            importers.keys().cloned().collect();
-        let mut skipped = crate::materialization_plan::compute_skip_set::<Reporter>(
-            crate::materialization_plan::SkipSetInputs {
-                requester,
-                importers,
-                snapshots,
-                packages,
-                installability_host: installability_host.as_ref(),
-                seed,
-                // The frozen path always installs the groups it was
-                // given, so `--no-optional` needs no further
-                // qualification here.
-                exclude_optional: !include_optional,
-                skip_runtimes,
-                closure_lockfile: lockfile,
-                closure_root: workspace_root,
-                closure_importer_ids: &closure_importer_ids,
-                included: pnpm_modules_yaml::IncludedDependencies {
-                    dependencies: dependency_groups.contains(&DependencyGroup::Prod),
-                    dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
-                    optional_dependencies: include_optional,
-                },
-            },
-        )
-        .map_err(InstallFrozenLockfileError::Installability)?;
+        // The host detection is what costs a `node --version` probe
+        // (~150 ms of node startup). The global-virtual-store layout
+        // needs the engine name — and so the host — synchronously
+        // below, but otherwise the detection is spawned and only
+        // resolved once the skip-set computation needs the host, so
+        // the probe runs under the store-side warm-cache prefetch
+        // instead of serializing before it.
+        let host_detection = if needs_installability_check && !config.enable_global_virtual_store {
+            crate::materialization_plan::HostDetection::Pending(tokio::spawn({
+                let engine_strict = config.engine_strict;
+                let supported_architectures = supported_architectures.cloned();
+                async move {
+                    crate::materialization_plan::detect_installability_host(
+                        true,
+                        engine_strict,
+                        node_version,
+                        supported_architectures.as_ref(),
+                    )
+                    .await
+                }
+            }))
+        } else {
+            crate::materialization_plan::HostDetection::Resolved(
+                crate::materialization_plan::detect_installability_host(
+                    needs_installability_check,
+                    config.engine_strict,
+                    node_version,
+                    supported_architectures,
+                )
+                .await,
+            )
+        };
 
         // `engine_name` feeds two sites:
         //
@@ -506,22 +502,6 @@ where
         //   write-gate (see `build_modules.rs:346-350`); when
         //   `None`, both gates close and the cache is bypassed.
         //
-        // Three paths:
-        // - Already detected the host for the installability check
-        //   (constraint-bearing lockfile): reuse the cached version
-        //   synchronously. Synthetic-fallback (`node_detected = false`)
-        //   yields `None` so a bogus `99999.0.0`-derived key can't
-        //   poison either the cache or the GVS hash.
-        // - GVS on, no host yet: spawn `node --version` synchronously
-        //   — layout construction below needs the result.
-        // - GVS off, no host yet: spawn into the blocking pool and
-        //   keep the join handle. The spawn runs concurrently with
-        //   `CreateVirtualStore::run`'s I/O, so the `node --version`
-        //   cost (~tens of ms) is hidden under the install. The
-        //   handle is awaited right before `BuildModules` —
-        //   `VirtualStoreLayout` is built with `None` here, which
-        //   is fine because GVS is off and the layout ignores the
-        //   field in that path.
         // Honour `engines.runtime` / `devEngines.runtime` pin (if
         // one reached the lockfile): the runtime resolver writes
         // the chosen Node as a `node@runtime:<version>` snapshot, and
@@ -531,18 +511,43 @@ where
         // `node --version` returns from the shell, splitting the
         // shared store between pinned and non-pinned installs on the
         // same host.
-        // A cache-eligible install needs the engine name synchronously
-        // like GVS does — see [`crate::DirCloneCache::build`] for why
-        // the two must agree.
-        let dir_clone_cache_eligible = crate::DirCloneCache::eligible(config, node_linker);
-        let (initial_engine_name, deferred_engine_handle) =
-            crate::materialization_plan::resolve_engine_name(
-                config.enable_global_virtual_store || dir_clone_cache_eligible,
-                snapshots,
-                host_node.as_ref(),
-            )
-            .await;
-        let engine_name = initial_engine_name;
+        //
+        // Four paths, the first that applies wins:
+        // - Runtime pin in the lockfile: the name is known outright.
+        // - Host detection still pending (constraint-bearing lockfile,
+        //   GVS off): the name is derived from the host once it
+        //   resolves below; until then the directory-clone cache reads
+        //   it through a shared slot from its lazily built layout.
+        // - Host already detected (GVS on, or no check needed): reuse
+        //   it synchronously. Synthetic-fallback (`node_detected =
+        //   false`) yields `None` so a bogus `99999.0.0`-derived key
+        //   can't poison either the cache or the GVS hash.
+        // - No host at all: GVS spawns `node --version` synchronously
+        //   (its layout needs the result); otherwise the probe is
+        //   deferred into the blocking pool, overlaps
+        //   `CreateVirtualStore::run`'s I/O, and is awaited right
+        //   before `BuildModules`.
+        let mut pending_host_engine_slot = None;
+        let (engine_name, deferred_engine_name) = match &host_detection {
+            crate::materialization_plan::HostDetection::Pending(_) => {
+                if let Some(major) = find_runtime_node_major(snapshots) {
+                    (Some(pnpm_graph_hasher::engine_name(major, None, None)), None)
+                } else {
+                    pending_host_engine_slot =
+                        Some(std::sync::Arc::new(std::sync::OnceLock::new()));
+                    (None, None)
+                }
+            }
+            crate::materialization_plan::HostDetection::Resolved(host) => {
+                let host_node = host.as_ref().map(crate::materialization_plan::HostNode::from);
+                crate::materialization_plan::resolve_engine_name(
+                    config.enable_global_virtual_store,
+                    snapshots,
+                    host_node.as_ref(),
+                )
+                .await
+            }
+        };
 
         // Build the install-scoped slot-directory layout. When
         // `enable_global_virtual_store` is on the layout precomputes
@@ -577,19 +582,84 @@ where
         // Built after the offline lockfile checks above: constructing
         // the cache probes the filesystem (a store-side write), which a
         // rejected lockfile must never reach.
-        let dir_clone_cache = dir_clone_cache_eligible
-            .then(|| {
-                crate::DirCloneCache::build(
-                    config,
-                    node_linker,
-                    engine_name.as_deref(),
-                    snapshots,
-                    packages,
-                    Some(&allow_build_policy),
-                    Some(workspace_root),
-                )
-            })
-            .flatten();
+        let dir_clone_cache = crate::DirCloneCache::build(
+            config,
+            node_linker,
+            match (&pending_host_engine_slot, &deferred_engine_name) {
+                (Some(slot), _) => crate::EngineNameSource::Pending(std::sync::Arc::clone(slot)),
+                (None, Some(deferred)) => crate::EngineNameSource::Pending(deferred.shared()),
+                (None, None) => crate::EngineNameSource::Ready(engine_name.clone()),
+            },
+            snapshots,
+            packages,
+            Some(&allow_build_policy),
+            Some(workspace_root),
+        );
+
+        // Kick off the store-side half of `CreateVirtualStore::run`'s
+        // planning — like the directory-clone cache above, only after
+        // the offline lockfile checks — so its index reads run while a
+        // pending host detection finishes its `node --version`.
+        let cas_prefetch = crate::create_virtual_store::CasPrefetch::start(
+            config,
+            snapshots,
+            packages,
+            supported_architectures,
+            None,
+        )
+        .await;
+
+        let phase_start = std::time::Instant::now();
+        let installability_host = host_detection.resolve().await;
+        if needs_installability_check {
+            tracing::info!(
+                target: "pacquet::install::phase",
+                phase = "await_installability_host",
+                elapsed_ms = phase_start.elapsed().as_millis() as u64,
+                "phase complete",
+            );
+        }
+        let host_node =
+            installability_host.as_ref().map(crate::materialization_plan::HostNode::from);
+        // Deliver the host-derived engine name to the directory-clone
+        // cache's shared slot before anything can wait on it, and pick
+        // it up for `BuildModules` below.
+        let engine_name = match &pending_host_engine_slot {
+            Some(slot) => {
+                let name =
+                    host_node.as_ref().and_then(crate::materialization_plan::engine_name_from_host);
+                let _ = slot.set(name.clone());
+                name
+            }
+            None => engine_name,
+        };
+
+        let closure_importer_ids: std::collections::HashSet<String> =
+            importers.keys().cloned().collect();
+        let mut skipped = crate::materialization_plan::compute_skip_set::<Reporter>(
+            crate::materialization_plan::SkipSetInputs {
+                requester,
+                importers,
+                snapshots,
+                packages,
+                installability_host: installability_host.as_ref(),
+                seed,
+                // The frozen path always installs the groups it was
+                // given, so `--no-optional` needs no further
+                // qualification here.
+                exclude_optional: !include_optional,
+                skip_runtimes,
+                closure_lockfile: lockfile,
+                closure_root: workspace_root,
+                closure_importer_ids: &closure_importer_ids,
+                included: pnpm_modules_yaml::IncludedDependencies {
+                    dependencies: dependency_groups.contains(&DependencyGroup::Prod),
+                    dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
+                    optional_dependencies: include_optional,
+                },
+            },
+        )
+        .map_err(InstallFrozenLockfileError::Installability)?;
 
         // The frozen path runs no resolve-time prefetcher, so the warm
         // batch owns package-status progress for store hits. An empty set
@@ -636,6 +706,7 @@ where
                 requester,
                 store_index_writer: &store_index_writer,
                 store_context: None,
+                cas_prefetch: Some(cas_prefetch),
                 allow_build_policy: &allow_build_policy,
                 skipped: &skipped,
                 include_optional_dependencies: include_optional,
@@ -787,8 +858,8 @@ where
         // overlapped with install I/O. Falls back to the synchronous
         // value when the spawn was never deferred (GVS on, or host
         // already detected for the installability check).
-        let engine_name = match deferred_engine_handle {
-            Some(handle) => handle.await.ok().flatten(),
+        let engine_name = match deferred_engine_name {
+            Some(deferred) => deferred.handle.await.ok().flatten(),
             None => engine_name,
         };
 

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -466,10 +466,11 @@ where
         // the probe runs under the store-side warm-cache prefetch
         // instead of serializing before it.
         let host_detection = if needs_installability_check && !config.enable_global_virtual_store {
+            let supported_architectures = supported_architectures.cloned();
             crate::materialization_plan::HostDetection::Pending {
                 task: tokio::spawn({
                     let engine_strict = config.engine_strict;
-                    let supported_architectures = supported_architectures.cloned();
+                    let supported_architectures = supported_architectures.clone();
                     async move {
                         crate::materialization_plan::detect_installability_host(
                             true,
@@ -481,6 +482,7 @@ where
                     }
                 }),
                 engine_strict: config.engine_strict,
+                supported_architectures,
             }
         } else {
             crate::materialization_plan::HostDetection::Resolved(

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -466,19 +466,22 @@ where
         // the probe runs under the store-side warm-cache prefetch
         // instead of serializing before it.
         let host_detection = if needs_installability_check && !config.enable_global_virtual_store {
-            crate::materialization_plan::HostDetection::Pending(tokio::spawn({
-                let engine_strict = config.engine_strict;
-                let supported_architectures = supported_architectures.cloned();
-                async move {
-                    crate::materialization_plan::detect_installability_host(
-                        true,
-                        engine_strict,
-                        node_version,
-                        supported_architectures.as_ref(),
-                    )
-                    .await
-                }
-            }))
+            crate::materialization_plan::HostDetection::Pending {
+                task: tokio::spawn({
+                    let engine_strict = config.engine_strict;
+                    let supported_architectures = supported_architectures.cloned();
+                    async move {
+                        crate::materialization_plan::detect_installability_host(
+                            true,
+                            engine_strict,
+                            node_version,
+                            supported_architectures.as_ref(),
+                        )
+                        .await
+                    }
+                }),
+                engine_strict: config.engine_strict,
+            }
         } else {
             crate::materialization_plan::HostDetection::Resolved(
                 crate::materialization_plan::detect_installability_host(
@@ -529,9 +532,11 @@ where
         //   before `BuildModules`.
         let mut pending_host_engine_slot = None;
         let (engine_name, deferred_engine_name) = match &host_detection {
-            crate::materialization_plan::HostDetection::Pending(_) => {
-                if let Some(major) = find_runtime_node_major(snapshots) {
-                    (Some(pnpm_graph_hasher::engine_name(major, None, None)), None)
+            crate::materialization_plan::HostDetection::Pending { .. } => {
+                if let Some(name) =
+                    crate::materialization_plan::engine_name_from_runtime_pin(snapshots)
+                {
+                    (Some(name), None)
                 } else {
                     pending_host_engine_slot =
                         Some(std::sync::Arc::new(std::sync::OnceLock::new()));

--- a/pnpm/crates/deps-restorer/src/materialization_plan.rs
+++ b/pnpm/crates/deps-restorer/src/materialization_plan.rs
@@ -50,8 +50,10 @@ pub enum HostDetection {
     Pending {
         task: tokio::task::JoinHandle<Option<InstallabilityHost>>,
         /// Carried so a joined-task failure can synthesize the same
-        /// fallback host [`detect_installability_host`] would have.
+        /// fallback host [`detect_installability_host`] would have,
+        /// CLI-merged `supportedArchitectures` accept lists included.
         engine_strict: bool,
+        supported_architectures: Option<SupportedArchitectures>,
     },
 }
 
@@ -63,14 +65,18 @@ impl HostDetection {
     pub async fn resolve(self) -> Option<InstallabilityHost> {
         match self {
             HostDetection::Resolved(host) => host,
-            HostDetection::Pending { task, engine_strict } => task.await.unwrap_or_else(|error| {
-                tracing::warn!(
-                    target: "pacquet::install",
-                    ?error,
-                    "host detection task failed; falling back to the synthetic host",
-                );
-                Some(synthetic_installability_host(engine_strict))
-            }),
+            HostDetection::Pending { task, engine_strict, supported_architectures } => {
+                task.await.unwrap_or_else(|error| {
+                    tracing::warn!(
+                        target: "pacquet::install",
+                        ?error,
+                        "host detection task failed; falling back to the synthetic host",
+                    );
+                    let mut host = synthetic_installability_host(engine_strict);
+                    host.supported_architectures = supported_architectures;
+                    Some(host)
+                })
+            }
         }
     }
 }

--- a/pnpm/crates/deps-restorer/src/materialization_plan.rs
+++ b/pnpm/crates/deps-restorer/src/materialization_plan.rs
@@ -20,6 +20,7 @@ use pnpm_package_is_installable::{InstallabilityError, SupportedArchitectures};
 use std::{
     collections::{HashMap, HashSet},
     path::Path,
+    sync::{Arc, OnceLock},
 };
 
 /// The host Node, reduced to what the phases after the installability
@@ -36,6 +37,28 @@ pub struct HostNode {
 impl From<&InstallabilityHost> for HostNode {
     fn from(host: &InstallabilityHost) -> Self {
         HostNode { version: host.node_version.clone(), detected: host.node_detected }
+    }
+}
+
+/// A host detection that is either done or still probing on a spawned
+/// task. The frozen install path spawns the detection early and only
+/// resolves it once the skip set needs the host, so the `node
+/// --version` inside overlaps the store-side warm-cache prefetch
+/// instead of serializing before it.
+pub enum HostDetection {
+    Resolved(Option<InstallabilityHost>),
+    Pending(tokio::task::JoinHandle<Option<InstallabilityHost>>),
+}
+
+impl HostDetection {
+    /// Wait for the detection. A joined-task failure degrades to `None`
+    /// — the same "no installability checks this run" shape as a
+    /// lockfile that needs none.
+    pub async fn resolve(self) -> Option<InstallabilityHost> {
+        match self {
+            HostDetection::Resolved(host) => host,
+            HostDetection::Pending(task) => task.await.ok().flatten(),
+        }
     }
 }
 
@@ -190,6 +213,71 @@ pub fn compute_skip_set<Reporter: pnpm_reporter::Reporter>(
     Ok(skipped)
 }
 
+/// A `node --version` probe still in flight. See
+/// [`resolve_engine_name`] for when one is spawned.
+///
+/// The result is delivered twice: [`Self::handle`] for the async
+/// consumer (the side-effects-cache key in the build phase, awaited
+/// after linking), and a shared slot for a synchronous consumer that
+/// needs the name from a worker thread before the handle is awaited —
+/// the directory-clone cache's lazily built layout (see
+/// [`crate::DirCloneCache`]).
+pub struct DeferredEngineName {
+    pub handle: tokio::task::JoinHandle<Option<String>>,
+    shared: Arc<OnceLock<Option<String>>>,
+}
+
+impl DeferredEngineName {
+    fn spawn() -> Self {
+        /// Fills the slot with `None` on unwind: a synchronous consumer
+        /// blocked in [`OnceLock::wait`] would otherwise sleep forever
+        /// if the probe panicked.
+        struct FillOnDrop(Arc<OnceLock<Option<String>>>);
+        impl Drop for FillOnDrop {
+            fn drop(&mut self) {
+                let _ = self.0.set(None);
+            }
+        }
+
+        let shared = Arc::new(OnceLock::new());
+        let handle = tokio::task::spawn_blocking({
+            let shared = Arc::clone(&shared);
+            move || {
+                let guard = FillOnDrop(Arc::clone(&shared));
+                let name = probe_engine_name();
+                let _ = shared.set(name.clone());
+                drop(guard);
+                name
+            }
+        });
+        DeferredEngineName { handle, shared }
+    }
+
+    /// The slot the probe fills on completion. Blocking on it via
+    /// [`OnceLock::wait`] must happen off the async reactor.
+    #[must_use]
+    pub fn shared(&self) -> Arc<OnceLock<Option<String>>> {
+        Arc::clone(&self.shared)
+    }
+}
+
+fn probe_engine_name() -> Option<String> {
+    pnpm_graph_hasher::detect_node_major()
+        .map(|major| pnpm_graph_hasher::engine_name(major, None, None))
+}
+
+/// The engine name a detected host implies. `None` for the synthetic
+/// fallback host: a bogus `99999.0.0`-derived key must not poison the
+/// side-effects cache or the GVS hash.
+#[must_use]
+pub fn engine_name_from_host(host_node: &HostNode) -> Option<String> {
+    if !host_node.detected {
+        return None;
+    }
+    parse_major_from_version(&host_node.version)
+        .map(|major| pnpm_graph_hasher::engine_name(major, None, None))
+}
+
 /// Resolve the engine name that keys the install's store slots and the
 /// side-effects-cache prefix.
 ///
@@ -198,33 +286,25 @@ pub fn compute_skip_set<Reporter: pnpm_reporter::Reporter>(
 /// splitting it under whatever `node --version` the shell reports. Then
 /// the already-detected host, then a probe.
 ///
-/// The probe comes back as a still-running
-/// [`JoinHandle`][tokio::task::JoinHandle] so it overlaps the
-/// virtual-store I/O — except under the global virtual store, whose
-/// layout needs the name synchronously.
+/// The probe comes back as a still-running [`DeferredEngineName`] so it
+/// overlaps the virtual-store I/O — except under the global virtual
+/// store, whose layout needs the name synchronously.
 pub async fn resolve_engine_name(
     enable_global_virtual_store: bool,
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     host_node: Option<&HostNode>,
-) -> (Option<String>, Option<tokio::task::JoinHandle<Option<String>>>) {
-    fn probe() -> Option<String> {
-        pnpm_graph_hasher::detect_node_major()
-            .map(|major| pnpm_graph_hasher::engine_name(major, None, None))
-    }
-
+) -> (Option<String>, Option<DeferredEngineName>) {
     if let Some(major) = find_runtime_node_major(snapshots) {
         return (Some(pnpm_graph_hasher::engine_name(major, None, None)), None);
     }
     match host_node {
-        Some(HostNode { version, detected: true }) => (
-            parse_major_from_version(version)
-                .map(|major| pnpm_graph_hasher::engine_name(major, None, None)),
-            None,
-        ),
+        Some(host_node @ HostNode { detected: true, .. }) => {
+            (engine_name_from_host(host_node), None)
+        }
         Some(HostNode { detected: false, .. }) => (None, None),
         None if enable_global_virtual_store => {
-            (tokio::task::spawn_blocking(probe).await.ok().flatten(), None)
+            (tokio::task::spawn_blocking(probe_engine_name).await.ok().flatten(), None)
         }
-        None => (None, Some(tokio::task::spawn_blocking(probe))),
+        None => (None, Some(DeferredEngineName::spawn())),
     }
 }

--- a/pnpm/crates/deps-restorer/src/materialization_plan.rs
+++ b/pnpm/crates/deps-restorer/src/materialization_plan.rs
@@ -47,18 +47,47 @@ impl From<&InstallabilityHost> for HostNode {
 /// instead of serializing before it.
 pub enum HostDetection {
     Resolved(Option<InstallabilityHost>),
-    Pending(tokio::task::JoinHandle<Option<InstallabilityHost>>),
+    Pending {
+        task: tokio::task::JoinHandle<Option<InstallabilityHost>>,
+        /// Carried so a joined-task failure can synthesize the same
+        /// fallback host [`detect_installability_host`] would have.
+        engine_strict: bool,
+    },
 }
 
 impl HostDetection {
-    /// Wait for the detection. A joined-task failure degrades to `None`
-    /// — the same "no installability checks this run" shape as a
-    /// lockfile that needs none.
+    /// Wait for the detection. A joined-task failure degrades to the
+    /// synthetic fallback host, so the installability checks still run
+    /// — the same degradation [`detect_installability_host`] applies
+    /// when its own probe task fails.
     pub async fn resolve(self) -> Option<InstallabilityHost> {
         match self {
             HostDetection::Resolved(host) => host,
-            HostDetection::Pending(task) => task.await.ok().flatten(),
+            HostDetection::Pending { task, engine_strict } => task.await.unwrap_or_else(|error| {
+                tracing::warn!(
+                    target: "pacquet::install",
+                    ?error,
+                    "host detection task failed; falling back to the synthetic host",
+                );
+                Some(synthetic_installability_host(engine_strict))
+            }),
         }
+    }
+}
+
+/// The stand-in host used when `node --version` cannot be probed. Its
+/// `node_detected: false` keeps the bogus version out of the store keys
+/// (see [`engine_name_from_host`]) while the `os` / `cpu` / `libc`
+/// platform checks still run against the real host triple.
+fn synthetic_installability_host(engine_strict: bool) -> InstallabilityHost {
+    InstallabilityHost {
+        node_version: "99999.0.0".to_string(),
+        node_detected: false,
+        os: pnpm_graph_hasher::host_platform(),
+        cpu: pnpm_graph_hasher::host_arch(),
+        libc: pnpm_graph_hasher::host_libc(),
+        supported_architectures: None,
+        engine_strict,
     }
 }
 
@@ -89,15 +118,7 @@ pub async fn detect_installability_host(
             InstallabilityHost::detect_with(engine_strict, None)
         })
         .await
-        .unwrap_or_else(|_| InstallabilityHost {
-            node_version: "99999.0.0".to_string(),
-            node_detected: false,
-            os: pnpm_graph_hasher::host_platform(),
-            cpu: pnpm_graph_hasher::host_arch(),
-            libc: pnpm_graph_hasher::host_libc(),
-            supported_architectures: None,
-            engine_strict,
-        }),
+        .unwrap_or_else(|_| synthetic_installability_host(engine_strict)),
     };
     // Plant the CLI-merged `supportedArchitectures` (yaml +
     // `--cpu`/`--os`/`--libc`) onto the host so `check_platform`'s
@@ -229,9 +250,13 @@ pub struct DeferredEngineName {
 
 impl DeferredEngineName {
     fn spawn() -> Self {
-        /// Fills the slot with `None` on unwind: a synchronous consumer
-        /// blocked in [`OnceLock::wait`] would otherwise sleep forever
-        /// if the probe panicked.
+        /// Fills the slot with `None` when dropped: a synchronous
+        /// consumer blocked in [`OnceLock::wait`] would otherwise sleep
+        /// forever if the probe panicked — or never ran at all, which
+        /// is why the guard is captured by the closure rather than
+        /// created inside it: a shutting-down runtime that discards the
+        /// still-queued closure drops its environment, and the guard
+        /// with it.
         struct FillOnDrop(Arc<OnceLock<Option<String>>>);
         impl Drop for FillOnDrop {
             fn drop(&mut self) {
@@ -241,9 +266,9 @@ impl DeferredEngineName {
 
         let shared = Arc::new(OnceLock::new());
         let handle = tokio::task::spawn_blocking({
+            let guard = FillOnDrop(Arc::clone(&shared));
             let shared = Arc::clone(&shared);
             move || {
-                let guard = FillOnDrop(Arc::clone(&shared));
                 let name = probe_engine_name();
                 let _ = shared.set(name.clone());
                 drop(guard);
@@ -278,6 +303,18 @@ pub fn engine_name_from_host(host_node: &HostNode) -> Option<String> {
         .map(|major| pnpm_graph_hasher::engine_name(major, None, None))
 }
 
+/// The engine name a lockfile `node@runtime:` pin implies, when one is
+/// present. Both engine-resolution paths — [`resolve_engine_name`] and
+/// the frozen path's deferred-host branch — apply this one rule, so
+/// they can't drift apart on how a pin keys the store.
+#[must_use]
+pub fn engine_name_from_runtime_pin(
+    snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+) -> Option<String> {
+    find_runtime_node_major(snapshots)
+        .map(|major| pnpm_graph_hasher::engine_name(major, None, None))
+}
+
 /// Resolve the engine name that keys the install's store slots and the
 /// side-effects-cache prefix.
 ///
@@ -294,8 +331,8 @@ pub async fn resolve_engine_name(
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
     host_node: Option<&HostNode>,
 ) -> (Option<String>, Option<DeferredEngineName>) {
-    if let Some(major) = find_runtime_node_major(snapshots) {
-        return (Some(pnpm_graph_hasher::engine_name(major, None, None)), None);
+    if let Some(name) = engine_name_from_runtime_pin(snapshots) {
+        return (Some(name), None);
     }
     match host_node {
         Some(host_node @ HostNode { detected: true, .. }) => {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1391,14 +1391,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             .as_ref()
             .map(pnpm_deps_restorer::materialization_plan::HostNode::from);
 
-        // A cache-eligible install needs the engine name synchronously
-        // like GVS does — see [`DirCloneCache::build`] for why the two
-        // must agree.
-        let dir_clone_cache_eligible =
-            pnpm_deps_restorer::DirCloneCache::eligible(config, node_linker);
-        let (engine_name, deferred_engine_handle) =
+        let (engine_name, deferred_engine_name) =
             pnpm_deps_restorer::materialization_plan::resolve_engine_name(
-                config.enable_global_virtual_store || dir_clone_cache_eligible,
+                config.enable_global_virtual_store,
                 initial_materialization_lockfile.snapshots.as_ref(),
                 host_node.as_ref(),
             )
@@ -1414,19 +1409,18 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             Some(&allow_build_policy),
             Some(lockfile_dir),
         );
-        let dir_clone_cache = dir_clone_cache_eligible
-            .then(|| {
-                pnpm_deps_restorer::DirCloneCache::build(
-                    config,
-                    node_linker,
-                    engine_name.as_deref(),
-                    initial_materialization_lockfile.snapshots.as_ref(),
-                    initial_materialization_lockfile.packages.as_ref(),
-                    Some(&allow_build_policy),
-                    Some(lockfile_dir),
-                )
-            })
-            .flatten();
+        let dir_clone_cache = pnpm_deps_restorer::DirCloneCache::build(
+            config,
+            node_linker,
+            match &deferred_engine_name {
+                Some(deferred) => pnpm_deps_restorer::EngineNameSource::Pending(deferred.shared()),
+                None => pnpm_deps_restorer::EngineNameSource::Ready(engine_name.clone()),
+            },
+            initial_materialization_lockfile.snapshots.as_ref(),
+            initial_materialization_lockfile.packages.as_ref(),
+            Some(&allow_build_policy),
+            Some(lockfile_dir),
+        );
         if config.enable_global_virtual_store {
             tracing::info!(
                 target: "pacquet::install::phase",
@@ -1526,6 +1520,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
                 index: store_index_ref,
                 verified_files_cache: &verified_files_cache,
             }),
+            cas_prefetch: None,
             allow_build_policy: &allow_build_policy,
             skipped: &skipped,
             include_optional_dependencies: include_transitive_optional_dependencies,
@@ -1656,8 +1651,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // Resolve the deferred `node --version` probe (non-GVS path);
         // it overlapped `CreateVirtualStore` above. Falls back to the
         // synchronous value when the probe wasn't deferred.
-        let engine_name = match deferred_engine_handle {
-            Some(handle) => handle.await.ok().flatten(),
+        let engine_name = match deferred_engine_name {
+            Some(deferred) => deferred.handle.await.ok().flatten(),
             None => engine_name,
         };
 


### PR DESCRIPTION
## Summary

Follow-up macOS install-performance work after pnpm/pnpm#14248 and pnpm/pnpm#14256 (related to pnpm/pnpm#14231).

Profiling the hot frozen install of the 1,352-package benchmark fixture showed the planning phase spending ~375 ms strictly serially on two independent pieces of work:

- **~160 ms: `node --version`** for the installability host. Any lockfile carrying `os`/`cpu`/`engines` metadata (i.e. practically every real project, via `fsevents`, `esbuild`, etc.) pays this before the skip set is computed.
- **~215 ms: the store-index warm-cache prefetch** (SQLite open, per-snapshot cache-key SELECTs, per-file integrity stats) inside `CreateVirtualStore::run`.

Neither depends on the other, so this PR runs them concurrently:

- The frozen path now **spawns the host detection** and resolves it only where the skip-set computation needs the host. The global-virtual-store path keeps its synchronous order (its layout needs the host-derived engine name up front).
- The store-side half of `CreateVirtualStore::run`'s planning is extracted into **`CasPrefetch`** (index open + cache-key derivation + prefetch task), which the frozen path starts before resolving the host. Callers that don't pass one get it started inside `run()`, which also lets `plan_snapshots`' slot probes overlap the prefetch's index reads for every install path.
- The cache-key derivation `Result`s flow through `plan_snapshots`, preserving the strict-for-survivors / lenient-for-skipped asymmetry without a second derivation pass.
- `resolve_engine_name` no longer forces a synchronous probe for dir-clone-cache-eligible installs (a regression of pnpm/pnpm#14248, which serialized ~170 ms of `node` startup before layout construction): **`DirCloneCache` now builds its canonical-slot layout lazily** on first use, reading the engine name through a shared slot filled by the deferred probe or the resolved host. The first `try_import` runs on a rayon worker (under `block_in_place`), so a still-pending probe never blocks the async reactor.

Measured on the fixture (M-series MBP, APFS): planning window ~375 ms → ~190 ms; hot rebuild of `node_modules` ~2.75 s → ~2.65 s. An instant-`node` shim control now produces the same times as real `node`, i.e. the probe is fully off the critical path (before this PR the shim was ~200 ms faster).

Rust-only change; the TypeScript CLI runs inside Node and reads `process.version` for free, so there is nothing to mirror.

## Squash Commit Body

```text
A hot frozen install of a constraint-bearing lockfile (any lockfile
with fsevents-style os/cpu/engines metadata) spent ~160 ms running
node --version for the installability host, then another ~215 ms
reading the store index for the warm-cache prefetch, strictly one
after the other. Both are independent of each other, so run them
concurrently:

- The frozen path spawns the host detection instead of awaiting it,
  and only resolves it where the skip-set computation needs the host.
  The global-virtual-store path keeps the synchronous order - its
  layout needs the host-derived engine name up front.
- The store-side half of CreateVirtualStore's planning (index open,
  per-snapshot cache-key derivation, prefetch) is extracted into
  CasPrefetch, which the frozen path starts before resolving the
  host. Callers that pass none get one started inside run(), which
  also lets the plan pass's slot probes run while the prefetch task
  reads the index.
- The cache-key derivation Results move through plan_snapshots so the
  strict/lenient survivor/skipped asymmetry is preserved without a
  second derivation pass.
- resolve_engine_name no longer forces a synchronous probe for
  dir-clone-cache-eligible installs: DirCloneCache now builds its
  canonical-slot layout lazily on first use, reading the engine name
  through a shared slot that the deferred probe (or the resolved
  host) fills. The first try_import runs on a rayon worker, so a
  still-pending probe blocks no async work.

On the 1,352-package benchmark fixture the planning window shrinks
from ~375 ms to ~190 ms and a hot rebuild of node_modules goes from
~2.75 s to ~2.65 s; an instant-node control shows the probe is now
fully off the critical path.

Related to pnpm/pnpm#14231.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790471870&installation_model_id=426870&pr_number=14265&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14265&signature=028f576ebfe58881e307ebf823c8a419098706445fe2e518226ef3148569ecd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Rebuilding dependencies from an up-to-date lockfile is now up to approximately 200 ms faster.
  - Dependency cache reads and environment checks can run concurrently for quicker installations.

- **Bug Fixes**
  - Improved deferred environment detection during installation, including safer fallback handling when detection fails.
  - Enhanced dependency restoration and cache handling across supported installation scenarios.
  - Improved handling of runtime version information when determining installation compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->