### PR TITLE
fix(deps-restorer): preserve bundled dependency trees

### DIFF
--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -120,7 +120,7 @@ enum Placement {
 enum PreservedModules {
     None,
     Directory,
-    Entries(Vec<OsString>),
+    Merged { backup: PathBuf, moved_entries: Vec<OsString> },
 }
 
 impl PreservedModules {
@@ -128,7 +128,7 @@ impl PreservedModules {
         match self {
             PreservedModules::None => false,
             PreservedModules::Directory => true,
-            PreservedModules::Entries(entries) => !entries.is_empty(),
+            PreservedModules::Merged { .. } => true,
         }
     }
 }
@@ -617,6 +617,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
     keep_modules_dir: bool,
 ) -> Result<(), ImportIndexedDirError> {
     let stage = pick_stage_path(dir_path);
+    let modules_backup = pick_stage_path(dir_path);
     let target_modules = dir_path.join("node_modules");
     let stage_modules = stage.join("node_modules");
 
@@ -655,7 +656,7 @@ fn stage_and_swap<Reporter: self::Reporter>(
     //    pnpm's `moveOrMergeModulesDirs`.
     let preserved_modules = match nm_kind {
         Some(file_type) if file_type.is_dir() => {
-            match preserve_modules_dir(&target_modules, &stage_modules) {
+            match preserve_modules_dir(&target_modules, &stage_modules, &modules_backup) {
                 Ok(preserved) => preserved,
                 Err(PreserveModulesFailure { error, preserved }) => {
                     finalize_stage_cleanup_after_failure(
@@ -676,9 +677,9 @@ fn stage_and_swap<Reporter: self::Reporter>(
     };
 
     // 4. Remove the old contents. If this fails after step 3, the
-    //    staged copy of `node_modules/` is the user's only copy —
-    //    try to move it back into place before bailing, and leak
-    //    the staging directory if the move can't run.
+    //    the staged tree and any merge backup hold the preserved data.
+    //    Try to move it back into place before bailing, and retain
+    //    those temporary paths if restoration can't run.
     if let Err(error) = fs::remove_dir_all(dir_path) {
         finalize_stage_cleanup_after_failure(
             &preserved_modules,
@@ -710,16 +711,18 @@ fn stage_and_swap<Reporter: self::Reporter>(
                 &target_modules,
             );
         } else {
-            leak_stage(&stage, &stage_modules);
+            leak_stage(&stage, &stage_modules, &preserved_modules);
         }
         return Err(ImportIndexedDirError::Swap { from: stage, to: dir_path.to_path_buf(), error });
     }
+    discard_replaced_modules(&preserved_modules);
     Ok(())
 }
 
 fn preserve_modules_dir(
     source: &Path,
     destination: &Path,
+    backup: &Path,
 ) -> Result<PreservedModules, PreserveModulesFailure> {
     match fs::rename(source, destination) {
         Ok(()) => return Ok(PreservedModules::Directory),
@@ -729,18 +732,35 @@ fn preserve_modules_dir(
         }
     }
 
+    fs::rename(source, backup)
+        .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
+
     let destination_entries = fs::read_dir(destination)
         .and_then(|entries| entries.map(|entry| entry.map(|entry| entry.file_name())).collect())
-        .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
+        .map_err(|error| PreserveModulesFailure {
+            error,
+            preserved: PreservedModules::Merged {
+                backup: backup.to_path_buf(),
+                moved_entries: Vec::new(),
+            },
+        })?;
     let destination_entries: HashSet<OsString> = destination_entries;
-    let source_entries = fs::read_dir(source)
-        .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
+    let source_entries = fs::read_dir(backup).map_err(|error| PreserveModulesFailure {
+        error,
+        preserved: PreservedModules::Merged {
+            backup: backup.to_path_buf(),
+            moved_entries: Vec::new(),
+        },
+    })?;
     let mut moved_entries = Vec::new();
 
     for entry in source_entries {
         let entry = entry.map_err(|error| PreserveModulesFailure {
             error,
-            preserved: PreservedModules::Entries(moved_entries.clone()),
+            preserved: PreservedModules::Merged {
+                backup: backup.to_path_buf(),
+                moved_entries: moved_entries.clone(),
+            },
         })?;
         let name = entry.file_name();
         if destination_entries.contains(&name) {
@@ -749,12 +769,15 @@ fn preserve_modules_dir(
         fs::rename(entry.path(), destination.join(&name)).map_err(|error| {
             PreserveModulesFailure {
                 error,
-                preserved: PreservedModules::Entries(moved_entries.clone()),
+                preserved: PreservedModules::Merged {
+                    backup: backup.to_path_buf(),
+                    moved_entries: moved_entries.clone(),
+                },
             }
         })?;
         moved_entries.push(name);
     }
-    Ok(PreservedModules::Entries(moved_entries))
+    Ok(PreservedModules::Merged { backup: backup.to_path_buf(), moved_entries })
 }
 
 fn is_modules_dir_collision(error: &io::Error) -> bool {
@@ -769,11 +792,8 @@ fn is_modules_dir_collision(error: &io::Error) -> bool {
 /// Combined post-failure cleanup for steps 4 and 5: restore the
 /// preserved `node_modules/` if it was moved, then rimraf the
 /// staging directory — but only if the restore actually ran.
-/// Leaving the staging directory on disk after a failed restore is
-/// deliberate: it contains the user's only copy of the preserved
-/// `node_modules/`, and silently destroying it would compound the
-/// install failure with data loss. The emit warning gives an
-/// operator the exact path to recover from.
+/// Leaving the staging tree and any merge backup on disk after a
+/// failed restore retains every remaining copy of the preserved data.
 fn finalize_stage_cleanup_after_failure(
     preserved_modules: &PreservedModules,
     stage: &Path,
@@ -784,7 +804,7 @@ fn finalize_stage_cleanup_after_failure(
     if restored {
         let _ = fs::remove_dir_all(stage);
     } else {
-        leak_stage(stage, stage_modules);
+        leak_stage(stage, stage_modules, preserved_modules);
     }
 }
 
@@ -801,12 +821,12 @@ fn restore_preserved_node_modules(
     let result = match preserved_modules {
         PreservedModules::None => return true,
         PreservedModules::Directory => fs::rename(stage_modules, target_modules),
-        PreservedModules::Entries(entries) => fs::create_dir_all(target_modules).and_then(|()| {
-            for entry in entries {
-                fs::rename(stage_modules.join(entry), target_modules.join(entry))?;
-            }
-            Ok(())
-        }),
+        PreservedModules::Merged { backup, moved_entries } => {
+            let restored_backup = moved_entries
+                .iter()
+                .try_for_each(|entry| fs::rename(stage_modules.join(entry), backup.join(entry)));
+            restored_backup.and_then(|()| fs::rename(backup, target_modules))
+        }
     };
     if let Err(error) = result {
         tracing::warn!(
@@ -822,17 +842,35 @@ fn restore_preserved_node_modules(
     }
 }
 
+fn discard_replaced_modules(preserved_modules: &PreservedModules) {
+    if let PreservedModules::Merged { backup, .. } = preserved_modules
+        && let Err(error) = fs::remove_dir_all(backup)
+    {
+        tracing::warn!(
+            target: "pacquet::import_indexed_dir",
+            ?backup,
+            %error,
+            "failed to remove replaced node_modules/ entries after a successful stage-and-swap",
+        );
+    }
+}
+
 /// Emit a warning that the staging directory is being left in place
 /// because removing it would destroy preserved data. Used by both
 /// post-failure cleanup paths.
-fn leak_stage(stage: &Path, stage_modules: &Path) {
+fn leak_stage(stage: &Path, stage_modules: &Path, preserved_modules: &PreservedModules) {
+    let modules_backup = match preserved_modules {
+        PreservedModules::Merged { backup, .. } => Some(backup),
+        PreservedModules::None | PreservedModules::Directory => None,
+    };
     tracing::warn!(
         target: "pacquet::import_indexed_dir",
         ?stage,
         ?stage_modules,
-        "staging directory left in place after a partial stage-and-swap because the preserved \
+        ?modules_backup,
+        "temporary paths left in place after a partial stage-and-swap because the preserved \
          node_modules/ could not be restored to its original location; recover manually from \
-         the staged copy",
+         the reported paths",
     );
 }
 

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -9,6 +9,7 @@ use pnpm_reporter::Reporter;
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
+    ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU8, AtomicU64, Ordering},
@@ -75,10 +76,6 @@ pub enum ImportIndexedDirError {
         #[error(source)]
         error: io::Error,
     },
-    #[display(
-        "the indexed file map already contains a node_modules/ entry at {path:?}, which would conflict with the directory being preserved"
-    )]
-    NodeModulesCollision { path: PathBuf },
     #[display("failed to remove existing directory {path:?} prior to swap: {error}")]
     RemoveExisting {
         path: PathBuf,
@@ -118,6 +115,27 @@ enum Placement {
     /// not match the store entry, so a file damaged or truncated by an
     /// interrupted import is healed rather than adopted.
     Repair,
+}
+
+enum PreservedModules {
+    None,
+    Directory,
+    Entries(Vec<OsString>),
+}
+
+impl PreservedModules {
+    fn has_moved_data(&self) -> bool {
+        match self {
+            PreservedModules::None => false,
+            PreservedModules::Directory => true,
+            PreservedModules::Entries(entries) => !entries.is_empty(),
+        }
+    }
+}
+
+struct PreserveModulesFailure {
+    error: io::Error,
+    preserved: PreservedModules,
 }
 
 impl Placement {
@@ -630,33 +648,31 @@ fn stage_and_swap<Reporter: self::Reporter>(
         None
     };
 
-    // 3. Preserve `node_modules/` if it's a real directory. Track the
-    //    move so steps 4 and 5 can rescue it on failure.
-    //
-    //    Indexed file maps for npm tarballs never contain
-    //    `node_modules/` entries (npm and pnpm strip them at pack
-    //    time), so a pre-existing `<stage>/node_modules/` would be
-    //    pathological; surface it as an error rather than silently
-    //    merging. Upstream's `moveOrMergeModulesDirs` performs a real
-    //    merge for this case, but the hoisted-linker call site does
-    //    not exercise it in practice.
-    let nm_moved = match nm_kind {
+    // 3. Preserve `node_modules/` if it's a real directory. A package
+    //    may ship bundled dependencies, so merge non-conflicting
+    //    top-level entries when the staged import already has its own
+    //    `node_modules/`. The staged package wins conflicts, matching
+    //    pnpm's `moveOrMergeModulesDirs`.
+    let preserved_modules = match nm_kind {
         Some(file_type) if file_type.is_dir() => {
-            if stage_modules.exists() {
-                let _ = fs::remove_dir_all(&stage);
-                return Err(ImportIndexedDirError::NodeModulesCollision { path: stage_modules });
+            match preserve_modules_dir(&target_modules, &stage_modules) {
+                Ok(preserved) => preserved,
+                Err(PreserveModulesFailure { error, preserved }) => {
+                    finalize_stage_cleanup_after_failure(
+                        &preserved,
+                        &stage,
+                        &stage_modules,
+                        &target_modules,
+                    );
+                    return Err(ImportIndexedDirError::PreserveModulesDir {
+                        from: target_modules,
+                        to: stage_modules,
+                        error,
+                    });
+                }
             }
-            if let Err(error) = fs::rename(&target_modules, &stage_modules) {
-                let _ = fs::remove_dir_all(&stage);
-                return Err(ImportIndexedDirError::PreserveModulesDir {
-                    from: target_modules,
-                    to: stage_modules,
-                    error,
-                });
-            }
-            true
         }
-        Some(_) | None => false,
+        Some(_) | None => PreservedModules::None,
     };
 
     // 4. Remove the old contents. If this fails after step 3, the
@@ -664,7 +680,12 @@ fn stage_and_swap<Reporter: self::Reporter>(
     //    try to move it back into place before bailing, and leak
     //    the staging directory if the move can't run.
     if let Err(error) = fs::remove_dir_all(dir_path) {
-        finalize_stage_cleanup_after_failure(nm_moved, &stage, &stage_modules, &target_modules);
+        finalize_stage_cleanup_after_failure(
+            &preserved_modules,
+            &stage,
+            &stage_modules,
+            &target_modules,
+        );
         return Err(ImportIndexedDirError::RemoveExisting { path: dir_path.to_path_buf(), error });
     }
 
@@ -679,15 +700,70 @@ fn stage_and_swap<Reporter: self::Reporter>(
         // `create_dir_all` is the gate: without `dir_path`, the rescue
         // rename has no destination. Treat its failure as "rescue
         // can't run" and leak the staging directory below.
-        let rescue_target_ready = !nm_moved || fs::create_dir_all(dir_path).is_ok();
+        let rescue_target_ready =
+            !preserved_modules.has_moved_data() || fs::create_dir_all(dir_path).is_ok();
         if rescue_target_ready {
-            finalize_stage_cleanup_after_failure(nm_moved, &stage, &stage_modules, &target_modules);
+            finalize_stage_cleanup_after_failure(
+                &preserved_modules,
+                &stage,
+                &stage_modules,
+                &target_modules,
+            );
         } else {
             leak_stage(&stage, &stage_modules);
         }
         return Err(ImportIndexedDirError::Swap { from: stage, to: dir_path.to_path_buf(), error });
     }
     Ok(())
+}
+
+fn preserve_modules_dir(
+    source: &Path,
+    destination: &Path,
+) -> Result<PreservedModules, PreserveModulesFailure> {
+    match fs::rename(source, destination) {
+        Ok(()) => return Ok(PreservedModules::Directory),
+        Err(error) if is_modules_dir_collision(&error) => {}
+        Err(error) => {
+            return Err(PreserveModulesFailure { error, preserved: PreservedModules::None });
+        }
+    }
+
+    let destination_entries = fs::read_dir(destination)
+        .and_then(|entries| entries.map(|entry| entry.map(|entry| entry.file_name())).collect())
+        .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
+    let destination_entries: HashSet<OsString> = destination_entries;
+    let source_entries = fs::read_dir(source)
+        .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
+    let mut moved_entries = Vec::new();
+
+    for entry in source_entries {
+        let entry = entry.map_err(|error| PreserveModulesFailure {
+            error,
+            preserved: PreservedModules::Entries(moved_entries.clone()),
+        })?;
+        let name = entry.file_name();
+        if destination_entries.contains(&name) {
+            continue;
+        }
+        fs::rename(entry.path(), destination.join(&name)).map_err(|error| {
+            PreserveModulesFailure {
+                error,
+                preserved: PreservedModules::Entries(moved_entries.clone()),
+            }
+        })?;
+        moved_entries.push(name);
+    }
+    Ok(PreservedModules::Entries(moved_entries))
+}
+
+fn is_modules_dir_collision(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::AlreadyExists
+            | io::ErrorKind::DirectoryNotEmpty
+            | io::ErrorKind::PermissionDenied,
+    )
 }
 
 /// Combined post-failure cleanup for steps 4 and 5: restore the
@@ -699,12 +775,12 @@ fn stage_and_swap<Reporter: self::Reporter>(
 /// install failure with data loss. The emit warning gives an
 /// operator the exact path to recover from.
 fn finalize_stage_cleanup_after_failure(
-    nm_moved: bool,
+    preserved_modules: &PreservedModules,
     stage: &Path,
     stage_modules: &Path,
     target_modules: &Path,
 ) {
-    let restored = restore_preserved_node_modules(nm_moved, stage_modules, target_modules);
+    let restored = restore_preserved_node_modules(preserved_modules, stage_modules, target_modules);
     if restored {
         let _ = fs::remove_dir_all(stage);
     } else {
@@ -718,25 +794,31 @@ fn finalize_stage_cleanup_after_failure(
 /// caller must not clean up the staging directory (it contains the
 /// user's only copy of the data).
 fn restore_preserved_node_modules(
-    nm_moved: bool,
+    preserved_modules: &PreservedModules,
     stage_modules: &Path,
     target_modules: &Path,
 ) -> bool {
-    if !nm_moved {
-        return true;
-    }
-    match fs::rename(stage_modules, target_modules) {
-        Ok(()) => true,
-        Err(error) => {
-            tracing::warn!(
-                target: "pacquet::import_indexed_dir",
-                ?stage_modules,
-                ?target_modules,
-                %error,
-                "failed to restore preserved node_modules/ after a partial stage-and-swap",
-            );
-            false
-        }
+    let result = match preserved_modules {
+        PreservedModules::None => return true,
+        PreservedModules::Directory => fs::rename(stage_modules, target_modules),
+        PreservedModules::Entries(entries) => fs::create_dir_all(target_modules).and_then(|()| {
+            for entry in entries {
+                fs::rename(stage_modules.join(entry), target_modules.join(entry))?;
+            }
+            Ok(())
+        }),
+    };
+    if let Err(error) = result {
+        tracing::warn!(
+            target: "pacquet::import_indexed_dir",
+            ?stage_modules,
+            ?target_modules,
+            %error,
+            "failed to restore preserved node_modules/ after a partial stage-and-swap",
+        );
+        false
+    } else {
+        true
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -383,7 +383,8 @@ fn remove_dir_all_failure_restores_preserved_node_modules() {
     let src_root = tmp.path().join("cas");
     fs::create_dir_all(&src_root).unwrap();
     let pkg_json = write_source(&src_root, "package.json", b"new");
-    let cas = cas_map(&[("package.json", pkg_json)]);
+    let bundled = write_source(&src_root, "bundled.js", b"bundled");
+    let cas = cas_map(&[("package.json", pkg_json), ("node_modules/inner/bundled.js", bundled)]);
 
     let target = tmp.path().join("pkg");
     fs::create_dir_all(&target).unwrap();
@@ -424,6 +425,10 @@ fn remove_dir_all_failure_restores_preserved_node_modules() {
         fs::read(target.join("node_modules/inner/sentinel")).unwrap(),
         b"survivor",
         "preserved node_modules/ contents must be intact",
+    );
+    assert!(
+        !target.join("node_modules/inner/bundled.js").exists(),
+        "a failed swap must restore the conflicting dependency tree",
     );
     // No staging directory left behind anywhere under the outer
     // tempdir.

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -300,11 +300,8 @@ fn fresh_target_creates_nested_directories() {
     assert_eq!(fs::read(target.join("lib/deep/nested/file.js")).unwrap(), b"deeper");
 }
 
-/// Upstream's `moveOrMergeModulesDirs` would merge; pacquet's slice-1
-/// consumer (the hoisted-linker) never produces this state, so erroring
-/// loudly is the right call until a real caller demands the merge.
 #[test]
-fn node_modules_collision_in_file_map_errors() {
+fn node_modules_collision_in_file_map_merges() {
     let tmp = tempdir().unwrap();
     let src_root = tmp.path().join("cas");
     fs::create_dir_all(&src_root).unwrap();
@@ -315,21 +312,21 @@ fn node_modules_collision_in_file_map_errors() {
     let target = tmp.path().join("pkg");
     fs::create_dir_all(target.join("node_modules/existing")).unwrap();
     fs::write(target.join("node_modules/existing/keep.js"), b"survivor").unwrap();
+    fs::create_dir_all(target.join("node_modules/foo")).unwrap();
+    fs::write(target.join("node_modules/foo/stale.js"), b"replaced").unwrap();
 
-    let err = import_indexed_dir::<SilentReporter>(
+    import_indexed_dir::<SilentReporter>(
         &AtomicU8::new(0),
         PackageImportMethod::Copy,
         &target,
         &cas,
         FORCE_KEEP,
     )
-    .expect_err("collision should surface");
-    assert!(matches!(err, ImportIndexedDirError::NodeModulesCollision { .. }), "got: {err:?}");
+    .expect("bundled and preserved node_modules should merge");
 
-    // After the error, the existing nested dep must still be on disk —
-    // the function's cleanup must not have rimrafed it as a side
-    // effect of the failed stage.
     assert_eq!(fs::read(target.join("node_modules/existing/keep.js")).unwrap(), b"survivor");
+    assert_eq!(fs::read(target.join("node_modules/foo/index.js")).unwrap(), b"shipped-nm");
+    assert!(!target.join("node_modules/foo/stale.js").exists());
 }
 
 /// On Unix, when `Hardlink` is available we want force re-imports to


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14278.

Pacquet now merges an existing nested `node_modules` tree into a staged package import when the package itself contains bundled dependencies. Non-conflicting existing entries are preserved, while bundled entries from the staged package win conflicts, matching the TypeScript CLI's behavior.

## Squash Commit Body

```text
Packages with bundled dependencies can contribute their own `node_modules` directory to a staged import. Merge non-conflicting entries from the existing hoisted tree and keep staged package entries on conflicts, matching the TypeScript implementation.

Closes pnpm/pnpm#14278
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790513085&installation_model_id=426870&pr_number=14280&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14280&signature=c8516ecb7f661c0a5d97e1bdcb00681e37a9ab5e82ef1b15726486f60d51c0d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forced dependency swaps when existing `node_modules` content is present.
  * Merges staged packages with existing entries instead of failing on collisions.
  * Ensures staged files replace stale conflicting files while preserving unrelated existing files.
  * Improved recovery during partial import or cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->