### PR TITLE
fix(cli): accept every install setting as a command-line flag

### DIFF
--- a/.changeset/pnpm-14281-setting-flags.md
+++ b/.changeset/pnpm-14281-setting-flags.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The settings that pnpm accepts as command-line flags are recognized again: `--package-import-method`, `--hoist-pattern`, `--public-hoist-pattern`, `--no-hoist`, `--global-dir`, `--virtual-store-dir`, `--modules-dir`, `--child-concurrency`, `--no-lockfile`, `--strict-peer-dependencies`, `--side-effects-cache`, `--side-effects-cache-readonly`, `--trust-policy`, `--trust-policy-exclude`, `--trust-policy-ignore-after`, and `--optimistic-repeat-install`. Each is accepted anywhere on the command line, spelled either `--setting=value` or `--setting value`, and overrides the same setting read from `pnpm-workspace.yaml` or `.npmrc` [#14281](https://github.com/pnpm/pnpm/issues/14281).

--- a/.changeset/pnpm-strict-builds-manifest-write.md
+++ b/.changeset/pnpm-strict-builds-manifest-write.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm add`, `pnpm update`, and `pnpm remove` now save `package.json` before failing with `ERR_PNPM_IGNORED_BUILDS`. The dependency they were asked to change is already materialized by that point, so the manifest has to record it — otherwise the next install removes the packages again.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -154,11 +154,6 @@ pub struct AddArgs {
     pub lockfile_only: bool,
     #[clap(flatten)]
     pub lockfile_dir: LockfileDirArg,
-    /// The directory with links to the store (default is `node_modules/.pnpm`).
-    /// All direct and indirect dependencies of the project are linked into this directory
-    #[clap(long = "virtual-store-dir", default_value = "node_modules/.pnpm")]
-    pub virtual_store_dir: Option<PathBuf>, // TODO: make use of this
-
     /// Install the package globally, linking its bins into the global bin directory.
     #[clap(short = 'g', long)]
     pub global: bool,

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -140,7 +140,7 @@ impl CliArgs {
         let Ok(mut config) = loaded else {
             return false;
         };
-        config_overrides.apply(&mut config);
+        config_overrides.apply(&mut config, &dir);
         config.apply_proxy_cli_overrides(
             self.https_proxy.as_deref(),
             self.http_proxy.as_deref(),
@@ -296,7 +296,7 @@ impl CliArgs {
         // including `self-update`'s.
         let finalize_config =
             |mut cfg: Config, anchor: &Path| -> miette::Result<&'static mut Config> {
-                config_overrides.apply(&mut cfg);
+                config_overrides.apply(&mut cfg, anchor);
                 cfg.color = if let Some(color) = color {
                     color
                 } else if no_color {

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -219,7 +219,7 @@ fn pre_command_plan_from_input(
             .current::<Host>(&dir)
             .map_err(miette::Report::new)
             .wrap_err("load configuration")?;
-    config_overrides.apply(&mut config);
+    config_overrides.apply(&mut config, &dir);
     if let Some(color) = switch.color {
         config.color = color;
     }

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -179,20 +179,17 @@ impl ConfigOverrides {
                 remaining.push(arg);
                 continue;
             }
-            // The token after a `--<setting> <value>` pair's flag, unless
-            // the flag ends argv or that token is already the child's.
-            //
-            // A token that opens with `-` is never a value: it is the
-            // `--` separator, another flag, or a short option. Claiming
-            // one would drop the separator and point a path setting at a
-            // directory literally named `--`; leaving it in place makes
-            // the valueless flag clap's to report.
-            let mut following = |accept: fn(&str) -> bool| {
+            // The token after a `--<setting> <value>` pair's flag, when the
+            // setting claims it — see [`claims_as_value`]. `None` when the
+            // flag ends argv, the token is already the child's, or it is
+            // not a value the setting takes, all of which leave the
+            // valueless flag for clap to report.
+            let mut following = |key: &str| {
                 let value = argv
                     .peek()
                     .filter(|&&(index, _)| !is_forwarded(index))
                     .and_then(|(_, token)| token.to_str())
-                    .filter(|token| !token.starts_with('-') && accept(token))
+                    .filter(|token| claims_as_value(key, token))
                     .map(str::to_owned)?;
                 argv.next();
                 Some(value)
@@ -205,19 +202,14 @@ impl ConfigOverrides {
                 }
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
                 ConfigToken::BooleanFollows(key) => {
-                    let value = following(is_boolean_value);
-                    overrides.set(key, value.as_deref().unwrap_or("true"));
+                    overrides.set(key, following(key).as_deref().unwrap_or("true"));
                 }
-                ConfigToken::ValueFollows(key) => match following(|_| true) {
-                    Some(value) if setting_takes(key, &value) => overrides.set(key, &value),
-                    // The flag goes back in place, with the value it did
-                    // not take, for clap to report — see [`classify`]. A
-                    // flag that ends argv has no value at all, which is
-                    // just as much an invocation clap has to report.
-                    Some(value) => {
-                        remaining.push(arg);
-                        remaining.push(OsString::from(value));
-                    }
+                // A flag whose value is missing — because it ends argv, or
+                // because the token after it is one the setting does not
+                // take — goes back in place for clap to report; see
+                // [`classify`].
+                ConfigToken::ValueFollows(key) => match following(key) {
+                    Some(value) => overrides.set(key, &value),
                     None => remaining.push(arg),
                 },
                 ConfigToken::Malformed => {}
@@ -731,7 +723,7 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
     let Some((key, value)) = flag.split_once('=') else {
         return match setting(flag) {
             Some((key, SettingArity::Boolean)) => ConfigToken::BooleanFollows(key),
-            Some((key, SettingArity::Value(_))) => ConfigToken::ValueFollows(key),
+            Some((key, _)) => ConfigToken::ValueFollows(key),
             None => ConfigToken::NotOurs,
         };
     };
@@ -743,16 +735,19 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
 }
 
 /// How much of argv a bare `--<setting>` flag claims, and which values it
-/// accepts there.
+/// takes there. A setting whose value is a list repeats the flag, one
+/// value per occurrence.
 #[derive(Debug, Clone, Copy)]
 enum SettingArity {
     /// `--<setting>`, `--no-<setting>`, `--<setting>=<bool>`, and
     /// `--<setting> <bool>`.
     Boolean,
-    /// `--<setting>=<value>` and `--<setting> <value>`, where the value is
-    /// one the carried predicate accepts. A setting whose value is a list
-    /// repeats the flag, one value per occurrence.
-    Value(fn(&str) -> bool),
+    /// A path, a glob pattern, or another free-form value: every spelling
+    /// is one the setting takes, so the token after the flag is claimed
+    /// only when it cannot be anything else — see [`claims_as_value`].
+    Text,
+    /// A value the carried predicate accepts, and only such a value.
+    Parsed(fn(&str) -> bool),
 }
 
 /// Settings pnpm accepts as a bare `--<setting>` command-line flag, with
@@ -767,32 +762,26 @@ enum SettingArity {
 /// clap; a setting that collides with a *global* option would be claimed
 /// on every command line and so must not appear here at all.
 const BARE_SETTING_FLAGS: [(&str, SettingArity); 19] = [
-    ("child-concurrency", SettingArity::Value(is_i32)),
-    ("global-dir", SettingArity::Value(is_text)),
+    ("child-concurrency", SettingArity::Parsed(is_i32)),
+    ("global-dir", SettingArity::Text),
     ("hoist", SettingArity::Boolean),
-    ("hoist-pattern", SettingArity::Value(is_text)),
+    ("hoist-pattern", SettingArity::Text),
     ("lockfile", SettingArity::Boolean),
-    ("modules-dir", SettingArity::Value(is_text)),
+    ("modules-dir", SettingArity::Text),
     ("optimistic-repeat-install", SettingArity::Boolean),
-    ("package-import-method", SettingArity::Value(is_enum::<PackageImportMethod>)),
-    ("pm-on-fail", SettingArity::Value(is_enum::<PmOnFail>)),
-    ("public-hoist-pattern", SettingArity::Value(is_text)),
-    ("runtime-on-fail", SettingArity::Value(is_enum::<RuntimeOnFail>)),
+    ("package-import-method", SettingArity::Parsed(is_enum::<PackageImportMethod>)),
+    ("pm-on-fail", SettingArity::Parsed(is_enum::<PmOnFail>)),
+    ("public-hoist-pattern", SettingArity::Text),
+    ("runtime-on-fail", SettingArity::Parsed(is_enum::<RuntimeOnFail>)),
     ("shamefully-hoist", SettingArity::Boolean),
     ("side-effects-cache", SettingArity::Boolean),
     ("side-effects-cache-readonly", SettingArity::Boolean),
     ("strict-peer-dependencies", SettingArity::Boolean),
-    ("trust-policy", SettingArity::Value(is_enum::<TrustPolicy>)),
-    ("trust-policy-exclude", SettingArity::Value(is_text)),
-    ("trust-policy-ignore-after", SettingArity::Value(is_u64)),
-    ("virtual-store-dir", SettingArity::Value(is_text)),
+    ("trust-policy", SettingArity::Parsed(is_enum::<TrustPolicy>)),
+    ("trust-policy-exclude", SettingArity::Text),
+    ("trust-policy-ignore-after", SettingArity::Parsed(is_u64)),
+    ("virtual-store-dir", SettingArity::Text),
 ];
-
-/// A path, a glob pattern, or any other free-form value: every spelling
-/// is one the setting takes.
-fn is_text(_: &str) -> bool {
-    true
-}
 
 fn is_i32(value: &str) -> bool {
     value.parse::<i32>().is_ok()
@@ -816,8 +805,26 @@ fn named_bare_setting_flag(key: &str) -> Option<(&'static str, SettingArity)> {
 fn setting_takes(key: &str, value: &str) -> bool {
     match named_bare_setting_flag(key) {
         Some((_, SettingArity::Boolean)) => parse_bool(value).is_some(),
-        Some((_, SettingArity::Value(takes))) => takes(value),
+        Some((_, SettingArity::Text)) => true,
+        Some((_, SettingArity::Parsed(takes))) => takes(value),
         None => true,
+    }
+}
+
+/// Whether the `key` setting claims `token` — the argv token after its
+/// flag — as its value.
+///
+/// A free-form setting refuses one that opens with `-`: that token is the
+/// `--` separator, another flag, or a short option, and claiming it would
+/// drop the separator or point a path setting at a directory named `--`.
+/// A parsed setting decides on its own terms instead, which is what lets
+/// `--child-concurrency -1` mean "every core but one".
+fn claims_as_value(key: &str, token: &str) -> bool {
+    match named_bare_setting_flag(key) {
+        Some((_, SettingArity::Boolean)) => is_boolean_value(token),
+        Some((_, SettingArity::Text)) => !token.starts_with('-'),
+        Some((_, SettingArity::Parsed(takes))) => takes(token),
+        None => false,
     }
 }
 
@@ -849,12 +856,7 @@ pub(crate) fn bare_boolean_setting_claims(flag: &str, next: Option<&str>) -> boo
 /// [`BARE_SETTING_FLAGS`], or one whose value is missing, which
 /// [`ConfigOverrides::extract`] hands to clap intact.
 pub(crate) fn bare_setting_flag_width(flag: &str, next: Option<&str>) -> usize {
-    let claims_next = match named_bare_setting_flag(flag) {
-        Some((_, SettingArity::Boolean)) => next.is_some_and(is_boolean_value),
-        Some((_, SettingArity::Value(_))) => next.is_some_and(|next| !next.starts_with('-')),
-        None => false,
-    };
-    1 + usize::from(claims_next)
+    1 + usize::from(next.is_some_and(|next| claims_as_value(flag, next)))
 }
 
 fn scoped_registry_key(key: &str) -> Option<&str> {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -181,12 +181,18 @@ impl ConfigOverrides {
             }
             // The token after a `--<setting> <value>` pair's flag, unless
             // the flag ends argv or that token is already the child's.
+            //
+            // A token that opens with `-` is never a value: it is the
+            // `--` separator, another flag, or a short option. Claiming
+            // one would drop the separator and point a path setting at a
+            // directory literally named `--`; leaving it in place makes
+            // the valueless flag clap's to report.
             let mut following = |accept: fn(&str) -> bool| {
                 let value = argv
                     .peek()
                     .filter(|&&(index, _)| !is_forwarded(index))
                     .and_then(|(_, token)| token.to_str())
-                    .filter(|token| accept(token))
+                    .filter(|token| !token.starts_with('-') && accept(token))
                     .map(str::to_owned)?;
                 argv.next();
                 Some(value)
@@ -839,13 +845,16 @@ pub(crate) fn bare_boolean_setting_claims(flag: &str, next: Option<&str>) -> boo
 
 /// How many argv slots a bare `--<setting>` flag occupies, given the
 /// token after it — for the scan that has to find the subcommand before
-/// the settings are stripped. `None` for a token that is not one of the
-/// [`BARE_SETTING_FLAGS`], leaving the arity to clap's own tables.
-pub(crate) fn bare_setting_flag_width(flag: &str, next: Option<&str>) -> Option<usize> {
-    match named_bare_setting_flag(flag)? {
-        (_, SettingArity::Boolean) => Some(1 + usize::from(next.is_some_and(is_boolean_value))),
-        (_, SettingArity::Value(_)) => Some(2),
-    }
+/// the settings are stripped. `1` for a token that is not one of the
+/// [`BARE_SETTING_FLAGS`], or one whose value is missing, which
+/// [`ConfigOverrides::extract`] hands to clap intact.
+pub(crate) fn bare_setting_flag_width(flag: &str, next: Option<&str>) -> usize {
+    let claims_next = match named_bare_setting_flag(flag) {
+        Some((_, SettingArity::Boolean)) => next.is_some_and(is_boolean_value),
+        Some((_, SettingArity::Value(_))) => next.is_some_and(|next| !next.starts_with('-')),
+        None => false,
+    };
+    1 + usize::from(claims_next)
 }
 
 fn scoped_registry_key(key: &str) -> Option<&str> {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1,11 +1,12 @@
 use pnpm_config::{
-    ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, PmOnFail,
-    RuntimeOnFail, VerifyDepsBeforeRun, default_state_dir,
+    ColorMode, Config, EnvVar, GLOBAL_LAYOUT_VERSION, GetCurrentDir, GetHomeDir, LinkProbe,
+    NodeLinker, PackageImportMethod, PmOnFail, RuntimeOnFail, TrustPolicy, VerifyDepsBeforeRun,
+    default_state_dir, resolve_child_concurrency,
 };
 use pnpm_fs::lexical_normalize;
 use pnpm_store_dir::StoreDir;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     ffi::{OsStr, OsString},
     path::Path,
 };
@@ -110,14 +111,20 @@ pub struct ConfigOverrides {
     reverse: Option<bool>,
     shamefully_hoist: Option<bool>,
     shell_emulator: Option<bool>,
+    side_effects_cache: Option<bool>,
+    side_effects_cache_readonly: Option<bool>,
     skip_manifest_obfuscation: Option<bool>,
     sort: Option<bool>,
     use_beta_cli: Option<bool>,
     registry: Option<String>,
     scope: Option<String>,
     registries: BTreeMap<String, String>,
+    child_concurrency: Option<i32>,
     deploy_all_files: Option<bool>,
     force_legacy_deploy: Option<bool>,
+    global_dir: Option<String>,
+    hoist: Option<bool>,
+    hoist_pattern: Option<Vec<String>>,
     ignore_scripts: Option<bool>,
     inject_workspace_packages: Option<bool>,
     /// `maxsockets`, npm's spelling of [`Self::max_sockets`]. Kept apart
@@ -129,10 +136,22 @@ pub struct ConfigOverrides {
     minimum_release_age_exclude: Option<Vec<String>>,
     minimum_release_age_ignore_missing_time: Option<bool>,
     minimum_release_age_strict: Option<bool>,
+    /// The raw `modulesDir` / `virtualStoreDir` spellings, kept unresolved
+    /// so [`Config::anchor_lockfile_paths`] can re-resolve them against
+    /// whichever directory ends up anchoring the install.
+    modules_dir: Option<String>,
+    virtual_store_dir: Option<String>,
     node_linker: Option<NodeLinker>,
+    optimistic_repeat_install: Option<bool>,
+    package_import_method: Option<PackageImportMethod>,
     pm_on_fail: Option<PmOnFail>,
+    public_hoist_pattern: Option<Vec<String>>,
     runtime_on_fail: Option<RuntimeOnFail>,
     shared_workspace_lockfile: Option<bool>,
+    strict_peer_dependencies: Option<bool>,
+    trust_policy: Option<TrustPolicy>,
+    trust_policy_exclude: Option<Vec<String>>,
+    trust_policy_ignore_after: Option<u64>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
     https_proxy: Option<String>,
     http_proxy: Option<String>,
@@ -140,29 +159,57 @@ pub struct ConfigOverrides {
 }
 
 impl ConfigOverrides {
-    /// Pull `--config.<key>=<value>` tokens out of `argv` and collect
-    /// them. Returns the parsed overrides together with the remaining
-    /// argv tokens (in their original order) for clap to parse.
+    /// Pull `--config.<key>=<value>` tokens and [`BARE_SETTING_FLAGS`]
+    /// spellings out of `argv` and collect them. Returns the parsed
+    /// overrides together with the remaining argv tokens (in their
+    /// original order) for clap to parse.
     pub fn extract<Argv>(argv: Argv) -> (Self, Vec<OsString>)
     where
         Argv: IntoIterator<Item = OsString>,
     {
         let argv = argv.into_iter().collect::<Vec<_>>();
         let passthrough_from = crate::parse_boundary::passthrough_from(&argv);
+        let claimed_by_command = crate::parse_boundary::subcommand_option_names(&argv);
+        let is_forwarded = |index: usize| passthrough_from.is_some_and(|from| index >= from);
         let mut overrides = Self::default();
         let mut remaining = Vec::new();
-        for (index, arg) in argv.into_iter().enumerate() {
-            if passthrough_from.is_some_and(|boundary| index >= boundary) {
+        let mut argv = argv.into_iter().enumerate().peekable();
+        while let Some((index, arg)) = argv.next() {
+            if is_forwarded(index) {
                 remaining.push(arg);
                 continue;
             }
-            match classify(&arg) {
+            // The token after a `--<setting> <value>` pair's flag, unless
+            // the flag ends argv or that token is already the child's.
+            let mut following = |accept: fn(&str) -> bool| {
+                let value = argv
+                    .peek()
+                    .filter(|&&(index, _)| !is_forwarded(index))
+                    .and_then(|(_, token)| token.to_str())
+                    .filter(|token| accept(token))
+                    .map(str::to_owned)?;
+                argv.next();
+                Some(value)
+            };
+            match classify(&arg, &claimed_by_command) {
                 ConfigToken::WellFormed { key, value }
                     if matches!(key, "state-dir" | "store-dir") =>
                 {
                     remaining.push(OsString::from(format!("--{key}={value}")));
                 }
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
+                ConfigToken::BooleanFollows(key) => {
+                    // nopt claims the next token only when it spells a
+                    // boolean, so `pnpm --shamefully-hoist install` still
+                    // finds its command.
+                    let value = following(|token| matches!(token, "true" | "false"));
+                    overrides.set(key, value.as_deref().unwrap_or("true"));
+                }
+                ConfigToken::ValueFollows(key) => {
+                    if let Some(value) = following(|_| true) {
+                        overrides.set(key, &value);
+                    }
+                }
                 ConfigToken::Malformed => {}
                 ConfigToken::NotOurs => remaining.push(arg),
             }
@@ -183,7 +230,9 @@ impl ConfigOverrides {
             "ignore-workspace-root-check" => {
                 self.ignore_workspace_root_check = parse_bool(value);
             }
+            "hoist" => self.hoist = parse_bool(value),
             "lockfile" => self.lockfile = parse_bool(value),
+            "optimistic-repeat-install" => self.optimistic_repeat_install = parse_bool(value),
             "optional" => self.optional = parse_bool(value),
             "package-lock" => self.package_lock = parse_bool(value),
             "pending" => self.pending = parse_bool(value),
@@ -191,10 +240,15 @@ impl ConfigOverrides {
             "reverse" => self.reverse = parse_bool(value),
             "shamefully-hoist" => self.shamefully_hoist = parse_bool(value),
             "shell-emulator" => self.shell_emulator = parse_bool(value),
+            "side-effects-cache" => self.side_effects_cache = parse_bool(value),
+            "side-effects-cache-readonly" => {
+                self.side_effects_cache_readonly = parse_bool(value);
+            }
             "skip-manifest-obfuscation" => {
                 self.skip_manifest_obfuscation = parse_bool(value);
             }
             "sort" => self.sort = parse_bool(value),
+            "strict-peer-dependencies" => self.strict_peer_dependencies = parse_bool(value),
             "use-beta-cli" => self.use_beta_cli = parse_bool(value),
             _ => {}
         }
@@ -218,12 +272,24 @@ impl ConfigOverrides {
             self.no_proxy = Some(value.to_string());
             return;
         }
+        if key == "child-concurrency" {
+            self.child_concurrency = value.parse().ok();
+            return;
+        }
         if key == "deploy-all-files" {
             self.deploy_all_files = parse_bool(value);
             return;
         }
         if key == "force-legacy-deploy" {
             self.force_legacy_deploy = parse_bool(value);
+            return;
+        }
+        if key == "global-dir" {
+            self.global_dir = Some(value.to_string());
+            return;
+        }
+        if key == "hoist-pattern" {
+            self.hoist_pattern.get_or_insert_default().push(value.to_string());
             return;
         }
         if key == "ignore-scripts" {
@@ -260,8 +326,20 @@ impl ConfigOverrides {
             self.minimum_release_age_strict = parse_bool(value);
             return;
         }
+        if key == "modules-dir" {
+            self.modules_dir = Some(value.to_string());
+            return;
+        }
         if key == "node-linker" {
             self.node_linker = parse_enum(value);
+            return;
+        }
+        if key == "package-import-method" {
+            self.package_import_method = parse_enum(value);
+            return;
+        }
+        if key == "public-hoist-pattern" {
+            self.public_hoist_pattern.get_or_insert_default().push(value.to_string());
             return;
         }
         if key == "pm-on-fail" {
@@ -280,6 +358,22 @@ impl ConfigOverrides {
             self.verify_deps_before_run = value.parse().ok();
             return;
         }
+        if key == "trust-policy" {
+            self.trust_policy = parse_enum(value);
+            return;
+        }
+        if key == "trust-policy-exclude" {
+            self.trust_policy_exclude.get_or_insert_default().push(value.to_string());
+            return;
+        }
+        if key == "trust-policy-ignore-after" {
+            self.trust_policy_ignore_after = value.parse().ok();
+            return;
+        }
+        if key == "virtual-store-dir" {
+            self.virtual_store_dir = Some(value.to_string());
+            return;
+        }
         if let Some(scope) = scoped_registry_key(key) {
             self.registries.insert(scope.to_owned(), normalize_registry_url(value));
         }
@@ -288,7 +382,10 @@ impl ConfigOverrides {
     /// Layer the CLI overrides on top of a [`Config`] that has already
     /// been built from defaults, `.npmrc`, and `pnpm-workspace.yaml`.
     /// Mirrors pnpm 11's "CLI > yaml > .npmrc > defaults" precedence.
-    pub fn apply(&self, config: &mut Config) {
+    ///
+    /// `dir` is the canonicalized `--dir`, the fallback base for a
+    /// relative path-valued setting outside a workspace.
+    pub fn apply(&self, config: &mut Config, dir: &Path) {
         config.apply_proxy_cli_overrides(
             self.https_proxy.as_deref(),
             self.http_proxy.as_deref(),
@@ -334,6 +431,33 @@ impl ConfigOverrides {
         if let Some(value) = self.shamefully_hoist {
             config.shamefully_hoist = value;
             config.explicit_settings.insert("shamefullyHoist".to_string(), value.into());
+        }
+        if let Some(value) = self.hoist {
+            config.hoist = value;
+            config.explicit_settings.insert("hoist".to_string(), value.into());
+        }
+        if let Some(value) = &self.hoist_pattern {
+            config.hoist_pattern = Some(value.clone());
+            config.explicit_settings.insert("hoistPattern".to_string(), value.as_slice().into());
+        }
+        if let Some(value) = &self.public_hoist_pattern {
+            config.public_hoist_pattern = Some(value.clone());
+            config
+                .explicit_settings
+                .insert("publicHoistPattern".to_string(), value.as_slice().into());
+        }
+        if self.shamefully_hoist.is_some()
+            || self.hoist.is_some()
+            || self.hoist_pattern.is_some()
+            || self.public_hoist_pattern.is_some()
+        {
+            // `hoist: false` nullifies the private pattern whichever layer
+            // supplied either, so the two derivations below re-run over the
+            // command line's contribution the way `WorkspaceSettings::apply_to`
+            // runs them over yaml's.
+            if !config.hoist {
+                config.hoist_pattern = None;
+            }
             config.apply_shamefully_hoist_derivation();
             config.apply_virtual_store_only_derivation();
         }
@@ -435,6 +559,93 @@ impl ConfigOverrides {
         {
             config.verify_deps_before_run = value;
         }
+        // `pnpm config get <setting>` answers from the explicitly-set
+        // settings, and pnpm seeds those from the command line as well as
+        // from the config files, so each override below records itself
+        // there alongside the value it resolves.
+        if let Some(value) = self.package_import_method {
+            config.package_import_method = value;
+            config
+                .explicit_settings
+                .insert("packageImportMethod".to_string(), setting_value(value));
+        }
+        if let Some(value) = self.child_concurrency {
+            config.child_concurrency = resolve_child_concurrency(Some(value));
+            config.explicit_settings.insert("childConcurrency".to_string(), value.into());
+        }
+        if let Some(value) = self.strict_peer_dependencies {
+            config.strict_peer_dependencies = value;
+            config.explicit_settings.insert("strictPeerDependencies".to_string(), value.into());
+        }
+        if let Some(value) = self.side_effects_cache {
+            config.side_effects_cache = value;
+            config.explicit_settings.insert("sideEffectsCache".to_string(), value.into());
+        }
+        if let Some(value) = self.side_effects_cache_readonly {
+            config.side_effects_cache_readonly = value;
+            config.explicit_settings.insert("sideEffectsCacheReadonly".to_string(), value.into());
+        }
+        if let Some(value) = self.optimistic_repeat_install {
+            config.optimistic_repeat_install = value;
+            config.explicit_settings.insert("optimisticRepeatInstall".to_string(), value.into());
+        }
+        if let Some(value) = self.trust_policy {
+            config.trust_policy = value;
+            config.explicit_settings.insert("trustPolicy".to_string(), setting_value(value));
+        }
+        if let Some(value) = &self.trust_policy_exclude {
+            config.trust_policy_exclude = Some(value.clone());
+            config
+                .explicit_settings
+                .insert("trustPolicyExclude".to_string(), value.as_slice().into());
+        }
+        if let Some(value) = self.trust_policy_ignore_after {
+            config.trust_policy_ignore_after = Some(value);
+            config.explicit_settings.insert("trustPolicyIgnoreAfter".to_string(), value.into());
+        }
+        if let Some(value) = self.global_dir.as_deref().filter(|value| !value.is_empty()) {
+            let global_dir = lexical_normalize(&dir.join(value));
+            config.global_pkg_dir = Some(global_dir.join(GLOBAL_LAYOUT_VERSION));
+            config.global_dir = Some(global_dir);
+            config.explicit_settings.insert("globalDir".to_string(), value.into());
+        }
+        self.apply_lockfile_anchored_paths(config, dir);
+    }
+
+    /// Re-anchor the root `node_modules` and the virtual store onto a
+    /// command-line `--modules-dir` / `--virtual-store-dir`.
+    ///
+    /// Both reach [`Config::explicit_settings`] as the raw spelling, which
+    /// is what [`Config::anchor_lockfile_paths`] resolves — so a later
+    /// `--lockfile-dir` pin moves the CLI-set paths along with it.
+    fn apply_lockfile_anchored_paths(&self, config: &mut Config, dir: &Path) {
+        let raw_settings = [
+            ("modulesDir", self.modules_dir.as_deref()),
+            ("virtualStoreDir", self.virtual_store_dir.as_deref()),
+        ];
+        let mut anchored = false;
+        for (setting, value) in raw_settings {
+            if let Some(value) = value {
+                config.explicit_settings.insert(setting.to_string(), value.into());
+                anchored = true;
+            }
+        }
+        if !anchored {
+            return;
+        }
+        let anchor = config
+            .lockfile_dir
+            .clone()
+            .or_else(|| config.workspace_dir.clone())
+            .unwrap_or_else(|| dir.to_path_buf());
+        config.anchor_lockfile_paths(&anchor);
+        let virtual_store_dir_explicit = config.explicit_settings.contains_key("virtualStoreDir");
+        let global_virtual_store_dir_explicit =
+            config.explicit_settings.contains_key("globalVirtualStoreDir");
+        config.apply_global_virtual_store_derivation(
+            virtual_store_dir_explicit,
+            global_virtual_store_dir_explicit,
+        );
     }
 }
 
@@ -447,7 +658,16 @@ fn verify_deps_env_is_set() -> bool {
 }
 
 enum ConfigToken<'a> {
-    WellFormed { key: &'a str, value: &'a str },
+    WellFormed {
+        key: &'a str,
+        value: &'a str,
+    },
+    /// A bare `--<setting>` for a boolean setting: `true`, unless the next
+    /// argv token spells a boolean and is claimed as its value.
+    BooleanFollows(&'static str),
+    /// A bare `--<setting>` for a value-taking setting: the next argv
+    /// token is its value.
+    ValueFollows(&'static str),
     Malformed,
     NotOurs,
 }
@@ -457,7 +677,20 @@ enum ConfigToken<'a> {
 /// `--config.` prefix is claimed, so a typo like `--config.foo` never
 /// escapes into clap's "unexpected argument" path; every other token is
 /// returned untouched.
-fn classify(arg: &OsStr) -> ConfigToken<'_> {
+///
+/// `claimed_by_command` names the options the invoked command declares
+/// itself, which win over the setting of the same name — see
+/// [`subcommand_option_names`].
+///
+/// A boolean setting given a value that is not one is left for clap,
+/// which reports it as an unexpected argument — silently dropping it
+/// would leave the install running under a setting the user believes
+/// they changed.
+///
+/// [`subcommand_option_names`]: crate::parse_boundary::subcommand_option_names
+fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigToken<'a> {
+    let setting =
+        |key: &str| named_bare_setting_flag(key).filter(|_| !claimed_by_command.contains(key));
     let Some(arg) = arg.to_str() else {
         return ConfigToken::NotOurs;
     };
@@ -468,34 +701,91 @@ fn classify(arg: &OsStr) -> ConfigToken<'_> {
         if key.is_empty() {
             return ConfigToken::Malformed;
         }
-        if key == "shamefully-hoist" && parse_bool(value).is_none() {
+        // The dotted spelling names a setting outright, so a command
+        // option of the same name never shadows it.
+        if named_bare_setting_flag(key).is_some_and(|(_, arity)| arity == SettingArity::Boolean)
+            && parse_bool(value).is_none()
+        {
             return ConfigToken::NotOurs;
         }
         return ConfigToken::WellFormed { key, value };
     }
-    match arg {
-        "--shamefully-hoist" => {
-            return ConfigToken::WellFormed { key: "shamefully-hoist", value: "true" };
-        }
-        "--no-shamefully-hoist" => {
-            return ConfigToken::WellFormed { key: "shamefully-hoist", value: "false" };
-        }
-        _ => {}
+    let Some(flag) = arg.strip_prefix("--") else {
+        return ConfigToken::NotOurs;
+    };
+    if let Some(negated) = flag.strip_prefix("no-")
+        && let Some((key, SettingArity::Boolean)) = setting(negated)
+    {
+        return ConfigToken::WellFormed { key, value: "false" };
     }
-    match arg.strip_prefix("--").and_then(|flag| flag.split_once('=')) {
-        Some(("shamefully-hoist", value)) if parse_bool(value).is_none() => ConfigToken::NotOurs,
-        Some((key, value)) if BARE_SETTING_FLAGS.contains(&key) => {
-            ConfigToken::WellFormed { key, value }
-        }
-        _ => ConfigToken::NotOurs,
+    let Some((key, value)) = flag.split_once('=') else {
+        return match setting(flag) {
+            Some((key, SettingArity::Boolean)) => ConfigToken::BooleanFollows(key),
+            Some((key, SettingArity::Value)) => ConfigToken::ValueFollows(key),
+            None => ConfigToken::NotOurs,
+        };
+    };
+    match setting(key) {
+        Some((_, SettingArity::Boolean)) if parse_bool(value).is_none() => ConfigToken::NotOurs,
+        Some((key, _)) => ConfigToken::WellFormed { key, value },
+        None => ConfigToken::NotOurs,
     }
 }
 
-/// Settings pnpm's own error hints tell the user to pass as a bare
-/// `--<setting>=<value>` flag. pnpm accepts every setting that way; pacquet
-/// only declares a clap flag for a subset, so these are recognized here to
-/// keep the hints they appear in actionable.
-const BARE_SETTING_FLAGS: [&str; 3] = ["pm-on-fail", "runtime-on-fail", "shamefully-hoist"];
+/// How much of argv a bare `--<setting>` flag claims.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SettingArity {
+    /// `--<setting>`, `--no-<setting>`, `--<setting>=<bool>`, and
+    /// `--<setting> <bool>`.
+    Boolean,
+    /// `--<setting>=<value>` and `--<setting> <value>`. A setting whose
+    /// value is a list repeats the flag, one value per occurrence.
+    Value,
+}
+
+/// Settings pnpm accepts as a bare `--<setting>` command-line flag.
+///
+/// pnpm declares a `nopt` type for every setting, which makes all of them
+/// spellable on the command line; pacquet declares a clap flag for only a
+/// subset, so the rest are recognized here and layered onto [`Config`]
+/// exactly like a `--config.<setting>=<value>` token
+/// ([pnpm/pnpm#14281](https://github.com/pnpm/pnpm/issues/14281)). A
+/// setting the invoked command declares as its own option is left for
+/// clap; a setting that collides with a *global* option would be claimed
+/// on every command line and so must not appear here at all.
+const BARE_SETTING_FLAGS: [(&str, SettingArity); 19] = [
+    ("child-concurrency", SettingArity::Value),
+    ("global-dir", SettingArity::Value),
+    ("hoist", SettingArity::Boolean),
+    ("hoist-pattern", SettingArity::Value),
+    ("lockfile", SettingArity::Boolean),
+    ("modules-dir", SettingArity::Value),
+    ("optimistic-repeat-install", SettingArity::Boolean),
+    ("package-import-method", SettingArity::Value),
+    ("pm-on-fail", SettingArity::Value),
+    ("public-hoist-pattern", SettingArity::Value),
+    ("runtime-on-fail", SettingArity::Value),
+    ("shamefully-hoist", SettingArity::Boolean),
+    ("side-effects-cache", SettingArity::Boolean),
+    ("side-effects-cache-readonly", SettingArity::Boolean),
+    ("strict-peer-dependencies", SettingArity::Boolean),
+    ("trust-policy", SettingArity::Value),
+    ("trust-policy-exclude", SettingArity::Value),
+    ("trust-policy-ignore-after", SettingArity::Value),
+    ("virtual-store-dir", SettingArity::Value),
+];
+
+fn named_bare_setting_flag(key: &str) -> Option<(&'static str, SettingArity)> {
+    BARE_SETTING_FLAGS.into_iter().find(|&(name, _)| name == key)
+}
+
+/// Whether a bare `--<setting>` flag claims the token after it, for the
+/// argv scan that has to find the subcommand before the settings are
+/// stripped. `None` for a token that is not one of the
+/// [`BARE_SETTING_FLAGS`], leaving the arity to clap's own tables.
+pub(crate) fn bare_setting_flag_consumes_value(key: &str) -> Option<bool> {
+    named_bare_setting_flag(key).map(|(_, arity)| arity == SettingArity::Value)
+}
 
 fn scoped_registry_key(key: &str) -> Option<&str> {
     key.strip_suffix(":registry")
@@ -522,6 +812,12 @@ fn normalize_registry_url(registry: &str) -> String {
 
 fn parse_enum<Value: serde::de::DeserializeOwned>(value: &str) -> Option<Value> {
     serde_json::from_value(serde_json::Value::String(value.to_string())).ok()
+}
+
+/// An enum setting's kebab-case spelling, for [`Config::explicit_settings`]
+/// — the form the config files and `pnpm config get` use.
+fn setting_value<Value: serde::Serialize>(value: Value) -> serde_json::Value {
+    serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
 }
 
 fn parse_bool(value: &str) -> Option<bool> {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -819,8 +819,22 @@ fn setting_takes(key: &str, value: &str) -> bool {
 /// its value — the same spellings the `--<setting>=<bool>` form takes,
 /// so the two agree. Only a boolean is claimed, which is what leaves
 /// `pnpm --shamefully-hoist install` its command.
-pub(crate) fn is_boolean_value(token: &str) -> bool {
+fn is_boolean_value(token: &str) -> bool {
     parse_bool(token).is_some()
+}
+
+/// Whether a bare boolean setting flag claims `next` as its value.
+///
+/// The scan that has to find the subcommand applies this ahead of clap's
+/// own arity: nothing else on a command line is spelled `true` /
+/// `false`, so stepping over that token is right whichever reading of
+/// the flag ends up applying — a command's option of the same name, or
+/// the setting. Without it the two readings disagree on width for a name
+/// that is both, and `pnpm --lockfile true --config.registry=… install`
+/// loses everything past the boolean to the script fallback.
+pub(crate) fn bare_boolean_setting_claims(flag: &str, next: Option<&str>) -> bool {
+    matches!(named_bare_setting_flag(flag), Some((_, SettingArity::Boolean)))
+        && next.is_some_and(is_boolean_value)
 }
 
 /// How many argv slots a bare `--<setting>` flag occupies, given the

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -199,18 +199,20 @@ impl ConfigOverrides {
                 }
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
                 ConfigToken::BooleanFollows(key) => {
-                    let value = following(spells_a_boolean);
+                    let value = following(is_boolean_value);
                     overrides.set(key, value.as_deref().unwrap_or("true"));
                 }
                 ConfigToken::ValueFollows(key) => match following(|_| true) {
                     Some(value) if setting_takes(key, &value) => overrides.set(key, &value),
-                    // Both tokens go back in their original order, for
-                    // clap to report — see [`classify`].
+                    // The flag goes back in place, with the value it did
+                    // not take, for clap to report — see [`classify`]. A
+                    // flag that ends argv has no value at all, which is
+                    // just as much an invocation clap has to report.
                     Some(value) => {
                         remaining.push(arg);
                         remaining.push(OsString::from(value));
                     }
-                    None => {}
+                    None => remaining.push(arg),
                 },
                 ConfigToken::Malformed => {}
                 ConfigToken::NotOurs => remaining.push(arg),
@@ -814,10 +816,11 @@ fn setting_takes(key: &str, value: &str) -> bool {
 }
 
 /// Whether a token spells a boolean a bare `--<setting>` flag claims as
-/// its value. nopt claims only the two literals, so
-/// `pnpm --shamefully-hoist install` still finds its command.
-pub(crate) fn spells_a_boolean(token: &str) -> bool {
-    matches!(token, "true" | "false")
+/// its value — the same spellings the `--<setting>=<bool>` form takes,
+/// so the two agree. Only a boolean is claimed, which is what leaves
+/// `pnpm --shamefully-hoist install` its command.
+pub(crate) fn is_boolean_value(token: &str) -> bool {
+    parse_bool(token).is_some()
 }
 
 /// How many argv slots a bare `--<setting>` flag occupies, given the
@@ -826,7 +829,7 @@ pub(crate) fn spells_a_boolean(token: &str) -> bool {
 /// [`BARE_SETTING_FLAGS`], leaving the arity to clap's own tables.
 pub(crate) fn bare_setting_flag_width(flag: &str, next: Option<&str>) -> Option<usize> {
     match named_bare_setting_flag(flag)? {
-        (_, SettingArity::Boolean) => Some(1 + usize::from(next.is_some_and(spells_a_boolean))),
+        (_, SettingArity::Boolean) => Some(1 + usize::from(next.is_some_and(is_boolean_value))),
         (_, SettingArity::Value(_)) => Some(2),
     }
 }

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -199,17 +199,19 @@ impl ConfigOverrides {
                 }
                 ConfigToken::WellFormed { key, value } => overrides.set(key, value),
                 ConfigToken::BooleanFollows(key) => {
-                    // nopt claims the next token only when it spells a
-                    // boolean, so `pnpm --shamefully-hoist install` still
-                    // finds its command.
-                    let value = following(|token| matches!(token, "true" | "false"));
+                    let value = following(spells_a_boolean);
                     overrides.set(key, value.as_deref().unwrap_or("true"));
                 }
-                ConfigToken::ValueFollows(key) => {
-                    if let Some(value) = following(|_| true) {
-                        overrides.set(key, &value);
+                ConfigToken::ValueFollows(key) => match following(|_| true) {
+                    Some(value) if setting_takes(key, &value) => overrides.set(key, &value),
+                    // Both tokens go back in their original order, for
+                    // clap to report — see [`classify`].
+                    Some(value) => {
+                        remaining.push(arg);
+                        remaining.push(OsString::from(value));
                     }
-                }
+                    None => {}
+                },
                 ConfigToken::Malformed => {}
                 ConfigToken::NotOurs => remaining.push(arg),
             }
@@ -682,10 +684,12 @@ enum ConfigToken<'a> {
 /// itself, which win over the setting of the same name — see
 /// [`subcommand_option_names`].
 ///
-/// A boolean setting given a value that is not one is left for clap,
-/// which reports it as an unexpected argument — silently dropping it
-/// would leave the install running under a setting the user believes
-/// they changed.
+/// A setting given a value it does not take — a misspelled boolean, an
+/// unknown `--trust-policy`, a non-numeric `--child-concurrency` — is
+/// left for clap, which reports it as an unexpected argument. Dropping
+/// it instead would leave the install running under a setting the user
+/// believes they changed, which for a supply-chain setting like
+/// `trustPolicy` means failing open.
 ///
 /// [`subcommand_option_names`]: crate::parse_boundary::subcommand_option_names
 fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigToken<'a> {
@@ -703,9 +707,7 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
         }
         // The dotted spelling names a setting outright, so a command
         // option of the same name never shadows it.
-        if named_bare_setting_flag(key).is_some_and(|(_, arity)| arity == SettingArity::Boolean)
-            && parse_bool(value).is_none()
-        {
+        if !setting_takes(key, value) {
             return ConfigToken::NotOurs;
         }
         return ConfigToken::WellFormed { key, value };
@@ -721,29 +723,32 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
     let Some((key, value)) = flag.split_once('=') else {
         return match setting(flag) {
             Some((key, SettingArity::Boolean)) => ConfigToken::BooleanFollows(key),
-            Some((key, SettingArity::Value)) => ConfigToken::ValueFollows(key),
+            Some((key, SettingArity::Value(_))) => ConfigToken::ValueFollows(key),
             None => ConfigToken::NotOurs,
         };
     };
     match setting(key) {
-        Some((_, SettingArity::Boolean)) if parse_bool(value).is_none() => ConfigToken::NotOurs,
+        Some(_) if !setting_takes(key, value) => ConfigToken::NotOurs,
         Some((key, _)) => ConfigToken::WellFormed { key, value },
         None => ConfigToken::NotOurs,
     }
 }
 
-/// How much of argv a bare `--<setting>` flag claims.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// How much of argv a bare `--<setting>` flag claims, and which values it
+/// accepts there.
+#[derive(Debug, Clone, Copy)]
 enum SettingArity {
     /// `--<setting>`, `--no-<setting>`, `--<setting>=<bool>`, and
     /// `--<setting> <bool>`.
     Boolean,
-    /// `--<setting>=<value>` and `--<setting> <value>`. A setting whose
-    /// value is a list repeats the flag, one value per occurrence.
-    Value,
+    /// `--<setting>=<value>` and `--<setting> <value>`, where the value is
+    /// one the carried predicate accepts. A setting whose value is a list
+    /// repeats the flag, one value per occurrence.
+    Value(fn(&str) -> bool),
 }
 
-/// Settings pnpm accepts as a bare `--<setting>` command-line flag.
+/// Settings pnpm accepts as a bare `--<setting>` command-line flag, with
+/// the values each takes.
 ///
 /// pnpm declares a `nopt` type for every setting, which makes all of them
 /// spellable on the command line; pacquet declares a clap flag for only a
@@ -754,37 +759,76 @@ enum SettingArity {
 /// clap; a setting that collides with a *global* option would be claimed
 /// on every command line and so must not appear here at all.
 const BARE_SETTING_FLAGS: [(&str, SettingArity); 19] = [
-    ("child-concurrency", SettingArity::Value),
-    ("global-dir", SettingArity::Value),
+    ("child-concurrency", SettingArity::Value(is_i32)),
+    ("global-dir", SettingArity::Value(is_text)),
     ("hoist", SettingArity::Boolean),
-    ("hoist-pattern", SettingArity::Value),
+    ("hoist-pattern", SettingArity::Value(is_text)),
     ("lockfile", SettingArity::Boolean),
-    ("modules-dir", SettingArity::Value),
+    ("modules-dir", SettingArity::Value(is_text)),
     ("optimistic-repeat-install", SettingArity::Boolean),
-    ("package-import-method", SettingArity::Value),
-    ("pm-on-fail", SettingArity::Value),
-    ("public-hoist-pattern", SettingArity::Value),
-    ("runtime-on-fail", SettingArity::Value),
+    ("package-import-method", SettingArity::Value(is_enum::<PackageImportMethod>)),
+    ("pm-on-fail", SettingArity::Value(is_enum::<PmOnFail>)),
+    ("public-hoist-pattern", SettingArity::Value(is_text)),
+    ("runtime-on-fail", SettingArity::Value(is_enum::<RuntimeOnFail>)),
     ("shamefully-hoist", SettingArity::Boolean),
     ("side-effects-cache", SettingArity::Boolean),
     ("side-effects-cache-readonly", SettingArity::Boolean),
     ("strict-peer-dependencies", SettingArity::Boolean),
-    ("trust-policy", SettingArity::Value),
-    ("trust-policy-exclude", SettingArity::Value),
-    ("trust-policy-ignore-after", SettingArity::Value),
-    ("virtual-store-dir", SettingArity::Value),
+    ("trust-policy", SettingArity::Value(is_enum::<TrustPolicy>)),
+    ("trust-policy-exclude", SettingArity::Value(is_text)),
+    ("trust-policy-ignore-after", SettingArity::Value(is_u64)),
+    ("virtual-store-dir", SettingArity::Value(is_text)),
 ];
+
+/// A path, a glob pattern, or any other free-form value: every spelling
+/// is one the setting takes.
+fn is_text(_: &str) -> bool {
+    true
+}
+
+fn is_i32(value: &str) -> bool {
+    value.parse::<i32>().is_ok()
+}
+
+fn is_u64(value: &str) -> bool {
+    value.parse::<u64>().is_ok()
+}
+
+fn is_enum<Value: serde::de::DeserializeOwned>(value: &str) -> bool {
+    parse_enum::<Value>(value).is_some()
+}
 
 fn named_bare_setting_flag(key: &str) -> Option<(&'static str, SettingArity)> {
     BARE_SETTING_FLAGS.into_iter().find(|&(name, _)| name == key)
 }
 
-/// Whether a bare `--<setting>` flag claims the token after it, for the
-/// argv scan that has to find the subcommand before the settings are
-/// stripped. `None` for a token that is not one of the
+/// Whether `value` is a spelling the `key` setting takes. `true` for a
+/// key outside [`BARE_SETTING_FLAGS`], which keeps the `--config.<key>`
+/// tolerance for the settings pacquet has not ported.
+fn setting_takes(key: &str, value: &str) -> bool {
+    match named_bare_setting_flag(key) {
+        Some((_, SettingArity::Boolean)) => parse_bool(value).is_some(),
+        Some((_, SettingArity::Value(takes))) => takes(value),
+        None => true,
+    }
+}
+
+/// Whether a token spells a boolean a bare `--<setting>` flag claims as
+/// its value. nopt claims only the two literals, so
+/// `pnpm --shamefully-hoist install` still finds its command.
+pub(crate) fn spells_a_boolean(token: &str) -> bool {
+    matches!(token, "true" | "false")
+}
+
+/// How many argv slots a bare `--<setting>` flag occupies, given the
+/// token after it — for the scan that has to find the subcommand before
+/// the settings are stripped. `None` for a token that is not one of the
 /// [`BARE_SETTING_FLAGS`], leaving the arity to clap's own tables.
-pub(crate) fn bare_setting_flag_consumes_value(key: &str) -> Option<bool> {
-    named_bare_setting_flag(key).map(|(_, arity)| arity == SettingArity::Value)
+pub(crate) fn bare_setting_flag_width(flag: &str, next: Option<&str>) -> Option<usize> {
+    match named_bare_setting_flag(flag)? {
+        (_, SettingArity::Boolean) => Some(1 + usize::from(next.is_some_and(spells_a_boolean))),
+        (_, SettingArity::Value(_)) => Some(2),
+    }
 }
 
 fn scoped_registry_key(key: &str) -> Option<&str> {

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -885,3 +885,58 @@ fn a_command_option_wins_over_the_setting_of_the_same_name() {
     overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.lockfile, Config::default().lockfile);
 }
+
+/// A value the setting does not take must reach clap, which reports it:
+/// dropping `--trust-policy=typo` would run the install under the default
+/// `off` policy the user meant to replace.
+#[test]
+fn extract_leaves_invalid_setting_values_for_clap() {
+    for tokens in [
+        ["--trust-policy=typo"].as_slice(),
+        &["--trust-policy", "typo"],
+        &["--config.trust-policy=typo"],
+        &["--package-import-method=symlink"],
+        &["--child-concurrency=lots"],
+        &["--child-concurrency", "lots"],
+        &["--trust-policy-ignore-after=soon"],
+    ] {
+        let command_line = ["pacquet", "install"]
+            .into_iter()
+            .chain(tokens.iter().copied())
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        let (overrides, remaining) = ConfigOverrides::extract(command_line.clone());
+        assert_eq!(remaining, command_line, "{tokens:?}");
+
+        let mut config = Config::default();
+        overrides.apply(&mut config, Path::new("/workspace"));
+        let defaults = Config::default();
+        assert_eq!(config.trust_policy, defaults.trust_policy, "{tokens:?}");
+        assert_eq!(config.package_import_method, defaults.package_import_method, "{tokens:?}");
+        assert_eq!(config.child_concurrency, defaults.child_concurrency, "{tokens:?}");
+        assert_eq!(
+            config.trust_policy_ignore_after, defaults.trust_policy_ignore_after,
+            "{tokens:?}",
+        );
+    }
+}
+
+/// The boundary scan and the extraction have to agree on how much a bare
+/// boolean setting claims, or the settings after an explicit `true` /
+/// `false` are mistaken for a script's arguments and forwarded to clap.
+#[test]
+fn a_boolean_settings_explicit_value_does_not_move_the_command_boundary() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--strict-peer-dependencies",
+        "false",
+        "--config.registry=https://example.test/",
+        "install",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config { strict_peer_dependencies: true, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(!config.strict_peer_dependencies);
+    assert_eq!(config.registry, "https://example.test/");
+}

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -960,3 +960,27 @@ fn a_boolean_settings_value_is_claimed_even_when_a_command_declares_the_name() {
     assert!(config.lockfile);
     assert_eq!(config.registry, "https://example.test/");
 }
+
+/// A `--` or another flag is never a setting's value: claiming one would
+/// drop the separator and point `modulesDir` at a directory named `--`.
+#[test]
+fn a_setting_flag_never_claims_a_separator_or_another_flag() {
+    for tokens in [
+        ["--modules-dir", "--", "extra"].as_slice(),
+        &["--modules-dir", "--"],
+        &["--modules-dir", "--prod"],
+        &["--modules-dir", "-C"],
+    ] {
+        let command_line = ["pacquet", "install"]
+            .into_iter()
+            .chain(tokens.iter().copied())
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        let (overrides, remaining) = ConfigOverrides::extract(command_line.clone());
+        assert_eq!(remaining, command_line, "{tokens:?}");
+
+        let mut config = Config::default();
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert_eq!(config.modules_dir, Config::default().modules_dir, "{tokens:?}");
+    }
+}

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -2,12 +2,15 @@ use super::{
     ConfigOverrides, apply_registry_override, apply_state_dir_override, apply_store_dir_override,
 };
 use pnpm_config::{
-    ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker, PmOnFail,
-    RuntimeOnFail,
+    ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker,
+    PackageImportMethod, PmOnFail, RuntimeOnFail, TrustPolicy,
 };
 use pnpm_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
-use std::{ffi::OsString, path::PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Path, PathBuf},
+};
 
 fn argv<Items: IntoIterator<Item = &'static str>>(items: Items) -> Vec<OsString> {
     items.into_iter().map(OsString::from).collect()
@@ -23,7 +26,7 @@ fn extract_separates_config_tokens_from_argv() {
     ]));
     assert_eq!(remaining, argv(["pacquet", "install", "--frozen-lockfile"]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, "https://example.test/");
     assert_eq!(config.package_manager_bootstrap.registry, "https://example.test/");
     assert_eq!(
@@ -42,7 +45,7 @@ fn extract_reads_the_login_scope() {
         ConfigOverrides::extract(argv(["pacquet", "--config.scope=@my-org", "login"]));
     assert_eq!(remaining, argv(["pacquet", "login"]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.scope.as_deref(), Some("@my-org"));
 }
 
@@ -56,7 +59,7 @@ fn extract_accepts_the_on_fail_settings_as_bare_flags() {
     ]));
     assert_eq!(remaining, argv(["pacquet", "install"]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.pm_on_fail, Some(PmOnFail::Ignore));
     assert_eq!(config.runtime_on_fail, Some(RuntimeOnFail::Warn));
 }
@@ -79,7 +82,7 @@ fn extract_accepts_shamefully_hoist_cli_spellings() {
         assert_eq!(remaining, argv(["pacquet", "--version"]));
 
         let mut config = Config::default();
-        overrides.apply(&mut config);
+        overrides.apply(&mut config, Path::new("/workspace"));
         assert_eq!(config.shamefully_hoist, expected);
         let expected_public_hoist_pattern = expected.then(|| vec!["*".to_string()]);
         assert_eq!(config.public_hoist_pattern, expected_public_hoist_pattern);
@@ -101,7 +104,7 @@ fn shamefully_hoist_override_preserves_virtual_store_only_precedence() {
         hoist_pattern: Some(vec!["*".to_string()]),
         ..Config::default()
     };
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
 
     assert_eq!(config.hoist_pattern, Some(Vec::new()));
     assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
@@ -119,7 +122,7 @@ fn extract_leaves_invalid_shamefully_hoist_values_for_clap() {
         assert_eq!(remaining, argv(["pacquet", flag, "--version"]));
 
         let mut config = Config::default();
-        overrides.apply(&mut config);
+        overrides.apply(&mut config, Path::new("/workspace"));
         assert!(!config.explicit_settings.contains_key("shamefullyHoist"));
     }
 }
@@ -148,7 +151,7 @@ fn extract_leaves_config_tokens_after_the_separator_for_the_child() {
         ]),
     );
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.pm_on_fail, None);
     assert_eq!(config.registry, Config::default().registry);
 }
@@ -222,7 +225,7 @@ fn extract_applies_scoped_registry_overrides() {
     ]));
     assert_eq!(remaining, argv(["pacquet", "install"]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(
         config.registries_by_scope.get("@private").map(String::as_str),
         Some("https://private.example/npm/"),
@@ -245,7 +248,7 @@ fn scoped_registry_override_wins_over_existing_config() {
         .package_manager_bootstrap
         .registries
         .insert("@private".to_string(), "https://json-env.example/npm/".to_string());
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(
         config.registries_by_scope.get("@private").map(String::as_str),
         Some("https://cli.example/npm/"),
@@ -263,7 +266,7 @@ fn unknown_keys_are_dropped_silently() {
     assert_eq!(remaining, argv(["pacquet", "install"]));
     let default_registry = Config::default().registry;
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, default_registry, "no known key set ⇒ registry untouched");
 }
 
@@ -280,7 +283,7 @@ fn extract_applies_inject_workspace_packages_and_node_linker_overrides() {
     let mut config = Config::default();
     assert!(!config.inject_workspace_packages);
     assert_eq!(config.node_linker, NodeLinker::Isolated);
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert!(config.inject_workspace_packages);
     assert_eq!(config.node_linker, NodeLinker::Hoisted);
 }
@@ -300,7 +303,7 @@ fn extract_applies_the_minimum_release_age_overrides() {
     assert_eq!(config.minimum_release_age, Some(1440));
     assert!(config.minimum_release_age_ignore_missing_time);
     assert_eq!(config.minimum_release_age_strict, None);
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.minimum_release_age, Some(0));
     assert!(!config.minimum_release_age_ignore_missing_time);
     assert_eq!(config.minimum_release_age_strict, Some(false));
@@ -313,7 +316,7 @@ fn max_sockets_overrides_win_over_the_config_layers_in_either_spelling() {
         ConfigOverrides::extract(argv(["pacquet", "--config.maxsockets=4", "install"]));
     assert_eq!(remaining, argv(["pacquet", "install"]));
     let mut config = Config { max_sockets: Some(2), ..Config::default() };
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.max_sockets, Some(4));
 
     let (overrides, _) = ConfigOverrides::extract(argv([
@@ -323,7 +326,7 @@ fn max_sockets_overrides_win_over_the_config_layers_in_either_spelling() {
         "install",
     ]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.max_sockets, Some(9), "the canonical spelling wins over npm's");
 }
 
@@ -337,7 +340,7 @@ fn repeated_minimum_release_age_exclude_overrides_collect_into_a_list() {
         minimum_release_age_exclude: Some(vec!["from-yaml".to_string()]),
         ..Config::default()
     };
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(
         config.minimum_release_age_exclude,
         Some(vec!["pnpm".to_string(), "@pnpm/exe".to_string()]),
@@ -352,7 +355,7 @@ fn node_linker_override_rederives_prefer_symlinked_executables() {
     let mut config = Config { node_linker: NodeLinker::Hoisted, ..Config::default() };
     config.apply_prefer_symlinked_executables_derivation();
     assert_eq!(config.prefer_symlinked_executables, Some(true));
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.node_linker, NodeLinker::Isolated);
     assert_eq!(config.prefer_symlinked_executables, None);
 
@@ -361,7 +364,7 @@ fn node_linker_override_rederives_prefer_symlinked_executables() {
     let (overrides, _) =
         ConfigOverrides::extract(argv(["pacquet", "--config.node-linker=hoisted", "install"]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.prefer_symlinked_executables, Some(true));
 
     // An explicit `false` — recorded in `explicit_settings` by the
@@ -372,7 +375,7 @@ fn node_linker_override_rederives_prefer_symlinked_executables() {
     config
         .explicit_settings
         .insert("preferSymlinkedExecutables".to_string(), serde_json::Value::Bool(false));
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.node_linker, NodeLinker::Hoisted);
     assert_eq!(config.prefer_symlinked_executables, Some(false));
 }
@@ -384,14 +387,14 @@ fn extract_applies_ignore_scripts_override() {
     assert_eq!(remaining, argv(["pacquet", "pack"]));
     let mut config = Config::default();
     assert!(!config.ignore_scripts);
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert!(config.ignore_scripts);
     assert_eq!(config.explicit_settings.get("ignoreScripts"), Some(&serde_json::Value::Bool(true)));
 
     let (overrides, _) =
         ConfigOverrides::extract(argv(["pacquet", "--config.ignore-scripts=false", "pack"]));
     let mut config = Config { ignore_scripts: true, ..Config::default() };
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert!(!config.ignore_scripts);
     assert_eq!(
         config.explicit_settings.get("ignoreScripts"),
@@ -422,7 +425,7 @@ fn extract_applies_default_parity_overrides() {
     assert_eq!(remaining, argv(["pacquet", "install"]));
 
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert!(!config.bail);
     assert!(config.ci);
     assert_eq!(config.color, ColorMode::Never);
@@ -449,7 +452,7 @@ fn explicit_lockfile_override_wins_over_package_lock() {
         "install",
     ]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert!(!config.package_lock);
     assert!(config.lockfile);
 }
@@ -467,7 +470,7 @@ fn config_tokens_after_external_command_stay_in_argv() {
     let expected = argv(["pacquet", "--dir", "project", "commitlint", "--config.foo=bar"]);
     assert_eq!(remaining, expected);
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, "https://example.test/");
 }
 
@@ -487,7 +490,7 @@ fn non_utf8_token_stops_config_token_extraction() {
     assert_eq!(remaining, expected);
 
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, "https://example.test/");
 }
 
@@ -505,7 +508,7 @@ fn last_value_wins_for_repeated_keys() {
         "--config.registry=https://second.test/",
     ]));
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, "https://second.test/");
     assert_eq!(config.package_manager_bootstrap.registry, "https://second.test/");
 }
@@ -523,7 +526,7 @@ fn dotted_proxy_overrides_apply_to_network_config() {
     config.proxy.https_proxy = Some("http://yaml.example:9443".to_string());
     config.proxy.http_proxy = Some("http://yaml.example:9080".to_string());
     config.package_manager_bootstrap.proxy = config.proxy.clone();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
 
     assert_eq!(config.proxy.https_proxy.as_deref(), Some("http://proxy.example:8443"));
     assert_eq!(config.proxy.http_proxy.as_deref(), Some("http://proxy.example:8080"));
@@ -542,7 +545,7 @@ fn apply_is_a_noop_when_no_overrides_set() {
     let (overrides, _) = ConfigOverrides::extract(argv(["pacquet", "install"]));
     let default_registry = Config::default().registry;
     let mut config = Config::default();
-    overrides.apply(&mut config);
+    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.registry, default_registry);
 }
 
@@ -684,4 +687,201 @@ fn empty_store_dir_override_uses_the_injected_default_provider() {
         config.explicit_settings.get("storeDir"),
         Some(&serde_json::Value::String(String::new())),
     );
+}
+
+#[test]
+fn extract_accepts_the_install_settings_as_bare_flags() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--package-import-method=hardlink",
+        "--child-concurrency=3",
+        "--strict-peer-dependencies",
+        "--side-effects-cache",
+        "--side-effects-cache-readonly",
+        "--optimistic-repeat-install",
+        "--trust-policy=no-downgrade",
+        "--trust-policy-exclude=lodash",
+        "--trust-policy-ignore-after=5",
+        "--no-lockfile",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.package_import_method, PackageImportMethod::Hardlink);
+    assert_eq!(config.child_concurrency, 3);
+    assert!(config.strict_peer_dependencies);
+    assert!(config.side_effects_cache);
+    assert!(config.side_effects_cache_readonly);
+    assert!(config.optimistic_repeat_install);
+    assert_eq!(config.trust_policy, TrustPolicy::NoDowngrade);
+    assert_eq!(config.trust_policy_exclude, Some(vec!["lodash".to_string()]));
+    assert_eq!(config.trust_policy_ignore_after, Some(5));
+    assert!(!config.lockfile);
+}
+
+#[test]
+fn a_value_taking_setting_reads_the_next_argv_token() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "--package-import-method", "copy", "install"]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.package_import_method, PackageImportMethod::Copy);
+}
+
+#[test]
+fn a_boolean_setting_claims_the_next_token_only_when_it_spells_a_boolean() {
+    for (tokens, expected) in [
+        (vec!["--side-effects-cache", "install"], true),
+        (vec!["--side-effects-cache", "false", "install"], false),
+        (vec!["--side-effects-cache", "true", "install"], true),
+    ] {
+        let (overrides, remaining) =
+            ConfigOverrides::extract(argv(["pacquet"]).into_iter().chain(argv(tokens)));
+        assert_eq!(remaining, argv(["pacquet", "install"]));
+
+        let mut config = Config::default();
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert_eq!(config.side_effects_cache, expected);
+    }
+}
+
+#[test]
+fn a_repeated_list_setting_accumulates_its_values() {
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--hoist-pattern",
+        "eslint",
+        "--hoist-pattern=babel",
+        "--public-hoist-pattern=types",
+    ]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.hoist_pattern, Some(vec!["eslint".to_string(), "babel".to_string()]));
+    assert_eq!(config.public_hoist_pattern, Some(vec!["types".to_string()]));
+}
+
+#[test]
+fn no_hoist_clears_the_private_hoist_pattern() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--no-hoist",
+        "--hoist-pattern=eslint",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(!config.hoist);
+    assert_eq!(config.hoist_pattern, None);
+}
+
+#[test]
+fn shamefully_hoist_wins_over_a_public_hoist_pattern_on_the_same_command_line() {
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--public-hoist-pattern=types",
+        "--shamefully-hoist",
+    ]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.public_hoist_pattern, Some(vec!["*".to_string()]));
+}
+
+#[test]
+fn the_modules_and_virtual_store_dirs_are_anchored_at_the_workspace_root() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--modules-dir=custom_modules",
+        "--virtual-store-dir=custom_store",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let workspace_dir = PathBuf::from("/workspace");
+    let mut config = Config { workspace_dir: Some(workspace_dir.clone()), ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace/pkg"));
+    assert_eq!(config.modules_dir, workspace_dir.join("custom_modules"));
+    assert_eq!(config.virtual_store_dir, workspace_dir.join("custom_store"));
+}
+
+#[test]
+fn the_modules_dir_alone_re_anchors_the_default_virtual_store() {
+    let (overrides, _) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--modules-dir=custom_modules"]));
+
+    let workspace_dir = PathBuf::from("/workspace");
+    let mut config = Config { workspace_dir: Some(workspace_dir.clone()), ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.virtual_store_dir, workspace_dir.join("custom_modules/.pnpm"));
+}
+
+#[test]
+fn the_global_dir_override_re_derives_the_global_package_dir() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "add", "-g", "--global-dir", "/custom/global"]));
+    assert_eq!(remaining, argv(["pacquet", "add", "-g"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.global_dir.as_deref(), Some(Path::new("/custom/global")));
+    assert_eq!(
+        config.global_pkg_dir,
+        Some(Path::new("/custom/global").join(pnpm_config::GLOBAL_LAYOUT_VERSION)),
+    );
+}
+
+#[test]
+fn a_setting_flag_does_not_swallow_the_command_it_precedes() {
+    let (_, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--modules-dir",
+        "custom_modules",
+        "run",
+        "build",
+        "--hoist-pattern=eslint",
+    ]));
+
+    // `--hoist-pattern` is past the script name, so it is the script's.
+    assert_eq!(remaining, argv(["pacquet", "run", "build", "--hoist-pattern=eslint"]));
+}
+
+/// A setting is stripped from argv before clap runs, so one spelled like
+/// a *global* option would claim that option on every command line — a
+/// command's own option is left for clap instead, and can collide.
+#[test]
+fn no_bare_setting_flag_shadows_a_global_option() {
+    let grammar = crate::cli_args::grammar();
+    let declared: Vec<&str> = grammar
+        .get_arguments()
+        .flat_map(|arg| {
+            arg.get_long().into_iter().chain(arg.get_all_aliases().into_iter().flatten())
+        })
+        .collect();
+    let shadowed: Vec<&str> = super::BARE_SETTING_FLAGS
+        .iter()
+        .map(|&(setting, _)| setting)
+        .filter(|setting| declared.contains(setting))
+        .collect();
+    assert_eq!(shadowed, Vec::<&str>::new());
+}
+
+/// `pnpm clean --lockfile` removes lockfiles; it does not turn the
+/// `lockfile` setting on.
+#[test]
+fn a_command_option_wins_over_the_setting_of_the_same_name() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", "clean", "--lockfile"]));
+    assert_eq!(remaining, argv(["pacquet", "clean", "--lockfile"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.lockfile, Config::default().lockfile);
 }

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -961,8 +961,9 @@ fn a_boolean_settings_value_is_claimed_even_when_a_command_declares_the_name() {
     assert_eq!(config.registry, "https://example.test/");
 }
 
-/// A `--` or another flag is never a setting's value: claiming one would
-/// drop the separator and point `modulesDir` at a directory named `--`.
+/// A `--` or another flag is never a free-form setting's value: claiming
+/// one would drop the separator and point `modulesDir` at a directory
+/// named `--`.
 #[test]
 fn a_setting_flag_never_claims_a_separator_or_another_flag() {
     for tokens in [
@@ -982,5 +983,29 @@ fn a_setting_flag_never_claims_a_separator_or_another_flag() {
         let mut config = Config::default();
         overrides.apply(&mut config, Path::new("/workspace"));
         assert_eq!(config.modules_dir, Config::default().modules_dir, "{tokens:?}");
+    }
+}
+
+/// A parsed setting decides for itself: `childConcurrency` reads a
+/// negative value as "every core but this many", so the flag claims it
+/// even though it opens with `-`.
+#[test]
+fn a_numeric_setting_claims_a_negative_value() {
+    for tokens in [["--child-concurrency", "-1"].as_slice(), &["--child-concurrency=-1"]] {
+        let command_line = ["pacquet", "install"]
+            .into_iter()
+            .chain(tokens.iter().copied())
+            .map(OsString::from)
+            .collect::<Vec<_>>();
+        let (overrides, remaining) = ConfigOverrides::extract(command_line);
+        assert_eq!(remaining, argv(["pacquet", "install"]), "{tokens:?}");
+
+        let mut config = Config::default();
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert_eq!(
+            config.child_concurrency,
+            pnpm_config::resolve_child_concurrency(Some(-1)),
+            "{tokens:?}",
+        );
     }
 }

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -940,3 +940,23 @@ fn a_boolean_settings_explicit_value_does_not_move_the_command_boundary() {
     assert!(!config.strict_peer_dependencies);
     assert_eq!(config.registry, "https://example.test/");
 }
+
+/// `lockfile` is both a setting and `clean`'s own option, so the boundary
+/// scan and the extraction have to agree on how much `--lockfile true`
+/// claims even when the command is not `clean`.
+#[test]
+fn a_boolean_settings_value_is_claimed_even_when_a_command_declares_the_name() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--lockfile",
+        "true",
+        "--config.registry=https://example.test/",
+        "install",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config { lockfile: false, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.lockfile);
+    assert_eq!(config.registry, "https://example.test/");
+}

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -227,7 +227,7 @@ fn option_width(arg: &str, next: Option<&str>, arity: &ArgTable) -> Option<usize
         // the same option owns it, there and here.
         return match arity.long_consumes_value(name) {
             Some(consumes_value) => Some(1 + usize::from(consumes_value)),
-            None => Some(crate::config_overrides::bare_setting_flag_width(name, next).unwrap_or(1)),
+            None => Some(crate::config_overrides::bare_setting_flag_width(name, next)),
         };
     }
     let short = rest.chars().next().expect("checked non-empty");

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -10,7 +10,7 @@
 
 use crate::{cli_args::grammar, flag_relocation::ArgTable};
 use clap::Command;
-use std::ffi::OsString;
+use std::{collections::HashSet, ffi::OsString};
 
 /// Commands whose own arguments are unconditionally a foreign command line.
 ///
@@ -65,10 +65,7 @@ pub(crate) struct CommandBoundary {
 /// The boundary implied by the command alone, ignoring any `--`.
 pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
     let command = grammar();
-    // Both halves of the union: a global lives on the top-level command,
-    // a command's own options on its subcommand.
-    let mut arity = ArgTable::top_level(command);
-    arity.absorb_subcommands(command);
+    let arity = union_arity();
     let mut index = 1;
     let mut prefix_allowed = true;
     while index < argv.len() {
@@ -80,7 +77,7 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
             // The separator governs from here; see `passthrough_from`.
             return None;
         }
-        if let Some(width) = option_width(arg, &arity) {
+        if let Some(width) = option_width(arg, arity) {
             index += width;
             continue;
         }
@@ -95,7 +92,7 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
             return Some(CommandBoundary { index: index + 1, is_script_shortcut: false });
         };
         if COMMANDS_TAKING_A_FOREIGN_COMMAND_LINE.contains(&subcommand.get_name()) {
-            let index = next_positional(argv, index + 1, &arity)? + 1;
+            let index = next_positional(argv, index + 1, arity)? + 1;
             return Some(CommandBoundary { index, is_script_shortcut: false });
         }
         if SCRIPT_SHORTCUTS.contains(&subcommand.get_name()) {
@@ -105,7 +102,7 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
             // `with` splits on its version. Any version but `current` execs a
             // child pnpm, whose command line is its own, so stripping an
             // override there would lose it.
-            let version = next_positional(argv, index + 1, &arity)?;
+            let version = next_positional(argv, index + 1, arity)?;
             if argv[version] != "current" {
                 return Some(CommandBoundary { index: version + 1, is_script_shortcut: false });
             }
@@ -122,6 +119,54 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
         return None;
     }
     None
+}
+
+/// The long options — including aliases — that the command named in `argv`
+/// declares itself.
+///
+/// A setting spelled like one of them belongs to the command: nopt merges
+/// the universal setting table with the invoked command's own table, and
+/// the command's entry is the one its handler reads (`pnpm clean
+/// --lockfile` removes lockfiles rather than turning the `lockfile`
+/// setting on). Empty when argv names no known command.
+pub(crate) fn subcommand_option_names(argv: &[OsString]) -> HashSet<&'static str> {
+    let command = grammar();
+    let arity = union_arity();
+    let mut index = 1;
+    while let Some(positional) = next_positional(argv, index, arity) {
+        let Some(name) = argv[positional].to_str().filter(|name| *name != "--") else {
+            break;
+        };
+        if COMMAND_PREFIXES.contains(&name) {
+            index = positional + 1;
+            continue;
+        }
+        let Some(subcommand) = matching_subcommand(command, name) else {
+            break;
+        };
+        return subcommand
+            .get_arguments()
+            .flat_map(|arg| {
+                arg.get_long().into_iter().chain(arg.get_all_aliases().into_iter().flatten())
+            })
+            .collect();
+    }
+    HashSet::new()
+}
+
+/// The arity view the pre-clap passes share: the top-level grammar with
+/// every subcommand's options folded in, because the command is not known
+/// yet. Both halves of the union — a global lives on the top-level
+/// command, a command's own options on its subcommand — and both are
+/// derived from the static [`grammar`], so the table is built once.
+fn union_arity() -> &'static ArgTable {
+    static ARITY: std::sync::OnceLock<ArgTable> = std::sync::OnceLock::new();
+    ARITY.get_or_init(|| {
+        let command = grammar();
+        let mut arity = ArgTable::top_level(command);
+        arity.absorb_subcommands(command);
+        arity
+    })
 }
 
 /// The index of the first positional at or after `from`, or `None` when the
@@ -163,7 +208,15 @@ fn option_width(arg: &str, arity: &ArgTable) -> Option<usize> {
         }
         let (name, has_inline_value) =
             long.split_once('=').map_or((long, false), |(name, _)| (name, true));
-        let consumes_value = arity.long_consumes_value(name).unwrap_or(false);
+        // A setting spelled as a bare flag is stripped by
+        // [`ConfigOverrides::extract`], which computes this boundary — so
+        // clap declares no arity for it and the setting table answers
+        // instead. Clap goes first: a command that declares the same
+        // option owns it, there and here.
+        let consumes_value = arity
+            .long_consumes_value(name)
+            .or_else(|| crate::config_overrides::bare_setting_flag_consumes_value(name))
+            .unwrap_or(false);
         return Some(if consumes_value && !has_inline_value { 2 } else { 1 });
     }
     let short = rest.chars().next().expect("checked non-empty");

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -77,7 +77,7 @@ pub(crate) fn command_boundary(argv: &[OsString]) -> Option<CommandBoundary> {
             // The separator governs from here; see `passthrough_from`.
             return None;
         }
-        if let Some(width) = option_width(arg, arity) {
+        if let Some(width) = option_width(arg, next_token(argv, index), arity) {
             index += width;
             continue;
         }
@@ -182,7 +182,7 @@ fn next_positional(argv: &[OsString], from: usize, arity: &ArgTable) -> Option<u
             // script name to anchor on.
             return Some(index);
         }
-        match option_width(arg, arity) {
+        match option_width(arg, next_token(argv, index), arity) {
             Some(width) => index += width,
             None => return Some(index),
         }
@@ -190,8 +190,14 @@ fn next_positional(argv: &[OsString], from: usize, arity: &ArgTable) -> Option<u
     None
 }
 
+/// The token after the one at `index`, as far as it can be classified.
+fn next_token(argv: &[OsString], index: usize) -> Option<&str> {
+    argv.get(index + 1).and_then(|token| token.to_str())
+}
+
 /// The number of argv slots `arg` occupies when it is an option, or `None`
-/// when it is a positional.
+/// when it is a positional. `next` is the token after it, which decides
+/// the width of a bare boolean setting flag.
 ///
 /// Arity comes from clap rather than a hand-listed set of option names: a
 /// value-taking option missing from such a list makes its *value* look like
@@ -199,25 +205,27 @@ fn next_positional(argv: &[OsString], from: usize, arity: &ArgTable) -> Option<u
 /// (`pnpm dlx --package cowsay --silent cowsay` would forward pnpm's own
 /// `--silent`). The union across subcommands is what the pre-clap passes
 /// have to work with, since the command is not yet known.
-fn option_width(arg: &str, arity: &ArgTable) -> Option<usize> {
+fn option_width(arg: &str, next: Option<&str>, arity: &ArgTable) -> Option<usize> {
     let rest = arg.strip_prefix('-').filter(|rest| !rest.is_empty())?;
     if let Some(long) = rest.strip_prefix('-') {
         // `--config.<key>=<value>` is always self-contained.
         if long.starts_with("config.") {
             return Some(1);
         }
-        let (name, has_inline_value) =
-            long.split_once('=').map_or((long, false), |(name, _)| (name, true));
+        // An inline value is self-contained whatever the option's arity.
+        let Some(name) = long.split_once('=').map_or(Some(long), |_| None) else {
+            return Some(1);
+        };
         // A setting spelled as a bare flag is stripped by
         // [`ConfigOverrides::extract`], which computes this boundary — so
         // clap declares no arity for it and the setting table answers
-        // instead. Clap goes first: a command that declares the same
-        // option owns it, there and here.
-        let consumes_value = arity
-            .long_consumes_value(name)
-            .or_else(|| crate::config_overrides::bare_setting_flag_consumes_value(name))
-            .unwrap_or(false);
-        return Some(if consumes_value && !has_inline_value { 2 } else { 1 });
+        // instead, with the same next-token rule extraction applies. Clap
+        // goes first: a command that declares the same option owns it,
+        // there and here.
+        return match arity.long_consumes_value(name) {
+            Some(consumes_value) => Some(1 + usize::from(consumes_value)),
+            None => Some(crate::config_overrides::bare_setting_flag_width(name, next).unwrap_or(1)),
+        };
     }
     let short = rest.chars().next().expect("checked non-empty");
     let is_bare_short = rest.chars().count() == 1;

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -219,9 +219,12 @@ fn option_width(arg: &str, next: Option<&str>, arity: &ArgTable) -> Option<usize
         // A setting spelled as a bare flag is stripped by
         // [`ConfigOverrides::extract`], which computes this boundary — so
         // clap declares no arity for it and the setting table answers
-        // instead, with the same next-token rule extraction applies. Clap
-        // goes first: a command that declares the same option owns it,
-        // there and here.
+        // instead, with the same next-token rule extraction applies.
+        if crate::config_overrides::bare_boolean_setting_claims(name, next) {
+            return Some(2);
+        }
+        // Clap goes first for every other shape: a command that declares
+        // the same option owns it, there and here.
         return match arity.long_consumes_value(name) {
             Some(consumes_value) => Some(1 + usize::from(consumes_value)),
             None => Some(crate::config_overrides::bare_setting_flag_width(name, next).unwrap_or(1)),

--- a/pnpm/crates/cli/tests/suite/lifecycle_scripts.rs
+++ b/pnpm/crates/cli/tests/suite/lifecycle_scripts.rs
@@ -753,7 +753,14 @@ mod dependency_build_scripts {
 
         // The dependency was still added and materialized; only its
         // blocked scripts did not run. Mirrors pnpm, which writes the
-        // artifacts before failing.
+        // manifest and the artifacts before failing.
+        let manifest: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(workspace.join("package.json")).unwrap())
+                .expect("parse package.json");
+        assert_eq!(
+            manifest["dependencies"],
+            serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
+        );
         let pkg_dir = workspace.join(
             "node_modules/.pnpm/@pnpm.e2e+pre-and-postinstall-scripts-example@1.0.0\
              /node_modules/@pnpm.e2e/pre-and-postinstall-scripts-example",

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -108,6 +108,7 @@ mod scope_report;
 mod search;
 mod self_update;
 mod set_script;
+mod setting_flags;
 mod side_effects_cache;
 mod stage;
 mod stale_pin_dedupe;

--- a/pnpm/crates/cli/tests/suite/setting_flags.rs
+++ b/pnpm/crates/cli/tests/suite/setting_flags.rs
@@ -1,0 +1,55 @@
+//! Settings spelled as bare `--<setting>` command-line flags.
+//!
+//! pnpm types every setting for its argument parser, so each one is
+//! accepted on the command line as well as in `pnpm-workspace.yaml`
+//! ([pnpm/pnpm#14281](https://github.com/pnpm/pnpm/issues/14281)).
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::bin::CommandTempCwd;
+use pretty_assertions::assert_eq;
+use std::{fs, process::Command};
+
+/// Every setting flag, the value it is given, and what `pnpm config get`
+/// reports back for it.
+const SETTING_FLAGS: [(&[&str], &str, &str); 17] = [
+    (&["--package-import-method", "hardlink"], "package-import-method", "hardlink"),
+    (&["--hoist-pattern=eslint"], "hoist-pattern", "[\n  \"eslint\"\n]"),
+    (&["--public-hoist-pattern=@types/*"], "public-hoist-pattern", "[\n  \"@types/*\"\n]"),
+    (&["--no-hoist"], "hoist", "false"),
+    (&["--global-dir=/custom/global"], "global-dir", "/custom/global"),
+    (&["--virtual-store-dir=custom_store"], "virtual-store-dir", "custom_store"),
+    (&["--modules-dir=custom_modules"], "modules-dir", "custom_modules"),
+    (&["--child-concurrency=3"], "child-concurrency", "3"),
+    (&["--no-lockfile"], "lockfile", "false"),
+    (&["--strict-peer-dependencies"], "strict-peer-dependencies", "true"),
+    (&["--side-effects-cache"], "side-effects-cache", "true"),
+    (&["--side-effects-cache-readonly"], "side-effects-cache-readonly", "true"),
+    (&["--trust-policy", "no-downgrade"], "trust-policy", "no-downgrade"),
+    (&["--trust-policy-exclude=lodash"], "trust-policy-exclude", "[\n  \"lodash\"\n]"),
+    (&["--trust-policy-ignore-after=5"], "trust-policy-ignore-after", "5"),
+    (&["--optimistic-repeat-install"], "optimistic-repeat-install", "true"),
+    (&["--shamefully-hoist"], "shamefully-hoist", "true"),
+];
+
+#[test]
+fn every_setting_flag_reaches_the_config() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages: []\n")
+        .expect("write pnpm-workspace.yaml");
+
+    for (flag, setting, expected) in SETTING_FLAGS {
+        let output = Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&workspace)
+            .with_args(flag)
+            .with_args(["config", "get", setting])
+            .output()
+            .expect("run pacquet config get");
+        eprintln!("{flag:?} stderr={}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success(), "{flag:?} was rejected");
+        assert_eq!(String::from_utf8_lossy(&output.stdout).trim_end(), expected, "{flag:?}");
+    }
+
+    drop(root);
+}

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -6,8 +6,8 @@ use crate::{
         WriteWorkspaceCatalogsError, post_install_prune, write_workspace_catalogs,
         write_workspace_catalogs_selected,
     },
-    decide_catalog_outcome, emit_initial_package_manifest, included_direct_groups,
-    package_manifest_prefix,
+    decide_catalog_outcome, defer_ignored_builds, emit_initial_package_manifest,
+    included_direct_groups, package_manifest_prefix,
     resolution_policy::{PickPolicy, pick_package_context},
     resolve_latest::LatestPicker,
     selected_project_indices,
@@ -15,6 +15,7 @@ use crate::{
 use derive_more::{Display, Error};
 use futures_util::{StreamExt, stream::FuturesOrdered};
 use miette::Diagnostic;
+use pipe_trait::Pipe;
 use pnpm_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
@@ -269,7 +270,7 @@ where
         // reach the resolver.
         let named_a_version = !seed_policies.is_empty();
 
-        Install {
+        let ignored_builds = Install {
             tarball_mem_cache,
             http_client,
             http_client_arc,
@@ -329,6 +330,7 @@ where
         }
         .run::<Reporter>()
         .await
+        .pipe(defer_ignored_builds)
         .map_err(AddError::Install)?;
 
         persist_manifest::<Reporter>(manifest)?;
@@ -336,6 +338,9 @@ where
         post_install_prune(config, Some(&catalog_ctx.workspace_dir), manifest)
             .map_err(AddError::WriteWorkspaceManifest)?;
 
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(AddError::Install(ignored_builds));
+        }
         Ok(())
     }
 
@@ -426,7 +431,7 @@ where
         // reach the resolver.
         let named_a_version = !seed_policies.is_empty();
 
-        Box::pin(
+        let ignored_builds = Box::pin(
             Install {
                 tarball_mem_cache,
                 http_client,
@@ -484,12 +489,16 @@ where
             }),
         )
         .await
+        .pipe(defer_ignored_builds)
         .map_err(AddError::Install)?;
 
         persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
 
         post_install_prune(config, Some(&prepared.workspace_dir), manifest)
             .map_err(AddError::WriteWorkspaceManifest)?;
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(AddError::Install(ignored_builds));
+        }
         Ok(())
     }
 }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -867,6 +867,26 @@ pub enum InstallError {
     ConfigConflictVirtualStoreOnlyWithNoModulesDir,
 }
 
+/// Hold back an [`InstallError::IgnoredBuilds`] verdict so the calling
+/// command can finish writing `package.json` and `pnpm-workspace.yaml`
+/// before it aborts: the install materialized the tree, and pnpm reports
+/// the blocked builds only after both writes (`handleIgnoredBuilds` in
+/// `installDeps`). The returned error is the caller's to raise once those
+/// writes are done.
+///
+/// Every other error propagates straight away and leaves the manifests
+/// untouched, matching pnpm — which throws those from inside the install
+/// itself, before it reaches the writes.
+pub fn defer_ignored_builds(
+    outcome: Result<(), InstallError>,
+) -> Result<Option<InstallError>, InstallError> {
+    match outcome {
+        Ok(()) => Ok(None),
+        Err(error @ InstallError::IgnoredBuilds { .. }) => Ok(Some(error)),
+        Err(error) => Err(error),
+    }
+}
+
 struct InstallRunOptions<'install, 'selection> {
     lockfile_verification_override: Option<LockfileVerificationOverride<'install>>,
     rebuild: Option<RebuildOptions>,

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -5,11 +5,12 @@ use crate::{
         WriteWorkspaceCatalogsError, post_install_prune, write_workspace_catalogs,
         write_workspace_catalogs_selected,
     },
-    emit_initial_package_manifest, included_direct_groups, package_manifest_prefix,
-    selected_project_indices,
+    defer_ignored_builds, emit_initial_package_manifest, included_direct_groups,
+    package_manifest_prefix, selected_project_indices,
 };
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pipe_trait::Pipe;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::Config;
 use pnpm_lockfile::{Lockfile, MaybeLazyLockfile};
@@ -103,7 +104,7 @@ impl Remove<'_> {
         validate_removable(manifest, package_names, save_type).map_err(RemoveError::Validation)?;
         prepare_manifest::<Reporter>(manifest, package_names, save_type);
 
-        Install {
+        let ignored_builds = Install {
             tarball_mem_cache,
             http_client,
             http_client_arc,
@@ -155,6 +156,7 @@ impl Remove<'_> {
         }
         .run::<Reporter>()
         .await
+        .pipe(defer_ignored_builds)
         .map_err(RemoveError::Install)?;
 
         persist_manifest::<Reporter>(manifest)?;
@@ -164,6 +166,9 @@ impl Remove<'_> {
 
         post_install_prune(config, None, manifest).map_err(RemoveError::WriteWorkspaceManifest)?;
 
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(RemoveError::Install(ignored_builds));
+        }
         Ok(())
     }
 
@@ -206,7 +211,7 @@ impl Remove<'_> {
             manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf()
         });
 
-        Install {
+        let ignored_builds = Install {
             tarball_mem_cache,
             http_client,
             http_client_arc,
@@ -250,6 +255,7 @@ impl Remove<'_> {
             active_manifest_is_standin,
         })
         .await
+        .pipe(defer_ignored_builds)
         .map_err(RemoveError::Install)?;
 
         persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
@@ -259,6 +265,9 @@ impl Remove<'_> {
 
         post_install_prune(config, Some(&workspace_root), manifest)
             .map_err(RemoveError::WriteWorkspaceManifest)?;
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(RemoveError::Install(ignored_builds));
+        }
         Ok(())
     }
 }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -6,7 +6,7 @@ use crate::{
         WriteWorkspaceCatalogsError, post_install_prune, write_workspace_catalogs,
         write_workspace_catalogs_selected,
     },
-    decide_catalog, emit_initial_package_manifest, included_direct_groups,
+    decide_catalog, defer_ignored_builds, emit_initial_package_manifest, included_direct_groups,
     manifest_spec_bumps::ManifestSpecBumps,
     package_manifest_prefix,
     resolution_policy::{PickPolicy, create_configured_npm_resolver},
@@ -16,6 +16,7 @@ use chrono::{DateTime, Utc};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
+use pipe_trait::Pipe;
 use pnpm_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
@@ -436,7 +437,7 @@ impl Update<'_> {
             pnpmfile_hook_override: read_package_hook.as_ref().map(|(hook, _)| Arc::clone(hook)),
             workspace_projects_override: None,
         };
-        match lockfile_specifier_project_manifests {
+        let ignored_builds = match lockfile_specifier_project_manifests {
             Some(manifests) => {
                 install
                     .run_with_lockfile_specifier_project_manifests::<Reporter>(
@@ -450,6 +451,7 @@ impl Update<'_> {
                 None => install.run::<Reporter>().await,
             },
         }
+        .pipe(defer_ignored_builds)
         .map_err(UpdateError::Install)?;
 
         let applied = bumps.map(|bumps| bumps.applied.into_inner().expect("never poisoned"));
@@ -479,6 +481,9 @@ impl Update<'_> {
                 .map_err(UpdateError::WriteWorkspaceManifest)?;
         }
 
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(UpdateError::Install(ignored_builds));
+        }
         Ok(())
     }
 
@@ -638,7 +643,7 @@ impl Update<'_> {
             install_dirs,
             active_manifest_is_standin,
         };
-        match lockfile_specifier_project_manifests {
+        let ignored_builds = match lockfile_specifier_project_manifests {
             Some(manifests) => {
                 install
                     .run_selected_with_lockfile_specifier_project_manifests::<Reporter>(
@@ -657,6 +662,7 @@ impl Update<'_> {
                 None => install.run_selected::<Reporter>(selection).await,
             },
         }
+        .pipe(defer_ignored_builds)
         .map_err(UpdateError::Install)?;
 
         let applied = bumps.map(|bumps| bumps.applied.into_inner().expect("never poisoned"));
@@ -692,6 +698,9 @@ impl Update<'_> {
                 prepared.workspace_dir_for_catalogs.as_deref().unwrap_or(&workspace_root);
             post_install_prune(config, Some(workspace_dir), manifest)
                 .map_err(UpdateError::WriteWorkspaceManifest)?;
+        }
+        if let Some(ignored_builds) = ignored_builds {
+            return Err(UpdateError::Install(ignored_builds));
         }
         Ok(())
     }


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14281.

pnpm declares a `nopt` type for every setting, which makes each one spellable on
the command line as well as in `pnpm-workspace.yaml`. The Rust CLI declares a
clap flag for only a subset and stripped just three settings out of argv before
clap ran, so sixteen flags that pnpm 11 accepts aborted the parse with
`error: unexpected argument '--…' found`:

`--package-import-method`, `--hoist-pattern`, `--public-hoist-pattern`,
`--no-hoist`, `--global-dir`, `--virtual-store-dir`, `--modules-dir`,
`--child-concurrency`, `--no-lockfile`, `--strict-peer-dependencies`,
`--side-effects-cache`, `--side-effects-cache-readonly`, `--trust-policy`,
`--trust-policy-exclude`, `--trust-policy-ignore-after`,
`--optimistic-repeat-install`. (The issue's other two, `--shamefully-hoist` and
`--fix-lockfile`, already work on `main`.)

All sixteen are accepted again, anywhere on the command line, spelled either
`--setting=value` or `--setting value`.

Worth a reviewer's attention:

- **`pnpm clean --lockfile` keeps its own meaning.** nopt merges the universal
  setting table with the invoked command's table, and the command's entry is
  the one its handler reads. The pre-clap strip now resolves the subcommand
  first and leaves its own options for clap, so `clean --lockfile` still removes
  lockfiles instead of turning the `lockfile` setting on. `add`'s
  `--virtual-store-dir` was dead code (declared, never read) that shadowed the
  setting, so it is removed — the flag now does what it says on `add` too.
- **A value the flag does not take is reported, never dropped.** An unknown
  `--trust-policy`, a non-numeric `--child-concurrency`, a `--modules-dir` with
  no value, and a `--modules-dir --` that would otherwise swallow the separator
  all go back to clap, which names them. Silently dropping any of them leaves
  the command running under a setting the user believes they changed — for
  `trustPolicy` that means failing open on a supply-chain check.
- **A second bug, surfaced by the first fix.** `--config.optimistic-repeat-install=false`
  used to be silently dropped, which was masking a manifest bug in a test: `add`
  / `update` / `remove` returned `ERR_PNPM_IGNORED_BUILDS` *before* writing
  `package.json`, so a strict install left the dependency it had just
  materialized out of the manifest and the next install removed it again. pnpm's
  `handleIgnoredBuilds` runs after `writeProjectManifest`, so that verdict is now
  deferred until the manifest writes are done. `add_fails_under_strict_dep_builds_when_a_build_is_ignored`
  gains the manifest assertion pnpm's own test makes.

No TypeScript change: pnpm 11 already accepts every flag listed and already
writes the manifest before the ignored-builds check. This is the Rust CLI
catching up to it.

## Squash Commit Body

```text
pnpm types every setting for `nopt`, so each one is spellable on the
command line as well as in `pnpm-workspace.yaml`. pacquet declared a clap
flag for only a subset and stripped just three settings out of argv before
clap ran, so sixteen flags that pnpm 11 accepts aborted the parse with
"unexpected argument".

`BARE_SETTING_FLAGS` grows from a flat list of three names into a table of
nineteen `(setting, arity)` pairs, where a value-taking arity carries the
predicate for the values that setting takes. The pre-clap pass reads the
arity to decide whether the token after the flag is its value, so both
`--package-import-method=hardlink` and `--package-import-method hardlink`
parse. A boolean claims the following token only when it spells one, and
nothing claims a token that opens with `-`: that is the `--` separator,
another flag, or a short option, and swallowing it would drop the
separator and point a path setting at a directory named `--`.

`parse_boundary` reads the same table, so the scan that locates the
subcommand steps over a setting's value instead of mistaking it for a
script name, and agrees with the extraction on the width even for a name
both a setting and a command declare. Its arity view is now built once and
shared by all four pre-clap passes.

A value the setting does not take — a misspelled boolean, an unknown
`--trust-policy`, a non-numeric `--child-concurrency`, or no value at all —
goes back to clap, which reports it. Dropping it instead would leave the
command running under a setting the user believes they changed, which for
`trustPolicy` means failing open on a supply-chain check.

nopt merges the universal setting table with the invoked command's own
table, and the command's entry is the one its handler reads: `pnpm clean
--lockfile` removes lockfiles rather than turning the `lockfile` setting
on. `subcommand_option_names` resolves the command ahead of the strip so
its own options are left for clap. `add`'s `--virtual-store-dir` was dead
code — declared, never read, and shadowing the setting — so it is gone.

The path-valued settings record their raw spelling in `explicit_settings`
and re-run the derivations that depend on them, so `--modules-dir` /
`--virtual-store-dir` move with a later `--lockfile-dir` pin,
`--global-dir` re-derives `globalPkgDir`, and `--no-hoist` nullifies
`hoistPattern` the way `hoist: false` does in yaml.

Honoring `optimisticRepeatInstall` from the command line surfaced a second
bug that a test had been masking: `add` / `update` / `remove` returned
`ERR_PNPM_IGNORED_BUILDS` before writing `package.json`, so a strict
install left the dependency it had just materialized out of the manifest
and the next install removed it again. pnpm's `handleIgnoredBuilds` runs
after `writeProjectManifest`, so that verdict is now deferred until the
manifest writes are done.

Closes pnpm/pnpm#14281.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored support for numerous pnpm configuration flags on the command line, including hoisting, directory, concurrency, lockfile, trust policy, and side-effects settings.
  * Command-line settings now support both `--setting=value` and `--setting value` formats and take precedence over configuration files.

* **Bug Fixes**
  * Configuration overrides now resolve relative to the selected project directory.
  * Dependency changes are saved before commands fail due to ignored build scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->