### PR TITLE
fix: protect symlinked modules during install

### DIFF
--- a/.changeset/calm-wombats-link.md
+++ b/.changeset/calm-wombats-link.md
@@ -1,7 +1,6 @@
 ---
 "@pnpm/installing.context": patch
-"@pnpm/installing.deps-installer": patch
 "pnpm": patch
 ---
 
-Prevent installs through a symlinked `node_modules` directory from rewriting the target checkout, and make `pnpm add --lockfile-only` skip dependency linking [pnpm/pnpm#14286](https://github.com/pnpm/pnpm/issues/14286).
+Prevent installs through a symlinked `node_modules` directory from rewriting the target checkout [pnpm/pnpm#14286](https://github.com/pnpm/pnpm/issues/14286).

--- a/.changeset/calm-wombats-link.md
+++ b/.changeset/calm-wombats-link.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.context": patch
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Prevent installs through a symlinked `node_modules` directory from rewriting the target checkout, and make `pnpm add --lockfile-only` skip dependency linking [pnpm/pnpm#14286](https://github.com/pnpm/pnpm/issues/14286).

--- a/.changeset/kind-otters-lock.md
+++ b/.changeset/kind-otters-lock.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+---
+
+Make `pnpm add --lockfile-only` skip dependency linking [pnpm/pnpm#14286](https://github.com/pnpm/pnpm/issues/14286).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5586,6 +5586,9 @@ importers:
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
+      realpath-missing:
+        specifier: 'catalog:'
+        version: 2.0.0
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'

--- a/pnpm11/installing/context/package.json
+++ b/pnpm11/installing/context/package.json
@@ -42,7 +42,8 @@
     "@pnpm/store.controller": "workspace:*",
     "@pnpm/types": "workspace:*",
     "path-absolute": "catalog:",
-    "ramda": "catalog:"
+    "ramda": "catalog:",
+    "realpath-missing": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"

--- a/pnpm11/installing/context/src/index.ts
+++ b/pnpm11/installing/context/src/index.ts
@@ -23,6 +23,7 @@ import type {
 } from '@pnpm/types'
 import { pathAbsolute } from 'path-absolute'
 import { clone } from 'ramda'
+import { realpathMissing } from 'realpath-missing'
 
 import { readLockfiles } from './readLockfiles.js'
 
@@ -121,7 +122,9 @@ export async function getContext (
 ): Promise<PnpmContext> {
   const modulesDir = opts.modulesDir ?? 'node_modules'
   const importersContext = await readProjectsContext(opts.allProjects, { lockfileDir: opts.lockfileDir, modulesDir })
-  const virtualStoreDir = pathAbsolute(opts.virtualStoreDir ?? path.join(modulesDir, '.pnpm'), opts.lockfileDir)
+  const virtualStoreDir = opts.virtualStoreDir == null
+    ? path.join(importersContext.rootModulesDir, '.pnpm')
+    : await realpathMissing(pathAbsolute(opts.virtualStoreDir, opts.lockfileDir))
 
   if (!opts.frozenStore) {
     await fs.mkdir(opts.storeDir, { recursive: true })
@@ -295,7 +298,9 @@ export async function getContextForSingleImporter (
   const importer = projects[0]
   const modulesDir = importer.modulesDir
   const importerId = importer.id
-  const virtualStoreDir = pathAbsolute(opts.virtualStoreDir ?? 'node_modules/.pnpm', opts.lockfileDir)
+  const virtualStoreDir = opts.virtualStoreDir == null
+    ? path.join(rootModulesDir, '.pnpm')
+    : await realpathMissing(pathAbsolute(opts.virtualStoreDir, opts.lockfileDir))
 
   if (!opts.frozenStore) {
     await fs.mkdir(storeDir, { recursive: true })

--- a/pnpm11/installing/context/test/index.ts
+++ b/pnpm11/installing/context/test/index.ts
@@ -47,6 +47,33 @@ test('getContext - extendNodePath true', async () => {
   expect(context.extraNodePaths).toEqual([path.join(context.virtualStoreDir, 'node_modules')])
 })
 
+test('getContext resolves the virtual store through a symlinked modules directory', async () => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pnpm-get-context-'))
+  const primaryDir = path.join(tempDir, 'primary')
+  const primaryModulesDir = path.join(primaryDir, 'node_modules')
+  const worktreeDir = path.join(tempDir, 'worktree')
+  await Promise.all([
+    fs.mkdir(path.join(primaryModulesDir, '.pnpm'), { recursive: true }),
+    fs.mkdir(worktreeDir, { recursive: true }),
+  ])
+  await fs.symlink(primaryModulesDir, path.join(worktreeDir, 'node_modules'), process.platform === 'win32' ? 'junction' : 'dir')
+
+  const context = await getContext({
+    ...DEFAULT_OPTIONS,
+    allProjects: [{
+      buildIndex: 0,
+      manifest: {},
+      rootDir: worktreeDir as ProjectRootDir,
+    }],
+    lockfileDir: worktreeDir,
+    storeDir: path.join(tempDir, 'store'),
+  })
+
+  const realPrimaryModulesDir = await fs.realpath(primaryModulesDir)
+  expect(context.rootModulesDir).toBe(realPrimaryModulesDir)
+  expect(context.virtualStoreDir).toBe(path.join(realPrimaryModulesDir, '.pnpm'))
+})
+
 // This is supported for compatibility with Yarn's implementation
 // see https://github.com/pnpm/pnpm/issues/2648
 test('arrayOfWorkspacePackagesToMap() treats private packages with no version as packages with 0.0.0 version', () => {

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2161,6 +2161,7 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
             })
           }
         }
+        if (opts.lockfileOnly) return await _installInContext(newProjects, ctx, opts)
         const result = await installInContext(newProjects, ctx, {
           ...opts,
           lockfileOnly: true,

--- a/pnpm11/installing/deps-installer/test/install/lockfileOnly.ts
+++ b/pnpm11/installing/deps-installer/test/install/lockfileOnly.ts
@@ -3,13 +3,16 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { assertStore } from '@pnpm/assert-store'
-import { ABBREVIATED_META_DIR } from '@pnpm/constants'
+import { ABBREVIATED_META_DIR, WANTED_LOCKFILE } from '@pnpm/constants'
 import {
   addDependenciesToPackage,
   install,
+  mutateModules,
 } from '@pnpm/installing.deps-installer'
-import { prepareEmpty } from '@pnpm/prepare'
+import { prepareEmpty, preparePackages } from '@pnpm/prepare'
 import { addDistTag, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
+import type { ProjectRootDir } from '@pnpm/types'
+import { readYamlFileSync } from 'read-yaml-file'
 
 import { testDefaults } from '../utils/index.js'
 
@@ -61,4 +64,50 @@ test('do not update the lockfile when lockfileOnly and frozenLockfile are both u
     lockfileOnly: true,
     frozenLockfile: true,
   }))).rejects.toThrow(/is not up to date/)
+})
+
+test('a partial workspace install with lockfileOnly does not create node_modules', async () => {
+  preparePackages([
+    {
+      location: 'project-1',
+      package: { name: 'project-1' },
+    },
+    {
+      location: 'project-2',
+      package: { name: 'project-2' },
+    },
+  ])
+  const allProjects = [
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-1',
+        dependencies: {
+          'is-positive': '1.0.0',
+        },
+      },
+      rootDir: path.resolve('project-1') as ProjectRootDir,
+    },
+    {
+      buildIndex: 0,
+      manifest: {
+        name: 'project-2',
+        dependencies: {
+          'is-negative': '1.0.0',
+        },
+      },
+      rootDir: path.resolve('project-2') as ProjectRootDir,
+    },
+  ]
+
+  await mutateModules([{
+    mutation: 'install',
+    rootDir: allProjects[0].rootDir,
+  }], testDefaults({ allProjects, lockfileOnly: true }))
+
+  expect(fs.existsSync(path.resolve('node_modules'))).toBe(false)
+  expect(fs.existsSync(path.resolve('project-1/node_modules'))).toBe(false)
+  expect(fs.existsSync(path.resolve('project-2/node_modules'))).toBe(false)
+  const lockfile = readYamlFileSync(WANTED_LOCKFILE) as { importers: Record<string, unknown> }
+  expect(Object.keys(lockfile.importers)).toStrictEqual(['project-1', 'project-2'])
 })

--- a/pnpm11/pnpm/test/install/symlinkedModulesDir.ts
+++ b/pnpm11/pnpm/test/install/symlinkedModulesDir.ts
@@ -1,0 +1,84 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { preparePackages, tempDir } from '@pnpm/prepare'
+import { readYamlFileSync } from 'read-yaml-file'
+import { writeYamlFileSync } from 'write-yaml-file'
+
+import { execPnpmSync } from '../utils/index.js'
+
+test('add --lockfile-only through symlinked node_modules does not mutate the target checkout', () => {
+  const testDir = tempDir()
+  const primaryDir = path.join(testDir, 'primary')
+  const worktreeDir = path.join(testDir, 'worktree')
+  preparePackages([
+    {
+      location: 'primary',
+      package: {
+        name: 'root',
+        private: true,
+        dependencies: { 'is-odd': '3.0.1' },
+      },
+    },
+    {
+      location: 'primary/pkgs/a',
+      package: {
+        name: 'a',
+        private: true,
+        dependencies: { 'is-even': '1.0.0' },
+      },
+    },
+    {
+      location: 'primary/pkgs/b',
+      package: {
+        name: 'b',
+        private: true,
+        dependencies: { 'is-number': '7.0.0' },
+      },
+    },
+  ], { tempDir: path.join(testDir, 'project') })
+  writeYamlFileSync(path.join(primaryDir, 'pnpm-workspace.yaml'), { packages: ['pkgs/*'] })
+  execPnpmSync(['install'], { cwd: primaryDir, expectSuccess: true })
+
+  for (const relativeDir of ['', 'pkgs/a', 'pkgs/b']) {
+    const targetDir = path.join(worktreeDir, relativeDir)
+    fs.mkdirSync(targetDir, { recursive: true })
+    fs.copyFileSync(path.join(primaryDir, relativeDir, 'package.json'), path.join(targetDir, 'package.json'))
+  }
+  fs.copyFileSync(path.join(primaryDir, 'pnpm-workspace.yaml'), path.join(worktreeDir, 'pnpm-workspace.yaml'))
+  fs.copyFileSync(path.join(primaryDir, WANTED_LOCKFILE), path.join(worktreeDir, WANTED_LOCKFILE))
+
+  for (const relativeDir of ['', 'pkgs/a', 'pkgs/b']) {
+    fs.symlinkSync(
+      path.join(primaryDir, relativeDir, 'node_modules'),
+      path.join(worktreeDir, relativeDir, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+  }
+
+  const dependencyLinks = [
+    path.join(primaryDir, 'node_modules/is-odd'),
+    path.join(primaryDir, 'pkgs/a/node_modules/is-even'),
+    path.join(primaryDir, 'pkgs/b/node_modules/is-number'),
+  ]
+  const linkTargetsBefore = dependencyLinks.map(link => fs.readlinkSync(link))
+  const modulesManifestPath = path.join(primaryDir, 'node_modules/.modules.yaml')
+  const modulesManifestBefore = fs.readFileSync(modulesManifestPath, 'utf8')
+
+  execPnpmSync(['add', 'left-pad', '--lockfile-only'], {
+    cwd: path.join(worktreeDir, 'pkgs/a'),
+    expectSuccess: true,
+  })
+
+  expect(dependencyLinks.map(link => fs.readlinkSync(link))).toStrictEqual(linkTargetsBefore)
+  expect(fs.readFileSync(modulesManifestPath, 'utf8')).toBe(modulesManifestBefore)
+  expect(fs.existsSync(path.join(primaryDir, 'pkgs/a/node_modules/left-pad'))).toBe(false)
+  expect(JSON.parse(fs.readFileSync(path.join(worktreeDir, 'pkgs/a/package.json'), 'utf8')))
+    .toHaveProperty('dependencies.left-pad')
+  const lockfile = readYamlFileSync(path.join(worktreeDir, WANTED_LOCKFILE)) as {
+    importers: Record<string, { dependencies?: Record<string, unknown> }>
+  }
+  expect(lockfile.importers['pkgs/a'].dependencies).toHaveProperty('left-pad')
+})

--- a/pnpm11/pnpm/test/install/symlinkedModulesDir.ts
+++ b/pnpm11/pnpm/test/install/symlinkedModulesDir.ts
@@ -1,15 +1,16 @@
-import fs from 'node:fs'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { preparePackages, tempDir } from '@pnpm/prepare'
-import { readYamlFileSync } from 'read-yaml-file'
-import { writeYamlFileSync } from 'write-yaml-file'
+import { pathExists } from 'path-exists'
+import { readYamlFile } from 'read-yaml-file'
+import { writeYamlFile } from 'write-yaml-file'
 
 import { execPnpmSync } from '../utils/index.js'
 
-test('add --lockfile-only through symlinked node_modules does not mutate the target checkout', () => {
+test('add --lockfile-only through symlinked node_modules does not mutate the target checkout', async () => {
   const testDir = tempDir()
   const primaryDir = path.join(testDir, 'primary')
   const worktreeDir = path.join(testDir, 'worktree')
@@ -39,46 +40,57 @@ test('add --lockfile-only through symlinked node_modules does not mutate the tar
       },
     },
   ], { tempDir: path.join(testDir, 'project') })
-  writeYamlFileSync(path.join(primaryDir, 'pnpm-workspace.yaml'), { packages: ['pkgs/*'] })
+  await writeYamlFile(path.join(primaryDir, 'pnpm-workspace.yaml'), { packages: ['pkgs/*'] })
   execPnpmSync(['install'], { cwd: primaryDir, expectSuccess: true })
 
-  for (const relativeDir of ['', 'pkgs/a', 'pkgs/b']) {
+  const relativeDirs = ['', 'pkgs/a', 'pkgs/b']
+  await Promise.all(relativeDirs.map(async relativeDir => {
     const targetDir = path.join(worktreeDir, relativeDir)
-    fs.mkdirSync(targetDir, { recursive: true })
-    fs.copyFileSync(path.join(primaryDir, relativeDir, 'package.json'), path.join(targetDir, 'package.json'))
-  }
-  fs.copyFileSync(path.join(primaryDir, 'pnpm-workspace.yaml'), path.join(worktreeDir, 'pnpm-workspace.yaml'))
-  fs.copyFileSync(path.join(primaryDir, WANTED_LOCKFILE), path.join(worktreeDir, WANTED_LOCKFILE))
+    await fs.mkdir(targetDir, { recursive: true })
+    await fs.copyFile(path.join(primaryDir, relativeDir, 'package.json'), path.join(targetDir, 'package.json'))
+  }))
+  await Promise.all([
+    fs.copyFile(path.join(primaryDir, 'pnpm-workspace.yaml'), path.join(worktreeDir, 'pnpm-workspace.yaml')),
+    fs.copyFile(path.join(primaryDir, WANTED_LOCKFILE), path.join(worktreeDir, WANTED_LOCKFILE)),
+  ])
 
-  for (const relativeDir of ['', 'pkgs/a', 'pkgs/b']) {
-    fs.symlinkSync(
+  await Promise.all(relativeDirs.map(relativeDir =>
+    fs.symlink(
       path.join(primaryDir, relativeDir, 'node_modules'),
       path.join(worktreeDir, relativeDir, 'node_modules'),
       process.platform === 'win32' ? 'junction' : 'dir'
     )
-  }
+  ))
 
   const dependencyLinks = [
     path.join(primaryDir, 'node_modules/is-odd'),
     path.join(primaryDir, 'pkgs/a/node_modules/is-even'),
     path.join(primaryDir, 'pkgs/b/node_modules/is-number'),
   ]
-  const linkTargetsBefore = dependencyLinks.map(link => fs.readlinkSync(link))
   const modulesManifestPath = path.join(primaryDir, 'node_modules/.modules.yaml')
-  const modulesManifestBefore = fs.readFileSync(modulesManifestPath, 'utf8')
+  const [linkTargetsBefore, modulesManifestBefore] = await Promise.all([
+    Promise.all(dependencyLinks.map(link => fs.readlink(link))),
+    fs.readFile(modulesManifestPath, 'utf8'),
+  ])
 
   execPnpmSync(['add', 'left-pad', '--lockfile-only'], {
     cwd: path.join(worktreeDir, 'pkgs/a'),
     expectSuccess: true,
   })
 
-  expect(dependencyLinks.map(link => fs.readlinkSync(link))).toStrictEqual(linkTargetsBefore)
-  expect(fs.readFileSync(modulesManifestPath, 'utf8')).toBe(modulesManifestBefore)
-  expect(fs.existsSync(path.join(primaryDir, 'pkgs/a/node_modules/left-pad'))).toBe(false)
-  expect(JSON.parse(fs.readFileSync(path.join(worktreeDir, 'pkgs/a/package.json'), 'utf8')))
+  const [linkTargetsAfter, modulesManifestAfter, leftPadExists, packageJson, lockfile] = await Promise.all([
+    Promise.all(dependencyLinks.map(link => fs.readlink(link))),
+    fs.readFile(modulesManifestPath, 'utf8'),
+    pathExists(path.join(primaryDir, 'pkgs/a/node_modules/left-pad')),
+    fs.readFile(path.join(worktreeDir, 'pkgs/a/package.json'), 'utf8').then(JSON.parse),
+    readYamlFile(path.join(worktreeDir, WANTED_LOCKFILE)) as Promise<{
+      importers: Record<string, { dependencies?: Record<string, unknown> }>
+    }>,
+  ])
+  expect(linkTargetsAfter).toStrictEqual(linkTargetsBefore)
+  expect(modulesManifestAfter).toBe(modulesManifestBefore)
+  expect(leftPadExists).toBe(false)
+  expect(packageJson)
     .toHaveProperty('dependencies.left-pad')
-  const lockfile = readYamlFileSync(path.join(worktreeDir, WANTED_LOCKFILE)) as {
-    importers: Record<string, { dependencies?: Record<string, unknown> }>
-  }
   expect(lockfile.importers['pkgs/a'].dependencies).toHaveProperty('left-pad')
 })


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14286.

- Resolve the virtual store through the canonical modules directory so an install through a symlinked `node_modules` does not rewrite another checkout's dependency links or `.modules.yaml`.
- Keep partial workspace `--lockfile-only` operations in the resolution path, but return before dependency materialization.
- Add regressions for canonical virtual-store resolution and lockfile-only workspace updates without linking.

Pacquet already returns before materialization for `lockfileOnly` installs and keeps its logical link and store paths consistent, so no Rust change is required.

Verification:

- `pnpm --filter @pnpm/installing.context test`
- Focused `lockfileOnly.ts` Jest run: 3 tests passed
- `pnpm --filter pnpm run compile`
- Full pre-push TypeScript, spellcheck, metadata, and lint hooks
- Exact issue reproduction: direct symlink text and `.modules.yaml` checksum remained unchanged; the added dependency was not linked

## Squash Commit Body

```text
Resolve virtual store paths against the canonical modules directory so installs through a
symlink do not rewrite another checkout.

Keep partial workspace lockfile-only operations in the resolution path and stop before
materializing dependencies.

Fixes pnpm/pnpm#14286
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790546325&installation_model_id=426870&pr_number=14298&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14298&signature=d0437812b235fccbc7f66104b17314c152cfbf7db4a65cac4827d33a5631c6b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented installs through symlinked `node_modules` directories from modifying the linked target project.
  * Updated `pnpm add --lockfile-only` to avoid creating or linking `node_modules` directories.
  * Improved virtual store path resolution for projects using symlinked module directories.
  * Ensured lockfile-only workspace updates can modify dependency metadata without materializing installed dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->