### PR TITLE
feat: name the remote cache env vars for the setting

### DIFF
--- a/.changeset/retire-execution-barriers.md
+++ b/.changeset/retire-execution-barriers.md
@@ -10,8 +10,8 @@
 "@pnpm/releasing.commands": patch
 "@pnpm/workspace.projects-sorter": major
 "@pnpm/workspace.task-scheduler": major
-"pacquet": patch
-"pnpm": patch
+"pacquet": minor
+"pnpm": minor
 ---
 
 Workspace install, rebuild, pack, publish, stage, and lifecycle work now starts as soon as its dependencies finish instead of waiting for an unrelated topological group.

--- a/.changeset/side-effects-cache-remote-env.md
+++ b/.changeset/side-effects-cache-remote-env.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+The environment variables for the remote side-effects cache are named for the setting they configure: `PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID`, `..._BUILDER_ID`, `..._IMAGE_DIGEST`, `..._ARCHITECTURE_BASELINE`, `..._PRIVATE_KEY`, `..._BUILD_ENV`, `..._TRUSTED_KEYS` and `..._PUBLISH`. The `PNPM_REMOTE_SIDE_EFFECTS_CACHE_*` names keep working, and the new one wins when both are set.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -79,7 +79,7 @@ impl Config {
     pub(crate) fn apply_remote_side_effects_cache_env<Sys: EnvVar>(&mut self) {
         let mut settings = RemoteSideEffectsCacheSettings::default();
         let mut set_any = false;
-        if let Some(publish) = side_effects_cache_remote_env::<Sys>("PUBLISH") {
+        if let Some((publish, _)) = side_effects_cache_remote_env::<Sys>("PUBLISH") {
             settings.publish = Some(publish == "true");
             set_any = true;
         }
@@ -90,7 +90,7 @@ impl Config {
             (&mut settings.architecture_baseline, "ARCHITECTURE_BASELINE"),
             (&mut settings.private_key, "PRIVATE_KEY"),
         ] {
-            if let Some(value) = side_effects_cache_remote_env::<Sys>(suffix) {
+            if let Some((value, _)) = side_effects_cache_remote_env::<Sys>(suffix) {
                 *field = Some(value);
                 set_any = true;
             }
@@ -98,8 +98,9 @@ impl Config {
         for (field, suffix) in
             [(&mut settings.build_env, "BUILD_ENV"), (&mut settings.trusted_keys, "TRUSTED_KEYS")]
         {
-            let variable = format!("PNPM_SIDE_EFFECTS_CACHE_REMOTE_{suffix}");
-            let Some(value) = side_effects_cache_remote_env::<Sys>(suffix) else { continue };
+            let Some((value, variable)) = side_effects_cache_remote_env::<Sys>(suffix) else {
+                continue;
+            };
             match serde_json::from_str::<BTreeMap<String, String>>(&value) {
                 Ok(parsed) => {
                     *field = Some(parsed);
@@ -3980,7 +3981,16 @@ fn full_metadata_policy(
 ///
 /// A machine configured for `remoteSideEffectsCache` keeps working; a machine
 /// setting both gets the name that matches the setting it is configuring.
-fn side_effects_cache_remote_env<Sys: EnvVar>(suffix: &str) -> Option<String> {
-    Sys::var(&format!("PNPM_SIDE_EFFECTS_CACHE_REMOTE_{suffix}"))
-        .or_else(|| Sys::var(&format!("PNPM_REMOTE_SIDE_EFFECTS_CACHE_{suffix}")))
+/// The name comes back with the value because a malformed one is reported by
+/// name, and naming a variable the user did not set sends them looking for it.
+fn side_effects_cache_remote_env<Sys: EnvVar>(suffix: &str) -> Option<(String, String)> {
+    for variable in [
+        format!("PNPM_SIDE_EFFECTS_CACHE_REMOTE_{suffix}"),
+        format!("PNPM_REMOTE_SIDE_EFFECTS_CACHE_{suffix}"),
+    ] {
+        if let Some(value) = Sys::var(&variable) {
+            return Some((value, variable));
+        }
+    }
+    None
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -79,30 +79,27 @@ impl Config {
     pub(crate) fn apply_remote_side_effects_cache_env<Sys: EnvVar>(&mut self) {
         let mut settings = RemoteSideEffectsCacheSettings::default();
         let mut set_any = false;
-        if let Some(publish) = Sys::var("PNPM_REMOTE_SIDE_EFFECTS_CACHE_PUBLISH") {
+        if let Some(publish) = side_effects_cache_remote_env::<Sys>("PUBLISH") {
             settings.publish = Some(publish == "true");
             set_any = true;
         }
-        for (field, variable) in [
-            (&mut settings.key_id, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID"),
-            (&mut settings.builder_id, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILDER_ID"),
-            (&mut settings.image_digest, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_IMAGE_DIGEST"),
-            (
-                &mut settings.architecture_baseline,
-                "PNPM_REMOTE_SIDE_EFFECTS_CACHE_ARCHITECTURE_BASELINE",
-            ),
-            (&mut settings.private_key, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_PRIVATE_KEY"),
+        for (field, suffix) in [
+            (&mut settings.key_id, "KEY_ID"),
+            (&mut settings.builder_id, "BUILDER_ID"),
+            (&mut settings.image_digest, "IMAGE_DIGEST"),
+            (&mut settings.architecture_baseline, "ARCHITECTURE_BASELINE"),
+            (&mut settings.private_key, "PRIVATE_KEY"),
         ] {
-            if let Some(value) = Sys::var(variable) {
+            if let Some(value) = side_effects_cache_remote_env::<Sys>(suffix) {
                 *field = Some(value);
                 set_any = true;
             }
         }
-        for (field, variable) in [
-            (&mut settings.build_env, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILD_ENV"),
-            (&mut settings.trusted_keys, "PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS"),
-        ] {
-            let Some(value) = Sys::var(variable) else { continue };
+        for (field, suffix) in
+            [(&mut settings.build_env, "BUILD_ENV"), (&mut settings.trusted_keys, "TRUSTED_KEYS")]
+        {
+            let variable = format!("PNPM_SIDE_EFFECTS_CACHE_REMOTE_{suffix}");
+            let Some(value) = side_effects_cache_remote_env::<Sys>(suffix) else { continue };
             match serde_json::from_str::<BTreeMap<String, String>>(&value) {
                 Ok(parsed) => {
                     *field = Some(parsed);
@@ -3976,4 +3973,14 @@ fn full_metadata_policy(
     supports_time_field: bool,
 ) -> bool {
     trust_policy == TrustPolicy::NoDowngrade || (time_based && !supports_time_field)
+}
+
+/// Reads one field of the remote tier from the environment, under the name
+/// that matches the setting and under the one that matched its older spelling.
+///
+/// A machine configured for `remoteSideEffectsCache` keeps working; a machine
+/// setting both gets the name that matches the setting it is configuring.
+fn side_effects_cache_remote_env<Sys: EnvVar>(suffix: &str) -> Option<String> {
+    Sys::var(&format!("PNPM_SIDE_EFFECTS_CACHE_REMOTE_{suffix}"))
+        .or_else(|| Sys::var(&format!("PNPM_REMOTE_SIDE_EFFECTS_CACHE_{suffix}")))
 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -18,8 +18,10 @@ use tempfile::tempdir;
 use tracing::Level;
 use tracing_subscriber::{Layer, layer::SubscriberExt};
 
-/// Capture all tracing WARN messages emitted during a closure.
-fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
+/// Capture all tracing WARN messages emitted during a closure, each followed
+/// by its structured fields, since some warnings say which setting or variable
+/// they are about in a field rather than in the message.
+pub(crate) fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
     let messages: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let messages_clone = Arc::clone(&messages);
 
@@ -31,26 +33,35 @@ fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
             _ctx: tracing_subscriber::layer::Context<'_, Sub>,
         ) {
             if *event.metadata().level() == Level::WARN {
-                struct Visitor(String);
+                #[derive(Default)]
+                struct Visitor {
+                    message: String,
+                    fields: String,
+                }
+                impl Visitor {
+                    fn record(&mut self, name: &str, value: String) {
+                        if name == "message" {
+                            self.message = value;
+                        } else {
+                            self.fields.push_str(&format!(" {name}={value}"));
+                        }
+                    }
+                }
                 impl tracing::field::Visit for Visitor {
                     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-                        if field.name() == "message" {
-                            self.0 = value.to_string();
-                        }
+                        self.record(field.name(), value.to_string());
                     }
                     fn record_debug(
                         &mut self,
                         field: &tracing::field::Field,
                         value: &dyn std::fmt::Debug,
                     ) {
-                        if field.name() == "message" {
-                            self.0 = format!("{value:?}");
-                        }
+                        self.record(field.name(), format!("{value:?}"));
                     }
                 }
-                let mut visitor = Visitor(String::new());
+                let mut visitor = Visitor::default();
                 event.record(&mut visitor);
-                self.0.lock().unwrap().push(visitor.0);
+                self.0.lock().unwrap().push(format!("{}{}", visitor.message, visitor.fields));
             }
         }
     }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -7,6 +7,7 @@ use crate::defaults::{default_state_dir, default_store_dir};
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::env_guard::EnvGuard;
 use pretty_assertions::assert_eq;
+use std::fmt::Write as _;
 use std::{
     env,
     ffi::OsString,
@@ -43,7 +44,7 @@ pub(crate) fn capture_warnings<Func: FnOnce()>(f: Func) -> Vec<String> {
                         if name == "message" {
                             self.message = value;
                         } else {
-                            self.fields.push_str(&format!(" {name}={value}"));
+                            let _ = write!(self.fields, " {name}={value}");
                         }
                     }
                 }

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -7,10 +7,10 @@ use crate::defaults::{default_state_dir, default_store_dir};
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::env_guard::EnvGuard;
 use pretty_assertions::assert_eq;
-use std::fmt::Write as _;
 use std::{
     env,
     ffi::OsString,
+    fmt::Write as _,
     io,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1388,6 +1388,44 @@ fn malformed_json_names_the_environment_variable_that_was_set() {
     );
 }
 
+/// Precedence is by presence, not by validity: a malformed value under the name
+/// matching the setting is not quietly replaced by a valid one under the older
+/// name, because that would use a variable the reader did not reach for and
+/// leave the broken one unreported.
+#[test]
+fn a_malformed_canonical_value_is_not_replaced_by_a_valid_older_one() {
+    struct Both;
+    impl crate::EnvVar for Both {
+        fn var(key: &str) -> Option<String> {
+            match key {
+                "PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS" => Some("not json".to_string()),
+                "PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS" => {
+                    Some(r#"{"acme-2026":"AA=="}"#.to_string())
+                }
+                _ => None,
+            }
+        }
+    }
+
+    let mut config = Config::new();
+    let warnings = crate::tests::capture_warnings(|| {
+        config.apply_remote_side_effects_cache_env::<Both>();
+    });
+
+    let warning = warnings
+        .iter()
+        .find(|warning| warning.contains("not a string-valued JSON object"))
+        .expect("a warning about the malformed variable");
+    assert!(
+        warning.contains("PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS"),
+        "expected the variable that was selected, got {warning}",
+    );
+    assert!(
+        config.remote_side_effects_cache.is_none_or(|shared| shared.trusted_keys.is_none()),
+        "the older variable's value must not stand in for the malformed one",
+    );
+}
+
 /// When both spellings are set, the one matching the setting decides.
 #[test]
 fn the_canonical_environment_spelling_wins() {

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1361,6 +1361,33 @@ fn the_remote_tier_reads_both_environment_spellings() {
     }
 }
 
+/// A malformed JSON variable is reported by name, so it has to be the name the
+/// reader actually set — pointing at the spelling they did not use sends them
+/// looking for a variable that is not in their environment.
+#[test]
+fn malformed_json_names_the_environment_variable_that_was_set() {
+    struct Older;
+    impl crate::EnvVar for Older {
+        fn var(key: &str) -> Option<String> {
+            (key == "PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS").then(|| "not json".to_string())
+        }
+    }
+
+    let warnings = crate::tests::capture_warnings(|| {
+        let mut config = Config::new();
+        config.apply_remote_side_effects_cache_env::<Older>();
+    });
+
+    let warning = warnings
+        .iter()
+        .find(|warning| warning.contains("not a string-valued JSON object"))
+        .expect("a warning about the malformed variable");
+    assert!(
+        warning.contains("PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS"),
+        "expected the variable that was set, got {warning}",
+    );
+}
+
 /// When both spellings are set, the one matching the setting decides.
 #[test]
 fn the_canonical_environment_spelling_wins() {

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1287,6 +1287,52 @@ remoteSideEffectsCache:
     assert_eq!(shared.key_id.as_deref(), Some("acme-2026"));
 }
 
+/// The variables are named for the setting they configure, and the names that
+/// matched the older spelling keep working — a machine set up before the rename
+/// is not something a `pnpm install` should start ignoring.
+#[test]
+fn the_remote_tier_reads_both_environment_spellings() {
+    struct Canonical;
+    impl crate::EnvVar for Canonical {
+        fn var(key: &str) -> Option<String> {
+            match key {
+                "PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID" => Some("canonical".to_string()),
+                _ => None,
+            }
+        }
+    }
+    struct Older;
+    impl crate::EnvVar for Older {
+        fn var(key: &str) -> Option<String> {
+            match key {
+                "PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID" => Some("older".to_string()),
+                _ => None,
+            }
+        }
+    }
+    struct Both;
+    impl crate::EnvVar for Both {
+        fn var(key: &str) -> Option<String> {
+            match key {
+                "PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID" => Some("canonical".to_string()),
+                "PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID" => Some("older".to_string()),
+                _ => None,
+            }
+        }
+    }
+
+    for (expected, apply) in [("canonical", 0), ("older", 1), ("canonical", 2)] {
+        let mut config = Config::new();
+        match apply {
+            0 => config.apply_remote_side_effects_cache_env::<Canonical>(),
+            1 => config.apply_remote_side_effects_cache_env::<Older>(),
+            _ => config.apply_remote_side_effects_cache_env::<Both>(),
+        }
+        let shared = config.remote_side_effects_cache.expect("shared cache config");
+        assert_eq!(shared.key_id.as_deref(), Some(expected));
+    }
+}
+
 /// The environment holds the signing material a CI runner must not commit, so
 /// it is the last word on the section.
 #[test]

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1290,28 +1290,82 @@ remoteSideEffectsCache:
 /// The variables are named for the setting they configure, and the names that
 /// matched the older spelling keep working — a machine set up before the rename
 /// is not something a `pnpm install` should start ignoring.
+///
+/// Every suffix is covered because they do not share a parsing path: `PUBLISH`
+/// is a boolean, `BUILD_ENV` and `TRUSTED_KEYS` are JSON, the rest are strings.
 #[test]
 fn the_remote_tier_reads_both_environment_spellings() {
-    struct Canonical;
-    impl crate::EnvVar for Canonical {
-        fn var(key: &str) -> Option<String> {
-            match key {
-                "PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID" => Some("canonical".to_string()),
-                _ => None,
+    const CANONICAL: &str = "PNPM_SIDE_EFFECTS_CACHE_REMOTE_";
+    const OLDER: &str = "PNPM_REMOTE_SIDE_EFFECTS_CACHE_";
+
+    fn read(prefixes: &[&'static str], suffix: &'static str, value: &'static str) -> Config {
+        // A thread-local rather than a generic per case: `EnvVar` is a trait
+        // with an associated function, so the case has to reach it somehow.
+        CASE.with(|case| *case.borrow_mut() = Some((prefixes.to_vec(), suffix, value)));
+        struct Env;
+        impl crate::EnvVar for Env {
+            fn var(key: &str) -> Option<String> {
+                CASE.with(|case| {
+                    let borrowed = case.borrow();
+                    let (prefixes, suffix, value) = borrowed.as_ref()?;
+                    prefixes
+                        .iter()
+                        .any(|prefix| key == format!("{prefix}{suffix}"))
+                        .then(|| (*value).to_string())
+                })
             }
         }
+        let mut config = Config::new();
+        config.apply_remote_side_effects_cache_env::<Env>();
+        config
     }
-    struct Older;
-    impl crate::EnvVar for Older {
-        fn var(key: &str) -> Option<String> {
-            match key {
-                "PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID" => Some("older".to_string()),
-                _ => None,
-            }
+
+    for suffix in ["KEY_ID", "BUILDER_ID", "IMAGE_DIGEST", "ARCHITECTURE_BASELINE", "PRIVATE_KEY"] {
+        for prefixes in [vec![CANONICAL], vec![OLDER], vec![CANONICAL, OLDER]] {
+            let config = read(&prefixes, suffix, "value");
+            let shared = config.remote_side_effects_cache.expect("shared cache config");
+            let read_back = match suffix {
+                "KEY_ID" => shared.key_id,
+                "BUILDER_ID" => shared.builder_id,
+                "IMAGE_DIGEST" => shared.image_digest,
+                "ARCHITECTURE_BASELINE" => shared.architecture_baseline,
+                _ => shared.private_key,
+            };
+            assert_eq!(read_back.as_deref(), Some("value"), "{suffix} under {prefixes:?}");
         }
     }
-    struct Both;
-    impl crate::EnvVar for Both {
+
+    for prefixes in [vec![CANONICAL], vec![OLDER], vec![CANONICAL, OLDER]] {
+        let config = read(&prefixes, "PUBLISH", "true");
+        assert_eq!(
+            config.remote_side_effects_cache.expect("shared cache config").publish,
+            Some(true),
+            "PUBLISH under {prefixes:?}",
+        );
+
+        let config = read(&prefixes, "BUILD_ENV", r#"{"CC":"clang"}"#);
+        let shared = config.remote_side_effects_cache.expect("shared cache config");
+        assert_eq!(
+            shared.build_env.expect("build env").get("CC").map(String::as_str),
+            Some("clang"),
+            "BUILD_ENV under {prefixes:?}",
+        );
+
+        let config = read(&prefixes, "TRUSTED_KEYS", r#"{"acme-2026":"AA=="}"#);
+        let shared = config.remote_side_effects_cache.expect("shared cache config");
+        assert_eq!(
+            shared.trusted_keys.expect("trusted keys").get("acme-2026").map(String::as_str),
+            Some("AA=="),
+            "TRUSTED_KEYS under {prefixes:?}",
+        );
+    }
+}
+
+/// When both spellings are set, the one matching the setting decides.
+#[test]
+fn the_canonical_environment_spelling_wins() {
+    struct Env;
+    impl crate::EnvVar for Env {
         fn var(key: &str) -> Option<String> {
             match key {
                 "PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID" => Some("canonical".to_string()),
@@ -1321,16 +1375,17 @@ fn the_remote_tier_reads_both_environment_spellings() {
         }
     }
 
-    for (expected, apply) in [("canonical", 0), ("older", 1), ("canonical", 2)] {
-        let mut config = Config::new();
-        match apply {
-            0 => config.apply_remote_side_effects_cache_env::<Canonical>(),
-            1 => config.apply_remote_side_effects_cache_env::<Older>(),
-            _ => config.apply_remote_side_effects_cache_env::<Both>(),
-        }
-        let shared = config.remote_side_effects_cache.expect("shared cache config");
-        assert_eq!(shared.key_id.as_deref(), Some(expected));
-    }
+    let mut config = Config::new();
+    config.apply_remote_side_effects_cache_env::<Env>();
+    assert_eq!(
+        config.remote_side_effects_cache.expect("shared cache config").key_id.as_deref(),
+        Some("canonical"),
+    );
+}
+
+thread_local! {
+    static CASE: std::cell::RefCell<Option<(Vec<&'static str>, &'static str, &'static str)>> =
+        const { std::cell::RefCell::new(None) };
 }
 
 /// The environment holds the signing material a CI runner must not commit, so

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -1396,16 +1396,16 @@ function applyRemoteSideEffectsCacheEnv (
   const settings: Partial<RemoteSideEffectsCacheSettings> = {}
   const publish = readSideEffectsCacheEnv(env, 'PUBLISH')
   if (publish != null) {
-    settings.publish = publish === 'true'
+    settings.publish = publish.value === 'true'
   }
   for (const [field, suffix] of SIDE_EFFECTS_CACHE_REMOTE_ENV_STRINGS) {
-    const value = readSideEffectsCacheEnv(env, suffix)
-    if (value != null) settings[field] = value
+    const read = readSideEffectsCacheEnv(env, suffix)
+    if (read != null) settings[field] = read.value
   }
   for (const [field, suffix] of SIDE_EFFECTS_CACHE_REMOTE_ENV_JSON) {
-    const value = readSideEffectsCacheEnv(env, suffix)
-    if (value == null) continue
-    settings[field] = parseStringValuedJsonObject(value, `PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`)
+    const read = readSideEffectsCacheEnv(env, suffix)
+    if (read == null) continue
+    settings[field] = parseStringValuedJsonObject(read.value, read.variable)
   }
   if (Object.keys(settings).length === 0) return
   pnpmConfig.remoteSideEffectsCache = {
@@ -1435,8 +1435,14 @@ const SIDE_EFFECTS_CACHE_REMOTE_ENV_JSON = [
  * A machine configured for `remoteSideEffectsCache` keeps working; a machine
  * setting both gets the name that matches the setting it is configuring.
  */
-function readSideEffectsCacheEnv (env: NodeJS.ProcessEnv, suffix: string): string | undefined {
-  return env[`PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`] ?? env[`PNPM_REMOTE_SIDE_EFFECTS_CACHE_${suffix}`]
+function readSideEffectsCacheEnv (env: NodeJS.ProcessEnv, suffix: string): { value: string, variable: string } | undefined {
+  // The name comes back with the value because a malformed one is reported by
+  // name, and naming a variable the user did not set sends them looking for it.
+  for (const variable of [`PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`, `PNPM_REMOTE_SIDE_EFFECTS_CACHE_${suffix}`]) {
+    const value = env[variable]
+    if (value != null) return { value, variable }
+  }
+  return undefined
 }
 
 function parseStringValuedJsonObject (value: string, variable: string): Record<string, string> {

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -1394,17 +1394,18 @@ function applyRemoteSideEffectsCacheEnv (
   env: NodeJS.ProcessEnv
 ): void {
   const settings: Partial<RemoteSideEffectsCacheSettings> = {}
-  if (env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_PUBLISH != null) {
-    settings.publish = env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_PUBLISH === 'true'
+  const publish = readSideEffectsCacheEnv(env, 'PUBLISH')
+  if (publish != null) {
+    settings.publish = publish === 'true'
   }
-  for (const [field, variable] of REMOTE_SIDE_EFFECTS_CACHE_ENV_STRINGS) {
-    const value = env[variable]
+  for (const [field, suffix] of SIDE_EFFECTS_CACHE_REMOTE_ENV_STRINGS) {
+    const value = readSideEffectsCacheEnv(env, suffix)
     if (value != null) settings[field] = value
   }
-  for (const [field, variable] of REMOTE_SIDE_EFFECTS_CACHE_ENV_JSON) {
-    const value = env[variable]
+  for (const [field, suffix] of SIDE_EFFECTS_CACHE_REMOTE_ENV_JSON) {
+    const value = readSideEffectsCacheEnv(env, suffix)
     if (value == null) continue
-    settings[field] = parseStringValuedJsonObject(value, variable)
+    settings[field] = parseStringValuedJsonObject(value, `PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`)
   }
   if (Object.keys(settings).length === 0) return
   pnpmConfig.remoteSideEffectsCache = {
@@ -1414,18 +1415,29 @@ function applyRemoteSideEffectsCacheEnv (
   pnpmConfig.explicitlySetKeys.add('remoteSideEffectsCache')
 }
 
-const REMOTE_SIDE_EFFECTS_CACHE_ENV_STRINGS = [
-  ['keyId', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID'],
-  ['builderId', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILDER_ID'],
-  ['imageDigest', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_IMAGE_DIGEST'],
-  ['architectureBaseline', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_ARCHITECTURE_BASELINE'],
-  ['privateKey', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_PRIVATE_KEY'],
+const SIDE_EFFECTS_CACHE_REMOTE_ENV_STRINGS = [
+  ['keyId', 'KEY_ID'],
+  ['builderId', 'BUILDER_ID'],
+  ['imageDigest', 'IMAGE_DIGEST'],
+  ['architectureBaseline', 'ARCHITECTURE_BASELINE'],
+  ['privateKey', 'PRIVATE_KEY'],
 ] as const satisfies ReadonlyArray<[keyof RemoteSideEffectsCacheSettings, string]>
 
-const REMOTE_SIDE_EFFECTS_CACHE_ENV_JSON = [
-  ['buildEnv', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_BUILD_ENV'],
-  ['trustedKeys', 'PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS'],
+const SIDE_EFFECTS_CACHE_REMOTE_ENV_JSON = [
+  ['buildEnv', 'BUILD_ENV'],
+  ['trustedKeys', 'TRUSTED_KEYS'],
 ] as const satisfies ReadonlyArray<[keyof RemoteSideEffectsCacheSettings, string]>
+
+/**
+ * Reads one field of the remote tier from the environment, under the name that
+ * matches the setting and under the one that matched its older spelling.
+ *
+ * A machine configured for `remoteSideEffectsCache` keeps working; a machine
+ * setting both gets the name that matches the setting it is configuring.
+ */
+function readSideEffectsCacheEnv (env: NodeJS.ProcessEnv, suffix: string): string | undefined {
+  return env[`PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`] ?? env[`PNPM_REMOTE_SIDE_EFFECTS_CACHE_${suffix}`]
+}
 
 function parseStringValuedJsonObject (value: string, variable: string): Record<string, string> {
   let parsed: unknown

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -6037,3 +6037,30 @@ test('getConfig() prefers the canonical org across the two remote spellings', as
 
   expect(config.remoteSideEffectsCache).toStrictEqual({ org: 'canonical' })
 })
+
+test('getConfig() reads the remote tier from either environment spelling', async () => {
+  // The variables are named for the setting they configure, and the names that
+  // matched the older spelling keep working — a machine set up before the
+  // rename is not something an install should start ignoring.
+  prepareEmpty()
+  process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID = 'older'
+  try {
+    const older = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+    expect(older.config.remoteSideEffectsCache?.keyId).toBe('older')
+
+    process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID = 'canonical'
+    const both = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+    expect(both.config.remoteSideEffectsCache?.keyId).toBe('canonical')
+  } finally {
+    delete process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID
+    delete process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID
+  }
+})

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -6038,29 +6038,71 @@ test('getConfig() prefers the canonical org across the two remote spellings', as
   expect(config.remoteSideEffectsCache).toStrictEqual({ org: 'canonical' })
 })
 
-test('getConfig() reads the remote tier from either environment spelling', async () => {
-  // The variables are named for the setting they configure, and the names that
-  // matched the older spelling keep working — a machine set up before the
-  // rename is not something an install should start ignoring.
+test.each([
+  ['KEY_ID', 'keyId', 'value', 'value'],
+  ['BUILDER_ID', 'builderId', 'value', 'value'],
+  ['IMAGE_DIGEST', 'imageDigest', 'value', 'value'],
+  ['ARCHITECTURE_BASELINE', 'architectureBaseline', 'value', 'value'],
+  ['PRIVATE_KEY', 'privateKey', 'value', 'value'],
+  ['PUBLISH', 'publish', 'true', true],
+  ['BUILD_ENV', 'buildEnv', '{"CC":"clang"}', { CC: 'clang' }],
+  ['TRUSTED_KEYS', 'trustedKeys', '{"acme-2026":"AA=="}', { 'acme-2026': 'AA==' }],
+])('getConfig() reads %s of the remote tier under either environment spelling', async (suffix, field, raw, expected) => {
+  // The suffixes do not share a parsing path — PUBLISH is a boolean, BUILD_ENV
+  // and TRUSTED_KEYS are JSON, the rest are strings — so each is covered under
+  // the name matching the setting and the name that matched its older spelling.
+  prepareEmpty()
+  const canonical = `PNPM_SIDE_EFFECTS_CACHE_REMOTE_${suffix}`
+  const older = `PNPM_REMOTE_SIDE_EFFECTS_CACHE_${suffix}`
+  const read = async (): Promise<unknown> => {
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+    return (config.remoteSideEffectsCache as Record<string, unknown> | undefined)?.[field]
+  }
+
+  try {
+    process.env[canonical] = raw
+    expect(await read()).toStrictEqual(expected)
+    delete process.env[canonical]
+
+    process.env[older] = raw
+    expect(await read()).toStrictEqual(expected)
+  } finally {
+    delete process.env[canonical]
+    delete process.env[older]
+  }
+})
+
+test('getConfig() prefers the environment name that matches the setting', async () => {
   prepareEmpty()
   process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID = 'older'
+  process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID = 'canonical'
   try {
-    const older = await getConfig({
+    const { config } = await getConfig({
       cliOptions: {},
       packageManager: { name: 'pnpm', version: '1.0.0' },
       workspaceDir: process.cwd(),
     })
-    expect(older.config.remoteSideEffectsCache?.keyId).toBe('older')
-
-    process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID = 'canonical'
-    const both = await getConfig({
-      cliOptions: {},
-      packageManager: { name: 'pnpm', version: '1.0.0' },
-      workspaceDir: process.cwd(),
-    })
-    expect(both.config.remoteSideEffectsCache?.keyId).toBe('canonical')
+    expect(config.remoteSideEffectsCache?.keyId).toBe('canonical')
   } finally {
     delete process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID
     delete process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID
+  }
+})
+
+test('getConfig() names the environment variable the user actually set when its JSON is malformed', async () => {
+  prepareEmpty()
+  process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS = 'not json'
+  try {
+    await expect(getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })).rejects.toThrow(/PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS/)
+  } finally {
+    delete process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS
   }
 })

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -6038,6 +6038,34 @@ test('getConfig() prefers the canonical org across the two remote spellings', as
   expect(config.remoteSideEffectsCache).toStrictEqual({ org: 'canonical' })
 })
 
+/**
+ * Sets environment variables for one test and puts back exactly what was there,
+ * including "not set at all". Deleting instead would strip a value the suite
+ * inherited, and the tests after it would silently run against a different
+ * environment than the ones before.
+ */
+async function withEnv (values: Record<string, string | undefined>, run: () => Promise<void>): Promise<void> {
+  const previous = Object.keys(values).map((name): [string, string | undefined] => [name, process.env[name]])
+  for (const [name, value] of Object.entries(values)) {
+    if (value === undefined) {
+      delete process.env[name]
+    } else {
+      process.env[name] = value
+    }
+  }
+  try {
+    await run()
+  } finally {
+    for (const [name, value] of previous) {
+      if (value === undefined) {
+        delete process.env[name]
+      } else {
+        process.env[name] = value
+      }
+    }
+  }
+}
+
 test.each([
   ['KEY_ID', 'keyId', 'value', 'value'],
   ['BUILDER_ID', 'builderId', 'value', 'value'],
@@ -6063,46 +6091,39 @@ test.each([
     return (config.remoteSideEffectsCache as Record<string, unknown> | undefined)?.[field]
   }
 
-  try {
-    process.env[canonical] = raw
+  await withEnv({ [canonical]: raw, [older]: undefined }, async () => {
     expect(await read()).toStrictEqual(expected)
-    delete process.env[canonical]
-
-    process.env[older] = raw
+  })
+  await withEnv({ [older]: raw, [canonical]: undefined }, async () => {
     expect(await read()).toStrictEqual(expected)
-  } finally {
-    delete process.env[canonical]
-    delete process.env[older]
-  }
+  })
 })
 
 test('getConfig() prefers the environment name that matches the setting', async () => {
   prepareEmpty()
-  process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID = 'older'
-  process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID = 'canonical'
-  try {
+  await withEnv({
+    PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID: 'older',
+    PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID: 'canonical',
+  }, async () => {
     const { config } = await getConfig({
       cliOptions: {},
       packageManager: { name: 'pnpm', version: '1.0.0' },
       workspaceDir: process.cwd(),
     })
     expect(config.remoteSideEffectsCache?.keyId).toBe('canonical')
-  } finally {
-    delete process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_KEY_ID
-    delete process.env.PNPM_SIDE_EFFECTS_CACHE_REMOTE_KEY_ID
-  }
+  })
 })
 
 test('getConfig() names the environment variable the user actually set when its JSON is malformed', async () => {
   prepareEmpty()
-  process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS = 'not json'
-  try {
+  await withEnv({
+    PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS: 'not json',
+    PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS: undefined,
+  }, async () => {
     await expect(getConfig({
       cliOptions: {},
       packageManager: { name: 'pnpm', version: '1.0.0' },
       workspaceDir: process.cwd(),
     })).rejects.toThrow(/PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS/)
-  } finally {
-    delete process.env.PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS
-  }
+  })
 })

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -6127,3 +6127,19 @@ test('getConfig() names the environment variable the user actually set when its 
     })).rejects.toThrow(/PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS/)
   })
 })
+
+test('getConfig() does not fall back to a valid older variable when the canonical one is malformed', async () => {
+  // Precedence is by presence, not by validity: falling back would use a
+  // variable the reader did not reach for and leave the broken one unreported.
+  prepareEmpty()
+  await withEnv({
+    PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS: 'not json',
+    PNPM_REMOTE_SIDE_EFFECTS_CACHE_TRUSTED_KEYS: '{"acme-2026":"AA=="}',
+  }, async () => {
+    await expect(getConfig({
+      cliOptions: {},
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })).rejects.toThrow(/PNPM_SIDE_EFFECTS_CACHE_REMOTE_TRUSTED_KEYS/)
+  })
+})


### PR DESCRIPTION
## Summary

Two loose ends before 11.25.0 / 12.1.0, both cheap now and not later.

### The remote cache's environment variables

They were named after `remoteSideEffectsCache`, which pnpm/pnpm#14285 made the older spelling of `sideEffectsCache.remote` — so every one of them pointed at a setting that no longer has that name. They are `PNPM_SIDE_EFFECTS_CACHE_REMOTE_*`: `..._KEY_ID`, `..._BUILDER_ID`, `..._IMAGE_DIGEST`, `..._ARCHITECTURE_BASELINE`, `..._PRIVATE_KEY`, `..._BUILD_ENV`, `..._TRUSTED_KEYS`, `..._PUBLISH`.

The old names keep working and the new ones win when both are set. **The compatibility matters more here than it did for the settings**: these carry a CI runner's signing material, and a rename that silently stopped reading them would not fail loudly — it would quietly stop publishing artifacts, which is the kind of breakage nobody notices for a week.

Same timing argument as the settings: they shipped in `pacquet@12.0.0` and in no released `pnpm@11.x`, so the window closes with 11.25.0.

### `retire-execution-barriers` is a minor, not a patch

That changeset says *"workspace install, rebuild, pack, publish, stage, and lifecycle work now starts as soon as its dependencies finish instead of waiting for an unrelated topological group"* — it changes when install-time lifecycle scripts run, for every user, and scripts that relied on the old incidental ordering can now overlap.

The repository's guideline puts `patch` at "changes that don't require documentation updates" and `minor` at "anything users should know about". This is the widest blast radius of anything pending, so it is `minor` on both CLIs. It is an unconsumed intent, so this is just an edit.

## Squash Commit Body

```text
The remote side-effects cache's environment variables were named after
`remoteSideEffectsCache`, which is now the older spelling of
`sideEffectsCache.remote`, so every one of them pointed at a setting that
no longer has that name. They are `PNPM_SIDE_EFFECTS_CACHE_REMOTE_*`.

The old names keep working and the new ones win when both are set, which
matters more here than for the settings themselves: these carry a CI
runner's signing material, and a rename that silently stopped reading
them would quietly stop publishing rather than fail.

Also raises `retire-execution-barriers` from patch to minor on both CLIs,
since it changes when install-time lifecycle scripts run for every user.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port.
- [x] Added a changeset.
- [x] Added or updated tests — each stack asserts the new name, the old name, and the new one winning when both are set.
- [x] Updated the documentation — pnpm/pnpm.io#905.

Verified: full TypeScript build and lint, `@pnpm/config.reader` (494 passing, with a scratch `XDG_CONFIG_HOME`), `cargo check --workspace --all-targets`, `cargo test -p pnpm-config` (605 passing), and the Rust pre-push gates.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790539353&installation_model_id=426870&pr_number=14295&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14295&signature=1e24d2da46a1df7fbc1538df96d7c0fb50ba446e860c770c82fe1e861e9379b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace operations now begin as soon as their dependencies are ready, improving execution efficiency.
  * Remote side-effects cache settings support the `PNPM_SIDE_EFFECTS_CACHE_REMOTE_*` environment variable names.
  * Existing `PNM_REMOTE_SIDE_EFFECTS_CACHE_*` names remain supported, with canonical names taking precedence when both are set.
  * Invalid JSON configuration warnings now identify the specific environment variable that caused the error.

* **Documentation**
  * Updated release information for workspace execution and environment variable naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->