### PR TITLE
fix(cli): enable virtual terminal processing on the Windows console

### DIFF
--- a/.changeset/windows-console-ansi-colors.md
+++ b/.changeset/windows-console-ansi-colors.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Colored output is no longer printed as raw escape sequences in the Windows Command Prompt [#14292](https://github.com/pnpm/pnpm/issues/14292). Commands such as `pnpm list` now style their output instead of writing `←[32m` and friends into the console.
+Colored output is no longer printed as raw escape sequences in the Windows Command Prompt [#14292](https://github.com/pnpm/pnpm/issues/14292). Commands such as `pnpm list` now style their output there.

--- a/.changeset/windows-console-ansi-colors.md
+++ b/.changeset/windows-console-ansi-colors.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Colored output is no longer printed as raw escape sequences in the Windows Command Prompt [#14292](https://github.com/pnpm/pnpm/issues/14292). Commands such as `pnpm list` now style their output instead of writing `←[32m` and friends into the console.

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -117,6 +117,7 @@ wax                  = { workspace = true }
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
+  "Win32_System_Console",
   "Win32_System_SystemInformation",
   "Win32_UI_Shell",
   "Win32_UI_WindowsAndMessaging",

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -16,6 +16,7 @@ mod renamed_options;
 mod shim_dispatch;
 mod shorthands;
 mod state;
+mod virtual_terminal;
 mod with_current;
 
 use boolean_negations::with_boolean_negations;
@@ -29,6 +30,9 @@ use state::State;
 use std::{ffi::OsString, future::Future, path::Path, process::ExitCode};
 
 pub fn main() -> ExitCode {
+    // Runs before anything can print, so the first styled byte already
+    // reaches a console that understands it; see `virtual_terminal`.
+    virtual_terminal::enable();
     enable_tracing_by_env();
     install_report_handler();
     set_panic_hook();

--- a/pnpm/crates/cli/src/virtual_terminal.rs
+++ b/pnpm/crates/cli/src/virtual_terminal.rs
@@ -3,9 +3,9 @@
 //! `supports-color`, the backend behind `owo-colors`, treats every Windows
 //! 10 console as ANSI-capable and leaves it to the application to switch
 //! the console into virtual-terminal mode. Until that happens `cmd.exe`
-//! prints each escape sequence literally — `←[32m` in place of green text.
-//! Unix terminals interpret the sequences without any setup, so [`enable`]
-//! is a no-op there.
+//! prints each escape sequence literally, so `←[32m` shows up where green
+//! text belongs. Unix terminals interpret the sequences without any setup,
+//! so [`enable`] is a no-op there.
 
 #[cfg(windows)]
 pub fn enable() {

--- a/pnpm/crates/cli/src/virtual_terminal.rs
+++ b/pnpm/crates/cli/src/virtual_terminal.rs
@@ -1,0 +1,39 @@
+//! Turn on the Windows console's ANSI escape handling.
+//!
+//! `supports-color`, the backend behind `owo-colors`, treats every Windows
+//! 10 console as ANSI-capable and leaves it to the application to switch
+//! the console into virtual-terminal mode. Until that happens `cmd.exe`
+//! prints each escape sequence literally — `←[32m` in place of green text.
+//! Unix terminals interpret the sequences without any setup, so [`enable`]
+//! is a no-op there.
+
+#[cfg(windows)]
+pub fn enable() {
+    use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::{
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_ERROR_HANDLE,
+        STD_OUTPUT_HANDLE, SetConsoleMode,
+    };
+
+    // SAFETY: these are standard Win32 console calls. `GetStdHandle` returns
+    // a borrowed handle that must not be closed, and the only pointer passed
+    // is a stack local that outlives the call.
+    unsafe {
+        for stream in [STD_OUTPUT_HANDLE, STD_ERROR_HANDLE] {
+            let handle = GetStdHandle(stream);
+            if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+                continue;
+            }
+            let mut mode = 0;
+            // Fails when the stream is redirected to a file or a pipe, which
+            // has no console mode to change.
+            if GetConsoleMode(handle, &mut mode) == 0 {
+                continue;
+            }
+            SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+        }
+    }
+}
+
+#[cfg(not(windows))]
+pub fn enable() {}

--- a/pnpm/crates/cli/src/virtual_terminal.rs
+++ b/pnpm/crates/cli/src/virtual_terminal.rs
@@ -11,8 +11,8 @@
 pub fn enable() {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::System::Console::{
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_ERROR_HANDLE,
-        STD_OUTPUT_HANDLE, SetConsoleMode,
+        ENABLE_PROCESSED_OUTPUT, ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle,
+        STD_ERROR_HANDLE, STD_OUTPUT_HANDLE, SetConsoleMode,
     };
 
     // SAFETY: these are standard Win32 console calls. `GetStdHandle` returns
@@ -30,7 +30,14 @@ pub fn enable() {
             if GetConsoleMode(handle, &mut mode) == 0 {
                 continue;
             }
-            SetConsoleMode(handle, mode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+            // `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is documented as requiring
+            // `ENABLE_PROCESSED_OUTPUT`, so both are set. A console that
+            // refuses the new mode keeps the old one and prints the escape
+            // sequences it did before, which is why the result is ignored.
+            SetConsoleMode(
+                handle,
+                mode | ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING,
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary

In the Windows Command Prompt, colored output from the Rust CLI arrives as literal escape sequences (`←[32m` where green text should be) instead of styled text. `supports-color`, the backend behind `owo-colors`, treats every Windows 10 console as ANSI-capable, but a console only interprets those sequences once the process turns on `ENABLE_VIRTUAL_TERMINAL_PROCESSING` for its handles, and nothing in the CLI did that.

`pnpm_cli::main` now switches the stdout and stderr consoles into virtual-terminal mode before anything is written, and leaves a stream alone when it has no console mode to read, which is the case for a redirected pipe or file. Node.js enables the mode for its own handles, so the TypeScript CLI is unaffected and needs no matching change.

I did not add a test: the change is a Win32 console-mode call whose effect is only observable in a real Windows console.

Fixes pnpm/pnpm#14292

## Squash Commit Body

```text
A Windows console does not interpret ANSI escape sequences until the
process enables ENABLE_VIRTUAL_TERMINAL_PROCESSING on its handles. The
supports-color backend behind owo-colors reports Windows 10 as
ANSI-capable regardless of that mode, so every styled string the CLI
printed reached cmd.exe as raw escape sequences.

Enable the mode on the stdout and stderr handles at the top of
pnpm_cli::main, before any output is produced. A stream whose console
mode cannot be read is skipped, since a pipe or a file has none.

The TypeScript CLI does not need the same change: Node.js already
enables virtual-terminal processing for its own stdout handle.

Closes pnpm/pnpm#14292
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790531778&installation_model_id=426870&pr_number=14293&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14293&signature=0a12474bf3b5f73efa6309d95dde882a259aa61c2ce07bd86bc6cfce01b28baa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved colored command-line output on Windows.
  * Styled output now renders correctly in Command Prompt instead of displaying raw ANSI escape sequences.
  * Commands such as `pnpm list` now display colors as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->