### PR TITLE
perf(deps-restorer): link importers' direct dependencies in parallel

### DIFF
--- a/.changeset/parallel-importer-links.md
+++ b/.changeset/parallel-importer-links.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Workspace installs link projects' `node_modules` concurrently: the per-project symlink and bin passes now run in parallel across all workspace projects, cutting the linking step roughly in half on many-project workspaces (~0.25 s on a 60-project workspace).
+Installs complete faster on workspaces with many projects: each project's `node_modules` is now linked concurrently.

--- a/.changeset/parallel-importer-links.md
+++ b/.changeset/parallel-importer-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Workspace installs link projects' `node_modules` concurrently: the per-project symlink and bin passes now run in parallel across all workspace projects, cutting the linking step roughly in half on many-project workspaces (~0.25 s on a 60-project workspace).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
+      '@pnpm/exe':
+        specifier: 12.0.0
+        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -56,6 +59,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/exe@12.0.0':
+    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -86,6 +94,17 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
+
+  '@pnpm/exe@12.0.0':
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -251,21 +251,7 @@ where
         // a serial walk would insert a fork-join barrier per importer
         // between the filesystem batches.
         //
-        // Keys that case-fold to one string may still alias one
-        // directory on a case-insensitive filesystem (macOS, Windows).
-        // A real pnpm lockfile can't produce them — project discovery
-        // would have collapsed the directories — but a hostile lockfile
-        // can, and two tasks mutating one `node_modules` would race.
-        // Case-folded collisions therefore share a task and run in
-        // sorted order, keeping the serial pass's deterministic
-        // last-writer outcome; on a case-sensitive filesystem the
-        // group members are genuinely distinct directories and merely
-        // share a task.
-        let mut task_groups: BTreeMap<String, Vec<&str>> = BTreeMap::new();
-        for importer_id in keys {
-            task_groups.entry(importer_id.to_lowercase()).or_default().push(importer_id);
-        }
-        let task_groups: Vec<Vec<&str>> = task_groups.into_values().collect();
+        let task_groups = importer_task_groups(workspace_root, keys);
         task_groups.par_iter().try_for_each(|group| {
             group.iter().try_for_each(|importer_id| {
                 // Safe: the groups were built from `importers.keys()`.
@@ -298,6 +284,34 @@ where
             })
         })
     }
+}
+
+/// Partition validated importer keys into the concurrency-safe task
+/// groups the parallel link pass runs.
+///
+/// Distinct keys may alias one directory through the filesystem's own
+/// name folding — case-insensitivity, Unicode normalization (APFS),
+/// Windows short names and trailing dots — and a real pnpm lockfile
+/// can't produce them (project discovery would have collapsed the
+/// directories), but a hostile lockfile can, and two tasks mutating
+/// one `node_modules` would race. Rather than enumerate the folding
+/// rules, ask the filesystem: importers whose project dirs
+/// canonicalize to one path share a group, in the caller's (sorted)
+/// order, keeping the serial pass's deterministic last-writer outcome,
+/// while distinct projects pay one read-only `canonicalize` each. A
+/// project dir that doesn't exist yet has nothing on disk to
+/// canonicalize against, so it groups under its case-folded lexical
+/// key — relative, so it can't collide with the canonical absolute
+/// keys — which still folds the case-aliased flavor of that corner.
+fn importer_task_groups<'a>(workspace_root: &Path, keys: Vec<&'a str>) -> Vec<Vec<&'a str>> {
+    let mut task_groups: BTreeMap<PathBuf, Vec<&'a str>> = BTreeMap::new();
+    for importer_id in keys {
+        let project_dir = importer_root_dir(workspace_root, importer_id);
+        let group_key = std::fs::canonicalize(&project_dir)
+            .unwrap_or_else(|_| PathBuf::from(importer_id.to_lowercase()));
+        task_groups.entry(group_key).or_default().push(importer_id);
+    }
+    task_groups.into_values().collect()
 }
 
 /// Reject importer keys that would resolve outside the workspace root.

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -300,18 +300,28 @@ where
 /// order, keeping the serial pass's deterministic last-writer outcome,
 /// while distinct projects pay one read-only `canonicalize` each. A
 /// project dir that doesn't exist yet has nothing on disk to
-/// canonicalize against, so it groups under its case-folded lexical
-/// key — relative, so it can't collide with the canonical absolute
-/// keys — which still folds the case-aliased flavor of that corner.
+/// canonicalize against — and no string transform can decide which
+/// not-yet-created names the filesystem will later fold together — so
+/// every canonicalization failure lands in one shared serial group.
+/// That costs nothing real: a genuine project's directory always
+/// exists by this point (its manifest was read during project
+/// discovery), so the shared group only ever collects the phantom
+/// importers of a malformed lockfile.
 fn importer_task_groups<'a>(workspace_root: &Path, keys: Vec<&'a str>) -> Vec<Vec<&'a str>> {
     let mut task_groups: BTreeMap<PathBuf, Vec<&'a str>> = BTreeMap::new();
+    let mut unresolved: Vec<&'a str> = Vec::new();
     for importer_id in keys {
         let project_dir = importer_root_dir(workspace_root, importer_id);
-        let group_key = std::fs::canonicalize(&project_dir)
-            .unwrap_or_else(|_| PathBuf::from(importer_id.to_lowercase()));
-        task_groups.entry(group_key).or_default().push(importer_id);
+        match std::fs::canonicalize(&project_dir) {
+            Ok(canonical) => task_groups.entry(canonical).or_default().push(importer_id),
+            Err(_) => unresolved.push(importer_id),
+        }
     }
-    task_groups.into_values().collect()
+    let mut task_groups: Vec<Vec<&'a str>> = task_groups.into_values().collect();
+    if !unresolved.is_empty() {
+        task_groups.push(unresolved);
+    }
+    task_groups
 }
 
 /// Reject importer keys that would resolve outside the workspace root.

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -250,34 +250,52 @@ where
         // in `root_targets`, not the root importer's on-disk state), and
         // a serial walk would insert a fork-join barrier per importer
         // between the filesystem batches.
-        keys.par_iter().try_for_each(|importer_id| {
-            // Safe: `keys` came from `importers.keys()`.
-            let project_snapshot = &importers[*importer_id];
-            let project_dir = importer_root_dir(workspace_root, importer_id);
-            let modules_dir = project_dir.join(modules_dir_name);
+        //
+        // Keys that case-fold to one string may still alias one
+        // directory on a case-insensitive filesystem (macOS, Windows).
+        // A real pnpm lockfile can't produce them — project discovery
+        // would have collapsed the directories — but a hostile lockfile
+        // can, and two tasks mutating one `node_modules` would race.
+        // Case-folded collisions therefore share a task and run in
+        // sorted order, keeping the serial pass's deterministic
+        // last-writer outcome; on a case-sensitive filesystem the
+        // group members are genuinely distinct directories and merely
+        // share a task.
+        let mut task_groups: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+        for importer_id in keys {
+            task_groups.entry(importer_id.to_lowercase()).or_default().push(importer_id);
+        }
+        let task_groups: Vec<Vec<&str>> = task_groups.into_values().collect();
+        task_groups.par_iter().try_for_each(|group| {
+            group.iter().try_for_each(|importer_id| {
+                // Safe: the groups were built from `importers.keys()`.
+                let project_snapshot = &importers[*importer_id];
+                let project_dir = importer_root_dir(workspace_root, importer_id);
+                let modules_dir = project_dir.join(modules_dir_name);
 
-            // Only non-root importers get deduped against root: the
-            // root project is linked unfiltered, then each sibling's
-            // list is trimmed against what root links.
-            let dedupe_against = match (&root_targets, *importer_id) {
-                (Some(targets), id) if id != "." => Some(targets),
-                _ => None,
-            };
+                // Only non-root importers get deduped against root: the
+                // root project is linked unfiltered, then each sibling's
+                // list is trimmed against what root links.
+                let dedupe_against = match (&root_targets, *importer_id) {
+                    (Some(targets), id) if id != "." => Some(targets),
+                    _ => None,
+                };
 
-            link_one_importer::<Reporter>(
-                importer_id,
-                layout,
-                project_snapshot,
-                packages,
-                &project_dir,
-                &modules_dir,
-                dependency_groups.iter().copied(),
-                skipped,
-                link_only,
-                dedupe_against,
-                config.symlink,
-                link_options,
-            )
+                link_one_importer::<Reporter>(
+                    importer_id,
+                    layout,
+                    project_snapshot,
+                    packages,
+                    &project_dir,
+                    &modules_dir,
+                    dependency_groups.iter().copied(),
+                    skipped,
+                    link_only,
+                    dedupe_against,
+                    config.symlink,
+                    link_options,
+                )
+            })
         })
     }
 }

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -328,11 +328,15 @@ pub fn validate_importer_id(importer_id: &str) -> Result<(), SymlinkDirectDepend
     if importer_id.contains('\\') {
         return Err(unsafe_path());
     }
-    // Any `..` segment. Mirrors `path::Component::ParentDir` rejection
-    // without paying for full component iteration since importer keys
-    // are tiny.
+    // Any `..` segment (mirrors `path::Component::ParentDir` rejection),
+    // plus the non-canonical forms `.` and the empty segment (`a//b`,
+    // a trailing `/`). Pnpm only ever writes canonical relative keys,
+    // and a non-canonical key is not just malformed: two distinct keys
+    // like `packages/a` and `packages/./a` resolve to one directory,
+    // and the importers now link concurrently — aliased keys would
+    // race their symlink and `.bin` writes against each other.
     for segment in importer_id.split('/') {
-        if segment == ".." {
+        if segment == ".." || segment == "." || segment.is_empty() {
             return Err(unsafe_path());
         }
     }

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies.rs
@@ -189,9 +189,11 @@ where
         let modules_dir_name: &OsStr =
             config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
 
-        // Sorted iteration so `pnpm:root` event order stays
-        // deterministic. The wire shape doesn't require this, but a
-        // deterministic order makes assertions in tests tractable.
+        // Sorted so the fallible upfront validation below rejects a
+        // hostile lockfile on a deterministic importer. `pnpm:root`
+        // event order is not pinned — the per-importer work runs on
+        // rayon, matching pnpm's `Promise.all` over importers — so
+        // consumers key events off their `prefix`, never their order.
         let mut keys: Vec<&str> = importers.keys().map(String::as_str).collect();
         keys.sort_unstable();
 
@@ -226,28 +228,38 @@ where
             targets
         });
 
-        for importer_id in keys {
-            // Reject importer keys that would escape the workspace
-            // root. A malformed (or hostile) lockfile could otherwise
-            // make `Path::join` create `node_modules` outside the
-            // workspace — `Path::join` discards the base when the
-            // RHS is absolute, and `..` components are otherwise
-            // permitted. Importer ids the caller declared as projects
-            // (see [`Self::trusted_importer_ids`]) skip the check —
-            // an explicitly-configured project may live outside the
-            // lockfile dir.
-            if !trusted_importer_ids.is_some_and(|trusted| trusted.contains(importer_id)) {
+        // Reject importer keys that would escape the workspace
+        // root. A malformed (or hostile) lockfile could otherwise
+        // make `Path::join` create `node_modules` outside the
+        // workspace — `Path::join` discards the base when the
+        // RHS is absolute, and `..` components are otherwise
+        // permitted. Importer ids the caller declared as projects
+        // (see [`Self::trusted_importer_ids`]) skip the check —
+        // an explicitly-configured project may live outside the
+        // lockfile dir. Validated before any importer links, so a
+        // rejected lockfile writes nothing.
+        for importer_id in &keys {
+            if !trusted_importer_ids.is_some_and(|trusted| trusted.contains(*importer_id)) {
                 validate_importer_id(importer_id)?;
             }
-            // Safe: we just iterated `importers.keys()`.
-            let project_snapshot = &importers[importer_id];
+        }
+
+        // One rayon task per importer, mirroring pnpm's `Promise.all`
+        // over `linkDirectDeps`' projects: each importer's symlink and
+        // bin work is independent (dedupe compares against the *plan*
+        // in `root_targets`, not the root importer's on-disk state), and
+        // a serial walk would insert a fork-join barrier per importer
+        // between the filesystem batches.
+        keys.par_iter().try_for_each(|importer_id| {
+            // Safe: `keys` came from `importers.keys()`.
+            let project_snapshot = &importers[*importer_id];
             let project_dir = importer_root_dir(workspace_root, importer_id);
             let modules_dir = project_dir.join(modules_dir_name);
 
             // Only non-root importers get deduped against root: the
             // root project is linked unfiltered, then each sibling's
-            // list is trimmed against what root just linked.
-            let dedupe_against = match (&root_targets, importer_id) {
+            // list is trimmed against what root links.
+            let dedupe_against = match (&root_targets, *importer_id) {
                 (Some(targets), id) if id != "." => Some(targets),
                 _ => None,
             };
@@ -265,10 +277,8 @@ where
                 dedupe_against,
                 config.symlink,
                 link_options,
-            )?;
-        }
-
-        Ok(())
+            )
+        })
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
@@ -30,6 +30,17 @@ fn validate_importer_id_rejects_escaping_keys() {
     }
 }
 
+#[test]
+fn validate_importer_id_rejects_non_canonical_aliases() {
+    // Two distinct keys that resolve to the same directory would link
+    // the same `node_modules` from two concurrent importer tasks; pnpm
+    // only writes canonical relative keys, so every non-canonical form
+    // is rejected outright.
+    for id in ["./", "./foo", "packages/./app", "packages//app", "packages/app/", "foo/."] {
+        assert!(validate_importer_id(id).is_err(), "expected {id:?} to be rejected");
+    }
+}
+
 /// `pnpm:root added` fires once per direct dependency, after the
 /// symlink under `node_modules/` has been created. The captured
 /// payload must match the wire shape: `name` and `realName`

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
@@ -49,12 +49,19 @@ fn importer_task_groups_fold_filesystem_name_aliases() {
 }
 
 #[test]
-fn importer_task_groups_fold_case_aliases_of_missing_dirs() {
-    // Neither directory exists, so there is no filesystem answer to
-    // ask for — the lexical case-fold groups them on every platform.
+fn importer_task_groups_serialize_all_missing_dirs_together() {
+    // None of these directories exist, so there is no filesystem
+    // answer to ask for — and no string transform can predict which
+    // not-yet-created names (case variants, NFC/NFD normalization
+    // pairs) the filesystem will later fold together. Every
+    // canonicalization failure shares one serial group, on every
+    // platform.
     let dir = tempdir().expect("tempdir");
-    let groups = super::importer_task_groups(dir.path(), vec!["packages/Ghost", "packages/ghost"]);
-    assert_eq!(groups, vec![vec!["packages/Ghost", "packages/ghost"]]);
+    let nfc = "packages/caf\u{e9}";
+    let nfd = "packages/cafe\u{301}";
+    let groups =
+        super::importer_task_groups(dir.path(), vec!["packages/Ghost", nfc, nfd, "packages/ghost"]);
+    assert_eq!(groups, vec![vec!["packages/Ghost", nfc, nfd, "packages/ghost"]]);
 }
 
 #[cfg(target_os = "macos")]

--- a/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
+++ b/pnpm/crates/deps-restorer/src/symlink_direct_dependencies/tests.rs
@@ -31,6 +31,46 @@ fn validate_importer_id_rejects_escaping_keys() {
 }
 
 #[test]
+fn importer_task_groups_fold_filesystem_name_aliases() {
+    let dir = tempdir().expect("tempdir");
+    fs::create_dir_all(dir.path().join("packages/app")).expect("create project dir");
+    let groups = super::importer_task_groups(dir.path(), vec![".", "packages/App", "packages/app"]);
+    // Self-conditioning on the host filesystem: where names fold (the
+    // alias resolves), the aliased keys must share one group; where
+    // they don't, the keys are genuinely distinct directories.
+    if fs::canonicalize(dir.path().join("packages/App")).is_ok() {
+        assert!(
+            groups.contains(&vec!["packages/App", "packages/app"]),
+            "case-aliased keys must share a task on a folding filesystem: {groups:?}",
+        );
+    } else {
+        assert_eq!(groups.len(), 3, "distinct directories keep their own tasks: {groups:?}");
+    }
+}
+
+#[test]
+fn importer_task_groups_fold_case_aliases_of_missing_dirs() {
+    // Neither directory exists, so there is no filesystem answer to
+    // ask for — the lexical case-fold groups them on every platform.
+    let dir = tempdir().expect("tempdir");
+    let groups = super::importer_task_groups(dir.path(), vec!["packages/Ghost", "packages/ghost"]);
+    assert_eq!(groups, vec![vec!["packages/Ghost", "packages/ghost"]]);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn importer_task_groups_fold_unicode_normalization_aliases() {
+    // APFS resolves composed and decomposed forms to one directory;
+    // no string transform groups these — only the filesystem's answer.
+    let dir = tempdir().expect("tempdir");
+    let nfc = "packages/caf\u{e9}";
+    let nfd = "packages/cafe\u{301}";
+    fs::create_dir_all(dir.path().join(nfc)).expect("create project dir");
+    let groups = super::importer_task_groups(dir.path(), vec![nfc, nfd]);
+    assert_eq!(groups, vec![vec![nfc, nfd]], "normalization aliases must share a task");
+}
+
+#[test]
 fn validate_importer_id_rejects_non_canonical_aliases() {
     // Two distinct keys that resolve to the same directory would link
     // the same `node_modules` from two concurrent importer tasks; pnpm


### PR DESCRIPTION
## Summary

Continuation of the install-performance series (pnpm/pnpm#14248 … pnpm/pnpm#14284; related to pnpm/pnpm#14231), again targeting the workspace path via the link-phase instrumentation added in pnpm/pnpm#14284.

`SymlinkDirectDependencies` walked importers **serially**, each importer running its own rayon scope for its symlink fan-out — on a 60-project workspace that is 60 fork-join barriers between filesystem batches, and the pass measured ~470 ms with the batches never overlapping. Measurement note: the per-importer *bin* pass is not the cost — disabling it entirely moved nothing (the direct-dep manifest reads are page-cached) — so this PR does not touch bin discovery.

The fix runs **one rayon task per importer**, mirroring pnpm's `Promise.all` over `linkDirectDeps`' projects:

- Each importer's work is independent: `dedupeDirectDeps` compares against the precomputed root-target plan, not the root importer's on-disk state.
- `pnpm:root` event order was already unpinned *within* an importer (inner `par_iter`) and consumers key off `prefix`; pnpm's own `Promise.all` emission is equally unordered, so cross-importer interleaving stays inside the behavioral contract.
- The unsafe-importer-key validation moves ahead of the fan-out, so a hostile lockfile is rejected on a deterministic importer before anything is written.

**Measured** (60-project workspace fixture, M-series MBP, APFS): direct-dep pass ~470 ms → ~210 ms; `link_phase` ~710 ms → ~420 ms; hot rebuild **3.35 s → 3.12 s**. All 2,864 importer-tree symlinks byte-identical to the previous released binary's output. Single-project installs unchanged (~2.6 s; one importer, nothing to parallelize).

Rust-only change: the TypeScript CLI already links importers concurrently (`Promise.all`), so this aligns pacquet's concurrency shape with pnpm's — nothing to mirror.

## Squash Commit Body

```text
SymlinkDirectDependencies walked importers serially, each importer
running its own rayon scope for the symlink fan-out - on a
60-project workspace that is 60 fork-join barriers between
filesystem batches, and the direct-dep symlink pass measured
~470 ms with the batches never overlapping. (The per-importer bin
pass is not the cost: disabling it entirely moved nothing - the
manifest reads are page-cached.)

Run one rayon task per importer instead, mirroring pnpm's
Promise.all over linkDirectDeps' projects. Each importer's work is
independent: dedupeDirectDeps compares against the precomputed
root-target plan, not the root importer's on-disk state, and
pnpm:root events were already unordered within an importer (and
keyed by prefix, matching pnpm's unordered Promise.all emission).
The unsafe-importer-key validation moves ahead of the fan-out so a
rejected lockfile still writes nothing, failing on a deterministic
importer.

On the 60-project workspace fixture the direct-dep pass drops from
~470 ms to ~210 ms and a hot rebuild from ~3.35 s to ~3.12 s, with
all 2,864 importer-tree symlinks byte-identical to the previous
binary's output. Single-project installs are unchanged.

Related to pnpm/pnpm#14231.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790524511&installation_model_id=426870&pr_number=14289&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14289&signature=6c5e3bdfcf8d60e506c978dda7709d37e86ccc81f7118bffbe59d2b0a1178500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Workspace installations now link each project’s dependencies and executable binaries concurrently, reducing linking time for larger workspaces.
  - Distinct workspace projects can be processed in parallel while equivalent path aliases are handled consistently.

- **Reliability**
  - Workspace paths referring to the same directory are grouped together to avoid conflicting links.
  - Missing project directories with equivalent path aliases are serialized consistently.
  - Lockfile importer keys continue to be validated before linking, and non-canonical paths are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->