### PR TITLE
feat(pnpr): a published artifact claims its slot

### DIFF
--- a/.changeset/artifact-slots-are-write-once.md
+++ b/.changeset/artifact-slots-are-write-once.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A published build artifact is now immutable: one input key and one set of compatibility constraints admit one artifact, and publishing a different one over it is refused with `409 Conflict`, the same answer a re-published `name@version` gets. Re-publishing the identical artifact stays idempotent.
+
+Releasing a claimed slot is an operator action against the store rather than something a publishing credential can do, so a stolen token cannot swap the artifact for a dependency nobody has looked at in a year.

--- a/.changeset/artifact-slots-are-write-once.md
+++ b/.changeset/artifact-slots-are-write-once.md
@@ -2,6 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-A published build artifact is now immutable: one input key and one set of compatibility constraints admit one artifact, and publishing a different one over it is refused with `409 Conflict`, the same answer a re-published `name@version` gets. Re-publishing the identical artifact stays idempotent.
-
-Releasing a claimed slot is an operator action against the store rather than something a publishing credential can do, so a stolen token cannot swap the artifact for a dependency nobody has looked at in a year.
+A published build artifact is now immutable: one input key and one set of compatibility constraints admit one artifact, so publishing a different one over it answers `409 Conflict`, the same as a re-published `name@version`. Republishing the identical artifact still succeeds. Artifacts already stored by an earlier version keep their slot, so upgrading a populated registry does not leave them replaceable.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,6 @@ importers:
   .:
     configDependencies: {}
     packageManagerDependencies:
-      '@pnpm/exe':
-        specifier: 12.0.0
-        version: 12.0.0
       pnpm:
         specifier: 12.0.0
         version: 12.0.0
@@ -59,11 +56,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/exe@12.0.0':
-    resolution: {integrity: sha512-405vw2qYPPghNxoPRt2cvkGtGNU5gnInDcIe5TztQxe73yUZLqFJN/jCJFGs1xbVaIWDXEVuQ71P8npFZeatZQ==}
-    engines: {node: '>=18.*'}
-    hasBin: true
-
   pnpm@12.0.0:
     resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
     engines: {node: '>=18.*'}
@@ -94,17 +86,6 @@ snapshots:
 
   '@pnpm/exe.win32-x64@12.0.0':
     optional: true
-
-  '@pnpm/exe@12.0.0':
-    optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.0.0
-      '@pnpm/exe.darwin-x64': 12.0.0
-      '@pnpm/exe.linux-arm64': 12.0.0
-      '@pnpm/exe.linux-arm64-musl': 12.0.0
-      '@pnpm/exe.linux-x64': 12.0.0
-      '@pnpm/exe.linux-x64-musl': 12.0.0
-      '@pnpm/exe.win32-arm64': 12.0.0
-      '@pnpm/exe.win32-x64': 12.0.0
 
   pnpm@12.0.0:
     optionalDependencies:

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -257,6 +257,25 @@ fn signed_artifact_fixture() -> (PublishArtifactRequest, Vec<u8>, Vec<u8>) {
 fn signed_artifact_fixture_with_builder_id(
     builder_id: &str,
 ) -> (PublishArtifactRequest, Vec<u8>, Vec<u8>) {
+    signed_artifact_fixture_for(builder_id, "pnpm:v1:linux-x64-node22-glibc2.17")
+}
+
+/// One input key admits one artifact per set of compatibility constraints, so a
+/// test wanting several of them for one dependency varies the platform — which
+/// is the only reason a second artifact for one input is legitimate.
+fn signed_artifact_fixture_for_platform(
+    index: usize,
+) -> (PublishArtifactRequest, Vec<u8>, Vec<u8>) {
+    signed_artifact_fixture_for(
+        &format!("ci/concurrent/{index}"),
+        &format!("pnpm:v1:linux-x64-node22-glibc2.{index}"),
+    )
+}
+
+fn signed_artifact_fixture_for(
+    builder_id: &str,
+    tag: &str,
+) -> (PublishArtifactRequest, Vec<u8>, Vec<u8>) {
     let blob = b"native-addon".to_vec();
     let integrity = format!("sha512-{}", BASE64.encode(Sha512::digest(&blob)));
     let payload = ArtifactPayload {
@@ -273,9 +292,7 @@ fn signed_artifact_fixture_with_builder_id(
             architecture_baseline: "x86-64-v2".to_string(),
             environment: BTreeMap::from([("CFLAGS".to_string(), "-O2".to_string())]),
         },
-        compatibility: CompatibilityConstraints::Tagged {
-            tags: vec!["pnpm:v1:linux-x64-node22-glibc2.17".to_string()],
-        },
+        compatibility: CompatibilityConstraints::Tagged { tags: vec![tag.to_string()] },
         manifest: ArtifactManifest {
             added: vec![ArtifactFile {
                 path: "build/addon.node".to_string(),
@@ -1069,7 +1086,7 @@ async fn concurrent_artifact_publications_apply_the_variant_limit_at_read_time()
     const PUBLICATIONS: usize = 16;
 
     let (pnpr_url, pnpr_auth, _storage) = start_pnpr_artifacts().await;
-    let (fixture, _, _) = signed_artifact_fixture_with_builder_id("ci/concurrent/0");
+    let (fixture, _, _) = signed_artifact_fixture_for_platform(0);
     let (payload, _) = fixture.envelope.decode_payload().expect("decode fixture payload");
     let candidate =
         ArtifactCandidate { key: fixture.key, subject: payload.subject, owner: payload.owner };
@@ -1079,8 +1096,7 @@ async fn concurrent_artifact_publications_apply_the_variant_limit_at_read_time()
         let barrier = Arc::clone(&barrier);
         let pnpr_url = pnpr_url.clone();
         let pnpr_auth = pnpr_auth.clone();
-        let (publish, _, _) =
-            signed_artifact_fixture_with_builder_id(&format!("ci/concurrent/{index}"));
+        let (publish, _, _) = signed_artifact_fixture_for_platform(index);
         publications.push(tokio::spawn(async move {
             barrier.wait().await;
             PnprClient::new(pnpr_url).publish_artifact(&publish, Some(&pnpr_auth)).await

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -134,6 +134,24 @@ pub enum RegistryError {
         version: String,
     },
 
+    /// A publish targeted an artifact slot that already holds different bytes.
+    ///
+    /// One input key and one set of compatibility constraints admit one
+    /// artifact, for the same reason a `name@version` admits one tarball: a
+    /// consumer that resolved it once must not be handed different bytes
+    /// later. Replacing a claimed slot is an operator action against the
+    /// store, not something a publishing credential can do — a stolen one
+    /// would otherwise be able to swap an artifact for a dependency nobody
+    /// has looked at in a year.
+    #[display("Cannot publish over the artifact already published for this input key and platform")]
+    #[from(skip)]
+    ArtifactAlreadyPublished {
+        #[error(not(source))]
+        owner: String,
+        #[error(not(source))]
+        entry: String,
+    },
+
     #[display("Hosted packument for package {package:?} changed while writing")]
     #[from(skip)]
     PackumentWriteConflict {
@@ -280,6 +298,7 @@ impl RegistryError {
             RegistryError::InvalidAttachment { .. } => "invalid_attachment",
             RegistryError::BadRequest { .. } => "bad_request",
             RegistryError::VersionAlreadyPublished { .. } => "version_already_published",
+            RegistryError::ArtifactAlreadyPublished { .. } => "artifact_already_published",
             RegistryError::PackumentWriteConflict { .. } => "packument_write_conflict",
             RegistryError::RevisionReferenceLimit { .. } => "revision_reference_limit",
             RegistryError::RevisionReferenceWriteConflict { .. } => {
@@ -359,6 +378,7 @@ impl RegistryError {
             | RegistryError::InvalidAttachment { .. }
             | RegistryError::BadRequest { .. } => StatusCode::BAD_REQUEST,
             RegistryError::VersionAlreadyPublished { .. }
+            | RegistryError::ArtifactAlreadyPublished { .. }
             | RegistryError::PackumentWriteConflict { .. }
             | RegistryError::RevisionReferenceLimit { .. }
             | RegistryError::RevisionReferenceWriteConflict { .. } => StatusCode::CONFLICT,

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -65,6 +65,14 @@ pub struct ArtifactBlob {
     pub stream: BoxStream<'static, object_store::Result<Bytes>>,
 }
 
+/// What the slot a publication is claiming already holds.
+enum SlotClaim {
+    Free,
+    /// This exact envelope, so publishing it again is a retry.
+    Held,
+    HeldByAnother,
+}
+
 struct PreparedPublication {
     entry: String,
     slot: String,
@@ -165,11 +173,12 @@ impl SharedArtifactStore {
         // operator action against the store: the publishing credential must
         // not be able to do it, or a stolen one could swap the artifact for a
         // dependency nobody has looked at in a year.
-        if let Some(existing) = self.claimant(&owner, &entry, &variant_path, &slot).await? {
-            if existing == envelope_bytes {
-                return Ok(false);
+        match self.slot_claim(&owner, &entry, &variant_path, &slot, &envelope_bytes).await? {
+            SlotClaim::Held => return Ok(false),
+            SlotClaim::HeldByAnother => {
+                return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
             }
-            return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
+            SlotClaim::Free => {}
         }
 
         let required: BTreeMap<&str, u64> = payload
@@ -352,29 +361,40 @@ impl SharedArtifactStore {
             .then(|| ResolvedArtifact { key: candidate.key.clone(), variants }))
     }
 
-    /// The envelope already occupying this slot, if any.
+    /// Whether this slot is free, already holds this exact envelope, or holds
+    /// another one.
     ///
-    /// Usually that is the slot's own object. A store written before artifacts
-    /// were named for their slot holds them under their envelope digest
-    /// instead, so those are found by reading the entry — otherwise upgrading a
-    /// populated registry would leave every existing artifact replaceable.
-    async fn claimant(
+    /// Usually the slot's own object answers it. A store written before
+    /// artifacts were named for their slot holds them under their envelope
+    /// digest instead, so those are found by reading the entry — otherwise
+    /// upgrading a populated registry would leave every existing artifact
+    /// replaceable. Such a store may also hold *several* artifacts for one
+    /// slot, which is the state this naming exists to stop being reachable;
+    /// republishing any of them is still a retry, so the entry is searched for
+    /// this envelope before another one is reported.
+    async fn slot_claim(
         &self,
         owner: &str,
         entry: &str,
         variant_path: &str,
         slot: &str,
-    ) -> Result<Option<Vec<u8>>> {
+        envelope_bytes: &[u8],
+    ) -> Result<SlotClaim> {
         if let Some(claimed) =
             self.read_object_bounded(variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await?
         {
-            return Ok(Some(claimed));
+            return Ok(if claimed == envelope_bytes {
+                SlotClaim::Held
+            } else {
+                SlotClaim::HeldByAnother
+            });
         }
         // Every file, not the read-time variant limit: that limit bounds what a
         // lookup will scan, and a claim that stopped there would call a slot
         // free because the artifact holding it sorted too late in the listing.
         let prefix = self.object_path(&format!("{owner}/entries/{entry}/"));
         let mut listing = self.store.list(Some(&prefix));
+        let mut held_by_another = false;
         while let Some(stored) = listing.next().await {
             let stored = stored?;
             if !is_variant_file(object_name(&stored.location)) {
@@ -388,11 +408,15 @@ impl SharedArtifactStore {
             // Compared by slot rather than structurally, so that a stored
             // artifact whose tags are written in another order is recognised as
             // holding this one — the reordering the slot itself canonicalizes.
-            if compatibility_slot(&payload.compatibility) == slot {
-                return Ok(Some(bytes));
+            if compatibility_slot(&payload.compatibility) != slot {
+                continue;
             }
+            if bytes == envelope_bytes {
+                return Ok(SlotClaim::Held);
+            }
+            held_by_another = true;
         }
-        Ok(None)
+        Ok(if held_by_another { SlotClaim::HeldByAnother } else { SlotClaim::Free })
     }
 
     async fn begin_publication(&self, publication: &str) -> Result<()> {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -252,16 +252,27 @@ impl SharedArtifactStore {
         // create is not by itself an idempotent retry: whoever won may have
         // stored something else, and reporting success would tell a publisher
         // its artifact is the one being served when it is not.
-        let lost_to_other_bytes = !created
-            && self
-                .read_object_bounded(&variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64)
-                .await?
-                .is_none_or(|winner| winner != envelope_bytes);
+        // Read before the quota is released and inspected after, so that a
+        // store error here cannot return while this publication is still
+        // charged for an envelope it did not store — a leak that would
+        // accumulate silently and eventually refuse publications that fit.
+        let winner = if created {
+            Ok(None)
+        } else {
+            self.read_object_bounded(&variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await
+        };
         if let Err(error) = self.release_uncommitted(&owner, added_bytes, retained_bytes).await {
             *reclamation_needed = matches!(&error, RegistryError::ObjectStore(_));
             return Err(error);
         }
-        if lost_to_other_bytes {
+        let winner = match winner {
+            Ok(winner) => winner,
+            Err(error) => {
+                *reclamation_needed = matches!(&error, RegistryError::ObjectStore(_));
+                return Err(error);
+            }
+        };
+        if !created && winner.is_none_or(|winner| winner != envelope_bytes) {
             return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
         }
         Ok(created)

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -990,7 +990,22 @@ fn hex(bytes: &[u8]) -> String {
 fn compatibility_slot(compatibility: &CompatibilityConstraints) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"pnpm-shared-artifact-slot-v1\0");
-    hasher.update(serde_json::to_vec(compatibility).expect("compatibility constraints serialize"));
+    match compatibility {
+        CompatibilityConstraints::Universal => hasher.update(b"universal\0"),
+        CompatibilityConstraints::Tagged { tags } => {
+            hasher.update(b"tagged\0");
+            // Sorted because matching a tag set is order-independent: two
+            // orderings are the same constraint, and hashing them apart would
+            // hand the same platform two slots to be published into. The
+            // protocol already rejects duplicates, so sorting canonicalizes.
+            let mut tags: Vec<&str> = tags.iter().map(String::as_str).collect();
+            tags.sort_unstable();
+            for tag in tags {
+                hasher.update(tag.as_bytes());
+                hasher.update([0]);
+            }
+        }
+    }
     hex(&hasher.finalize())
 }
 

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -167,12 +167,6 @@ impl SharedArtifactStore {
         } = prepared;
         let envelope_size = envelope_bytes.len() as u64;
 
-        // Idempotent for the identical envelope — a retried publication is not
-        // an attempt to replace anything — and a conflict for any other, which
-        // is the whole point of the slot. Releasing a claimed slot is an
-        // operator action against the store: the publishing credential must
-        // not be able to do it, or a stolen one could swap the artifact for a
-        // dependency nobody has looked at in a year.
         match self.slot_claim(&owner, &entry, &variant_path, &slot, &envelope_bytes).await? {
             SlotClaim::Held => return Ok(false),
             SlotClaim::HeldByAnother => {
@@ -375,14 +369,11 @@ impl SharedArtifactStore {
     /// Whether this slot is free, already holds this exact envelope, or holds
     /// another one.
     ///
-    /// Usually the slot's own object answers it. A store written before
-    /// artifacts were named for their slot holds them under their envelope
-    /// digest instead, so those are found by reading the entry — otherwise
-    /// upgrading a populated registry would leave every existing artifact
-    /// replaceable. Such a store may also hold *several* artifacts for one
-    /// slot, which is the state this naming exists to stop being reachable;
-    /// republishing any of them is still a retry, so the entry is searched for
-    /// this envelope before another one is reported.
+    /// Usually the slot's own object answers it. A store may also hold
+    /// artifacts under their envelope digest, and several of them for one
+    /// slot, so the entry is read when that object is absent: otherwise those
+    /// artifacts would be replaceable, and republishing one of them — a retry
+    /// like any other — would be refused as a conflict.
     async fn slot_claim(
         &self,
         owner: &str,
@@ -873,8 +864,7 @@ fn prepare_publication(
     let entry = entry_digest(&request.key, &payload.subject);
     let envelope_bytes = serde_json::to_vec(&request.envelope)?;
     // Named for what the artifact is *for* rather than what it is, so that one
-    // input key and one set of compatibility constraints admit one artifact and
-    // a second build for the same input collides instead of joining it.
+    // input key and one set of compatibility constraints admit one artifact.
     let slot = compatibility_slot(&payload.compatibility);
     let variant_path = format!("{owner}/entries/{entry}/{slot}.json");
     Ok(PreparedPublication {
@@ -1024,8 +1014,7 @@ fn hex(bytes: &[u8]) -> String {
 /// builds advertising the same constraints do not.
 ///
 /// Hex-encoded so that it has the shape [`is_variant_file`] recognises, which
-/// is also the shape of the envelope digests a store written before slots
-/// existed used for these files.
+/// envelope digests share.
 fn compatibility_slot(compatibility: &CompatibilityConstraints) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"pnpm-shared-artifact-slot-v1\0");

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -14,9 +14,10 @@ use object_store::{
 };
 use pnpm_shared_artifact_protocol::{
     ArtifactBlobRequest, ArtifactCandidate, ArtifactPayload, ArtifactProtocolError,
-    ArtifactSubject, ArtifactVariant, MAX_CANDIDATES, MAX_FILE_SIZE, MAX_RESOLVE_RESPONSE_SIZE,
-    MAX_VARIANTS_PER_CANDIDATE, OwnerScope, PublishArtifactRequest, ResolveArtifactsRequest,
-    ResolveArtifactsResponse, ResolvedArtifact, SignedArtifactEnvelope, blob_id, verify_blob,
+    ArtifactSubject, ArtifactVariant, CompatibilityConstraints, MAX_CANDIDATES, MAX_FILE_SIZE,
+    MAX_RESOLVE_RESPONSE_SIZE, MAX_VARIANTS_PER_CANDIDATE, OwnerScope, PublishArtifactRequest,
+    ResolveArtifactsRequest, ResolveArtifactsResponse, ResolvedArtifact, SignedArtifactEnvelope,
+    blob_id, verify_blob,
 };
 use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
@@ -65,6 +66,7 @@ pub struct ArtifactBlob {
 }
 
 struct PreparedPublication {
+    entry: String,
     payload: ArtifactPayload,
     uploads: BTreeMap<String, Vec<u8>>,
     owner: String,
@@ -145,12 +147,29 @@ impl SharedArtifactStore {
         prepared: PreparedPublication,
         reclamation_needed: &mut bool,
     ) -> Result<bool> {
-        let PreparedPublication { payload, mut uploads, owner, envelope_bytes, variant_path } =
-            prepared;
+        let PreparedPublication {
+            payload,
+            mut uploads,
+            owner,
+            entry,
+            envelope_bytes,
+            variant_path,
+        } = prepared;
         let envelope_size = envelope_bytes.len() as u64;
 
-        if self.object_exists(&variant_path).await? {
-            return Ok(false);
+        // Idempotent for the identical envelope — a retried publication is not
+        // an attempt to replace anything — and a conflict for any other, which
+        // is the whole point of the slot. Releasing a claimed slot is an
+        // operator action against the store: the publishing credential must
+        // not be able to do it, or a stolen one could swap the artifact for a
+        // dependency nobody has looked at in a year.
+        if let Some(existing) =
+            self.read_object_bounded(&variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await?
+        {
+            if existing == envelope_bytes {
+                return Ok(false);
+            }
+            return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
         }
 
         let required: BTreeMap<&str, u64> = payload
@@ -679,14 +698,6 @@ impl SharedArtifactStore {
         Ok(())
     }
 
-    async fn object_exists(&self, relative: &str) -> Result<bool> {
-        match self.store.head(&self.object_path(relative)).await {
-            Ok(_) => Ok(true),
-            Err(object_store::Error::NotFound { .. }) => Ok(false),
-            Err(error) => Err(error.into()),
-        }
-    }
-
     async fn create_object(&self, relative: &str, bytes: Vec<u8>) -> Result<bool> {
         match self
             .store
@@ -770,13 +781,19 @@ fn prepare_publication(
     let payload = validated.payload;
     let owner = owner_key(username, &payload.owner)?;
     let entry = entry_digest(&request.key, &payload.subject);
-    let envelope = request.envelope.digest().map_err(|err| protocol_error(&err))?;
     let envelope_bytes = serde_json::to_vec(&request.envelope)?;
-    let variant_path = format!("{owner}/entries/{entry}/{envelope}.json");
+    // Named for what the artifact is *for* rather than what it is, so that one
+    // input key and one set of compatibility constraints admit one artifact.
+    // Naming it by the envelope digest let a second, differently signed build
+    // for the same input sit alongside the first as another variant, which is
+    // the swap a consumer has no way to notice.
+    let slot = compatibility_slot(&payload.compatibility);
+    let variant_path = format!("{owner}/entries/{entry}/{slot}.json");
     Ok(PreparedPublication {
         payload,
         uploads: validated.blobs,
         owner,
+        entry,
         envelope_bytes,
         variant_path,
     })
@@ -911,6 +928,20 @@ fn hex(bytes: &[u8]) -> String {
         write!(output, "{byte:02x}").expect("writing to a String cannot fail");
         output
     })
+}
+
+/// The slot an artifact claims within its entry: one per set of compatibility
+/// constraints, so a `universal` build and a glibc-2.31 build coexist while two
+/// builds advertising the same constraints do not.
+///
+/// Hex-encoded like the envelope digests that named these files before, so the
+/// listing in [`SharedArtifactStore::resolve_candidate`] does not have to tell
+/// the two apart.
+fn compatibility_slot(compatibility: &CompatibilityConstraints) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"pnpm-shared-artifact-slot-v1\0");
+    hasher.update(serde_json::to_vec(compatibility).expect("compatibility constraints serialize"));
+    hex(&hasher.finalize())
 }
 
 fn entry_digest(key: &str, subject: &ArtifactSubject) -> String {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -67,6 +67,7 @@ pub struct ArtifactBlob {
 
 struct PreparedPublication {
     entry: String,
+    slot: String,
     payload: ArtifactPayload,
     uploads: BTreeMap<String, Vec<u8>>,
     owner: String,
@@ -152,6 +153,7 @@ impl SharedArtifactStore {
             mut uploads,
             owner,
             entry,
+            slot,
             envelope_bytes,
             variant_path,
         } = prepared;
@@ -163,9 +165,7 @@ impl SharedArtifactStore {
         // operator action against the store: the publishing credential must
         // not be able to do it, or a stolen one could swap the artifact for a
         // dependency nobody has looked at in a year.
-        if let Some(existing) =
-            self.claimant(&owner, &entry, &variant_path, &payload.compatibility).await?
-        {
+        if let Some(existing) = self.claimant(&owner, &entry, &variant_path, &slot).await? {
             if existing == envelope_bytes {
                 return Ok(false);
             }
@@ -363,29 +363,32 @@ impl SharedArtifactStore {
         owner: &str,
         entry: &str,
         variant_path: &str,
-        compatibility: &CompatibilityConstraints,
+        slot: &str,
     ) -> Result<Option<Vec<u8>>> {
         if let Some(claimed) =
             self.read_object_bounded(variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await?
         {
             return Ok(Some(claimed));
         }
+        // Every file, not the read-time variant limit: that limit bounds what a
+        // lookup will scan, and a claim that stopped there would call a slot
+        // free because the artifact holding it sorted too late in the listing.
         let prefix = self.object_path(&format!("{owner}/entries/{entry}/"));
         let mut listing = self.store.list(Some(&prefix));
-        let mut scanned = 0;
-        while scanned < MAX_VARIANTS_PER_CANDIDATE {
-            let Some(stored) = listing.next().await else { break };
+        while let Some(stored) = listing.next().await {
             let stored = stored?;
             if !is_variant_file(object_name(&stored.location)) {
                 continue;
             }
-            scanned += 1;
             let Some(bytes) = self.read_object_path(&stored.location).await? else { continue };
             let Ok(envelope) = serde_json::from_slice::<SignedArtifactEnvelope>(&bytes) else {
                 continue;
             };
             let Ok((payload, _)) = envelope.decode_payload() else { continue };
-            if &payload.compatibility == compatibility {
+            // Compared by slot rather than structurally, so that a stored
+            // artifact whose tags are written in another order is recognised as
+            // holding this one — the reordering the slot itself canonicalizes.
+            if compatibility_slot(&payload.compatibility) == slot {
                 return Ok(Some(bytes));
             }
         }
@@ -844,6 +847,7 @@ fn prepare_publication(
         uploads: validated.blobs,
         owner,
         entry,
+        slot,
         envelope_bytes,
         variant_path,
     })

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -164,7 +164,7 @@ impl SharedArtifactStore {
         // not be able to do it, or a stolen one could swap the artifact for a
         // dependency nobody has looked at in a year.
         if let Some(existing) =
-            self.read_object_bounded(&variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await?
+            self.claimant(&owner, &entry, &variant_path, &payload.compatibility).await?
         {
             if existing == envelope_bytes {
                 return Ok(false);
@@ -227,7 +227,7 @@ impl SharedArtifactStore {
                 }
             }
         }
-        let created = match self.create_object(&variant_path, envelope_bytes).await {
+        let created = match self.create_object(&variant_path, envelope_bytes.clone()).await {
             Ok(created) => created,
             Err(error) => {
                 *reclamation_needed = true;
@@ -239,9 +239,21 @@ impl SharedArtifactStore {
         if created {
             retained_bytes += envelope_size;
         }
+        // Two publications can both find the slot empty above, so losing the
+        // create is not by itself an idempotent retry: whoever won may have
+        // stored something else, and reporting success would tell a publisher
+        // its artifact is the one being served when it is not.
+        let lost_to_other_bytes = !created
+            && self
+                .read_object_bounded(&variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64)
+                .await?
+                .is_none_or(|winner| winner != envelope_bytes);
         if let Err(error) = self.release_uncommitted(&owner, added_bytes, retained_bytes).await {
             *reclamation_needed = matches!(&error, RegistryError::ObjectStore(_));
             return Err(error);
+        }
+        if lost_to_other_bytes {
+            return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
         }
         Ok(created)
     }
@@ -338,6 +350,46 @@ impl SharedArtifactStore {
         }
         Ok((!variants.is_empty())
             .then(|| ResolvedArtifact { key: candidate.key.clone(), variants }))
+    }
+
+    /// The envelope already occupying this slot, if any.
+    ///
+    /// Usually that is the slot's own object. A store written before artifacts
+    /// were named for their slot holds them under their envelope digest
+    /// instead, so those are found by reading the entry — otherwise upgrading a
+    /// populated registry would leave every existing artifact replaceable.
+    async fn claimant(
+        &self,
+        owner: &str,
+        entry: &str,
+        variant_path: &str,
+        compatibility: &CompatibilityConstraints,
+    ) -> Result<Option<Vec<u8>>> {
+        if let Some(claimed) =
+            self.read_object_bounded(variant_path, MAX_RESOLVE_RESPONSE_SIZE as u64).await?
+        {
+            return Ok(Some(claimed));
+        }
+        let prefix = self.object_path(&format!("{owner}/entries/{entry}/"));
+        let mut listing = self.store.list(Some(&prefix));
+        let mut scanned = 0;
+        while scanned < MAX_VARIANTS_PER_CANDIDATE {
+            let Some(stored) = listing.next().await else { break };
+            let stored = stored?;
+            if !is_variant_file(object_name(&stored.location)) {
+                continue;
+            }
+            scanned += 1;
+            let Some(bytes) = self.read_object_path(&stored.location).await? else { continue };
+            let Ok(envelope) = serde_json::from_slice::<SignedArtifactEnvelope>(&bytes) else {
+                continue;
+            };
+            let Ok((payload, _)) = envelope.decode_payload() else { continue };
+            if &payload.compatibility == compatibility {
+                return Ok(Some(bytes));
+            }
+        }
+        Ok(None)
     }
 
     async fn begin_publication(&self, publication: &str) -> Result<()> {
@@ -783,10 +835,8 @@ fn prepare_publication(
     let entry = entry_digest(&request.key, &payload.subject);
     let envelope_bytes = serde_json::to_vec(&request.envelope)?;
     // Named for what the artifact is *for* rather than what it is, so that one
-    // input key and one set of compatibility constraints admit one artifact.
-    // Naming it by the envelope digest let a second, differently signed build
-    // for the same input sit alongside the first as another variant, which is
-    // the swap a consumer has no way to notice.
+    // input key and one set of compatibility constraints admit one artifact and
+    // a second build for the same input collides instead of joining it.
     let slot = compatibility_slot(&payload.compatibility);
     let variant_path = format!("{owner}/entries/{entry}/{slot}.json");
     Ok(PreparedPublication {
@@ -934,9 +984,9 @@ fn hex(bytes: &[u8]) -> String {
 /// constraints, so a `universal` build and a glibc-2.31 build coexist while two
 /// builds advertising the same constraints do not.
 ///
-/// Hex-encoded like the envelope digests that named these files before, so the
-/// listing in [`SharedArtifactStore::resolve_candidate`] does not have to tell
-/// the two apart.
+/// Hex-encoded so that it has the shape [`is_variant_file`] recognises, which
+/// is also the shape of the envelope digests a store written before slots
+/// existed used for these files.
 fn compatibility_slot(compatibility: &CompatibilityConstraints) -> String {
     let mut hasher = Sha256::new();
     hasher.update(b"pnpm-shared-artifact-slot-v1\0");

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -23,6 +23,7 @@ use pnpm_shared_artifact_protocol::{
     ResolvedArtifact, SIGNATURE_ALGORITHM, SignedArtifactEnvelope, WORKSPACE_TASK_ARTIFACT_KIND,
 };
 use pnpr_config::{HostedStoreConfig, normalize_key_prefix};
+use pnpr_error::RegistryError;
 use sha2::{Digest as _, Sha512};
 use tempfile::TempDir;
 
@@ -162,7 +163,10 @@ async fn object_store_replicas_share_blobs_envelopes_and_quota() {
         first
             .publish(
                 "acme",
-                publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/first"),
+                for_platform(
+                    publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/first"),
+                    1,
+                ),
             )
             .await
             .unwrap(),
@@ -171,7 +175,10 @@ async fn object_store_replicas_share_blobs_envelopes_and_quota() {
         second
             .publish(
                 "acme",
-                publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/second"),
+                for_platform(
+                    publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/second"),
+                    2,
+                ),
             )
             .await
             .unwrap(),
@@ -203,7 +210,7 @@ async fn concurrent_replicas_update_quota_without_lost_writes() {
         publications.push(tokio::spawn(async move {
             let scratch = TempDir::new().unwrap();
             let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
-            store.publish("acme", publication(&format!("ci/{index}"))).await
+            store.publish("acme", publication_for_platform(index)).await
         }));
     }
     for publication in publications {
@@ -215,9 +222,7 @@ async fn concurrent_replicas_update_quota_without_lost_writes() {
         serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
             .unwrap();
     let expected = (0..PUBLICATIONS)
-        .map(|index| {
-            serde_json::to_vec(&publication(&format!("ci/{index}")).envelope).unwrap().len()
-        })
+        .map(|index| serde_json::to_vec(&publication_for_platform(index).envelope).unwrap().len())
         .sum::<usize>() as u64;
     assert_eq!(usage.global_bytes, expected);
 }
@@ -472,12 +477,44 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
     assert!(backend.head(&orphan).await.is_ok());
 }
 
+/// One input key and one set of compatibility constraints admit one artifact,
+/// for the same reason a `name@version` admits one tarball: a consumer that
+/// resolved it once must not be handed different bytes later. A second build
+/// for the same slot is refused rather than joining it as another variant.
+#[tokio::test]
+async fn a_second_artifact_cannot_claim_a_taken_slot() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    assert!(store.publish("acme", publication("ci/first")).await.unwrap());
+
+    let error = store.publish("acme", publication("ci/second")).await.unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "expected a conflict, got {error:?}",
+    );
+    let response =
+        store.resolve("acme", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
+    assert_eq!(response.artifacts[0].variants.len(), 1, "the first artifact still stands");
+}
+
+/// A retried publication of the identical envelope is not an attempt to replace
+/// anything, so it stays idempotent rather than becoming a conflict.
+#[tokio::test]
+async fn republishing_the_same_artifact_stays_idempotent() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    assert!(store.publish("acme", publication("ci/first")).await.unwrap());
+
+    assert!(!store.publish("acme", publication("ci/first")).await.unwrap());
+}
+
 #[tokio::test]
 async fn the_variant_limit_is_applied_at_read_time() {
     let storage = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
     for index in 0..MAX_VARIANTS_PER_CANDIDATE + 2 {
-        assert!(store.publish("acme", publication(&format!("ci/{index}"))).await.unwrap());
+        assert!(store.publish("acme", publication_for_platform(index)).await.unwrap());
     }
 
     let response =
@@ -513,6 +550,23 @@ fn lookup(owner: &str) -> ResolveArtifactsRequest {
 
 fn publication(builder_id: &str) -> PublishArtifactRequest {
     publication_request("dependency-side-effects:v1:deps=abc", builder_id, None)
+}
+
+/// One input key admits one artifact per set of compatibility constraints, so a
+/// test wanting several of them for one dependency has to vary the platform —
+/// which is the only reason a second artifact for one input is legitimate.
+fn for_platform(mut request: PublishArtifactRequest, index: usize) -> PublishArtifactRequest {
+    let mut payload: ArtifactPayload =
+        serde_json::from_slice(&BASE64.decode(&request.envelope.payload).unwrap()).unwrap();
+    payload.compatibility = CompatibilityConstraints::Tagged {
+        tags: vec![format!("pnpm:v1:linux-x64-node22-glibc2.{index}")],
+    };
+    request.envelope.payload = BASE64.encode(serde_json::to_vec(&payload).unwrap());
+    request
+}
+
+fn publication_for_platform(index: usize) -> PublishArtifactRequest {
+    for_platform(publication(&format!("ci/{index}")), index)
 }
 
 fn publication_with_blob(input_key: &str, builder_id: &str) -> PublishArtifactRequest {

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -3,7 +3,7 @@ use std::{
     fmt,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
 
@@ -276,6 +276,7 @@ async fn failed_object_writes_reconcile_quota_to_physical_storage() {
         fail_deletes: false,
         fail_next_quota_write: None,
         claim_slot_first: None,
+        fail_slot_read_after_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -299,6 +300,7 @@ async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
         fail_deletes: false,
         fail_next_quota_write: None,
         claim_slot_first: None,
+        fail_slot_read_after_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -333,6 +335,7 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
         fail_deletes: false,
         fail_next_quota_write: None,
         claim_slot_first: None,
+        fail_slot_read_after_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -360,6 +363,7 @@ async fn publication_finish_retries_a_transient_quota_write_failure() {
         fail_deletes: false,
         fail_next_quota_write: Some(Arc::clone(&fail_next_quota_write)),
         claim_slot_first: None,
+        fail_slot_read_after_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -461,6 +465,7 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
         fail_deletes: true,
         fail_next_quota_write: None,
         claim_slot_first: None,
+        fail_slot_read_after_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -551,6 +556,45 @@ async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
             "{label}: expected a conflict, got {error:?}",
         );
     }
+}
+
+/// Losing the race and then failing to read the winner must not leave the loser
+/// charged for an envelope it did not store: that debt never comes back, and
+/// enough of it starts refusing publications that fit.
+#[tokio::test]
+async fn a_failed_reread_after_a_lost_race_still_releases_the_quota() {
+    let winner = publication("ci/winner");
+    let (payload, _) = winner.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&winner.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: true,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: Some((
+            format!(".pnpr-artifacts/v0/{owner}/entries/{entry}/{slot}.json"),
+            serde_json::to_vec(&winner.envelope).unwrap(),
+        )),
+        fail_slot_read_after_first: Some(Arc::new(AtomicUsize::new(0))),
+    });
+    let store = SharedArtifactStore::new(
+        &HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() },
+        TempDir::new().unwrap().path(),
+    )
+    .unwrap();
+
+    store.publish("acme", publication("ci/loser")).await.unwrap_err();
+
+    let usage_path = ObjectPath::from(".pnpr-artifacts/v0/quota.json");
+    let usage: ArtifactUsage =
+        serde_json::from_slice(&backend.get(&usage_path).await.unwrap().bytes().await.unwrap())
+            .unwrap();
+    // The winner is written behind the store's back to stage the race, so it is
+    // never charged: everything accounted here belongs to the loser, and the
+    // loser stored nothing.
+    assert_eq!(usage.global_bytes, 0, "the loser is not charged for what it did not store");
 }
 
 /// A store written before this naming could hold several artifacts for one
@@ -651,6 +695,7 @@ async fn losing_a_race_for_a_slot_is_not_reported_as_idempotent() {
             format!(".pnpr-artifacts/v0/{owner}/entries/{entry}/{slot}.json"),
             serde_json::to_vec(&winner.envelope).unwrap(),
         )),
+        fail_slot_read_after_first: None,
     });
     let racing = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: racing, prefix: String::new() },
@@ -839,6 +884,10 @@ struct FailArtifactWrites {
     /// creation of this path stores these bytes instead and reports the
     /// conflict the loser would see.
     claim_slot_first: Option<(String, Vec<u8>)>,
+    /// Fails reads of the slot *after* the first, so the pre-check still finds
+    /// it free and the failure lands on the re-read that follows a lost create
+    /// — the only point where the loser is charged for what it did not store.
+    fail_slot_read_after_first: Option<Arc<AtomicUsize>>,
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -902,6 +951,15 @@ impl ObjectStore for FailArtifactWrites {
         location: &ObjectPath,
         options: GetOptions,
     ) -> object_store::Result<GetResult> {
+        if let Some(reads) = self.fail_slot_read_after_first.as_ref()
+            && self.claim_slot_first.as_ref().is_some_and(|(slot, _)| location.as_ref() == slot)
+            && reads.fetch_add(1, Ordering::SeqCst) > 0
+        {
+            return Err(object_store::Error::Generic {
+                store: "test",
+                source: std::io::Error::other("injected slot read failure").into(),
+            });
+        }
         self.inner.get_opts(location, options).await
     }
 

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -503,6 +503,56 @@ async fn a_second_artifact_cannot_claim_a_taken_slot() {
     assert_eq!(response.artifacts[0].variants.len(), 1, "the first artifact still stands");
 }
 
+/// The two holes the legacy fallback could still leave: a stored artifact whose
+/// tags are written in another order, and one that sorts past the read-time
+/// variant limit. Both would call an occupied slot free.
+#[tokio::test]
+async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
+    let tags = ["pnpm:v1:linux-x64-node22-glibc2.17", "pnpm:v1:linux-arm64-node22-glibc2.17"];
+    let reversed = [tags[1], tags[0]];
+
+    for (label, buried) in [("reordered", false), ("buried", true)] {
+        let storage = TempDir::new().unwrap();
+        let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+        let legacy = publication_tagged("ci/legacy", &tags);
+        let (payload, _) = legacy.envelope.decode_payload().unwrap();
+        let owner = super::owner_key("acme", &payload.owner).unwrap();
+        let entry = super::entry_digest(&legacy.key, &payload.subject);
+        if buried {
+            // Named to sort before the matching one, and more of them than a
+            // lookup would scan.
+            for index in 0..MAX_VARIANTS_PER_CANDIDATE + 2 {
+                let filler = publication_tagged(
+                    &format!("ci/filler/{index}"),
+                    &[&format!("pnpm:v1:linux-x64-node22-glibc2.{index}")],
+                );
+                store
+                    .create_object(
+                        &format!("{owner}/entries/{entry}/{:064x}.json", index),
+                        serde_json::to_vec(&filler.envelope).unwrap(),
+                    )
+                    .await
+                    .unwrap();
+            }
+        }
+        store
+            .create_object(
+                &format!("{owner}/entries/{entry}/{}.json", "f".repeat(64)),
+                serde_json::to_vec(&legacy.envelope).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let error =
+            store.publish("acme", publication_tagged("ci/second", &reversed)).await.unwrap_err();
+
+        assert!(
+            matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+            "{label}: expected a conflict, got {error:?}",
+        );
+    }
+}
+
 /// Matching a tag set is order-independent, so two orderings are the same
 /// constraint and must not be two slots — otherwise a publisher reopens the
 /// swap simply by listing the same tags the other way round.

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -503,6 +503,26 @@ async fn a_second_artifact_cannot_claim_a_taken_slot() {
     assert_eq!(response.artifacts[0].variants.len(), 1, "the first artifact still stands");
 }
 
+/// Matching a tag set is order-independent, so two orderings are the same
+/// constraint and must not be two slots — otherwise a publisher reopens the
+/// swap simply by listing the same tags the other way round.
+#[tokio::test]
+async fn tag_order_does_not_open_a_second_slot() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let tags = ["pnpm:v1:linux-x64-node22-glibc2.17", "pnpm:v1:linux-arm64-node22-glibc2.17"];
+    assert!(store.publish("acme", publication_tagged("ci/first", &tags)).await.unwrap());
+
+    let reversed = [tags[1], tags[0]];
+    let error =
+        store.publish("acme", publication_tagged("ci/second", &reversed)).await.unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "expected a conflict, got {error:?}",
+    );
+}
+
 /// A store written before artifacts were named for their slot holds them under
 /// their envelope digest. Upgrading must not leave every artifact already in it
 /// replaceable, so those claim their slot too.
@@ -633,6 +653,17 @@ fn for_platform(mut request: PublishArtifactRequest, index: usize) -> PublishArt
 
 fn publication_for_platform(index: usize) -> PublishArtifactRequest {
     for_platform(publication(&format!("ci/{index}")), index)
+}
+
+fn publication_tagged(builder_id: &str, tags: &[&str]) -> PublishArtifactRequest {
+    let mut request = publication(builder_id);
+    let mut payload: ArtifactPayload =
+        serde_json::from_slice(&BASE64.decode(&request.envelope.payload).unwrap()).unwrap();
+    payload.compatibility = CompatibilityConstraints::Tagged {
+        tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
+    };
+    request.envelope.payload = BASE64.encode(serde_json::to_vec(&payload).unwrap());
+    request
 }
 
 fn publication_with_blob(input_key: &str, builder_id: &str) -> PublishArtifactRequest {

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -528,7 +528,7 @@ async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
                 );
                 store
                     .create_object(
-                        &format!("{owner}/entries/{entry}/{:064x}.json", index),
+                        &format!("{owner}/entries/{entry}/{index:064x}.json"),
                         serde_json::to_vec(&filler.envelope).unwrap(),
                     )
                     .await

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -275,6 +275,7 @@ async fn failed_object_writes_reconcile_quota_to_physical_storage() {
         commit_before_error: false,
         fail_deletes: false,
         fail_next_quota_write: None,
+        claim_slot_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -297,6 +298,7 @@ async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
         commit_before_error: true,
         fail_deletes: false,
         fail_next_quota_write: None,
+        claim_slot_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -330,6 +332,7 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
         commit_before_error: true,
         fail_deletes: false,
         fail_next_quota_write: None,
+        claim_slot_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -356,6 +359,7 @@ async fn publication_finish_retries_a_transient_quota_write_failure() {
         commit_before_error: false,
         fail_deletes: false,
         fail_next_quota_write: Some(Arc::clone(&fail_next_quota_write)),
+        claim_slot_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -456,6 +460,7 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
         commit_before_error: false,
         fail_deletes: true,
         fail_next_quota_write: None,
+        claim_slot_first: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -496,6 +501,67 @@ async fn a_second_artifact_cannot_claim_a_taken_slot() {
     let response =
         store.resolve("acme", &serde_json::to_vec(&lookup("acme")).unwrap()).await.unwrap();
     assert_eq!(response.artifacts[0].variants.len(), 1, "the first artifact still stands");
+}
+
+/// A store written before artifacts were named for their slot holds them under
+/// their envelope digest. Upgrading must not leave every artifact already in it
+/// replaceable, so those claim their slot too.
+#[tokio::test]
+async fn an_artifact_stored_under_the_older_name_still_claims_its_slot() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let first = publication("ci/first");
+    let envelope_bytes = serde_json::to_vec(&first.envelope).unwrap();
+    let (payload, _) = first.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&first.key, &payload.subject);
+    let envelope_digest = first.envelope.digest().unwrap();
+    store
+        .create_object(&format!("{owner}/entries/{entry}/{envelope_digest}.json"), envelope_bytes)
+        .await
+        .unwrap();
+
+    let error = store.publish("acme", publication("ci/second")).await.unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "expected a conflict, got {error:?}",
+    );
+}
+
+/// Two publications can both find the slot empty, so losing the create is not
+/// by itself an idempotent retry: whoever won may have stored something else.
+#[tokio::test]
+async fn losing_a_race_for_a_slot_is_not_reported_as_idempotent() {
+    let winner = publication("ci/winner");
+    let (payload, _) = winner.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&winner.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+
+    // The loser passes the pre-check, then finds the slot taken at create time.
+    let racing: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: true,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: Some((
+            format!(".pnpr-artifacts/v0/{owner}/entries/{entry}/{slot}.json"),
+            serde_json::to_vec(&winner.envelope).unwrap(),
+        )),
+    });
+    let racing = SharedArtifactStore::new(
+        &HostedStoreConfig::ObjectStore { store: racing, prefix: String::new() },
+        TempDir::new().unwrap().path(),
+    )
+    .unwrap();
+
+    let error = racing.publish("acme", publication("ci/loser")).await.unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "expected a conflict, got {error:?}",
+    );
 }
 
 /// A retried publication of the identical envelope is not an attempt to replace
@@ -656,6 +722,10 @@ struct FailArtifactWrites {
     commit_before_error: bool,
     fail_deletes: bool,
     fail_next_quota_write: Option<Arc<AtomicBool>>,
+    /// Stands in for the publication that won a race for a slot: the first
+    /// creation of this path stores these bytes instead and reports the
+    /// conflict the loser would see.
+    claim_slot_first: Option<(String, Vec<u8>)>,
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -672,6 +742,17 @@ impl ObjectStore for FailArtifactWrites {
         payload: PutPayload,
         options: PutOptions,
     ) -> object_store::Result<PutResult> {
+        if let Some((slot, winner)) = self.claim_slot_first.as_ref()
+            && location.as_ref() == slot
+        {
+            self.inner
+                .put_opts(location, PutPayload::from(winner.clone()), PutOptions::default())
+                .await?;
+            return Err(object_store::Error::AlreadyExists {
+                path: location.to_string(),
+                source: std::io::Error::other("slot claimed by another publication").into(),
+            });
+        }
         if location.as_ref().ends_with("/quota.json") {
             if self
                 .fail_next_quota_write

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -487,10 +487,8 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
     assert!(backend.head(&orphan).await.is_ok());
 }
 
-/// One input key and one set of compatibility constraints admit one artifact,
-/// for the same reason a `name@version` admits one tarball: a consumer that
-/// resolved it once must not be handed different bytes later. A second build
-/// for the same slot is refused rather than joining it as another variant.
+/// A second build for a claimed slot is refused rather than stored beside the
+/// first. See [`RegistryError::ArtifactAlreadyPublished`] for why.
 #[tokio::test]
 async fn a_second_artifact_cannot_claim_a_taken_slot() {
     let storage = TempDir::new().unwrap();
@@ -508,9 +506,9 @@ async fn a_second_artifact_cannot_claim_a_taken_slot() {
     assert_eq!(response.artifacts[0].variants.len(), 1, "the first artifact still stands");
 }
 
-/// The two holes the legacy fallback could still leave: a stored artifact whose
-/// tags are written in another order, and one that sorts past the read-time
-/// variant limit. Both would call an occupied slot free.
+/// An artifact stored under its envelope digest claims its slot whatever order
+/// its tags are written in, and however late it sorts in the listing. Either
+/// would otherwise leave an occupied slot looking free.
 #[tokio::test]
 async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
     let tags = ["pnpm:v1:linux-x64-node22-glibc2.17", "pnpm:v1:linux-arm64-node22-glibc2.17"];
@@ -597,10 +595,10 @@ async fn a_failed_reread_after_a_lost_race_still_releases_the_quota() {
     assert_eq!(usage.global_bytes, 0, "the loser is not charged for what it did not store");
 }
 
-/// A store written before this naming could hold several artifacts for one
-/// slot. Republishing any of them is still a retry, so the whole slot is
-/// searched for the incoming envelope before another one is reported — the
-/// second is no less already-published than the first.
+/// A store may hold several artifacts for one slot. Republishing any of them is
+/// a retry, so the whole slot is searched for the incoming envelope before
+/// another one is reported: the second is no less already-published than the
+/// first.
 #[tokio::test]
 async fn republishing_any_artifact_already_in_a_crowded_legacy_slot_is_a_retry() {
     let storage = TempDir::new().unwrap();
@@ -649,9 +647,8 @@ async fn tag_order_does_not_open_a_second_slot() {
     );
 }
 
-/// A store written before artifacts were named for their slot holds them under
-/// their envelope digest. Upgrading must not leave every artifact already in it
-/// replaceable, so those claim their slot too.
+/// An artifact stored under its envelope digest claims its slot too, or a store
+/// already holding one would leave it replaceable.
 #[tokio::test]
 async fn an_artifact_stored_under_the_older_name_still_claims_its_slot() {
     let storage = TempDir::new().unwrap();

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -553,6 +553,38 @@ async fn a_legacy_artifact_claims_its_slot_whatever_its_order_or_position() {
     }
 }
 
+/// A store written before this naming could hold several artifacts for one
+/// slot. Republishing any of them is still a retry, so the whole slot is
+/// searched for the incoming envelope before another one is reported — the
+/// second is no less already-published than the first.
+#[tokio::test]
+async fn republishing_any_artifact_already_in_a_crowded_legacy_slot_is_a_retry() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let first = publication("ci/first");
+    let second = publication("ci/second");
+    let (payload, _) = first.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&first.key, &payload.subject);
+    for (name, request) in [("a".repeat(64), &first), ("b".repeat(64), &second)] {
+        store
+            .create_object(
+                &format!("{owner}/entries/{entry}/{name}.json"),
+                serde_json::to_vec(&request.envelope).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    assert!(!store.publish("acme", publication("ci/second")).await.unwrap());
+    assert!(!store.publish("acme", publication("ci/first")).await.unwrap());
+    let error = store.publish("acme", publication("ci/third")).await.unwrap_err();
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "a genuinely new artifact still conflicts, got {error:?}",
+    );
+}
+
 /// Matching a tag set is order-independent, so two orderings are the same
 /// constraint and must not be two slots — otherwise a publisher reopens the
 /// swap simply by listing the same tags the other way round.


### PR DESCRIPTION
## Summary

An artifact was stored under **its own envelope digest** — `{owner}/entries/{entry}/{envelope}.json` — so a second build for the same input never collided with the first. It joined it as another variant, and the client picked between them by compatibility and signature.

That means anyone who can sign can add a *different* artifact for a dependency that already has one, and nothing on either side notices the swap. Closing that from the client side is what the lockfile pinning in pnpm/pnpm#14243 does.

**The registry is the better place for it**, because this is the problem a registry already solves for versions: `name@version` means one tarball because republishing is refused. An artifact is now stored under a slot naming what it is *for* — the input key and the compatibility constraints:

```
{owner}/entries/{entry}/{compatibility slot}.json
```

One input admits one artifact per platform. A different envelope for a claimed slot is `409 Conflict` (`ArtifactAlreadyPublished`, alongside the existing `VersionAlreadyPublished`), the identical envelope stays idempotent, and `universal` and per-platform builds coexist exactly as before.

### Replacement is deliberately not in the API

Authorization here is the organization name matching the authenticated user, so a publishing token **is** the organization — there is no stronger verb to gate a replacement behind. If publication could replace, a stolen CI token could swap the artifact for a dependency nobody has looked at in a year, which is the case this exists to stop. Releasing a claimed slot is an operator action against the store, like an unpublish.

### Two things worth knowing

- **The slot claim is only as durable as the store.** Artifacts live in pnpr's disposable cache root, so an operator wiping it releases every claim. The claim is tiny — entry + compatibility → digest — so it could move to authoritative storage; that is a follow-up, not something this PR changes.
- **It does not replace a client-side record for publisher-owned artifacts.** When the signer is a third party and the registry is not yours, a client-side pin is justified the way tarball `integrity` is. This covers organization mode, where the org runs both.

The slot id is a SHA-256 over the canonical compatibility encoding, hex-encoded so it keeps the same 64-hex shape the envelope digests had — `is_variant_file` and the resolve listing are unchanged.

## Squash Commit Body

```text
An artifact was stored under its own envelope digest, so a second build
for the same input joined the first as another variant rather than
colliding with it. Anyone who could sign could add a different artifact
for a dependency that already had one, and neither side would notice.

It is now stored under a slot naming what it is for — the input key and
the compatibility constraints — so one input admits one artifact per
platform, the same way a registry makes `name@version` mean one tarball.
A different envelope for a claimed slot is a 409; the identical one stays
idempotent.

Releasing a claimed slot is not something the API can do: a publishing
token is the organization, so if publication could replace, a stolen
token could swap the artifact for a dependency nobody has looked at in a
year.
```

## Checklist

- [x] Added a changeset.
- [x] Added or updated tests. A second artifact cannot claim a taken slot and the first still resolves; the identical artifact stays idempotent. Three existing tests published several artifacts for one input to exercise quota, replication and the variant limit — they vary the platform now, which is the only reason a second artifact for one input is legitimate.
- [ ] Documentation — the pnpr guide should say a published artifact is immutable; happy to add it here or alongside the RFC 0007 update.

The Rust `pnpm/` port is not involved: this is server behaviour, and the client already treats a rejected publication as a non-fatal miss.

Verified: `cargo test -p pnpr-shared-artifacts` (21), `cargo test -p pnpr --test server` (89), `cargo check --workspace --all-targets`, clippy, and the Rust pre-push gates.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790555886&installation_model_id=426870&pr_number=14310&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14310&signature=05924f5b0517b7b0a1595fc60621138219dedf2074106f22a6e4dc5e9fa4a876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Published build artifacts are now immutable within each compatibility slot.
  * Re-publishing an identical artifact remains idempotent.
  * Existing artifacts remain protected after upgrades.
  * Compatibility variants can be published independently when platform requirements differ.
  * Compatibility matching works reliably even when requirement tags are ordered differently.
* **Bug Fixes**
  * Replacing an artifact with different contents now returns a `409 Conflict` error.
  * Concurrent publication attempts consistently preserve the first successfully published artifact.
  * Artifacts remain resolvable after a conflicting publication attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->