### PR TITLE
fix(config): stop a stored credential deciding where packages come from

### DIFF
--- a/.changeset/auth-file-does-not-mandate-the-registry.md
+++ b/.changeset/auth-file-does-not-mandate-the-registry.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+An `_auth` entry in the global config file no longer decides which registry packages come from when something else says. A `registry` or `registries` declared in `pnpm-workspace.yaml` or the global config now wins over the route inferred from a stored credential, which still applies where nothing else declares one. The `pnpm_config__auth` environment variable is unchanged: it stays the way to point a CI runner at a mandated proxy, and still overrides what a repository declares.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3517,7 +3517,11 @@ impl Config {
         // resolution must fire only when the user has *not* pinned a
         // path. See [`crate::store_path::resolve_store_dir`].
         let mut store_dir_explicit = false;
+        // Collected as each file is applied, since applying it is what makes
+        // a declared route indistinguishable by value from a resolved one.
+        let mut declared_registries = crate::npmrc_auth::DeclaredRegistries::default();
         if let Some(mut global_settings) = global_settings {
+            note_declared_registries(&mut declared_registries, &global_settings);
             virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
             global_virtual_store_dir_explicit |= global_settings.global_virtual_store_dir.is_some();
             store_dir_explicit |= global_settings.store_dir.is_some();
@@ -3605,6 +3609,7 @@ impl Config {
                     settings.clear_self_update_policy();
                 }
                 self.workspace_key_issues = settings.key_issues.clone();
+                note_declared_registries(&mut declared_registries, &settings);
                 collect_explicit_settings(&mut self.explicit_settings, &settings);
                 settings.apply_to(&mut self, &base_dir);
                 // `overrides` reaches `Config` only from the workspace
@@ -3624,8 +3629,7 @@ impl Config {
         // repo-controlled registries) but before `PNPM_CONFIG_*` (so an
         // explicit `pnpm_config_registry` / `--registry` still wins) —
         // pnpm's "CLI > _auth > yaml" precedence.
-        let registry_declared = self.explicit_settings.contains_key("registry");
-        npmrc_auth.apply_json_env_registries(&mut self, registry_declared);
+        npmrc_auth.apply_json_env_registries(&mut self, &declared_registries);
 
         // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`:
         // env vars override yaml. The `WorkspaceSettings::apply_to`
@@ -3827,6 +3831,25 @@ impl Config {
 /// [`WorkspaceSettings::apply_to`] and fills in the spelling the source left
 /// out, or `pnpm config get` would answer one of the two with the value the
 /// install did not use.
+/// Record what `settings` declares about registry routing, before
+/// [`WorkspaceSettings::apply_to`] consumes it.
+fn note_declared_registries(
+    declared: &mut crate::npmrc_auth::DeclaredRegistries,
+    settings: &WorkspaceSettings,
+) {
+    declared.registry |= settings.registry.is_some();
+    let Some(entries) = settings.registries.as_ref() else {
+        return;
+    };
+    for scope in crate::workspace_yaml::registries::routed_scopes(entries) {
+        if scope == crate::workspace_yaml::registries::DEFAULT_REGISTRY_SCOPE {
+            declared.registry = true;
+        } else {
+            declared.scopes.insert(scope);
+        }
+    }
+}
+
 fn collect_explicit_settings(
     target: &mut serde_json::Map<String, serde_json::Value>,
     settings: &WorkspaceSettings,
@@ -3871,7 +3894,9 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     trusted_auth.warnings.clear();
     let mut config = Config::default();
     trusted_auth.apply_registry_and_warn(&mut config);
-    trusted_auth.apply_json_env_registries(&mut config, false);
+    // No config file reaches the bootstrap cascade, so none declares here.
+    trusted_auth
+        .apply_json_env_registries(&mut config, &crate::npmrc_auth::DeclaredRegistries::default());
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
     trusted_auth.build_auth_headers(&mut config)?;

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3474,6 +3474,12 @@ impl Config {
         }
 
         npmrc_auth.apply_registry_and_warn(&mut self);
+        // The routing before any config file speaks, so that applying the
+        // `_auth` file routes below can tell a declaration from a default.
+        let routes_before_files = crate::npmrc_auth::RegistryRoutes {
+            registry: self.registry.clone(),
+            by_scope: self.registries_by_scope.clone(),
+        };
         // Proxy cascade fires unconditionally — even when no `.npmrc`
         // is found — because the env-var fallback is a normalization step
         // on the resolved config, not a function of `.npmrc` presence.
@@ -3624,7 +3630,7 @@ impl Config {
         // repo-controlled registries) but before `PNPM_CONFIG_*` (so an
         // explicit `pnpm_config_registry` / `--registry` still wins) —
         // pnpm's "CLI > _auth > yaml" precedence.
-        npmrc_auth.apply_json_env_registries(&mut self);
+        npmrc_auth.apply_json_env_registries(&mut self, &routes_before_files);
 
         // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`:
         // env vars override yaml. The `WorkspaceSettings::apply_to`
@@ -3870,7 +3876,11 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     trusted_auth.warnings.clear();
     let mut config = Config::default();
     trusted_auth.apply_registry_and_warn(&mut config);
-    trusted_auth.apply_json_env_registries(&mut config);
+    let routes_before_files = crate::npmrc_auth::RegistryRoutes {
+        registry: config.registry.clone(),
+        by_scope: config.registries_by_scope.clone(),
+    };
+    trusted_auth.apply_json_env_registries(&mut config, &routes_before_files);
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
     trusted_auth.build_auth_headers(&mut config)?;

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3474,12 +3474,6 @@ impl Config {
         }
 
         npmrc_auth.apply_registry_and_warn(&mut self);
-        // The routing before any config file speaks, so that applying the
-        // `_auth` file routes below can tell a declaration from a default.
-        let routes_before_files = crate::npmrc_auth::RegistryRoutes {
-            registry: self.registry.clone(),
-            by_scope: self.registries_by_scope.clone(),
-        };
         // Proxy cascade fires unconditionally — even when no `.npmrc`
         // is found — because the env-var fallback is a normalization step
         // on the resolved config, not a function of `.npmrc` presence.
@@ -3630,7 +3624,8 @@ impl Config {
         // repo-controlled registries) but before `PNPM_CONFIG_*` (so an
         // explicit `pnpm_config_registry` / `--registry` still wins) —
         // pnpm's "CLI > _auth > yaml" precedence.
-        npmrc_auth.apply_json_env_registries(&mut self, &routes_before_files);
+        let registry_declared = self.explicit_settings.contains_key("registry");
+        npmrc_auth.apply_json_env_registries(&mut self, registry_declared);
 
         // Apply `PNPM_CONFIG_*` env vars *after* `pnpm-workspace.yaml`:
         // env vars override yaml. The `WorkspaceSettings::apply_to`
@@ -3876,11 +3871,7 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     trusted_auth.warnings.clear();
     let mut config = Config::default();
     trusted_auth.apply_registry_and_warn(&mut config);
-    let routes_before_files = crate::npmrc_auth::RegistryRoutes {
-        registry: config.registry.clone(),
-        by_scope: config.registries_by_scope.clone(),
-    };
-    trusted_auth.apply_json_env_registries(&mut config, &routes_before_files);
+    trusted_auth.apply_json_env_registries(&mut config, false);
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
     trusted_auth.build_auth_headers(&mut config)?;

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -96,12 +96,22 @@ pub(crate) struct NpmrcAuth {
     /// preserved verbatim through to [`PerRegistryTls`] construction
     /// so lookup keys stay byte-equivalent to the keys as written.
     pub tls_by_uri: HashMap<String, RegistryTls>,
-    /// Scope→URL registry routes inferred from `_auth` (`"@"` → `"default"`,
-    /// `"@org"` → that scope). Safe because the credential and its
-    /// destination host come from the same trusted value, so repo config
-    /// can't redirect the token elsewhere. Applied after workspace yaml by
+    /// Scope→URL registry routes inferred from the `_auth` **environment
+    /// variable** (`"@"` → `"default"`, `"@org"` → that scope). Safe because
+    /// the credential and its destination host come from the same trusted
+    /// value, so repo config can't redirect the token elsewhere. The
+    /// environment is the operator's channel — a CI runner pointed at a
+    /// mandated proxy — so these outrank what any config file declares.
+    /// Applied after workspace yaml by
     /// [`Self::apply_json_env_registries`].
     pub json_env_registries: BTreeMap<String, String>,
+    /// The same routes inferred from the `_auth` of the global config
+    /// **file**. That file is the user's own store rather than a mandate —
+    /// it is where `pnpm login` puts a credential — so a `registry` or
+    /// `registries` a config file declares outranks these, and they fill in
+    /// only what nothing else declares. See
+    /// [`Self::apply_json_env_registries`].
+    pub json_file_registries: BTreeMap<String, String>,
     /// Raw INI config keys (those for which
     /// [`crate::config_types::is_ini_config_key`] holds), post-`${VAR}`
     /// substitution, captured verbatim for `pnpm config get` / `list`. This
@@ -234,7 +244,10 @@ impl NpmrcAuth {
     ) -> Result<Self, serde_json::Error> {
         let mut auth = NpmrcAuth::default();
         if let Some(global_value) = global_value {
-            auth.apply_json_auth(serde_json::from_value(global_value.clone())?);
+            auth.apply_json_auth(
+                serde_json::from_value(global_value.clone())?,
+                JsonAuthOrigin::File,
+            );
         }
         // Lowercase is the documented form; UPPER covers the all-caps shell
         // convention some CI runners apply.
@@ -242,7 +255,7 @@ impl NpmrcAuth {
             .filter(|value| !value.is_empty())
             .or_else(|| Sys::var("PNPM_CONFIG__AUTH").filter(|value| !value.is_empty()));
         if let Some(value) = env_value {
-            auth.apply_json_auth(serde_json::from_str(&value)?);
+            auth.apply_json_auth(serde_json::from_str(&value)?, JsonAuthOrigin::Env);
         }
         Ok(auth)
     }
@@ -251,7 +264,7 @@ impl NpmrcAuth {
     /// object applied after the global one overrides on conflict): each
     /// entry becomes a `//host/:_authToken` credential and an inferred
     /// registry route (see [`Self::json_env_registries`]).
-    fn apply_json_auth(&mut self, parsed: JsonAuth) {
+    fn apply_json_auth(&mut self, parsed: JsonAuth, origin: JsonAuthOrigin) {
         for (registry, scopes) in parsed.0 {
             for (scope, creds) in scopes {
                 let key = match &scope {
@@ -268,7 +281,11 @@ impl NpmrcAuth {
                     JsonAuthScope::Default => "default".to_string(),
                     JsonAuthScope::Package(scope) => scope,
                 };
-                self.json_env_registries.insert(route_key, registry.normalized.clone());
+                let routes = match origin {
+                    JsonAuthOrigin::Env => &mut self.json_env_registries,
+                    JsonAuthOrigin::File => &mut self.json_file_registries,
+                };
+                routes.insert(route_key, registry.normalized.clone());
             }
         }
     }
@@ -565,7 +582,27 @@ impl NpmrcAuth {
     /// [`Self::apply_registry_and_warn`] (which runs *before* workspace
     /// yaml), this is called *after* yaml so the inferred routes win over
     /// repo-controlled registries.
-    pub fn apply_json_env_registries(&mut self, config: &mut Config) {
+    ///
+    /// `before_files` is the routing as it stood before any config file
+    /// spoke, which is what lets the file-sourced routes tell a declaration
+    /// from a default: they replace only what no config file has since
+    /// changed. The environment-sourced ones replace whatever they find.
+    pub fn apply_json_env_registries(
+        &mut self,
+        config: &mut Config,
+        before_files: &RegistryRoutes,
+    ) {
+        for (scope, url) in std::mem::take(&mut self.json_file_registries) {
+            if scope == "default" {
+                if config.registry == before_files.registry {
+                    config.registry.clone_from(&url);
+                }
+                continue;
+            }
+            if config.registries_by_scope.get(&scope) == before_files.by_scope.get(&scope) {
+                config.registries_by_scope.insert(scope, url);
+            }
+        }
         for (scope, url) in std::mem::take(&mut self.json_env_registries) {
             if scope == "default" {
                 config.registry.clone_from(&url);
@@ -758,6 +795,9 @@ impl NpmrcAuth {
         }
         for (scope, registry) in lower.json_env_registries {
             self.json_env_registries.entry(scope).or_insert(registry);
+        }
+        for (scope, registry) in lower.json_file_registries {
+            self.json_file_registries.entry(scope).or_insert(registry);
         }
         for (key, value) in lower.raw_ini_config {
             self.raw_ini_config.entry(key).or_insert(value);
@@ -1205,6 +1245,26 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "tokenHelper" => creds.token_helper = Some(value),
         _ => {}
     }
+}
+
+/// The registry and its scope routes at a point in the cascade, so a later
+/// layer can tell what a config file has since declared from what it left
+/// alone. Taken before the files are applied; see
+/// [`NpmrcAuth::apply_json_env_registries`].
+#[derive(Debug, Default, Clone)]
+pub struct RegistryRoutes {
+    pub registry: String,
+    pub by_scope: BTreeMap<String, String>,
+}
+
+/// Which of `_auth`'s two trusted sources a value came from. They differ in
+/// standing, not in shape: the environment is the operator's channel and
+/// mandates its routes, while the config file is the user's own store and
+/// only fills in what nothing else declares.
+#[derive(Clone, Copy)]
+enum JsonAuthOrigin {
+    Env,
+    File,
 }
 
 /// The parsed `_auth` setting: registry URL → scope → credentials.

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -583,25 +583,21 @@ impl NpmrcAuth {
     /// yaml), this is called *after* yaml so the inferred routes win over
     /// repo-controlled registries.
     ///
-    /// `before_files` is the routing as it stood before any config file
-    /// spoke, which is what lets the file-sourced routes tell a declaration
-    /// from a default: they replace only what no config file has since
-    /// changed. The environment-sourced ones replace whatever they find.
-    pub fn apply_json_env_registries(
-        &mut self,
-        config: &mut Config,
-        before_files: &RegistryRoutes,
-    ) {
+    /// The file-sourced routes fill in only what nothing else names:
+    /// `registry_declared` says whether a config file set `registry` at all,
+    /// and a scope already routed keeps the route it has. Provenance rather
+    /// than value, because pinning the registry a lower layer already
+    /// resolved to is still a declaration. The environment-sourced routes
+    /// replace whatever they find.
+    pub fn apply_json_env_registries(&mut self, config: &mut Config, registry_declared: bool) {
         for (scope, url) in std::mem::take(&mut self.json_file_registries) {
             if scope == "default" {
-                if config.registry == before_files.registry {
+                if !registry_declared {
                     config.registry.clone_from(&url);
                 }
                 continue;
             }
-            if config.registries_by_scope.get(&scope) == before_files.by_scope.get(&scope) {
-                config.registries_by_scope.insert(scope, url);
-            }
+            config.registries_by_scope.entry(scope).or_insert(url);
         }
         for (scope, url) in std::mem::take(&mut self.json_env_registries) {
             if scope == "default" {
@@ -1245,16 +1241,6 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "tokenHelper" => creds.token_helper = Some(value),
         _ => {}
     }
-}
-
-/// The registry and its scope routes at a point in the cascade, so a later
-/// layer can tell what a config file has since declared from what it left
-/// alone. Taken before the files are applied; see
-/// [`NpmrcAuth::apply_json_env_registries`].
-#[derive(Debug, Default, Clone)]
-pub struct RegistryRoutes {
-    pub registry: String,
-    pub by_scope: BTreeMap<String, String>,
 }
 
 /// Which of `_auth`'s two trusted sources a value came from. They differ in

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -6,7 +6,7 @@ use pnpm_network::{
     base64_encode, base64_encode_bytes, nerf_dart,
 };
 use std::{
-    collections::{BTreeMap, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -583,21 +583,27 @@ impl NpmrcAuth {
     /// yaml), this is called *after* yaml so the inferred routes win over
     /// repo-controlled registries.
     ///
-    /// The file-sourced routes fill in only what nothing else names:
-    /// `registry_declared` says whether a config file set `registry` at all,
-    /// and a scope already routed keeps the route it has. Provenance rather
-    /// than value, because pinning the registry a lower layer already
-    /// resolved to is still a declaration. The environment-sourced routes
-    /// replace whatever they find.
-    pub fn apply_json_env_registries(&mut self, config: &mut Config, registry_declared: bool) {
+    /// The file-sourced routes fill in only what a config file has not
+    /// declared, which `declared` names: provenance rather than value,
+    /// because pinning the registry a lower layer already resolved to is
+    /// still a declaration. A route the `.npmrc` merely resolved is not one,
+    /// so those give way. The environment-sourced routes replace whatever
+    /// they find.
+    pub fn apply_json_env_registries(
+        &mut self,
+        config: &mut Config,
+        declared: &DeclaredRegistries,
+    ) {
         for (scope, url) in std::mem::take(&mut self.json_file_registries) {
             if scope == "default" {
-                if !registry_declared {
+                if !declared.registry {
                     config.registry.clone_from(&url);
                 }
                 continue;
             }
-            config.registries_by_scope.entry(scope).or_insert(url);
+            if !declared.scopes.contains(&scope) {
+                config.registries_by_scope.insert(scope, url);
+            }
         }
         for (scope, url) in std::mem::take(&mut self.json_env_registries) {
             if scope == "default" {
@@ -1241,6 +1247,18 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
         "tokenHelper" => creds.token_helper = Some(value),
         _ => {}
     }
+}
+
+/// What the config files declared about registry routing, as opposed to what
+/// the cascade merely resolved to. Collected before each layer is applied,
+/// because applying it is what makes the two indistinguishable by value.
+#[derive(Debug, Default, Clone)]
+pub struct DeclaredRegistries {
+    /// Whether any config file named the registry packages resolve from,
+    /// through `registry` or a `registries` entry routing the bare `@`.
+    pub registry: bool,
+    /// The package scopes any config file routed.
+    pub scopes: BTreeSet<String>,
 }
 
 /// Which of `_auth`'s two trusted sources a value came from. They differ in

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4285,3 +4285,72 @@ pub fn a_detached_head_leaves_the_install_on_the_shared_lockfile() {
     assert_eq!(config.git_branch_lockfile_name, None);
     assert_eq!(config.wanted_lockfile_name(), "pnpm-lock.yaml");
 }
+
+/// Writing a global `config.yaml` whose `_auth` credits `registry` and the
+/// project manifest `project_yaml`, then loading config from that project.
+fn load_with_auth_file(auth_yaml: &str, project_yaml: Option<&str>) -> Config {
+    fake_env!(load_with_fake_env);
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.yaml"), auth_yaml).expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    if let Some(project_yaml) = project_yaml {
+        fs::write(project.path().join("pnpm-workspace.yaml"), project_yaml)
+            .expect("write pnpm-workspace.yaml");
+    }
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+
+    load_with_fake_env(project.path())
+}
+
+const STORED_LOGIN: &str = "\
+_auth:
+  https://private.example/:
+    '@': { authToken: stored-token }
+    '@org': { authToken: stored-org-token }
+";
+
+/// The global config file's `_auth` is where a `pnpm login` stores what it
+/// was granted. Holding a credential for a registry is not a statement that
+/// packages come from it, so a project that declares its own registry keeps
+/// it.
+#[test]
+pub fn a_declared_registry_beats_the_global_auth_file() {
+    let config =
+        load_with_auth_file(STORED_LOGIN, Some("registry: https://project-choice.example/\n"));
+
+    assert_eq!(config.registry, "https://project-choice.example/");
+    // The credential still reaches the registry it was written for.
+    assert_eq!(
+        config.auth_tokens_by_uri.get("//private.example/").map(String::as_str),
+        Some("stored-token"),
+    );
+}
+
+#[test]
+pub fn a_declared_scope_route_beats_the_global_auth_file() {
+    let config = load_with_auth_file(
+        STORED_LOGIN,
+        Some("registries:\n  https://project-org.example/:\n    scopes: ['@org']\n"),
+    );
+
+    assert_eq!(
+        config.registries_by_scope.get("@org").map(String::as_str),
+        Some("https://project-org.example/"),
+    );
+}
+
+/// Only what something else declares is kept back; the stored credential
+/// still supplies a route nothing competes for.
+#[test]
+pub fn the_global_auth_file_routes_what_nothing_else_declares() {
+    let config = load_with_auth_file(STORED_LOGIN, None);
+
+    assert_eq!(config.registry, "https://private.example/");
+    assert_eq!(
+        config.registries_by_scope.get("@org").map(String::as_str),
+        Some("https://private.example/"),
+    );
+}

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4401,3 +4401,16 @@ pub fn the_global_auth_file_outranks_an_npmrc_scope_route() {
         Some("https://private.example/"),
     );
 }
+
+/// The older `registries: { default: … }` spelling names the default
+/// registry as much as a declaration routing the bare `@` does, and the
+/// reader treats it that way, so the declaration must be seen through it too.
+#[test]
+pub fn a_legacy_default_registries_key_beats_the_global_auth_file() {
+    let config = load_with_auth_file(
+        STORED_LOGIN,
+        Some("registries:\n  default: https://legacy-declared.example/\n"),
+    );
+
+    assert_eq!(config.registry, "https://legacy-declared.example/");
+}

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4354,3 +4354,13 @@ pub fn the_global_auth_file_routes_what_nothing_else_declares() {
         Some("https://private.example/"),
     );
 }
+
+/// Whether a registry was declared is a question about the key, not its
+/// value: pinning the one a lower layer already resolved to is still a
+/// declaration, and a stored credential must not quietly replace it.
+#[test]
+pub fn a_registry_pinned_to_the_default_still_beats_the_global_auth_file() {
+    let config = load_with_auth_file(STORED_LOGIN, Some("registry: https://registry.npmjs.org/\n"));
+
+    assert_eq!(config.registry, "https://registry.npmjs.org/");
+}

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4364,3 +4364,40 @@ pub fn a_registry_pinned_to_the_default_still_beats_the_global_auth_file() {
 
     assert_eq!(config.registry, "https://registry.npmjs.org/");
 }
+
+/// A `registries` map naming the default registry declares it as plainly as
+/// a `registry:` does, and is recorded under a different key, so asking only
+/// about `registry` would miss it.
+#[test]
+pub fn a_registries_map_declaring_the_default_beats_the_global_auth_file() {
+    let config = load_with_auth_file(
+        STORED_LOGIN,
+        Some("registries:\n  https://declared.example/:\n    scopes: ['@']\n"),
+    );
+
+    assert_eq!(config.registry, "https://declared.example/");
+}
+
+/// An `.npmrc` route is what the cascade resolved, not what a config file
+/// declared, so the stored credential's route outranks it — as it does in
+/// pnpm's `config.reader`.
+#[test]
+pub fn the_global_auth_file_outranks_an_npmrc_scope_route() {
+    fake_env!(load_with_fake_env);
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.yaml"), STORED_LOGIN).expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    fs::write(project.path().join(".npmrc"), "@org:registry=https://from-npmrc.example/\n")
+        .expect("write .npmrc");
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+
+    let config = load_with_fake_env(project.path());
+
+    assert_eq!(
+        config.registries_by_scope.get("@org").map(String::as_str),
+        Some("https://private.example/"),
+    );
+}

--- a/pnpm/crates/config/src/workspace_yaml/registries.rs
+++ b/pnpm/crates/config/src/workspace_yaml/registries.rs
@@ -122,6 +122,25 @@ pub struct RegistryLookups {
     pub registry_options_by_url: BTreeMap<String, RegistryOptions>,
 }
 
+/// The scopes `entries` routes, `@`-prefixed, with the bare `@` among them
+/// when one names the default registry.
+///
+/// Read without consuming the map, unlike [`into_lookups`], so that a later
+/// layer can tell a route a config file declared from one inferred from a
+/// credential.
+#[must_use]
+pub fn routed_scopes(entries: &BTreeMap<String, RegistryEntry>) -> BTreeSet<String> {
+    entries
+        .iter()
+        .flat_map(|(key, entry)| match entry {
+            RegistryEntry::ScopeRoute(_) => vec![key.clone()],
+            RegistryEntry::Declaration(declaration) => {
+                declaration.scopes.clone().unwrap_or_default()
+            }
+        })
+        .collect()
+}
+
 /// Reject a `registries` map pnpm would otherwise read as something other
 /// than what it says.
 pub fn validate(entries: &BTreeMap<String, RegistryEntry>) -> Result<(), LoadWorkspaceYamlError> {

--- a/pnpm/crates/config/src/workspace_yaml/registries.rs
+++ b/pnpm/crates/config/src/workspace_yaml/registries.rs
@@ -127,12 +127,17 @@ pub struct RegistryLookups {
 ///
 /// Read without consuming the map, unlike [`into_lookups`], so that a later
 /// layer can tell a route a config file declared from one inferred from a
-/// credential.
+/// credential. Both spellings of the default reach it: the `scopes` list of a
+/// declaration, and the older `default:` key that [`into_lookups`] reads as
+/// the same thing.
 #[must_use]
 pub fn routed_scopes(entries: &BTreeMap<String, RegistryEntry>) -> BTreeSet<String> {
     entries
         .iter()
         .flat_map(|(key, entry)| match entry {
+            RegistryEntry::ScopeRoute(_) if key == "default" => {
+                vec![DEFAULT_REGISTRY_SCOPE.to_owned()]
+            }
             RegistryEntry::ScopeRoute(_) => vec![key.clone()],
             RegistryEntry::Declaration(declaration) => {
                 declaration.scopes.clone().unwrap_or_default()

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -395,6 +395,10 @@ export async function getConfig (opts: {
   }
   pnpmConfig.packageManagerRegistries = {
     default: normalizeRegistryUrl(trustedAuthConfig.registry as string),
+    // The file fallback applies to the bootstrap cascade too, so a registry
+    // reached only through a stored credential is reached the same way when
+    // pnpm downloads itself as when it installs.
+    ...npmrcResult.jsonAuth.fallbackRegistries,
     ...trustedNetworkConfigs.registries,
     // `_auth` routes apply here too so bootstrap (self-download / version
     // switching) resolves the same way as regular installs.
@@ -576,9 +580,10 @@ export async function getConfig (opts: {
   // A `registry:` in either yaml declares the default as plainly as a
   // `registries` entry does, but reaches `pnpmConfig.registry` instead of the
   // map, so it has to be restated here to outrank the `_auth` file fallback.
-  const yamlDeclaredDefault =
-    typeof pnpmConfig.registry === 'string' &&
-    normalizeRegistryUrl(pnpmConfig.registry) !== registriesFromNpmrc.default
+  // Asked of the key rather than of its value: pinning the registry a lower
+  // layer already resolved to is still a declaration.
+  const declaredDefault =
+    explicitlySetKeys.has('registry') && typeof pnpmConfig.registry === 'string'
       ? { default: normalizeRegistryUrl(pnpmConfig.registry) }
       : undefined
   pnpmConfig.registriesByScope = {
@@ -589,7 +594,7 @@ export async function getConfig (opts: {
     ...npmrcResult.jsonAuth.fallbackRegistries,
     ...globalYamlRegistries,
     ...workspaceManifestRegistries,
-    ...yamlDeclaredDefault,
+    ...declaredDefault,
     // The `_auth` env var is the operator's channel — a CI runner pointed at
     // a mandated proxy — so its routes win over what any file declares.
     ...npmrcResult.jsonAuth.registries,

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -296,6 +296,10 @@ export async function getConfig (opts: {
 
   // Track which keys are explicitly set (not defaults)
   const explicitlySetKeys = new Set<string>(Object.keys(configFromCliOpts))
+  // The command line alone, before any config file adds to the set above. A
+  // `registry` a yaml declared is explicit too, but it is not the command
+  // line, and only the command line outranks the `_auth` environment.
+  const registrySetOnCommandLine = explicitlySetKeys.has('registry')
   pnpmConfig.explicitlySetKeys = explicitlySetKeys
   pnpmConfig.cliOptions = cliOptions
 
@@ -564,25 +568,39 @@ export async function getConfig (opts: {
     }
   }
 
-  // Precedence: builtin < .npmrc < yaml < `_auth` < CLI. CLI
+  // Precedence: builtin < .npmrc < `_auth` file < yaml < `_auth` env < CLI. CLI
   // `--@scope:registry` / `--registry` already entered `registriesFromNpmrc`
   // via `authConfig`, so they're re-applied last here to avoid being buried
   // by yaml. `cliScopedRegistries` iterates raw `cliOptions` because
   // `explicitlySetKeys` is camelCased, which mangles `@org-a:registry`.
+  // A `registry:` in either yaml declares the default as plainly as a
+  // `registries` entry does, but reaches `pnpmConfig.registry` instead of the
+  // map, so it has to be restated here to outrank the `_auth` file fallback.
+  const yamlDeclaredDefault =
+    typeof pnpmConfig.registry === 'string' &&
+    normalizeRegistryUrl(pnpmConfig.registry) !== registriesFromNpmrc.default
+      ? { default: normalizeRegistryUrl(pnpmConfig.registry) }
+      : undefined
   pnpmConfig.registriesByScope = {
     ...registriesFromNpmrc,
+    // The global config file's `_auth` only fills in what nothing declares:
+    // it is where a `pnpm login` stores a credential, and holding one is not
+    // a statement about where packages come from.
+    ...npmrcResult.jsonAuth.fallbackRegistries,
     ...globalYamlRegistries,
     ...workspaceManifestRegistries,
-    // `_auth` routes win over repo-controlled yaml on conflicting scopes.
+    ...yamlDeclaredDefault,
+    // The `_auth` env var is the operator's channel — a CI runner pointed at
+    // a mandated proxy — so its routes win over what any file declares.
     ...npmrcResult.jsonAuth.registries,
     // CLI per-scope registries last, so `--@scope:registry=...` wins over
-    // both yaml and `_auth` ("CLI > _auth > yaml").
+    // both yaml and `_auth` ("CLI > _auth env > yaml > _auth file").
     ...cliScopedRegistries,
   }
   // Re-apply an unscoped `--registry` CLI flag last for the same reason
   // as `cliScopedRegistries` — it entered `registriesFromNpmrc` via
   // `authConfig.registry` and would otherwise be buried by env JSON.
-  if (explicitlySetKeys.has('registry') && typeof pnpmConfig.registry === 'string') {
+  if (registrySetOnCommandLine && typeof pnpmConfig.registry === 'string') {
     pnpmConfig.registriesByScope.default = normalizeRegistryUrl(pnpmConfig.registry)
   }
   if (!pnpmConfig.registriesByScope.default) {
@@ -599,7 +617,7 @@ export async function getConfig (opts: {
   // registry configured in pnpm-workspace.yaml. Only sync when the workspace
   // manifest actually contributed a different default than what .npmrc provided,
   // and when registry was not explicitly set via CLI.
-  if (!explicitlySetKeys.has('registry') && pnpmConfig.registriesByScope.default !== registriesFromNpmrc.default) {
+  if (!registrySetOnCommandLine && pnpmConfig.registriesByScope.default !== registriesFromNpmrc.default) {
     pnpmConfig.registry = pnpmConfig.registriesByScope.default
   }
 

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -38,16 +38,22 @@ export interface NpmrcConfigResult {
  *
  * - `auth` — `.npmrc`-shaped URL-scoped keys (`//host/:_authToken`, …)
  *   ready to merge into the existing auth-config pipeline.
- * - `registries` — trusted scope→URL routes inferred from the same
- *   value. `"default"` is set by the `"@"` scope; `"@org"` by a package
- *   scope. Because both the credential and its destination host arrive
- *   in one trusted value, repo-controlled `pnpm-workspace.yaml` /
- *   project `.npmrc` cannot redirect these tokens to a different host.
+ * - `registries` — trusted scope→URL routes inferred from the `_auth`
+ *   **environment variable**. `"default"` is set by the `"@"` scope;
+ *   `"@org"` by a package scope. The environment is the operator's
+ *   channel — a CI runner pointed at a mandated proxy — so these outrank
+ *   what any config file declares, and repo-controlled
+ *   `pnpm-workspace.yaml` / project `.npmrc` cannot redirect them.
  *   Merged above workspace yaml but below CLI flags.
+ * - `fallbackRegistries` — the same routes inferred from the `_auth` of
+ *   the global config **file**. That file is the user's own store rather
+ *   than a mandate, so an explicitly declared `registries` / `registry`
+ *   outranks it and it only fills in what nothing else declares.
  */
 export interface JsonAuthResult {
   auth: Record<string, string>
   registries: Record<string, string>
+  fallbackRegistries: Record<string, string>
 }
 
 export interface LoadNpmrcConfigOpts {
@@ -134,7 +140,8 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
   const globalConfigJsonAuth = readGlobalConfigAuth(opts.globalConfigAuth)
   const jsonAuth: JsonAuthResult = {
     auth: { ...globalConfigJsonAuth.auth, ...envJsonAuth.auth },
-    registries: { ...globalConfigJsonAuth.registries, ...envJsonAuth.registries },
+    registries: envJsonAuth.registries,
+    fallbackRegistries: globalConfigJsonAuth.registries,
   }
 
   // Read pnpm builtin rc + inline defaults
@@ -241,7 +248,7 @@ function readUrlScopedEnvConfig (env: Record<string, string | undefined>): Recor
 
 function readJsonAuthEnv (env: Record<string, string | undefined>): JsonAuthResult {
   const value = readJsonAuthEnvValue(env)
-  if (value == null) return { auth: {}, registries: {} }
+  if (value == null) return { auth: {}, registries: {}, fallbackRegistries: {} }
 
   let parsed: unknown
   try {
@@ -287,12 +294,12 @@ function parseJsonAuth (parsed: unknown, source: string): JsonAuthResult {
       registries[scope === '@' ? 'default' : scope] = registry.normalized
     }
   }
-  return { auth, registries }
+  return { auth, registries, fallbackRegistries: {} }
 }
 
 /** Parse `_auth` from the global pnpm config yaml (already a parsed object). */
 function readGlobalConfigAuth (globalConfigAuth: unknown): JsonAuthResult {
-  if (globalConfigAuth == null) return { auth: {}, registries: {} }
+  if (globalConfigAuth == null) return { auth: {}, registries: {}, fallbackRegistries: {} }
   return parseJsonAuth(globalConfigAuth, '_auth')
 }
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -2899,6 +2899,85 @@ test('a malformed global yaml _auth value aborts the load', async () => {
   })).rejects.toThrow('object keyed by scope')
 })
 
+test('a registry declared in pnpm-workspace.yaml beats the global _auth file', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', { registry: 'https://project-choice.example/' })
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://private.example': {
+          '@': { authToken: 'stored-token' },
+        },
+      },
+    },
+    { workspaceDir: process.cwd() }
+  )
+
+  // The credential still reaches the registry it was written for.
+  expect(config.authConfig['//private.example/:_authToken']).toBe('stored-token')
+  // But a stored login is not a statement about where packages come from.
+  expect(config.registry).toBe('https://project-choice.example/')
+  expect(config.registriesByScope.default).toBe('https://project-choice.example/')
+})
+
+test('a scope declared in pnpm-workspace.yaml beats the global _auth file', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: { 'https://project-choice.example/': { scopes: ['@org'] } },
+  })
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://private.example': {
+          '@org': { authToken: 'stored-token' },
+        },
+      },
+    },
+    { workspaceDir: process.cwd() }
+  )
+
+  expect(config.registriesByScope['@org']).toBe('https://project-choice.example/')
+})
+
+test('the global _auth file still routes a scope nothing else declares', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://private.example': {
+        '@org': { authToken: 'stored-token' },
+      },
+    },
+  })
+
+  expect(config.registriesByScope['@org']).toBe('https://private.example/')
+})
+
+test('the _auth env var still overrides a registry declared in pnpm-workspace.yaml', async () => {
+  prepareEmpty()
+
+  writeYamlFileSync('pnpm-workspace.yaml', { registry: 'https://project-choice.example/' })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: {
+      ...env,
+      pnpm_config__auth: JSON.stringify({
+        'https://my-npm-proxy.example': { '@': { authToken: 'proxy-token' } },
+      }),
+    },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  // The environment is the operator's channel: a mandated CI proxy still wins.
+  expect(config.registry).toBe('https://my-npm-proxy.example/')
+})
+
 test('_auth in a project pnpm-workspace.yaml is ignored (not honored as registry auth)', async () => {
   prepareEmpty()
 

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -2922,6 +2922,27 @@ test('a registry declared in pnpm-workspace.yaml beats the global _auth file', a
   expect(config.registriesByScope.default).toBe('https://project-choice.example/')
 })
 
+test('a registry pinned to the default value still beats the global _auth file', async () => {
+  prepareEmpty()
+
+  // Whether a registry was declared is a question about the key, not its
+  // value: pinning the one a lower layer already resolved to is a declaration.
+  writeYamlFileSync('pnpm-workspace.yaml', { registry: 'https://registry.npmjs.org/' })
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://private.example': {
+          '@': { authToken: 'stored-token' },
+        },
+      },
+    },
+    { workspaceDir: process.cwd() }
+  )
+
+  expect(config.registry).toBe('https://registry.npmjs.org/')
+})
+
 test('a scope declared in pnpm-workspace.yaml beats the global _auth file', async () => {
   prepareEmpty()
 
@@ -2941,6 +2962,56 @@ test('a scope declared in pnpm-workspace.yaml beats the global _auth file', asyn
   )
 
   expect(config.registriesByScope['@org']).toBe('https://project-choice.example/')
+})
+
+test('a registry declared in the global config beats its own _auth file', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml({
+    registry: 'https://global-choice.example/',
+    _auth: {
+      'https://private.example': {
+        '@': { authToken: 'stored-token' },
+      },
+    },
+  })
+
+  expect(config.registry).toBe('https://global-choice.example/')
+  // The credential stays keyed to the host it was written for.
+  expect(config.authConfig['//private.example/:_authToken']).toBe('stored-token')
+})
+
+test('a scope declared in the global config beats its own _auth file', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml({
+    registries: { 'https://global-org.example/': { scopes: ['@org'] } },
+    _auth: {
+      'https://private.example': {
+        '@org': { authToken: 'stored-org-token' },
+      },
+    },
+  })
+
+  expect(config.registriesByScope['@org']).toBe('https://global-org.example/')
+  expect(config.authConfig['//private.example/:@org:_authToken']).toBe('stored-org-token')
+})
+
+test('an uncontested _auth file route reaches the package-manager registries too', async () => {
+  prepareEmpty()
+
+  const { config } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://private.example': {
+        '@': { authToken: 'stored-token' },
+        '@org': { authToken: 'stored-org-token' },
+      },
+    },
+  })
+
+  // Bootstrap resolves the same way an install does.
+  expect(config.packageManagerRegistries?.default).toBe('https://private.example/')
+  expect(config.packageManagerRegistries?.['@org']).toBe('https://private.example/')
 })
 
 test('the global _auth file still routes a scope nothing else declares', async () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -2943,6 +2943,28 @@ test('a registry pinned to the default value still beats the global _auth file',
   expect(config.registry).toBe('https://registry.npmjs.org/')
 })
 
+test('a legacy registries default key beats the global _auth file', async () => {
+  prepareEmpty()
+
+  // The older `<scope>: <url>` shape spells the default as `default:`.
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    registries: { default: 'https://legacy-declared.example/' },
+  })
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://private.example': {
+          '@': { authToken: 'stored-token' },
+        },
+      },
+    },
+    { workspaceDir: process.cwd() }
+  )
+
+  expect(config.registry).toBe('https://legacy-declared.example/')
+})
+
 test('a scope declared in pnpm-workspace.yaml beats the global _auth file', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
## Summary

`_auth` yields two things from one value: a credential, and a scope→registry
route inferred from it. Those routes outranked what a config file declared.

That is right for the **`pnpm_config__auth` environment variable** — the
operator's channel, how a CI runner is pointed at a mandated proxy, which a
repository must not be able to override. It is wrong for the **global config
file**, which is the user's own store: holding a credential for a registry is
not a statement that packages come from it.

The two sources are now told apart. Environment routes keep their standing.
File routes fill in only what nothing else declares — a `registry` or
`registries` in `pnpm-workspace.yaml` or the global config wins, while a scope
no one competes for still resolves through the credential.

```
CLI flags  >  _auth env  >  declared registry / registries  >  _auth file  >  .npmrc
```

### The stacks disagreed, which is what surfaced it

The TypeScript reader already restored a declared `registry` over the inferred
default — but through `explicitlySetKeys`, which `addSettingsFromWorkspaceManifestToConfig`
adds to as well as the command line. Two consequences, both wrong:

- a repository's `registry:` overrode the environment's mandated proxy, and
- a `registries: {default: …}` saying the very same thing did not.

That check now asks about the command line alone.

The Rust reader had no such guard, so a stored credential relocated the
registry every project resolved from:

```
# global config.yaml holds only a credential
_auth: { https://private.example/: { "@": { authToken: … } } }
# the project declares its own registry
registry: https://project-choice.example/

$ pnpm config get registry
https://private.example/        # before
https://project-choice.example/ # after
```

### Why not simply drop the derivation

I tried that first and reverted it. Four tests pin the routes deliberately —
`pnpm_config__auth "@" scope routes the default registry to its host` and
`pnpm_config__auth env default registry wins over pnpm-workspace.yaml default`
among them — and the fixture name (`my-npm-proxy.example`) names the use case.
The derivation is the point of the feature; only its standing when it comes
from a file was wrong.

### Coverage

Three cases in each stack: a declared `registry` and a declared scope route
each beat the file, the file still routes what nothing else declares, and the
environment still mandates over a project.

## Squash Commit Body

```text
`_auth` yields both a credential and a scope→registry route, and the route
outranked what a config file declared. That is right for the
`pnpm_config__auth` environment variable — the operator's channel, how a CI
runner is pointed at a mandated proxy, which a repository must not override
— but the global config *file* is the user's own store, and holding a
credential for a registry is not a statement that packages come from it.

The two sources are now told apart. Environment routes keep their standing.
File routes fill in only what nothing else declares: a `registry` or
`registries` in `pnpm-workspace.yaml` or the global config wins, while a
scope no one competes for still resolves through the credential.

The stacks disagreed about this, which is what surfaced it. The TypeScript
reader already restored a declared `registry` over the inferred default,
but only via `explicitlySetKeys` — which a yaml adds to as well as the
command line, so it also let a repository's `registry:` override the
environment's mandated proxy, while a `registries: {default: …}` saying the
same thing did not. That check now asks about the command line alone. The
Rust reader had no such guard at all, so a credential relocated the
registry every project resolved from.

Both stacks now read: CLI > `_auth` env > declared registries > `_auth`
file > `.npmrc`.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790480034&installation_model_id=426870&pr_number=14268&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14268&signature=fabab53f0625f7738d92ad122251edf11e9638e717b9ef0a3ea0087261bab696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace and global registry declarations now take precedence over registry routes inferred from stored authentication credentials.
  * Stored credentials continue to apply to otherwise undeclared registries.
  * Authentication supplied through the `pnpm_config__auth` environment variable continues to override workspace registry settings.
* **Tests**
  * Added coverage for registry and scope precedence across workspace, global configuration, and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->