### PR TITLE
Fix `--json` handling for view/info errors

### DIFF
--- a/.changeset/pacquet-view-json-errors.md
+++ b/.changeset/pacquet-view-json-errors.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Print errors as JSON on stdout when `--json` is passed to `pnpm view` or its aliases (`info`, `show`, and `v`).

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -593,7 +593,11 @@ fn route<'a>(command: CliCommand, ctx: &RunCtx<'a>) -> miette::Result<CommandFut
 }
 
 fn prints_json_errors(command: &CliCommand) -> bool {
-    matches!(command, CliCommand::Publish(args) if args.flags.json)
+    match command {
+        CliCommand::Publish(args) => args.flags.json,
+        CliCommand::View(args) => args.json,
+        _ => false,
+    }
 }
 
 fn print_json_error(error: &miette::Report) {

--- a/pnpm/crates/cli/tests/suite/view.rs
+++ b/pnpm/crates/cli/tests/suite/view.rs
@@ -230,11 +230,57 @@ fn registry_flag_404_exits_with_code_1() {
 
     mock.assert();
     assert_eq!(output.status.code(), Some(1), "a 404 must exit with code 1");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("ERR_PNPM_FETCH_404"),
-        "stderr must name the fetch-404 diagnostic; got:\n{stderr}",
+        stdout.contains("ERR_PNPM_FETCH_404"),
+        "stdout must name the fetch-404 diagnostic; got:\n{stdout}",
     );
+    drop((root, server));
+}
+
+#[test]
+fn json_flag_prints_errors_to_stdout_for_all_aliases() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let mock = server.mock("GET", "/not-a-real-package").with_status(404).expect(4).create();
+    let auth_file = empty_auth_file(root.path());
+
+    for alias in ["view", "info", "show", "v"] {
+        let output = pacquet_at(&workspace)
+            .with_arg("--npmrc-auth-file")
+            .with_arg(&auth_file)
+            .with_args([
+                alias,
+                "not-a-real-package",
+                "versions",
+                "--registry",
+                &server.url(),
+                "--json",
+            ])
+            .output()
+            .expect("spawn pnpm view alias");
+
+        assert_eq!(output.status.code(), Some(1), "a 404 must exit with code 1");
+        assert!(
+            output.stderr.is_empty(),
+            "{alias} --json errors must not be rendered to stderr; stderr: {}",
+            String::from_utf8_lossy(&output.stderr),
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let parsed: Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+            panic!("stdout must be a JSON error envelope: {error}; stdout: {stdout}")
+        });
+        assert_eq!(
+            parsed,
+            serde_json::json!({
+                "error": {
+                    "code": "ERR_PNPM_FETCH_404",
+                    "message": format!("GET {}/not-a-real-package: Not Found - 404", server.url()),
+                },
+            }),
+        );
+    }
+    mock.assert();
     drop((root, server));
 }
 


### PR DESCRIPTION
## Summary

I found this issue when testing Changeset with pnpm 12. It's something we need to handle things correctly in a programmatic fashion

## Squash Commit Body

```text
Fix `--json` handling for view/info errors
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790525119&installation_model_id=426870&pr_number=14290&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14290&signature=28acac424652042c2d2befb66f36632ad322cc1e1f4f84a53860bbc7bb90c675"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm view --json` now outputs errors as JSON on stdout.
  * The same behavior is supported by the `info`, `show`, and `v` aliases.
  * Registry 404 errors now appear in the expected output stream and include structured error details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->