### PR TITLE
perf(resolver): share workspace resolutions across importers

### DIFF
--- a/.changeset/calm-links-share.md
+++ b/.changeset/calm-links-share.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced workspace dependency resolution work by sharing canonical resolver output across importers while preserving consumer-relative links and hook contexts.

--- a/.changeset/calm-links-share.md
+++ b/.changeset/calm-links-share.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Reduced workspace dependency resolution work by sharing canonical resolver output across importers while preserving consumer-relative links and hook contexts.
+Sped up installs in large workspaces by resolving each named `workspace:` dependency (`workspace:*`, `workspace:^`, `workspace:1.2.3`) once and reusing it across every project that declares it, instead of re-resolving it per project.

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -52,9 +52,11 @@ pub enum HookError {
 #[derive(Clone)]
 pub struct HookContext {
     pub log: Arc<dyn Fn(String) + Send + Sync>,
-    /// Lockfile-root-relative directory of the resolution, set when the
-    /// manifest being transformed was resolved from a local directory (an
-    /// injected workspace project or a `file:` dependency). A host-supplied
+    /// Directory recorded by the resolution, set when the manifest being
+    /// transformed was resolved from a local directory. An injected workspace
+    /// project or a `file:` dependency records it relative to the lockfile
+    /// root; a linked workspace project records it relative to the consuming
+    /// importer. A host-supplied
     /// `readPackage` callback uses it to recognize a workspace project's
     /// dependency instance and substitute the project's raw manifest.
     /// Only the node-API bridge forwards it to JS; the `.pnpmfile.cjs`

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1123,6 +1123,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let workspace_result = resolve::run_resolve_pass::<Reporter>(resolve::ResolvePassInputs {
             config,
             resolver: &*resolver,
+            share_workspace_resolutions: custom_resolvers_raw.is_empty(),
             importer_manifests: &importer_manifests,
             dependency_groups: &dependency_groups,
             catalogs: &catalogs,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -400,13 +400,8 @@ pub(super) async fn warn_stale_convergence_overrides<Reporter: pnpm_reporter::Re
 pub(super) struct ResolvePassInputs<'a> {
     pub config: &'a Config,
     pub resolver: &'a dyn Resolver,
-    /// Whether named workspace resolutions may be shared across importers.
-    /// When `true`, eligible named workspace requests reuse a canonical
-    /// resolution through a shared cache key that omits the importer's location
-    /// (`project_dir`). This increases cache hits for repeated workspace
-    /// resolutions. pnpm then renders and caches the final result for each
-    /// importer-relative `link:` variant. This preserves the correct link for
-    /// each importer.
+    /// See
+    /// [`WorkspaceResolveOptions::share_workspace_resolutions`](pnpm_resolving_deps_resolver::WorkspaceResolveOptions::share_workspace_resolutions).
     pub share_workspace_resolutions: bool,
     pub importer_manifests: &'a BTreeMap<String, &'a PackageManifest>,
     pub dependency_groups: &'a [DependencyGroup],

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -400,6 +400,14 @@ pub(super) async fn warn_stale_convergence_overrides<Reporter: pnpm_reporter::Re
 pub(super) struct ResolvePassInputs<'a> {
     pub config: &'a Config,
     pub resolver: &'a dyn Resolver,
+    /// Whether named workspace resolutions may be shared across importers.
+    /// When `true`, eligible named workspace requests reuse a canonical
+    /// resolution through a shared cache key that omits the importer's location
+    /// (`project_dir`). This increases cache hits for repeated workspace
+    /// resolutions. pnpm then renders and caches the final result for each
+    /// importer-relative `link:` variant. This preserves the correct link for
+    /// each importer.
+    pub share_workspace_resolutions: bool,
     pub importer_manifests: &'a BTreeMap<String, &'a PackageManifest>,
     pub dependency_groups: &'a [DependencyGroup],
     pub catalogs: &'a Catalogs,
@@ -451,6 +459,7 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
     let ResolvePassInputs {
         config,
         resolver,
+        share_workspace_resolutions,
         importer_manifests,
         dependency_groups,
         catalogs,
@@ -504,6 +513,7 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
         exclude_links_from_lockfile: config.exclude_links_from_lockfile,
         lockfile_dir: lockfile_dir.to_path_buf(),
         peers_suffix_max_length,
+        share_workspace_resolutions,
         manifest_hook: manifest_hook.clone(),
         overrides_hook: overrides_hook.clone(),
         pnpmfile_hook,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1209,20 +1209,24 @@ fn shared_workspace_key(
     if !bare_specifier.starts_with("workspace:") || bare_specifier.starts_with("workspace:.") {
         return None;
     }
-    cache_key.6.as_ref()?;
+    // The consumer scope is exactly what the shared key drops. Every
+    // `workspace:` selector carries one, so its absence means this edge is not
+    // the shape assumed here.
     let mut wanted_key = cache_key.clone();
-    wanted_key.6 = None;
+    wanted_key.6.take()?;
     Some(SharedWorkspaceWantedKey::new(wanted_key, wanted.prev_specifier.clone(), opts))
 }
 
-/// Look the wanted edge up in the final dedup cache or run the resolver chain
-/// and manifest-hook pipeline. Conservatively eligible named workspace
-/// selectors use two additional layers: a consumer-independent canonical
-/// resolver result and a hook-processed result keyed by its rendered link
-/// variant. Everything else remains under the project-scoped `cache_key`.
-/// Concurrent first-callers can both miss and resolve in parallel — the
-/// resolver's own per-cache-key fetch locker coalesces network work, and the
-/// second `or_insert` loses the race harmlessly.
+/// Look the wanted edge up in the per-wanted dedup cache or run the resolver
+/// chain and the manifest-hook pipeline, caching the `Arc<ResolveResult>`
+/// under `cache_key`. Eligible named workspace selectors add two more layers:
+/// a canonical resolver result, shared by every importer, and a hook-processed
+/// result keyed by the `link:` this importer renders, shared only with the
+/// importers that render the same one. A second importer therefore always
+/// skips the resolver chain, and skips the hooks as well when its rendered
+/// link matches. Concurrent first-callers can both miss and resolve in parallel —
+/// the resolver's own per-cache-key fetch locker coalesces the network work,
+/// and the second `or_insert` loses the race harmlessly.
 async fn resolve_wanted_cached<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
@@ -1304,6 +1308,12 @@ where
             .get(key)
             .map(Arc::clone)
     {
+        // Both return paths record the project-scoped entry, so the lookup at
+        // the top of this function stays authoritative: a repeat of this edge
+        // costs one lookup rather than a shared-key rebuild and a re-render.
+        lock_recoverable(&ctx.workspace.resolved_by_wanted)
+            .entry(cache_key)
+            .or_insert_with(|| Arc::clone(&cached));
         return Ok(cached);
     }
     if result.manifest.is_none() {
@@ -1324,9 +1334,9 @@ where
         && let Some(manifest) = result.manifest.take()
     {
         let log = ctx.workspace.read_package_log.clone().unwrap_or_else(|| Arc::new(|_| {}));
-        // Directory resolutions carry the path rendered for this consumer so
-        // the hook can tell a workspace project's dependency instance apart
-        // from a registry manifest — see `HookContext::dir`.
+        // Directory resolutions carry their directory so the hook can tell a
+        // workspace project's dependency instance apart from a registry
+        // manifest — see `HookContext::dir`.
         let dir = match &result.resolution {
             pnpm_lockfile::LockfileResolution::Directory(directory_resolution) => {
                 Some(directory_resolution.directory.clone())
@@ -1359,11 +1369,10 @@ where
         lock_recoverable(&ctx.workspace.resolved_workspace_final_by_wanted)
             .entry(key)
             .or_insert_with(|| Arc::clone(&result));
-    } else {
-        lock_recoverable(&ctx.workspace.resolved_by_wanted)
-            .entry(cache_key)
-            .or_insert_with(|| Arc::clone(&result));
     }
+    lock_recoverable(&ctx.workspace.resolved_by_wanted)
+        .entry(cache_key)
+        .or_insert_with(|| Arc::clone(&result));
     Ok(result)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -44,10 +44,11 @@ use super::{
         project_relative_cache_scope,
     },
     workspace_ctx::{
-        ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, WantedKey, claim_children_owner,
-        claim_children_warmup, insert_tree_node, is_current_children_owner, lazy_children,
-        make_non_owner_nodes_lazy, record_children, recorded_children_match,
-        register_peer_dep_names, remember_node_parent_ids,
+        ChildSpec, ChildrenOwnerClaim, RecordedChildrenContext, SharedWorkspaceWantedKey,
+        WantedKey, WorkspaceFinalWantedKey, claim_children_owner, claim_children_warmup,
+        insert_tree_node, is_current_children_owner, lazy_children, make_non_owner_nodes_lazy,
+        record_children, recorded_children_match, register_peer_dep_names,
+        remember_node_parent_ids,
     },
 };
 
@@ -1117,11 +1118,110 @@ fn overlay_lookup_names<'edge>(
     [alias.map(Cow::Borrowed), real_name]
 }
 
-/// Look the wanted edge up in the per-wanted dedup cache or run the
-/// resolver chain and the manifest-hook pipeline, caching the
-/// `Arc<ResolveResult>` under `cache_key`. Concurrent first-callers
-/// can both miss and resolve in parallel — the resolver's own
-/// per-cache-key fetch locker coalesces the network work, and the
+/// Convert a workspace directory resolution into the representation shared by
+/// every importer. A `link:` target is stored relative to the lockfile root;
+/// an injected `file:` target already has that representation.
+fn canonical_workspace_resolution(
+    result: &pnpm_resolving_resolver_base::ResolveResult,
+    project_dir: &Path,
+    lockfile_dir: &Path,
+) -> Option<pnpm_resolving_resolver_base::ResolveResult> {
+    if result.resolved_via != "workspace" {
+        return None;
+    }
+    let pnpm_lockfile::LockfileResolution::Directory(directory_resolution) = &result.resolution
+    else {
+        return None;
+    };
+    if result.id.as_str().strip_prefix("file:") == Some(&directory_resolution.directory) {
+        return Some(result.clone());
+    }
+    if result.id.as_str().strip_prefix("link:") != Some(&directory_resolution.directory) {
+        return None;
+    }
+
+    let target = Path::new(&directory_resolution.directory);
+    let absolute_target = if target.is_absolute() {
+        pnpm_fs::lexical_normalize(target)
+    } else {
+        pnpm_fs::lexical_normalize(&project_dir.join(target))
+    };
+    let canonical_target = pathdiff::diff_paths(&absolute_target, lockfile_dir)
+        .unwrap_or(absolute_target)
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    let mut canonical = result.clone();
+    canonical.id =
+        pnpm_resolving_resolver_base::PkgResolutionId::from(format!("link:{canonical_target}"));
+    let pnpm_lockfile::LockfileResolution::Directory(canonical_directory) =
+        &mut canonical.resolution
+    else {
+        unreachable!("the cloned workspace resolution remains a directory")
+    };
+    canonical_directory.directory = canonical_target;
+    Some(canonical)
+}
+
+/// Render a canonical workspace resolution for one consuming importer before
+/// its manifest hooks run.
+fn render_workspace_resolution(
+    canonical: &pnpm_resolving_resolver_base::ResolveResult,
+    project_dir: &Path,
+    lockfile_dir: &Path,
+) -> pnpm_resolving_resolver_base::ResolveResult {
+    let mut rendered = canonical.clone();
+    let pnpm_lockfile::LockfileResolution::Directory(directory_resolution) =
+        &mut rendered.resolution
+    else {
+        unreachable!("the shared workspace cache contains only directory resolutions")
+    };
+    if canonical.id.as_str().starts_with("file:") {
+        return rendered;
+    }
+
+    let target = Path::new(&directory_resolution.directory);
+    let absolute_target = if target.is_absolute() {
+        pnpm_fs::lexical_normalize(target)
+    } else {
+        pnpm_fs::lexical_normalize(&lockfile_dir.join(target))
+    };
+    let project_dir = pnpm_fs::lexical_normalize(project_dir);
+    let consumer_target = pathdiff::diff_paths(&absolute_target, project_dir)
+        .unwrap_or(absolute_target)
+        .display()
+        .to_string()
+        .replace('\\', "/");
+    rendered.id =
+        pnpm_resolving_resolver_base::PkgResolutionId::from(format!("link:{consumer_target}"));
+    directory_resolution.directory = consumer_target;
+    rendered
+}
+
+/// Remove the consumer directory from a named `workspace:` request while
+/// retaining every other input the explicit workspace resolver reads.
+fn shared_workspace_key(
+    cache_key: &WantedKey,
+    wanted: &WantedDependency,
+    opts: &ResolveOptions,
+) -> Option<SharedWorkspaceWantedKey> {
+    let bare_specifier = wanted.bare_specifier.as_deref()?;
+    if !bare_specifier.starts_with("workspace:") || bare_specifier.starts_with("workspace:.") {
+        return None;
+    }
+    cache_key.6.as_ref()?;
+    let mut wanted_key = cache_key.clone();
+    wanted_key.6 = None;
+    Some(SharedWorkspaceWantedKey::new(wanted_key, wanted.prev_specifier.clone(), opts))
+}
+
+/// Look the wanted edge up in the final dedup cache or run the resolver chain
+/// and manifest-hook pipeline. Conservatively eligible named workspace
+/// selectors use two additional layers: a consumer-independent canonical
+/// resolver result and a hook-processed result keyed by its rendered link
+/// variant. Everything else remains under the project-scoped `cache_key`.
+/// Concurrent first-callers can both miss and resolve in parallel — the
+/// resolver's own per-cache-key fetch locker coalesces network work, and the
 /// second `or_insert` loses the race harmlessly.
 async fn resolve_wanted_cached<Chain>(
     ctx: &TreeCtx,
@@ -1162,15 +1262,52 @@ where
     } else {
         opts
     };
-    let mut result = resolver.resolve(wanted, opts).await.map_err(map_resolve_error)?;
-    let Some(result_inner) = result.as_mut() else {
-        return Err(ResolveDependencyTreeError::SpecNotSupported {
-            specifier: render_specifier(wanted),
-        });
+    let shared_workspace_key = ctx
+        .workspace
+        .share_workspace_resolutions
+        .then(|| shared_workspace_key(&cache_key, wanted, opts))
+        .flatten();
+    let cached_workspace = shared_workspace_key.as_ref().and_then(|key| {
+        lock_recoverable(&ctx.workspace.resolved_workspace_by_wanted).get(key).map(Arc::clone)
+    });
+    let mut canonical_workspace = cached_workspace.clone();
+    let mut result = if let Some(canonical) = cached_workspace {
+        render_workspace_resolution(&canonical, &opts.project_dir, &opts.lockfile_dir)
+    } else {
+        let result = resolver.resolve(wanted, opts).await.map_err(map_resolve_error)?;
+        let Some(result) = result else {
+            return Err(ResolveDependencyTreeError::SpecNotSupported {
+                specifier: render_specifier(wanted),
+            });
+        };
+        if let Some(shared_workspace_key) = shared_workspace_key.as_ref()
+            && let Some(canonical) =
+                canonical_workspace_resolution(&result, &opts.project_dir, &opts.lockfile_dir)
+        {
+            let canonical = Arc::new(canonical);
+            canonical_workspace = Some(Arc::clone(
+                lock_recoverable(&ctx.workspace.resolved_workspace_by_wanted)
+                    .entry(shared_workspace_key.clone())
+                    .or_insert(canonical),
+            ));
+        }
+        result
     };
-    if result_inner.manifest.is_none() {
-        result_inner.manifest =
-            Some(Arc::new(fallback_manifest(wanted, opts.current_pkg.as_ref())));
+    let workspace_final_key = match (shared_workspace_key, canonical_workspace.as_deref()) {
+        (Some(shared_wanted), Some(canonical)) => {
+            Some(WorkspaceFinalWantedKey::new(shared_wanted, &canonical.id, &result.id))
+        }
+        _ => None,
+    };
+    if let Some(key) = workspace_final_key.as_ref()
+        && let Some(cached) = lock_recoverable(&ctx.workspace.resolved_workspace_final_by_wanted)
+            .get(key)
+            .map(Arc::clone)
+    {
+        return Ok(cached);
+    }
+    if result.manifest.is_none() {
+        result.manifest = Some(Arc::new(fallback_manifest(wanted, opts.current_pkg.as_ref())));
     }
     // Apply the configured `readPackageHook` (today:
     // `packageExtensions`) to the manifest fragment before
@@ -1178,19 +1315,19 @@ where
     // only when it modifies it, so unrelated manifests keep sharing the
     // resolver's cached `Arc`.
     if let Some(hook) = ctx.workspace.manifest_hook.as_ref()
-        && let Some(manifest) = result_inner.manifest.take()
+        && let Some(manifest) = result.manifest.take()
     {
-        result_inner.manifest = Some(hook(manifest));
+        result.manifest = Some(hook(manifest));
     }
 
     if let Some(pnpmfile_hook) = ctx.workspace.pnpmfile_hook.as_ref()
-        && let Some(manifest) = result_inner.manifest.take()
+        && let Some(manifest) = result.manifest.take()
     {
         let log = ctx.workspace.read_package_log.clone().unwrap_or_else(|| Arc::new(|_| {}));
-        // Directory resolutions carry their lockfile-root-relative dir so the
-        // hook can tell a workspace project's dependency instance apart from a
-        // registry manifest — see `HookContext::dir`.
-        let dir = match &result_inner.resolution {
+        // Directory resolutions carry the path rendered for this consumer so
+        // the hook can tell a workspace project's dependency instance apart
+        // from a registry manifest — see `HookContext::dir`.
+        let dir = match &result.resolution {
             pnpm_lockfile::LockfileResolution::Directory(directory_resolution) => {
                 Some(directory_resolution.directory.clone())
             }
@@ -1202,26 +1339,31 @@ where
             .read_package((*manifest).clone(), hook_ctx)
             .await
             .map_err(ResolveDependencyTreeError::PnpmfileHook)?;
-        result_inner.manifest = Some(updated);
+        result.manifest = Some(updated);
     }
 
     // Overrides run last so a pnpmfile hook that replaced the manifest
     // cannot erase them — see `WorkspaceTreeCtx::overrides_hook`.
     if let Some(hook) = ctx.workspace.overrides_hook.as_ref()
-        && let Some(manifest) = result_inner.manifest.take()
+        && let Some(manifest) = result.manifest.take()
     {
-        result_inner.manifest = Some(hook(manifest));
+        result.manifest = Some(hook(manifest));
     }
 
-    let result = result.expect("Some-guarded above");
     // Wrap in `Arc` once so the cache, the per-id
     // `ResolvedPackage` envelope, and the later peer-resolved
     // graph node share one heap-allocated `ResolveResult`
     // instead of cloning every `String` field per occurrence.
     let result = Arc::new(result);
-    lock_recoverable(&ctx.workspace.resolved_by_wanted)
-        .entry(cache_key)
-        .or_insert_with(|| Arc::clone(&result));
+    if let Some(key) = workspace_final_key {
+        lock_recoverable(&ctx.workspace.resolved_workspace_final_by_wanted)
+            .entry(key)
+            .or_insert_with(|| Arc::clone(&result));
+    } else {
+        lock_recoverable(&ctx.workspace.resolved_by_wanted)
+            .entry(cache_key)
+            .or_insert_with(|| Arc::clone(&result));
+    }
     Ok(result)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests.rs
@@ -1,3 +1,5 @@
+mod shared_workspace_resolution_cache;
+
 use pnpm_lockfile::{LockfileResolution, PkgNameVerPeer, RegistryResolution, TarballRevision};
 
 use super::{

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
@@ -1,0 +1,85 @@
+use pnpm_resolving_resolver_base::{ResolveOptions, WantedDependency};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+
+use crate::resolve_dependency_tree::workspace_ctx::WantedKey;
+
+fn wanted(specifier: &str) -> WantedDependency {
+    WantedDependency {
+        alias: Some("shared".to_string()),
+        bare_specifier: Some(specifier.to_string()),
+        ..WantedDependency::default()
+    }
+}
+
+fn key(wanted: &WantedDependency, project_dir: &str) -> WantedKey {
+    (
+        wanted.alias.clone(),
+        wanted.bare_specifier.clone(),
+        wanted.optional,
+        wanted.injected,
+        false,
+        None,
+        Some(PathBuf::from(project_dir)),
+        None,
+        Vec::new(),
+        None,
+        false,
+    )
+}
+
+fn opts(project_dir: &str) -> ResolveOptions {
+    ResolveOptions {
+        project_dir: PathBuf::from(project_dir),
+        lockfile_dir: PathBuf::from("/repo"),
+        workspace_packages: Some(Arc::new(BTreeMap::new())),
+        ..ResolveOptions::default()
+    }
+}
+
+#[test]
+fn shares_only_named_workspace_selectors_and_ignores_project_dir() {
+    let base_wanted = wanted("workspace:^");
+    let options = opts("/repo/packages/a");
+    let shared = super::super::shared_workspace_key(
+        &key(&base_wanted, "/repo/packages/a"),
+        &base_wanted,
+        &options,
+    )
+    .expect("named workspace selector is shareable");
+    assert!(
+        shared
+            == super::super::shared_workspace_key(
+                &key(&base_wanted, "/repo/apps/b"),
+                &base_wanted,
+                &ResolveOptions {
+                    project_dir: PathBuf::from("/repo/apps/b"),
+                    workspace_packages: options.workspace_packages.clone(),
+                    ..options.clone()
+                },
+            )
+            .expect("consumer-independent key"),
+    );
+
+    for specifier in ["^1.0.0", "link:../shared", "file:../shared", "workspace:./shared"] {
+        let wanted = wanted(specifier);
+        assert!(
+            super::super::shared_workspace_key(
+                &key(&wanted, "/repo/packages/a"),
+                &wanted,
+                &options,
+            )
+            .is_none(),
+        );
+    }
+}
+
+#[test]
+fn separates_distinct_workspace_maps() {
+    let wanted = wanted("workspace:^");
+    let first = opts("/repo/packages/a");
+    let second = opts("/repo/apps/b");
+    assert!(
+        super::super::shared_workspace_key(&key(&wanted, "/repo/packages/a"), &wanted, &first,)
+            != super::super::shared_workspace_key(&key(&wanted, "/repo/apps/b"), &wanted, &second,),
+    );
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
@@ -1,6 +1,14 @@
-use pnpm_resolving_resolver_base::{ResolveOptions, WantedDependency};
-use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use pnpm_lockfile::{DirectoryResolution, LockfileResolution};
+use pnpm_resolving_resolver_base::{
+    PkgResolutionId, ResolveOptions, ResolveResult, WantedDependency,
+};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
+use super::super::{canonical_workspace_resolution, render_workspace_resolution};
 use crate::resolve_dependency_tree::workspace_ctx::WantedKey;
 
 fn wanted(specifier: &str) -> WantedDependency {
@@ -36,6 +44,32 @@ fn opts(project_dir: &str) -> ResolveOptions {
     }
 }
 
+/// A directory resolution shaped like the npm resolver's workspace output:
+/// the id repeats the recorded directory behind its protocol prefix.
+fn directory_result(id: &str, resolved_via: &str) -> ResolveResult {
+    let directory =
+        id.split_once(':').map_or_else(|| id.to_string(), |(_, directory)| directory.to_string());
+    ResolveResult {
+        id: PkgResolutionId::from(id.to_string()),
+        name_ver: None,
+        latest: None,
+        published_at: None,
+        manifest: None,
+        resolution: LockfileResolution::Directory(DirectoryResolution { directory }),
+        resolved_via: resolved_via.to_string(),
+        normalized_bare_specifier: None,
+        alias: Some("shared".to_string()),
+        policy_violation: None,
+    }
+}
+
+fn rendered_link(canonical: &ResolveResult, project_dir: &str) -> String {
+    render_workspace_resolution(canonical, Path::new(project_dir), Path::new("/repo"))
+        .id
+        .as_str()
+        .to_string()
+}
+
 #[test]
 fn shares_only_named_workspace_selectors_and_ignores_project_dir() {
     let base_wanted = wanted("workspace:^");
@@ -46,29 +80,26 @@ fn shares_only_named_workspace_selectors_and_ignores_project_dir() {
         &options,
     )
     .expect("named workspace selector is shareable");
-    assert!(
-        shared
-            == super::super::shared_workspace_key(
-                &key(&base_wanted, "/repo/apps/b"),
-                &base_wanted,
-                &ResolveOptions {
-                    project_dir: PathBuf::from("/repo/apps/b"),
-                    workspace_packages: options.workspace_packages.clone(),
-                    ..options.clone()
-                },
-            )
-            .expect("consumer-independent key"),
+    assert_eq!(
+        shared,
+        super::super::shared_workspace_key(
+            &key(&base_wanted, "/repo/apps/b"),
+            &base_wanted,
+            &ResolveOptions { project_dir: PathBuf::from("/repo/apps/b"), ..options.clone() },
+        )
+        .expect("consumer-independent key"),
     );
 
     for specifier in ["^1.0.0", "link:../shared", "file:../shared", "workspace:./shared"] {
         let wanted = wanted(specifier);
-        assert!(
+        assert_eq!(
             super::super::shared_workspace_key(
                 &key(&wanted, "/repo/packages/a"),
                 &wanted,
-                &options,
-            )
-            .is_none(),
+                &options
+            ),
+            None,
+            "{specifier} must stay scoped to its consumer",
         );
     }
 }
@@ -78,8 +109,60 @@ fn separates_distinct_workspace_maps() {
     let wanted = wanted("workspace:^");
     let first = opts("/repo/packages/a");
     let second = opts("/repo/apps/b");
-    assert!(
-        super::super::shared_workspace_key(&key(&wanted, "/repo/packages/a"), &wanted, &first,)
-            != super::super::shared_workspace_key(&key(&wanted, "/repo/apps/b"), &wanted, &second,),
+    assert_ne!(
+        super::super::shared_workspace_key(&key(&wanted, "/repo/packages/a"), &wanted, &first),
+        super::super::shared_workspace_key(&key(&wanted, "/repo/apps/b"), &wanted, &second),
     );
+}
+
+#[test]
+fn link_resolution_round_trips_through_the_lockfile_root() {
+    let resolved_for_a = directory_result("link:../shared", "workspace");
+    let canonical = canonical_workspace_resolution(
+        &resolved_for_a,
+        Path::new("/repo/packages/a"),
+        Path::new("/repo"),
+    )
+    .expect("a workspace link canonicalises against the lockfile root");
+    assert_eq!(canonical.id.as_str(), "link:packages/shared");
+
+    assert_eq!(rendered_link(&canonical, "/repo/packages/a"), resolved_for_a.id.as_str());
+    assert_eq!(rendered_link(&canonical, "/repo/apps/nested/b"), "link:../../../packages/shared");
+    assert_eq!(rendered_link(&canonical, "/repo"), "link:packages/shared");
+    // A package that depends on itself keeps the bare `link:` the npm
+    // resolver renders for an empty relative path.
+    assert_eq!(rendered_link(&canonical, "/repo/packages/shared"), "link:");
+}
+
+#[test]
+fn injected_resolution_is_already_consumer_independent() {
+    let injected = directory_result("file:packages/shared", "workspace");
+    let canonical = canonical_workspace_resolution(
+        &injected,
+        Path::new("/repo/packages/a"),
+        Path::new("/repo"),
+    )
+    .expect("an injected workspace package is shareable as resolved");
+    assert_eq!(canonical, injected);
+    assert_eq!(rendered_link(&canonical, "/repo/apps/nested/b"), injected.id.as_str());
+}
+
+#[test]
+fn rejects_resolutions_that_are_not_shareable_workspace_links() {
+    let project_dir = Path::new("/repo/packages/a");
+    let lockfile_dir = Path::new("/repo");
+    // A local `link:` claimed by the local resolver, not the workspace one.
+    assert_eq!(
+        canonical_workspace_resolution(
+            &directory_result("link:../shared", "local-directory"),
+            project_dir,
+            lockfile_dir,
+        ),
+        None,
+    );
+    // An id that does not restate the recorded directory: the round trip
+    // through the lockfile root would not reproduce it.
+    let mut mismatched = directory_result("link:../shared", "workspace");
+    mismatched.id = PkgResolutionId::from("link:../other".to_string());
+    assert_eq!(canonical_workspace_resolution(&mismatched, project_dir, lockfile_dir), None);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -6,9 +6,11 @@
 use chrono::{DateTime, Utc};
 use pnpm_hooks::PnpmfileHooks;
 use pnpm_lockfile::{PkgName, PkgNameVerPeer, RegistryContext};
+use pnpm_resolving_resolver_base::{PkgResolutionId, ResolveOptions, WorkspacePackages};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{
     collections::BTreeMap,
+    hash::{Hash, Hasher},
     path::PathBuf,
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -98,6 +100,104 @@ pub(super) type WantedKey = (
     Option<String>,
     bool,
 );
+
+/// A wanted dependency key without its consumer directory, plus the resolver
+/// inputs that may vary between importers.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub(super) struct SharedWorkspaceWantedKey {
+    wanted: WantedKey,
+    previous_specifier: Option<String>,
+    resolve_options: WorkspaceResolutionOptionsKey,
+}
+
+impl SharedWorkspaceWantedKey {
+    pub(super) fn new(
+        wanted: WantedKey,
+        previous_specifier: Option<String>,
+        resolve_options: &ResolveOptions,
+    ) -> Self {
+        Self {
+            wanted,
+            previous_specifier,
+            resolve_options: WorkspaceResolutionOptionsKey::new(resolve_options),
+        }
+    }
+}
+
+/// Resolver inputs that can change a named workspace resolution independently
+/// of the consuming project directory.
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct WorkspaceResolutionOptionsKey {
+    workspace_packages: Option<WorkspacePackagesKey>,
+    lockfile_dir: PathBuf,
+    default_tag: Option<String>,
+    inject_workspace_packages: bool,
+    calc_specifier: bool,
+    range_spec_style_discriminant: Option<u8>,
+    save_workspace_protocol_discriminant: u8,
+}
+
+impl WorkspaceResolutionOptionsKey {
+    fn new(options: &ResolveOptions) -> Self {
+        Self {
+            workspace_packages: options.workspace_packages.as_ref().map(WorkspacePackagesKey::new),
+            lockfile_dir: options.lockfile_dir.clone(),
+            default_tag: options.default_tag.clone(),
+            inject_workspace_packages: options.inject_workspace_packages,
+            calc_specifier: options.calc_specifier,
+            range_spec_style_discriminant: options.range_spec_style.map(|style| style as u8),
+            save_workspace_protocol_discriminant: options.save_workspace_protocol as u8,
+        }
+    }
+}
+
+/// Keeps the immutable workspace map alive.
+/// The key uses pointer identity instead of hashing the map for every dependency edge.
+/// Clones of the same [`Arc`] share a key. Separately allocated maps use separate keys.
+#[derive(Clone)]
+struct WorkspacePackagesKey(Arc<WorkspacePackages>);
+
+impl WorkspacePackagesKey {
+    fn new(packages: &Arc<WorkspacePackages>) -> Self {
+        Self(Arc::clone(packages))
+    }
+}
+
+impl PartialEq for WorkspacePackagesKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for WorkspacePackagesKey {}
+
+impl Hash for WorkspacePackagesKey {
+    fn hash<State: Hasher>(&self, state: &mut State) {
+        Arc::as_ptr(&self.0).hash(state);
+    }
+}
+
+/// Cache key for a hook-processed workspace result.
+#[derive(PartialEq, Eq, Hash)]
+pub(super) struct WorkspaceFinalWantedKey {
+    shared_wanted: SharedWorkspaceWantedKey,
+    canonical_resolution_id: PkgResolutionId,
+    rendered_resolution_id: PkgResolutionId,
+}
+
+impl WorkspaceFinalWantedKey {
+    pub(super) fn new(
+        shared_wanted: SharedWorkspaceWantedKey,
+        canonical_resolution_id: &PkgResolutionId,
+        rendered_resolution_id: &PkgResolutionId,
+    ) -> Self {
+        Self {
+            shared_wanted,
+            canonical_resolution_id: canonical_resolution_id.clone(),
+            rendered_resolution_id: rendered_resolution_id.clone(),
+        }
+    }
+}
 
 type SubtreeReuseKey = (Option<String>, PkgNameVerPeer, i32);
 
@@ -253,6 +353,26 @@ pub struct WorkspaceTreeCtx {
     pub(super) applied_patches: Mutex<HashSet<String>>,
     pub(super) resolved_by_wanted:
         Mutex<HashMap<WantedKey, Arc<pnpm_resolving_resolver_base::ResolveResult>>>,
+    /// Resolver output for workspace directory resolutions before manifest
+    /// hooks run. `link:` paths are canonicalised relative to the lockfile
+    /// root, so one entry can be rendered for every consuming importer.
+    pub(super) resolved_workspace_by_wanted:
+        Mutex<HashMap<SharedWorkspaceWantedKey, Arc<pnpm_resolving_resolver_base::ResolveResult>>>,
+    /// Hook-processed workspace results indexed by their canonical target and
+    /// rendered consumer link. This is intentionally separate from
+    /// `resolved_by_wanted`: the latter remains project-scoped for every
+    /// resolution that has not passed the conservative workspace-sharing
+    /// eligibility and result validation.
+    pub(super) resolved_workspace_final_by_wanted:
+        Mutex<HashMap<WorkspaceFinalWantedKey, Arc<pnpm_resolving_resolver_base::ResolveResult>>>,
+    /// Whether named workspace resolutions may be shared across importers.
+    /// When `true`, eligible named workspace requests reuse a canonical
+    /// resolution through a shared cache key that omits the importer's location
+    /// (`project_dir`). This increases cache hits for repeated workspace
+    /// resolutions. pnpm then renders and caches the final result for each
+    /// importer-relative `link:` variant. This preserves the correct link for
+    /// each importer.
+    pub(super) share_workspace_resolutions: bool,
     pub(super) children_specs_by_id: Mutex<HashMap<Arc<str>, Arc<Vec<ChildSpec>>>>,
     /// Package ids whose children have already been speculatively
     /// resolved. A package is warmed once, however many occurrences of
@@ -497,6 +617,9 @@ impl Default for WorkspaceTreeCtx {
             policy_violations: Mutex::new(Vec::new()),
             applied_patches: Mutex::new(HashSet::default()),
             resolved_by_wanted: Mutex::new(HashMap::default()),
+            resolved_workspace_by_wanted: Mutex::new(HashMap::default()),
+            resolved_workspace_final_by_wanted: Mutex::new(HashMap::default()),
+            share_workspace_resolutions: false,
             children_specs_by_id: Mutex::new(HashMap::default()),
             warmed_children_by_id: Mutex::new(HashSet::default()),
             children_by_id: Mutex::new(HashMap::default()),
@@ -528,6 +651,14 @@ impl Default for WorkspaceTreeCtx {
 }
 
 impl WorkspaceTreeCtx {
+    /// Sets whether pnpm can share named workspace resolutions across importers.
+    /// Pass `false` if a resolver can use the current importer's directory.
+    #[must_use]
+    pub fn with_shared_workspace_resolutions(mut self, share_workspace_resolutions: bool) -> Self {
+        self.share_workspace_resolutions = share_workspace_resolutions;
+        self
+    }
+
     /// Snapshot the workspace context into a [`ResolvedTree`] without
     /// consuming `self`. `direct` carries the combined direct-dep
     /// envelopes the caller built up across importers; multi-importer

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -103,7 +103,7 @@ pub(super) type WantedKey = (
 
 /// A wanted dependency key without its consumer directory, plus the resolver
 /// inputs that may vary between importers.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) struct SharedWorkspaceWantedKey {
     wanted: WantedKey,
     previous_specifier: Option<String>,
@@ -126,7 +126,7 @@ impl SharedWorkspaceWantedKey {
 
 /// Resolver inputs that can change a named workspace resolution independently
 /// of the consuming project directory.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct WorkspaceResolutionOptionsKey {
     workspace_packages: Option<WorkspacePackagesKey>,
     lockfile_dir: PathBuf,
@@ -163,6 +163,12 @@ impl WorkspacePackagesKey {
     }
 }
 
+impl std::fmt::Debug for WorkspacePackagesKey {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.debug_tuple("WorkspacePackagesKey").field(&Arc::as_ptr(&self.0)).finish()
+    }
+}
+
 impl PartialEq for WorkspacePackagesKey {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
@@ -178,7 +184,7 @@ impl Hash for WorkspacePackagesKey {
 }
 
 /// Cache key for a hook-processed workspace result.
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub(super) struct WorkspaceFinalWantedKey {
     shared_wanted: SharedWorkspaceWantedKey,
     canonical_resolution_id: PkgResolutionId,
@@ -359,19 +365,12 @@ pub struct WorkspaceTreeCtx {
     pub(super) resolved_workspace_by_wanted:
         Mutex<HashMap<SharedWorkspaceWantedKey, Arc<pnpm_resolving_resolver_base::ResolveResult>>>,
     /// Hook-processed workspace results indexed by their canonical target and
-    /// rendered consumer link. This is intentionally separate from
-    /// `resolved_by_wanted`: the latter remains project-scoped for every
-    /// resolution that has not passed the conservative workspace-sharing
-    /// eligibility and result validation.
+    /// rendered consumer link, so importers that render the same `link:` reuse
+    /// one hook pass. `resolved_by_wanted` keeps its project-scoped entry for
+    /// these too — this map is what a *different* importer hits.
     pub(super) resolved_workspace_final_by_wanted:
         Mutex<HashMap<WorkspaceFinalWantedKey, Arc<pnpm_resolving_resolver_base::ResolveResult>>>,
-    /// Whether named workspace resolutions may be shared across importers.
-    /// When `true`, eligible named workspace requests reuse a canonical
-    /// resolution through a shared cache key that omits the importer's location
-    /// (`project_dir`). This increases cache hits for repeated workspace
-    /// resolutions. pnpm then renders and caches the final result for each
-    /// importer-relative `link:` variant. This preserves the correct link for
-    /// each importer.
+    /// See [`crate::WorkspaceResolveOptions::share_workspace_resolutions`].
     pub(super) share_workspace_resolutions: bool,
     pub(super) children_specs_by_id: Mutex<HashMap<Arc<str>, Arc<Vec<ChildSpec>>>>,
     /// Package ids whose children have already been speculatively
@@ -651,8 +650,7 @@ impl Default for WorkspaceTreeCtx {
 }
 
 impl WorkspaceTreeCtx {
-    /// Sets whether pnpm can share named workspace resolutions across importers.
-    /// Pass `false` if a resolver can use the current importer's directory.
+    /// Sets [`crate::WorkspaceResolveOptions::share_workspace_resolutions`].
     #[must_use]
     pub fn with_shared_workspace_resolutions(mut self, share_workspace_resolutions: bool) -> Self {
         self.share_workspace_resolutions = share_workspace_resolutions;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -64,12 +64,12 @@ pub struct WorkspaceResolveOptions {
     pub lockfile_dir: PathBuf,
     pub peers_suffix_max_length: usize,
     /// Whether named workspace resolutions may be shared across importers.
-    /// When `true`, eligible named workspace requests reuse a canonical
-    /// resolution through a shared cache key that omits the importer's location
-    /// (`project_dir`). This increases cache hits for repeated workspace
-    /// resolutions. pnpm then renders and caches the final result for each
-    /// importer-relative `link:` variant. This preserves the correct link for
-    /// each importer.
+    /// When `true`, an eligible named `workspace:` request resolves once
+    /// against a cache key that omits the consuming importer's `project_dir`,
+    /// and the importer-relative `link:` is rendered from that canonical
+    /// result afterwards. Must stay `false` whenever the resolver chain can
+    /// make a resolution depend on the consuming importer beyond that
+    /// rendering — a pnpmfile custom resolver above all.
     pub share_workspace_resolutions: bool,
     /// `readPackageHook` applied to every resolved manifest before it
     /// enters the wanted-dep cache. Workspace-wide (one hook per

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -63,6 +63,14 @@ pub struct WorkspaceResolveOptions {
     pub exclude_links_from_lockfile: bool,
     pub lockfile_dir: PathBuf,
     pub peers_suffix_max_length: usize,
+    /// Whether named workspace resolutions may be shared across importers.
+    /// When `true`, eligible named workspace requests reuse a canonical
+    /// resolution through a shared cache key that omits the importer's location
+    /// (`project_dir`). This increases cache hits for repeated workspace
+    /// resolutions. pnpm then renders and caches the final result for each
+    /// importer-relative `link:` variant. This preserves the correct link for
+    /// each importer.
+    pub share_workspace_resolutions: bool,
     /// `readPackageHook` applied to every resolved manifest before it
     /// enters the wanted-dep cache. Workspace-wide (one hook per
     /// install); the install layer typically threads
@@ -199,6 +207,7 @@ where
         exclude_links_from_lockfile,
         lockfile_dir,
         peers_suffix_max_length,
+        share_workspace_resolutions,
         manifest_hook,
         overrides_hook,
         pnpmfile_hook,
@@ -225,6 +234,7 @@ where
         .flatten();
     let workspace = Arc::new(
         WorkspaceTreeCtx::default()
+            .with_shared_workspace_resolutions(share_workspace_resolutions)
             .with_manifest_hook(manifest_hook)
             .with_overrides_hook(overrides_hook)
             .with_wanted_lockfile(wanted_lockfile)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -70,12 +70,20 @@ impl Resolver for RecordingResolver {
 
 struct ProjectRelativeWorkspaceResolver {
     target_dir: std::path::PathBuf,
+    /// The `shared` specifier this resolver claims. Only a named
+    /// `workspace:` selector is eligible for the cross-importer cache, so the
+    /// tests vary it to cover both sides of that gate.
+    shared_specifier: &'static str,
     workspace_resolutions: AtomicUsize,
 }
 
 impl ProjectRelativeWorkspaceResolver {
     fn new(target_dir: std::path::PathBuf) -> Self {
-        Self { target_dir, workspace_resolutions: AtomicUsize::new(0) }
+        Self::claiming("workspace:^", target_dir)
+    }
+
+    fn claiming(shared_specifier: &'static str, target_dir: std::path::PathBuf) -> Self {
+        Self { target_dir, shared_specifier, workspace_resolutions: AtomicUsize::new(0) }
     }
 
     fn workspace_resolution_count(&self) -> usize {
@@ -93,6 +101,7 @@ impl Resolver for ProjectRelativeWorkspaceResolver {
         let range = wanted.bare_specifier.clone().unwrap_or_default();
         let target_dir = self.target_dir.clone();
         let project_dir = opts.project_dir.clone();
+        let shared_specifier = self.shared_specifier;
         Box::pin(async move {
             if alias == "wrapper" && range == "1.0.0" {
                 return Ok(Some(fake_result(
@@ -102,11 +111,11 @@ impl Resolver for ProjectRelativeWorkspaceResolver {
                     serde_json::json!({
                         "name": "wrapper",
                         "version": "1.0.0",
-                        "dependencies": { "shared": "workspace:^" },
+                        "dependencies": { "shared": shared_specifier },
                     }),
                 )));
             }
-            if alias != "shared" || range != "workspace:^" {
+            if alias != "shared" || range != shared_specifier {
                 return Ok(None);
             }
             self.workspace_resolutions.fetch_add(1, Ordering::Relaxed);
@@ -547,6 +556,55 @@ async fn workspace_resolution_is_shared_and_rendered_per_importer() {
         shared_hook_dirs,
         [Some("../../packages/shared".to_string()), Some("../shared".to_string())],
     );
+}
+
+#[tokio::test]
+async fn semver_workspace_matches_stay_scoped_to_each_importer() {
+    // `always_try_workspace_packages` lets a plain semver range land on a
+    // workspace package too, but only a named `workspace:` selector is
+    // guaranteed to depend on the importer solely through the rendered link.
+    // A range keeps its per-importer resolution.
+    let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let (_b_tmp, b_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
+    let resolver = ProjectRelativeWorkspaceResolver::claiming(
+        "^1.0.0",
+        std::path::PathBuf::from("/repo/packages/shared"),
+    );
+    let importers = vec![
+        WorkspaceImporter { id: "packages/a".to_string(), manifest: &a_manifest },
+        WorkspaceImporter { id: "apps/b".to_string(), manifest: &b_manifest },
+    ];
+    let lockfile_dir = std::path::PathBuf::from("/repo");
+    let workspace_packages = std::sync::Arc::new(std::collections::BTreeMap::default());
+    let mut opts = workspace_opts(false, false);
+    opts.lockfile_dir.clone_from(&lockfile_dir);
+
+    let result =
+        resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
+            let project_dir = match importer.id.as_str() {
+                "packages/a" => std::path::PathBuf::from("/repo/packages/a"),
+                "apps/b" => std::path::PathBuf::from("/repo/apps/b"),
+                _ => unreachable!("unexpected importer"),
+            };
+            let mut opts = importer_opts(project_dir, None);
+            opts.lockfile_dir = Some(lockfile_dir.clone());
+            opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
+            opts.base_opts.always_try_workspace_packages = true;
+            opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
+            opts
+        })
+        .await
+        .expect("resolve workspace");
+
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["packages/a"]["shared"].as_str(),
+        "link:../shared",
+    );
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["apps/b"]["shared"].as_str(),
+        "link:../../packages/shared",
+    );
+    assert_eq!(resolver.workspace_resolution_count(), 2);
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -5,7 +5,10 @@ use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{
     collections::BTreeMap,
     str::FromStr,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicUsize, Ordering},
+    },
 };
 
 use chrono::{DateTime, TimeZone, Utc};
@@ -19,7 +22,10 @@ use pnpm_resolving_resolver_base::{
 use pretty_assertions::assert_eq;
 
 use super::{WorkspaceImporter, WorkspaceResolveOptions, resolve_workspace};
-use crate::resolve_importer::ResolveImporterOptions;
+use crate::{
+    resolve_importer::ResolveImporterOptions,
+    tests::{RecordedReadPackageCalls, RecordingHooks},
+};
 
 /// The `(pick_lowest_version, published_by)` pair recorded per alias.
 type RecordedOpts = (bool, Option<DateTime<Utc>>);
@@ -64,6 +70,17 @@ impl Resolver for RecordingResolver {
 
 struct ProjectRelativeWorkspaceResolver {
     target_dir: std::path::PathBuf,
+    workspace_resolutions: AtomicUsize,
+}
+
+impl ProjectRelativeWorkspaceResolver {
+    fn new(target_dir: std::path::PathBuf) -> Self {
+        Self { target_dir, workspace_resolutions: AtomicUsize::new(0) }
+    }
+
+    fn workspace_resolution_count(&self) -> usize {
+        self.workspace_resolutions.load(Ordering::Relaxed)
+    }
 }
 
 impl Resolver for ProjectRelativeWorkspaceResolver {
@@ -85,13 +102,14 @@ impl Resolver for ProjectRelativeWorkspaceResolver {
                     serde_json::json!({
                         "name": "wrapper",
                         "version": "1.0.0",
-                        "dependencies": { "shared": "^1.0.0" },
+                        "dependencies": { "shared": "workspace:^" },
                     }),
                 )));
             }
-            if alias != "shared" || range != "^1.0.0" {
+            if alias != "shared" || range != "workspace:^" {
                 return Ok(None);
             }
+            self.workspace_resolutions.fetch_add(1, Ordering::Relaxed);
             let rel = pathdiff::diff_paths(&target_dir, &project_dir)
                 .expect("target can be relativized")
                 .display()
@@ -205,6 +223,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         exclude_links_from_lockfile: false,
         lockfile_dir: std::path::PathBuf::from("/lockfile-dir"),
         peers_suffix_max_length: 1000,
+        share_workspace_resolutions: true,
         manifest_hook: None,
         overrides_hook: None,
         pnpmfile_hook: None,
@@ -467,33 +486,37 @@ async fn importer_scoped_update_route_owns_shared_parent_children_in_either_orde
 }
 
 #[tokio::test]
-async fn workspace_link_results_are_cached_per_importer_project_dir() {
-    let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
-    let (_b_tmp, b_manifest) = fake_manifest(serde_json::json!({ "shared": "^1.0.0" }));
-    let resolver = ProjectRelativeWorkspaceResolver {
-        target_dir: std::path::PathBuf::from("/repo/packages/shared"),
-    };
+async fn workspace_resolution_is_shared_and_rendered_per_importer() {
+    let (_a_tmp, a_manifest) = fake_manifest(serde_json::json!({ "shared": "workspace:^" }));
+    let (_b_tmp, b_manifest) = fake_manifest(serde_json::json!({ "shared": "workspace:^" }));
+    let (_c_tmp, c_manifest) = fake_manifest(serde_json::json!({ "shared": "workspace:^" }));
+    let resolver =
+        ProjectRelativeWorkspaceResolver::new(std::path::PathBuf::from("/repo/packages/shared"));
     let importers = vec![
         WorkspaceImporter { id: "packages/a".to_string(), manifest: &a_manifest },
         WorkspaceImporter { id: "apps/b".to_string(), manifest: &b_manifest },
+        WorkspaceImporter { id: "packages/c".to_string(), manifest: &c_manifest },
     ];
     let lockfile_dir = std::path::PathBuf::from("/repo");
+    let workspace_packages = std::sync::Arc::new(std::collections::BTreeMap::default());
+    let hook_calls: RecordedReadPackageCalls = Arc::new(Mutex::new(Vec::new()));
     let mut opts = workspace_opts(false, false);
     opts.lockfile_dir.clone_from(&lockfile_dir);
+    opts.pnpmfile_hook = Some(Arc::new(RecordingHooks { calls: Arc::clone(&hook_calls) }));
 
     let result =
         resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |importer| {
             let project_dir = match importer.id.as_str() {
                 "packages/a" => std::path::PathBuf::from("/repo/packages/a"),
                 "apps/b" => std::path::PathBuf::from("/repo/apps/b"),
+                "packages/c" => std::path::PathBuf::from("/repo/packages/c"),
                 _ => unreachable!("unexpected importer"),
             };
             let mut opts = importer_opts(project_dir, None);
             opts.lockfile_dir = Some(lockfile_dir.clone());
             opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
             opts.base_opts.always_try_workspace_packages = true;
-            opts.base_opts.workspace_packages =
-                Some(std::sync::Arc::new(std::collections::BTreeMap::default()));
+            opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
             opts
         })
         .await
@@ -507,21 +530,38 @@ async fn workspace_link_results_are_cached_per_importer_project_dir() {
         result.peers.direct_dependencies_by_importer["apps/b"]["shared"].as_str(),
         "link:../../packages/shared",
     );
+    assert_eq!(
+        result.peers.direct_dependencies_by_importer["packages/c"]["shared"].as_str(),
+        "link:../shared",
+    );
+    assert_eq!(resolver.workspace_resolution_count(), 1);
+    let mut shared_hook_dirs = hook_calls
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(name, _)| name == "shared")
+        .map(|(_, dir)| dir.clone())
+        .collect::<Vec<_>>();
+    shared_hook_dirs.sort();
+    assert_eq!(
+        shared_hook_dirs,
+        [Some("../../packages/shared".to_string()), Some("../shared".to_string())],
+    );
 }
 
 #[tokio::test]
 async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() {
     let (_nested_tmp, nested_manifest) = fake_manifest(serde_json::json!({
-        "shared": "^1.0.0",
+        "shared": "workspace:^",
         "wrapper": "1.0.0",
     }));
     let (_shallow_tmp, shallow_manifest) = fake_manifest(serde_json::json!({
-        "shared": "^1.0.0",
+        "shared": "workspace:^",
         "wrapper": "1.0.0",
     }));
     let lockfile_dir = std::path::PathBuf::from("/repo");
-    let resolver =
-        ProjectRelativeWorkspaceResolver { target_dir: lockfile_dir.join("packages/shared") };
+    let workspace_packages = std::sync::Arc::new(std::collections::BTreeMap::default());
+    let resolver = ProjectRelativeWorkspaceResolver::new(lockfile_dir.join("packages/shared"));
     let importers = vec![
         WorkspaceImporter { id: "apps/nested/app".to_string(), manifest: &nested_manifest },
         WorkspaceImporter { id: "packages/consumer".to_string(), manifest: &shallow_manifest },
@@ -540,8 +580,7 @@ async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() 
             opts.lockfile_dir = Some(lockfile_dir.clone());
             opts.base_opts.lockfile_dir.clone_from(&lockfile_dir);
             opts.base_opts.always_try_workspace_packages = true;
-            opts.base_opts.workspace_packages =
-                Some(std::sync::Arc::new(std::collections::BTreeMap::default()));
+            opts.base_opts.workspace_packages = Some(std::sync::Arc::clone(&workspace_packages));
             opts
         })
         .await
@@ -560,6 +599,7 @@ async fn canonical_snapshot_link_keeps_direct_links_relative_to_each_importer() 
     assert_eq!(wrapper.children.get("shared"), Some(&crate::DepPath::from("link:packages/shared")));
     assert!(result.merged_tree.packages.contains_key("link:packages/shared"));
     assert!(!result.merged_tree.packages.contains_key("link:../../../packages/shared"));
+    assert_eq!(resolver.workspace_resolution_count(), 1);
 }
 
 #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -3724,12 +3724,12 @@ mod cycle_edges {
 }
 
 /// The `(name, dir)` pairs recorded by [`RecordingHooks`].
-type RecordedReadPackageCalls = std::sync::Arc<Mutex<Vec<(String, Option<String>)>>>;
+pub(crate) type RecordedReadPackageCalls = std::sync::Arc<Mutex<Vec<(String, Option<String>)>>>;
 
 /// [`pnpm_hooks::PnpmfileHooks`] stub that records the `(name, dir)` pair
 /// of every `read_package` call and returns the manifest unchanged.
-struct RecordingHooks {
-    calls: RecordedReadPackageCalls,
+pub(crate) struct RecordingHooks {
+    pub(crate) calls: RecordedReadPackageCalls,
 }
 
 #[async_trait::async_trait]

--- a/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
+++ b/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
@@ -284,6 +284,7 @@ fn workspace_options() -> WorkspaceResolveOptions {
         exclude_links_from_lockfile: false,
         lockfile_dir: PathBuf::from("/workspace"),
         peers_suffix_max_length: 1000,
+        share_workspace_resolutions: true,
         manifest_hook: None,
         overrides_hook: None,
         pick_lowest_direct: false,


### PR DESCRIPTION
<!-- Maintainers will start the review after CodeRabbit approves the PR and CI passes. -->

## Summary

The wanted-cache key includes `projectDir`. This makes pnpm resolve each named `workspace:`
dependency separately for every importer.

This PR shares workspace package selection across eligible importers. It renders the correct
relative `link:` value for each importer. It then caches the result for each rendered `link:`
variant.

Sharing applies only to named `workspace:*`, `workspace:^`, and exact-version selectors. pnpm
shares results only when it uses the built-in resolver chain.

pnpm keeps project-scoped resolution for:

- custom resolvers
- relative workspace paths
- explicit `link:` or `file:` selectors
- ordinary semver fallback

## Benchmark

The [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) contains
6,833 projects and 87,630 shared `workspace:*` edges. It does not use a pnpmfile hook. Yarn and
pnpm resolve the same package manifests.

Each tool ran five times. The benchmark alternated the tool order. An untimed no-op install warmed
the caches before each timed run. The benchmark then changed one root dependency from
`workspace:*` to `workspace:^` and updated the lockfile.

| Tool | Resolution median | vs pnpm baseline | Total wall time median | vs pnpm baseline |
| --- | ---: | ---: | ---: | ---: |
| Yarn 4.18.0 | 500 ms | -33.51% | 4,854.25 ms | -48.60% |
| pnpm baseline | 752 ms | — | 9,443.16 ms | — |
| This PR | 492 ms | **-34.57%** | 9,164.63 ms | -2.95% |

Yarn reports resolution time as `Resolution step`. pnpm measures the interval from
`resolution_started` to `resolution_done`. The pnpm baseline and this PR produced byte-identical
lockfiles.

## Validation

- All 346 resolver tests passed.
- Clippy, Dylint, Rustdoc, rustfmt, and diff checks passed.
- CI passed on macOS, Linux, and Windows.
- The microbenchmark workflow and integrated benchmark workflow passed.

## Squash Commit Body

```text
pnpm resolved named workspace dependencies separately for each importer. The wanted-cache key
included the importer directory.

pnpm needs the importer directory to render the final relative link. It does not need the directory
to select the workspace package.

Share built-in resolution for eligible named workspace selectors. Render the link separately for
each importer. Cache the processed result for each rendered-link variant.

Use existing project-scoped resolution for custom resolvers, relative workspace paths, explicit
local protocols, and ordinary semver fallback.
```

## Checklist

- [x] I found no duplicate workspace-resolution cache change.
- [x] This optimization changes only Rust code. The TypeScript implementation uses a different
  resolver path.
- [x] I added a patch changeset for `pacquet`.
- [x] I added resolver coverage. I also updated the microbenchmark coverage.
- [x] Workspace resolution behavior does not change. This PR does not require documentation
  changes.

---

Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved installation speed in large workspaces by resolving shared `workspace:` dependencies once and reusing results across projects.
  * Preserved correct project-specific links and manifest processing when reused resolutions are applied.

* **Bug Fixes**
  * Limited resolution sharing to supported named `workspace:` selectors and importer-independent scenarios.

* **Tests**
  * Added coverage for shared resolution caching, relative links, self-dependencies, hooks, and unsupported selectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->