### PR TITLE
Preserve lifecycle output and JSON errors when packing

### DIFF
--- a/.changeset/pacquet-pack-json-output.md
+++ b/.changeset/pacquet-pack-json-output.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fix `pnpm pack --json` to report errors as JSON and preserve lifecycle script stdout and stderr before the final JSON output.

--- a/.changeset/pacquet-pack-json-output.md
+++ b/.changeset/pacquet-pack-json-output.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fix `pnpm pack --json` to report errors as JSON and preserve lifecycle script stdout and stderr before the final JSON output.
+`pnpm pack --json` now reports errors as JSON. Lifecycle script stdout and stderr appear before the final JSON output.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -623,6 +623,7 @@ fn prints_json_errors(command: &CliCommand) -> bool {
     match command {
         CliCommand::Publish(args) => args.flags.json,
         CliCommand::View(args) => args.json,
+        CliCommand::Pack(args) => args.json,
         _ => false,
     }
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -24,7 +24,7 @@ use super::{
     not_implemented::NotImplementedError,
     outdated::{OutdatedArgs, OutdatedOutcome},
     owner::OwnerArgs,
-    pack::PackArgs,
+    pack::{PackArgs, PackJsonReporter},
     pack_app::PackAppArgs,
     peers::{PeersArgs, PeersOutcome},
     ping::PingArgs,
@@ -437,19 +437,25 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: PackArgs) -> miette::Result<Comma
     let dir = ctx.dir;
     let recursive = ctx.recursive;
     let reporter = ctx.reporter;
+    async fn run<Reporter: pnpm_reporter::Reporter>(
+        args: PackArgs,
+        dir: &std::path::Path,
+        config: &mut Config,
+        recursive: bool,
+    ) -> miette::Result<String> {
+        let hooks = prepare_config::<Reporter>(config, dir).await?;
+        args.run::<Reporter>(dir, config, recursive, hooks).await
+    }
     Ok(Box::pin(async move {
-        let output = match reporter {
-            ReporterType::Default | ReporterType::AppendOnly => {
-                let hooks = prepare_config::<DefaultReporter>(config, dir).await?;
-                args.run::<DefaultReporter>(dir, config, recursive, hooks).await?
-            }
-            ReporterType::Ndjson => {
-                let hooks = prepare_config::<NdjsonReporter>(config, dir).await?;
-                args.run::<NdjsonReporter>(dir, config, recursive, hooks).await?
-            }
-            ReporterType::Silent => {
-                let hooks = prepare_config::<SilentReporter>(config, dir).await?;
-                args.run::<SilentReporter>(dir, config, recursive, hooks).await?
+        let output = if args.json {
+            run::<PackJsonReporter>(args, dir, config, recursive).await?
+        } else {
+            match reporter {
+                ReporterType::Default | ReporterType::AppendOnly => {
+                    run::<DefaultReporter>(args, dir, config, recursive).await?
+                }
+                ReporterType::Ndjson => run::<NdjsonReporter>(args, dir, config, recursive).await?,
+                ReporterType::Silent => run::<SilentReporter>(args, dir, config, recursive).await?,
             }
         };
         if !output.is_empty() {

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -25,12 +25,13 @@ use pnpm_pack::{
     Host, PackError, PackOptions, PackOutputLocks, PackResultJson, api, format_pack_output,
     pack_output_path, to_pack_result_json,
 };
-use pnpm_reporter::Reporter;
+use pnpm_reporter::{LifecycleMessage, LifecycleStdio, LogEvent, Reporter};
 use pnpm_workspace_task_scheduler::{
     ScheduleGraphAsyncOptions, TaskCompletion, graph_sequencer, schedule_graph_async,
 };
 use std::{
     collections::HashMap,
+    io::{self, Write},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
 };
@@ -40,6 +41,31 @@ use std::{
 /// underlying pack diagnostic instead of this wrapper, so the two sites must
 /// share one definition.
 pub(crate) const PACK_ERROR_CONTEXT: &str = "pack the package";
+
+/// Keep lifecycle output on its original stream before the final pack JSON.
+pub(super) struct PackJsonReporter;
+
+impl Reporter for PackJsonReporter {
+    fn emit(event: &LogEvent) {
+        let LogEvent::Lifecycle(log) = event else {
+            return;
+        };
+        match &log.message {
+            LifecycleMessage::Script { script, .. } => {
+                let _ = writeln!(io::stderr().lock(), "$ {script}");
+            }
+            LifecycleMessage::Stdio { line, stdio, .. } => match stdio {
+                LifecycleStdio::Stdout => {
+                    let _ = writeln!(io::stdout().lock(), "{line}");
+                }
+                LifecycleStdio::Stderr => {
+                    let _ = writeln!(io::stderr().lock(), "{line}");
+                }
+            },
+            LifecycleMessage::Exit { .. } => {}
+        }
+    }
+}
 
 /// Create a tarball from a package.
 #[derive(Debug, Args)]
@@ -250,7 +276,13 @@ impl PackArgs {
                     api::<Reporter, Host>(&options)
                         .await
                         .map_err(miette::Report::new)
-                        .wrap_err_with(|| format!("pack {}", project.root_dir.display()))
+                        .wrap_err_with(|| {
+                            if self.json {
+                                PACK_ERROR_CONTEXT.to_string()
+                            } else {
+                                format!("pack {}", project.root_dir.display())
+                            }
+                        })
                 }
                 .await;
                 match result {

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -42,7 +42,12 @@ use std::{
 /// share one definition.
 pub(crate) const PACK_ERROR_CONTEXT: &str = "pack the package";
 
-/// Keep lifecycle output on its original stream before the final pack JSON.
+/// The reporter for `pack --json`. It stands in for the selected
+/// `--reporter` / `--loglevel` (which pnpm skips entirely under `--json`)
+/// and mirrors pnpm running the pack lifecycle scripts with inherited stdio:
+/// the `$ <script>` banner goes to stderr, each script line stays on the
+/// stream it was written to, and every other event is dropped so the JSON
+/// result (or JSON error) is the last thing on stdout.
 pub(super) struct PackJsonReporter;
 
 impl Reporter for PackJsonReporter {

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -10,7 +10,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use serde_json::json;
-use std::{fs, path::Path};
+use std::{fmt::Write, fs, path::Path};
 
 #[test]
 fn pack_uses_embed_readme_and_manifest_obfuscation_settings() {
@@ -499,4 +499,111 @@ fn read_manifest_from_tarball(tarball: &Path) -> serde_json::Value {
         }
     }
     panic!("package/package.json not found in {}", tarball.display());
+}
+
+#[test]
+fn pack_json_preserves_lifecycle_streams_before_the_result() {
+    assert_pack_json_lifecycle_streams(None, false);
+}
+
+#[test]
+fn pack_json_preserves_lifecycle_streams_before_the_error() {
+    for stage in ["prepack", "prepare", "postpack"] {
+        assert_pack_json_lifecycle_streams(Some(stage), false);
+    }
+}
+
+#[test]
+fn recursive_pack_json_preserves_lifecycle_streams_before_the_error() {
+    for stage in ["prepack", "prepare", "postpack"] {
+        assert_pack_json_lifecycle_streams(Some(stage), true);
+    }
+}
+
+fn assert_pack_json_lifecycle_streams(failing_stage: Option<&str>, recursive: bool) {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    if recursive {
+        fs::write(workspace.join("pnpm-workspace.yaml"), "packages: []\n")
+            .expect("write pnpm-workspace.yaml");
+    }
+    let stages = ["prepack", "prepare", "postpack"];
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pack-json-streams",
+            "version": "1.0.0",
+            "scripts": {
+                "prepack": "node lifecycle.cjs prepack",
+                "prepare": "node lifecycle.cjs prepare",
+                "postpack": "node lifecycle.cjs postpack",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join("lifecycle.cjs"),
+        r"const stage = process.argv[2];
+console.log(JSON.stringify({ error: { code: stage } }));
+console.log(`${stage} stdout`);
+console.error(`${stage} stderr`);
+process.exitCode = stage === process.env.FAILING_STAGE ? 1 : 0;
+",
+    )
+    .expect("write lifecycle script");
+
+    let output = pacquet
+        .with_args(["pack", "--json"])
+        .with_args(recursive.then_some("--recursive"))
+        .with_env("FAILING_STAGE", failing_stage.unwrap_or(""))
+        .output()
+        .expect("run pack --json");
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    eprintln!("failing stage: {failing_stage:?}; stdout: {stdout}; stderr: {stderr}");
+    assert_eq!(output.status.success(), failing_stage.is_none());
+    let mut expected_stdout = String::new();
+    let mut expected_stderr = String::new();
+    for stage in stages {
+        writeln!(expected_stdout, "{{\"error\":{{\"code\":\"{stage}\"}}}}\n{stage} stdout")
+            .expect("write expected stdout");
+        writeln!(expected_stderr, "$ node lifecycle.cjs {stage}\n{stage} stderr")
+            .expect("write expected stderr");
+        if Some(stage) == failing_stage {
+            break;
+        }
+    }
+    assert_eq!(stderr, expected_stderr);
+    let result = stdout.strip_prefix(&expected_stdout).expect("lifecycle stdout precedes JSON");
+    let result: serde_json::Value = serde_json::from_str(result).expect("final JSON result");
+    if let Some(stage) = failing_stage {
+        assert_eq!(result["error"]["code"], "ERR_PNPM_EXECUTOR_LIFECYCLE_SCRIPT_FAILED");
+        let message = result["error"]["message"].as_str().expect("error message");
+        assert!(
+            message.contains(&format!("{stage}: `node lifecycle.cjs {stage}` exited with")),
+            "{message}"
+        );
+    } else {
+        assert_eq!(result["name"], "pack-json-streams");
+        assert_eq!(result["version"], "1.0.0");
+        assert!(workspace.join("pack-json-streams-1.0.0.tgz").is_file());
+    }
+    drop(root);
+}
+
+#[test]
+fn pack_json_prints_structured_errors_without_lifecycle_scripts() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), json!({ "name": "pack-json" }).to_string())
+        .expect("write package.json");
+
+    let output = pacquet.with_args(["pack", "--json"]).output().expect("run pack --json");
+    eprintln!("output: {output:?}");
+    assert!(!output.status.success());
+    assert_eq!(output.stderr, b"");
+    assert_eq!(
+        String::from_utf8(output.stdout).expect("UTF-8 stdout"),
+        "{\n  \"error\": {\n    \"code\": \"ERR_PNPM_PACKAGE_VERSION_NOT_FOUND\",\n    \"message\": \"Package version is not defined in the package.json.\"\n  }\n}\n",
+    );
+    drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -598,11 +598,13 @@ fn pack_json_prints_structured_errors_without_lifecycle_scripts() {
         .expect("write package.json");
 
     let output = pacquet.with_args(["pack", "--json"]).output().expect("run pack --json");
-    eprintln!("output: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    eprintln!("status: {}; stdout:\n{stdout}\nstderr:\n{stderr}", output.status);
     assert!(!output.status.success());
-    assert_eq!(output.stderr, b"");
+    assert_eq!(stderr, "");
     assert_eq!(
-        String::from_utf8(output.stdout).expect("UTF-8 stdout"),
+        stdout,
         "{\n  \"error\": {\n    \"code\": \"ERR_PNPM_PACKAGE_VERSION_NOT_FOUND\",\n    \"message\": \"Package version is not defined in the package.json.\"\n  }\n}\n",
     );
     drop(root);

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -581,7 +581,7 @@ process.exitCode = stage === process.env.FAILING_STAGE ? 1 : 0;
         let message = result["error"]["message"].as_str().expect("error message");
         assert!(
             message.contains(&format!("{stage}: `node lifecycle.cjs {stage}` exited with")),
-            "{message}"
+            "{message}",
         );
     } else {
         assert_eq!(result["name"], "pack-json-streams");


### PR DESCRIPTION
## Summary

Similar to https://github.com/pnpm/pnpm/pull/14290 . I was testing Changesets with pnpm 12 and found this blocker (a regression from pnpm 11)

With this PR `pack --json` should correctly handle lifecycle output combined with the final JSON "response".

## Squash Commit Body

```text
Preserve lifecycle output and JSON errors when packing
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790528236&installation_model_id=426870&pr_number=14291&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14291&signature=0a4b169fa35d1cf42eb0829717f1e302db2627b5c6209d97bf8e72d5b4e326c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm pack --json` now provides structured JSON errors.
  - Lifecycle script output remains visible on stdout and stderr before the final JSON result.
  - Recursive packaging errors are reported consistently in JSON format.

- **Bug Fixes**
  - Improved error reporting for packages missing a version.
  - Preserved lifecycle output across successful and failed packaging stages.
  - Ensured errors from prepack, prepare, and postpack stages are reported correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->