### PR TITLE
fix(dlx): resolve a catalog package spec against the caller's catalogs

### DIFF
--- a/.changeset/dlx-resolves-catalog-package-specs.md
+++ b/.changeset/dlx-resolves-catalog-package-specs.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dlx <pkg>@catalog:` now resolves the specifier through the calling workspace's catalogs instead of failing with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` [#14294](https://github.com/pnpm/pnpm/issues/14294).

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -11,7 +11,6 @@ use crate::{
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
-use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
 use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_resolver::{
     CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
@@ -353,19 +352,15 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The cache install inherits the caller project's `overrides` (pnpm's
     // dlx likewise runs its install with the invoking project's
     // already-loaded config), and a `catalog:` value in them resolves
-    // against the caller's catalogs. Those catalogs are only reachable
-    // through `workspace_dir`, which is severed right below — resolve the
-    // references now, or the install would look them up against an empty
-    // catalog set and fail with ERR_PNPM_CATALOG_IN_OVERRIDES.
-    if let (Some(overrides), Some(workspace_dir)) =
-        (config.overrides.as_ref(), config.workspace_dir.as_deref())
+    // against the caller's catalogs. Those catalogs go with `workspace_dir`,
+    // which is severed right below — resolve the references now, or the
+    // install would look them up against an empty catalog set and fail with
+    // ERR_PNPM_CATALOG_IN_OVERRIDES.
+    if let Some(overrides) = config.overrides.as_ref()
+        && config.workspace_dir.is_some()
         && overrides.values().any(|spec| spec.starts_with("catalog:"))
     {
-        let workspace_manifest =
-            pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-            .into_diagnostic()
-            .wrap_err("reading the caller's catalogs for the dlx install")?;
+        let catalogs = configured_catalogs(config)?;
         let resolved = parse_overrides_iter(overrides.iter(), &catalogs)
             .map_err(miette::Report::new)?
             .into_iter()

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -13,6 +13,7 @@ use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_resolver::{
     CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
 };
+use pnpm_catalogs_types::Catalogs;
 use pnpm_cmd_shim::{Host as CmdShimHost, get_bins_from_package_manifest};
 use pnpm_config::Config;
 use pnpm_config_parse_overrides::parse_overrides_iter;
@@ -240,12 +241,10 @@ impl DlxArgs {
         // names the bin to run; otherwise the command is also the package.
         let pkgs: Vec<String> =
             if package.is_empty() { vec![bin_command.clone()] } else { package.clone() };
-        // A `catalog:` spec dereferences against the caller's catalogs,
-        // reachable only through `workspace_dir`, which the install below
-        // re-anchors at the throwaway cache project. Resolve here rather
-        // than there so the catalog's version also feeds the cache key:
-        // two callers whose catalogs pin different versions of the same
-        // package must not share a cache entry.
+        // Resolved here rather than in the install below so the catalog's
+        // version also feeds the cache key: two callers whose catalogs pin
+        // different versions of the same package must not share a cache
+        // entry.
         let pkgs = resolve_catalog_specs(&pkgs, config.workspace_dir.as_deref())?;
 
         // Read the config values needed before (and after) the install,
@@ -360,11 +359,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
         (config.overrides.as_ref(), config.workspace_dir.as_deref())
         && overrides.values().any(|spec| spec.starts_with("catalog:"))
     {
-        let workspace_manifest =
-            pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-            .into_diagnostic()
-            .wrap_err("reading the caller's catalogs for the dlx install")?;
+        let catalogs = read_caller_catalogs(workspace_dir)?;
         let resolved = parse_overrides_iter(overrides.iter(), &catalogs)
             .map_err(miette::Report::new)?
             .into_iter()
@@ -609,6 +604,17 @@ async fn run_package_manager<Reporter: self::Reporter + 'static>(
     )
 }
 
+/// The catalogs of the workspace the dlx invocation was made from. The
+/// throwaway cache project has none of its own, so both the `overrides`
+/// and the package specs it inherits are dereferenced against these.
+fn read_caller_catalogs(workspace_dir: &Path) -> miette::Result<Catalogs> {
+    let workspace_manifest =
+        pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
+    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("reading the caller's catalogs for the dlx install")
+}
+
 /// Replace the `catalog:` specifier of each dlx package spec with the
 /// specifier the caller workspace's catalogs hold. Any other spec passes
 /// through untouched, and the catalogs are only read when at least one
@@ -626,11 +632,7 @@ fn resolve_catalog_specs(
     let Some(workspace_dir) = workspace_dir.filter(|_| pkgs.iter().any(uses_catalog)) else {
         return Ok(pkgs.to_vec());
     };
-    let workspace_manifest =
-        pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-    let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-        .into_diagnostic()
-        .wrap_err("reading the caller's catalogs for the dlx install")?;
+    let catalogs = read_caller_catalogs(workspace_dir)?;
     pkgs.iter()
         .map(|pkg| {
             let parsed = parse_wanted_dependency(pkg);

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -1,6 +1,9 @@
 use crate::{
     State,
-    cli_args::{add::add_package, supported_architectures::SupportedArchitecturesArgs},
+    cli_args::{
+        add::add_package, catalogs::configured_catalogs,
+        supported_architectures::SupportedArchitecturesArgs,
+    },
     engine_pm::{channel::PackageManager, provision::provision},
     path_env::{BadPathDir, prepend_dirs_to_path, set_command_path},
     shim_dispatch::materialize_runtime,
@@ -13,7 +16,6 @@ use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_resolver::{
     CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
 };
-use pnpm_catalogs_types::Catalogs;
 use pnpm_cmd_shim::{Host as CmdShimHost, get_bins_from_package_manifest};
 use pnpm_config::Config;
 use pnpm_config_parse_overrides::parse_overrides_iter;
@@ -245,7 +247,7 @@ impl DlxArgs {
         // version also feeds the cache key: two callers whose catalogs pin
         // different versions of the same package must not share a cache
         // entry.
-        let pkgs = resolve_catalog_specs(&pkgs, config.workspace_dir.as_deref())?;
+        let pkgs = resolve_catalog_specs(&pkgs, config)?;
 
         // Read the config values needed before (and after) the install,
         // because the install path consumes `config` to anchor it at the
@@ -359,7 +361,11 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
         (config.overrides.as_ref(), config.workspace_dir.as_deref())
         && overrides.values().any(|spec| spec.starts_with("catalog:"))
     {
-        let catalogs = read_caller_catalogs(workspace_dir)?;
+        let workspace_manifest =
+            pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
+        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+            .into_diagnostic()
+            .wrap_err("reading the caller's catalogs for the dlx install")?;
         let resolved = parse_overrides_iter(overrides.iter(), &catalogs)
             .map_err(miette::Report::new)?
             .into_iter()
@@ -604,35 +610,21 @@ async fn run_package_manager<Reporter: self::Reporter + 'static>(
     )
 }
 
-/// The catalogs of the workspace the dlx invocation was made from. The
-/// throwaway cache project has none of its own, so both the `overrides`
-/// and the package specs it inherits are dereferenced against these.
-fn read_caller_catalogs(workspace_dir: &Path) -> miette::Result<Catalogs> {
-    let workspace_manifest =
-        pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-        .into_diagnostic()
-        .wrap_err("reading the caller's catalogs for the dlx install")
-}
-
 /// Replace the `catalog:` specifier of each dlx package spec with the
-/// specifier the caller workspace's catalogs hold. Any other spec passes
-/// through untouched, and the catalogs are only read when at least one
-/// spec needs them. A misconfigured entry is reported as the pnpm error
-/// the caller would get from `pnpm add`.
-fn resolve_catalog_specs(
-    pkgs: &[String],
-    workspace_dir: Option<&Path>,
-) -> miette::Result<Vec<String>> {
+/// specifier the caller's catalogs hold. Any other spec passes through
+/// untouched, and the catalogs are only read when at least one spec needs
+/// them. A misconfigured entry is reported as the pnpm error the caller
+/// would get from `pnpm add`.
+fn resolve_catalog_specs(pkgs: &[String], config: &Config) -> miette::Result<Vec<String>> {
     let uses_catalog = |pkg: &String| {
         parse_wanted_dependency(pkg)
             .bare_specifier
             .is_some_and(|bare_specifier| parse_catalog_protocol(&bare_specifier).is_some())
     };
-    let Some(workspace_dir) = workspace_dir.filter(|_| pkgs.iter().any(uses_catalog)) else {
+    if !pkgs.iter().any(uses_catalog) {
         return Ok(pkgs.to_vec());
-    };
-    let catalogs = read_caller_catalogs(workspace_dir)?;
+    }
+    let catalogs = configured_catalogs(config)?;
     pkgs.iter()
         .map(|pkg| {
             let parsed = parse_wanted_dependency(pkg);

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -9,6 +9,10 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
+use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
+use pnpm_catalogs_resolver::{
+    CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
+};
 use pnpm_cmd_shim::{Host as CmdShimHost, get_bins_from_package_manifest};
 use pnpm_config::Config;
 use pnpm_config_parse_overrides::parse_overrides_iter;
@@ -236,6 +240,13 @@ impl DlxArgs {
         // names the bin to run; otherwise the command is also the package.
         let pkgs: Vec<String> =
             if package.is_empty() { vec![bin_command.clone()] } else { package.clone() };
+        // A `catalog:` spec dereferences against the caller's catalogs,
+        // reachable only through `workspace_dir`, which the install below
+        // re-anchors at the throwaway cache project. Resolve here rather
+        // than there so the catalog's version also feeds the cache key:
+        // two callers whose catalogs pin different versions of the same
+        // package must not share a cache entry.
+        let pkgs = resolve_catalog_specs(&pkgs, config.workspace_dir.as_deref())?;
 
         // Read the config values needed before (and after) the install,
         // because the install path consumes `config` to anchor it at the
@@ -596,6 +607,48 @@ async fn run_package_manager<Reporter: self::Reporter + 'static>(
         engine.bin_dirs,
         spawn,
     )
+}
+
+/// Replace the `catalog:` specifier of each dlx package spec with the
+/// specifier the caller workspace's catalogs hold. Any other spec passes
+/// through untouched, and the catalogs are only read when at least one
+/// spec needs them. A misconfigured entry is reported as the pnpm error
+/// the caller would get from `pnpm add`.
+fn resolve_catalog_specs(
+    pkgs: &[String],
+    workspace_dir: Option<&Path>,
+) -> miette::Result<Vec<String>> {
+    let uses_catalog = |pkg: &String| {
+        parse_wanted_dependency(pkg)
+            .bare_specifier
+            .is_some_and(|bare_specifier| parse_catalog_protocol(&bare_specifier).is_some())
+    };
+    let Some(workspace_dir) = workspace_dir.filter(|_| pkgs.iter().any(uses_catalog)) else {
+        return Ok(pkgs.to_vec());
+    };
+    let workspace_manifest =
+        pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
+    let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("reading the caller's catalogs for the dlx install")?;
+    pkgs.iter()
+        .map(|pkg| {
+            let parsed = parse_wanted_dependency(pkg);
+            let (Some(alias), Some(bare_specifier)) = (parsed.alias, parsed.bare_specifier) else {
+                return Ok(pkg.clone());
+            };
+            let wanted = CatalogWantedDependency { alias: alias.clone(), bare_specifier };
+            match resolve_from_catalog(&catalogs, &wanted) {
+                CatalogResolutionResult::Found(found) => {
+                    Ok(format!("{alias}@{}", found.resolution.specifier))
+                }
+                CatalogResolutionResult::Unused => Ok(pkg.clone()),
+                CatalogResolutionResult::Misconfiguration(misconfiguration) => {
+                    Err(miette::Report::new(misconfiguration.error))
+                }
+            }
+        })
+        .collect()
 }
 
 /// Build the `{ "default": registry, <alias>: url, … }` map fed into the

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -154,33 +154,40 @@ fn dlx_resolves_a_package_spec_against_a_named_caller_catalog() {
 }
 
 /// A spec naming a catalog that holds no entry for it is a user error, and
-/// must stay one once the caller's catalogs are consulted.
+/// must stay one once the caller's catalogs are consulted. The failure
+/// comes before the install, so neither case needs the mocked registry.
 #[test]
-#[cfg_attr(not(unix), ignore = "dlx bin execution is only exercised on Unix")]
 fn dlx_fails_when_a_package_spec_is_missing_from_the_catalog() {
-    let CommandTempCwd { pacquet, root, workspace, .. } =
-        CommandTempCwd::init().add_mocked_registry();
+    for (catalogs_yaml, spec, catalog_name) in [
+        ("catalog:\n  is-positive: 3.1.0\n", "@foo/touch-file-one-bin@catalog:", "default"),
+        (
+            "catalogs:\n  tools:\n    is-positive: 3.1.0\n",
+            "@foo/touch-file-one-bin@catalog:tools",
+            "tools",
+        ),
+    ] {
+        let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
 
-    append_workspace_yaml_key(&workspace, "catalog", "{ is-positive: 3.1.0 }");
+        std::fs::write(workspace.join("pnpm-workspace.yaml"), catalogs_yaml)
+            .expect("write the caller's catalogs");
 
-    let output = pacquet
-        .with_args(["dlx", "@foo/touch-file-one-bin@catalog:"])
-        .output()
-        .expect("run pacquet dlx");
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    eprintln!("STDERR:\n{stderr}\n");
-    assert!(!output.status.success(), "dlx with a missing catalog entry must fail");
-    assert!(
-        stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
-        "the failure must carry the missing-entry error code: {stderr}",
-    );
-    assert!(
-        flatten_report(&stderr)
-            .contains("Nocatalogentry'@foo/touch-file-one-bin'wasfoundforcatalog'default'."),
-        "the failure must name the missing entry and its catalog: {stderr}",
-    );
+        let output = pacquet.with_args(["dlx", spec]).output().expect("run pacquet dlx");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(!output.status.success(), "dlx with a missing catalog entry must fail");
+        assert!(
+            stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
+            "the failure must carry the missing-entry error code: {stderr}",
+        );
+        assert!(
+            flatten_report(&stderr).contains(&format!(
+                "Nocatalogentry'@foo/touch-file-one-bin'wasfoundforcatalog'{catalog_name}'."
+            )),
+            "the failure must name the missing entry and its catalog: {stderr}",
+        );
 
-    drop(root);
+        drop(root);
+    }
 }
 
 /// pnpm's dlx installs the package unpatched, and the caller's patch paths

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -1,6 +1,10 @@
+#[cfg(unix)]
+use crate::_utils::flatten_report;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::CommandTempCwd;
+#[cfg(unix)]
+use std::path::Path;
 
 /// `pacquet dlx` with no command is an error, mirroring pnpm's dlx, which
 /// prints help and exits non-zero when given neither a command nor a
@@ -96,6 +100,92 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
     );
 
     drop(root);
+}
+
+/// A `catalog:` package spec names an entry of the caller's catalogs, which
+/// the throwaway cache project the install is anchored at does not have.
+/// Regression test for `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` on every
+/// `pnpm dlx <pkg>@catalog:` (pnpm/pnpm#14294).
+#[cfg(unix)]
+#[test]
+fn dlx_resolves_a_package_spec_against_the_callers_default_catalog() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    add_catalogs_to_workspace_yaml(&workspace, "catalog:\n  '@foo/touch-file-one-bin': 1.0.0\n");
+
+    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin@catalog:").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+
+    drop(root);
+}
+
+/// Same as the default catalog, for the `catalog:<name>` form.
+#[cfg(unix)]
+#[test]
+fn dlx_resolves_a_package_spec_against_a_named_caller_catalog() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    add_catalogs_to_workspace_yaml(
+        &workspace,
+        "catalogs:\n  tools:\n    '@foo/touch-file-one-bin': 1.0.0\n",
+    );
+
+    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin@catalog:tools").assert().success();
+
+    assert!(
+        workspace.join("touch.txt").exists(),
+        "the package's bin should run in the process cwd and write `touch.txt`",
+    );
+
+    drop(root);
+}
+
+/// A spec naming a catalog that holds no entry for it is a user error, and
+/// must stay one once the caller's catalogs are consulted.
+#[cfg(unix)]
+#[test]
+fn dlx_fails_when_a_package_spec_is_missing_from_the_catalog() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    add_catalogs_to_workspace_yaml(&workspace, "catalog:\n  is-positive: 3.1.0\n");
+
+    let output = pacquet
+        .with_args(["dlx", "@foo/touch-file-one-bin@catalog:"])
+        .output()
+        .expect("run pacquet dlx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    assert!(!output.status.success(), "dlx with a missing catalog entry must fail");
+    assert!(
+        stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
+        "the failure must carry the missing-entry error code: {stderr}",
+    );
+    assert!(
+        flatten_report(&stderr)
+            .contains("Nocatalogentry'@foo/touch-file-one-bin'wasfoundforcatalog'default'."),
+        "the failure must name the missing entry and its catalog: {stderr}",
+    );
+
+    drop(root);
+}
+
+/// Append to the `pnpm-workspace.yaml` that
+/// [`pnpm_testing_utils::bin::CommandTempCwd::add_mocked_registry`] wrote,
+/// rather than replacing it, so the store and cache stay redirected at the
+/// test's own temp dirs.
+#[cfg(unix)]
+fn add_catalogs_to_workspace_yaml(workspace: &Path, catalogs: &str) {
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = std::fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    yaml.push_str(catalogs);
+    std::fs::write(&yaml_path, yaml).expect("write the caller's catalogs");
 }
 
 /// pnpm's dlx installs the package unpatched, and the caller's patch paths

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -1,10 +1,7 @@
-#[cfg(unix)]
-use crate::_utils::flatten_report;
+use crate::_utils::{append_workspace_yaml_key, flatten_report};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::CommandTempCwd;
-#[cfg(unix)]
-use std::path::Path;
 
 /// `pacquet dlx` with no command is an error, mirroring pnpm's dlx, which
 /// prints help and exits non-zero when given neither a command nor a
@@ -106,13 +103,13 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
 /// the throwaway cache project the install is anchored at does not have.
 /// Regression test for `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` on every
 /// `pnpm dlx <pkg>@catalog:` (pnpm/pnpm#14294).
-#[cfg(unix)]
 #[test]
+#[cfg_attr(not(unix), ignore = "dlx bin execution is only exercised on Unix")]
 fn dlx_resolves_a_package_spec_against_the_callers_default_catalog() {
     let CommandTempCwd { pacquet, root, workspace, .. } =
         CommandTempCwd::init().add_mocked_registry();
 
-    add_catalogs_to_workspace_yaml(&workspace, "catalog:\n  '@foo/touch-file-one-bin': 1.0.0\n");
+    append_workspace_yaml_key(&workspace, "catalog", "{ '@foo/touch-file-one-bin': 1.0.0 }");
 
     pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin@catalog:").assert().success();
 
@@ -124,19 +121,29 @@ fn dlx_resolves_a_package_spec_against_the_callers_default_catalog() {
     drop(root);
 }
 
-/// Same as the default catalog, for the `catalog:<name>` form.
-#[cfg(unix)]
+/// The `catalog:<name>` form, passed through `--package` so the other
+/// source of the dlx package list is covered too.
 #[test]
+#[cfg_attr(not(unix), ignore = "dlx bin execution is only exercised on Unix")]
 fn dlx_resolves_a_package_spec_against_a_named_caller_catalog() {
     let CommandTempCwd { pacquet, root, workspace, .. } =
         CommandTempCwd::init().add_mocked_registry();
 
-    add_catalogs_to_workspace_yaml(
+    append_workspace_yaml_key(
         &workspace,
-        "catalogs:\n  tools:\n    '@foo/touch-file-one-bin': 1.0.0\n",
+        "catalogs",
+        "{ tools: { '@foo/touch-file-one-bin': 1.0.0 } }",
     );
 
-    pacquet.with_arg("dlx").with_arg("@foo/touch-file-one-bin@catalog:tools").assert().success();
+    pacquet
+        .with_args([
+            "dlx",
+            "--package",
+            "@foo/touch-file-one-bin@catalog:tools",
+            "touch-file-one-bin",
+        ])
+        .assert()
+        .success();
 
     assert!(
         workspace.join("touch.txt").exists(),
@@ -148,13 +155,13 @@ fn dlx_resolves_a_package_spec_against_a_named_caller_catalog() {
 
 /// A spec naming a catalog that holds no entry for it is a user error, and
 /// must stay one once the caller's catalogs are consulted.
-#[cfg(unix)]
 #[test]
+#[cfg_attr(not(unix), ignore = "dlx bin execution is only exercised on Unix")]
 fn dlx_fails_when_a_package_spec_is_missing_from_the_catalog() {
     let CommandTempCwd { pacquet, root, workspace, .. } =
         CommandTempCwd::init().add_mocked_registry();
 
-    add_catalogs_to_workspace_yaml(&workspace, "catalog:\n  is-positive: 3.1.0\n");
+    append_workspace_yaml_key(&workspace, "catalog", "{ is-positive: 3.1.0 }");
 
     let output = pacquet
         .with_args(["dlx", "@foo/touch-file-one-bin@catalog:"])
@@ -174,18 +181,6 @@ fn dlx_fails_when_a_package_spec_is_missing_from_the_catalog() {
     );
 
     drop(root);
-}
-
-/// Append to the `pnpm-workspace.yaml` that
-/// [`pnpm_testing_utils::bin::CommandTempCwd::add_mocked_registry`] wrote,
-/// rather than replacing it, so the store and cache stay redirected at the
-/// test's own temp dirs.
-#[cfg(unix)]
-fn add_catalogs_to_workspace_yaml(workspace: &Path, catalogs: &str) {
-    let yaml_path = workspace.join("pnpm-workspace.yaml");
-    let mut yaml = std::fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
-    yaml.push_str(catalogs);
-    std::fs::write(&yaml_path, yaml).expect("write the caller's catalogs");
 }
 
 /// pnpm's dlx installs the package unpatched, and the caller's patch paths


### PR DESCRIPTION
## Summary

`pnpm dlx <pkg>@catalog:` failed with `ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC` in the Rust CLI. `install_into_cache` dereferences `catalog:` values in `overrides`, but the package specs themselves were handed to `add_package` untouched, and by then `config.workspace_dir` points at the throwaway cache project, which has no catalogs.

The specs now go through `resolve_from_catalog` in `DlxArgs::run`, while the caller's workspace is still the current one. Doing it there rather than inside `install_into_cache` also puts the catalog's version into the dlx cache key, so two projects whose catalogs pin different versions of the same package don't share a cache entry.

Rust-only: the TypeScript CLI already resolves these specs (pnpm/pnpm#11308).

Fixes pnpm/pnpm#14294

## Squash Commit Body

```text
`pnpm dlx <pkg>@catalog:` resolved the specifier against the throwaway dlx cache
project instead of the calling workspace, so every catalog spec failed with
ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC. install_into_cache already resolved
`catalog:` values in `overrides` before re-anchoring config.workspace_dir at the
cache dir, but the package specs were passed to add_package unchanged.

Resolve them in DlxArgs::run instead, before the cache key is computed: the
caller's catalogs are still reachable there, and the catalog's version then
participates in the key, so two callers pinning different versions of the same
package no longer share a cache entry. Reading the workspace manifest is skipped
unless a spec actually uses the protocol, and a missing or malformed entry
surfaces the same diagnostic `pnpm add` would give.

The TypeScript CLI already has this behavior (pnpm/pnpm#11308), so this is a
Rust-only catch-up.

Closes pnpm/pnpm#14294
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790539640&installation_model_id=426870&pr_number=14296&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14296&signature=49ae964b44f8db44dd69967e27c9ae6affca690516067e56d131725bb008b54d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm dlx <package>`@catalog`:` now resolves package versions from the calling workspace’s catalogs.
  * Supports both default and named catalogs.

* **Bug Fixes**
  * Fixed failures when using catalog-based package specifications with `pnpm dlx`.
  * Improved handling and reporting when referenced catalog entries are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->