### PR TITLE
fix(pacquet): apply patches to git dependencies

### DIFF
--- a/.changeset/patch-git-dependencies.md
+++ b/.changeset/patch-git-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `patchedDependencies` matching for git-hosted dependencies during fresh and frozen installs [pnpm/pnpm#14273](https://github.com/pnpm/pnpm/issues/14273).

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -8,6 +8,7 @@ use pnpm_store_dir::{StoreDir, StoreIndex};
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::is_symlink_or_junction,
+    git_repo::GitRepoFixture,
 };
 use serde_json::Value;
 use std::{ffi::OsStr, fmt::Write as _, fs, path::Path, process::Command};
@@ -438,6 +439,62 @@ fn install_level_patch_applies_when_the_package_is_not_in_allow_builds() {
         "is-positive@1.0.0.patch",
         "allowBuilds: {}\n",
     );
+}
+
+/// Regression test for <https://github.com/pnpm/pnpm/issues/14273>.
+#[test]
+fn git_dependency_patch_applies_on_fresh_and_frozen_install() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, store_dir, cache_dir, .. } = npmrc_info;
+    let repo = GitRepoFixture::init(root.path(), "patched-git-dependency");
+    repo.write_file(
+        "package.json",
+        &serde_json::json!({
+            "name": "is-positive",
+            "version": "3.1.0",
+            "main": "index.js",
+        })
+        .to_string(),
+    );
+    repo.write_file("index.js", "module.exports = true\n");
+    let commit = repo.commit("initial package");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "is-positive": repo.git_url_at(&commit),
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::create_dir_all(workspace.join("patches")).expect("create patches dir");
+    fs::write(workspace.join("patches/is-positive@3.1.0.patch"), MARKER_PATCH)
+        .expect("write patch file");
+    append_workspace_yaml_key(
+        &workspace,
+        "patchedDependencies",
+        "\n  is-positive@3.1.0: patches/is-positive@3.1.0.patch",
+    );
+
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+    let marker = workspace.join("node_modules/is-positive/patched-marker.txt");
+    assert_eq!(fs::read_to_string(&marker).expect("read fresh marker"), "patched\n");
+    let patch_hash = patch_file_hash(&workspace, "is-positive@3.1.0.patch");
+    let snapshots = snapshot_keys(&read_wanted_lockfile(&workspace));
+    assert!(
+        snapshots.iter().any(|key| key.contains(&format!("(patch_hash={patch_hash})"))),
+        "snapshots: {snapshots:?}",
+    );
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    remove_dir_if_exists(&store_dir);
+    remove_dir_if_exists(&cache_dir);
+    pacquet(&workspace, ["install", "--frozen-lockfile", "--reporter=silent"]).assert().success();
+    assert_eq!(fs::read_to_string(&marker).expect("read frozen marker"), "patched\n");
+
+    drop((root, mock_instance));
 }
 
 /// TS: `the patched package is updated if the patch is modified`

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -61,6 +61,7 @@ pub fn resolve_snapshot_patches(
     config: &Config,
     pre_resolved: Option<&pnpm_patching::PatchGroupRecord>,
     snapshots: Option<&HashMap<PackageKey, SnapshotEntry>>,
+    packages: Option<&HashMap<PackageKey, PackageMetadata>>,
 ) -> Result<Option<HashMap<PackageKey, ExtendedPatchInfo>>, BuildPhaseError> {
     // Reuse the caller's grouped record when it already resolved it (the
     // fresh-lockfile path builds it to feed the resolver), so the patch
@@ -77,13 +78,16 @@ pub fn resolve_snapshot_patches(
             let mut map = HashMap::new();
             for key in snaps.keys() {
                 let metadata_key = key.without_peer();
-                let metadata_key_str = metadata_key.to_string();
-                let (name, version) =
-                    crate::build_modules::parse_name_version_from_key(&metadata_key_str);
+                let name = metadata_key.name.to_string();
+                let version_from_key = metadata_key.suffix.version().to_string();
+                let version = packages
+                    .and_then(|packages| packages.get(&metadata_key))
+                    .and_then(|metadata| metadata.version.as_deref())
+                    .unwrap_or(&version_from_key);
                 // Propagate `ERR_PNPM_PATCH_KEY_CONFLICT` rather than
                 // silently skipping the snapshot. Failing here makes the
                 // user add an exact-version entry to disambiguate.
-                if let Some(info) = get_patch_info(Some(groups), &name, &version)
+                if let Some(info) = get_patch_info(Some(groups), &name, version)
                     .map_err(BuildPhaseError::PatchKeyConflict)?
                 {
                     map.insert(metadata_key, info.clone());
@@ -187,7 +191,7 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         link_options,
     } = inputs;
 
-    let patches = resolve_snapshot_patches(config, patch_groups, snapshots)?;
+    let patches = resolve_snapshot_patches(config, patch_groups, snapshots, packages)?;
     let shared_side_effects_publisher =
         crate::shared_side_effects::shared_side_effects_publisher(config, snapshots);
 

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -78,16 +78,11 @@ pub fn resolve_snapshot_patches(
             let mut map = HashMap::new();
             for key in snaps.keys() {
                 let metadata_key = key.without_peer();
-                let name = metadata_key.name.to_string();
-                let version_from_key = metadata_key.suffix.version().to_string();
-                let version = packages
-                    .and_then(|packages| packages.get(&metadata_key))
-                    .and_then(|metadata| metadata.version.as_deref())
-                    .unwrap_or(&version_from_key);
+                let (name, version) = crate::name_version_from_package_key(&metadata_key, packages);
                 // Propagate `ERR_PNPM_PATCH_KEY_CONFLICT` rather than
                 // silently skipping the snapshot. Failing here makes the
                 // user add an exact-version entry to disambiguate.
-                if let Some(info) = get_patch_info(Some(groups), &name, version)
+                if let Some(info) = get_patch_info(Some(groups), &name, &version)
                     .map_err(BuildPhaseError::PatchKeyConflict)?
                 {
                     map.insert(metadata_key, info.clone());

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase/tests.rs
@@ -1,10 +1,58 @@
 use super::{
     AllowBuildPolicy, AtomicU8, BuildPhaseInputs, Config, DependencyGroup, HashMap, PackageKey,
-    ProjectSnapshot, SkippedSnapshots, StoreIndexWriter, VirtualStoreLayout, run_build_phase,
+    ProjectSnapshot, SkippedSnapshots, StoreIndexWriter, VirtualStoreLayout,
+    resolve_snapshot_patches, run_build_phase,
 };
 use pnpm_cmd_shim::LinkBinsOptions;
+use pnpm_lockfile::{GitResolution, LockfileResolution, PackageMetadata, SnapshotEntry};
+use pnpm_patching::{ExtendedPatchInfo, PatchGroup, PatchGroupRecord};
 use pnpm_reporter::SilentReporter;
 use tempfile::tempdir;
+
+#[test]
+fn resolves_git_snapshot_patch_from_package_version() {
+    let patch = ExtendedPatchInfo {
+        hash: "abc123".to_string(),
+        patch_file_path: None,
+        key: "foo@1.0.0".to_string(),
+    };
+    let mut group = PatchGroup::default();
+    group.exact.insert("1.0.0".to_string(), patch.clone());
+    let groups = PatchGroupRecord::from([("foo".to_string(), group)]);
+    let key = "foo@git+file:///repo#0123456789012345678901234567890123456789(patch_hash=abc123)"
+        .parse::<PackageKey>()
+        .expect("parse git snapshot key");
+    let snapshots = HashMap::from([(key.clone(), SnapshotEntry::default())]);
+    let packages = HashMap::from([(
+        key.without_peer(),
+        PackageMetadata {
+            resolution: LockfileResolution::Git(GitResolution {
+                repo: "file:///repo".to_string(),
+                commit: "0123456789012345678901234567890123456789".to_string(),
+                integrity: None,
+                path: None,
+            }),
+            version: Some("1.0.0".to_string()),
+            engines: None,
+            cpu: None,
+            os: None,
+            libc: None,
+            deprecated: None,
+            has_bin: None,
+            prepare: None,
+            bundled_dependencies: None,
+            peer_dependencies: None,
+            peer_dependencies_meta: None,
+        },
+    )]);
+
+    let patches =
+        resolve_snapshot_patches(&Config::new(), Some(&groups), Some(&snapshots), Some(&packages))
+            .expect("resolve snapshot patches")
+            .expect("patches are configured");
+
+    assert_eq!(patches.get(&key.without_peer()), Some(&patch));
+}
 
 #[tokio::test]
 async fn ignored_scripts_fast_path_defers_only_materialized_snapshots() {

--- a/pnpm/crates/deps-restorer/src/lib.rs
+++ b/pnpm/crates/deps-restorer/src/lib.rs
@@ -99,6 +99,27 @@ pub fn snapshot_has_patch(snapshot_key: &pnpm_lockfile::PackageKey) -> bool {
     pnpm_deps_path::index_of_dep_path_suffix(&snapshot_key.to_string()).patch_hash_index.is_some()
 }
 
+/// Returns the package identity used to match a lockfile snapshot against
+/// `patchedDependencies`.
+///
+/// Non-registry package keys carry their resolution in the version slot, so
+/// the manifest version recorded in `packages:` takes precedence when present.
+#[must_use]
+pub fn name_version_from_package_key(
+    key: &pnpm_lockfile::PackageKey,
+    packages: Option<
+        &std::collections::HashMap<pnpm_lockfile::PackageKey, pnpm_lockfile::PackageMetadata>,
+    >,
+) -> (String, String) {
+    let metadata_key = key.without_peer();
+    let name = metadata_key.name.to_string();
+    let version = packages
+        .and_then(|packages| packages.get(&metadata_key))
+        .and_then(|metadata| metadata.version.clone())
+        .unwrap_or_else(|| metadata_key.suffix.version().to_string());
+    (name, version)
+}
+
 const MAX_SCRIPT_THREADS: usize = 256;
 
 #[must_use]

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies.rs
@@ -316,13 +316,8 @@ fn applied_patch_keys<'a>(
     };
     let mut applied = BTreeSet::new();
     for key in snapshots.keys() {
-        // Keyed exactly as `resolve_snapshot_patches` keys the patches it
-        // applies from a loaded lockfile, so this agrees with what the
-        // materializer would do. The peer suffix carries any
-        // `(patch_hash=...)` segment too, so stripping it leaves the
-        // `name@version` the patch keys match on.
-        let metadata_key = key.without_peer().to_string();
-        let (name, version) = pnpm_deps_restorer::parse_name_version_from_key(&metadata_key);
+        let (name, version) =
+            pnpm_deps_restorer::name_version_from_package_key(key, lockfile.packages.as_ref());
         if let Some(info) = get_patch_info(Some(patch_groups), &name, &version).ok()? {
             applied.insert(info.key.as_str());
         }

--- a/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_patched_dependencies/tests.rs
@@ -56,6 +56,18 @@ snapshots:
   foo@1.1.0(patch_hash=deadbeef): {}
 ";
 
+const PATCHED_GIT_LOCKFILE: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .: {}
+packages:
+  foo@git+file:///repo#0123456789012345678901234567890123456789:
+    resolution: {type: git, repo: file:///repo, commit: '0123456789012345678901234567890123456789'}
+    version: 1.0.0
+snapshots:
+  foo@git+file:///repo#0123456789012345678901234567890123456789(patch_hash=PATCH_HASH): {}
+";
+
 /// `foo` comes from a named registry, so the key's version slot holds
 /// `work:1.1.0` rather than a plain semver the patch keys can match.
 const REGISTRY_QUALIFIED_LOCKFILE: &str = r"
@@ -410,6 +422,30 @@ fn rejects_an_unused_patch_when_unused_patches_are_not_allowed() {
         .is_none(),
         "the resolver has to run so it can raise ERR_PNPM_UNUSED_PATCH",
     );
+}
+
+#[test]
+fn recognizes_a_git_patch_while_absorbing_unrelated_settings_drift() {
+    let dir = workspace(&["foo@1.0.0"]);
+    let config = Config {
+        exclude_links_from_lockfile: true,
+        allow_unused_patches: false,
+        ..config(dir.path(), &["foo@1.0.0"], false)
+    };
+    let patch_hashes = config
+        .patched_dependency_hashes()
+        .expect("hash the patch files")
+        .expect("a configured patch");
+    let hash = &patch_hashes["foo@1.0.0"];
+    let mut subject = lockfile(&PATCHED_GIT_LOCKFILE.replace("PATCH_HASH", hash));
+    subject.patched_dependencies = Some(patch_hashes.clone());
+    subject.settings =
+        Some(crate::fast_update_settings::lockfile_settings_from_config(&Config::default()));
+
+    let updated = try_fast_update_patched_dependencies(&subject, &config)
+        .expect("the git patch remains applied while the settings update is absorbed");
+
+    assert!(updated.settings.expect("settings").exclude_links_from_lockfile);
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -29,10 +29,11 @@ use super::{
 ///    `ERR_PNPM_UNUSED_PATCH` check sees the hit.
 ///
 /// Packages whose resolver didn't supply [`pnpm_resolving_resolver_base::ResolveResult::name_ver`]
-/// use the manifest's `name` and `version`. Git, tarball, and local
-/// resolvers learn their identity from that manifest at fetch time. The
-/// lookup is skipped when either field is unavailable or no patches are
-/// configured.
+/// use the manifest's `name` and, for non-directory resolutions, its
+/// `version`. Local directories remain linked rather than patched, matching
+/// the TypeScript CLI and the lockfile format, which omits their manifest
+/// version. The lookup is skipped when either field is unavailable or no
+/// patches are configured.
 pub(super) async fn build_pkg_id_with_patch_hash(
     ctx: &TreeCtx,
     result: &pnpm_resolving_resolver_base::ResolveResult,
@@ -63,11 +64,16 @@ pub(super) async fn build_pkg_id_with_patch_hash(
         .as_ref()
         .and_then(|manifest| manifest.get("name"))
         .and_then(serde_json::Value::as_str);
-    let manifest_version = result
-        .manifest
-        .as_ref()
-        .and_then(|manifest| manifest.get("version"))
-        .and_then(serde_json::Value::as_str);
+    let manifest_version =
+        (!matches!(result.resolution, pnpm_lockfile::LockfileResolution::Directory(_)))
+            .then(|| {
+                result
+                    .manifest
+                    .as_ref()
+                    .and_then(|manifest| manifest.get("version"))
+                    .and_then(serde_json::Value::as_str)
+            })
+            .flatten();
     let (name, version) = match (result.name_ver.as_ref(), manifest_name) {
         (Some(name_ver), _) => (name_ver.name.to_string(), name_ver.suffix.to_string()),
         (None, Some(name)) => (name.to_string(), manifest_version.unwrap_or_default().to_string()),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -29,11 +29,10 @@ use super::{
 ///    `ERR_PNPM_UNUSED_PATCH` check sees the hit.
 ///
 /// Packages whose resolver didn't supply [`pnpm_resolving_resolver_base::ResolveResult::name_ver`]
-/// (git / tarball / local — they learn the name from the manifest at
-/// fetch time) skip the patch lookup. That matches the surface
-/// `patchedDependencies` covers today: keys are `name[@version]`, so a
-/// package without a resolve-time name can't match a configured entry
-/// anyway. The lookup is also skipped when no patches are configured.
+/// use the manifest's `name` and `version`. Git, tarball, and local
+/// resolvers learn their identity from that manifest at fetch time. The
+/// lookup is skipped when either field is unavailable or no patches are
+/// configured.
 pub(super) async fn build_pkg_id_with_patch_hash(
     ctx: &TreeCtx,
     result: &pnpm_resolving_resolver_base::ResolveResult,
@@ -64,9 +63,14 @@ pub(super) async fn build_pkg_id_with_patch_hash(
         .as_ref()
         .and_then(|manifest| manifest.get("name"))
         .and_then(serde_json::Value::as_str);
+    let manifest_version = result
+        .manifest
+        .as_ref()
+        .and_then(|manifest| manifest.get("version"))
+        .and_then(serde_json::Value::as_str);
     let (name, version) = match (result.name_ver.as_ref(), manifest_name) {
         (Some(name_ver), _) => (name_ver.name.to_string(), name_ver.suffix.to_string()),
-        (None, Some(name)) => (name.to_string(), String::new()),
+        (None, Some(name)) => (name.to_string(), manifest_version.unwrap_or_default().to_string()),
         (None, None) => return Ok(raw_id.to_string()),
     };
     let prefixed = if raw_id.starts_with(&format!("{name}@")) {
@@ -74,12 +78,9 @@ pub(super) async fn build_pkg_id_with_patch_hash(
     } else {
         format!("{name}@{raw_id}")
     };
-    // `patched_dependencies` keys carry a `name@version` shape, so
-    // entries that came in without a `name_ver` (file: / git: /
-    // tarball: resolutions whose name we just learned from the
-    // manifest above) can't match unless the manifest also surfaced
-    // a version. Bail out when version is empty so the patch lookup
-    // doesn't run a `name@""` query.
+    // `patched_dependencies` keys carry a `name@version` shape. Bail
+    // out when the resolver and manifest both omitted the version so
+    // the patch lookup doesn't run a `name@""` query.
     if version.is_empty() {
         return Ok(prefixed);
     }

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2570,7 +2570,7 @@ mod patched_dependencies {
         sync::{Arc, Mutex},
     };
 
-    use pnpm_lockfile::{GitResolution, LockfileResolution};
+    use pnpm_lockfile::{DirectoryResolution, GitResolution, LockfileResolution};
     use pnpm_package_manifest::DependencyGroup;
     use pnpm_patching::{ExtendedPatchInfo, PatchGroup, PatchGroupRangeItem, PatchGroupRecord};
     use pnpm_resolving_resolver_base::{PkgResolutionId, ResolveOptions};
@@ -2680,6 +2680,46 @@ mod patched_dependencies {
 
         assert_eq!(tree.direct[0].id, format!("foo@{git_ref}(patch_hash=abc123)"));
         assert!(tree.applied_patches.contains("foo@1.0.0"));
+    }
+
+    #[tokio::test]
+    async fn leaves_local_directory_dependencies_unpatched() {
+        let local_ref = "file:../foo";
+        let mut result =
+            fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" }));
+        result.id = PkgResolutionId::from(local_ref);
+        result.name_ver = None;
+        result.latest = None;
+        result.resolution =
+            LockfileResolution::Directory(DirectoryResolution { directory: "../foo".to_string() });
+        result.resolved_via = "local-filesystem".to_string();
+
+        let mut table = HashMap::default();
+        table.insert(("foo".to_string(), local_ref.to_string()), result);
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": local_ref }));
+        let mut groups = PatchGroupRecord::new();
+        groups.insert("foo".to_string(), exact_group("1.0.0", "foo@1.0.0", "abc123"));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions::default(),
+                patched_dependencies: Some(Arc::new(groups)),
+                manifest_hook: None,
+                overrides_hook: None,
+                pnpmfile_hook: None,
+                read_package_log: None,
+                auto_install_peers: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tree.direct[0].id, "foo@file:../foo");
+        assert!(tree.applied_patches.is_empty());
     }
 
     #[tokio::test]

--- a/pnpm/crates/resolving-deps-resolver/src/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/tests.rs
@@ -2570,9 +2570,10 @@ mod patched_dependencies {
         sync::{Arc, Mutex},
     };
 
+    use pnpm_lockfile::{GitResolution, LockfileResolution};
     use pnpm_package_manifest::DependencyGroup;
     use pnpm_patching::{ExtendedPatchInfo, PatchGroup, PatchGroupRangeItem, PatchGroupRecord};
-    use pnpm_resolving_resolver_base::ResolveOptions;
+    use pnpm_resolving_resolver_base::{PkgResolutionId, ResolveOptions};
     use pretty_assertions::assert_eq;
 
     use super::{StubResolver, fake_manifest, fake_result};
@@ -2635,6 +2636,50 @@ mod patched_dependencies {
             result.direct_dependencies_by_alias.get("foo"),
             Some(&DepPath::from("foo@1.0.0(patch_hash=abc123)".to_string())),
         );
+    }
+
+    #[tokio::test]
+    async fn patches_git_dependency_with_manifest_version() {
+        let git_ref = "git+file:///repo#0123456789012345678901234567890123456789";
+        let mut result =
+            fake_result("foo", "1.0.0", serde_json::json!({ "name": "foo", "version": "1.0.0" }));
+        result.id = PkgResolutionId::from(git_ref);
+        result.name_ver = None;
+        result.latest = None;
+        result.resolution = LockfileResolution::Git(GitResolution {
+            repo: "file:///repo".to_string(),
+            commit: "0123456789012345678901234567890123456789".to_string(),
+            integrity: None,
+            path: None,
+        });
+        result.resolved_via = "git-repository".to_string();
+
+        let mut table = HashMap::default();
+        table.insert(("foo".to_string(), git_ref.to_string()), result);
+        let resolver = StubResolver { table, calls: Mutex::new(Vec::new()) };
+        let (_tmp, manifest) = fake_manifest(serde_json::json!({ "foo": git_ref }));
+        let mut groups = PatchGroupRecord::new();
+        groups.insert("foo".to_string(), exact_group("1.0.0", "foo@1.0.0", "abc123"));
+
+        let tree = resolve_dependency_tree(
+            &resolver,
+            &manifest,
+            [DependencyGroup::Prod],
+            ResolveDependencyTreeOptions {
+                base_opts: ResolveOptions::default(),
+                patched_dependencies: Some(Arc::new(groups)),
+                manifest_hook: None,
+                overrides_hook: None,
+                pnpmfile_hook: None,
+                read_package_log: None,
+                auto_install_peers: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(tree.direct[0].id, format!("foo@{git_ref}(patch_hash=abc123)"));
+        assert!(tree.applied_patches.contains("foo@1.0.0"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes `patchedDependencies` matching for git-hosted dependencies in the Rust pnpm CLI.

Fresh resolutions now use the fetched manifest version when a non-directory resolver does not provide `name_ver`. Frozen installs and patched-dependency fast updates share a package-identity lookup that prefers the package metadata version recorded in the lockfile instead of attempting to parse a semver version from the git URL-shaped snapshot key.

Local directory dependencies remain linked and unpatched, matching the TypeScript CLI and the lockfile format, which intentionally omits their manifest version.

The TypeScript CLI already uses package snapshot metadata for git patch lookup and exhibits the expected behavior, so no TypeScript change is needed.

Closes pnpm/pnpm#14273.

## Squash Commit Body

```text
Git-hosted package IDs do not carry the package semver version needed to match patchedDependencies entries. Read that version from the fetched manifest during fresh resolution and from package metadata when restoring or fast-updating a lockfile, matching the TypeScript CLI behavior.

Keep local directory dependencies on their existing linked, unpatched path because their lockfile entries intentionally omit the manifest version.

Add resolver, restorer, fast-update, and end-to-end coverage for fresh and frozen installs from a local git repository.

Closes pnpm/pnpm#14273.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `patchedDependencies` matching for Git-hosted dependencies during fresh and frozen-lockfile installs.
  * Improved patch matching when package versions come from dependency metadata.
  * Ensured patches remain applied after reinstalling dependencies or refreshing cached data.
  * Preserved Git dependency patches while unrelated lockfile settings are updated.

* **Tests**
  * Added regression coverage for Git dependency patching, frozen-lockfile installs, and lockfile updates.

* **Release**
  * Scheduled a patch-level release for `pacquet`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->