### PR TITLE
fix(napi): validate peer issue options

### DIFF
--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -174,6 +174,14 @@ jobs:
             --output .bench/pacquet-tests-all.json \
             -- just test-pacquet
 
+      - name: Test N-API boundary
+        if: runner.os == 'Linux'
+        run: |
+          cargo build --locked -p pnpm-napi
+          cp target/debug/libpnpm_napi.so "$RUNNER_TEMP/pnpm-napi.node"
+          PNPM_NAPI_BINARY="$RUNNER_TEMP/pnpm-napi.node" \
+            node --test pnpm/npm/napi/test/*.test.mjs
+
       - name: Test pnpr
         shell: bash
         run: |

--- a/pnpm/crates/napi/src/install.rs
+++ b/pnpm/crates/napi/src/install.rs
@@ -176,6 +176,26 @@ pub struct InstallOptions {
     pub reporter: Option<ReporterOptions>,
 }
 
+/// Options for [`get_peer_dependency_issues`]. Mirrors the TypeScript
+/// declaration in `index.d.ts`.
+#[napi(object)]
+pub struct PeerIssuesOptions {
+    pub dir: String,
+    pub projects: Vec<NodeApiProject>,
+    pub store_dir: Option<String>,
+    pub cache_dir: Option<String>,
+    pub registries: Option<HashMap<String, String>>,
+    pub auth_header_by_uri: Option<HashMap<String, String>>,
+    pub proxy_config: Option<ProxyConfigInput>,
+    pub network_config: Option<NetworkConfigInput>,
+    pub overrides: Option<IndexMap<String, String>>,
+    // napi narrows JavaScript numbers to `u32` without rejecting overflow, so
+    // these enter as numbers and are checked before conversion.
+    pub peers_suffix_max_length: Option<f64>,
+    pub virtual_store_dir_max_length: Option<f64>,
+    pub auto_install_peers: Option<bool>,
+}
+
 #[napi(object)]
 #[expect(clippy::struct_field_names, reason = "fields mirror the JavaScript proxyConfig contract")]
 pub struct ProxyConfigInput {
@@ -951,7 +971,7 @@ fn run_rebuild_blocking(
 
 #[napi(js_name = "getPeerDependencyIssues")]
 pub async fn get_peer_dependency_issues(
-    options: serde_json::Value,
+    options: PeerIssuesOptions,
 ) -> napi::Result<serde_json::Value> {
     let _guard = engine_call_lock().lock().await;
     let (tx, rx) = tokio::sync::oneshot::channel();
@@ -959,7 +979,7 @@ pub async fn get_peer_dependency_issues(
         .name("pnpm-napi-peer-issues".to_string())
         .stack_size(32 * 1024 * 1024)
         .spawn(move || {
-            let _ = tx.send(run_peer_issues_blocking(&options));
+            let _ = tx.send(run_peer_issues_blocking(options));
         })
         .map_err(|error| {
             napi::Error::from_reason(format!("failed to spawn peer-issues thread: {error}"))
@@ -967,84 +987,14 @@ pub async fn get_peer_dependency_issues(
     rx.await.map_err(|_| napi::Error::from_reason("peer-issues worker thread panicked"))?
 }
 
-/// Map the `PeerIssuesOptions` JSON (a subset of [`InstallOptions`] — see
-/// `index.d.ts`) onto the install options struct, run a sink-driven
-/// `dry_run` resolve, and serialize the per-importer issues into the
-/// `PeerDependencyIssuesByProjects` wire shape, including the
+/// Run a sink-driven `dry_run` resolve and serialize the per-importer issues
+/// into the `PeerDependencyIssuesByProjects` wire shape, including the
 /// `conflicts` / `intersections` derivation v11's `mergePeers` does.
-fn run_peer_issues_blocking(options: &serde_json::Value) -> napi::Result<serde_json::Value> {
+fn run_peer_issues_blocking(options: PeerIssuesOptions) -> napi::Result<serde_json::Value> {
     // No log sink for this query — engine events would interleave with
     // the caller's own reporting for what is a silent resolution.
     let _sink_guard = EngineCallGuard::new(None);
-    let obj = options.as_object().ok_or_else(|| {
-        napi::Error::from_reason("getPeerDependencyIssues: options must be an object")
-    })?;
-    let str_field =
-        |key: &str| obj.get(key).and_then(serde_json::Value::as_str).map(ToString::to_string);
-    // Generic over the target map so `overrides` can collect into the
-    // order-preserving `IndexMap` its field requires (serde_json's
-    // `preserve_order` feature keeps the JS object's key order here).
-    fn string_map<Map: FromIterator<(String, String)>>(
-        obj: &serde_json::Map<String, serde_json::Value>,
-        key: &str,
-    ) -> Option<Map> {
-        obj.get(key).and_then(serde_json::Value::as_object).map(|map| {
-            map.iter()
-                .filter_map(|(key, value)| {
-                    value.as_str().map(|value| (key.clone(), value.to_string()))
-                })
-                .collect()
-        })
-    }
-    let dir = str_field("dir")
-        .ok_or_else(|| napi::Error::from_reason("getPeerDependencyIssues: `dir` is required"))?;
-    let projects: Vec<NodeApiProject> = obj
-        .get("projects")
-        .and_then(serde_json::Value::as_array)
-        .map(|entries| {
-            entries
-                .iter()
-                .filter_map(|entry| {
-                    let entry = entry.as_object()?;
-                    Some(NodeApiProject {
-                        root_dir: entry.get("rootDir")?.as_str()?.to_string(),
-                        manifest: entry
-                            .get("manifest")
-                            .cloned()
-                            .unwrap_or_else(|| serde_json::json!({})),
-                        dependency_manifest: entry.get("dependencyManifest").cloned(),
-                    })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    let install_options = InstallOptions {
-        dir,
-        projects,
-        store_dir: str_field("storeDir"),
-        cache_dir: str_field("cacheDir"),
-        registries: string_map(obj, "registries"),
-        auth_header_by_uri: string_map(obj, "authHeaderByUri"),
-        overrides: string_map(obj, "overrides"),
-        // Report every missing peer: with pnpm's default
-        // `autoInstallPeers: true` the resolver satisfies the peer
-        // itself and the issue never surfaces, but this query's whole
-        // point is the report (Bit derives the `intersections` it
-        // auto-adds from it). Callers can still opt back in.
-        auto_install_peers: Some(
-            obj.get("autoInstallPeers").and_then(serde_json::Value::as_bool).unwrap_or(false),
-        ),
-        peers_suffix_max_length: obj
-            .get("peersSuffixMaxLength")
-            .and_then(serde_json::Value::as_u64)
-            .map(|value| value as u32),
-        virtual_store_dir_max_length: obj
-            .get("virtualStoreDirMaxLength")
-            .and_then(serde_json::Value::as_u64)
-            .map(|value| value as u32),
-        ..InstallOptions::default()
-    };
+    let install_options = peer_issues_install_options(options)?;
 
     let sink: pnpm_package_manager::PeerIssuesSink = Arc::default();
     run_install_inner(&install_options, None, EngineMode::PeerIssues(Arc::clone(&sink)))?;
@@ -1056,6 +1006,49 @@ fn run_peer_issues_blocking(options: &serde_json::Value) -> napi::Result<serde_j
         result.insert(importer_id, peer_issues_to_json(&issues));
     }
     Ok(serde_json::Value::Object(result))
+}
+
+fn peer_issues_install_options(options: PeerIssuesOptions) -> napi::Result<InstallOptions> {
+    Ok(InstallOptions {
+        dir: options.dir,
+        projects: options.projects,
+        store_dir: options.store_dir,
+        cache_dir: options.cache_dir,
+        registries: options.registries,
+        auth_header_by_uri: options.auth_header_by_uri,
+        proxy_config: options.proxy_config,
+        network_config: options.network_config,
+        overrides: options.overrides,
+        peers_suffix_max_length: checked_u32_option(
+            options.peers_suffix_max_length,
+            "peersSuffixMaxLength",
+        )?,
+        virtual_store_dir_max_length: checked_u32_option(
+            options.virtual_store_dir_max_length,
+            "virtualStoreDirMaxLength",
+        )?,
+        // Unlike install, this query must expose missing peers by default.
+        auto_install_peers: Some(options.auto_install_peers.unwrap_or(false)),
+        ..InstallOptions::default()
+    })
+}
+
+fn checked_u32_option(value: Option<f64>, name: &str) -> napi::Result<Option<u32>> {
+    value
+        .map(|value| {
+            if value.is_finite()
+                && value.fract() == 0.0
+                && (0.0..=f64::from(u32::MAX)).contains(&value)
+            {
+                Ok(value as u32)
+            } else {
+                Err(napi::Error::from_reason(format!(
+                    "getPeerDependencyIssues: `{name}` must be an integer from 0 through {}",
+                    u32::MAX,
+                )))
+            }
+        })
+        .transpose()
 }
 
 /// Serialize one importer's issues into v11's `PeerDependencyIssues`

--- a/pnpm/crates/napi/src/install/tests.rs
+++ b/pnpm/crates/napi/src/install/tests.rs
@@ -10,8 +10,9 @@ use pnpm_testing_utils::registry::TestRegistry;
 
 use super::{
     DepsRequiringBuildSink, EngineMode, InstallOptions, NetworkConfigInput, NodeApiProject,
-    ProxyConfigInput, build_overlay, reject_non_object_manifests,
-    reject_unsupported_install_options, run_install_inner, take_deps_requiring_build,
+    PeerIssuesOptions, ProxyConfigInput, build_overlay, peer_issues_install_options,
+    reject_non_object_manifests, reject_unsupported_install_options, run_install_inner,
+    take_deps_requiring_build,
 };
 use crate::{
     config::{ConfigOverlay, resolve_config},
@@ -236,6 +237,95 @@ fn newly_supported_install_options_are_accepted() {
     options.network_config = Some(NetworkConfigInput { max_sockets: Some(20), ..network_config() });
     assert!(reject_unsupported_install_options(&options).is_ok());
     assert_eq!(build_overlay(&options, false).expect("overlay").max_sockets, Some(20));
+}
+
+#[test]
+fn peer_issues_options_preserve_shared_engine_options() {
+    let install_options = peer_issues_install_options(PeerIssuesOptions {
+        dir: "/project".to_string(),
+        projects: vec![NodeApiProject {
+            root_dir: "/project".to_string(),
+            manifest: serde_json::json!({ "name": "project" }),
+            dependency_manifest: None,
+        }],
+        store_dir: Some("/store".to_string()),
+        cache_dir: Some("/cache".to_string()),
+        registries: Some(
+            [("default".to_string(), "https://registry.example.com".to_string())].into(),
+        ),
+        auth_header_by_uri: Some(
+            [("//registry.example.com/".to_string(), "Bearer token".to_string())].into(),
+        ),
+        proxy_config: Some(ProxyConfigInput {
+            http_proxy: Some("http://proxy.example.com".to_string()),
+            https_proxy: Some("https://proxy.example.com".to_string()),
+            no_proxy: Some(serde_json::json!(true)),
+        }),
+        network_config: Some(NetworkConfigInput {
+            ca: Some(serde_json::json!("certificate")),
+            strict_ssl: Some(false),
+            network_concurrency: Some(12),
+            ..network_config()
+        }),
+        overrides: Some([("foo".to_string(), "1.0.0".to_string())].into()),
+        peers_suffix_max_length: Some(1_000.0),
+        virtual_store_dir_max_length: Some(120.0),
+        auto_install_peers: Some(true),
+    })
+    .expect("valid peer issues options");
+
+    assert_eq!(install_options.dir, "/project");
+    assert_eq!(install_options.projects.len(), 1);
+    assert_eq!(install_options.store_dir.as_deref(), Some("/store"));
+    assert_eq!(install_options.cache_dir.as_deref(), Some("/cache"));
+    assert_eq!(
+        install_options.registries.as_ref().unwrap()["default"],
+        "https://registry.example.com",
+    );
+    assert_eq!(
+        install_options.auth_header_by_uri.as_ref().unwrap()["//registry.example.com/"],
+        "Bearer token",
+    );
+    assert_eq!(install_options.overrides.as_ref().unwrap()["foo"], "1.0.0");
+    assert_eq!(install_options.peers_suffix_max_length, Some(1_000));
+    assert_eq!(install_options.virtual_store_dir_max_length, Some(120));
+    assert_eq!(install_options.auto_install_peers, Some(true));
+
+    let overlay = build_overlay(&install_options, false).expect("overlay");
+    assert_eq!(overlay.network_concurrency, Some(12));
+    assert_eq!(overlay.proxy.unwrap().no_proxy, Some(NoProxySetting::Bypass));
+    let tls = overlay.tls.expect("tls");
+    assert_eq!(tls.ca, vec!["certificate".to_string()]);
+    assert_eq!(tls.strict_ssl, Some(false));
+}
+
+#[test]
+fn peer_issues_options_disable_auto_install_peers_by_default() {
+    assert_eq!(
+        peer_issues_install_options(peer_issues_options())
+            .expect("valid peer issues options")
+            .auto_install_peers,
+        Some(false),
+    );
+}
+
+#[test]
+fn peer_issues_options_reject_invalid_u32_values() {
+    for value in [-1.0, 1.5, f64::from(u32::MAX) + 1.0, f64::INFINITY, f64::NAN] {
+        let mut options = peer_issues_options();
+        options.peers_suffix_max_length = Some(value);
+        assert!(
+            peer_issues_install_options(options).is_err(),
+            "peersSuffixMaxLength accepted {value:?}",
+        );
+
+        let mut options = peer_issues_options();
+        options.virtual_store_dir_max_length = Some(value);
+        assert!(
+            peer_issues_install_options(options).is_err(),
+            "virtualStoreDirMaxLength accepted {value:?}",
+        );
+    }
 }
 
 /// `ignorePackageManifest` carries pnpm's `pnpm fetch` shape into the
@@ -884,6 +974,23 @@ fn install_options() -> InstallOptions {
         auth_header_by_uri: None,
         pnpm_home_dir: None,
         reporter: None,
+    }
+}
+
+fn peer_issues_options() -> PeerIssuesOptions {
+    PeerIssuesOptions {
+        dir: String::new(),
+        projects: Vec::new(),
+        store_dir: None,
+        cache_dir: None,
+        registries: None,
+        auth_header_by_uri: None,
+        proxy_config: None,
+        network_config: None,
+        overrides: None,
+        peers_suffix_max_length: None,
+        virtual_store_dir_max_length: None,
+        auto_install_peers: None,
     }
 }
 

--- a/pnpm/crates/napi/src/lib.rs
+++ b/pnpm/crates/napi/src/lib.rs
@@ -35,8 +35,8 @@ mod specifier;
 
 pub use dependents::{DependentsOptions, RenderDependentsInput, get_dependents, render_dependents};
 pub use install::{
-    InstallOptions, InstallResult, InstallStatsResult, NodeApiProject, get_peer_dependency_issues,
-    install, rebuild,
+    InstallOptions, InstallResult, InstallStatsResult, NodeApiProject, PeerIssuesOptions,
+    get_peer_dependency_issues, install, rebuild,
 };
 pub use lockfile::{
     FilterLockfileOptions, ReadLockfileOptions, WriteLockfileOptions, filter_lockfile_by_importers,

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -37,7 +37,7 @@ See [`index.d.ts`](./index.d.ts) for the full typed contract.
 | `filterLockfileByImporters(lockfile, importerIds, options?)` | Narrow a lockfile to the transitive closure of what the named importers reach. |
 | `readModulesManifest(modulesDir)` | The `.modules.yaml` state of an installed `node_modules`. |
 | `engineVersion()` | Version string of the underlying Rust engine (pacquet). |
-| `getPeerDependencyIssues(options)` | **Not yet implemented** — throws `ERR_PNPM_NAPI_UNIMPLEMENTED`. Peer-issue reporting is not ported in pacquet's CLI either; consumers should degrade gracefully. |
+| `getPeerDependencyIssues(options)` | Resolve the in-memory importers without writing an install and return missing or incompatible peer dependencies by importer. `autoInstallPeers` defaults to `false` for this query. |
 
 ### Output
 

--- a/pnpm/npm/napi/test/peer-dependency-issues.test.mjs
+++ b/pnpm/npm/napi/test/peer-dependency-issues.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, it } from 'node:test'
+
+const { getPeerDependencyIssues } = createRequire(import.meta.url)('../index.js')
+
+describe('getPeerDependencyIssues', () => {
+  it('rejects malformed options at the JavaScript boundary', async () => {
+    const project = { rootDir: process.cwd(), manifest: {} }
+    const options = { dir: process.cwd(), projects: [project] }
+
+    await assertCallRejects(
+      { dir: process.cwd(), projects: [{ rootDir: process.cwd() }] },
+      /Missing field `manifest`/,
+    )
+    await assertCallRejects(
+      { ...options, registries: { default: 42 } },
+      /into rust type `String`/,
+    )
+    for (const field of ['peersSuffixMaxLength', 'virtualStoreDirMaxLength']) {
+      await assertCallRejects(
+        { ...options, [field]: 2 ** 32 },
+        new RegExp(`${field}.*must be an integer from 0 through ${2 ** 32 - 1}`),
+      )
+    }
+  })
+
+  it('returns missing peer issues from a valid query', async (context) => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-napi-peer-issues-'))
+    context.after(() => fs.rmSync(rootDir, { force: true, recursive: true }))
+
+    const appDir = path.join(rootDir, 'app')
+    const pluginDir = path.join(rootDir, 'plugin')
+    fs.mkdirSync(appDir)
+    fs.mkdirSync(pluginDir)
+    fs.writeFileSync(path.join(pluginDir, 'package.json'), JSON.stringify({
+      name: 'plugin',
+      version: '1.0.0',
+      peerDependencies: { host: '^1.0.0' },
+    }))
+
+    const result = await getPeerDependencyIssues({
+      dir: appDir,
+      projects: [
+        {
+          rootDir: appDir,
+          manifest: {
+            name: 'app',
+            dependencies: { plugin: 'file:../plugin' },
+          },
+        },
+        {
+          rootDir: pluginDir,
+          manifest: {
+            name: 'plugin',
+            version: '1.0.0',
+            peerDependencies: { host: '^1.0.0' },
+          },
+        },
+      ],
+      storeDir: path.join(rootDir, 'store'),
+      cacheDir: path.join(rootDir, 'cache'),
+    })
+
+    assert.deepEqual(result['.'], {
+      missing: {
+        host: [{
+          parents: [{ name: 'plugin', version: '' }],
+          optional: false,
+          wantedRange: '^1.0.0',
+        }],
+      },
+      bad: {},
+      conflicts: [],
+      intersections: { host: '^1.0.0' },
+    })
+  })
+})
+
+async function assertCallRejects (options, pattern) {
+  await assert.rejects(
+    Promise.resolve().then(() => getPeerDependencyIssues(options)),
+    pattern,
+  )
+}


### PR DESCRIPTION
## Summary

- Replace the permissive JSON parser in the Rust N-API `getPeerDependencyIssues` function with a typed options object.
- Preserve proxy and network settings, and reject malformed projects, maps, and numeric length values at the N-API boundary.
- Keep the query-specific `autoInstallPeers: false` default.
- Add compiled-addon boundary coverage and correct the public API table.

This is a Rust N-API embedder API. It has no parallel TypeScript CLI command to change.

Fixes pnpm/pnpm#14312.

## Squash Commit Body

```text
Decode peer dependency query options through the typed N-API boundary instead of manually rebuilding install options from JSON. This preserves shared proxy and network settings and rejects malformed fields.

Range-check the two u32 length values because N-API number conversion does not reject overflow.

Fixes pnpm/pnpm#14312.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).
