### PR TITLE
Avoid printing double colon in the OTP prompt

### DIFF
--- a/.changeset/pacquet-otp-prompt-colon.md
+++ b/.changeset/pacquet-otp-prompt-colon.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Remove the duplicate colon from the one-time password prompt.

--- a/pnpm/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pnpm/crates/network-web-auth/src/with_otp_handling.rs
@@ -313,7 +313,7 @@ where
                 .map_err(WithOtpError::Timeout)
         }
         None => {
-            match Sys::input("This operation requires a one-time password.\nEnter OTP:").await {
+            match Sys::input("This operation requires a one-time password.\nEnter OTP").await {
                 Ok(value) => Ok(value.filter(|otp| !otp.is_empty())),
                 // The user aborted the prompt: leave the challenge unsatisfied.
                 Err(PromptError::Cancelled) => Ok(None),


### PR DESCRIPTION
## Summary

`dialoguer` already adds a colon so this one just makes the prompt to be printed as "Enter OTP::"

I wasn't sure if you want to have tests for such a thing so I just decided to skip adding one but I could certainly add one if requested.

## Squash Commit Body

```text
Fixed an accidental double colon printed in the OTP prompt
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790523831&installation_model_id=426870&pr_number=14288&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14288&signature=d0606adeba272383e37d3e8c7221bc1c9854123c651dd0917a81b7c88e483a6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate colon from the one-time password prompt for cleaner, more consistent messaging.

* **Releases**
  * Included a patch release update for the affected package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->