### PR TITLE
fix(npm-resolver): preserve corrupt trust history

### DIFF
--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -24,7 +24,7 @@ use dashmap::DashMap;
 use pacquet_config::{TrustPolicy, version_policy::PackageVersionPolicy};
 use pacquet_lockfile::{LockfileResolution, PkgName};
 use pacquet_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_url_credentials};
-use pacquet_registry::{Approver, NpmUser, Package, PackageDistribution, PackageVersion};
+use pacquet_registry::Package;
 use pacquet_resolving_resolver_base::{
     ResolutionVerification, ResolutionVerifier, VerifyCtx, VerifyFuture, parse_packument_timestamp,
 };
@@ -38,7 +38,7 @@ use crate::{
     lookup_context::{PublishedAtLookupContext, PublishedAtTimeMap, package_key, version_key},
     named_registry::{build_named_registry_prefixes, pick_registry_for_package},
     pick_package::PackageMetaCache,
-    trust_checks::fail_if_trust_downgraded,
+    trust_checks::{TrustHistory, fail_if_trust_downgraded_in_history},
     violation_codes::{
         MINIMUM_RELEASE_AGE_VIOLATION_CODE, TARBALL_URL_MISMATCH_VIOLATION_CODE,
         TRUST_DOWNGRADE_VIOLATION_CODE,
@@ -527,7 +527,7 @@ impl NpmResolutionVerifier {
         name: &PkgName,
         version: &str,
     ) -> Option<ResolutionVerification> {
-        let meta = match self.fetch_full_meta_for_trust(registry, name).await {
+        let meta = match self.fetch_trust_history(registry, name).await {
             Ok(meta) => meta,
             // A transport failure propagates the registry's own fetch error so
             // the install aborts with it rather than folding it into a policy
@@ -539,7 +539,7 @@ impl NpmResolutionVerifier {
             trust_policy_ignore_after_minutes: self.trust_policy_ignore_after,
             now: self.now,
         };
-        match fail_if_trust_downgraded(&meta, version, &trust_opts) {
+        match fail_if_trust_downgraded_in_history(&meta, version, &trust_opts) {
             Ok(()) => None,
             Err(err) => Some(ResolutionVerification::Err {
                 code: TRUST_DOWNGRADE_VIOLATION_CODE,
@@ -800,14 +800,14 @@ impl NpmResolutionVerifier {
         .clone()
     }
 
-    async fn fetch_full_meta_for_trust(
+    async fn fetch_trust_history(
         &self,
         registry: &str,
         name: &PkgName,
-    ) -> Result<Arc<Package>, String> {
+    ) -> Result<Arc<TrustHistory>, String> {
         let key = package_key(registry, &name.to_string());
         let cell = {
-            let mut cache = self.lookup_context.full_meta_for_trust.lock().await;
+            let mut cache = self.lookup_context.trust_history.lock().await;
             Arc::clone(cache.entry(key.clone()).or_insert_with(|| Arc::new(OnceCell::new())))
         };
         cell.get_or_init(|| async {
@@ -817,28 +817,27 @@ impl NpmResolutionVerifier {
             // when `pick_package` upgrades for `minimumReleaseAge`),
             // reuse it. The filtered form is accepted: `clear_meta`
             // keeps `time`, per-version `_npmUser`, and `dist`, which is
-            // everything `fail_if_trust_downgraded` reads. Abbreviated
-            // entries are rejected — they lack per-version `time` and
-            // trust evidence.
+            // everything needed to build the trust history. Abbreviated
+            // entries are rejected because they lack per-version `time`
+            // and trust evidence.
             let shared = self.meta_cache.as_ref().and_then(|cache| {
                 cache
                     .get(&format!("{key}:full"))
                     .or_else(|| cache.get(&format!("{key}:full:filtered")))
             });
             if let Some(cached) = shared {
-                return Ok(Arc::new(project_trust_meta(cached.meta.as_ref())));
+                return Ok(Arc::new(TrustHistory::from_package(cached.meta.as_ref())));
             }
-            // Project the packument to just the fields `fail_if_trust_downgraded`
-            // reads before stashing in the cache. The full document — dependency
-            // graphs, dist-tags, scripts, READMEs for every version — would
-            // otherwise stay resident in this map for the entire install, which
-            // on multi-thousand-entry workspaces OOMs CI runners with a 2GB heap
-            // cap (see [#11860]).
+            // Keep only publish times, trust evidence, and explicit decode
+            // failures in this cache. The full document — dependency graphs,
+            // dist-tags, scripts, and READMEs for every version — would otherwise
+            // stay resident for the entire install. This can exhaust the 2 GB
+            // heap on large workspaces (see [#11860]).
             //
             // [#11860]: <https://github.com/pnpm/pnpm/issues/11860>
             self.fetch_full_meta(registry, name)
                 .await
-                .map(|meta| project_trust_meta(&meta))
+                .map(|meta| TrustHistory::from_package(&meta))
                 .map(Arc::new)
         })
         .await
@@ -963,88 +962,6 @@ fn build_policy_snapshot(
         },
     );
     map
-}
-
-/// Build a [`Package`] that retains only the fields
-/// [`fail_if_trust_downgraded`] reads: the package name, the per-version
-/// `time` map, and per-version trust evidence (`_npmUser.approver`,
-/// `_npmUser.trustedPublisher`, and `dist.attestations.provenance`).
-/// Drops everything else — dependency
-/// graphs, scripts, READMEs — so the per-install trust-meta cache stays
-/// bounded by the trust-evidence footprint, not the full packument size.
-///
-/// [`fail_if_trust_downgraded`]: crate::trust_checks::fail_if_trust_downgraded
-fn project_trust_meta(meta: &Package) -> Package {
-    // Borrowed `meta` so the shared-cache fast path (which only holds
-    // `Arc<Package>`) doesn't pay for a full deep-clone of the
-    // packument it's about to discard. Only the fields downstream
-    // reads are cloned out; the bulk of the document (per-version
-    // dependency maps, scripts, README) drops on the original.
-    let versions = meta
-        .versions
-        .iter()
-        .map(|(version, manifest)| (version.clone(), project_trust_package_version(&manifest)))
-        .collect();
-    Package {
-        name: meta.name.clone(),
-        dist_tags: std::collections::HashMap::new(),
-        versions,
-        time: meta.time.clone(),
-        modified: meta.modified.clone(),
-        etag: meta.etag.clone(),
-        // `homepage` is only read by `outdated --long`, never by trust
-        // verification, so it is dropped here to keep the trust-meta cache
-        // bounded by the trust-evidence footprint (see the fn doc).
-        homepage: None,
-        mutex: std::sync::Arc::new(std::sync::Mutex::new(0)),
-    }
-}
-
-fn project_trust_package_version(version: &PackageVersion) -> PackageVersion {
-    let attestations =
-        version.dist.attestations.as_ref().and_then(|att| att.provenance.as_ref()).map(|prov| {
-            pacquet_registry::AttestationsDist { provenance: Some(prov.clone()), url: None }
-        });
-    // `get_trust_evidence` only reads `npm_user.approver` (presence) and
-    // `npm_user.trusted_publisher`; drop the maintainer `name` / `email`
-    // PII — including the approver's — so the projected cache entry
-    // doesn't hold per-version publisher metadata that downstream
-    // doesn't need.
-    let approver = version.npm_user.as_ref().and_then(|user| user.approver.as_ref());
-    let trusted_publisher =
-        version.npm_user.as_ref().and_then(|user| user.trusted_publisher.as_ref());
-    let npm_user = (approver.is_some() || trusted_publisher.is_some()).then(|| NpmUser {
-        name: None,
-        email: None,
-        approver: approver.map(|_| Approver { name: None, email: None }),
-        trusted_publisher: trusted_publisher.cloned(),
-    });
-    PackageVersion {
-        // `fail_if_trust_downgraded` keys off the outer `meta.versions`
-        // map and the version-level npm_user / attestations fields. The
-        // per-version `name`, `version`, and `dist` non-attestation fields
-        // are never read, so empty placeholders are fine — clone of the
-        // parsed semver keeps the typed shape valid without paying for
-        // the registry packument's dependency graph.
-        name: String::new(),
-        version: version.version.clone(),
-        dist: PackageDistribution {
-            integrity: None,
-            shasum: None,
-            tarball: String::new(),
-            file_count: None,
-            unpacked_size: None,
-            attestations,
-        },
-        dependencies: None,
-        dev_dependencies: None,
-        peer_dependencies: None,
-        optional_dependencies: None,
-        peer_dependencies_meta: None,
-        npm_user,
-        deprecated: None,
-        other: HashMap::new(),
-    }
 }
 
 /// Pull the `(modified, versionTarballs)` projection the verifier

--- a/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -18,6 +18,7 @@ use super::{
 use crate::{
     mirror::{ABBREVIATED_META_DIR, get_pkg_mirror_path, load_meta},
     persist_meta_to_mirror,
+    pick_package::{InMemoryPackageMetaCache, PackageMetaCache},
 };
 
 const FAKE_INTEGRITY: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
@@ -137,6 +138,29 @@ fn trust_downgrade_packument(name: &str) -> serde_json::Value {
                     "shasum": "0000000000000000000000000000000000000000",
                     "tarball": format!("https://registry/{name}-1.1.0.tgz"),
                     "attestations": { "provenance": { "predicateType": "https://slsa.dev/provenance/v1" } }
+                }
+            }
+        }
+    })
+}
+
+fn undecodable_trust_packument(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "dist-tags": { "latest": "1.1.0" },
+        "time": {
+            "1.0.0": "2025-01-01T00:00:00.000Z",
+            "1.1.0": "2025-02-01T00:00:00.000Z"
+        },
+        "versions": {
+            "1.0.0": { "corrupt": "fragment" },
+            "1.1.0": {
+                "name": name,
+                "version": "1.1.0",
+                "dist": {
+                    "integrity": FAKE_INTEGRITY,
+                    "shasum": "0000000000000000000000000000000000000000",
+                    "tarball": format!("https://registry/{name}-1.1.0.tgz")
                 }
             }
         }
@@ -693,6 +717,57 @@ async fn trust_downgrade_publisher_to_provenance_fails() {
     };
     assert_eq!(code, "TRUST_DOWNGRADE");
     assert!(reason.contains("trust downgrade"), "got reason: {reason}");
+}
+
+#[tokio::test]
+async fn trust_check_fails_closed_for_undecodable_prior_version() {
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let _full_mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(undecodable_trust_packument("acme").to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let mut opts = default_opts(&registry);
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.1.0"))
+        .await;
+
+    let ResolutionVerification::Err { code, reason } = result else {
+        panic!("expected Err, got {result:?}");
+    };
+    assert_eq!(code, "TRUST_DOWNGRADE");
+    assert!(reason.contains("undecodable version object"), "got reason: {reason}");
+}
+
+#[tokio::test]
+async fn cached_trust_check_fails_closed_for_undecodable_prior_version() {
+    let registry = "https://registry.example/";
+    let cache = Arc::new(InMemoryPackageMetaCache::default());
+    let package: Package =
+        serde_json::from_value(undecodable_trust_packument("acme")).expect("deserialize package");
+    cache.set(format!("{registry}\x00acme:full"), Arc::new(package));
+    let mut opts = default_opts(registry);
+    opts.trust_policy = Some(TrustPolicy::NoDowngrade);
+    opts.meta_cache = Some(cache);
+    opts.now = Some(now_at("2025-12-01T00:00:00Z"));
+    let verifier = create_npm_resolution_verifier(opts);
+
+    let result = verifier
+        .verify(&registry_resolution(), ctx(&"acme".parse::<PkgName>().expect("parse"), "1.1.0"))
+        .await;
+
+    let ResolutionVerification::Err { code, reason } = result else {
+        panic!("expected Err, got {result:?}");
+    };
+    assert_eq!(code, "TRUST_DOWNGRADE");
+    assert!(reason.contains("undecodable version object"), "got reason: {reason}");
 }
 
 #[tokio::test]

--- a/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/lookup_context.rs
@@ -15,8 +15,9 @@
 //!
 use std::{collections::HashMap, sync::Arc};
 
-use pacquet_registry::Package;
 use tokio::sync::{Mutex, OnceCell};
+
+use crate::trust_checks::TrustHistory;
 
 /// Per-version time map keyed by version string. The verifier only
 /// reads the publish timestamp for a specific version, so storing
@@ -64,7 +65,7 @@ pub(crate) type SingleflightMap<Value> = Mutex<HashMap<String, Arc<OnceCell<Valu
 pub(crate) struct PublishedAtLookupContext {
     pub published_at: SingleflightMap<Result<Option<String>, String>>,
     pub full_meta: SingleflightMap<Result<Option<Arc<PublishedAtTimeMap>>, String>>,
-    pub full_meta_for_trust: SingleflightMap<Result<Arc<Package>, String>>,
+    pub trust_history: SingleflightMap<Result<Arc<TrustHistory>, String>>,
     /// `Ok(projection)` on a successful fetch, `Err(reason)` on a fetch
     /// failure (auth/network/5xx). The error is carried as a value rather than
     /// discarded so the tarball-URL check can tell a transport failure apart

--- a/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
+++ b/pacquet/crates/resolving-npm-resolver/src/trust_checks.rs
@@ -9,6 +9,8 @@
 //! signal — and the verifier rejects the entry with
 //! [`crate::TRUST_DOWNGRADE_VIOLATION_CODE`].
 
+use std::collections::HashMap;
+
 use chrono::{DateTime, Utc};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
@@ -33,6 +35,76 @@ pub enum TrustEvidence {
     /// staged publish requiring a 2FA approval — the strongest signal,
     /// ranked above a trusted publisher.
     StagedPublish,
+}
+
+/// Package history projected to the only fields the trust check reads.
+/// Undecodable version objects remain explicit so a cached projection
+/// cannot turn corrupt registry metadata into an apparently clean history.
+#[derive(Debug)]
+pub(crate) struct TrustHistory {
+    name: String,
+    versions: HashMap<String, TrustHistoryVersion>,
+}
+
+#[derive(Debug)]
+struct TrustHistoryVersion {
+    published_at: Option<String>,
+    evidence: DecodedTrustEvidence,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DecodedTrustEvidence {
+    Decoded(Option<TrustEvidence>),
+    Undecodable,
+}
+
+#[derive(Clone, Copy)]
+struct TrustVersionRef<'a> {
+    version: &'a str,
+    published_at: Option<&'a str>,
+    evidence: DecodedTrustEvidence,
+}
+
+impl TrustHistory {
+    pub(crate) fn from_package(meta: &Package) -> Self {
+        let versions = meta
+            .versions
+            .keys()
+            .map(|version| {
+                let evidence = meta
+                    .versions
+                    .get(version)
+                    .map_or(DecodedTrustEvidence::Undecodable, |manifest| {
+                        DecodedTrustEvidence::Decoded(get_trust_evidence(&manifest))
+                    });
+                (
+                    version.clone(),
+                    TrustHistoryVersion {
+                        published_at: meta.published_at(version).map(str::to_string),
+                        evidence,
+                    },
+                )
+            })
+            .collect();
+        Self { name: meta.name.clone(), versions }
+    }
+
+    fn get(&self, version: &str) -> Option<TrustVersionRef<'_>> {
+        let (version, entry) = self.versions.get_key_value(version)?;
+        Some(TrustVersionRef {
+            version: version.as_str(),
+            published_at: entry.published_at.as_deref(),
+            evidence: entry.evidence,
+        })
+    }
+
+    fn iter(&self) -> impl Iterator<Item = TrustVersionRef<'_>> {
+        self.versions.iter().map(|(version, entry)| TrustVersionRef {
+            version,
+            published_at: entry.published_at.as_deref(),
+            evidence: entry.evidence,
+        })
+    }
 }
 
 /// Failure surfaced by [`fail_if_trust_downgraded`]. Each variant
@@ -100,29 +172,63 @@ pub fn fail_if_trust_downgraded(
     version: &str,
     opts: &TrustCheckOptions<'_>,
 ) -> Result<(), TrustViolation> {
-    // Exclude policy short-circuit.
-    if let Some(exclude) = opts.trust_policy_exclude {
-        match exclude.matches(&meta.name) {
-            PolicyMatch::AnyVersion => return Ok(()),
-            PolicyMatch::ExactVersions(versions) => {
-                if versions.iter().any(|exact| exact == version) {
-                    return Ok(());
-                }
-            }
-            PolicyMatch::No => {}
-        }
+    if is_excluded(&meta.name, version, opts) {
+        return Ok(());
     }
+    let current = TrustVersionRef {
+        version,
+        published_at: meta.published_at(version),
+        evidence: meta
+            .versions
+            .get(version)
+            .map_or(DecodedTrustEvidence::Undecodable, |manifest| {
+                DecodedTrustEvidence::Decoded(get_trust_evidence(&manifest))
+            }),
+    };
+    let history = meta.versions.keys().map(|version| TrustVersionRef {
+        version,
+        published_at: meta.published_at(version),
+        evidence: meta
+            .versions
+            .get(version)
+            .map_or(DecodedTrustEvidence::Undecodable, |manifest| {
+                DecodedTrustEvidence::Decoded(get_trust_evidence(&manifest))
+            }),
+    });
+    fail_if_trust_downgraded_with_history(&meta.name, current, history, opts)
+}
 
+pub(crate) fn fail_if_trust_downgraded_in_history(
+    history: &TrustHistory,
+    version: &str,
+    opts: &TrustCheckOptions<'_>,
+) -> Result<(), TrustViolation> {
+    if is_excluded(&history.name, version, opts) {
+        return Ok(());
+    }
+    let current = history.get(version).unwrap_or(TrustVersionRef {
+        version,
+        published_at: None,
+        evidence: DecodedTrustEvidence::Undecodable,
+    });
+    fail_if_trust_downgraded_with_history(&history.name, current, history.iter(), opts)
+}
+
+fn fail_if_trust_downgraded_with_history<'a>(
+    name: &str,
+    current: TrustVersionRef<'a>,
+    history: impl Iterator<Item = TrustVersionRef<'a>>,
+    opts: &TrustCheckOptions<'_>,
+) -> Result<(), TrustViolation> {
     // Pull the version's publish time. We treat both "no time map" and
     // "no entry for this version" as the same `TRUST_CHECK_FAIL` shape
     // so the verifier surfaces a single "could not be checked" reason.
-    let published_at =
-        meta.published_at(version).ok_or_else(|| TrustViolation::TrustCheckFailed {
-            reason: format!(
-                "missing time for version {version} of {name} in metadata",
-                name = meta.name,
-            ),
-        })?;
+    let published_at = current.published_at.ok_or_else(|| TrustViolation::TrustCheckFailed {
+        reason: format!(
+            "missing time for version {version} of {name} in metadata",
+            version = current.version,
+        ),
+    })?;
     let version_date = parse_packument_timestamp(published_at).ok_or_else(|| {
         TrustViolation::TrustCheckFailed {
             reason: "publish timestamp is not a valid date".to_string(),
@@ -139,32 +245,48 @@ pub fn fail_if_trust_downgraded(
         }
     }
 
-    let manifest = meta.versions.get(version).ok_or_else(|| TrustViolation::TrustCheckFailed {
-        reason: format!(
-            "missing version object for version {version} of {name} in metadata",
-            name = meta.name,
-        ),
-    })?;
+    let DecodedTrustEvidence::Decoded(current_evidence) = current.evidence else {
+        return Err(TrustViolation::TrustCheckFailed {
+            reason: format!(
+                "missing version object for version {version} of {name} in metadata",
+                version = current.version,
+            ),
+        });
+    };
 
-    let exclude_prerelease = !is_prerelease(version);
+    let exclude_prerelease = !is_prerelease(current.version);
     let Some(strongest_prior) =
-        detect_strongest_trust_evidence_before(meta, version_date, exclude_prerelease)?
+        detect_strongest_trust_evidence_before(name, history, version_date, exclude_prerelease)?
     else {
         return Ok(());
     };
 
-    let current = get_trust_evidence(&manifest);
-    let current_rank = current.map_or(0u8, trust_rank);
+    let current_rank = current_evidence.map_or(0u8, trust_rank);
     let prior_rank = trust_rank(strongest_prior);
     if current_rank < prior_rank {
         return Err(TrustViolation::TrustDowngrade {
-            name: meta.name.clone(),
-            version: version.to_string(),
+            name: name.to_string(),
+            version: current.version.to_string(),
             past_pretty: pretty_print_trust_evidence(Some(strongest_prior)),
-            current_pretty: pretty_print_trust_evidence(current),
+            current_pretty: pretty_print_trust_evidence(current_evidence),
         });
     }
     Ok(())
+}
+
+fn is_excluded(name: &str, version: &str, opts: &TrustCheckOptions<'_>) -> bool {
+    if let Some(exclude) = opts.trust_policy_exclude {
+        match exclude.matches(name) {
+            PolicyMatch::AnyVersion => return true,
+            PolicyMatch::ExactVersions(versions) => {
+                if versions.iter().any(|exact| exact == version) {
+                    return true;
+                }
+            }
+            PolicyMatch::No => {}
+        }
+    }
+    false
 }
 
 /// Map a [`TrustEvidence`] rank to its numeric weight. "No evidence"
@@ -195,14 +317,15 @@ fn pretty_print_trust_evidence(evidence: Option<TrustEvidence>) -> &'static str 
 /// not decode makes the scan error rather than skip — skipping could
 /// hide the strongest prior evidence and let a trust downgrade pass
 /// undetected.
-fn detect_strongest_trust_evidence_before(
-    meta: &Package,
+fn detect_strongest_trust_evidence_before<'a>(
+    name: &str,
+    history: impl Iterator<Item = TrustVersionRef<'a>>,
     before_date: DateTime<Utc>,
     exclude_prerelease: bool,
 ) -> Result<Option<TrustEvidence>, TrustViolation> {
     let mut best: Option<TrustEvidence> = None;
-    for version in meta.versions.keys() {
-        if exclude_prerelease && is_prerelease(version) {
+    for entry in history {
+        if exclude_prerelease && is_prerelease(entry.version) {
             continue;
         }
         // Skip individual versions that lack a publish timestamp
@@ -210,7 +333,7 @@ fn detect_strongest_trust_evidence_before(
         // prior version with no `time` entry would otherwise mask
         // every earlier version's evidence and allow a downgrade
         // to slip through. Each timestamp is checked in isolation.
-        let Some(ts) = meta.published_at(version) else {
+        let Some(ts) = entry.published_at else {
             continue;
         };
         let Some(parsed) = parse_packument_timestamp(ts) else {
@@ -219,15 +342,15 @@ fn detect_strongest_trust_evidence_before(
         if parsed >= before_date {
             continue;
         }
-        let Some(manifest) = meta.versions.get(version) else {
+        let DecodedTrustEvidence::Decoded(evidence) = entry.evidence else {
             return Err(TrustViolation::TrustCheckFailed {
                 reason: format!(
                     "undecodable version object for version {version} of {name} in metadata",
-                    name = meta.name,
+                    version = entry.version,
                 ),
             });
         };
-        let Some(evidence) = get_trust_evidence(&manifest) else {
+        let Some(evidence) = evidence else {
             continue;
         };
         // Keep the highest-ranked evidence seen so far. Don't short-


### PR DESCRIPTION
## Summary

- replace the synthetic trust-only `Package` cache with a dedicated `TrustHistory` model
- preserve undecodable version objects in that model so cached trust checks fail closed
- cover both the registry-fetch path and the shared metadata-cache path with regression tests

The TypeScript CLI does not use the affected lazy Rust packument projection, so it does not need a matching change.

## Squash Commit Body

```text
Store trust-check history as a dedicated projection that records publish times, decoded evidence, and undecodable version objects.

This keeps the bounded-memory cache while preventing corrupt registry metadata from disappearing during projection and making a trust downgrade appear valid. Preserve the existing exclusion, prerelease, timestamp, and ignore-after rules.
```

## Validation

- 289 resolver tests passed
- all 4,999 pacquet tests were accounted for: 4 Node-based tests needed the bundled Node runtime instead of the local Vite+ shim
- workspace Cargo check and Clippy passed
- Rustdoc, Dylint, Rustfmt, Taplo, and changed-file typo checks passed

The aggregate `just ready` command stops at repository-wide typo reports in unchanged files. The remaining checks were run directly and passed.

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pacquet/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790558049&installation_model_id=426870&pr_number=14311&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14311&signature=af198dc8a7775d5a2e35e5bf32958d6a6ec3f1476e8a1830be5307debdbaba66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trust verification when reviewing package history.
  * Trust checks now fail safely when earlier package metadata is missing or cannot be decoded.
  * Fixed cached and newly fetched verification paths to consistently report trust downgrades with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->