### PR TITLE
fix(deploy): exclude unselected fetched dependencies

### DIFF
--- a/.changeset/calm-dolphins-deploy.md
+++ b/.changeset/calm-dolphins-deploy.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm deploy --legacy` to exclude dependencies that are only reachable from unselected workspace projects after `pnpm fetch`.

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -676,6 +676,35 @@ fn legacy_deploy_installs_selected_project() {
 }
 
 #[test]
+fn legacy_deploy_excludes_fetched_dependencies_of_unselected_projects() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_reachability_workspace(&workspace);
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    pacquet_cmd(&workspace).with_arg("fetch").assert().success();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app...", "install", "--frozen-lockfile", "--offline"])
+        .assert()
+        .success();
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--legacy", "--prod", "legacy-deploy"])
+        .assert()
+        .success();
+
+    let virtual_store_entries = virtual_store_entries(&workspace.join("legacy-deploy"));
+    for excluded in ["@pnpm.e2e+bar@", "@pnpm.e2e+qar@"] {
+        assert!(
+            !virtual_store_entries.iter().any(|entry| entry.starts_with(excluded)),
+            "the deploy virtual store should exclude packages reachable only from unselected projects: {virtual_store_entries:#?}",
+        );
+    }
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn legacy_deploy_injects_transitive_workspace_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -694,6 +694,10 @@ fn legacy_deploy_excludes_fetched_dependencies_of_unselected_projects() {
         .success();
 
     let virtual_store_entries = virtual_store_entries(&workspace.join("legacy-deploy"));
+    assert!(
+        virtual_store_entries.iter().any(|entry| entry.starts_with("@pnpm.e2e+pkg-with-1-dep@")),
+        "the deploy virtual store should include the selected dependency closure: {virtual_store_entries:#?}",
+    );
     for excluded in ["@pnpm.e2e+bar@", "@pnpm.e2e+qar@"] {
         assert!(
             !virtual_store_entries.iter().any(|entry| entry.starts_with(excluded)),

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1089,7 +1089,7 @@ where
     }
 
     /// Execute the install a legacy `pacquet deploy` runs in its target
-    /// directory: the deployed manifest is the root importer, while
+    /// directory: the deployed manifest is the sole root importer, while
     /// workspace discovery stays anchored at the source workspace so
     /// `workspace:` dependencies still resolve to their projects.
     ///

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -285,23 +285,25 @@ where
         // `NoLockfile` or `OutdatedLockfile` error still fires when
         // the lockfile is missing or stale.
 
-        let manifest_is_root_importer = root_manifest_as_workspace_root
-            || workspace_projects_are_overridden
-            || !config.shares_one_lockfile();
         let project_manifests = match selection.as_ref() {
             Some(selection) => build_selected_project_manifests_list(
                 manifest,
                 selection.all_projects,
                 selection.active_manifest_is_standin,
             ),
-            None if manifest_is_root_importer => build_root_importer_project_manifests_list(
-                &workspace_root,
-                manifest,
-                // Dedicated per-project lockfiles record a single "."
-                // importer per project; sibling projects only feed the
-                // `workspace:` resolver, never the importer list.
-                config.shares_one_lockfile().then_some(workspace_projects).flatten(),
-            ),
+            None if root_manifest_as_workspace_root => {
+                build_root_importer_project_manifests_list(&workspace_root, manifest, None)
+            }
+            None if workspace_projects_are_overridden || !config.shares_one_lockfile() => {
+                build_root_importer_project_manifests_list(
+                    &workspace_root,
+                    manifest,
+                    // Dedicated per-project lockfiles record a single "."
+                    // importer per project; sibling projects only feed the
+                    // `workspace:` resolver, never the importer list.
+                    config.shares_one_lockfile().then_some(workspace_projects).flatten(),
+                )
+            }
             None => build_project_manifests_list(manifest, workspace_projects),
         };
         let install_importer_ids = selection.as_ref().map(|selection| {


### PR DESCRIPTION
## Summary

- Prevent the Rust CLI's legacy deploy from treating every discovered source workspace project as a deploy importer.
- Keep source projects available for `workspace:` resolution so transitive workspace dependencies remain self-contained.
- Add an end-to-end regression test covering `fetch`, a filtered offline install, and a production legacy deploy.

The TypeScript CLI already scopes legacy deploy to the selected project, so no TypeScript change is required.

Fixes pnpm/pnpm#14299.

## Squash Commit Body

```text
Legacy deploy mapped the copied manifest to the root importer but also kept
every source workspace project in the importer list. When pnpm fetch had
populated the virtual store, packages reachable only from sibling projects
could then be materialized into the deploy target.

Keep the deployed manifest as the sole importer while retaining source
workspace discovery for workspace protocol resolution. Add an end-to-end
regression test for the fetch and filtered-install sequence.

Fixes pnpm/pnpm#14299.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790552717&installation_model_id=426870&pr_number=14304&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14304&signature=8ec49bf331f61933f6711028d2f7ed42da4fbedbd08b45663f36e86c4fab7d11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed legacy deploys after `pnpm fetch` to exclude dependencies reachable only from unselected workspace projects.
  - Ensured deployments contain only packages required by the selected project and its production dependencies.

- **Tests**
  - Added coverage verifying that dependencies from unselected projects are not included in legacy deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->