### PR TITLE
fix(cli): let child pnpm select its version

### DIFF
--- a/.changeset/fresh-pandas-switch.md
+++ b/.changeset/fresh-pandas-switch.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed automatically switched pnpm versions forcing all descendant pnpm processes to use the same version [pnpm/pnpm#14309](https://github.com/pnpm/pnpm/issues/14309).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7945,9 +7945,6 @@ importers:
       '@pnpm/releasing.commands':
         specifier: workspace:*
         version: link:../releasing/commands
-      '@pnpm/shell.path':
-        specifier: workspace:*
-        version: link:../shell/path
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../store/cafs

--- a/pnpm/crates/cli/src/cli_args/with.rs
+++ b/pnpm/crates/cli/src/cli_args/with.rs
@@ -94,9 +94,9 @@ pub(crate) enum PackageManagerCheck {
     Disabled,
 }
 
-/// Spawn the downloaded `pnpm` with `bin_dirs` prepended to `PATH`,
-/// inheriting stdio. The first entry is the engine's own bin directory;
-/// any that follow are what it needs to run, such as a managed Node.js.
+/// Spawn the downloaded `pnpm`, inheriting stdio. The first entry is the
+/// engine's own bin directory; any that follow are what it needs to run,
+/// such as a managed Node.js.
 pub(crate) fn spawn_pnpm<Args, Arg>(
     bin_dirs: &[PathBuf],
     args: Args,
@@ -107,7 +107,6 @@ where
     Arg: AsRef<std::ffi::OsStr>,
 {
     let bin_dir = bin_dirs.first().expect("an installed engine has a bin directory");
-    let path = prepend_dirs_to_path(bin_dirs).map_err(WithError::from)?;
     let program = engine_bin(bin_dir, "pnpm").ok_or_else(|| EngineError::MissingEngineBin {
         name: "pnpm",
         dir: bin_dir.display().to_string(),
@@ -115,9 +114,20 @@ where
 
     let mut cmd = Command::new(program);
     cmd.args(args);
-    set_command_path(&mut cmd, &path);
-    disable_package_manager_switching(&mut cmd);
+    configure_pnpm_environment(&mut cmd, bin_dirs, package_manager_check)?;
+
+    cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
+}
+
+fn configure_pnpm_environment(
+    cmd: &mut Command,
+    bin_dirs: &[PathBuf],
+    package_manager_check: PackageManagerCheck,
+) -> miette::Result<()> {
     if matches!(package_manager_check, PackageManagerCheck::Disabled) {
+        let path = prepend_dirs_to_path(bin_dirs).map_err(WithError::from)?;
+        set_command_path(cmd, &path);
+        disable_package_manager_switching(cmd);
         // The child pnpm must skip the packageManager / devEngines check so the
         // requested version stays active. `COREPACK_ROOT` is honored by every
         // pnpm release that supports corepack (older versions skip the check
@@ -128,8 +138,7 @@ where
         }
         cmd.env("pnpm_config_pm_on_fail", "ignore");
     }
-
-    cmd.status().into_diagnostic().wrap_err("run the requested pnpm version")
+    Ok(())
 }
 
 fn disable_package_manager_switching(cmd: &mut Command) {

--- a/pnpm/crates/cli/src/cli_args/with/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/with/tests.rs
@@ -1,4 +1,4 @@
-use super::disable_package_manager_switching;
+use super::{PackageManagerCheck, configure_pnpm_environment};
 use crate::{
     cli_args::package_manager::PACKAGE_MANAGER_SWITCH_ENV_VARS,
     engine_pm::install::slot_from_package_dir,
@@ -8,13 +8,26 @@ use std::{ffi::OsStr, path::Path, process::Command};
 #[test]
 fn child_pnpm_disables_all_package_manager_switch_env_variants() {
     let mut command = Command::new("pnpm");
+    let bin_dir = Path::new("downloaded-pnpm").to_path_buf();
 
-    disable_package_manager_switching(&mut command);
+    configure_pnpm_environment(&mut command, &[bin_dir], PackageManagerCheck::Disabled)
+        .expect("configure pnpm environment");
 
     for name in PACKAGE_MANAGER_SWITCH_ENV_VARS {
         let value = command_env_value(&command, name);
         assert_eq!(value, Some(OsStr::new("false")), "expected {name}=false");
     }
+}
+
+#[test]
+fn automatically_switched_pnpm_inherits_the_parent_environment() {
+    let mut command = Command::new("pnpm");
+    let bin_dir = Path::new("downloaded-pnpm").to_path_buf();
+
+    configure_pnpm_environment(&mut command, &[bin_dir], PackageManagerCheck::Enabled)
+        .expect("configure pnpm environment");
+
+    assert_eq!(command.get_envs().count(), 0);
 }
 
 fn command_env_value<'command>(command: &'command Command, name: &str) -> Option<&'command OsStr> {

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -97,19 +97,25 @@ fn child_pnpm_selects_the_version_for_its_own_directory() {
     fs::write(project_b.join("package.json"), r#"{"packageManager":"pnpm@9.1.3"}"#)
         .expect("write project b package.json");
 
-    let version_script = r"
+    let version_script = root.path().join("child-version.cjs");
+    fs::write(
+        &version_script,
+        r"
         const { spawnSync } = require('node:child_process')
         const result = spawnSync('pnpm', ['--version'], {
-          cwd: process.argv[1],
+          cwd: process.argv[2],
           encoding: 'utf8',
         })
         if (result.status !== 0) throw new Error(result.stderr)
         process.stdout.write(result.stdout)
-    ";
+    ",
+    )
+    .expect("write child version script");
     let output = test_command(pacquet, root.path())
         .current_dir(&project_a)
         .env("PNPM_CONFIG_REGISTRY", mock_instance.url())
-        .args(["exec", "node", "-e", version_script])
+        .args(["exec", "node"])
+        .arg(&version_script)
         .arg(&project_b)
         .output()
         .expect("run child pnpm in project b");

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -83,6 +83,43 @@ fn version_flag_switches_to_project_package_manager_version() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn child_pnpm_selects_the_version_for_its_own_directory() {
+    let CommandTempCwd { pacquet, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let project_a = root.path().join("a");
+    let project_b = root.path().join("b");
+    fs::create_dir_all(&project_a).expect("create project a");
+    fs::create_dir_all(&project_b).expect("create project b");
+    fs::write(project_a.join("package.json"), r#"{"packageManager":"pnpm@9.3.0"}"#)
+        .expect("write project a package.json");
+    fs::write(project_b.join("package.json"), r#"{"packageManager":"pnpm@9.1.3"}"#)
+        .expect("write project b package.json");
+
+    let version_script = r"
+        const { spawnSync } = require('node:child_process')
+        const result = spawnSync('pnpm', ['--version'], {
+          cwd: process.argv[1],
+          encoding: 'utf8',
+        })
+        if (result.status !== 0) throw new Error(result.stderr)
+        process.stdout.write(result.stdout)
+    ";
+    let output = test_command(pacquet, root.path())
+        .current_dir(&project_a)
+        .env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .args(["exec", "node", "-e", version_script])
+        .arg(&project_b)
+        .output()
+        .expect("run child pnpm in project b");
+    dbg!(&output);
+    assert!(output.status.success(), "child pnpm should succeed");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "9.1.3\n");
+
+    drop((root, mock_instance));
+}
+
 /// `--version` runs the pre-command checks — that is what lets it switch to
 /// the pinned pnpm above. A pin the running pnpm already satisfies has nothing
 /// to switch to, but it is still recorded, so the entry does not depend on

--- a/pnpm11/pnpm/package.json
+++ b/pnpm11/pnpm/package.json
@@ -122,7 +122,6 @@
     "@pnpm/prepare": "workspace:*",
     "@pnpm/registry-access.commands": "workspace:*",
     "@pnpm/releasing.commands": "workspace:*",
-    "@pnpm/shell.path": "workspace:*",
     "@pnpm/store.cafs": "workspace:*",
     "@pnpm/store.commands": "workspace:*",
     "@pnpm/store.connection-manager": "workspace:*",

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -53,7 +53,7 @@ const envLockfile: EnvLockfile = {
 const installPnpmToStore = jest.fn<(version: string, opts: object) => Promise<{ binDir: string }>>(async () => ({ binDir: '/store/bin' }))
 const readEnvLockfile = jest.fn<(rootDir: string) => Promise<EnvLockfile | null>>(async () => envLockfile)
 const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: object) => Promise<EnvLockfile>>(async () => envLockfile)
-const spawnSync = jest.fn(() => ({ status: 0 }))
+const spawnSync = jest.fn<(command: string, args: string[], options: object) => { status: number }>(() => ({ status: 0 }))
 
 // Mutable so a test can pretend the running pnpm is itself a broken release.
 const mockPackageManager = { name: 'pnpm', version: '11.0.0' }
@@ -76,9 +76,6 @@ jest.unstable_mockModule('@pnpm/installing.env-installer', () => ({
 }))
 jest.unstable_mockModule('@pnpm/lockfile.fs', () => ({
   readEnvLockfile,
-}))
-jest.unstable_mockModule('@pnpm/shell.path', () => ({
-  prependDirsToPath: () => ({ name: 'PATH', updated: true, value: '/store/bin' }),
 }))
 jest.unstable_mockModule('@pnpm/store.connection-manager', () => ({
   createStoreController,
@@ -476,6 +473,9 @@ test('still switches to a release that is not broken', async () => {
   }
 
   expect(installPnpmToStore).toHaveBeenCalledWith('11.13.1', expect.anything())
+  expect(spawnSync).toHaveBeenCalledWith('/store/bin/pnpm', process.argv.slice(2), {
+    stdio: 'inherit',
+  })
 })
 
 /** The fixture above, re-pointed at `version` — same shape, so it still passes the

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+
 import { beforeEach, expect, jest, test } from '@jest/globals'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
 import type { EnvLockfile } from '@pnpm/lockfile.types'
@@ -473,7 +475,7 @@ test('still switches to a release that is not broken', async () => {
   }
 
   expect(installPnpmToStore).toHaveBeenCalledWith('11.13.1', expect.anything())
-  expect(spawnSync).toHaveBeenCalledWith('/store/bin/pnpm', process.argv.slice(2), {
+  expect(spawnSync).toHaveBeenCalledWith(path.join('/store/bin', 'pnpm'), process.argv.slice(2), {
     stdio: 'inherit',
   })
 })

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -8,7 +8,6 @@ import { PnpmError } from '@pnpm/error'
 import { isPackageManagerResolved, resolvePackageManagerIntegrities } from '@pnpm/installing.env-installer'
 import { readEnvLockfile } from '@pnpm/lockfile.fs'
 import { globalWarn } from '@pnpm/logger'
-import { prependDirsToPath } from '@pnpm/shell.path'
 import { createStoreController } from '@pnpm/store.connection-manager'
 import spawn from 'cross-spawn'
 import semver from 'semver'
@@ -188,12 +187,6 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
     await storeToUse.ctrl.close()
   }
 
-  const pnpmEnv = prependDirsToPath([wantedPnpmBinDir])
-  if (!pnpmEnv.updated) {
-    // We throw this error to prevent an infinite recursive call of the same pnpm version.
-    throw new VersionSwitchFail(pmVersion, wantedPnpmBinDir)
-  }
-
   // Specify the exact pnpm file path that's expected to execute to spawn.sync()
   //
   // It's not safe spawn 'pnpm' (without specifying an absolute path) and expect
@@ -207,11 +200,6 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
 
   const { status, signal, error } = spawn.sync(pnpmBinPath, process.argv.slice(2), {
     stdio: 'inherit',
-    env: {
-      ...process.env,
-      [pnpmEnv.name]: pnpmEnv.value,
-      npm_config_manage_package_manager_versions: 'false',
-    },
   })
 
   if (error) {

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -28,7 +28,6 @@ test('child pnpm processes select the version for their own directory', () => {
   const projectADir = path.join(rootDir, 'a')
   const projectBDir = path.join(rootDir, 'b')
   const pnpmHome = path.join(rootDir, 'pnpm')
-  const initialPnpmVersion = execPnpmSync(['--version'], { cwd: rootDir }).stdout.toString().trim()
   fs.mkdirSync(projectADir)
   fs.mkdirSync(projectBDir)
   writeJsonFileSync(path.join(projectADir, 'package.json'), {
@@ -57,10 +56,9 @@ test('child pnpm processes select the version for their own directory', () => {
     expectSuccess: true,
   })
 
-  expect(JSON.parse(result.stdout.toString())).toEqual({
-    projectB: '9.1.3',
-    unpinned: initialPnpmVersion,
-  })
+  const versions = JSON.parse(result.stdout.toString()) as { projectB: string, unpinned: string }
+  expect(versions.projectB).toBe('9.1.3')
+  expect(versions.unpinned).not.toBe('9.3.0')
 })
 
 test('packageManager field does not write pnpm resolution info to pnpm-lock.yaml', async () => {

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -22,6 +22,46 @@ test('switch to the pnpm version specified in the packageManager field of packag
   expect(stdout.toString()).toContain('Version 9.3.0')
 })
 
+test('child pnpm processes select the version for their own directory', () => {
+  prepare()
+  const rootDir = process.cwd()
+  const projectADir = path.join(rootDir, 'a')
+  const projectBDir = path.join(rootDir, 'b')
+  const pnpmHome = path.join(rootDir, 'pnpm')
+  const initialPnpmVersion = execPnpmSync(['--version'], { cwd: rootDir }).stdout.toString().trim()
+  fs.mkdirSync(projectADir)
+  fs.mkdirSync(projectBDir)
+  writeJsonFileSync(path.join(projectADir, 'package.json'), {
+    packageManager: 'pnpm@9.3.0',
+  })
+  writeJsonFileSync(path.join(projectBDir, 'package.json'), {
+    packageManager: 'pnpm@9.1.3',
+  })
+
+  const versionScript = `
+    const { spawnSync } = require('node:child_process')
+    const versionAt = (dir) => {
+      const result = spawnSync('pnpm', ['--version'], { cwd: dir, encoding: 'utf8' })
+      if (result.status !== 0) throw new Error(result.stderr)
+      return result.stdout.trim()
+    }
+    process.stdout.write(JSON.stringify({
+      projectB: versionAt(${JSON.stringify(projectBDir)}),
+      unpinned: versionAt(${JSON.stringify(rootDir)}),
+    }))
+  `
+  const result = execPnpmSync(['exec', 'node', '-e', versionScript], {
+    cwd: projectADir,
+    env: { PNPM_HOME: pnpmHome },
+    expectSuccess: true,
+  })
+
+  expect(JSON.parse(result.stdout.toString())).toEqual({
+    projectB: '9.1.3',
+    unpinned: initialPnpmVersion,
+  })
+})
+
 test('packageManager field does not write pnpm resolution info to pnpm-lock.yaml', async () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -38,7 +38,8 @@ test('child pnpm processes select the version for their own directory', () => {
     packageManager: 'pnpm@9.1.3',
   })
 
-  const versionScript = `
+  const versionScript = path.join(rootDir, 'child-versions.cjs')
+  fs.writeFileSync(versionScript, `
     const { spawnSync } = require('node:child_process')
     const versionAt = (dir) => {
       const result = spawnSync('pnpm', ['--version'], { cwd: dir, encoding: 'utf8' })
@@ -46,11 +47,11 @@ test('child pnpm processes select the version for their own directory', () => {
       return result.stdout.trim()
     }
     process.stdout.write(JSON.stringify({
-      projectB: versionAt(${JSON.stringify(projectBDir)}),
-      unpinned: versionAt(${JSON.stringify(rootDir)}),
+      projectB: versionAt(process.argv[2]),
+      unpinned: versionAt(process.argv[3]),
     }))
-  `
-  const result = execPnpmSync(['exec', 'node', '-e', versionScript], {
+  `)
+  const result = execPnpmSync(['exec', 'node', versionScript, projectBDir, rootDir], {
     cwd: projectADir,
     env: { PNPM_HOME: pnpmHome },
     expectSuccess: true,

--- a/pnpm11/pnpm/tsconfig.json
+++ b/pnpm11/pnpm/tsconfig.json
@@ -147,9 +147,6 @@
       "path": "../releasing/commands"
     },
     {
-      "path": "../shell/path"
-    },
-    {
       "path": "../store/cafs"
     },
     {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14309.

Automatic package-manager version switching now launches the requested pnpm executable directly without exporting its binary directory or disabling version management for descendant processes. A child pnpm invocation can therefore select the version pinned by its own working directory. An unpinned child resolves pnpm from the original inherited PATH instead of being forced to use the parent project’s pin. Explicit opt-outs and `pnpm with` keep their existing inherited environment behavior.

The change is implemented in both the TypeScript CLI and the Rust pnpm port, with unit and end-to-end regression coverage. The changeset covers both `pnpm` and `pacquet`.

## Squash Commit Body

```text
Automatic version switching executed the selected pnpm binary directly, but also prepended that binary to PATH and disabled package-manager version management in the inherited environment. As a result, every descendant pnpm process was forced to reuse the parent's pinned version, even after changing into a project with a different pin.

Keep launching the immediate selected binary by its exact path, while preserving the caller's environment for ordinary automatic switches. Descendant pnpm invocations can then resolve from the original PATH and evaluate the packageManager field for their own working directory. Retain the inherited overrides for explicit opt-outs and pnpm with.

Apply the same behavior to the TypeScript CLI and Rust pnpm port, and cover pinned sibling projects and unpinned child directories with regression tests.

Closes pnpm/pnpm#14309.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790591991&installation_model_id=426870&pr_number=14318&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14318&signature=e96dd422519b10e1b2ca84b14b1ed0790dd2df8dbec3fdf82df2936e37ecc996"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatically switched package-manager processes so child processes select the version required by their own project directory.
  * Prevented child processes from being forced to use the parent process’s package-manager version.
  * Preserved the active version for projects without a pinned version.
  * Improved version switching without altering inherited environment settings.

* **Tests**
  * Added regression coverage for version selection across parent and child projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->