### PR TITLE
fix(pacquet): preserve aliased peer contexts during dedupe

### DIFF
--- a/.changeset/steady-peers-settle.md
+++ b/.changeset/steady-peers-settle.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed repeated `pnpm dedupe` runs alternating between peer resolutions when a peer is provided through an npm alias.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -959,17 +959,14 @@ fn locked_peer_versions_for_key(
     key: &pnpm_lockfile::PkgNameVerPeer,
 ) -> Vec<(String, String)> {
     let explicit = peer_suffix_versions(key.suffix.peer()).collect::<Vec<_>>();
-    if !explicit.is_empty() || !is_hashed_peer_suffix(key.suffix.peer()) {
-        return explicit;
-    }
     let Some(snapshot) = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(key))
     else {
-        return Vec::new();
+        return explicit;
     };
     let Some(metadata) =
         lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
     else {
-        return Vec::new();
+        return explicit;
     };
     let peer_names = metadata
         .peer_dependencies
@@ -996,12 +993,6 @@ fn peer_suffix_versions(peer_suffix: &str) -> impl Iterator<Item = (String, Stri
         let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
         let (name, version) = segment.rsplit_once('@')?;
         (!name.is_empty()).then(|| (name.to_string(), version.to_string()))
-    })
-}
-
-fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
-    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
-        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
     })
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1015,18 +1015,17 @@ fn restore_aliased_peer_names(
     metadata: Option<&pnpm_lockfile::PackageMetadata>,
     peers: &mut [(String, String)],
 ) {
-    let providers = provider_aliases(snapshot, metadata);
+    let mut providers = provider_aliases(snapshot, metadata);
     if providers.is_empty() {
         return;
     }
     for (name, version) in peers.iter_mut() {
         let Some(alias) =
-            providers.get(&format!("{name}@{version}")).and_then(ProviderAliases::sole)
+            providers.get_mut(&format!("{name}@{version}")).and_then(ProviderAliases::claim)
         else {
             continue;
         };
-        name.clear();
-        name.push_str(alias);
+        *name = alias;
     }
 }
 
@@ -1068,41 +1067,52 @@ fn provider_aliases(
 
 /// The names one provider is installed under, split by whether the
 /// dependent declares that name as a peer.
+///
+/// The suffix spells one segment per peer-resolved edge and never merges
+/// equal ones, so each segment claims an edge of its own.
 #[derive(Default)]
 struct ProviderAliases {
-    declared_peer: Option<String>,
-    declared_peers: usize,
+    declared_peers: Vec<String>,
+    /// How many of `declared_peers` the segments seen so far claimed.
+    claimed: usize,
     ordinary: Option<String>,
     ordinaries: usize,
 }
 
 impl ProviderAliases {
     fn record(&mut self, alias: String, declares_peer: bool) {
-        let (first, count) = if declares_peer {
-            (&mut self.declared_peer, &mut self.declared_peers)
-        } else {
-            (&mut self.ordinary, &mut self.ordinaries)
-        };
-        *count += 1;
-        if *count == 1 {
-            *first = Some(alias);
+        if declares_peer {
+            self.declared_peers.push(alias);
+            return;
+        }
+        self.ordinaries += 1;
+        if self.ordinaries == 1 {
+            self.ordinary = Some(alias);
         }
     }
 
-    /// The name this provider's suffix segment belongs to.
+    /// The name to attribute the next segment naming this provider to.
     ///
-    /// A declared peer edge outranks an ordinary one, matching the
+    /// Declared peer edges go first, matching the
     /// `peerDependencies`-keyed lookup the TypeScript CLI restores peer
-    /// context with. Within a tier the segment is unattributable: an
-    /// ordinary dependency may be aliased onto the very package and
-    /// version a peer resolved to, and nothing in the lockfile tells two
-    /// such edges apart, so the suffix keeps the name it spelled.
-    fn sole(&self) -> Option<&str> {
-        match (self.declared_peers, self.ordinaries) {
-            (1, _) => self.declared_peer.as_deref(),
-            (0, 1) => self.ordinary.as_deref(),
-            _ => None,
+    /// context with; an ordinary edge takes the segment left over, which
+    /// is how a peer propagated up from a child — satisfied by an
+    /// ordinary dependency, under the name the child declared — gets its
+    /// name back.
+    ///
+    /// Competing ordinary edges are unattributable, since a dependency
+    /// may be aliased onto the very package and version a peer resolved
+    /// to and nothing in the lockfile tells the two apart, so the segment
+    /// keeps the name the suffix spelled.
+    fn claim(&mut self) -> Option<String> {
+        if self.claimed < self.declared_peers.len() {
+            self.claimed += 1;
+            return Some(self.declared_peers[self.claimed - 1].clone());
         }
+        if self.ordinaries == 1 {
+            return self.ordinary.take();
+        }
+        None
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -925,8 +925,8 @@ fn importer_locked_peer_context(
     };
     let Some(importer) = lockfile.importers.get(importer_id) else {
         let mut versions = HashMap::<String, HashSet<String>>::default();
-        for (key, _) in lockfile.snapshots.iter().flatten() {
-            for (name, version) in locked_peer_versions_for_key(lockfile, key) {
+        for (key, snapshot) in lockfile.snapshots.iter().flatten() {
+            for (name, version) in locked_peer_versions_for_key(lockfile, key, Some(snapshot)) {
                 versions.entry(name).or_default().insert(version);
             }
         }
@@ -943,7 +943,8 @@ fn importer_locked_peer_context(
             continue;
         };
         let mut names = HashSet::default();
-        for (name, version) in locked_peer_versions_for_key(lockfile, &key) {
+        let snapshot = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(&key));
+        for (name, version) in locked_peer_versions_for_key(lockfile, &key, snapshot) {
             names.insert(name.clone());
             versions.entry(name).or_default().insert(version);
         }
@@ -954,19 +955,34 @@ fn importer_locked_peer_context(
     ImporterLockedPeerContext { versions, names_by_alias }
 }
 
+/// The peer name/version pairs the wanted lockfile pinned for `key`.
+///
+/// An explicit suffix already spells them out, save for the names an
+/// npm alias renamed ([`restore_aliased_peer_names`]). A hashed suffix
+/// spells out nothing, so the pairs are recovered from the package's
+/// declared peers and the snapshot edges that resolved them.
 fn locked_peer_versions_for_key(
     lockfile: &pnpm_lockfile::Lockfile,
     key: &pnpm_lockfile::PkgNameVerPeer,
+    snapshot: Option<&pnpm_lockfile::SnapshotEntry>,
 ) -> Vec<(String, String)> {
-    let explicit = peer_suffix_versions(key.suffix.peer()).collect::<Vec<_>>();
-    let Some(snapshot) = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(key))
-    else {
+    let mut explicit = peer_suffix_versions(key.suffix.peer()).collect::<Vec<_>>();
+    if !explicit.is_empty() {
+        if let Some(snapshot) = snapshot {
+            restore_aliased_peer_names(snapshot, &mut explicit);
+        }
         return explicit;
+    }
+    if !is_hashed_peer_suffix(key.suffix.peer()) {
+        return explicit;
+    }
+    let Some(snapshot) = snapshot else {
+        return Vec::new();
     };
     let Some(metadata) =
         lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
     else {
-        return explicit;
+        return Vec::new();
     };
     let peer_names = metadata
         .peer_dependencies
@@ -986,6 +1002,50 @@ fn locked_peer_versions_for_key(
                 .map(|version| (name.to_string(), version.without_peer().to_string()))
         })
         .collect()
+}
+
+/// Rename the suffix segments an npm alias provides back to the alias
+/// the dependent declared.
+///
+/// A peer suffix names each provider by the package it resolved to,
+/// while peer resolution keys providers by the peer name — which for
+/// `"peer": "npm:provider@1"` is the alias, not `provider`. Reading the
+/// segment back verbatim would pin a peer nobody declares and leave the
+/// declared one unpinned, so a repeated resolution is free to pick the
+/// other variant.
+fn restore_aliased_peer_names(
+    snapshot: &pnpm_lockfile::SnapshotEntry,
+    peers: &mut [(String, String)],
+) {
+    for (alias, reference) in
+        snapshot.dependencies.iter().chain(snapshot.optional_dependencies.iter()).flatten()
+    {
+        let pnpm_lockfile::SnapshotDepRef::Alias(target) = reference else {
+            continue;
+        };
+        let target_name = target.name.to_string();
+        let target_version = target.suffix.without_peer().to_string();
+        // The rename makes the entry stop matching, so a second alias
+        // onto the same provider takes the next segment, not this one.
+        let Some(peer) = peers
+            .iter_mut()
+            .find(|(name, version)| *name == target_name && *version == target_version)
+        else {
+            continue;
+        };
+        peer.0 = alias.to_string();
+    }
+}
+
+/// Whether the suffix is the opaque hash
+/// [`create_peer_dep_graph_hash`](fn@pnpm_deps_path::create_peer_dep_graph_hash)
+/// emits once the spelled-out peers exceed
+/// [`ResolvePeersOptions::peers_suffix_max_length`], rather than
+/// segments [`peer_suffix_versions`] can read.
+fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
+    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
+        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
+    })
 }
 
 fn peer_suffix_versions(peer_suffix: &str) -> impl Iterator<Item = (String, String)> + '_ {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -1004,37 +1004,72 @@ fn locked_peer_versions_for_key(
         .collect()
 }
 
-/// Rename the suffix segments an npm alias provides back to the alias
-/// the dependent declared.
+/// Rename the suffix segments an npm alias provides back to the name
+/// the provider is installed under.
 ///
 /// A peer suffix names each provider by the package it resolved to,
-/// while peer resolution keys providers by the peer name — which for
-/// `"peer": "npm:provider@1"` is the alias, not `provider`. Reading the
-/// segment back verbatim would pin a peer nobody declares and leave the
-/// declared one unpinned, so a repeated resolution is free to pick the
-/// other variant.
+/// while peer resolution keys providers by the name they occupy in the
+/// dependent's `node_modules` — which for `"peer": "npm:provider@1"` is
+/// `peer`, not `provider`. Reading the segment back verbatim would pin a
+/// peer nobody declares and leave the declared one unpinned, so a
+/// repeated resolution is free to pick the other variant.
+///
+/// The dependent's own `peerDependencies` cannot drive this: a peer
+/// propagated up from a child is satisfied by an *ordinary* dependency
+/// of the dependent, under the name the child declared.
 fn restore_aliased_peer_names(
     snapshot: &pnpm_lockfile::SnapshotEntry,
     peers: &mut [(String, String)],
 ) {
-    for (alias, reference) in
-        snapshot.dependencies.iter().chain(snapshot.optional_dependencies.iter()).flatten()
+    if !dependency_edges(snapshot)
+        .any(|(_, reference)| matches!(reference, pnpm_lockfile::SnapshotDepRef::Alias(_)))
     {
-        let pnpm_lockfile::SnapshotDepRef::Alias(target) = reference else {
-            continue;
-        };
-        let target_name = target.name.to_string();
-        let target_version = target.suffix.without_peer().to_string();
-        // The rename makes the entry stop matching, so a second alias
-        // onto the same provider takes the next segment, not this one.
-        let Some(peer) = peers
-            .iter_mut()
-            .find(|(name, version)| *name == target_name && *version == target_version)
-        else {
-            continue;
-        };
-        peer.0 = alias.to_string();
+        return;
     }
+    for (name, version) in peers.iter_mut() {
+        if let Some(alias) = sole_alias_providing(snapshot, name, version) {
+            *name = alias;
+        }
+    }
+}
+
+/// The one name other than `name` that the snapshot installs
+/// `name@version` under.
+///
+/// `None` unless that name is unambiguous: an ordinary dependency may be
+/// aliased onto the very package and version a peer resolved to, and
+/// nothing in the lockfile tells the two apart. A provider the snapshot
+/// also installs under its own name, or one two aliases both supply,
+/// keeps the name the suffix spelled.
+fn sole_alias_providing(
+    snapshot: &pnpm_lockfile::SnapshotEntry,
+    name: &str,
+    version: &str,
+) -> Option<String> {
+    let mut alias: Option<String> = None;
+    for (edge_name, reference) in dependency_edges(snapshot) {
+        let provider = match reference {
+            pnpm_lockfile::SnapshotDepRef::Plain(ver_peer) => (edge_name.to_string(), ver_peer),
+            pnpm_lockfile::SnapshotDepRef::Alias(target) => {
+                (target.name.to_string(), &target.suffix)
+            }
+            pnpm_lockfile::SnapshotDepRef::Link(_) => continue,
+        };
+        if provider.0 != name || provider.1.without_peer().to_string() != version {
+            continue;
+        }
+        let edge_name = edge_name.to_string();
+        if edge_name == name || alias.replace(edge_name).is_some() {
+            return None;
+        }
+    }
+    alias
+}
+
+fn dependency_edges(
+    snapshot: &pnpm_lockfile::SnapshotEntry,
+) -> impl Iterator<Item = (&PkgName, &pnpm_lockfile::SnapshotDepRef)> {
+    snapshot.dependencies.iter().chain(snapshot.optional_dependencies.iter()).flatten()
 }
 
 /// Whether the suffix is the opaque hash

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -966,22 +966,19 @@ fn locked_peer_versions_for_key(
     key: &pnpm_lockfile::PkgNameVerPeer,
     snapshot: Option<&pnpm_lockfile::SnapshotEntry>,
 ) -> Vec<(String, String)> {
+    let metadata =
+        lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()));
     let mut explicit = peer_suffix_versions(key.suffix.peer()).collect::<Vec<_>>();
     if !explicit.is_empty() {
         if let Some(snapshot) = snapshot {
-            restore_aliased_peer_names(snapshot, &mut explicit);
+            restore_aliased_peer_names(snapshot, metadata, &mut explicit);
         }
         return explicit;
     }
     if !is_hashed_peer_suffix(key.suffix.peer()) {
         return explicit;
     }
-    let Some(snapshot) = snapshot else {
-        return Vec::new();
-    };
-    let Some(metadata) =
-        lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
-    else {
+    let (Some(snapshot), Some(metadata)) = (snapshot, metadata) else {
         return Vec::new();
     };
     let peer_names = metadata
@@ -1013,57 +1010,100 @@ fn locked_peer_versions_for_key(
 /// `peer`, not `provider`. Reading the segment back verbatim would pin a
 /// peer nobody declares and leave the declared one unpinned, so a
 /// repeated resolution is free to pick the other variant.
-///
-/// The dependent's own `peerDependencies` cannot drive this: a peer
-/// propagated up from a child is satisfied by an *ordinary* dependency
-/// of the dependent, under the name the child declared.
 fn restore_aliased_peer_names(
     snapshot: &pnpm_lockfile::SnapshotEntry,
+    metadata: Option<&pnpm_lockfile::PackageMetadata>,
     peers: &mut [(String, String)],
 ) {
-    if !dependency_edges(snapshot)
-        .any(|(_, reference)| matches!(reference, pnpm_lockfile::SnapshotDepRef::Alias(_)))
-    {
+    let providers = provider_aliases(snapshot, metadata);
+    if providers.is_empty() {
         return;
     }
     for (name, version) in peers.iter_mut() {
-        if let Some(alias) = sole_alias_providing(snapshot, name, version) {
-            *name = alias;
-        }
+        let Some(alias) =
+            providers.get(&format!("{name}@{version}")).and_then(ProviderAliases::sole)
+        else {
+            continue;
+        };
+        name.clear();
+        name.push_str(alias);
     }
 }
 
-/// The one name other than `name` that the snapshot installs
-/// `name@version` under.
+/// Index the snapshot's dependency edges by the `name@version` of the
+/// package each one installs, so every suffix segment is attributed in
+/// one lookup rather than another scan of the edges.
 ///
-/// `None` unless that name is unambiguous: an ordinary dependency may be
-/// aliased onto the very package and version a peer resolved to, and
-/// nothing in the lockfile tells the two apart. A provider the snapshot
-/// also installs under its own name, or one two aliases both supply,
-/// keeps the name the suffix spelled.
-fn sole_alias_providing(
+/// Empty — and every segment therefore left alone — unless some edge
+/// installs a package under a name other than its own, since that is the
+/// only shape that makes a segment disagree with its edge.
+fn provider_aliases(
     snapshot: &pnpm_lockfile::SnapshotEntry,
-    name: &str,
-    version: &str,
-) -> Option<String> {
-    let mut alias: Option<String> = None;
+    metadata: Option<&pnpm_lockfile::PackageMetadata>,
+) -> HashMap<String, ProviderAliases> {
+    if !dependency_edges(snapshot)
+        .any(|(_, reference)| matches!(reference, pnpm_lockfile::SnapshotDepRef::Alias(_)))
+    {
+        return HashMap::default();
+    }
+    let declared = metadata.and_then(|metadata| metadata.peer_dependencies.as_ref());
+    let mut providers = HashMap::<String, ProviderAliases>::default();
     for (edge_name, reference) in dependency_edges(snapshot) {
-        let provider = match reference {
+        let (provider, ver_peer) = match reference {
             pnpm_lockfile::SnapshotDepRef::Plain(ver_peer) => (edge_name.to_string(), ver_peer),
             pnpm_lockfile::SnapshotDepRef::Alias(target) => {
                 (target.name.to_string(), &target.suffix)
             }
             pnpm_lockfile::SnapshotDepRef::Link(_) => continue,
         };
-        if provider.0 != name || provider.1.without_peer().to_string() != version {
-            continue;
-        }
         let edge_name = edge_name.to_string();
-        if edge_name == name || alias.replace(edge_name).is_some() {
-            return None;
+        let declares_peer = declared.is_some_and(|peers| peers.contains_key(&edge_name));
+        providers
+            .entry(format!("{provider}@{}", ver_peer.without_peer()))
+            .or_default()
+            .record(edge_name, declares_peer);
+    }
+    providers
+}
+
+/// The names one provider is installed under, split by whether the
+/// dependent declares that name as a peer.
+#[derive(Default)]
+struct ProviderAliases {
+    declared_peer: Option<String>,
+    declared_peers: usize,
+    ordinary: Option<String>,
+    ordinaries: usize,
+}
+
+impl ProviderAliases {
+    fn record(&mut self, alias: String, declares_peer: bool) {
+        let (first, count) = if declares_peer {
+            (&mut self.declared_peer, &mut self.declared_peers)
+        } else {
+            (&mut self.ordinary, &mut self.ordinaries)
+        };
+        *count += 1;
+        if *count == 1 {
+            *first = Some(alias);
         }
     }
-    alias
+
+    /// The name this provider's suffix segment belongs to.
+    ///
+    /// A declared peer edge outranks an ordinary one, matching the
+    /// `peerDependencies`-keyed lookup the TypeScript CLI restores peer
+    /// context with. Within a tier the segment is unattributable: an
+    /// ordinary dependency may be aliased onto the very package and
+    /// version a peer resolved to, and nothing in the lockfile tells two
+    /// such edges apart, so the suffix keeps the name it spelled.
+    fn sole(&self) -> Option<&str> {
+        match (self.declared_peers, self.ordinaries) {
+            (1, _) => self.declared_peer.as_deref(),
+            (0, 1) => self.ordinary.as_deref(),
+            _ => None,
+        }
+    }
 }
 
 fn dependency_edges(

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -153,6 +153,56 @@ fn explicit_peer_suffix_uses_the_dependency_alias() {
     assert!(names_by_alias.is_empty());
 }
 
+/// An ordinary dependency may be aliased onto the very package and
+/// version a peer resolved to; only the suffix can tell them apart, so
+/// the segment keeps the name it spelled.
+#[test]
+fn an_ordinary_alias_onto_a_peers_provider_does_not_rename_it() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["peer"]))),
+        [(
+            "consumer@1.0.0(peer@1.0.0)",
+            snapshot_with_dependencies([
+                ("peer", plain_dependency("1.0.0")),
+                ("peer-alias", alias_dependency("peer@1.0.0")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
+    );
+}
+
+/// Two aliases onto one provider leave no way to tell which the peer
+/// resolved through, and guessing would vary with map order.
+#[test]
+fn competing_aliases_onto_one_provider_do_not_rename_the_segment() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["peer"]))),
+        [(
+            "consumer@1.0.0(alias-provider@1.0.0)",
+            snapshot_with_dependencies([
+                ("peer", alias_dependency("alias-provider@1.0.0")),
+                ("other", alias_dependency("alias-provider@1.0.0")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([(
+            "alias-provider".to_string(),
+            HashSet::from_iter(["1.0.0".to_string()]),
+        )]),
+    );
+}
+
 /// A package that declares no peers still carries the peers its own
 /// children resolved through it, so the suffix stays the only record of
 /// them.
@@ -237,13 +287,21 @@ fn snapshot_with_dependency(
     alias: &str,
     dependency: pnpm_lockfile::SnapshotDepRef,
 ) -> pnpm_lockfile::SnapshotEntry {
-    use pnpm_lockfile::{PkgName, SnapshotEntry};
+    snapshot_with_dependencies([(alias, dependency)])
+}
+
+fn snapshot_with_dependencies<const DEPS: usize>(
+    dependencies: [(&str, pnpm_lockfile::SnapshotDepRef); DEPS],
+) -> pnpm_lockfile::SnapshotEntry {
+    use pnpm_lockfile::PkgName;
 
     SnapshotEntry {
-        dependencies: Some(std::collections::HashMap::from([(
-            PkgName::parse(alias).unwrap(),
-            dependency,
-        )])),
+        dependencies: Some(
+            dependencies
+                .into_iter()
+                .map(|(alias, dependency)| (PkgName::parse(alias).unwrap(), dependency))
+                .collect(),
+        ),
         ..SnapshotEntry::default()
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -198,6 +198,72 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
     assert!(names_by_alias.is_empty());
 }
 
+#[test]
+fn explicit_peer_suffix_uses_the_dependency_alias() {
+    use pnpm_lockfile::{
+        ComVer, DirectoryResolution, Lockfile, LockfileResolution, LockfileVersion,
+        PackageMetadata, PkgName, PkgNameVerPeer, SnapshotDepRef, SnapshotEntry,
+    };
+
+    let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
+    let snapshot_key = PkgNameVerPeer::from_str("consumer@1.0.0(alias-provider@1.0.0)").unwrap();
+    let lockfile = Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: std::collections::HashMap::new(),
+        packages: Some(std::collections::HashMap::from([(
+            package_key,
+            PackageMetadata {
+                resolution: LockfileResolution::Directory(DirectoryResolution {
+                    directory: "consumer".to_string(),
+                }),
+                version: None,
+                engines: None,
+                cpu: None,
+                os: None,
+                libc: None,
+                deprecated: None,
+                has_bin: None,
+                prepare: None,
+                bundled_dependencies: None,
+                peer_dependencies: Some(std::collections::HashMap::from([(
+                    "peer".to_string(),
+                    "*".to_string(),
+                )])),
+                peer_dependencies_meta: None,
+            },
+        )])),
+        snapshots: Some(std::collections::HashMap::from([(
+            snapshot_key,
+            SnapshotEntry {
+                dependencies: Some(std::collections::HashMap::from([(
+                    PkgName::parse("peer").unwrap(),
+                    SnapshotDepRef::Alias(
+                        PkgNameVerPeer::from_str("alias-provider@1.0.0").unwrap(),
+                    ),
+                )])),
+                ..SnapshotEntry::default()
+            },
+        )])),
+        time: None,
+        extra: pnpm_lockfile::LockfileExtra::default(),
+    };
+
+    let ImporterLockedPeerContext { versions, names_by_alias } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
+    );
+    assert!(names_by_alias.is_empty());
+}
+
 fn locked_peer_names(wanted_lockfile: Option<&pnpm_lockfile::Lockfile>) -> HashSet<String> {
     let Some(lockfile) = wanted_lockfile else {
         return HashSet::default();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -177,16 +177,40 @@ fn an_ordinary_alias_onto_a_peers_provider_does_not_rename_it() {
     );
 }
 
-/// Two aliases onto one provider leave no way to tell which the peer
-/// resolved through, and guessing would vary with map order.
+/// The dependent's `peerDependencies` name the edge a peer resolved
+/// through, so a competing ordinary alias onto the same provider does
+/// not make the segment unattributable.
 #[test]
-fn competing_aliases_onto_one_provider_do_not_rename_the_segment() {
+fn a_declared_peer_alias_outranks_a_competing_ordinary_alias() {
     let lockfile = peer_context_lockfile(
         Some(("consumer@1.0.0", peer_declaring_metadata(["peer"]))),
         [(
             "consumer@1.0.0(alias-provider@1.0.0)",
             snapshot_with_dependencies([
                 ("peer", alias_dependency("alias-provider@1.0.0")),
+                ("other", alias_dependency("alias-provider@1.0.0")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
+    );
+}
+
+/// Nothing ranks two ordinary aliases onto one provider, and guessing
+/// between them would vary with map order.
+#[test]
+fn competing_ordinary_aliases_do_not_rename_the_segment() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata([]))),
+        [(
+            "consumer@1.0.0(alias-provider@1.0.0)",
+            snapshot_with_dependencies([
+                ("one", alias_dependency("alias-provider@1.0.0")),
                 ("other", alias_dependency("alias-provider@1.0.0")),
             ]),
         )],

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use pnpm_lockfile::SnapshotEntry;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_resolving_resolver_base::{
     EXISTING_VERSION_SELECTOR_WEIGHT, LatestQuery, PreferredVersions, ResolveError, ResolveFuture,
@@ -92,35 +93,16 @@ fn changed_direct_dependency_discards_prior_peer_context() {
 
 #[test]
 fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
-    use pnpm_lockfile::{ComVer, Lockfile, LockfileVersion, PkgNameVerPeer, SnapshotEntry};
-
-    let lockfile = Lockfile {
-        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
-        settings: None,
-        catalogs: None,
-        overrides: None,
-        package_extensions_checksum: None,
-        pnpmfile_checksum: None,
-        ignored_optional_dependencies: None,
-        patched_dependencies: None,
-        importers: std::collections::HashMap::new(),
-        packages: None,
-        snapshots: Some(std::collections::HashMap::from([
+    let lockfile = peer_context_lockfile(
+        None,
+        [
+            ("consumer@1.0.0(peer@1.0.0)", SnapshotEntry::default()),
             (
-                PkgNameVerPeer::from_str("consumer@1.0.0(peer@1.0.0)").unwrap(),
+                "other@1.0.0(@types/node@24.0.0)(provider@1.0.0(nested@2.0.0))",
                 SnapshotEntry::default(),
             ),
-            (
-                PkgNameVerPeer::from_str(
-                    "other@1.0.0(@types/node@24.0.0)(provider@1.0.0(nested@2.0.0))",
-                )
-                .unwrap(),
-                SnapshotEntry::default(),
-            ),
-        ])),
-        time: None,
-        extra: pnpm_lockfile::LockfileExtra::default(),
-    };
+        ],
+    );
 
     assert_eq!(
         locked_peer_names(Some(&lockfile)),
@@ -135,59 +117,13 @@ fn only_peer_suffix_versions_are_treated_as_locked_peer_providers() {
 
 #[test]
 fn hashed_peer_suffix_uses_package_peer_metadata() {
-    use pnpm_lockfile::{
-        ComVer, DirectoryResolution, Lockfile, LockfileResolution, LockfileVersion,
-        PackageMetadata, PkgName, PkgNameVerPeer, PkgVerPeer, SnapshotDepRef, SnapshotEntry,
-    };
-
-    let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
-    let snapshot_key =
-        PkgNameVerPeer::from_str("consumer@1.0.0(0123456789abcdef0123456789abcdef)").unwrap();
-    let lockfile = Lockfile {
-        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
-        settings: None,
-        catalogs: None,
-        overrides: None,
-        package_extensions_checksum: None,
-        pnpmfile_checksum: None,
-        ignored_optional_dependencies: None,
-        patched_dependencies: None,
-        importers: std::collections::HashMap::new(),
-        packages: Some(std::collections::HashMap::from([(
-            package_key,
-            PackageMetadata {
-                resolution: LockfileResolution::Directory(DirectoryResolution {
-                    directory: "consumer".to_string(),
-                }),
-                version: None,
-                engines: None,
-                cpu: None,
-                os: None,
-                libc: None,
-                deprecated: None,
-                has_bin: None,
-                prepare: None,
-                bundled_dependencies: None,
-                peer_dependencies: Some(std::collections::HashMap::from([
-                    ("peer".to_string(), "*".to_string()),
-                    ("missing".to_string(), "*".to_string()),
-                ])),
-                peer_dependencies_meta: None,
-            },
-        )])),
-        snapshots: Some(std::collections::HashMap::from([(
-            snapshot_key,
-            SnapshotEntry {
-                dependencies: Some(std::collections::HashMap::from([(
-                    PkgName::parse("peer").unwrap(),
-                    SnapshotDepRef::Plain(PkgVerPeer::from_str("1.0.0").unwrap()),
-                )])),
-                ..SnapshotEntry::default()
-            },
-        )])),
-        time: None,
-        extra: pnpm_lockfile::LockfileExtra::default(),
-    };
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["peer", "missing"]))),
+        [(
+            "consumer@1.0.0(0123456789abcdef0123456789abcdef)",
+            snapshot_with_dependency("peer", plain_dependency("1.0.0")),
+        )],
+    );
 
     let ImporterLockedPeerContext { versions, names_by_alias } =
         importer_locked_peer_context(Some(&lockfile), "missing-importer");
@@ -200,60 +136,13 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
 
 #[test]
 fn explicit_peer_suffix_uses_the_dependency_alias() {
-    use pnpm_lockfile::{
-        ComVer, DirectoryResolution, Lockfile, LockfileResolution, LockfileVersion,
-        PackageMetadata, PkgName, PkgNameVerPeer, SnapshotDepRef, SnapshotEntry,
-    };
-
-    let package_key = PkgNameVerPeer::from_str("consumer@1.0.0").unwrap();
-    let snapshot_key = PkgNameVerPeer::from_str("consumer@1.0.0(alias-provider@1.0.0)").unwrap();
-    let lockfile = Lockfile {
-        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
-        settings: None,
-        catalogs: None,
-        overrides: None,
-        package_extensions_checksum: None,
-        pnpmfile_checksum: None,
-        ignored_optional_dependencies: None,
-        patched_dependencies: None,
-        importers: std::collections::HashMap::new(),
-        packages: Some(std::collections::HashMap::from([(
-            package_key,
-            PackageMetadata {
-                resolution: LockfileResolution::Directory(DirectoryResolution {
-                    directory: "consumer".to_string(),
-                }),
-                version: None,
-                engines: None,
-                cpu: None,
-                os: None,
-                libc: None,
-                deprecated: None,
-                has_bin: None,
-                prepare: None,
-                bundled_dependencies: None,
-                peer_dependencies: Some(std::collections::HashMap::from([(
-                    "peer".to_string(),
-                    "*".to_string(),
-                )])),
-                peer_dependencies_meta: None,
-            },
-        )])),
-        snapshots: Some(std::collections::HashMap::from([(
-            snapshot_key,
-            SnapshotEntry {
-                dependencies: Some(std::collections::HashMap::from([(
-                    PkgName::parse("peer").unwrap(),
-                    SnapshotDepRef::Alias(
-                        PkgNameVerPeer::from_str("alias-provider@1.0.0").unwrap(),
-                    ),
-                )])),
-                ..SnapshotEntry::default()
-            },
-        )])),
-        time: None,
-        extra: pnpm_lockfile::LockfileExtra::default(),
-    };
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["peer"]))),
+        [(
+            "consumer@1.0.0(alias-provider@1.0.0)",
+            snapshot_with_dependency("peer", alias_dependency("alias-provider@1.0.0")),
+        )],
+    );
 
     let ImporterLockedPeerContext { versions, names_by_alias } =
         importer_locked_peer_context(Some(&lockfile), "missing-importer");
@@ -264,54 +153,114 @@ fn explicit_peer_suffix_uses_the_dependency_alias() {
     assert!(names_by_alias.is_empty());
 }
 
-fn locked_peer_names(wanted_lockfile: Option<&pnpm_lockfile::Lockfile>) -> HashSet<String> {
-    let Some(lockfile) = wanted_lockfile else {
-        return HashSet::default();
-    };
-    let mut names = HashSet::default();
-    for (key, snapshot) in lockfile.snapshots.iter().flatten() {
-        let peer_suffix = key.suffix.peer();
-        if peer_suffix.is_empty() {
-            continue;
-        }
-        names.extend(peer_suffix_names(peer_suffix));
-        if is_hashed_peer_suffix(peer_suffix)
-            && let Some(metadata) =
-                lockfile.packages.as_ref().and_then(|packages| packages.get(&key.without_peer()))
-        {
-            let resolved_names = snapshot
-                .dependencies
-                .iter()
-                .chain(snapshot.optional_dependencies.iter())
-                .flatten()
-                .map(|(name, _)| name.to_string())
-                .collect::<HashSet<_>>();
-            names.extend(
-                metadata
-                    .peer_dependencies
-                    .iter()
-                    .flatten()
-                    .map(|(name, _)| name)
-                    .filter(|name| resolved_names.contains(*name))
-                    .cloned(),
-            );
-        }
+/// A package that declares no peers still carries the peers its own
+/// children resolved through it, so the suffix stays the only record of
+/// them.
+#[test]
+fn explicit_peer_suffix_of_an_undeclared_peer_is_kept() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata([]))),
+        [(
+            "consumer@1.0.0(peer@2.0.0)",
+            snapshot_with_dependency("child", plain_dependency("1.0.0(peer@2.0.0)")),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["2.0.0".to_string()]))]),
+    );
+}
+
+/// A `packages:`/`snapshots:` pair keyed by the given depPaths, with
+/// every field the peer-context tests do not read left empty.
+fn peer_context_lockfile<const SNAPSHOTS: usize>(
+    package: Option<(&str, pnpm_lockfile::PackageMetadata)>,
+    snapshots: [(&str, pnpm_lockfile::SnapshotEntry); SNAPSHOTS],
+) -> pnpm_lockfile::Lockfile {
+    use pnpm_lockfile::{ComVer, Lockfile, LockfileVersion, PkgNameVerPeer};
+
+    Lockfile {
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0)).unwrap(),
+        settings: None,
+        catalogs: None,
+        overrides: None,
+        package_extensions_checksum: None,
+        pnpmfile_checksum: None,
+        ignored_optional_dependencies: None,
+        patched_dependencies: None,
+        importers: std::collections::HashMap::new(),
+        packages: package.map(|(key, metadata)| {
+            std::collections::HashMap::from([(PkgNameVerPeer::from_str(key).unwrap(), metadata)])
+        }),
+        snapshots: Some(
+            snapshots
+                .into_iter()
+                .map(|(key, entry)| (PkgNameVerPeer::from_str(key).unwrap(), entry))
+                .collect(),
+        ),
+        time: None,
+        extra: pnpm_lockfile::LockfileExtra::default(),
     }
-    names
 }
 
-fn peer_suffix_names(peer_suffix: &str) -> impl Iterator<Item = String> + '_ {
-    peer_suffix.match_indices('(').filter_map(|(start, _)| {
-        let segment = peer_suffix[start + 1..].split(['(', ')']).next()?;
-        let (name, _) = segment.rsplit_once('@')?;
-        (!name.is_empty()).then(|| name.to_string())
-    })
+/// `packages:` metadata whose only content is the declared peer names,
+/// each with a `*` range.
+fn peer_declaring_metadata<const PEERS: usize>(
+    peer_names: [&str; PEERS],
+) -> pnpm_lockfile::PackageMetadata {
+    use pnpm_lockfile::{DirectoryResolution, LockfileResolution, PackageMetadata};
+
+    PackageMetadata {
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "consumer".to_string(),
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: Some(
+            peer_names.into_iter().map(|name| (name.to_string(), "*".to_string())).collect(),
+        ),
+        peer_dependencies_meta: None,
+    }
 }
 
-fn is_hashed_peer_suffix(peer_suffix: &str) -> bool {
-    peer_suffix.rsplit_once('(').and_then(|(_, tail)| tail.strip_suffix(')')).is_some_and(|hash| {
-        hash.len() == 32 && hash.chars().all(|character| character.is_ascii_hexdigit())
-    })
+fn snapshot_with_dependency(
+    alias: &str,
+    dependency: pnpm_lockfile::SnapshotDepRef,
+) -> pnpm_lockfile::SnapshotEntry {
+    use pnpm_lockfile::{PkgName, SnapshotEntry};
+
+    SnapshotEntry {
+        dependencies: Some(std::collections::HashMap::from([(
+            PkgName::parse(alias).unwrap(),
+            dependency,
+        )])),
+        ..SnapshotEntry::default()
+    }
+}
+
+fn plain_dependency(ver_peer: &str) -> pnpm_lockfile::SnapshotDepRef {
+    pnpm_lockfile::SnapshotDepRef::Plain(pnpm_lockfile::PkgVerPeer::from_str(ver_peer).unwrap())
+}
+
+fn alias_dependency(key: &str) -> pnpm_lockfile::SnapshotDepRef {
+    pnpm_lockfile::SnapshotDepRef::Alias(pnpm_lockfile::PkgNameVerPeer::from_str(key).unwrap())
+}
+
+/// The locked peer names a lockfile yields for an importer it does not
+/// list — the union `importer_locked_peer_context` folds over every
+/// snapshot.
+fn locked_peer_names(wanted_lockfile: Option<&pnpm_lockfile::Lockfile>) -> HashSet<String> {
+    importer_locked_peer_context(wanted_lockfile, "missing-importer").versions.into_keys().collect()
 }
 
 struct StubResolver {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -280,6 +280,46 @@ fn competing_ordinary_aliases_do_not_rename_the_segment() {
     );
 }
 
+/// A `link:` edge resolves to a path, not a package version, so it can
+/// never be the provider a suffix segment names.
+#[test]
+fn a_linked_dependency_is_not_a_peer_provider() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["peer"]))),
+        [(
+            "consumer@1.0.0(alias-provider@1.0.0)",
+            snapshot_with_dependencies([
+                ("peer", alias_dependency("alias-provider@1.0.0")),
+                ("local", link_dependency("../local")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
+    );
+}
+
+/// A hashed suffix spells no peers out, so without the package metadata
+/// naming them there is nothing left to recover them from.
+#[test]
+fn a_hashed_peer_suffix_without_package_metadata_records_nothing() {
+    let lockfile = peer_context_lockfile(
+        None,
+        [(
+            "consumer@1.0.0(0123456789abcdef0123456789abcdef)",
+            snapshot_with_dependency("peer", plain_dependency("1.0.0")),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert!(versions.is_empty());
+}
+
 /// A package that declares no peers still carries the peers its own
 /// children resolved through it, so the suffix stays the only record of
 /// them.
@@ -389,6 +429,10 @@ fn plain_dependency(ver_peer: &str) -> pnpm_lockfile::SnapshotDepRef {
 
 fn alias_dependency(key: &str) -> pnpm_lockfile::SnapshotDepRef {
     pnpm_lockfile::SnapshotDepRef::Alias(pnpm_lockfile::PkgNameVerPeer::from_str(key).unwrap())
+}
+
+fn link_dependency(target: &str) -> pnpm_lockfile::SnapshotDepRef {
+    pnpm_lockfile::SnapshotDepRef::Link(target.to_string())
 }
 
 /// The locked peer names a lockfile yields for an importer it does not

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -201,6 +201,59 @@ fn a_declared_peer_alias_outranks_a_competing_ordinary_alias() {
     );
 }
 
+/// Two declared peers can share one provider, and the suffix then
+/// spells its segment twice — once per peer.
+#[test]
+fn declared_peers_sharing_a_provider_each_get_their_alias_back() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["first", "second"]))),
+        [(
+            "consumer@1.0.0(alias-provider@1.0.0)(alias-provider@1.0.0)",
+            snapshot_with_dependencies([
+                ("first", alias_dependency("alias-provider@1.0.0")),
+                ("second", alias_dependency("alias-provider@1.0.0")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([
+            ("first".to_string(), HashSet::from_iter(["1.0.0".to_string()])),
+            ("second".to_string(), HashSet::from_iter(["1.0.0".to_string()])),
+        ]),
+    );
+}
+
+/// A declared peer and a peer propagated from a child can resolve to one
+/// provider through separate edges. Taking the declared edge for the
+/// first segment must leave the ordinary edge for the second.
+#[test]
+fn a_declared_peer_does_not_consume_the_propagated_peers_segment() {
+    let lockfile = peer_context_lockfile(
+        Some(("consumer@1.0.0", peer_declaring_metadata(["provider"]))),
+        [(
+            "consumer@1.0.0(provider@1.0.0)(provider@1.0.0)",
+            snapshot_with_dependencies([
+                ("provider", plain_dependency("1.0.0")),
+                ("child-peer", alias_dependency("provider@1.0.0")),
+            ]),
+        )],
+    );
+
+    let ImporterLockedPeerContext { versions, .. } =
+        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    assert_eq!(
+        versions,
+        HashMap::from_iter([
+            ("provider".to_string(), HashSet::from_iter(["1.0.0".to_string()])),
+            ("child-peer".to_string(), HashSet::from_iter(["1.0.0".to_string()])),
+        ]),
+    );
+}
+
 /// Nothing ranks two ordinary aliases onto one provider, and guessing
 /// between them would vary with map order.
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

A depPath peer suffix names each provider by the package it **resolved to**, while
peer resolution keys peers by the **alias the dependent declared**. For
`"typescript": "npm:@typescript/typescript6@6"` the suffix reads
`@typescript/typescript6@6.0.2` while the peer name is `typescript`. pacquet's
`locked_peer_versions_for_key` read the suffix back verbatim, so it pinned a peer
nobody declares and left the declared one unpinned — repeated full resolutions were
then free to pick the other variant. A real occurrence in n8n's lockfile is
`@qdrant/js-client-rest@1.16.2(@typescript/typescript6@6.0.2)`, whose snapshot edge
is `typescript: '@typescript/typescript6@6.0.2'`.

The fix rewrites only the segments the snapshot resolved through an npm alias
(`SnapshotDepRef::Alias`) back to that alias. The suffix stays authoritative for
everything else.

The TypeScript CLI needs no matching change: `getLockedPeerContext` walks
`peerDependencies` keys and reads `snapshot.dependencies[peerName]`, so the edge key
*is* the alias — it never parses a suffix.

An earlier revision of this PR instead made snapshot edges plus the package's
declared peers authoritative for every explicit suffix. That regressed the
locked-peer context: a suffix also carries peers propagated up from children, which
the package itself does not declare. Simulated per snapshot key over n8n's lockfile,
that swap changed 306 of 624 suffixed keys and emptied 117 of them, because ~20% of
suffixed packages declare no `peerDependencies` at all. `locked_peer_versions` is a
filter in `get_hoistable_optional_peers_with_locked_versions` and its key set becomes
`locked_peer_names`, so dropping names silently loosens the dedupe idempotence that
pnpm/pnpm#13459 and pnpm/pnpm#13473 added. `explicit_peer_suffix_of_an_undeclared_peer_is_kept`
pins that case.

## Squash Commit Body

```text
A peer suffix names each provider by the package it resolved to, while peer
resolution keys peers by the alias the dependent declared. Reading the segment
back verbatim pins a peer nobody declares and leaves the declared one unpinned,
so repeated full resolutions alternate between the two variants.

Rewrite only the segments the snapshot resolved through an npm alias back to
that alias. The suffix stays authoritative for everything else: it also carries
peers propagated up from children, which the package's own peerDependencies
cannot reconstruct.

Thread the snapshot in from the callers so the all-snapshots pass stops looking
up a key it already holds.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it. (No issue is referenced; current and historical
  PR/code searches found no duplicate fix.)
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (TypeScript
  already reads the declared alias off the snapshot edge.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (No public interface or documented
  behavior changed.)

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where repeated `pnpm dedupe` runs could alternate between peer dependency resolutions when a peer was provided through an npm alias.
  * Improved peer dependency handling so explicitly declared aliases consistently resolve to the correct peer version.
  * Prevented competing, undeclared aliases from incorrectly changing peer resolution details.
  * Preserved peer resolution details for propagated peers when declared and undeclared aliases share a provider.
  * Added coverage for multiple peers resolved through the same provider alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->