### PR TITLE
fix(hooks): load ESM pnpmfiles from file URLs

### DIFF
--- a/.changeset/fuzzy-cats-load.md
+++ b/.changeset/fuzzy-cats-load.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed ESM pnpmfile hooks on Windows by loading them through file URLs [pnpm/pnpm#14301](https://github.com/pnpm/pnpm/issues/14301).

--- a/pnpm/crates/hooks/src/node_runtime.rs
+++ b/pnpm/crates/hooks/src/node_runtime.rs
@@ -55,7 +55,8 @@ impl NodeJsHooks {
                 "module",
                 format!(
                     r#"import {{ readFileSync }} from 'node:fs';
-const hooks = await import({file_path_escaped});
+import {{ pathToFileURL }} from 'node:url';
+const hooks = await import(pathToFileURL({file_path_escaped}).href);
 const ctx = JSON.parse(readFileSync(0, 'utf8'));
 const logger = {{
   info: (m) => {{ console.log(JSON.stringify({{"level":"info","message":String(m)}})); }},

--- a/pnpm/crates/hooks/src/worker.rs
+++ b/pnpm/crates/hooks/src/worker.rs
@@ -429,7 +429,7 @@ fn dispatch_line(pending: &PendingMap, stdin: &Arc<Mutex<ChildStdin>>, line: &st
 /// normalization that [`crate::node_runtime`] documents.
 fn build_runner(is_mjs: bool, file_escaped: &str) -> String {
     let load = if is_mjs {
-        format!("mod = await import({file_escaped});")
+        format!("mod = await import(require('node:url').pathToFileURL({file_escaped}).href);")
     } else {
         format!("mod = require({file_escaped});")
     };

--- a/pnpm/crates/hooks/tests/node_hooks.rs
+++ b/pnpm/crates/hooks/tests/node_hooks.rs
@@ -230,10 +230,6 @@ function filterLog(log) {
     );
 }
 
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
-)]
 #[tokio::test]
 async fn test_node_js_hooks_read_package_mjs() {
     let tmp = TempDir::new().expect("temp dir");
@@ -333,6 +329,7 @@ function preResolution(ctx, logger) {
   if (ctx.storeDir !== '/test/store') throw new Error('wrong storeDir');
   if (typeof logger.info !== 'function') throw new Error('missing logger.info');
   if (typeof logger.warn !== 'function') throw new Error('missing logger.warn');
+  logger.info('mjs loaded');
 }
 ",
     )
@@ -350,12 +347,19 @@ function preResolution(ctx, logger) {
         registries: serde_json::json!({ "default": "http://localhost:1234/" }),
     };
 
+    let logs = Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+    let sink = Arc::clone(&logs);
     hooks
         .pre_resolution(
             ctx,
-            pnpm_hooks::PreResolutionHookLogger { info: Arc::new(|_| {}), warn: Arc::new(|_| {}) },
+            pnpm_hooks::PreResolutionHookLogger {
+                info: Arc::new(move |message| sink.lock().unwrap().push(message)),
+                warn: Arc::new(|_| {}),
+            },
         )
         .await;
+
+    assert_eq!(logs.lock().unwrap().as_slice(), &["mjs loaded".to_string()]);
 }
 
 /// Helper: write `source` to a `.pnpmfile.cjs` in a fresh temp dir and return
@@ -859,10 +863,6 @@ module.exports = {
     assert!(err.to_string().contains("fetch crashed"), "got: {err}");
 }
 
-#[cfg_attr(
-    target_os = "windows",
-    ignore = "Node.js ESM import() on Windows resolves absolute paths differently"
-)]
 #[tokio::test]
 async fn custom_fetcher_works_with_mjs_pnpmfile() {
     let tmp = TempDir::new().expect("temp dir");


### PR DESCRIPTION
## Summary

- Convert native `.mjs` pnpmfile paths to file URLs in pacquet's persistent and one-shot Node hook loaders, fixing Windows drive-letter paths being parsed as URL schemes.
- Re-enable Windows coverage for ESM read-package and custom-fetcher hooks, and assert that one-shot pre-resolution hooks execute.
- The TypeScript CLI already uses `pathToFileURL`, so no TypeScript port is required.
- Closes pnpm/pnpm#14301.

## Squash Commit Body

```text
Convert native pnpmfile paths to file URLs before passing them to dynamic
import. Windows drive-letter paths are otherwise interpreted as URL schemes,
which prevents pnpm 12 from loading ESM config-dependency hooks.

Apply the conversion to both the persistent worker and one-shot hook loader.
The TypeScript hook loader already performs the same conversion.

Closes pnpm/pnpm#14301
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) because this changes the published
  `pacquet` package.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

Generated with Codex.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790553087&installation_model_id=426870&pr_number=14305&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14305&signature=5e24ce9f748ab4bc97e4926bf04ce0b9ae207427b251ea1f3ac68ab57eb099a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loading of ESM-based configuration hooks on Windows.
  * Improved compatibility when importing hook files through file-based paths.
  * CommonJS hook loading remains unchanged.

* **Tests**
  * Added Windows coverage for ESM hook loading.
  * Enhanced validation to confirm ESM hooks execute and produce the expected log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->