### PR TITLE
fix(pacquet): resolve caller catalogs in dlx

### DIFF
--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -9,6 +9,10 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
+use pnpm_catalogs_resolver::{
+    CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
+};
+use pnpm_catalogs_types::Catalogs;
 use pnpm_cmd_shim::{Host as CmdShimHost, get_bins_from_package_manifest};
 use pnpm_config::Config;
 use pnpm_config_parse_overrides::parse_overrides_iter;
@@ -338,23 +342,22 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The cache install is always fresh, so no lockfile is loaded from
     // the process working directory.
     config.lockfile = false;
-    // The cache install inherits the caller project's `overrides` (pnpm's
-    // dlx likewise runs its install with the invoking project's
-    // already-loaded config), and a `catalog:` value in them resolves
-    // against the caller's catalogs. Those catalogs are only reachable
-    // through `workspace_dir`, which is severed right below — resolve the
-    // references now, or the install would look them up against an empty
-    // catalog set and fail with ERR_PNPM_CATALOG_IN_OVERRIDES.
-    if let (Some(overrides), Some(workspace_dir)) =
-        (config.overrides.as_ref(), config.workspace_dir.as_deref())
-        && overrides.values().any(|spec| spec.starts_with("catalog:"))
-    {
+    // The cache install is not part of the caller workspace. Resolve its
+    // catalog references before anchoring it at the cache directory.
+    let caller_catalogs = if let Some(workspace_dir) = config.workspace_dir.as_deref() {
         let workspace_manifest =
             pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-        let catalogs = get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
             .into_diagnostic()
-            .wrap_err("reading the caller's catalogs for the dlx install")?;
-        let resolved = parse_overrides_iter(overrides.iter(), &catalogs)
+            .wrap_err("reading the caller's catalogs for the dlx install")?
+    } else {
+        Catalogs::default()
+    };
+    let pkgs = dereference_catalog_specs(pkgs, &caller_catalogs)?;
+    if let Some(overrides) = config.overrides.as_ref()
+        && overrides.values().any(|spec| spec.starts_with("catalog:"))
+    {
+        let resolved = parse_overrides_iter(overrides.iter(), &caller_catalogs)
             .map_err(miette::Report::new)?
             .into_iter()
             .map(|entry| (entry.selector, entry.new_bare_specifier))
@@ -387,7 +390,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // unable to distinguish two callers with different policies.
     config.dangerously_allow_all_builds = false;
     config.allow_builds.clear();
-    for spec in pkgs {
+    for spec in &pkgs {
         if let Some(alias) = parse_wanted_dependency(spec).alias {
             config.allow_builds.insert(alias, true);
         }
@@ -402,7 +405,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
             .wrap_err("initialize the dlx install state")?;
         add_package::<Reporter, _>(
             state,
-            pkg,
+            &pkg,
             // dlx records the default caret range; the spec is throwaway.
             RangeSpecStyle::default(),
             // dlx never catalogs.
@@ -415,6 +418,27 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
         .await?;
     }
     Ok(())
+}
+
+fn dereference_catalog_specs(pkgs: &[String], catalogs: &Catalogs) -> miette::Result<Vec<String>> {
+    pkgs.iter()
+        .map(|pkg| {
+            let parsed = parse_wanted_dependency(pkg);
+            let (Some(alias), Some(bare_specifier)) = (parsed.alias, parsed.bare_specifier) else {
+                return Ok(pkg.clone());
+            };
+            let wanted = CatalogWantedDependency { alias: alias.clone(), bare_specifier };
+            match resolve_from_catalog(catalogs, &wanted) {
+                CatalogResolutionResult::Found(found) => {
+                    Ok(format!("{alias}@{}", found.resolution.specifier))
+                }
+                CatalogResolutionResult::Misconfiguration(misconfiguration) => {
+                    Err(miette::Report::new(misconfiguration.error))
+                }
+                CatalogResolutionResult::Unused => Ok(pkg.clone()),
+            }
+        })
+        .collect()
 }
 
 /// How dlx spawns whatever it ends up running: the working directory and

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -9,6 +9,7 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
+use pnpm_catalogs_protocol_parser::parse_catalog_protocol;
 use pnpm_catalogs_resolver::{
     CatalogResolutionResult, WantedDependency as CatalogWantedDependency, resolve_from_catalog,
 };
@@ -238,8 +239,22 @@ impl DlxArgs {
 
         // `pkgs = package ?? [command]`. With `--package`, the command
         // names the bin to run; otherwise the command is also the package.
-        let pkgs: Vec<String> =
+        let mut pkgs: Vec<String> =
             if package.is_empty() { vec![bin_command.clone()] } else { package.clone() };
+        let needs_caller_catalogs = pkgs.iter().any(|pkg| {
+            parse_wanted_dependency(pkg)
+                .bare_specifier
+                .as_deref()
+                .is_some_and(|bare_specifier| parse_catalog_protocol(bare_specifier).is_some())
+        }) || config
+            .overrides
+            .as_ref()
+            .is_some_and(|overrides| overrides.values().any(|spec| spec.starts_with("catalog:")));
+        let caller_catalogs =
+            needs_caller_catalogs.then(|| read_caller_catalogs(config)).transpose()?;
+        if let Some(catalogs) = &caller_catalogs {
+            pkgs = dereference_catalog_specs(&pkgs, catalogs)?;
+        }
 
         // Read the config values needed before (and after) the install,
         // because the install path consumes `config` to anchor it at the
@@ -282,6 +297,7 @@ impl DlxArgs {
                     &allow_build,
                     &supported_architectures,
                     config,
+                    caller_catalogs.as_ref(),
                 )
                 .await
                 {
@@ -316,6 +332,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     allow_build: &[String],
     supported_architectures: &SupportedArchitecturesArgs,
     config: &'static mut Config,
+    caller_catalogs: Option<&Catalogs>,
 ) -> miette::Result<()> {
     fs::create_dir_all(prepare_dir)
         .map_err(|source| DlxError::Cache { dir: prepare_dir.display().to_string(), source })?;
@@ -342,22 +359,10 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // The cache install is always fresh, so no lockfile is loaded from
     // the process working directory.
     config.lockfile = false;
-    // The cache install is not part of the caller workspace. Resolve its
-    // catalog references before anchoring it at the cache directory.
-    let caller_catalogs = if let Some(workspace_dir) = config.workspace_dir.as_deref() {
-        let workspace_manifest =
-            pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
-        get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
-            .into_diagnostic()
-            .wrap_err("reading the caller's catalogs for the dlx install")?
-    } else {
-        Catalogs::default()
-    };
-    let pkgs = dereference_catalog_specs(pkgs, &caller_catalogs)?;
-    if let Some(overrides) = config.overrides.as_ref()
+    if let (Some(overrides), Some(catalogs)) = (config.overrides.as_ref(), caller_catalogs)
         && overrides.values().any(|spec| spec.starts_with("catalog:"))
     {
-        let resolved = parse_overrides_iter(overrides.iter(), &caller_catalogs)
+        let resolved = parse_overrides_iter(overrides.iter(), catalogs)
             .map_err(miette::Report::new)?
             .into_iter()
             .map(|entry| (entry.selector, entry.new_bare_specifier))
@@ -390,7 +395,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
     // unable to distinguish two callers with different policies.
     config.dangerously_allow_all_builds = false;
     config.allow_builds.clear();
-    for spec in &pkgs {
+    for spec in pkgs {
         if let Some(alias) = parse_wanted_dependency(spec).alias {
             config.allow_builds.insert(alias, true);
         }
@@ -405,7 +410,7 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
             .wrap_err("initialize the dlx install state")?;
         add_package::<Reporter, _>(
             state,
-            &pkg,
+            pkg,
             // dlx records the default caret range; the spec is throwaway.
             RangeSpecStyle::default(),
             // dlx never catalogs.
@@ -418,6 +423,17 @@ async fn install_into_cache<Reporter: self::Reporter + 'static>(
         .await?;
     }
     Ok(())
+}
+
+fn read_caller_catalogs(config: &Config) -> miette::Result<Catalogs> {
+    let Some(workspace_dir) = config.workspace_dir.as_deref() else {
+        return Ok(Catalogs::default());
+    };
+    let workspace_manifest =
+        pnpm_workspace::read_workspace_manifest(workspace_dir).into_diagnostic()?;
+    get_catalogs_from_workspace_manifest(workspace_manifest.as_ref())
+        .into_diagnostic()
+        .wrap_err("reading the caller's catalogs for the dlx install")
 }
 
 fn dereference_catalog_specs(pkgs: &[String], catalogs: &Catalogs) -> miette::Result<Vec<String>> {

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -157,6 +157,46 @@ fn dlx_reports_missing_caller_catalog_package_specifiers() {
     drop(root);
 }
 
+#[test]
+fn dlx_reports_missing_named_caller_catalog_package_specifiers() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    std::fs::write(workspace.join("pnpm-workspace.yaml"), "catalogs:\n  named: {}\n")
+        .expect("write caller project workspace yaml");
+
+    let output = pacquet
+        .with_args(["dlx", "@foo/touch-file-one-bin@catalog:named"])
+        .output()
+        .expect("run pacquet dlx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "dlx should fail for a missing catalog entry");
+    assert!(
+        stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
+        "dlx should report the missing catalog error\nstderr:\n{stderr}",
+    );
+
+    drop(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn dlx_ignores_invalid_catalogs_without_catalog_references() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "catalog:\n  foo: 1.0.0\ncatalogs:\n  default:\n    bar: 1.0.0\n",
+    )
+    .expect("write caller project workspace yaml");
+
+    pacquet.with_args(["dlx", "@foo/touch-file-one-bin"]).assert().success();
+
+    assert!(workspace.join("touch.txt").exists(), "dlx should run the requested package bin");
+
+    drop(root);
+}
+
 /// pnpm's dlx installs the package unpatched, and the caller's patch paths
 /// are relative to a workspace root the cache install does not have.
 #[test]

--- a/pnpm/crates/cli/tests/suite/dlx.rs
+++ b/pnpm/crates/cli/tests/suite/dlx.rs
@@ -98,6 +98,65 @@ fn dlx_resolves_caller_catalog_references_in_overrides() {
     drop(root);
 }
 
+#[cfg(unix)]
+#[test]
+fn dlx_resolves_caller_catalog_package_specifiers() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "catalog:\n  '@foo/touch-file-one-bin': 1.0.0\ncatalogs:\n  named:\n    '@foo/touch-file-one-bin': 1.0.0\n",
+    )
+    .expect("write caller project workspace yaml");
+
+    pacquet.with_args(["dlx", "@foo/touch-file-one-bin@catalog:"]).assert().success();
+
+    assert!(workspace.join("touch.txt").exists(), "dlx should run the catalog package bin");
+
+    drop(root);
+}
+
+#[cfg(unix)]
+#[test]
+fn dlx_resolves_named_caller_catalog_package_specifiers() {
+    let CommandTempCwd { pacquet, root, workspace, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+
+    std::fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "catalogs:\n  named:\n    '@foo/touch-file-one-bin': 1.0.0\n",
+    )
+    .expect("write caller project workspace yaml");
+
+    pacquet.with_args(["dlx", "@foo/touch-file-one-bin@catalog:named"]).assert().success();
+
+    assert!(workspace.join("touch.txt").exists(), "dlx should run the catalog package bin");
+
+    drop(root);
+}
+
+#[test]
+fn dlx_reports_missing_caller_catalog_package_specifiers() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+
+    std::fs::write(workspace.join("pnpm-workspace.yaml"), "catalog: {}\n")
+        .expect("write caller project workspace yaml");
+
+    let output = pacquet
+        .with_args(["dlx", "@foo/touch-file-one-bin@catalog:"])
+        .output()
+        .expect("run pacquet dlx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "dlx should fail for a missing catalog entry");
+    assert!(
+        stderr.contains("ERR_PNPM_CATALOG_ENTRY_NOT_FOUND_FOR_SPEC"),
+        "dlx should report the missing catalog error\nstderr:\n{stderr}",
+    );
+
+    drop(root);
+}
+
 /// pnpm's dlx installs the package unpatched, and the caller's patch paths
 /// are relative to a workspace root the cache install does not have.
 #[test]


### PR DESCRIPTION
Fixes #14294.

Resolve direct `dlx` package specifiers through the caller workspace catalogs before the cache install is anchored to its temporary directory. This preserves the isolation of the throwaway install while restoring TypeScript CLI parity for `pnpm dlx <package>@catalog:`.

The change:

- retains the existing pre-anchor resolution of catalog values in `overrides`;
- resolves direct package specifiers for the default and named catalogs; and
- reports the existing missing-catalog diagnostic when an entry is absent.

Tests:

- `cargo test -p pnpm-cli --test suite dlx`
- `cargo clippy -p pnpm-cli --tests -- -D warnings`

---
Written by an agent (GitHub Copilot CLI, gpt-5.6-terra).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790540621&installation_model_id=426870&pr_number=14297&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14297&signature=0a09f3e0e5aa88ce65bf6180642b980ed3d20ce9f68450a41e5c2908e86c1b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `dlx` now correctly resolves default and named `catalog:` package references from the calling workspace.
  * Packages using catalog references can now run successfully from the `dlx` cache.
  * Missing catalog entries now return a clear error instead of proceeding with an invalid package specification.
  * Unrelated invalid catalog definitions no longer block normal package resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->