### PR TITLE
perf(deps-restorer): shim hoisted workspace bins without re-walking every importer

### DIFF
--- a/.changeset/targeted-workspace-bins.md
+++ b/.changeset/targeted-workspace-bins.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Workspace installs are substantially faster (~0.7 s on a 60-project workspace): after hoisting, pnpm now shims only the bins of publicly hoisted workspace packages instead of re-walking every project's `node_modules` to rediscover bins that were already linked.

--- a/pnpm/crates/cli/tests/suite/hoist.rs
+++ b/pnpm/crates/cli/tests/suite/hoist.rs
@@ -483,6 +483,60 @@ fn public_hoist_bin_is_linked_via_root_bin_dir() {
     drop((root, mock_instance));
 }
 
+/// A publicly hoisted *workspace* package's bin must land in
+/// `<root>/node_modules/.bin/`. Neither of the other two bin passes
+/// can produce it — `SymlinkDirectDependencies` runs before hoisting,
+/// and the post-build top-level pass resolves bins out of
+/// virtual-store slots, which a workspace project doesn't have — so
+/// the link phase shims the hoist plan's public workspace aliases
+/// directly.
+#[test]
+fn publicly_hoisted_workspace_package_bin_lands_in_root_bin_dir() {
+    let CommandTempCwd { pacquet, pnpm, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "private": true }).to_string(),
+    )
+    .expect("write root package.json");
+    write_workspace_yaml(
+        &workspace,
+        "packages:\n  - 'packages/*'\npublicHoistPattern:\n  - '@local/*'\n",
+    );
+
+    let pkg_dir = workspace.join("packages/foo");
+    fs::create_dir_all(&pkg_dir).expect("mkdir packages/foo");
+    fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::json!({
+            "name": "@local/foo",
+            "version": "1.0.0",
+            "private": true,
+            "bin": { "local-foo": "./cli.js" },
+            "dependencies": { "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write packages/foo/package.json");
+    fs::write(pkg_dir.join("cli.js"), "#!/usr/bin/env node\nconsole.log('local-foo')\n")
+        .expect("write packages/foo/cli.js");
+
+    generate_lockfile(pnpm);
+    pacquet.with_args(["install", "--frozen-lockfile"]).assert().success();
+
+    let alias_link = workspace.join("node_modules/@local/foo");
+    assert!(
+        is_symlink_or_junction(&alias_link).unwrap(),
+        "the workspace package must be publicly hoisted to {alias_link:?}",
+    );
+    let shim = workspace.join("node_modules/.bin/local-foo");
+    assert!(shim.exists(), "the hoisted workspace package's bin must be shimmed at {shim:?}");
+
+    drop((root, mock_instance));
+}
+
 /// Workspace install (pnpm/pacquet#431) lands per-importer
 /// `node_modules` layouts; hoist must walk every importer's direct
 /// deps, not just the root, so transitives unique to a workspace

--- a/pnpm/crates/deps-restorer/src/linking.rs
+++ b/pnpm/crates/deps-restorer/src/linking.rs
@@ -233,6 +233,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     // dep that public-hoist lands at root has to be in
     // `SymlinkDirectDependencies`'s dedupe map, and `write_hoist_links`
     // reuses the plan rather than walking a second time.
+    let phase_start = std::time::Instant::now();
     let pre_hoist = compute_hoist_plan(
         config,
         snapshots,
@@ -246,6 +247,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
     let public_hoist_targets: Option<BTreeMap<String, PathBuf>> = pre_hoist
         .as_ref()
         .map(|plan| collect_public_hoist_targets(&plan.result, &plan.graph, layout, &plan.skipped));
+    tracing::info!(target: "pacquet::install::phase", phase = "link.hoist_plan", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
 
     // `nodeLinker: hoisted` writes no virtual store — `CreateVirtualStore`
     // skipped the slots — so there is nothing to link into or out of.
@@ -277,6 +279,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
             message: StatsMessage::Removed { prefix: requester.to_owned(), removed: removed_count },
         }));
 
+        let phase_start = std::time::Instant::now();
         SymlinkDirectDependencies {
             config,
             layout,
@@ -292,6 +295,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         }
         .run::<Reporter>()
         .map_err(LinkPhaseError::SymlinkDirectDependencies)?;
+        tracing::info!(target: "pacquet::install::phase", phase = "link.symlink_direct_deps", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
 
         // Bit "root components" — a no-op unless an importer declared
         // `installConfig.hoistingLimits: "workspaces"`.
@@ -311,6 +315,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         // `virtual_store_only`: the links it writes live inside the
         // virtual store, and the build phase — which `pnpm fetch` still
         // runs — resolves a dependency's sibling bin through them.
+        let phase_start = std::time::Instant::now();
         LinkVirtualStoreBins {
             layout,
             snapshots,
@@ -322,6 +327,7 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         }
         .run()
         .map_err(LinkPhaseError::LinkVirtualStoreBins)?;
+        tracing::info!(target: "pacquet::install::phase", phase = "link.virtual_store_bins", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
     }
 
     // Everything below writes into the project that `virtual_store_only`
@@ -356,10 +362,32 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         HoistedLinkerOutput::default()
     };
 
+    // Publicly hoisted *workspace* packages are the one source of root
+    // bins nothing else shims: every importer's direct-dep bins were
+    // written by `SymlinkDirectDependencies`, and publicly hoisted
+    // regular packages go through the post-build top-level pass
+    // (`publicly_hoisted_for_post_build`) — but that pass resolves bins
+    // out of virtual-store slots, which a workspace project doesn't
+    // have. Collected before `write_hoist_links` consumes the plan;
+    // shimmed after the hoist symlinks land.
+    let public_workspace_bin_deps: Vec<(String, PathBuf)> = pre_hoist
+        .as_ref()
+        .map(|plan| {
+            plan.result
+                .hoisted_workspace_aliases
+                .iter()
+                .filter(|(_, kind, _)| matches!(kind, pnpm_modules_yaml::HoistKind::Public))
+                .map(|(alias, _, project_dir)| (alias.clone(), project_dir.clone()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let phase_start = std::time::Instant::now();
     let HoistLinks { hoisted_dependencies, publicly_hoisted_with_bins } = match pre_hoist {
         Some(plan) => write_hoist_links(plan, config, layout, link_options)?,
         None => HoistLinks::none(),
     };
+    tracing::info!(target: "pacquet::install::phase", phase = "link.write_hoist_links", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
 
     if crate::should_write_package_map(config, node_linker) {
         crate::package_map::write_package_map(
@@ -378,12 +406,14 @@ pub fn run_link_phase<Reporter: self::Reporter>(
         crate::write_pnp_file(sidecar_lockfile, workspace_root, config, layout, project_manifests)
             .map_err(LinkPhaseError::WritePnpFile)?;
     }
-    relink_importer_bins_after_hoisting(
-        &config.modules_dir,
-        symlink_root,
-        trusted_importer_ids,
-        link_options,
-    )?;
+    if !public_workspace_bin_deps.is_empty() {
+        link_direct_dep_bins_resolved(
+            &config.modules_dir,
+            &public_workspace_bin_deps,
+            link_options,
+        )
+        .map_err(LinkPhaseError::LinkBins)?;
+    }
 
     Ok(LinkPhaseOutput {
         hoisted_dependencies,
@@ -432,36 +462,4 @@ fn write_hoist_links(
         hoisted_dependencies: result.hoisted_dependencies,
         publicly_hoisted_with_bins: result.publicly_hoisted_aliases_with_bins,
     })
-}
-
-/// Re-walk each trusted importer's `node_modules` and shim what it now
-/// holds.
-///
-/// [`SymlinkDirectDependencies`] already linked the direct-dep bins, but
-/// hoisting runs after it, so this pass is what shims a publicly-hoisted
-/// *workspace package*'s bin — those live in the hoist result's
-/// `hoisted_workspace_aliases`, which the post-build top-level bin link
-/// never sees.
-fn relink_importer_bins_after_hoisting(
-    modules_dir: &Path,
-    symlink_root: &Path,
-    trusted_importer_ids: &std::collections::HashSet<String>,
-    link_options: &LinkBinsOptions,
-) -> Result<(), LinkPhaseError> {
-    let modules_basename = modules_dir
-        .file_name()
-        .map_or_else(|| std::ffi::OsString::from("node_modules"), std::ffi::OsStr::to_os_string);
-    for importer_id in trusted_importer_ids {
-        let importer_modules_dir =
-            crate::symlink_direct_dependencies::importer_root_dir(symlink_root, importer_id)
-                .join(&modules_basename);
-        let bins_dir = importer_modules_dir.join(".bin");
-        pnpm_cmd_shim::link_bins::<pnpm_cmd_shim::Host>(
-            &importer_modules_dir,
-            &bins_dir,
-            link_options,
-        )
-        .map_err(LinkPhaseError::LinkBins)?;
-    }
-    Ok(())
 }


### PR DESCRIPTION
## Summary

Continuation of the install-performance series (pnpm/pnpm#14248, pnpm/pnpm#14256, pnpm/pnpm#14265, pnpm/pnpm#14269; related to pnpm/pnpm#14231) — this one found via the workspace fixture rather than the single-project one.

New link-phase sub-step instrumentation (added here, same style as the existing `pacquet::install::phase` events) showed a 60-project workspace hot rebuild spending **1.26 s in the link phase, of which ~0.6 s was an untimed tail**: `relink_importer_bins_after_hoisting` re-walked *every* trusted importer's `node_modules` with the discovery-based bin linker — a readdir plus a manifest read through every direct-dep symlink, ~10 ms per importer.

Per its own doc comment, that walk existed to cover exactly one gap: bins of **publicly hoisted workspace packages** (`hoistWorkspacePackages`), which land in the root modules dir and which neither the direct-dep bin pass (`SymlinkDirectDependencies`, runs before hoisting) nor the post-build top-level pass (which resolves bins out of virtual-store slots a workspace project doesn't have) can see. Non-root importers never receive hoist links at all, so 59 of the 60 walks rediscovered precisely the shims already written.

This PR shims the gap directly: the publicly hoisted workspace aliases and their project dirs are collected from the hoist plan and fed to the existing targeted resolved-location bin linker (`link_direct_dep_bins_resolved`) against the root modules dir.

**Measured** (60-project workspace fixture, M-series MBP, APFS): link phase 1.26 s → 0.71 s; hot rebuild 4.10 s → 3.35 s. Verified byte-identical `.bin` trees (176 entries: names, symlink targets, shim content hashes) against the previously released v12 binary. Single-project installs unchanged (~2.58 s; their single walk was ~10 ms).

Rust-only change: the TypeScript CLI links each importer's bins once (it has no earlier targeted pass to duplicate), so there is nothing to mirror — observable `.bin` output is identical in both stacks.

## Squash Commit Body

```text
After hoisting, the link phase re-walked every trusted importer's
node_modules with the discovery-based bin linker - a readdir plus a
manifest read through every direct-dep symlink, per importer - to
cover one gap: bins of publicly hoisted workspace packages, which
land in the root modules dir and which neither the direct-dep bin
pass (SymlinkDirectDependencies, runs before hoisting) nor the
post-build top-level pass (resolves bins out of virtual-store slots
a workspace project doesn't have) can see. Non-root importers never
receive hoist links at all, so their walks rediscovered exactly the
shims already written.

Shim that gap directly instead: collect the publicly hoisted
workspace aliases with their project dirs from the hoist plan and
feed them to the targeted resolved-location bin linker against the
root modules dir. On a 60-project workspace fixture this cuts the
link phase from ~1.26 s to ~0.71 s (hot rebuild 4.1 s -> 3.35 s),
with byte-identical .bin trees.

Also adds link-phase sub-step timing events (hoist plan, direct-dep
symlinks, virtual-store bins, hoist links) in the style of the
existing pacquet::install::phase instrumentation - the walk was
found by exactly this decomposition.

Related to pnpm/pnpm#14231.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790516943&installation_model_id=426870&pr_number=14284&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14284&signature=daa190addd8b951b64ad864cad4fc53f4aa7eefdbe51ea502d10462150a8ae78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Workspace installations are now substantially faster, especially in larger multi-project workspaces.
  - Executable commands from publicly hoisted workspace packages continue to be linked correctly after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->