### PR TITLE
fix(network): pair routed TLS clients

### DIFF
--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -167,20 +167,13 @@ impl Default for NetworkSettings {
 #[derive(Debug)]
 pub struct ThrottledClient {
     semaphore: PrioritySemaphore,
-    client: Client,
-    client_without_redirects: Client,
+    default_clients: ClientPair,
     /// Per-registry clients keyed by nerf-darted URI. Empty when no
     /// `//host/:cert=…` / `:key=…` / `:ca=…` / `:cafile=…` /
     /// `:certfile=…` / `:keyfile=…` `.npmrc` entries are present —
     /// in which case `acquire_for_url` short-circuits to the default
     /// client without paying the routing cost.
-    per_registry: HashMap<String, Client>,
-    per_registry_without_redirects: HashMap<String, Client>,
-    /// Pre-built routing table cloned from [`PerRegistryTls`] so the
-    /// hot path can call `pick_for_url` without holding a reference
-    /// to `PerRegistryTls` (which lives on `Config`). Empty when
-    /// `per_registry` is empty.
-    routing: PerRegistryTls,
+    per_registry: tls::PerRegistryMap<ClientPair>,
     /// Per-origin socket cap (the `maxSockets` setting). `None` (the
     /// default) leaves the per-origin socket count bounded only by
     /// `semaphore`; see [`HostSocketLimit`].
@@ -188,6 +181,18 @@ pub struct ThrottledClient {
     fetch_warn_timeout: Duration,
     fetch_min_speed_ki_bps: u64,
     warning_handler: std::sync::RwLock<fn(&str)>,
+}
+
+#[derive(Debug)]
+struct ClientPair {
+    follow_redirects: Client,
+    no_redirects: Client,
+}
+
+impl ClientPair {
+    fn select(&self, follow_redirects: bool) -> &Client {
+        if follow_redirects { &self.follow_redirects } else { &self.no_redirects }
+    }
 }
 
 /// Per-origin concurrent-connection cap, mirroring undici's `connections`
@@ -298,7 +303,11 @@ impl ThrottledClient {
     /// `send + body-consume` lifetime, not just `.send()`.
     pub async fn acquire(&self) -> ThrottledClientGuard<'_> {
         let permit = self.semaphore.acquire(UNPRIORITIZED).await;
-        ThrottledClientGuard { _permit: permit, _host_permit: None, client: &self.client }
+        ThrottledClientGuard {
+            _permit: permit,
+            _host_permit: None,
+            client: &self.default_clients.follow_redirects,
+        }
     }
 
     /// Install a per-origin socket cap (the `maxSockets` setting) on this
@@ -519,30 +528,27 @@ impl ThrottledClient {
             }
         };
 
-        let default_client = build_client(tls, false)?;
-        let default_client_without_redirects = build_client(tls, true)?;
+        let default_clients = ClientPair {
+            follow_redirects: build_client(tls, false)?,
+            no_redirects: build_client(tls, true)?,
+        };
         // Build one client per per-registry override. Each gets a
         // merged `TlsConfig` where the per-registry fields shadow
         // their top-level counterparts field-by-field. `strict_ssl` and
         // `local_address` are top-level-only, so the per-registry client
         // still honors the top-level values.
-        let mut per_registry_clients = HashMap::with_capacity(per_registry.iter().count());
-        let mut per_registry_clients_without_redirects =
-            HashMap::with_capacity(per_registry.iter().count());
-        for (uri, override_) in per_registry.iter() {
+        let per_registry = per_registry.try_map(|override_| -> Result<_, ForInstallsError> {
             let merged = merge_tls(tls, override_);
-            per_registry_clients.insert(uri.to_string(), build_client(&merged, false)?);
-            per_registry_clients_without_redirects
-                .insert(uri.to_string(), build_client(&merged, true)?);
-        }
+            Ok(ClientPair {
+                follow_redirects: build_client(&merged, false)?,
+                no_redirects: build_client(&merged, true)?,
+            })
+        })?;
 
         Ok(ThrottledClient {
             semaphore: PrioritySemaphore::new(settings.network_concurrency),
-            client: default_client,
-            client_without_redirects: default_client_without_redirects,
-            per_registry: per_registry_clients,
-            per_registry_without_redirects: per_registry_clients_without_redirects,
-            routing: per_registry.clone(),
+            default_clients,
+            per_registry,
             host_socket_limit: None,
             fetch_warn_timeout: settings.fetch_warn_timeout,
             fetch_min_speed_ki_bps: settings.fetch_min_speed_ki_bps,
@@ -559,11 +565,11 @@ impl ThrottledClient {
         let semaphore = PrioritySemaphore::new(default_network_concurrency());
         ThrottledClient {
             semaphore,
-            client_without_redirects,
-            client,
-            per_registry: HashMap::new(),
-            per_registry_without_redirects: HashMap::new(),
-            routing: PerRegistryTls::default(),
+            default_clients: ClientPair {
+                follow_redirects: client,
+                no_redirects: client_without_redirects,
+            },
+            per_registry: tls::PerRegistryMap::default(),
             host_socket_limit: None,
             fetch_warn_timeout: Duration::from_millis(DEFAULT_FETCH_WARN_TIMEOUT_MS),
             fetch_min_speed_ki_bps: DEFAULT_FETCH_MIN_SPEED_KI_BPS,
@@ -634,13 +640,8 @@ impl ThrottledClient {
             None => None,
         };
         let permit = self.semaphore.acquire(priority).await;
-        let (client, per_registry) = if follow_redirects {
-            (&self.client, &self.per_registry)
-        } else {
-            (&self.client_without_redirects, &self.per_registry_without_redirects)
-        };
-        let client =
-            self.routing.pick_for_url(url).and_then(|key| per_registry.get(key)).unwrap_or(client);
+        let clients = self.per_registry.pick_value_for_url(url).unwrap_or(&self.default_clients);
+        let client = clients.select(follow_redirects);
         ThrottledClientGuard { _permit: permit, _host_permit: host_permit, client }
     }
 }

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -1069,6 +1069,73 @@ async fn acquire_for_url_routes_per_registry_then_falls_back() {
 }
 
 #[tokio::test]
+async fn per_registry_route_selects_the_client_for_the_requested_redirect_mode() {
+    // Pointer identity proves a matched route has clients of its own,
+    // but not that the pair's two members are the right way round.
+    // Drive a real redirect through both accessors of one routed
+    // registry to pin that down.
+    use crate::RegistryTls;
+    use std::collections::HashMap;
+
+    let mut registry = mockito::Server::new_async().await;
+    let start_mock = registry
+        .mock("GET", "/start")
+        .with_status(302)
+        .with_header("location", "/final")
+        .expect(2)
+        .create_async()
+        .await;
+    let final_mock = registry
+        .mock("GET", "/final")
+        .with_status(200)
+        .with_body("followed")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mut map = HashMap::new();
+    map.insert(
+        format!("//{}/", registry.host_with_port()),
+        RegistryTls { ca: Some(TEST_CA_PEM.to_string()), ..RegistryTls::default() },
+    );
+    let per_registry = PerRegistryTls::from_map(map);
+    let throttled = ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &per_registry,
+        &NetworkSettings::default(),
+    )
+    .expect("valid");
+
+    let url = format!("{}/start", registry.url());
+    assert!(
+        per_registry.pick_for_url(&url).is_some(),
+        "the fixture URL must match the per-registry route, or this test proves nothing",
+    );
+
+    let blocked = throttled
+        .acquire_for_url_without_redirects_with_priority(&url, 0)
+        .await
+        .get(&url)
+        .send()
+        .await
+        .expect("the redirect response itself is successful HTTP transport");
+    assert_eq!(blocked.status(), 302, "the routed no-redirect client must not follow");
+
+    let followed = throttled
+        .acquire_for_url(&url)
+        .await
+        .get(&url)
+        .send()
+        .await
+        .expect("the routed redirect-following client reaches the target");
+    assert_eq!(followed.status(), 200, "the routed redirect-following client must follow");
+
+    start_mock.assert_async().await;
+    final_mock.assert_async().await;
+}
+
+#[tokio::test]
 async fn acquire_for_url_falls_back_to_default_when_no_overrides() {
     // The common case — no per-registry overrides at all. The lookup
     // short-circuits and `acquire_for_url` always returns the

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -1070,10 +1070,9 @@ async fn acquire_for_url_routes_per_registry_then_falls_back() {
 
 #[tokio::test]
 async fn per_registry_route_selects_the_client_for_the_requested_redirect_mode() {
-    // Pointer identity proves a matched route has clients of its own,
-    // but not that the pair's two members are the right way round.
-    // Drive a real redirect through both accessors of one routed
-    // registry to pin that down.
+    // Pointer identity cannot see a routed pair whose two members
+    // were built the wrong way round, so drive a real redirect
+    // through both accessors instead.
     use crate::RegistryTls;
     use std::collections::HashMap;
 
@@ -1108,10 +1107,16 @@ async fn per_registry_route_selects_the_client_for_the_requested_redirect_mode()
     .expect("valid");
 
     let url = format!("{}/start", registry.url());
-    assert!(
-        per_registry.pick_for_url(&url).is_some(),
-        "the fixture URL must match the per-registry route, or this test proves nothing",
-    );
+    // The statuses below hold for the default pair too, so pin the
+    // routing first: a route map that lost the key would fall back
+    // and still look green.
+    {
+        let routed_guard = throttled.acquire_for_url(&url).await;
+        let unmatched_guard = throttled.acquire_for_url("https://other.example.org/pkg").await;
+        let routed: *const reqwest::Client = &raw const *routed_guard;
+        let unmatched: *const reqwest::Client = &raw const *unmatched_guard;
+        assert_ne!(routed, unmatched, "the fixture URL must reach its own routed client");
+    }
 
     let blocked = throttled
         .acquire_for_url_without_redirects_with_priority(&url, 0)

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -967,6 +967,30 @@ fn for_installs_builds_per_registry_clients() {
 }
 
 #[test]
+fn for_installs_does_not_retain_per_registry_tls_material() {
+    use crate::RegistryTls;
+    use std::collections::HashMap;
+    const PRIVATE_KEY_MARKER: &str = "registry-private-key-marker";
+
+    let mut map = HashMap::new();
+    map.insert(
+        "//reg.example.com/".to_string(),
+        RegistryTls { key: Some(PRIVATE_KEY_MARKER.to_string()), ..RegistryTls::default() },
+    );
+    let per_registry = PerRegistryTls::from_map(map);
+    let client = ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &TlsConfig::default(),
+        &per_registry,
+        &NetworkSettings::default(),
+    )
+    .expect("per-registry config builds");
+
+    let debug = format!("{client:?}");
+    assert!(!debug.contains(PRIVATE_KEY_MARKER), "finished client retained TLS key: {debug}");
+}
+
+#[test]
 fn for_installs_per_registry_invalid_ca_errors() {
     // A malformed per-registry CA must surface as `InvalidCa` at
     // build time, same as the top-level path. The `index` in the
@@ -1028,6 +1052,19 @@ async fn acquire_for_url_routes_per_registry_then_falls_back() {
     assert_ne!(
         scoped_ptr, default_ptr,
         "scoped and default URLs must route through different reqwest clients",
+    );
+
+    let scoped_guard = throttled
+        .acquire_for_url_without_redirects_with_priority("https://reg.example.com/pkg", 0)
+        .await;
+    let default_guard = throttled
+        .acquire_for_url_without_redirects_with_priority("https://other.example.org/pkg", 0)
+        .await;
+    let scoped_ptr: *const reqwest::Client = &raw const *scoped_guard;
+    let default_ptr: *const reqwest::Client = &raw const *default_guard;
+    assert_ne!(
+        scoped_ptr, default_ptr,
+        "scoped and default URLs must route through different no-redirect clients",
     );
 }
 

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -124,15 +124,33 @@ pub enum TlsError {
 /// prefix > recursive no-port retry).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PerRegistryTls {
+    /// Values hold the explicit overrides for a prefix — every field
+    /// is `Option` because pnpm allows partial overrides (e.g. only
+    /// `ca` scoped, with `cert` / `key` falling through to
+    /// top-level).
     by_uri: PerRegistryMap<RegistryTls>,
 }
 
+/// Routing table from nerf-darted registry URI to whatever state a
+/// request to that registry needs: the [`RegistryTls`] overrides
+/// themselves, and the pair of clients [`crate::ThrottledClient`]
+/// derives from them. One implementation of the match chain serves both, so a URL
+/// that resolves to a route for TLS purposes resolves to the same
+/// route when a client is picked.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PerRegistryMap<Value> {
+    /// Keys are nerf-darted URIs (`//host[:port]/path/` form).
     by_uri: HashMap<String, Value>,
+    /// Cache of `key.split('/').count()` maxed across `by_uri.keys()`.
+    /// Bounds the path-prefix walk in [`Self::pick_for_url`] so the
+    /// loop stops after the longest user-supplied prefix instead of
+    /// down to `//`.
     max_parts: usize,
 }
 
+/// Written out rather than derived: an empty routing table is valid
+/// for any `Value`, while `#[derive(Default)]` would constrain
+/// `Value: Default`.
 impl<Value> Default for PerRegistryMap<Value> {
     fn default() -> Self {
         Self { by_uri: HashMap::new(), max_parts: 0 }
@@ -191,13 +209,6 @@ impl PerRegistryTls {
         self.by_uri.is_empty()
     }
 
-    /// Iterate `(nerf_dart_uri, &RegistryTls)` pairs. The network
-    /// layer uses this to pre-build a client per unique override
-    /// combo.
-    pub fn iter(&self) -> impl Iterator<Item = (&str, &RegistryTls)> {
-        self.by_uri.iter()
-    }
-
     /// Look up the per-registry override for `url` via the 5-step
     /// fallback chain:
     ///
@@ -207,9 +218,9 @@ impl PerRegistryTls {
     /// 4. Progressively shorter nerf-darted path prefixes.
     /// 5. Retry recursively without port.
     ///
-    /// Returns the **nerf-darted key** that matched (so the network
-    /// layer can index into its pre-built per-registry client map),
-    /// not the [`RegistryTls`] itself.
+    /// Returns the **nerf-darted key** that matched, not the
+    /// [`RegistryTls`] itself; pass it to [`Self::get`] to borrow the
+    /// override.
     #[must_use]
     pub fn pick_for_url(&self, url: &str) -> Option<&str> {
         self.by_uri.pick_for_url(url).map(|(key, _)| key)
@@ -222,6 +233,11 @@ impl PerRegistryTls {
         self.by_uri.get(key)
     }
 
+    /// Derive a routing table that answers [`Self::pick_for_url`]
+    /// identically but carries `map_value`'s output per route. The
+    /// network layer turns each override into its clients this way so
+    /// a matched route always owns the clients built from that same
+    /// override.
     pub(crate) fn try_map<Mapped, MapError>(
         &self,
         map_value: impl FnMut(&RegistryTls) -> Result<Mapped, MapError>,
@@ -240,14 +256,14 @@ impl<Value> PerRegistryMap<Value> {
         self.by_uri.is_empty()
     }
 
-    fn iter(&self) -> impl Iterator<Item = (&str, &Value)> {
-        self.by_uri.iter().map(|(key, value)| (key.as_str(), value))
-    }
-
+    /// The routed value for `url`, or `None` when no route matches.
     pub(crate) fn pick_value_for_url(&self, url: &str) -> Option<&Value> {
         self.pick_for_url(url).map(|(_, value)| value)
     }
 
+    /// The single implementation of the match chain documented on
+    /// [`PerRegistryTls::pick_for_url`]; the step numbers below refer
+    /// to that list.
     fn pick_for_url(&self, url: &str) -> Option<(&str, &Value)> {
         if self.by_uri.is_empty() {
             return None;
@@ -294,6 +310,8 @@ impl<Value> PerRegistryMap<Value> {
         self.by_uri.get(key)
     }
 
+    /// Rebuild over the same keys, so `max_parts` — and therefore
+    /// every lookup result — carries over unchanged.
     fn try_map<Mapped, MapError>(
         &self,
         mut map_value: impl FnMut(&Value) -> Result<Mapped, MapError>,

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -124,19 +124,12 @@ pub enum TlsError {
 /// prefix > recursive no-port retry).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PerRegistryTls {
-    /// Values hold the explicit overrides for a prefix — every field
-    /// is `Option` because pnpm allows partial overrides (e.g. only
-    /// `ca` scoped, with `cert` / `key` falling through to
-    /// top-level).
     by_uri: PerRegistryMap<RegistryTls>,
 }
 
-/// Routing table from nerf-darted registry URI to whatever state a
-/// request to that registry needs: the [`RegistryTls`] overrides
-/// themselves, and the pair of clients [`crate::ThrottledClient`]
-/// derives from them. One implementation of the match chain serves both, so a URL
-/// that resolves to a route for TLS purposes resolves to the same
-/// route when a client is picked.
+/// Routing table from nerf-darted registry URI to the per-registry
+/// state a request needs: the [`RegistryTls`] overrides, or the
+/// clients [`crate::ThrottledClient`] derives from them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct PerRegistryMap<Value> {
     /// Keys are nerf-darted URIs (`//host[:port]/path/` form).
@@ -148,9 +141,6 @@ pub(crate) struct PerRegistryMap<Value> {
     max_parts: usize,
 }
 
-/// Written out rather than derived: an empty routing table is valid
-/// for any `Value`, while `#[derive(Default)]` would constrain
-/// `Value: Default`.
 impl<Value> Default for PerRegistryMap<Value> {
     fn default() -> Self {
         Self { by_uri: HashMap::new(), max_parts: 0 }
@@ -234,10 +224,7 @@ impl PerRegistryTls {
     }
 
     /// Derive a routing table that answers [`Self::pick_for_url`]
-    /// identically but carries `map_value`'s output per route. The
-    /// network layer turns each override into its clients this way so
-    /// a matched route always owns the clients built from that same
-    /// override.
+    /// identically but carries `map_value`'s output per route.
     pub(crate) fn try_map<Mapped, MapError>(
         &self,
         map_value: impl FnMut(&RegistryTls) -> Result<Mapped, MapError>,
@@ -256,14 +243,12 @@ impl<Value> PerRegistryMap<Value> {
         self.by_uri.is_empty()
     }
 
-    /// The routed value for `url`, or `None` when no route matches.
     pub(crate) fn pick_value_for_url(&self, url: &str) -> Option<&Value> {
         self.pick_for_url(url).map(|(_, value)| value)
     }
 
-    /// The single implementation of the match chain documented on
-    /// [`PerRegistryTls::pick_for_url`]; the step numbers below refer
-    /// to that list.
+    /// Step numbers below index the chain documented on
+    /// [`PerRegistryTls::pick_for_url`].
     fn pick_for_url(&self, url: &str) -> Option<(&str, &Value)> {
         if self.by_uri.is_empty() {
             return None;
@@ -310,8 +295,6 @@ impl<Value> PerRegistryMap<Value> {
         self.by_uri.get(key)
     }
 
-    /// Rebuild over the same keys, so `max_parts` — and therefore
-    /// every lookup result — carries over unchanged.
     fn try_map<Mapped, MapError>(
         &self,
         mut map_value: impl FnMut(&Value) -> Result<Mapped, MapError>,

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -124,16 +124,19 @@ pub enum TlsError {
 /// prefix > recursive no-port retry).
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PerRegistryTls {
-    /// Keys are nerf-darted URIs (`//host[:port]/path/` form). Values
-    /// hold the explicit overrides for that prefix — every field is
-    /// `Option` because pnpm allows partial overrides (e.g. only `ca`
-    /// scoped, with `cert` / `key` falling through to top-level).
-    by_uri: HashMap<String, RegistryTls>,
-    /// Cache of `key.split('/').count()` maxed across `by_uri.keys()`.
-    /// Bounds the path-prefix walk in [`Self::pick_for_url`] so the
-    /// loop stops after the longest user-supplied prefix instead of
-    /// down to `//`.
+    by_uri: PerRegistryMap<RegistryTls>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PerRegistryMap<Value> {
+    by_uri: HashMap<String, Value>,
     max_parts: usize,
+}
+
+impl<Value> Default for PerRegistryMap<Value> {
+    fn default() -> Self {
+        Self { by_uri: HashMap::new(), max_parts: 0 }
+    }
 }
 
 /// `(ca, cert, key)` triple for a single registry override. Each field
@@ -178,8 +181,7 @@ impl PerRegistryTls {
     #[must_use]
     pub fn from_map(by_uri: HashMap<String, RegistryTls>) -> Self {
         let by_uri: HashMap<_, _> = by_uri.into_iter().filter(|(_, v)| !v.is_empty()).collect();
-        let max_parts = by_uri.keys().map(|key| key.split('/').count()).max().unwrap_or(0);
-        PerRegistryTls { by_uri, max_parts }
+        PerRegistryTls { by_uri: PerRegistryMap::from_map(by_uri) }
     }
 
     /// `true` when there are no per-registry overrides. Lets the
@@ -193,7 +195,7 @@ impl PerRegistryTls {
     /// layer uses this to pre-build a client per unique override
     /// combo.
     pub fn iter(&self) -> impl Iterator<Item = (&str, &RegistryTls)> {
-        self.by_uri.iter().map(|(k, v)| (k.as_str(), v))
+        self.by_uri.iter()
     }
 
     /// Look up the per-registry override for `url` via the 5-step
@@ -210,19 +212,56 @@ impl PerRegistryTls {
     /// not the [`RegistryTls`] itself.
     #[must_use]
     pub fn pick_for_url(&self, url: &str) -> Option<&str> {
+        self.by_uri.pick_for_url(url).map(|(key, _)| key)
+    }
+
+    /// Borrow the inner [`RegistryTls`] for a nerf-darted key. Returns
+    /// `None` when the key wasn't registered.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&RegistryTls> {
+        self.by_uri.get(key)
+    }
+
+    pub(crate) fn try_map<Mapped, MapError>(
+        &self,
+        map_value: impl FnMut(&RegistryTls) -> Result<Mapped, MapError>,
+    ) -> Result<PerRegistryMap<Mapped>, MapError> {
+        self.by_uri.try_map(map_value)
+    }
+}
+
+impl<Value> PerRegistryMap<Value> {
+    fn from_map(by_uri: HashMap<String, Value>) -> Self {
+        let max_parts = by_uri.keys().map(|key| key.split('/').count()).max().unwrap_or(0);
+        Self { by_uri, max_parts }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.by_uri.is_empty()
+    }
+
+    fn iter(&self) -> impl Iterator<Item = (&str, &Value)> {
+        self.by_uri.iter().map(|(key, value)| (key.as_str(), value))
+    }
+
+    pub(crate) fn pick_value_for_url(&self, url: &str) -> Option<&Value> {
+        self.pick_for_url(url).map(|(_, value)| value)
+    }
+
+    fn pick_for_url(&self, url: &str) -> Option<(&str, &Value)> {
         if self.by_uri.is_empty() {
             return None;
         }
         // Step 1: exact URL.
-        if let Some((key, _)) = self.by_uri.get_key_value(url) {
-            return Some(key.as_str());
+        if let Some((key, value)) = self.by_uri.get_key_value(url) {
+            return Some((key.as_str(), value));
         }
         // Step 2: nerf-darted URL.
         let nerf = nerf_dart(url);
         if !nerf.is_empty()
-            && let Some((key, _)) = self.by_uri.get_key_value(nerf.as_str())
+            && let Some((key, value)) = self.by_uri.get_key_value(nerf.as_str())
         {
-            return Some(key.as_str());
+            return Some((key.as_str(), value));
         }
         // Step 4: walk progressively shorter prefixes of the
         // nerf-darted form. `nerf` is `//host[:port]/path/`, splitting
@@ -234,8 +273,8 @@ impl PerRegistryTls {
             let upper = parts.len().min(self.max_parts);
             for i in (3..upper).rev() {
                 let key = format!("{}/", parts[..i].join("/"));
-                if let Some((found, _)) = self.by_uri.get_key_value(key.as_str()) {
-                    return Some(found.as_str());
+                if let Some((found, value)) = self.by_uri.get_key_value(key.as_str()) {
+                    return Some((found.as_str(), value));
                 }
             }
         }
@@ -251,11 +290,20 @@ impl PerRegistryTls {
         None
     }
 
-    /// Borrow the inner [`RegistryTls`] for a nerf-darted key. Returns
-    /// `None` when the key wasn't registered.
-    #[must_use]
-    pub fn get(&self, key: &str) -> Option<&RegistryTls> {
+    fn get(&self, key: &str) -> Option<&Value> {
         self.by_uri.get(key)
+    }
+
+    fn try_map<Mapped, MapError>(
+        &self,
+        mut map_value: impl FnMut(&Value) -> Result<Mapped, MapError>,
+    ) -> Result<PerRegistryMap<Mapped>, MapError> {
+        let by_uri = self
+            .by_uri
+            .iter()
+            .map(|(key, value)| Ok((key.clone(), map_value(value)?)))
+            .collect::<Result<_, MapError>>()?;
+        Ok(PerRegistryMap { by_uri, max_parts: self.max_parts })
     }
 }
 


### PR DESCRIPTION
## Summary

- replace the two parallel per-registry client maps with one route map whose value owns both redirect modes
- reuse the existing registry matcher when TLS settings become clients, so each request performs one route lookup
- stop retaining the source TLS configuration, including private key text, in the finished `ThrottledClient`
- preserve the public TLS configuration API and the existing registry-match precedence

Fixes pnpm/pnpm#14323.

This changes only the internal Rust network representation. It does not change the CLI or an on-disk contract, so no TypeScript port or changeset is needed.

Validation:

- `cargo nextest run -p pnpm-network`
- `cargo clippy --locked -p pnpm-network --all-targets -- --deny warnings`
- `just ready`
- repository pre-push checks

## Squash Commit Body

```text
Keep each registry route and its redirect client pair in one map so routing
cannot drift across parallel structures. Reuse the existing registry matcher
for both TLS configuration and constructed clients, which also removes a
second lookup from each routed request.

Do not retain the source TLS configuration in the finished client. This keeps
private key text out of its derived Debug representation.

Fixes pnpm/pnpm#14323.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14324"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790597469&installation_model_id=426870&pr_number=14324&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14324&signature=46abf9fcc0f91b0f47084bccf3e58ca73fd0b94e65494540ff5be965da033d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved routing for registry-specific network clients, including requests that do not follow redirects.
  - Ensured registry-specific TLS settings are applied consistently across request types.
  - Prevented private TLS key material from appearing in client debug output.
  - Improved consistency when switching between redirect-following and non-redirecting requests.

- **Refactor**
  - Consolidated network client and registry configuration handling for more consistent behavior.
  - Streamlined registry-specific routing and client selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->