### PR TITLE
perf(deps-restorer): skip the post-build bin relink when nothing was built

### DIFF
--- a/.changeset/skip-idle-postbuild-relink.md
+++ b/.changeset/skip-idle-postbuild-relink.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Installs that run no build scripts finish faster: the post-build bin pass no longer re-reads every project's dependency manifests when no lifecycle script, patch, or side-effects overlay changed anything.
+Installs that run no build scripts finish faster, especially in workspaces with many projects.

--- a/.changeset/skip-idle-postbuild-relink.md
+++ b/.changeset/skip-idle-postbuild-relink.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Installs that run no build scripts finish faster: the post-build bin pass no longer re-reads every project's dependency manifests when no lifecycle script, patch, or side-effects overlay changed anything.

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -346,6 +346,15 @@ pub struct BuildModulesOutput {
     /// Peers are kept here — unlike `ignored_builds`, whose keys are an
     /// `allowBuilds` lookup, these address a materialized slot.
     pub deferred_builds: Vec<String>,
+
+    /// Whether any linked slot's contents may have changed during the
+    /// build phase — a side-effects overlay was applied, a patch ran,
+    /// or a lifecycle script was attempted. `false` on the common warm
+    /// install where every candidate was ignored, deferred, or already
+    /// built, which lets the post-build importer bin relink skip
+    /// importers whose manifests provably match what the link phase
+    /// already shimmed.
+    pub mutated_slots: bool,
 }
 
 impl BuildModules<'_> {
@@ -491,6 +500,7 @@ impl BuildModules<'_> {
 
         let first_error: Mutex<Option<BuildModulesError>> = Mutex::new(None);
         let on_node_skipped: fn(&PackageKey) = |_| {};
+        let slot_mutations = std::sync::atomic::AtomicBool::new(false);
         let run_node = |snapshot_key: PackageKey| match build_one_snapshot::<Reporter>(
             &snapshot_key,
             snapshots,
@@ -523,6 +533,7 @@ impl BuildModules<'_> {
             ignore_scripts,
             import_method,
             logged_methods,
+            &slot_mutations,
             rebuild,
         ) {
             Ok(()) => TaskCompletion::Passed,
@@ -563,6 +574,7 @@ impl BuildModules<'_> {
         Ok(BuildModulesOutput {
             ignored_builds: ignored_builds.into_iter().collect(),
             deferred_builds: deferred_builds(requires_build_map.iter(), ignore_scripts),
+            mutated_slots: slot_mutations.into_inner(),
         })
     }
 }

--- a/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
@@ -1,5 +1,7 @@
 //! Running one package's build scripts.
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use super::{
     AllowBuildPolicy, BTreeSet, BuildModulesError, HashMap, LogEvent, LogLevel, Mutex,
     NEEDS_BUILD_MARKER, PackageImportMethod, PackageKey, Path, PathBuf, RebuildOptions, Reporter,
@@ -50,6 +52,11 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     ignore_scripts: bool,
     import_method: PackageImportMethod,
     logged_methods: &std::sync::atomic::AtomicU8,
+    // Raised before any write that can change a linked slot's contents
+    // (side-effects overlay, patch, lifecycle script) — set
+    // pre-attempt, so a half-applied write still counts. See
+    // `BuildModulesOutput::mutated_slots`.
+    slot_mutations: &AtomicBool,
     rebuild: Option<&RebuildOptions>,
 ) -> Result<(), BuildModulesError> {
     let metadata_key = snapshot_key.without_peer();
@@ -246,6 +253,7 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
             // The overlay carries the patched / built contents, so it
             // has to reach every hoisted copy for the same reason patch
             // application does.
+            slot_mutations.store(true, Ordering::Relaxed);
             let mut satisfied = true;
             for pkg_dir in pkg_roots_for_key(layout, pkg_roots_by_key, snapshot_key) {
                 // No slot to materialize into (skipped / never linked) —
@@ -374,6 +382,7 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
         // linker a version conflict nests further copies under their
         // consumers; leaving those unpatched would silently run the very
         // code the patch replaces.
+        slot_mutations.store(true, Ordering::Relaxed);
         for patched_dir in pkg_roots_for_key(layout, pkg_roots_by_key, snapshot_key) {
             if !patched_dir.exists() {
                 continue;
@@ -388,6 +397,7 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     };
 
     let has_side_effects = if should_run_scripts {
+        slot_mutations.store(true, Ordering::Relaxed);
         let result = run_postinstall_hooks::<Reporter>(&RunPostinstallHooks {
             dep_path: &snapshot_key.to_string(),
             pkg_root: &pkg_dir,

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -499,6 +499,125 @@ fn build_modules_collects_ignored_builds() {
     );
 }
 
+/// The post-build importer bin relink keys off
+/// [`BuildModulesOutput::mutated_slots`], so the signal must stay
+/// `false` when every candidate is blocked by the allow policy —
+/// nothing wrote into a linked slot, and the relink may skip.
+#[test]
+fn mutated_slots_is_false_when_every_build_is_ignored() {
+    let snapshots = HashMap::from([(key("zzz", "1.0.0"), SnapshotEntry::default())]);
+    let importers = root_importers(&[("zzz", "1.0.0")]);
+    let policy = AllowBuildPolicy::default(); // empty → default-deny
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
+    create_buildable_pkg(virtual_store_dir.path(), &key("zzz", "1.0.0"));
+
+    let output = BuildModules {
+        layout: &VirtualStoreLayout::legacy(
+            virtual_store_dir.path(),
+            pnpm_config::default_virtual_store_dir_max_length() as usize,
+        ),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        packages: None,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        requires_build_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: true,
+        side_effects_cache_write: false,
+        shared_side_effects_publisher: None,
+        store_dir: None,
+        store_index_writer: None,
+        patches: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        shell_emulator: false,
+        extra_env: &HashMap::new(),
+        user_agent: "pnpm/test",
+        unsafe_perm: true,
+        child_concurrency: 1,
+        skipped: &SkippedSnapshots::default(),
+        pkg_roots_by_key: None,
+        gather_ancestor_bin_paths: false,
+        frozen_store: false,
+        ignore_scripts: false,
+        import_method: PackageImportMethod::Auto,
+        logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
+    }
+    .run::<SilentReporter>()
+    .expect("run BuildModules");
+    assert!(!output.mutated_slots, "an ignored build must not report a slot mutation");
+}
+
+/// The converse of [`mutated_slots_is_false_when_every_build_is_ignored`]:
+/// an allowed candidate actually runs its script, so the signal must be
+/// `true` and the post-build importer bin relink must not skip.
+#[test]
+fn mutated_slots_is_true_when_a_script_runs() {
+    let snapshots = HashMap::from([(key("zzz", "1.0.0"), SnapshotEntry::default())]);
+    let importers = root_importers(&[("zzz", "1.0.0")]);
+    let policy = policy_from_specs([("zzz", true)], false);
+
+    let virtual_store_dir = tempdir().expect("create temp dir");
+    let modules_dir = tempdir().expect("create temp dir");
+    let lockfile_dir = tempdir().expect("create temp dir");
+    // `create_buildable_pkg` writes a `postinstall: true` script the
+    // policy above allows to run; swap the body for a portable no-op
+    // (`true` is not a command on Windows shells).
+    let pkg_dir = create_buildable_pkg(virtual_store_dir.path(), &key("zzz", "1.0.0"));
+    fs::write(
+        pkg_dir.join("package.json"),
+        serde_json::json!({ "scripts": { "postinstall": "node -e 0" } }).to_string(),
+    )
+    .expect("write manifest");
+
+    let output = BuildModules {
+        layout: &VirtualStoreLayout::legacy(
+            virtual_store_dir.path(),
+            pnpm_config::default_virtual_store_dir_max_length() as usize,
+        ),
+        modules_dir: modules_dir.path(),
+        lockfile_dir: lockfile_dir.path(),
+        snapshots: Some(&snapshots),
+        importers: &importers,
+        packages: None,
+        allow_build_policy: &policy,
+        side_effects_maps_by_snapshot: None,
+        requires_build_by_snapshot: None,
+        engine_name: None,
+        side_effects_cache: true,
+        side_effects_cache_write: false,
+        shared_side_effects_publisher: None,
+        store_dir: None,
+        store_index_writer: None,
+        patches: None,
+        scripts_prepend_node_path: ScriptsPrependNodePath::Never,
+        script_shell: None,
+        shell_emulator: false,
+        extra_env: &HashMap::new(),
+        user_agent: "pnpm/test",
+        unsafe_perm: true,
+        child_concurrency: 1,
+        skipped: &SkippedSnapshots::default(),
+        pkg_roots_by_key: None,
+        gather_ancestor_bin_paths: false,
+        frozen_store: false,
+        ignore_scripts: false,
+        import_method: PackageImportMethod::Auto,
+        logged_methods: &TEST_LOGGED_METHODS,
+        rebuild: None,
+    }
+    .run::<SilentReporter>()
+    .expect("run BuildModules");
+    assert!(output.mutated_slots, "an executed script must report a slot mutation");
+}
+
 /// Under `ignore_scripts`, the same default-deny build candidates that
 /// [`build_modules_collects_ignored_builds`] reports as ignored are
 /// instead silently skipped: no script runs and the returned set is

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile.rs
@@ -914,7 +914,7 @@ where
         // `allow_build_policy` was constructed up-front (before
         // `CreateVirtualStore`) so the git fetcher could consult it.
         let phase_start = std::time::Instant::now();
-        let crate::BuildModulesOutput { ignored_builds, deferred_builds } =
+        let crate::BuildModulesOutput { ignored_builds, deferred_builds, mutated_slots: _ } =
             run_build_phase::<Reporter>(&BuildPhaseInputs {
                 config,
                 workspace_root,

--- a/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
+++ b/pnpm/crates/deps-restorer/src/install_frozen_lockfile/build_phase.rs
@@ -216,6 +216,7 @@ pub fn run_build_phase<Reporter: self::Reporter>(
         crate::BuildModulesOutput {
             ignored_builds: Vec::new(),
             deferred_builds: crate::build_modules::deferred_builds(newly_deferred, true),
+            mutated_slots: false,
         }
     } else {
         BuildModules {
@@ -286,6 +287,24 @@ pub fn run_build_phase<Reporter: self::Reporter>(
     let modules_dir_basename: &OsStr =
         config.modules_dir.file_name().unwrap_or_else(|| OsStr::new("node_modules"));
     for (importer_id, importer_snapshot) in importers {
+        // Public-hoist promotes transitives into the workspace root's
+        // `<root>/node_modules/<alias>`, so only the root importer's
+        // `.bin` sees `BinOrigin::Hoisted` candidates.
+        let hoisted_names: &[String] = if importer_id == Lockfile::ROOT_IMPORTER_KEY {
+            publicly_hoisted_for_post_build
+        } else {
+            &[]
+        };
+        // When nothing this phase can change actually changed — no
+        // script, patch, or side-effects overlay touched a linked slot
+        // — the isolated link phase's own bin pass already shimmed
+        // exactly this candidate set, so re-resolving it would only
+        // re-read every direct dep's manifest per importer. Hoisted
+        // installs always relink: this pass is their only importer
+        // bin pass.
+        if !is_hoisted && !build_output.mutated_slots && hoisted_names.is_empty() {
+            continue;
+        }
         let project_dir = importer_root_dir(top_level_bin_root, importer_id);
         let modules_dir = project_dir.join(modules_dir_basename);
         // Same filter the symlink phase used so the post-build pass sees
@@ -297,14 +316,6 @@ pub fn run_build_phase<Reporter: self::Reporter>(
             skipped,
             false,
         );
-        // Public-hoist promotes transitives into the workspace root's
-        // `<root>/node_modules/<alias>`, so only the root importer's
-        // `.bin` sees `BinOrigin::Hoisted` candidates.
-        let hoisted_names: &[String] = if importer_id == Lockfile::ROOT_IMPORTER_KEY {
-            publicly_hoisted_for_post_build
-        } else {
-            &[]
-        };
         link_top_level_bins(&modules_dir, &direct_names, hoisted_names, link_options)
             .map_err(BuildPhaseError::TopLevelBinLink)?;
     }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1692,7 +1692,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // is the real lockfile dir (sets each script's `INIT_CWD`); the
         // post-build bin link anchors on `symlink_root` to match where
         // this path placed `node_modules`.
-        let crate::BuildModulesOutput { ignored_builds, deferred_builds } =
+        let crate::BuildModulesOutput { ignored_builds, deferred_builds, mutated_slots: _ } =
             crate::install_frozen_lockfile::run_build_phase::<Reporter>(
                 &crate::install_frozen_lockfile::BuildPhaseInputs {
                     config,


### PR DESCRIPTION
## Summary

Continuation of the install-performance series (pnpm/pnpm#14248 … pnpm/pnpm#14289; related to pnpm/pnpm#14231), third workspace-path win from the link/build-phase instrumentation.

The post-build per-importer top-level bin pass (`link_top_level_bins`) exists for two reasons: shimming bins that **lifecycle scripts create** after extract time, and resolving direct-over-hoisted **precedence** for publicly hoisted candidates at the root importer. On the common warm install neither applies — every build candidate is ignored, deferred, or served as already built — yet the pass still re-read every direct dep's manifest for every importer: **~160 ms on the 60-project workspace fixture** (vs 13–18 ms single-project), all of it rediscovering the shims the link phase had just written.

This PR:

- Tracks whether the build phase could have changed a linked slot, at its **three write sites** — side-effects overlay application, patch application, lifecycle-script execution — raised *before* the attempt, so a half-applied write still counts. Surfaced as `BuildModulesOutput::mutated_slots`.
- Skips the relink for importers with nothing to re-resolve: non-root importers whenever no slot mutated; the root importer additionally only when it has no publicly hoisted candidates. **Hoisted installs always relink** — this pass is their only importer bin pass.

**Measured** (60-project workspace fixture, M-series MBP, APFS): `build_phase` ~160 ms → ~7 ms; hot rebuild **3.12 s → 2.91 s** (from 4.4 s at the start of this series). `.bin` trees verified byte-identical against the previously released v12 binary (432 entries: names, targets, shim hashes). Single-project installs keep their root pass when publicly hoisted candidates exist, unchanged otherwise.

Test note: `sync_injected_deps_after_scripts` initially failed locally on this branch *and* on clean `main` — traced to this machine's user-level `enable-global-virtual-store=true` rc leaking into the test environment; all four tests pass with a clean `XDG_CONFIG_HOME`, and the lifecycle/patch/side-effects/rebuild/bin/hoist/install suites (264 tests) pass otherwise.

Rust-only change: observable `.bin` output is identical (the skipped work was idempotent re-shimming), so there is nothing to mirror in the TypeScript CLI.

## Squash Commit Body

```text
The post-build per-importer top-level bin pass exists for two
reasons: shimming bins that lifecycle scripts created after extract
time, and resolving direct-over-hoisted precedence for the publicly
hoisted candidates that reach the root importer. On the common warm
install neither applies - every build candidate is ignored,
deferred, or served as already built - yet the pass still re-read
every direct dep's manifest for every importer (~160 ms on a
60-project workspace, all of it rediscovering the shims the link
phase had just written).

Track whether the build phase could have changed a linked slot at
its three write sites (side-effects overlay application, patch
application, lifecycle-script execution - raised before the attempt,
so a half-applied write still counts) and surface it as
BuildModulesOutput::mutated_slots. The relink loop then skips
importers with nothing to re-resolve: non-root importers whenever no
slot mutated, the root importer additionally only when it has no
publicly hoisted candidates. Hoisted installs always relink - this
pass is their only importer bin pass.

On the 60-project workspace fixture build_phase drops from ~160 ms
to ~7 ms and a hot rebuild from ~3.12 s to ~2.91 s, with .bin trees
byte-identical to the previous binary's output.

Related to pnpm/pnpm#14231.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790549656&installation_model_id=426870&pr_number=14300&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14300&signature=ccbf8b586c94c9f0e5fe59d0ddeaf56dd2ec144a166a08d092f09ac06b6cef55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Faster installs when no build scripts, patches, or side-effects changes require post-build updates, especially in large workspaces.
  * Reduced redundant dependency manifest reads and bin relinking during warm installs.
  * Hoisted installations continue to perform required bin linking.
  * Installations now relink only when linked package contents may have changed, while preserving required updates after scripts or patches run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->