### PR TITLE
fix(fs-packlist): respect files for changelogs

### DIFF
--- a/.changeset/fuzzy-ravens-pack.md
+++ b/.changeset/fuzzy-ravens-pack.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm pack` to respect the `files` field when deciding whether to include root-level changelog, history, and notice files.

--- a/pnpm/crates/fs-packlist/src/lib.rs
+++ b/pnpm/crates/fs-packlist/src/lib.rs
@@ -21,9 +21,8 @@
 //!    anything outside that set (except the always-included files
 //!    handled in pass 3).
 //! 3. **Always-include** the standard files: `package.json`,
-//!    `README*` / `LICEN[SC]E*` / `CHANGES*` / `CHANGELOG*` /
-//!    `HISTORY*` / `NOTICE*` at the root, plus the paths declared in
-//!    `main` / `bin`. These survive `.npmignore` rejection and the
+//!    `README*` / `LICEN[SC]E*` at the root, plus the paths declared
+//!    in `main` / `bin`. These survive `.npmignore` rejection and the
 //!    `files`-field filter.
 //! 4. **`bundleDependencies` closure**: starting from the names in
 //!    `manifest.bundleDependencies` (or the legacy
@@ -85,8 +84,7 @@ const MAX_BUNDLE_DEPTH: u32 = 32;
 /// Case-insensitive prefix matches for files always-included at the
 /// package root regardless of `.npmignore` / `files`. Mirrors
 /// `npm-packlist`'s `alwaysIncluded` set.
-const ALWAYS_INCLUDED_PREFIXES: &[&str] =
-    &["readme", "license", "licence", "changes", "changelog", "history", "notice"];
+const ALWAYS_INCLUDED_PREFIXES: &[&str] = &["readme", "license", "licence"];
 
 /// Version-control directory names that exclude every file under
 /// them at any depth. Drops VCS state from a published package

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -113,7 +113,8 @@ fn files_field_does_not_force_include_changelog_files() {
         "version": "0.0.0",
         "files": ["dist/**"],
     });
-    let out = packlist(root, &manifest).unwrap();
+    let mut out = packlist(root, &manifest).unwrap();
+    out.sort();
 
     assert_eq!(out, vec!["dist/index.js".to_string(), "package.json".into()]);
 }

--- a/pnpm/crates/fs-packlist/src/tests.rs
+++ b/pnpm/crates/fs-packlist/src/tests.rs
@@ -98,6 +98,27 @@ fn files_field_restricts_to_listed_globs() {
 }
 
 #[test]
+fn files_field_does_not_force_include_changelog_files() {
+    let dir = tempdir().unwrap();
+    let root = dir.path();
+    touch(root, "package.json");
+    touch(root, "dist/index.js");
+    touch(root, "CHANGES.md");
+    touch(root, "CHANGELOG.md");
+    touch(root, "HISTORY.md");
+    touch(root, "NOTICE.md");
+
+    let manifest = json!({
+        "name": "x",
+        "version": "0.0.0",
+        "files": ["dist/**"],
+    });
+    let out = packlist(root, &manifest).unwrap();
+
+    assert_eq!(out, vec!["dist/index.js".to_string(), "package.json".into()]);
+}
+
+#[test]
 fn main_and_bin_paths_are_force_included_under_files_field() {
     let dir = tempdir().unwrap();
     let root = dir.path();


### PR DESCRIPTION
## Summary

Fixes pacquet's packlist so root-level `CHANGES*`, `CHANGELOG*`, `HISTORY*`, and `NOTICE*` files are not force-included when the package's `files` allowlist excludes them. `README*` and `LICEN[SC]E*` remain always included, matching npm-packlist and the TypeScript pnpm CLI.

Adds a regression test covering all four file families and a pacquet patch changeset.

Closes pnpm/pnpm#14315.

## Squash Commit Body

```text
Stop force-including changelog, history, and notice files outside the manifest files allowlist. Keep README and license files aligned with npm-packlist.

Closes pnpm/pnpm#14315
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The TypeScript CLI already has the expected behavior, so this regression
  fix is needed only in the Rust `pnpm/` port.
- [x] Added a `pacquet` patch changeset.
- [x] Added a regression test.
- [x] Updated the packlist module documentation; no user documentation change
  is needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14317"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790591161&installation_model_id=426870&pr_number=14317&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14317&signature=fde55da73b25bf30434ffcffae7fb18cb3d7cbb83ace97f942d6d738a5bf0e90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm pack` now respects the package’s `files` field when deciding whether to include root-level changelog, history, and notice files.
  - Packages can exclude `CHANGES`, `CHANGELOG`, `HISTORY`, and `NOTICE` files when they are not matched by configured file patterns.
  - Standard `README` and `LICENSE` files continue to be included automatically in package archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->