### PR TITLE
fix(deploy): omit peers of excluded dependencies

### DIFF
--- a/.changeset/fuzzy-ducks-deploy.md
+++ b/.changeset/fuzzy-ducks-deploy.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/releasing.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Fixed `pnpm deploy --prod` failing when an excluded dev dependency was also declared as an optional peer dependency [pnpm/pnpm#14302](https://github.com/pnpm/pnpm/issues/14302).

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -871,6 +871,7 @@ fn create_deploy_files(
         "optionalDependencies",
         target_snapshot.optional_dependencies.as_ref(),
     );
+    omit_peers_of_excluded_dependencies(&mut manifest, input_snapshot, &target_snapshot);
 
     let mut workspace_manifest = Map::new();
     let mut workspace_config =
@@ -1015,6 +1016,35 @@ fn set_manifest_dependencies(
     if let Some(object) = manifest.as_object_mut() {
         object.insert(field.to_string(), Value::Object(deps));
     }
+}
+
+fn omit_peers_of_excluded_dependencies(
+    manifest: &mut Value,
+    input_snapshot: &ProjectSnapshot,
+    target_snapshot: &ProjectSnapshot,
+) {
+    let included_dependencies = dependency_names(target_snapshot);
+    let excluded_dependencies = dependency_names(input_snapshot)
+        .difference(&included_dependencies)
+        .cloned()
+        .collect::<HashSet<_>>();
+    let Some(manifest) = manifest.as_object_mut() else { return };
+    for field in ["peerDependencies", "peerDependenciesMeta"] {
+        if let Some(Value::Object(dependencies)) = manifest.get_mut(field) {
+            dependencies.retain(|name, _| !excluded_dependencies.contains(name));
+        }
+    }
+}
+
+fn dependency_names(snapshot: &ProjectSnapshot) -> HashSet<String> {
+    snapshot
+        .dependencies
+        .iter()
+        .flatten()
+        .chain(snapshot.dev_dependencies.iter().flatten())
+        .chain(snapshot.optional_dependencies.iter().flatten())
+        .map(|(name, _)| name.to_string())
+        .collect()
 }
 
 fn convert_package_metadata(

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -752,36 +752,56 @@ fn create_deploy_files(
     target_snapshot.dependencies = Some(HashMap::new());
     target_snapshot.dev_dependencies = Some(HashMap::new());
     target_snapshot.optional_dependencies = Some(HashMap::new());
+    let declared_dependencies = selected
+        .project
+        .manifest
+        .available_dependency_names(None)
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let peer_only_dependencies = selected
+        .project
+        .manifest
+        .dependencies([DependencyGroup::Peer])
+        .map(|(name, _)| name.to_string())
+        .filter(|name| !declared_dependencies.contains(name))
+        .collect::<HashSet<_>>();
 
     let selected_root = lexical_normalize(&selected.project.root_dir);
     let selected_bases = ResolveBases { file_base: lockfile_dir, link_base: &selected_root };
     // An excluded group's direct dependencies are left out of both the
     // deployed manifest and the deployed importer, because the graph prune
     // below drops the packages they would point at.
-    if dependency_groups.contains(&DependencyGroup::Prod) {
-        fill_target_dependency_map(
-            &mut target_snapshot.dependencies,
-            input_snapshot.dependencies.as_ref(),
-            &ctx,
-            &selected_bases,
-        )?;
-    }
-    if dependency_groups.contains(&DependencyGroup::Dev) {
-        fill_target_dependency_map(
-            &mut target_snapshot.dev_dependencies,
-            input_snapshot.dev_dependencies.as_ref(),
-            &ctx,
-            &selected_bases,
-        )?;
-    }
-    if dependency_groups.contains(&DependencyGroup::Optional) {
-        fill_target_dependency_map(
-            &mut target_snapshot.optional_dependencies,
-            input_snapshot.optional_dependencies.as_ref(),
-            &ctx,
-            &selected_bases,
-        )?;
-    }
+    let include_prod = dependency_groups.contains(&DependencyGroup::Prod);
+    fill_target_dependency_map(
+        &mut target_snapshot.dependencies,
+        input_snapshot
+            .dependencies
+            .iter()
+            .flatten()
+            .filter(|(name, _)| include_prod || peer_only_dependencies.contains(&name.to_string())),
+        &ctx,
+        &selected_bases,
+    )?;
+    let include_dev = dependency_groups.contains(&DependencyGroup::Dev);
+    fill_target_dependency_map(
+        &mut target_snapshot.dev_dependencies,
+        input_snapshot
+            .dev_dependencies
+            .iter()
+            .flatten()
+            .filter(|(name, _)| include_dev || peer_only_dependencies.contains(&name.to_string())),
+        &ctx,
+        &selected_bases,
+    )?;
+    let include_optional = dependency_groups.contains(&DependencyGroup::Optional);
+    fill_target_dependency_map(
+        &mut target_snapshot.optional_dependencies,
+        input_snapshot.optional_dependencies.iter().flatten().filter(|(name, _)| {
+            include_optional || peer_only_dependencies.contains(&name.to_string())
+        }),
+        &ctx,
+        &selected_bases,
+    )?;
     drop_empty_dependency_map(&mut target_snapshot.dependencies);
     drop_empty_dependency_map(&mut target_snapshot.dev_dependencies);
     drop_empty_dependency_map(&mut target_snapshot.optional_dependencies);
@@ -871,7 +891,7 @@ fn create_deploy_files(
         "optionalDependencies",
         target_snapshot.optional_dependencies.as_ref(),
     );
-    omit_peers_of_excluded_dependencies(&mut manifest, input_snapshot, &target_snapshot);
+    omit_peers_of_excluded_dependencies(&mut manifest, &declared_dependencies, &target_snapshot);
 
     let mut workspace_manifest = Map::new();
     let mut workspace_config =
@@ -988,17 +1008,15 @@ fn drop_empty_dependency_map(dependencies: &mut Option<ResolvedDependencyMap>) {
     }
 }
 
-fn fill_target_dependency_map(
+fn fill_target_dependency_map<'a>(
     output: &mut Option<ResolvedDependencyMap>,
-    input: Option<&ResolvedDependencyMap>,
+    input: impl Iterator<Item = (&'a PkgName, &'a ResolvedDependencySpec)>,
     ctx: &ConvertCtx,
     bases: &ResolveBases,
 ) -> miette::Result<()> {
     let output = output.get_or_insert_with(HashMap::new);
-    if let Some(input) = input {
-        for (name, spec) in input {
-            output.insert(name.clone(), convert_resolved_dependency_spec(name, spec, ctx, bases)?);
-        }
+    for (name, spec) in input {
+        output.insert(name.clone(), convert_resolved_dependency_spec(name, spec, ctx, bases)?);
     }
     Ok(())
 }
@@ -1020,14 +1038,12 @@ fn set_manifest_dependencies(
 
 fn omit_peers_of_excluded_dependencies(
     manifest: &mut Value,
-    input_snapshot: &ProjectSnapshot,
+    declared_dependencies: &HashSet<String>,
     target_snapshot: &ProjectSnapshot,
 ) {
     let included_dependencies = dependency_names(target_snapshot);
-    let excluded_dependencies = dependency_names(input_snapshot)
-        .difference(&included_dependencies)
-        .cloned()
-        .collect::<HashSet<_>>();
+    let excluded_dependencies =
+        declared_dependencies.difference(&included_dependencies).cloned().collect::<HashSet<_>>();
     let Some(manifest) = manifest.as_object_mut() else { return };
     for field in ["peerDependencies", "peerDependenciesMeta"] {
         if let Some(Value::Object(dependencies)) = manifest.get_mut(field) {

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -318,6 +318,8 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
             "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
             "devDependencies": { "@pnpm.e2e/bar": "100.0.0" },
             "optionalDependencies": { "@pnpm.e2e/qar": "100.0.0" },
+            "peerDependencies": { "@pnpm.e2e/bar": "*" },
+            "peerDependenciesMeta": { "@pnpm.e2e/bar": { "optional": true } },
         }),
     );
 
@@ -344,6 +346,8 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
             "the deployed manifest should drop {excluded}: {deploy_manifest:#}",
         );
     }
+    assert_eq!(deploy_manifest["peerDependencies"], serde_json::json!({}));
+    assert_eq!(deploy_manifest["peerDependenciesMeta"], serde_json::json!({}));
 
     let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
     let importer = deploy_lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY).unwrap();

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -318,8 +318,14 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
             "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
             "devDependencies": { "@pnpm.e2e/bar": "100.0.0" },
             "optionalDependencies": { "@pnpm.e2e/qar": "100.0.0" },
-            "peerDependencies": { "@pnpm.e2e/bar": "*" },
-            "peerDependenciesMeta": { "@pnpm.e2e/bar": { "optional": true } },
+            "peerDependencies": {
+                "@pnpm.e2e/bar": "*",
+                "@pnpm.e2e/peer-c": "1.0.0",
+            },
+            "peerDependenciesMeta": {
+                "@pnpm.e2e/bar": { "optional": true },
+                "@pnpm.e2e/peer-c": { "optional": true },
+            },
         }),
     );
 
@@ -339,6 +345,10 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
         deploy_manifest["dependencies"]["@pnpm.e2e/foo"].is_string(),
         "the production dependency should survive: {deploy_manifest:#}",
     );
+    assert!(
+        deploy_manifest["dependencies"]["@pnpm.e2e/peer-c"].is_string(),
+        "the auto-installed peer should survive: {deploy_manifest:#}",
+    );
     for excluded in ["devDependencies", "optionalDependencies"] {
         assert_eq!(
             deploy_manifest[excluded],
@@ -346,8 +356,14 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
             "the deployed manifest should drop {excluded}: {deploy_manifest:#}",
         );
     }
-    assert_eq!(deploy_manifest["peerDependencies"], serde_json::json!({}));
-    assert_eq!(deploy_manifest["peerDependenciesMeta"], serde_json::json!({}));
+    assert_eq!(
+        deploy_manifest["peerDependencies"],
+        serde_json::json!({ "@pnpm.e2e/peer-c": "1.0.0" }),
+    );
+    assert_eq!(
+        deploy_manifest["peerDependenciesMeta"],
+        serde_json::json!({ "@pnpm.e2e/peer-c": { "optional": true } }),
+    );
 
     let deploy_lockfile = Lockfile::load_wanted_from_dir(&deploy_dir).unwrap().unwrap();
     let importer = deploy_lockfile.importers.get(Lockfile::ROOT_IMPORTER_KEY).unwrap();
@@ -368,6 +384,38 @@ fn shared_lockfile_deploy_drops_excluded_direct_dependencies() {
     assert!(
         dangling.is_empty(),
         "installing the deployed lockfile must not create dangling symlinks: {dangling:#?}",
+    );
+
+    let dev_deploy_dir = root.path().join("dev-deploy");
+    pacquet_cmd(&workspace)
+        .with_args(["--filter", "app", "deploy", "--dev", "--no-optional"])
+        .with_arg(&dev_deploy_dir)
+        .assert()
+        .success();
+    let dev_deploy_manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(dev_deploy_dir.join("package.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        dev_deploy_manifest["dependencies"],
+        serde_json::json!({ "@pnpm.e2e/peer-c": "1.0.0" }),
+    );
+    assert_eq!(
+        dev_deploy_manifest["devDependencies"],
+        serde_json::json!({ "@pnpm.e2e/bar": "100.0.0" }),
+    );
+    assert_eq!(
+        dev_deploy_manifest["peerDependencies"],
+        serde_json::json!({
+            "@pnpm.e2e/bar": "*",
+            "@pnpm.e2e/peer-c": "1.0.0",
+        }),
+    );
+    assert_eq!(
+        dev_deploy_manifest["peerDependenciesMeta"],
+        serde_json::json!({
+            "@pnpm.e2e/bar": { "optional": true },
+            "@pnpm.e2e/peer-c": { "optional": true },
+        }),
     );
 
     drop((root, mock_instance));

--- a/pnpm11/pnpm/test/deploy.ts
+++ b/pnpm11/pnpm/test/deploy.ts
@@ -161,8 +161,14 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
         dependencies: { '@pnpm.e2e/foo': '100.0.0' },
         devDependencies: { '@pnpm.e2e/bar': '100.0.0' },
         optionalDependencies: { '@pnpm.e2e/qar': '100.0.0' },
-        peerDependencies: { '@pnpm.e2e/bar': '*' },
-        peerDependenciesMeta: { '@pnpm.e2e/bar': { optional: true } },
+        peerDependencies: {
+          '@pnpm.e2e/bar': '*',
+          '@pnpm.e2e/peer-c': '1.0.0',
+        },
+        peerDependenciesMeta: {
+          '@pnpm.e2e/bar': { optional: true },
+          '@pnpm.e2e/peer-c': { optional: true },
+        },
       },
     },
   ])
@@ -180,11 +186,14 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
   await execPnpm(['--filter=app', 'deploy', '--prod', '--no-optional', deployDir])
 
   const deployManifest = loadJsonFileSync<Record<string, unknown>>(path.join(deployDir, 'package.json'))
-  expect(deployManifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '100.0.0' })
+  expect(deployManifest.dependencies).toStrictEqual({
+    '@pnpm.e2e/foo': '100.0.0',
+    '@pnpm.e2e/peer-c': '1.0.0',
+  })
   expect(deployManifest.devDependencies).toStrictEqual({})
   expect(deployManifest.optionalDependencies).toStrictEqual({})
-  expect(deployManifest.peerDependencies).toStrictEqual({})
-  expect(deployManifest.peerDependenciesMeta).toStrictEqual({})
+  expect(deployManifest.peerDependencies).toStrictEqual({ '@pnpm.e2e/peer-c': '1.0.0' })
+  expect(deployManifest.peerDependenciesMeta).toStrictEqual({ '@pnpm.e2e/peer-c': { optional: true } })
 
   const deployLockfile = readYamlFileSync<LockfileFile>(path.join(deployDir, 'pnpm-lock.yaml'))
   const importer = deployLockfile.importers!['.']
@@ -204,6 +213,20 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
   const dangling = fs.readdirSync(nodeModulesDir, { recursive: true, encoding: 'utf8' })
     .filter(entry => !fs.existsSync(path.join(nodeModulesDir, entry)))
   expect(dangling).toStrictEqual([])
+
+  const devDeployDir = path.join(tempDir(false), 'dev-deploy')
+  await execPnpm(['--filter=app', 'deploy', '--dev', '--no-optional', devDeployDir])
+  const devDeployManifest = loadJsonFileSync<Record<string, unknown>>(path.join(devDeployDir, 'package.json'))
+  expect(devDeployManifest.dependencies).toStrictEqual({ '@pnpm.e2e/peer-c': '1.0.0' })
+  expect(devDeployManifest.devDependencies).toStrictEqual({ '@pnpm.e2e/bar': '100.0.0' })
+  expect(devDeployManifest.peerDependencies).toStrictEqual({
+    '@pnpm.e2e/bar': '*',
+    '@pnpm.e2e/peer-c': '1.0.0',
+  })
+  expect(devDeployManifest.peerDependenciesMeta).toStrictEqual({
+    '@pnpm.e2e/bar': { optional: true },
+    '@pnpm.e2e/peer-c': { optional: true },
+  })
 })
 
 // `pacquet` is fetched from the real npm registry — registry-mock doesn't

--- a/pnpm11/pnpm/test/deploy.ts
+++ b/pnpm11/pnpm/test/deploy.ts
@@ -161,6 +161,8 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
         dependencies: { '@pnpm.e2e/foo': '100.0.0' },
         devDependencies: { '@pnpm.e2e/bar': '100.0.0' },
         optionalDependencies: { '@pnpm.e2e/qar': '100.0.0' },
+        peerDependencies: { '@pnpm.e2e/bar': '*' },
+        peerDependenciesMeta: { '@pnpm.e2e/bar': { optional: true } },
       },
     },
   ])
@@ -181,6 +183,8 @@ test('deploy with a shared lockfile drops excluded direct dependency groups', as
   expect(deployManifest.dependencies).toStrictEqual({ '@pnpm.e2e/foo': '100.0.0' })
   expect(deployManifest.devDependencies).toStrictEqual({})
   expect(deployManifest.optionalDependencies).toStrictEqual({})
+  expect(deployManifest.peerDependencies).toStrictEqual({})
+  expect(deployManifest.peerDependenciesMeta).toStrictEqual({})
 
   const deployLockfile = readYamlFileSync<LockfileFile>(path.join(deployDir, 'pnpm-lock.yaml'))
   const importer = deployLockfile.importers!['.']

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -155,12 +155,12 @@ export function createDeployFiles ({
       },
       packages: deployPackageSnapshots,
     },
-    manifest: {
+    manifest: omitPeersOfExcludedDependencies({
       ...selectedProjectManifest,
       dependencies: targetSnapshot.dependencies,
       devDependencies: targetSnapshot.devDependencies,
       optionalDependencies: targetSnapshot.optionalDependencies,
-    },
+    }, inputSnapshot, targetSnapshot),
   }
 
   if (lockfile.patchedDependencies && patchedDependencies) {
@@ -185,6 +185,33 @@ export function createDeployFiles ({
   }
 
   return result
+}
+
+function omitPeersOfExcludedDependencies (
+  manifest: ProjectManifest,
+  inputSnapshot: ProjectSnapshot,
+  targetSnapshot: ProjectSnapshot
+): ProjectManifest {
+  const includedDependencies = dependencyNames(targetSnapshot)
+  const excludedDependencies = new Set(
+    Array.from(dependencyNames(inputSnapshot)).filter(name => !includedDependencies.has(name))
+  )
+  if (excludedDependencies.size === 0) return manifest
+
+  return {
+    ...manifest,
+    peerDependencies: omitKeys(manifest.peerDependencies, excludedDependencies),
+    peerDependenciesMeta: omitKeys(manifest.peerDependenciesMeta, excludedDependencies),
+  }
+}
+
+function dependencyNames (snapshot: ProjectSnapshot): Set<string> {
+  return new Set(DEPENDENCIES_FIELD.flatMap(field => Object.keys(snapshot[field] ?? {})))
+}
+
+function omitKeys<T> (record: Record<string, T> | undefined, keys: Set<string>): Record<string, T> | undefined {
+  if (record == null) return undefined
+  return Object.fromEntries(Object.entries(record).filter(([key]) => !keys.has(key)))
 }
 
 /** Takes ownership of `packages`: the retained snapshots are edited in place. */

--- a/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
+++ b/pnpm11/releasing/commands/src/deploy/createDeployFiles.ts
@@ -69,6 +69,10 @@ export function createDeployFiles ({
     devDependencies: {},
     optionalDependencies: {},
   }
+  const directDependencyNames = dependencyNames(selectedProjectManifest)
+  const peerOnlyDependencies = new Set(
+    Object.keys(selectedProjectManifest.peerDependencies ?? {}).filter(name => !directDependencyNames.has(name))
+  )
 
   const targetPackageSnapshots: PackageSnapshots = {}
   for (const name in lockfile.packages) {
@@ -109,11 +113,11 @@ export function createDeployFiles ({
     // An excluded group's direct dependencies are left out of both the
     // deployed manifest and the deployed importer, because the graph filter
     // below drops the packages they would point at.
-    if (!include[field]) continue
     const targetDependencies = targetSnapshot[field] ?? {}
     const targetSpecifiers = targetSnapshot.specifiers
     const inputDependencies = inputSnapshot[field] ?? {}
     for (const name in inputDependencies) {
+      if (!include[field] && !peerOnlyDependencies.has(name)) continue
       const version = inputDependencies[name]
       const resolveResult = resolveLinkOrFile(version, {
         lockfileDir,
@@ -160,7 +164,7 @@ export function createDeployFiles ({
       dependencies: targetSnapshot.dependencies,
       devDependencies: targetSnapshot.devDependencies,
       optionalDependencies: targetSnapshot.optionalDependencies,
-    }, inputSnapshot, targetSnapshot),
+    }, selectedProjectManifest, targetSnapshot),
   }
 
   if (lockfile.patchedDependencies && patchedDependencies) {
@@ -189,12 +193,12 @@ export function createDeployFiles ({
 
 function omitPeersOfExcludedDependencies (
   manifest: ProjectManifest,
-  inputSnapshot: ProjectSnapshot,
+  inputManifest: ProjectManifest,
   targetSnapshot: ProjectSnapshot
 ): ProjectManifest {
   const includedDependencies = dependencyNames(targetSnapshot)
   const excludedDependencies = new Set(
-    Array.from(dependencyNames(inputSnapshot)).filter(name => !includedDependencies.has(name))
+    Array.from(dependencyNames(inputManifest)).filter(name => !includedDependencies.has(name))
   )
   if (excludedDependencies.size === 0) return manifest
 
@@ -205,8 +209,8 @@ function omitPeersOfExcludedDependencies (
   }
 }
 
-function dependencyNames (snapshot: ProjectSnapshot): Set<string> {
-  return new Set(DEPENDENCIES_FIELD.flatMap(field => Object.keys(snapshot[field] ?? {})))
+function dependencyNames (source: ProjectManifest | ProjectSnapshot): Set<string> {
+  return new Set(DEPENDENCIES_FIELD.flatMap(field => Object.keys(source[field] ?? {})))
 }
 
 function omitKeys<T> (record: Record<string, T> | undefined, keys: Set<string>): Record<string, T> | undefined {

--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -143,7 +143,7 @@ test('createDeployFiles drops excluded direct dependency groups from the importe
   const lockfile: LockfileObject = {
     lockfileVersion: '9.0',
     settings: {
-      autoInstallPeers: true,
+      autoInstallPeers: false,
       excludeLinksFromLockfile: false,
     },
     importers: {
@@ -174,6 +174,13 @@ test('createDeployFiles drops excluded direct dependency groups from the importe
       dependencies: { prod: '1.0.0' },
       devDependencies: { dev: '1.0.0' },
       optionalDependencies: { opt: '1.0.0' },
+      peerDependencies: { prod: '*', dev: '*', opt: '*', external: '*' },
+      peerDependenciesMeta: {
+        prod: { optional: true },
+        dev: { optional: true },
+        opt: { optional: true },
+        external: { optional: true },
+      },
     },
     projectId,
     rootProjectManifestDir: lockfileDir,
@@ -187,6 +194,13 @@ test('createDeployFiles drops excluded direct dependency groups from the importe
   expect(all.lockfile.importers[projectId].optionalDependencies).toStrictEqual({ opt: '1.0.0' })
   expect(all.manifest.devDependencies).toStrictEqual({ dev: '1.0.0' })
   expect(all.manifest.optionalDependencies).toStrictEqual({ opt: '1.0.0' })
+  expect(all.manifest.peerDependencies).toStrictEqual({ prod: '*', dev: '*', opt: '*', external: '*' })
+  expect(all.manifest.peerDependenciesMeta).toStrictEqual({
+    prod: { optional: true },
+    dev: { optional: true },
+    opt: { optional: true },
+    external: { optional: true },
+  })
 
   const prodOnly = createDeployFiles({
     ...commonOpts,
@@ -198,6 +212,11 @@ test('createDeployFiles drops excluded direct dependency groups from the importe
   expect(prodOnly.lockfile.importers[projectId].specifiers).toStrictEqual({ prod: '1.0.0' })
   expect(prodOnly.manifest.devDependencies).toStrictEqual({})
   expect(prodOnly.manifest.optionalDependencies).toStrictEqual({})
+  expect(prodOnly.manifest.peerDependencies).toStrictEqual({ prod: '*', external: '*' })
+  expect(prodOnly.manifest.peerDependenciesMeta).toStrictEqual({
+    prod: { optional: true },
+    external: { optional: true },
+  })
   expect(prodOnly.lockfile.packages?.[prodDepPath]).toBeDefined()
   expect(prodOnly.lockfile.packages?.[devDepPath]).toBeUndefined()
   expect(prodOnly.lockfile.packages?.[optionalDepPath]).toBeUndefined()

--- a/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
+++ b/pnpm11/releasing/commands/test/deploy/createDeployFiles.test.ts
@@ -221,3 +221,52 @@ test('createDeployFiles drops excluded direct dependency groups from the importe
   expect(prodOnly.lockfile.packages?.[devDepPath]).toBeUndefined()
   expect(prodOnly.lockfile.packages?.[optionalDepPath]).toBeUndefined()
 })
+
+test('createDeployFiles preserves peer-only dependencies auto-installed into an excluded group', () => {
+  const lockfileDir = path.resolve('workspace')
+  const projectId = '.' as ProjectId
+  const externalDepPath = 'external@1.0.0' as DepPath
+  const devDepPath = 'dev@1.0.0' as DepPath
+  const result = createDeployFiles({
+    allProjects: [{
+      rootDirRealPath: lockfileDir as ProjectRootDirRealPath,
+      manifest: { name: 'app', version: '1.0.0' },
+    }],
+    deployDir: path.join(lockfileDir, 'out'),
+    include: { dependencies: false, devDependencies: true, optionalDependencies: false },
+    lockfile: {
+      lockfileVersion: '9.0',
+      settings: {
+        autoInstallPeers: true,
+        excludeLinksFromLockfile: false,
+      },
+      importers: {
+        [projectId]: {
+          specifiers: { external: '1.0.0', dev: '1.0.0' },
+          dependencies: { external: '1.0.0' },
+          devDependencies: { dev: '1.0.0' },
+        },
+      },
+      packages: {
+        [externalDepPath]: { resolution: { integrity: 'sha512-external' }, version: '1.0.0' },
+        [devDepPath]: { resolution: { integrity: 'sha512-dev' }, version: '1.0.0' },
+      },
+    },
+    lockfileDir,
+    selectedProjectManifest: {
+      name: 'app',
+      version: '1.0.0',
+      devDependencies: { dev: '1.0.0' },
+      peerDependencies: { external: '*' },
+      peerDependenciesMeta: { external: { optional: true } },
+    },
+    projectId,
+    rootProjectManifestDir: lockfileDir,
+  })
+
+  expect(result.manifest.dependencies).toStrictEqual({ external: '1.0.0' })
+  expect(result.manifest.devDependencies).toStrictEqual({ dev: '1.0.0' })
+  expect(result.manifest.peerDependencies).toStrictEqual({ external: '*' })
+  expect(result.manifest.peerDependenciesMeta).toStrictEqual({ external: { optional: true } })
+  expect(result.lockfile.packages?.[externalDepPath]).toBeDefined()
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14302.

Filtered deploys rebuilt the direct dependency groups but retained peer declarations for
dependencies excluded by `--prod` or `--dev`. With `autoInstallPeers`, a frozen install in the
deployed directory then rejected the generated lockfile because those peers no longer had direct
dependency specifiers.

This change removes peer dependency and peer metadata entries only when the same package was a
direct dependency excluded from the filtered deploy. Standalone peer-only declarations and their auto-installed importer entries remain intact,\neven when the containing lockfile group is excluded. The behavior is implemented in both the TypeScript CLI and the Rust port, with unit and
end-to-end regression coverage.

## Squash Commit Body

```text
Filtered deploys rebuild the direct dependency groups but kept peer declarations for excluded
names. With auto-install-peers, the deploy install then treated those peers as missing specifiers
and rejected the generated lockfile.

Prune matching peer dependency and metadata entries in both implementations while preserving
standalone peers and their auto-installed importer entries. Add regression coverage for pnpm/pnpm#14302.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790554207&installation_model_id=426870&pr_number=14307&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14307&signature=3bf3f1416cf12329796b35f16373475da7b605a5e2d43b56c83783be91d8b7ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtered deployments incorrectly removing peer-only dependencies when their associated dependency group is excluded.
  * `pnpm deploy --prod` now preserves required peer dependencies and their metadata while excluding unrelated development or optional dependencies.
  * Improved consistency across production and development deployments, including cases with automatically installed optional peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
