### PR TITLE
fix(hooks): load .mjs pnpmfiles from file URLs

### DIFF
--- a/.changeset/fix-windows-mjs-pnpmfile.md
+++ b/.changeset/fix-windows-mjs-pnpmfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `.mjs` pnpmfile hooks failing to load on Windows, including hooks supplied by config dependencies [pnpm/pnpm#14301](https://github.com/pnpm/pnpm/issues/14301).

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -55,7 +55,8 @@ impl NodeJsHooks {
                 "module",
                 format!(
                     r#"import {{ readFileSync }} from 'node:fs';
-const hooks = await import({file_path_escaped});
+import {{ pathToFileURL }} from 'node:url';
+const hooks = await import(pathToFileURL({file_path_escaped}).href);
 const ctx = JSON.parse(readFileSync(0, 'utf8'));
 const logger = {{
   info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -429,12 +429,13 @@ fn dispatch_line(pending: &PendingMap, stdin: &Arc<Mutex<ChildStdin>>, line: &st
 /// normalization that [`crate::node_runtime`] documents.
 fn build_runner(is_mjs: bool, file_escaped: &str) -> String {
     let load = if is_mjs {
-        format!("mod = await import({file_escaped});")
+        format!("mod = await import(pathToFileURL({file_escaped}).href);")
     } else {
         format!("mod = require({file_escaped});")
     };
     format!(
         r#"const readline = require('node:readline');
+const {{ pathToFileURL }} = require('node:url');
 let mod = null;
 let loadErr = null;
 let nextCallbackId = 0;

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 
 use pnpm_hooks::{PnpmfileHooks, finder};
@@ -230,14 +230,12 @@ function filterLog(log) {
     );
 }
 
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
-)]
 #[tokio::test]
 async fn test_node_js_hooks_read_package_mjs() {
     let tmp = TempDir::new().expect("temp dir");
-    let pnpmfile_path = tmp.path().join(".pnpmfile.mjs");
+    let hooks_dir = tmp.path().join("hooks #100%");
+    std::fs::create_dir(&hooks_dir).expect("create hooks dir");
+    let pnpmfile_path = hooks_dir.join(".pnpmfile.mjs");
     std::fs::write(
         &pnpmfile_path,
         r"
@@ -321,7 +319,9 @@ function preResolution(ctx, logger) {
 #[tokio::test]
 async fn test_node_js_hooks_pre_resolution_mjs() {
     let tmp = TempDir::new().expect("temp dir");
-    let pnpmfile_path = tmp.path().join(".pnpmfile.mjs");
+    let hooks_dir = tmp.path().join("hooks #100%");
+    std::fs::create_dir(&hooks_dir).expect("create hooks dir");
+    let pnpmfile_path = hooks_dir.join(".pnpmfile.mjs");
     std::fs::write(
         &pnpmfile_path,
         r"
@@ -333,6 +333,7 @@ function preResolution(ctx, logger) {
   if (ctx.storeDir !== '/test/store') throw new Error('wrong storeDir');
   if (typeof logger.info !== 'function') throw new Error('missing logger.info');
   if (typeof logger.warn !== 'function') throw new Error('missing logger.warn');
+  logger.info('preResolution loaded');
 }
 ",
     )
@@ -350,12 +351,23 @@ function preResolution(ctx, logger) {
         registries: serde_json::json!({ "default": "http://localhost:1234/" }),
     };
 
+    let info_messages = Arc::new(Mutex::new(Vec::new()));
+    let captured_info_messages = Arc::clone(&info_messages);
     hooks
         .pre_resolution(
             ctx,
-            pnpm_hooks::PreResolutionHookLogger { info: Arc::new(|_| {}), warn: Arc::new(|_| {}) },
+            pnpm_hooks::PreResolutionHookLogger {
+                info: Arc::new(move |message| {
+                    captured_info_messages.lock().unwrap().push(message);
+                }),
+                warn: Arc::new(|_| {}),
+            },
         )
         .await;
+
+    let info_messages = info_messages.lock().unwrap();
+    dbg!(&*info_messages);
+    assert_eq!(info_messages.as_slice(), ["preResolution loaded"]);
 }
 
 /// Helper: write `source` to a `.pnpmfile.cjs` in a fresh temp dir and return
@@ -565,26 +577,36 @@ fn calc_pnpmfile_paths_skips_non_plugins_and_missing_dirs() {
 }
 
 #[tokio::test]
-async fn update_config_applies_hook_result() {
-    let tmp = TempDir::new().expect("temp dir");
-    let pnpmfile_path = tmp.path().join("pnpmfile.cjs");
-    std::fs::write(
-        &pnpmfile_path,
-        r"module.exports = { hooks: { updateConfig (config) {
+async fn update_config_applies_cjs_and_mjs_hook_results() {
+    for (file_name, source) in [
+        (
+            "pnpmfile.cjs",
+            r"module.exports = { hooks: { updateConfig (config) {
   config.catalogs = { default: { foo: '1.0.0' } };
   return config;
 } } }",
-    )
-    .expect("write pnpmfile");
+        ),
+        (
+            "pnpmfile.mjs",
+            r"export const hooks = { updateConfig (config) {
+  config.catalogs = { default: { foo: '1.0.0' } };
+  return config;
+} }",
+        ),
+    ] {
+        let tmp = TempDir::new().expect("temp dir");
+        let pnpmfile_path = tmp.path().join(file_name);
+        std::fs::write(&pnpmfile_path, source).expect("write pnpmfile");
 
-    let hooks = pnpm_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
-    let updated = hooks
-        .update_config(serde_json::json!({ "registry": "https://r/" }), noop_context())
-        .await
-        .expect("updateConfig should succeed");
+        let hooks = pnpm_hooks::node_runtime::NodeJsHooks::new(pnpmfile_path);
+        let updated = hooks
+            .update_config(serde_json::json!({ "registry": "https://r/" }), noop_context())
+            .await
+            .expect("updateConfig should succeed");
 
-    assert_eq!(updated["registry"], "https://r/", "untouched keys are preserved");
-    assert_eq!(updated["catalogs"]["default"]["foo"], "1.0.0", "hook-set key is applied");
+        assert_eq!(updated["registry"], "https://r/", "untouched keys are preserved");
+        assert_eq!(updated["catalogs"]["default"]["foo"], "1.0.0", "hook-set key is applied");
+    }
 }
 
 #[tokio::test]
@@ -859,10 +881,6 @@ module.exports = {
     assert!(err.to_string().contains("fetch crashed"), "got: {err}");
 }
 
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
-)]
 #[tokio::test]
 async fn custom_fetcher_works_with_mjs_pnpmfile() {
     let tmp = TempDir::new().expect("temp dir");


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Convert `.mjs` pnpmfile paths to file URLs before dynamic import in both Rust
Node bridges. This makes Windows drive-letter paths valid import specifiers and
also escapes URL-special characters in paths.

The tests now exercise ESM hooks from paths containing URL-special characters,
run the applicable ESM coverage on Windows, cover both module formats for
`updateConfig`, and verify that the one-shot `preResolution` hook actually ran.

This is Rust-only because the TypeScript CLI already converts pnpmfile paths
with `pathToFileURL`.

Closes pnpm/pnpm#14301.

## Squash Commit Body

```text
Convert native pnpmfile paths to file URLs before dynamic import in both Node
bridges. This preserves Windows drive-letter paths and escapes URL-special
characters while matching the TypeScript loader.

Extend ESM hook coverage across the persistent worker, updateConfig, custom
fetchers, and the one-shot preResolution loader.

Closes pnpm/pnpm#14301.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790552689&installation_model_id=426870&pr_number=14303&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14303&signature=fbca93f262775b71099a6770d0a2186f6d37bd9e785743f8815e986fa96b836f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed loading of `.mjs` pnpmfile hooks on Windows.
  - Improved support for hook files located in paths containing spaces and special characters.
  - Ensured hooks supplied through configuration dependencies load correctly.
  - Preserved existing CommonJS (`.cjs`) hook behavior.

- **Tests**
  - Expanded coverage for Windows-compatible `.mjs` hooks and mixed `.cjs`/`.mjs` configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->