### PR TITLE
fix(pnpr): write off a publication that never unregistered

### DIFF
--- a/.changeset/artifact-publications-expire.md
+++ b/.changeset/artifact-publications-expire.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A shared build artifact publication that cannot unregister itself no longer stops the registry reclaiming space or refusing further publications. A registration older than an hour is written off, so a publication whose bookkeeping write failed stops holding back the collector that reclaims unreferenced blobs and returns the compatibility scopes a failed publication claimed, and stops counting toward the limit on publications in flight.

--- a/.changeset/artifact-publications-expire.md
+++ b/.changeset/artifact-publications-expire.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-A shared build artifact publication that cannot unregister itself no longer stops the registry reclaiming space or refusing further publications. A registration older than an hour is written off, so a publication whose bookkeeping write failed stops holding back the collector that reclaims unreferenced blobs and returns the compatibility scopes a failed publication claimed, and stops counting toward the limit on publications in flight.
+A shared build artifact publication that cannot unregister itself no longer stops the registry reclaiming space or refusing further publications. A publication says at intervals that it is still working, and a registration that has gone quiet for an hour is written off, so a publication whose bookkeeping write failed stops holding back the collector that reclaims unreferenced blobs and returns the compatibility scopes a failed publication claimed, and stops counting toward the limit on publications in flight.

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -968,11 +968,11 @@ impl SharedArtifactStore {
                                 .to_string(),
                         });
                     }
-                    if !usage.active_publications.insert(publication.to_string()) {
-                        return Err(RegistryError::Internal {
-                            reason: "shared artifact publication is already active".to_string(),
-                        });
-                    }
+                    // Already registered is not a fault: a publication written
+                    // off while it was still working registers again before it
+                    // looks at what it may have lost, and may find its own
+                    // registration still there.
+                    usage.active_publications.insert(publication.to_string());
                     usage
                         .active_publication_times
                         .insert(publication.to_string(), registered_now());

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -962,12 +962,18 @@ impl SharedArtifactStore {
                     Ok(false) => self.release_uncommitted(owner, bytes, 0).await?,
                     Err(error) => {
                         // A store error says nothing about whether the marker
-                        // was written, so the charge is given back and the
-                        // reclamation this failure asks for reconciles the
-                        // counters against what is stored. Keeping it would
-                        // refuse an owner publications that fit for a marker
-                        // that may not be there.
-                        self.release_uncommitted(owner, bytes, 0).await?;
+                        // landed, so what is charged is settled by looking
+                        // rather than assumed. Only a marker this write put
+                        // there stays charged: one that is not there is nobody's
+                        // to pay for, and one holding another digest is charged
+                        // to whoever wrote it. A read that fails too leaves the
+                        // charge standing, since letting storage outgrow a quota
+                        // is the worse way to be wrong.
+                        if self.scope_marker(owner, entry, scope, &digest).await?
+                            != ScopeMarker::Ours
+                        {
+                            self.release_uncommitted(owner, bytes, 0).await?;
+                        }
                         return Err(error);
                     }
                 }

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -41,7 +41,7 @@ const PUBLICATION_FINISH_RETRIES: usize = 8;
 /// gives back the scopes a failed publication claimed. The bound is far longer
 /// than a publication that is merely slow, since expiring a live one lets a
 /// collector run beside it.
-const ACTIVE_PUBLICATION_EXPIRY: Duration = Duration::from_secs(60 * 60);
+const ACTIVE_PUBLICATION_EXPIRY: Duration = Duration::from_hours(1);
 const QUOTA_WRITE_RETRIES: usize = 32;
 const RECLAMATION_WAIT_RETRIES: usize = 600;
 /// A scope marker holds the envelope digest of the artifact that claimed it,

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -477,7 +477,15 @@ impl SharedArtifactStore {
             // publication; registering again waits for one that is running and
             // keeps another from starting, so what the recovery reads is still
             // there when it returns. A check on its own could not do that.
-            self.begin_publication(publication).await?;
+            if let Err(error) = self.begin_publication(publication).await {
+                // Without the registration nothing can be read and believed, so
+                // the artifact is taken out unlooked-at rather than left to
+                // stand for blobs a collector may already have taken. The
+                // scopes it holds name an artifact that is no longer there,
+                // which is what reclamation collects.
+                self.store.delete(&self.object_path(&variant_path)).await?;
+                return Err(error);
+            }
             self.recover_after_expiry(&owner, &entry, &variant_path, &payload, &envelope_digest)
                 .await?;
         }
@@ -551,10 +559,13 @@ impl SharedArtifactStore {
         if held {
             return Ok(());
         }
-        // The scopes retaken before the one that was gone name an artifact about
-        // to be removed. Reclamation would drop them eventually; until it did,
-        // they would refuse artifacts that reach those machines on behalf of one
-        // that is not there.
+        // The artifact goes first, and the scopes it retook after it. A store
+        // error between the two leaves markers held for an artifact that is not
+        // there, which refuses artifacts reaching those machines until
+        // reclamation drops them; the other order would leave the artifact
+        // resolvable while holding nothing, and one reaching the same machines
+        // could be published beside it.
+        self.store.delete(&self.object_path(variant_path)).await?;
         for scope in &retaken {
             // Only while it still names this artifact: a marker retaken here can
             // be collected and taken by somebody else before this loop reaches
@@ -569,7 +580,6 @@ impl SharedArtifactStore {
                 Err(error) => return Err(error.into()),
             }
         }
-        self.store.delete(&self.object_path(variant_path)).await?;
         Err(RegistryError::ArtifactAlreadyPublished {
             owner: owner.to_string(),
             entry: entry.to_string(),

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -52,10 +52,16 @@ const MAX_SCOPE_MARKER_BYTES: u64 = 128;
 struct ArtifactUsage {
     global_bytes: u64,
     owner_bytes: BTreeMap<String, u64>,
+    #[serde(default)]
+    active_publications: BTreeSet<String>,
     /// When each publication in flight registered, so one that never
     /// unregistered can be told from one still working.
-    #[serde(default, deserialize_with = "deserialize_active_publications")]
-    active_publications: BTreeMap<String, u64>,
+    ///
+    /// Beside the set rather than replacing it: a replica running an older
+    /// build shares this document, reads the set it knows, and ignores this.
+    /// One that writes drops these, and the next expiry pass stamps them again.
+    #[serde(default)]
+    active_publication_times: BTreeMap<String, u64>,
     #[serde(default)]
     reclamation_needed: bool,
     #[serde(default)]
@@ -247,6 +253,7 @@ impl SharedArtifactStore {
         if self.publication_is_complete(&prepared).await? {
             return Ok(false);
         }
+        let started = std::time::Instant::now();
         let mut prepared = prepared;
         let envelope_size = prepared.envelope_bytes.len() as u64;
         let owner = prepared.owner.clone();
@@ -333,7 +340,14 @@ impl SharedArtifactStore {
                 return Err(error);
             }
         }
-        let PreparedPublication { entry, envelope_bytes, variant_path, .. } = prepared;
+        let PreparedPublication {
+            entry,
+            envelope_bytes,
+            variant_path,
+            payload,
+            envelope_digest,
+            ..
+        } = prepared;
         for (path, bytes) in new_blobs {
             let size = bytes.len() as u64;
             match self.create_object(&path, bytes).await {
@@ -386,7 +400,44 @@ impl SharedArtifactStore {
         if !created && winner.is_none_or(|winner| winner != envelope_bytes) {
             return Err(RegistryError::ArtifactAlreadyPublished { owner, entry });
         }
+        if created && started.elapsed() >= ACTIVE_PUBLICATION_EXPIRY {
+            // Long enough to have been written off, which lets reclamation run
+            // and give back scopes this publication was still holding. Its
+            // artifact is stored now, so those scopes are its own again, and
+            // taking them back is what keeps it from reaching machines nothing
+            // says it reaches.
+            self.reclaim_own_scopes(&owner, &entry, &payload, &envelope_digest).await?;
+        }
         Ok(created)
+    }
+
+    /// Takes back the scopes of an artifact that has just been stored, for a
+    /// publication that ran long enough to be written off while it was running.
+    async fn reclaim_own_scopes(
+        &self,
+        owner: &str,
+        entry: &str,
+        payload: &ArtifactPayload,
+        holder: &str,
+    ) -> Result<()> {
+        let scopes = match compatibility_scopes(&payload.compatibility) {
+            CompatibilityScopes::Every => BTreeSet::from([UNIVERSAL_SCOPE.to_string()]),
+            CompatibilityScopes::These(scopes) => scopes,
+        };
+        for scope in &scopes {
+            if self.create_object(&scope_marker_path(owner, entry, scope), holder.into()).await? {
+                continue;
+            }
+            if self.scope_marker(owner, entry, scope, holder).await? != ScopeMarker::Ours {
+                return Err(RegistryError::Internal {
+                    reason: format!(
+                        "shared artifact scope {scope} of entry {entry} was claimed while a \
+                         publication of an artifact reaching it was still running",
+                    ),
+                });
+            }
+        }
+        Ok(())
     }
 
     pub async fn resolve(&self, username: &str, body: &[u8]) -> Result<ResolveArtifactsResponse> {
@@ -756,38 +807,45 @@ impl SharedArtifactStore {
         Ok(written)
     }
 
+    /// Settles which publications are still in flight, and writes that down.
+    ///
+    /// Deciding it inside the pass that goes on to refuse something would leave
+    /// the decision unwritten whenever the refusal happens, so a registration
+    /// nobody keeps would be re-stamped on every read and outlive every pass.
+    async fn expire_publications(&self) -> Result<()> {
+        self.mutate_usage(|usage| Ok(expire_stranded_publications(usage))).await?;
+        Ok(())
+    }
+
     async fn begin_publication(&self, publication: &str) -> Result<()> {
+        self.expire_publications().await?;
         for _ in 0..RECLAMATION_WAIT_RETRIES {
             let begun = match self
                 .mutate_usage(|usage| {
                     if usage.reclamation.is_some() {
                         return Ok(false);
                     }
-                    // Registrations nobody will ever remove would otherwise
-                    // fill the limit and refuse publications that could run.
-                    expire_stranded_publications(usage);
                     if usage.active_publications.len() >= MAX_ACTIVE_PUBLICATIONS {
                         return Err(RegistryError::Internal {
                             reason: "shared artifact publication concurrency limit reached"
                                 .to_string(),
                         });
                     }
-                    if usage
-                        .active_publications
-                        .insert(publication.to_string(), registered_now())
-                        .is_some()
-                    {
+                    if !usage.active_publications.insert(publication.to_string()) {
                         return Err(RegistryError::Internal {
                             reason: "shared artifact publication is already active".to_string(),
                         });
                     }
+                    usage
+                        .active_publication_times
+                        .insert(publication.to_string(), registered_now());
                     Ok(true)
                 })
                 .await
             {
                 Ok(begun) => begun,
                 Err(error) => {
-                    if self.load_usage().await?.0.active_publications.contains_key(publication) {
+                    if self.load_usage().await?.0.active_publications.contains(publication) {
                         return Ok(());
                     }
                     return Err(error);
@@ -808,12 +866,12 @@ impl SharedArtifactStore {
         for attempt in 0..PUBLICATION_FINISH_RETRIES {
             let finished = self
                 .mutate_usage(|usage| {
-                    if usage.active_publications.remove(publication).is_none() {
-                        return Err(RegistryError::Internal {
-                            reason: "shared artifact publication is not registered as active"
-                                .to_string(),
-                        });
-                    }
+                    // A registration missing here is not a fault: an expiry pass
+                    // can write one off. What must not be lost is the request to
+                    // reclaim, since the scopes a failed publication claimed come
+                    // back only that way.
+                    usage.active_publications.remove(publication);
+                    usage.active_publication_times.remove(publication);
                     usage.reclamation_needed |= reclamation_needed;
                     Ok(true)
                 })
@@ -828,7 +886,13 @@ impl SharedArtifactStore {
                 }
                 Err(error) => {
                     let retry_error = match self.load_usage().await {
-                        Ok((usage, _)) if !usage.active_publications.contains_key(publication) => {
+                        // Gone, and the reclamation this publication asked for
+                        // already recorded: whether this attempt wrote that or
+                        // an earlier one did, there is nothing left to do.
+                        Ok((usage, _))
+                            if !usage.active_publications.contains(publication)
+                                && (!reclamation_needed || usage.reclamation_needed) =>
+                        {
                             return Ok(());
                         }
                         Ok(_) => error,
@@ -845,13 +909,13 @@ impl SharedArtifactStore {
     }
 
     async fn try_reclaim_unreferenced_blobs(&self) -> Result<()> {
+        self.expire_publications().await?;
         let reclamation = artifact_operation_id()?;
         let acquired = match self
             .mutate_usage(|usage| {
                 // Dropped here rather than merely disregarded, so that the
                 // check on completion sees a publication that started during
                 // this run rather than one this run decided to ignore.
-                expire_stranded_publications(usage);
                 if !usage.reclamation_needed
                     || !usage.active_publications.is_empty()
                     || usage.reclamation.is_some()
@@ -1405,43 +1469,44 @@ fn quota_write_retry_delay(attempt: usize) -> Duration {
     Duration::from_millis(base + jitter)
 }
 
-/// Reads publications registered before they carried a registration time as
-/// having registered now, rather than at the epoch. A publication in flight
-/// across an upgrade is not a stranded one, and treating it as expired would
-/// let a collector run beside it; one that is stranded expires an interval
-/// after the first write that stamps it.
-fn deserialize_active_publications<'de, Source>(
-    deserializer: Source,
-) -> std::result::Result<BTreeMap<String, u64>, Source::Error>
-where
-    Source: serde::Deserializer<'de>,
-{
-    #[derive(serde::Deserialize)]
-    #[serde(untagged)]
-    enum Registered {
-        Timed(BTreeMap<String, u64>),
-        Untimed(BTreeSet<String>),
-    }
-    Ok(match <Registered as serde::Deserialize>::deserialize(deserializer)? {
-        Registered::Timed(publications) => publications,
-        Registered::Untimed(publications) => {
-            let now = registered_now();
-            publications.into_iter().map(|publication| (publication, now)).collect()
-        }
-    })
-}
-
 fn registered_now() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
 }
 
 /// Drops publications that registered longer ago than a publication can
-/// plausibly take, reporting whether any were.
+/// plausibly take, reporting whether it changed anything.
+///
+/// A publication with no registration time was registered by a replica that
+/// does not keep them, so it is stamped now rather than written off: it may be
+/// in flight, and expiring a live publication lets a collector run beside it.
+/// The stamp is what a later pass measures against, which is why the caller
+/// persists this whether or not anything was dropped.
 fn expire_stranded_publications(usage: &mut ArtifactUsage) -> bool {
-    let expiry = registered_now().saturating_sub(ACTIVE_PUBLICATION_EXPIRY.as_secs());
+    let now = registered_now();
+    let expiry = now.saturating_sub(ACTIVE_PUBLICATION_EXPIRY.as_secs());
     let before = usage.active_publications.len();
-    usage.active_publications.retain(|_, registered| *registered > expiry);
-    usage.active_publications.len() != before
+    let times = std::mem::take(&mut usage.active_publication_times);
+    let mut stamped = false;
+    usage.active_publication_times = usage
+        .active_publications
+        .iter()
+        .map(|publication| {
+            let registered = times.get(publication).copied().unwrap_or_else(|| {
+                stamped = true;
+                now
+            });
+            (publication.clone(), registered)
+        })
+        .collect();
+    usage
+        .active_publications
+        .retain(|publication| usage.active_publication_times[publication] > expiry);
+    usage
+        .active_publication_times
+        .retain(|publication, _| usage.active_publications.contains(publication));
+    stamped
+        || usage.active_publications.len() != before
+        || times.len() != usage.active_publication_times.len()
 }
 
 fn artifact_operation_id() -> Result<String> {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -894,15 +894,14 @@ impl SharedArtifactStore {
     /// would leave the scope that variant reaches unclaimed, which is the hole
     /// markers close. It runs once — an entry holding any marker is already
     /// described by them — and each read is bounded by the envelope limit.
-    async fn backfill_scopes(&self, publication: &PreparedPublication) -> Result<u64> {
+    async fn backfill_scopes(&self, publication: &PreparedPublication) -> Result<()> {
         let PreparedPublication { owner, entry, .. } = publication;
         // The sentinel, not the markers: they are written one at a time and the
         // scan stops at the first store error, so a marker only says some
         // artifact was reached, while the sentinel says every one was.
-        let mut written = 0_u64;
         let done = scope_marker_path(owner, entry, BACKFILLED_SCOPE);
         if self.read_object_bounded(&done, MAX_SCOPE_MARKER_BYTES).await?.is_some() {
-            return Ok(written);
+            return Ok(());
         }
         let prefix = self.object_path(&format!("{owner}/entries/{entry}/"));
         let mut listing = self.store.list(Some(&prefix));
@@ -932,16 +931,21 @@ impl SharedArtifactStore {
                 CompatibilityScopes::These(scopes) => scopes,
             };
             for scope in &scopes {
-                if self
+                // Reserved before it is written and kept afterwards, like every
+                // marker: these outlive the publication that writes them, and an
+                // owner over quota must not be able to write one either.
+                let bytes = digest.len() as u64;
+                self.reserve_quota(owner, bytes).await?;
+                if !self
                     .create_object(&scope_marker_path(owner, entry, scope), digest.as_str().into())
                     .await?
                 {
-                    written += digest.len() as u64;
+                    self.release_uncommitted(owner, bytes, 0).await?;
                 }
             }
         }
         self.create_object(&done, Vec::new()).await?;
-        Ok(written)
+        Ok(())
     }
 
     /// Settles which publications are still in flight, and writes that down.

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -220,9 +220,10 @@ impl SharedArtifactStore {
     ///
     /// A registration is written off so that one nobody will remove stops
     /// holding reclamation shut. Renewing keeps that from reaching a
-    /// publication that is merely slow: only one that has actually stopped goes
-    /// quiet long enough to be written off, so no collector runs beside a live
-    /// publication and the losses it would cause cannot arise.
+    /// publication that is merely slow: it takes every renewal across the
+    /// expiry failing for a live one to go quiet long enough. That is why the
+    /// recovery afterwards is not redundant — renewals can fail — but it is
+    /// what makes needing it rare rather than ordinary.
     async fn publish_renewing(
         &self,
         prepared: PreparedPublication,
@@ -564,6 +565,9 @@ impl SharedArtifactStore {
         })
     }
 
+    /// Whether nothing holds a scope named by a tag, which is what an artifact
+    /// reaching every machine has to know: its own key says nothing about the
+    /// keys tagged artifacts take. Stops at the first, and reads no artifact.
     async fn tagged_scopes_are_free(&self, owner: &str, entry: &str) -> Result<bool> {
         let prefix = self.object_path(&scopes_prefix(owner, entry));
         let mut listing = self.store.list(Some(&prefix));
@@ -755,14 +759,8 @@ impl SharedArtifactStore {
         // than reported as already published.
         match compatibility_scopes(&publication.payload.compatibility) {
             CompatibilityScopes::Every => {
-                let prefix = self.object_path(&scopes_prefix(owner, entry));
-                let mut listing = self.store.list(Some(&prefix));
-                while let Some(marker) = listing.next().await {
-                    if scope_name(&marker?.location)
-                        .is_some_and(|scope| !matches!(scope, UNIVERSAL_SCOPE | BACKFILLED_SCOPE))
-                    {
-                        return Ok(false);
-                    }
+                if !self.tagged_scopes_are_free(owner, entry).await? {
+                    return Ok(false);
                 }
             }
             CompatibilityScopes::These(_) => {
@@ -790,16 +788,7 @@ impl SharedArtifactStore {
         if !self.claim_scope(owner, entry, UNIVERSAL_SCOPE, holder, created).await? {
             return Ok(false);
         }
-        let prefix = self.object_path(&scopes_prefix(owner, entry));
-        let mut listing = self.store.list(Some(&prefix));
-        while let Some(marker) = listing.next().await {
-            if scope_name(&marker?.location)
-                .is_some_and(|scope| !matches!(scope, UNIVERSAL_SCOPE | BACKFILLED_SCOPE))
-            {
-                return Ok(false);
-            }
-        }
-        Ok(true)
+        self.tagged_scopes_are_free(owner, entry).await
     }
 
     async fn claim_tagged_scopes(

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -22,7 +22,7 @@ use pnpm_shared_artifact_protocol::{
 use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
 use sha2::{Digest as _, Sha256};
-use tokio::time::sleep;
+use tokio::time::{interval, sleep};
 
 const ARTIFACT_CACHE_DIR: &str = "shared-artifacts/v0";
 const ARTIFACT_OBJECT_PREFIX: &str = ".pnpr-artifacts/v0";
@@ -42,6 +42,11 @@ const PUBLICATION_FINISH_RETRIES: usize = 8;
 /// than a publication that is merely slow, since expiring a live one lets a
 /// collector run beside it.
 const ACTIVE_PUBLICATION_EXPIRY: Duration = Duration::from_hours(1);
+/// How often a publication says it is still working.
+///
+/// Well inside the expiry, so several renewals have to fail before a
+/// publication that is running is mistaken for one that stopped.
+const PUBLICATION_RENEWAL_INTERVAL: Duration = Duration::from_mins(5);
 const QUOTA_WRITE_RETRIES: usize = 32;
 const RECLAMATION_WAIT_RETRIES: usize = 600;
 /// A scope marker holds the envelope digest of the artifact that claimed it,
@@ -200,7 +205,7 @@ impl SharedArtifactStore {
         let publication = artifact_operation_id()?;
         self.begin_publication(&publication).await?;
         let mut reclamation_needed = false;
-        let result = self.publish_active(prepared, &mut reclamation_needed).await;
+        let result = self.publish_renewing(prepared, &publication, &mut reclamation_needed).await;
         let finish = self.finish_publication(&publication, reclamation_needed).await;
         if finish.is_ok()
             && let Err(error) = self.try_reclaim_unreferenced_blobs().await
@@ -209,6 +214,50 @@ impl SharedArtifactStore {
         }
         finish?;
         result
+    }
+
+    /// Runs a publication, saying at intervals that it is still working.
+    ///
+    /// A registration is written off so that one nobody will remove stops
+    /// holding reclamation shut. Renewing keeps that from reaching a
+    /// publication that is merely slow: only one that has actually stopped goes
+    /// quiet long enough to be written off, so no collector runs beside a live
+    /// publication and the losses it would cause cannot arise.
+    async fn publish_renewing(
+        &self,
+        prepared: PreparedPublication,
+        publication: &str,
+        reclamation_needed: &mut bool,
+    ) -> Result<bool> {
+        let mut renewals = interval(PUBLICATION_RENEWAL_INTERVAL);
+        renewals.tick().await;
+        let publishing = self.publish_active(prepared, reclamation_needed);
+        let mut publishing = std::pin::pin!(publishing);
+        loop {
+            tokio::select! {
+                outcome = &mut publishing => return outcome,
+                _ = renewals.tick() => {
+                    // A renewal that cannot be written is not fatal on its own:
+                    // the expiry is several renewals wide, and the publication
+                    // recovers what it lost if it is written off anyway.
+                    if let Err(error) = self.renew_publication(publication).await {
+                        tracing::warn!(%error, "shared artifact publication could not renew");
+                    }
+                }
+            }
+        }
+    }
+
+    async fn renew_publication(&self, publication: &str) -> Result<()> {
+        self.mutate_usage(|usage| {
+            if !usage.active_publications.contains(publication) {
+                return Ok(false);
+            }
+            usage.active_publication_times.insert(publication.to_string(), registered_now());
+            Ok(true)
+        })
+        .await?;
+        Ok(())
     }
 
     async fn publish_active(
@@ -411,13 +460,14 @@ impl SharedArtifactStore {
             // artifact is stored now, so those scopes are its own again, and
             // taking them back is what keeps it from reaching machines nothing
             // says it reaches.
+            // Asked for whatever the recovery finds: a collector that ran
+            // beside this publication rebuilt the usage document from what it
+            // could see, which was not yet everything this publication had
+            // written, and a recovery that gives up leaves an artifact and
+            // markers to collect.
+            *reclamation_needed = true;
             self.recover_after_expiry(&owner, &entry, &variant_path, &payload, &envelope_digest)
                 .await?;
-            // A collector that ran beside this publication rebuilt the usage
-            // document from what it could see, which was not yet everything this
-            // publication has written. Asking for another pass is what squares
-            // the count again.
-            *reclamation_needed = true;
         }
         Ok(created)
     }
@@ -494,6 +544,13 @@ impl SharedArtifactStore {
         // they would refuse artifacts that reach those machines on behalf of one
         // that is not there.
         for scope in &retaken {
+            // Only while it still names this artifact: a marker retaken here can
+            // be collected and taken by somebody else before this loop reaches
+            // it, and removing it by path alone would take that publication's
+            // claim instead.
+            if self.scope_marker(owner, entry, scope, holder).await? != ScopeMarker::Ours {
+                continue;
+            }
             let path = self.object_path(&scope_marker_path(owner, entry, scope));
             match self.store.delete(&path).await {
                 Ok(()) | Err(object_store::Error::NotFound { .. }) => {}

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -127,6 +127,11 @@ enum SlotClaim {
 }
 
 struct PreparedPublication {
+    /// When this publication began, which is what its registration is measured
+    /// against. Taken before the registration rather than after the reads that
+    /// follow it, so a slow read cannot let the registration expire while this
+    /// still counts itself young.
+    started: std::time::Instant,
     entry: String,
     /// Identifies the artifact itself, where the slot identifies only what it is
     /// built for, so a scope marker names which artifact holds it.
@@ -253,7 +258,7 @@ impl SharedArtifactStore {
         if self.publication_is_complete(&prepared).await? {
             return Ok(false);
         }
-        let started = std::time::Instant::now();
+        let started = prepared.started;
         let mut prepared = prepared;
         let envelope_size = prepared.envelope_bytes.len() as u64;
         let owner = prepared.owner.clone();
@@ -432,20 +437,49 @@ impl SharedArtifactStore {
             CompatibilityScopes::Every => BTreeSet::from([UNIVERSAL_SCOPE.to_string()]),
             CompatibilityScopes::These(scopes) => scopes,
         };
+        let mut held = true;
         for scope in &scopes {
             if self.create_object(&scope_marker_path(owner, entry, scope), holder.into()).await? {
                 continue;
             }
-            if self.scope_marker(owner, entry, scope, holder).await? == ScopeMarker::Ours {
-                continue;
+            if self.scope_marker(owner, entry, scope, holder).await? != ScopeMarker::Ours {
+                held = false;
+                break;
             }
-            self.store.delete(&self.object_path(variant_path)).await?;
-            return Err(RegistryError::ArtifactAlreadyPublished {
-                owner: owner.to_string(),
-                entry: entry.to_string(),
-            });
         }
-        Ok(())
+        // The other form of the vocabulary reaches these machines too, and a
+        // publication that took one while this was written off holds it under a
+        // key this one never claims.
+        if held {
+            held = match compatibility_scopes(&payload.compatibility) {
+                CompatibilityScopes::Every => self.tagged_scopes_are_free(owner, entry).await?,
+                CompatibilityScopes::These(_) => {
+                    self.scope_marker(owner, entry, UNIVERSAL_SCOPE, holder).await?
+                        != ScopeMarker::Another
+                }
+            };
+        }
+        if held {
+            return Ok(());
+        }
+        self.store.delete(&self.object_path(variant_path)).await?;
+        Err(RegistryError::ArtifactAlreadyPublished {
+            owner: owner.to_string(),
+            entry: entry.to_string(),
+        })
+    }
+
+    async fn tagged_scopes_are_free(&self, owner: &str, entry: &str) -> Result<bool> {
+        let prefix = self.object_path(&scopes_prefix(owner, entry));
+        let mut listing = self.store.list(Some(&prefix));
+        while let Some(marker) = listing.next().await {
+            if scope_name(&marker?.location)
+                .is_some_and(|scope| !matches!(scope, UNIVERSAL_SCOPE | BACKFILLED_SCOPE))
+            {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 
     pub async fn resolve(&self, username: &str, body: &[u8]) -> Result<ResolveArtifactsResponse> {
@@ -1338,9 +1372,11 @@ fn prepare_publication(
     // Named for what the artifact is *for* rather than what it is, so that one
     // input key and one set of compatibility constraints admit one artifact.
     let slot = compatibility_slot(&payload.compatibility);
+    let started = std::time::Instant::now();
     let envelope_digest = request.envelope.digest().map_err(|err| protocol_error(&err))?;
     let variant_path = format!("{owner}/entries/{entry}/{slot}.json");
     Ok(PreparedPublication {
+        started,
         payload,
         uploads: validated.blobs,
         owner,

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{File, OpenOptions, TryLockError},
     path::{Path, PathBuf},
     sync::Arc,
-    time::Duration,
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use bytes::Bytes;
@@ -33,6 +33,15 @@ const MAX_OWNER_ARTIFACT_BYTES: u64 = 1024 * 1024 * 1024;
 const MAX_GLOBAL_ARTIFACT_BYTES: u64 = 10 * MAX_OWNER_ARTIFACT_BYTES;
 const MAX_ACTIVE_PUBLICATIONS: usize = 1024;
 const PUBLICATION_FINISH_RETRIES: usize = 8;
+/// How long a publication may hold its registration before reclamation treats
+/// it as gone.
+///
+/// A publication that cannot unregister itself — every retry of the write
+/// failing — would otherwise hold the gate forever, and reclamation is what
+/// gives back the scopes a failed publication claimed. The bound is far longer
+/// than a publication that is merely slow, since expiring a live one lets a
+/// collector run beside it.
+const ACTIVE_PUBLICATION_EXPIRY: Duration = Duration::from_secs(60 * 60);
 const QUOTA_WRITE_RETRIES: usize = 32;
 const RECLAMATION_WAIT_RETRIES: usize = 600;
 /// A scope marker holds the envelope digest of the artifact that claimed it,
@@ -43,8 +52,10 @@ const MAX_SCOPE_MARKER_BYTES: u64 = 128;
 struct ArtifactUsage {
     global_bytes: u64,
     owner_bytes: BTreeMap<String, u64>,
-    #[serde(default)]
-    active_publications: BTreeSet<String>,
+    /// When each publication in flight registered, so one that never
+    /// unregistered can be told from one still working.
+    #[serde(default, deserialize_with = "deserialize_active_publications")]
+    active_publications: BTreeMap<String, u64>,
     #[serde(default)]
     reclamation_needed: bool,
     #[serde(default)]
@@ -752,13 +763,20 @@ impl SharedArtifactStore {
                     if usage.reclamation.is_some() {
                         return Ok(false);
                     }
+                    // Registrations nobody will ever remove would otherwise
+                    // fill the limit and refuse publications that could run.
+                    expire_stranded_publications(usage);
                     if usage.active_publications.len() >= MAX_ACTIVE_PUBLICATIONS {
                         return Err(RegistryError::Internal {
                             reason: "shared artifact publication concurrency limit reached"
                                 .to_string(),
                         });
                     }
-                    if !usage.active_publications.insert(publication.to_string()) {
+                    if usage
+                        .active_publications
+                        .insert(publication.to_string(), registered_now())
+                        .is_some()
+                    {
                         return Err(RegistryError::Internal {
                             reason: "shared artifact publication is already active".to_string(),
                         });
@@ -769,7 +787,7 @@ impl SharedArtifactStore {
             {
                 Ok(begun) => begun,
                 Err(error) => {
-                    if self.load_usage().await?.0.active_publications.contains(publication) {
+                    if self.load_usage().await?.0.active_publications.contains_key(publication) {
                         return Ok(());
                     }
                     return Err(error);
@@ -790,7 +808,7 @@ impl SharedArtifactStore {
         for attempt in 0..PUBLICATION_FINISH_RETRIES {
             let finished = self
                 .mutate_usage(|usage| {
-                    if !usage.active_publications.remove(publication) {
+                    if usage.active_publications.remove(publication).is_none() {
                         return Err(RegistryError::Internal {
                             reason: "shared artifact publication is not registered as active"
                                 .to_string(),
@@ -810,7 +828,7 @@ impl SharedArtifactStore {
                 }
                 Err(error) => {
                     let retry_error = match self.load_usage().await {
-                        Ok((usage, _)) if !usage.active_publications.contains(publication) => {
+                        Ok((usage, _)) if !usage.active_publications.contains_key(publication) => {
                             return Ok(());
                         }
                         Ok(_) => error,
@@ -830,6 +848,10 @@ impl SharedArtifactStore {
         let reclamation = artifact_operation_id()?;
         let acquired = match self
             .mutate_usage(|usage| {
+                // Dropped here rather than merely disregarded, so that the
+                // check on completion sees a publication that started during
+                // this run rather than one this run decided to ignore.
+                expire_stranded_publications(usage);
                 if !usage.reclamation_needed
                     || !usage.active_publications.is_empty()
                     || usage.reclamation.is_some()
@@ -1381,6 +1403,45 @@ fn quota_write_retry_delay(attempt: usize) -> Duration {
     let mut random = [0_u8; 1];
     let jitter = if getrandom::fill(&mut random).is_ok() { u64::from(random[0]) % base } else { 0 };
     Duration::from_millis(base + jitter)
+}
+
+/// Reads publications registered before they carried a registration time as
+/// having registered now, rather than at the epoch. A publication in flight
+/// across an upgrade is not a stranded one, and treating it as expired would
+/// let a collector run beside it; one that is stranded expires an interval
+/// after the first write that stamps it.
+fn deserialize_active_publications<'de, Source>(
+    deserializer: Source,
+) -> std::result::Result<BTreeMap<String, u64>, Source::Error>
+where
+    Source: serde::Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum Registered {
+        Timed(BTreeMap<String, u64>),
+        Untimed(BTreeSet<String>),
+    }
+    Ok(match <Registered as serde::Deserialize>::deserialize(deserializer)? {
+        Registered::Timed(publications) => publications,
+        Registered::Untimed(publications) => {
+            let now = registered_now();
+            publications.into_iter().map(|publication| (publication, now)).collect()
+        }
+    })
+}
+
+fn registered_now() -> u64 {
+    SystemTime::now().duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+/// Drops publications that registered longer ago than a publication can
+/// plausibly take, reporting whether any were.
+fn expire_stranded_publications(usage: &mut ArtifactUsage) -> bool {
+    let expiry = registered_now().saturating_sub(ACTIVE_PUBLICATION_EXPIRY.as_secs());
+    let before = usage.active_publications.len();
+    usage.active_publications.retain(|_, registered| *registered > expiry);
+    usage.active_publications.len() != before
 }
 
 fn artifact_operation_id() -> Result<String> {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -406,17 +406,25 @@ impl SharedArtifactStore {
             // artifact is stored now, so those scopes are its own again, and
             // taking them back is what keeps it from reaching machines nothing
             // says it reaches.
-            self.reclaim_own_scopes(&owner, &entry, &payload, &envelope_digest).await?;
+            self.reclaim_own_scopes(&owner, &entry, &variant_path, &payload, &envelope_digest)
+                .await?;
         }
         Ok(created)
     }
 
     /// Takes back the scopes of an artifact that has just been stored, for a
     /// publication that ran long enough to be written off while it was running.
+    ///
+    /// A scope may have gone to an artifact published while this one was
+    /// written off, and that artifact holds it. This one then has no claim on a
+    /// machine it reaches, so it takes its own artifact back out rather than
+    /// leaving two that reach it — the variant is named for constraints only an
+    /// identical artifact shares, so removing it removes nothing else's.
     async fn reclaim_own_scopes(
         &self,
         owner: &str,
         entry: &str,
+        variant_path: &str,
         payload: &ArtifactPayload,
         holder: &str,
     ) -> Result<()> {
@@ -428,14 +436,14 @@ impl SharedArtifactStore {
             if self.create_object(&scope_marker_path(owner, entry, scope), holder.into()).await? {
                 continue;
             }
-            if self.scope_marker(owner, entry, scope, holder).await? != ScopeMarker::Ours {
-                return Err(RegistryError::Internal {
-                    reason: format!(
-                        "shared artifact scope {scope} of entry {entry} was claimed while a \
-                         publication of an artifact reaching it was still running",
-                    ),
-                });
+            if self.scope_marker(owner, entry, scope, holder).await? == ScopeMarker::Ours {
+                continue;
             }
+            self.store.delete(&self.object_path(variant_path)).await?;
+            return Err(RegistryError::ArtifactAlreadyPublished {
+                owner: owner.to_string(),
+                entry: entry.to_string(),
+            });
         }
         Ok(())
     }

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -232,7 +232,7 @@ impl SharedArtifactStore {
     ) -> Result<bool> {
         let mut renewals = interval(PUBLICATION_RENEWAL_INTERVAL);
         renewals.tick().await;
-        let publishing = self.publish_active(prepared, reclamation_needed);
+        let publishing = self.publish_active(prepared, publication, reclamation_needed);
         let mut publishing = std::pin::pin!(publishing);
         loop {
             tokio::select! {
@@ -264,9 +264,11 @@ impl SharedArtifactStore {
     async fn publish_active(
         &self,
         prepared: PreparedPublication,
+        publication: &str,
         reclamation_needed: &mut bool,
     ) -> Result<bool> {
-        let (stored, created) = self.publish_claimed(prepared, reclamation_needed).await;
+        let (stored, created) =
+            self.publish_claimed(prepared, publication, reclamation_needed).await;
         if stored.is_err() && !created.is_empty() {
             // The scopes stay claimed. Giving them back here cannot be ordered
             // against a publication of the same envelope, which recognises these
@@ -288,16 +290,19 @@ impl SharedArtifactStore {
     async fn publish_claimed(
         &self,
         prepared: PreparedPublication,
+        publication: &str,
         reclamation_needed: &mut bool,
     ) -> (Result<bool>, Vec<String>) {
         let mut created = Vec::new();
-        let stored = self.publish_reserving(prepared, reclamation_needed, &mut created).await;
+        let stored =
+            self.publish_reserving(prepared, publication, reclamation_needed, &mut created).await;
         (stored, created)
     }
 
     async fn publish_reserving(
         &self,
         prepared: PreparedPublication,
+        publication: &str,
         reclamation_needed: &mut bool,
         created: &mut Vec<String>,
     ) -> Result<bool> {
@@ -467,6 +472,12 @@ impl SharedArtifactStore {
             // written, and a recovery that gives up leaves an artifact and
             // markers to collect.
             *reclamation_needed = true;
+            // Registered again first, and only then does the recovery look.
+            // Being written off is what let a collector run beside this
+            // publication; registering again waits for one that is running and
+            // keeps another from starting, so what the recovery reads is still
+            // there when it returns. A check on its own could not do that.
+            self.begin_publication(publication).await?;
             self.recover_after_expiry(&owner, &entry, &variant_path, &payload, &envelope_digest)
                 .await?;
         }

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -205,7 +205,13 @@ impl SharedArtifactStore {
         let publication = artifact_operation_id()?;
         self.begin_publication(&publication).await?;
         let mut reclamation_needed = false;
-        let result = self.publish_renewing(prepared, &publication, &mut reclamation_needed).await;
+        let result = self
+            .while_renewing(
+                &publication,
+                PUBLICATION_RENEWAL_INTERVAL,
+                self.publish_active(prepared, &publication, &mut reclamation_needed),
+            )
+            .await;
         let finish = self.finish_publication(&publication, reclamation_needed).await;
         if finish.is_ok()
             && let Err(error) = self.try_reclaim_unreferenced_blobs().await
@@ -216,7 +222,7 @@ impl SharedArtifactStore {
         result
     }
 
-    /// Runs a publication, saying at intervals that it is still working.
+    /// Runs `work`, saying at intervals that the publication is still working.
     ///
     /// A registration is written off so that one nobody will remove stops
     /// holding reclamation shut. Renewing keeps that from reaching a
@@ -224,28 +230,34 @@ impl SharedArtifactStore {
     /// expiry failing for a live one to go quiet long enough. That is why the
     /// recovery afterwards is not redundant — renewals can fail — but it is
     /// what makes needing it rare rather than ordinary.
-    async fn publish_renewing(
+    ///
+    /// The renewals are a branch of the select rather than a handler around it,
+    /// so `work` keeps being polled while a renewal waits. What a renewal waits
+    /// for is the lock a local usage mutation holds, and the publication holding
+    /// that lock is the one being renewed: handling renewals between polls would
+    /// leave each waiting on the other for good.
+    async fn while_renewing<Outcome>(
         &self,
-        prepared: PreparedPublication,
         publication: &str,
-        reclamation_needed: &mut bool,
-    ) -> Result<bool> {
-        let mut renewals = interval(PUBLICATION_RENEWAL_INTERVAL);
+        between_renewals: Duration,
+        work: impl Future<Output = Outcome>,
+    ) -> Outcome {
+        let mut renewals = interval(between_renewals);
         renewals.tick().await;
-        let publishing = self.publish_active(prepared, publication, reclamation_needed);
-        let mut publishing = std::pin::pin!(publishing);
-        loop {
-            tokio::select! {
-                outcome = &mut publishing => return outcome,
-                _ = renewals.tick() => {
-                    // A renewal that cannot be written is not fatal on its own:
-                    // the expiry is several renewals wide, and the publication
-                    // recovers what it lost if it is written off anyway.
-                    if let Err(error) = self.renew_publication(publication).await {
-                        tracing::warn!(%error, "shared artifact publication could not renew");
-                    }
+        let renewing = async {
+            loop {
+                renewals.tick().await;
+                // A renewal that cannot be written is not fatal on its own: the
+                // expiry is several renewals wide, and the publication recovers
+                // what it lost if it is written off anyway.
+                if let Err(error) = self.renew_publication(publication).await {
+                    tracing::warn!(%error, "shared artifact publication could not renew");
                 }
             }
+        };
+        tokio::select! {
+            outcome = work => outcome,
+            () = renewing => unreachable!("renewals stop only when the publication does"),
         }
     }
 

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -922,6 +922,11 @@ impl SharedArtifactStore {
                 variants.push(variant.location);
             }
         }
+        // Legacy variants can reach a scope another already reached — an overlap
+        // the markers are being written to stop. Writing the marker once rather
+        // than once per variant keeps a crowded entry from turning one backfill
+        // into a reservation and a release for each repeat.
+        let mut attempted = BTreeSet::new();
         for location in variants {
             let Some(relative) = self.relative_path(&location).map(str::to_string) else {
                 continue;
@@ -941,6 +946,9 @@ impl SharedArtifactStore {
                 CompatibilityScopes::These(scopes) => scopes,
             };
             for scope in &scopes {
+                if !attempted.insert(scope.clone()) {
+                    continue;
+                }
                 // Reserved before it is written and kept afterwards, like every
                 // marker: these outlive the publication that writes them, and an
                 // owner over quota must not be able to write one either.

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -411,21 +411,32 @@ impl SharedArtifactStore {
             // artifact is stored now, so those scopes are its own again, and
             // taking them back is what keeps it from reaching machines nothing
             // says it reaches.
-            self.reclaim_own_scopes(&owner, &entry, &variant_path, &payload, &envelope_digest)
+            self.recover_after_expiry(&owner, &entry, &variant_path, &payload, &envelope_digest)
                 .await?;
+            // A collector that ran beside this publication rebuilt the usage
+            // document from what it could see, which was not yet everything this
+            // publication has written. Asking for another pass is what squares
+            // the count again.
+            *reclamation_needed = true;
         }
         Ok(created)
     }
 
-    /// Takes back the scopes of an artifact that has just been stored, for a
-    /// publication that ran long enough to be written off while it was running.
+    /// Makes good what a publication that ran long enough to be written off may
+    /// have lost while it was running.
+    ///
+    /// Being written off lets reclamation run beside it, and reclamation
+    /// collects what nothing references — which, before this publication stored
+    /// its envelope, includes the blobs it had uploaded. An envelope naming
+    /// files that are not there is worse than no artifact, so they are read back
+    /// before the scopes are, and the artifact is taken out if any is gone.
     ///
     /// A scope may have gone to an artifact published while this one was
     /// written off, and that artifact holds it. This one then has no claim on a
     /// machine it reaches, so it takes its own artifact back out rather than
     /// leaving two that reach it — the variant is named for constraints only an
     /// identical artifact shares, so removing it removes nothing else's.
-    async fn reclaim_own_scopes(
+    async fn recover_after_expiry(
         &self,
         owner: &str,
         entry: &str,
@@ -433,13 +444,29 @@ impl SharedArtifactStore {
         payload: &ArtifactPayload,
         holder: &str,
     ) -> Result<()> {
+        for file in &payload.manifest.added {
+            let id = blob_id(&file.integrity).map_err(|err| protocol_error(&err))?;
+            let path = format!("{owner}/blobs/{id}");
+            let Some(bytes) = self.read_object_bounded(&path, file.size).await? else {
+                self.store.delete(&self.object_path(variant_path)).await?;
+                return Err(RegistryError::Internal {
+                    reason: format!(
+                        "blob {id} of a shared artifact was collected while the publication \
+                         storing it was still running",
+                    ),
+                });
+            };
+            verify_stored_blob(&id, &file.integrity, file.size, &bytes)?;
+        }
         let scopes = match compatibility_scopes(&payload.compatibility) {
             CompatibilityScopes::Every => BTreeSet::from([UNIVERSAL_SCOPE.to_string()]),
             CompatibilityScopes::These(scopes) => scopes,
         };
         let mut held = true;
+        let mut retaken = Vec::new();
         for scope in &scopes {
             if self.create_object(&scope_marker_path(owner, entry, scope), holder.into()).await? {
+                retaken.push(scope.clone());
                 continue;
             }
             if self.scope_marker(owner, entry, scope, holder).await? != ScopeMarker::Ours {
@@ -461,6 +488,17 @@ impl SharedArtifactStore {
         }
         if held {
             return Ok(());
+        }
+        // The scopes retaken before the one that was gone name an artifact about
+        // to be removed. Reclamation would drop them eventually; until it did,
+        // they would refuse artifacts that reach those machines on behalf of one
+        // that is not there.
+        for scope in &retaken {
+            let path = self.object_path(&scope_marker_path(owner, entry, scope));
+            match self.store.delete(&path).await {
+                Ok(()) | Err(object_store::Error::NotFound { .. }) => {}
+                Err(error) => return Err(error.into()),
+            }
         }
         self.store.delete(&self.object_path(variant_path)).await?;
         Err(RegistryError::ArtifactAlreadyPublished {

--- a/pnpr/crates/shared-artifacts/src/lib.rs
+++ b/pnpr/crates/shared-artifacts/src/lib.rs
@@ -946,11 +946,22 @@ impl SharedArtifactStore {
                 // owner over quota must not be able to write one either.
                 let bytes = digest.len() as u64;
                 self.reserve_quota(owner, bytes).await?;
-                if !self
+                match self
                     .create_object(&scope_marker_path(owner, entry, scope), digest.as_str().into())
-                    .await?
+                    .await
                 {
-                    self.release_uncommitted(owner, bytes, 0).await?;
+                    Ok(true) => {}
+                    Ok(false) => self.release_uncommitted(owner, bytes, 0).await?,
+                    Err(error) => {
+                        // A store error says nothing about whether the marker
+                        // was written, so the charge is given back and the
+                        // reclamation this failure asks for reconciles the
+                        // counters against what is stored. Keeping it would
+                        // refuse an owner publications that fit for a marker
+                        // that may not be there.
+                        self.release_uncommitted(owner, bytes, 0).await?;
+                        return Err(error);
+                    }
                 }
             }
         }

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1665,6 +1665,64 @@ async fn a_backfill_writes_each_marker_once_however_many_variants_reach_it() {
     );
 }
 
+/// A store error says nothing about whether the marker landed, so a marker
+/// that did stays charged: letting storage outgrow a quota is the worse way to
+/// be wrong, and reclamation gives back what turns out not to be there.
+#[tokio::test]
+async fn a_marker_written_by_a_failing_write_stays_charged() {
+    let stored = publication_tagged("ci/stored", &["pnpm:v1:linux-arm64-node22-glibc2.17"]);
+    let (payload, _) = stored.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&stored.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let marker = format!("{owner}/entries/{entry}/scopes/linux-arm64-node22");
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        // The write lands and then reports a failure, which is the case a
+        // conditional create cannot tell from one that stored nothing.
+        commit_before_error: true,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: None,
+        fail_slot_read_after_first: None,
+        publish_overlapping_after_create: None,
+        fail_reads_of: None,
+        fail_scope_writes: false,
+        fail_only: Some(FailOnly::WriteOf(format!(".pnpr-artifacts/v0/{marker}"))),
+        usage_writes: None,
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    // An entry holding no markers, which is what a backfill is for.
+    let envelope = serde_json::to_vec(&stored.envelope).unwrap();
+    let stored_bytes = envelope.len() as u64;
+    store.create_object(&format!("{owner}/entries/{entry}/{slot}.json"), envelope).await.unwrap();
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]);
+    let prepared = super::prepare_publication("acme", &ours).unwrap();
+
+    let error = store.backfill_scopes(&prepared).await.unwrap_err();
+
+    assert!(matches!(error, RegistryError::ObjectStore(_)), "{error:?}");
+    let usage: ArtifactUsage = serde_json::from_slice(
+        &backend
+            .get(&ObjectPath::from(".pnpr-artifacts/v0/quota.json"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let marker_bytes = stored.envelope.digest().unwrap().len() as u64;
+    assert_eq!(
+        usage.owner_bytes.values().copied().sum::<u64>(),
+        stored_bytes + marker_bytes,
+        "the marker that is there is charged for",
+    );
+}
+
 /// A marker the backfill cannot write leaves nothing charged for it: only a
 /// pass over what is stored can say whether the bytes are there, and an owner
 /// charged for what may not be is refused publications that fit.
@@ -1693,7 +1751,7 @@ async fn a_backfill_that_cannot_write_a_marker_gives_its_charge_back() {
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
     let scratch = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
-    // Written before markers existed, so the entry needs a backfill.
+    // An entry holding no markers, which is what a backfill is for.
     let envelope = serde_json::to_vec(&stored.envelope).unwrap();
     let stored_bytes = envelope.len() as u64;
     store.create_object(&format!("{owner}/entries/{entry}/{slot}.json"), envelope).await.unwrap();
@@ -1963,9 +2021,7 @@ enum FailOnly {
     /// publication takes again once its artifact is durable, rather than the
     /// reservation that precedes it.
     RegistrationAfter(String),
-    /// Deletes of this path.
     DeleteOf(String),
-    /// Writes of this path.
     WriteOf(String),
 }
 
@@ -2009,6 +2065,9 @@ impl ObjectStore for FailArtifactWrites {
                 FailOnly::DeleteOf(_) => false,
             };
             if injected {
+                if self.commit_before_error {
+                    self.inner.put_opts(location, payload, options).await?;
+                }
                 return Err(object_store::Error::Generic {
                     store: "test",
                     source: std::io::Error::other("injected write failure").into(),

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1493,6 +1493,43 @@ async fn renewing_a_publication_that_finished_records_nothing() {
     assert!(usage.active_publication_times.is_empty());
 }
 
+/// The markers an entry is given for artifacts already stored are objects like
+/// any other, so an owner with no room left cannot write them either.
+#[tokio::test]
+async fn an_owner_with_no_room_cannot_have_markers_written_for_them() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let stored = publication_tagged("ci/stored", &["pnpm:v1:linux-arm64-node22-glibc2.17"]);
+    let (payload, _) = stored.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&stored.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/{slot}.json"),
+            serde_json::to_vec(&stored.envelope).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let full =
+        SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap().with_limits(1, 1);
+    let error = full
+        .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("quota exceeded"), "{error}");
+    assert!(
+        store
+            .read_object_bounded(&format!("{owner}/entries/{entry}/scopes/linux-arm64-node22"), 128)
+            .await
+            .unwrap()
+            .is_none(),
+        "nothing is written for an owner who has no room for it",
+    );
+}
+
 /// A retried publication of the identical envelope is not an attempt to replace
 /// anything, so it stays idempotent rather than becoming a conflict.
 #[tokio::test]

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1265,7 +1265,7 @@ async fn a_publication_written_off_while_running_takes_its_scopes_back() {
         .unwrap();
 
     store
-        .reclaim_own_scopes(
+        .recover_after_expiry(
             &owner,
             &entry,
             &format!("{owner}/entries/{entry}/{slot}.json"),
@@ -1313,7 +1313,7 @@ async fn a_publication_whose_scope_went_elsewhere_takes_its_artifact_back_out() 
         .unwrap();
 
     let error = store
-        .reclaim_own_scopes(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .recover_after_expiry(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
         .await
         .unwrap_err();
 
@@ -1353,7 +1353,7 @@ async fn recovery_sees_a_scope_taken_through_the_other_form() {
         .unwrap();
 
     let error = store
-        .reclaim_own_scopes(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .recover_after_expiry(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
         .await
         .unwrap_err();
 
@@ -1364,6 +1364,79 @@ async fn recovery_sees_a_scope_taken_through_the_other_form() {
     assert!(
         store.read_object_bounded(&variant, 4096).await.unwrap().is_none(),
         "and its artifact does not stay beside the one reaching the same machines",
+    );
+}
+
+/// A publication reaching several machines can retake some scopes and then find
+/// one gone. What it retook names an artifact it is about to remove, so it puts
+/// those back too rather than refusing later artifacts on behalf of one that is
+/// not there.
+#[tokio::test]
+async fn recovery_that_loses_gives_back_what_it_had_retaken() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let tags = ["pnpm:v1:linux-arm64-node22-glibc2.17", "pnpm:v1:linux-x64-node22-glibc2.17"];
+    let ours = publication_tagged("ci/ours", &tags);
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let variant = format!("{owner}/entries/{entry}/{slot}.json");
+    store.create_object(&variant, serde_json::to_vec(&ours.envelope).unwrap()).await.unwrap();
+    // The second of the two scopes went to somebody else; the first is free, so
+    // recovery retakes it before finding the second gone.
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/scopes/linux-x64-node22"),
+            b"an artifact published meanwhile".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    store
+        .recover_after_expiry(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        store
+            .read_object_bounded(&format!("{owner}/entries/{entry}/scopes/linux-arm64-node22"), 128)
+            .await
+            .unwrap()
+            .is_none(),
+        "the scope it retook does not stay held for an artifact it removed",
+    );
+}
+
+/// Being written off lets reclamation run beside a publication, and before its
+/// envelope is stored the blobs it uploaded are referenced by nothing. An
+/// envelope naming files that are gone is worse than no artifact, so it is
+/// taken out rather than served.
+#[tokio::test]
+async fn recovery_refuses_an_artifact_whose_blobs_were_collected() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let ours = publication_with_blob("dependency-side-effects:v1:deps=abc", "ci/ours");
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let variant = format!("{owner}/entries/{entry}/{slot}.json");
+    // Stored, with the blob it names collected while the publication ran.
+    store.create_object(&variant, serde_json::to_vec(&ours.envelope).unwrap()).await.unwrap();
+
+    let error = store
+        .recover_after_expiry(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::Internal { .. }),
+        "the publication is told its artifact cannot stand, got {error:?}",
+    );
+    assert!(
+        store.read_object_bounded(&variant, 4096).await.unwrap().is_none(),
+        "and nothing is left naming files that are not there",
     );
 }
 

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1128,7 +1128,8 @@ async fn a_publication_that_never_finished_stops_holding_reclamation_shut() {
             serde_json::to_vec(&serde_json::json!({
                 "global_bytes": 0,
                 "owner_bytes": {},
-                "active_publications": { stranded: long_ago },
+                "active_publications": [stranded],
+                "active_publication_times": { stranded: long_ago },
                 "reclamation_needed": true,
             }))
             .unwrap(),
@@ -1151,16 +1152,18 @@ async fn publications_that_never_finished_stop_filling_the_limit() {
     let storage = TempDir::new().unwrap();
     let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
     let long_ago = super::registered_now() - super::ACTIVE_PUBLICATION_EXPIRY.as_secs() - 1;
-    let stranded: serde_json::Map<String, serde_json::Value> = (0..super::MAX_ACTIVE_PUBLICATIONS)
-        .map(|index| (format!("stranded-{index}"), serde_json::json!(long_ago)))
-        .collect();
+    let names: Vec<String> =
+        (0..super::MAX_ACTIVE_PUBLICATIONS).map(|index| format!("stranded-{index}")).collect();
+    let times: serde_json::Map<String, serde_json::Value> =
+        names.iter().map(|name| (name.clone(), serde_json::json!(long_ago))).collect();
     store
         .create_object(
             ".locks/usage.json",
             serde_json::to_vec(&serde_json::json!({
                 "global_bytes": 0,
                 "owner_bytes": {},
-                "active_publications": stranded,
+                "active_publications": names,
+                "active_publication_times": times,
             }))
             .unwrap(),
         )
@@ -1176,21 +1179,107 @@ async fn publications_that_never_finished_stop_filling_the_limit() {
     );
 }
 
-/// A store written before registrations carried a time has publications in
-/// flight across the upgrade, and reading those as having started at the epoch
-/// would expire them at once, letting a collector run beside one.
+/// A replica that does not keep registration times shares this document, so a
+/// publication can be registered without one. Writing it off at once would let
+/// a collector run beside one still in flight, so it is stamped instead — and
+/// the pass reports that it changed something, because a stamp nobody persists
+/// is re-made on every read and outlives every expiry.
 #[tokio::test]
-async fn a_publication_registered_before_times_were_kept_is_not_written_off() {
-    let usage: ArtifactUsage = serde_json::from_value(serde_json::json!({
+async fn a_publication_registered_without_a_time_is_stamped_rather_than_written_off() {
+    let mut usage: ArtifactUsage = serde_json::from_value(serde_json::json!({
         "global_bytes": 0,
         "owner_bytes": {},
         "active_publications": ["a-publication-in-flight"],
     }))
     .unwrap();
 
-    let mut usage = usage;
-    assert!(!super::expire_stranded_publications(&mut usage));
-    assert!(usage.active_publications.contains_key("a-publication-in-flight"));
+    assert!(super::expire_stranded_publications(&mut usage), "the stamp has to be written down");
+
+    assert!(usage.active_publications.contains("a-publication-in-flight"));
+    assert!(usage.active_publication_times.contains_key("a-publication-in-flight"));
+}
+
+/// A registration with no time is stamped, and the stamp has to reach the
+/// store even when the pass that made it goes on to refuse something: a stamp
+/// held only in memory is re-made on the next read, and the registration then
+/// outlives every expiry that would have written it off.
+#[tokio::test]
+async fn a_stamp_survives_the_pass_that_refused_on_its_account() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let names: Vec<String> =
+        (0..super::MAX_ACTIVE_PUBLICATIONS).map(|index| format!("untimed-{index}")).collect();
+    store
+        .create_object(
+            ".locks/usage.json",
+            serde_json::to_vec(&serde_json::json!({
+                "global_bytes": 0,
+                "owner_bytes": {},
+                "active_publications": names,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Refused: the limit is full of registrations that have only just been
+    // stamped, so none of them is old enough to write off yet.
+    store
+        .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
+        .await
+        .unwrap_err();
+
+    let usage: ArtifactUsage = serde_json::from_slice(
+        &store.read_object_bounded(".locks/usage.json", 1 << 20).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        usage.active_publication_times.len(),
+        super::MAX_ACTIVE_PUBLICATIONS,
+        "the stamps are on disk, so the hour they are measured against has started",
+    );
+}
+
+/// Writing off a publication that is merely slow lets reclamation give back
+/// scopes it is still holding. Its artifact is stored all the same, so it takes
+/// them back rather than being left reaching machines nothing says it reaches.
+#[tokio::test]
+async fn a_publication_written_off_while_running_takes_its_scopes_back() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let tags = ["pnpm:v1:linux-x64-node22-glibc2.17"];
+    let ours = publication_tagged("ci/ours", &tags);
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let marker = format!("{owner}/entries/{entry}/scopes/linux-x64-node22");
+    // The artifact is stored and its scope has been given back, which is where a
+    // publication written off mid-flight finds things when it comes to finish.
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/{slot}.json"),
+            serde_json::to_vec(&ours.envelope).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    store
+        .reclaim_own_scopes(&owner, &entry, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store.read_object_bounded(&marker, 128).await.unwrap().as_deref(),
+        Some(ours.envelope.digest().unwrap().as_bytes()),
+        "the stored artifact reaches its machines again",
+    );
+    let raised = ["pnpm:v1:linux-x64-node22-glibc2.31"];
+    let error = store.publish("acme", publication_tagged("ci/raised", &raised)).await.unwrap_err();
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "and one reaching the same machines is refused again, got {error:?}",
+    );
 }
 
 /// A retried publication of the identical envelope is not an attempt to replace

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1327,6 +1327,46 @@ async fn a_publication_whose_scope_went_elsewhere_takes_its_artifact_back_out() 
     );
 }
 
+/// The other form of the vocabulary reaches these machines too. A publication
+/// that took the universal key while this tagged one was written off holds it
+/// under a key this one never claims, so recovering only its own keys would
+/// leave both stored.
+#[tokio::test]
+async fn recovery_sees_a_scope_taken_through_the_other_form() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]);
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let variant = format!("{owner}/entries/{entry}/{slot}.json");
+    store.create_object(&variant, serde_json::to_vec(&ours.envelope).unwrap()).await.unwrap();
+    // Reaches every machine, including the ones this artifact reaches, and it
+    // took its key while this publication was written off.
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/scopes/universal"),
+            b"an artifact reaching everything".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    let error = store
+        .reclaim_own_scopes(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "the publication is told it lost, got {error:?}",
+    );
+    assert!(
+        store.read_object_bounded(&variant, 4096).await.unwrap().is_none(),
+        "and its artifact does not stay beside the one reaching the same machines",
+    );
+}
+
 /// A retried publication of the identical envelope is not an attempt to replace
 /// anything, so it stays idempotent rather than becoming a conflict.
 #[tokio::test]

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1265,7 +1265,13 @@ async fn a_publication_written_off_while_running_takes_its_scopes_back() {
         .unwrap();
 
     store
-        .reclaim_own_scopes(&owner, &entry, &payload, &ours.envelope.digest().unwrap())
+        .reclaim_own_scopes(
+            &owner,
+            &entry,
+            &format!("{owner}/entries/{entry}/{slot}.json"),
+            &payload,
+            &ours.envelope.digest().unwrap(),
+        )
         .await
         .unwrap();
 
@@ -1279,6 +1285,45 @@ async fn a_publication_written_off_while_running_takes_its_scopes_back() {
     assert!(
         matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
         "and one reaching the same machines is refused again, got {error:?}",
+    );
+}
+
+/// A scope can have gone to an artifact published while this one was written
+/// off, and that artifact holds it. This one is then reaching a machine nothing
+/// says it reaches, so it takes its own artifact back out rather than leaving
+/// two that reach it.
+#[tokio::test]
+async fn a_publication_whose_scope_went_elsewhere_takes_its_artifact_back_out() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]);
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let variant = format!("{owner}/entries/{entry}/{slot}.json");
+    store.create_object(&variant, serde_json::to_vec(&ours.envelope).unwrap()).await.unwrap();
+    // Published while this one was written off, and holding the scope now.
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/scopes/linux-x64-node22"),
+            b"an artifact published meanwhile".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    let error = store
+        .reclaim_own_scopes(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        matches!(error, RegistryError::ArtifactAlreadyPublished { .. }),
+        "the publication is told it lost, got {error:?}",
+    );
+    assert!(
+        store.read_object_bounded(&variant, 4096).await.unwrap().is_none(),
+        "and its artifact does not stay beside the one that holds the scope",
     );
 }
 

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -5,7 +5,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use async_trait::async_trait;
@@ -1216,6 +1216,34 @@ async fn a_publication_registered_without_a_time_is_stamped_rather_than_written_
     assert!(usage.active_publication_times.contains_key("a-publication-in-flight"));
 }
 
+/// A renewal waits for the lock a local usage mutation holds, and that
+/// mutation belongs to the publication being renewed. Waiting for it between
+/// polls of the publication would leave each waiting on the other for good.
+#[tokio::test]
+async fn a_renewal_waiting_for_the_lock_does_not_stop_the_publication() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    store.begin_publication("a-publication").await.unwrap();
+    let lock_path =
+        storage.path().join(super::ARTIFACT_CACHE_DIR).join(".locks").join("usage.lock");
+    let holding_the_lock = async {
+        let _lock = super::acquire_artifact_lock(lock_path).await.unwrap();
+        // Long enough that renewals tick while the lock is held, which is what
+        // a publication does across every usage mutation it makes.
+        tokio::time::sleep(super::ARTIFACT_LOCK_POLL_INTERVAL * 4).await;
+        "the work ran to the end"
+    };
+
+    let outcome = tokio::time::timeout(
+        Duration::from_secs(5),
+        store.while_renewing("a-publication", Duration::from_millis(1), holding_the_lock),
+    )
+    .await
+    .expect("the publication is polled while a renewal waits for the lock it holds");
+
+    assert_eq!(outcome, "the work ran to the end");
+}
+
 /// A registration with no time is stamped, and the stamp has to reach the
 /// store even when the pass that made it goes on to refuse something: a stamp
 /// held only in memory is re-made on the next read, and the registration then
@@ -1241,11 +1269,12 @@ async fn a_stamp_survives_the_pass_that_refused_on_its_account() {
 
     // Refused: the limit is full of registrations that have only just been
     // stamped, so none of them is old enough to write off yet.
-    let err = store
+    let error = store
         .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
         .await
         .unwrap_err();
-    eprintln!("ERR {err:?}");
+
+    assert!(error.to_string().contains("concurrency limit reached"), "{error}");
 
     let usage: ArtifactUsage = serde_json::from_slice(
         &store.read_object_bounded(".locks/usage.json", 1 << 20).await.unwrap().unwrap(),

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1440,6 +1440,59 @@ async fn recovery_refuses_an_artifact_whose_blobs_were_collected() {
     );
 }
 
+/// A publication says at intervals that it is still working, so one that is
+/// merely slow is never mistaken for one that stopped — which is what keeps a
+/// collector from running beside it and taking what it has not finished with.
+#[tokio::test]
+async fn a_publication_still_working_says_so() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let publication = super::artifact_operation_id().unwrap();
+    let long_ago = super::registered_now() - super::ACTIVE_PUBLICATION_EXPIRY.as_secs() - 1;
+    store
+        .create_object(
+            ".locks/usage.json",
+            serde_json::to_vec(&serde_json::json!({
+                "global_bytes": 0,
+                "owner_bytes": {},
+                "active_publications": [publication.clone()],
+                "active_publication_times": { publication.clone(): long_ago },
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    store.renew_publication(&publication).await.unwrap();
+
+    let mut usage: ArtifactUsage = serde_json::from_slice(
+        &store.read_object_bounded(".locks/usage.json", 1 << 20).await.unwrap().unwrap(),
+    )
+    .unwrap();
+    assert!(
+        !super::expire_stranded_publications(&mut usage),
+        "a registration that has just spoken is not written off",
+    );
+    assert!(usage.active_publications.contains(&publication));
+}
+
+/// Renewing says nothing about a publication that has already finished, since
+/// its registration is gone and putting a time back would leave one nothing
+/// removes.
+#[tokio::test]
+async fn renewing_a_publication_that_finished_records_nothing() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+
+    store.renew_publication("a-publication-that-finished").await.unwrap();
+
+    let usage: ArtifactUsage = serde_json::from_slice(
+        &store.read_object_bounded(".locks/usage.json", 1 << 20).await.unwrap().unwrap_or_default(),
+    )
+    .unwrap_or_default();
+    assert!(usage.active_publication_times.is_empty());
+}
+
 /// A retried publication of the identical envelope is not an attempt to replace
 /// anything, so it stays idempotent rather than becoming a conflict.
 #[tokio::test]

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -291,6 +291,7 @@ async fn failed_object_writes_reconcile_quota_to_physical_storage() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -319,6 +320,7 @@ async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -358,6 +360,7 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -393,6 +396,7 @@ async fn publication_finish_retries_a_transient_quota_write_failure() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -499,6 +503,7 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -613,6 +618,7 @@ async fn a_failed_reread_after_a_lost_race_still_releases_the_quota() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let store = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() },
@@ -820,6 +826,7 @@ async fn losing_a_race_for_a_slot_is_not_reported_as_idempotent() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let racing = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: racing, prefix: String::new() },
@@ -894,6 +901,7 @@ async fn a_publication_that_fails_gives_back_the_scopes_it_claimed() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: None,
+        usage_writes: None,
     });
     let store = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: failing, prefix: String::new() },
@@ -1269,6 +1277,7 @@ async fn a_publication_that_cannot_register_again_does_not_leave_its_artifact() 
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: Some(FailOnly::RegistrationAfter(variant.clone())),
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -1402,6 +1411,7 @@ async fn a_recovery_that_cannot_remove_its_artifact_keeps_the_scopes_it_retook()
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: Some(FailOnly::DeleteOf(format!(".pnpr-artifacts/v0/{variant}"))),
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -1601,6 +1611,60 @@ async fn renewing_a_publication_that_finished_records_nothing() {
     assert!(usage.active_publication_times.is_empty());
 }
 
+/// Legacy variants can reach a scope another already reached, and each repeat
+/// would otherwise cost a reservation and a release against the usage document.
+#[tokio::test]
+async fn a_backfill_writes_each_marker_once_however_many_variants_reach_it() {
+    let usage_writes = Arc::new(AtomicUsize::new(0));
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: None,
+        fail_slot_read_after_first: None,
+        publish_overlapping_after_create: None,
+        fail_reads_of: None,
+        fail_scope_writes: false,
+        fail_only: Some(FailOnly::WriteOf(String::new())),
+        usage_writes: Some(Arc::clone(&usage_writes)),
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    // Two artifacts stored before markers existed, whose tags differ only in a
+    // floor — so they reach the same scope, which is the overlap markers stop.
+    let floors = ["pnpm:v1:linux-x64-node22-glibc2.17", "pnpm:v1:linux-x64-node22-glibc2.31"];
+    let stored = publication_tagged("ci/stored", &floors[..1]);
+    let (payload, _) = stored.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&stored.key, &payload.subject);
+    for floor in floors {
+        let legacy = publication_tagged("ci/stored", &[floor]);
+        let (payload, _) = legacy.envelope.decode_payload().unwrap();
+        let slot = super::compatibility_slot(&payload.compatibility);
+        store
+            .create_object(
+                &format!("{owner}/entries/{entry}/{slot}.json"),
+                serde_json::to_vec(&legacy.envelope).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-arm64-node22-glibc2.17"]);
+    let prepared = super::prepare_publication("acme", &ours).unwrap();
+    usage_writes.store(0, Ordering::SeqCst);
+
+    store.backfill_scopes(&prepared).await.unwrap();
+
+    assert_eq!(
+        usage_writes.load(Ordering::SeqCst),
+        1,
+        "the one marker both variants reach is reserved once, not once each",
+    );
+}
+
 /// A marker the backfill cannot write leaves nothing charged for it: only a
 /// pass over what is stored can say whether the bytes are there, and an owner
 /// charged for what may not be is refused publications that fit.
@@ -1623,6 +1687,7 @@ async fn a_backfill_that_cannot_write_a_marker_gives_its_charge_back() {
         fail_reads_of: None,
         fail_scope_writes: false,
         fail_only: Some(FailOnly::WriteOf(format!(".pnpr-artifacts/v0/{marker}"))),
+        usage_writes: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -1887,6 +1952,9 @@ struct FailArtifactWrites {
     /// Lets every operation through except the one named, so a test can put a
     /// failure exactly where it means it.
     fail_only: Option<FailOnly>,
+    /// Counts writes of the usage document, which is what a reservation and a
+    /// release each cost against a hosted store.
+    usage_writes: Option<Arc<AtomicUsize>>,
 }
 
 #[derive(Debug)]
@@ -1915,6 +1983,11 @@ impl ObjectStore for FailArtifactWrites {
         payload: PutPayload,
         options: PutOptions,
     ) -> object_store::Result<PutResult> {
+        if let Some(writes) = self.usage_writes.as_ref()
+            && location.as_ref().ends_with("/quota.json")
+        {
+            writes.fetch_add(1, Ordering::SeqCst);
+        }
         if let Some((slot, winner)) = self.claim_slot_first.as_ref()
             && location.as_ref() == slot
         {

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1233,10 +1233,11 @@ async fn a_stamp_survives_the_pass_that_refused_on_its_account() {
 
     // Refused: the limit is full of registrations that have only just been
     // stamped, so none of them is old enough to write off yet.
-    store
+    let err = store
         .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
         .await
         .unwrap_err();
+    eprintln!("ERR {err:?}");
 
     let usage: ArtifactUsage = serde_json::from_slice(
         &store.read_object_bounded(".locks/usage.json", 1 << 20).await.unwrap().unwrap(),
@@ -1600,6 +1601,60 @@ async fn renewing_a_publication_that_finished_records_nothing() {
     assert!(usage.active_publication_times.is_empty());
 }
 
+/// A marker the backfill cannot write leaves nothing charged for it: only a
+/// pass over what is stored can say whether the bytes are there, and an owner
+/// charged for what may not be is refused publications that fit.
+#[tokio::test]
+async fn a_backfill_that_cannot_write_a_marker_gives_its_charge_back() {
+    let stored = publication_tagged("ci/stored", &["pnpm:v1:linux-arm64-node22-glibc2.17"]);
+    let (payload, _) = stored.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&stored.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let marker = format!("{owner}/entries/{entry}/scopes/linux-arm64-node22");
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: None,
+        fail_slot_read_after_first: None,
+        publish_overlapping_after_create: None,
+        fail_reads_of: None,
+        fail_scope_writes: false,
+        fail_only: Some(FailOnly::WriteOf(format!(".pnpr-artifacts/v0/{marker}"))),
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    // Written before markers existed, so the entry needs a backfill.
+    let envelope = serde_json::to_vec(&stored.envelope).unwrap();
+    let stored_bytes = envelope.len() as u64;
+    store.create_object(&format!("{owner}/entries/{entry}/{slot}.json"), envelope).await.unwrap();
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]);
+    let prepared = super::prepare_publication("acme", &ours).unwrap();
+
+    let error = store.backfill_scopes(&prepared).await.unwrap_err();
+
+    assert!(matches!(error, RegistryError::ObjectStore(_)), "{error:?}");
+    let usage: ArtifactUsage = serde_json::from_slice(
+        &backend
+            .get(&ObjectPath::from(".pnpr-artifacts/v0/quota.json"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        usage.owner_bytes.values().copied().sum::<u64>(),
+        stored_bytes,
+        "the artifact that is stored is charged, and the marker that is not is not",
+    );
+}
+
 /// The markers an entry is given for artifacts already stored are objects like
 /// any other, so an owner with no room left cannot write them either.
 #[tokio::test]
@@ -1621,10 +1676,10 @@ async fn an_owner_with_no_room_cannot_have_markers_written_for_them() {
 
     let full =
         SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap().with_limits(1, 1);
-    let error = full
-        .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
-        .await
-        .unwrap_err();
+    let ours = publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]);
+    let prepared = super::prepare_publication("acme", &ours).unwrap();
+
+    let error = full.backfill_scopes(&prepared).await.unwrap_err();
 
     assert!(error.to_string().contains("quota exceeded"), "{error}");
     assert!(
@@ -1842,6 +1897,8 @@ enum FailOnly {
     RegistrationAfter(String),
     /// Deletes of this path.
     DeleteOf(String),
+    /// Writes of this path.
+    WriteOf(String),
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -1870,13 +1927,18 @@ impl ObjectStore for FailArtifactWrites {
             });
         }
         if let Some(fail) = self.fail_only.as_ref() {
-            if let FailOnly::RegistrationAfter(stored) = fail
-                && location.as_ref().ends_with("/quota.json")
-                && self.inner.head(&ObjectPath::from(stored.as_str())).await.is_ok()
-            {
+            let injected = match fail {
+                FailOnly::RegistrationAfter(stored) => {
+                    location.as_ref().ends_with("/quota.json")
+                        && self.inner.head(&ObjectPath::from(stored.as_str())).await.is_ok()
+                }
+                FailOnly::WriteOf(path) => location.as_ref() == path,
+                FailOnly::DeleteOf(_) => false,
+            };
+            if injected {
                 return Err(object_store::Error::Generic {
                     store: "test",
-                    source: std::io::Error::other("injected registration failure").into(),
+                    source: std::io::Error::other("injected write failure").into(),
                 });
             }
             return self.inner.put_opts(location, payload, options).await;

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -1103,6 +1103,96 @@ async fn publishing_into_an_entry_that_needs_markers_keeps_its_quota_straight() 
     );
 }
 
+/// Reclamation is what gives back the scopes a failed publication claimed, and
+/// it runs only when no publication is in flight. A publication that could not
+/// unregister itself would hold that shut forever, so a registration older than
+/// any publication can plausibly take is dropped.
+#[tokio::test]
+async fn a_publication_that_never_finished_stops_holding_reclamation_shut() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let tags = ["pnpm:v1:linux-x64-node22-glibc2.17"];
+    let stranded = super::artifact_operation_id().unwrap();
+    let long_ago = super::registered_now() - super::ACTIVE_PUBLICATION_EXPIRY.as_secs() - 1;
+    let entry = {
+        let ours = publication_tagged("ci/ours", &tags);
+        let (payload, _) = ours.envelope.decode_payload().unwrap();
+        super::entry_digest(&ours.key, &payload.subject)
+    };
+    let owner = super::owner_key("acme", &OwnerScope::organization("acme")).unwrap();
+    let marker = format!("{owner}/entries/{entry}/scopes/linux-x64-node22");
+    store.create_object(&marker, b"an artifact nobody stored".to_vec()).await.unwrap();
+    store
+        .create_object(
+            ".locks/usage.json",
+            serde_json::to_vec(&serde_json::json!({
+                "global_bytes": 0,
+                "owner_bytes": {},
+                "active_publications": { stranded: long_ago },
+                "reclamation_needed": true,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    store.try_reclaim_unreferenced_blobs().await.unwrap();
+
+    assert!(
+        store.read_object_bounded(&marker, 128).await.unwrap().is_none(),
+        "the scope goes back once the publication holding the gate is written off",
+    );
+}
+
+/// Registrations nobody will remove would otherwise fill the concurrency limit
+/// and refuse publications that could run.
+#[tokio::test]
+async fn publications_that_never_finished_stop_filling_the_limit() {
+    let storage = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&HostedStoreConfig::Fs, storage.path()).unwrap();
+    let long_ago = super::registered_now() - super::ACTIVE_PUBLICATION_EXPIRY.as_secs() - 1;
+    let stranded: serde_json::Map<String, serde_json::Value> = (0..super::MAX_ACTIVE_PUBLICATIONS)
+        .map(|index| (format!("stranded-{index}"), serde_json::json!(long_ago)))
+        .collect();
+    store
+        .create_object(
+            ".locks/usage.json",
+            serde_json::to_vec(&serde_json::json!({
+                "global_bytes": 0,
+                "owner_bytes": {},
+                "active_publications": stranded,
+            }))
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .publish("acme", publication_tagged("ci/ours", &["pnpm:v1:linux-x64-node22-glibc2.17"]))
+            .await
+            .unwrap(),
+        "a full set of registrations nobody will remove does not refuse a publication",
+    );
+}
+
+/// A store written before registrations carried a time has publications in
+/// flight across the upgrade, and reading those as having started at the epoch
+/// would expire them at once, letting a collector run beside one.
+#[tokio::test]
+async fn a_publication_registered_before_times_were_kept_is_not_written_off() {
+    let usage: ArtifactUsage = serde_json::from_value(serde_json::json!({
+        "global_bytes": 0,
+        "owner_bytes": {},
+        "active_publications": ["a-publication-in-flight"],
+    }))
+    .unwrap();
+
+    let mut usage = usage;
+    assert!(!super::expire_stranded_publications(&mut usage));
+    assert!(usage.active_publications.contains_key("a-publication-in-flight"));
+}
+
 /// A retried publication of the identical envelope is not an attempt to replace
 /// anything, so it stays idempotent rather than becoming a conflict.
 #[tokio::test]

--- a/pnpr/crates/shared-artifacts/src/tests.rs
+++ b/pnpr/crates/shared-artifacts/src/tests.rs
@@ -5,6 +5,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    time::Instant,
 };
 
 use async_trait::async_trait;
@@ -289,6 +290,7 @@ async fn failed_object_writes_reconcile_quota_to_physical_storage() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -316,6 +318,7 @@ async fn committed_blob_writes_without_an_envelope_are_reclaimed() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -354,6 +357,7 @@ async fn committed_envelope_writes_that_report_failure_remain_charged() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -388,6 +392,7 @@ async fn publication_finish_retries_a_transient_quota_write_failure() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -493,6 +498,7 @@ async fn failed_reclamation_releases_its_gate_for_later_retries() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let config =
         HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
@@ -606,6 +612,7 @@ async fn a_failed_reread_after_a_lost_race_still_releases_the_quota() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let store = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() },
@@ -812,6 +819,7 @@ async fn losing_a_race_for_a_slot_is_not_reported_as_idempotent() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let racing = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: racing, prefix: String::new() },
@@ -885,6 +893,7 @@ async fn a_publication_that_fails_gives_back_the_scopes_it_claimed() {
         publish_overlapping_after_create: None,
         fail_reads_of: None,
         fail_scope_writes: false,
+        fail_only: None,
     });
     let store = SharedArtifactStore::new(
         &HostedStoreConfig::ObjectStore { store: failing, prefix: String::new() },
@@ -1240,6 +1249,49 @@ async fn a_stamp_survives_the_pass_that_refused_on_its_account() {
     );
 }
 
+/// Registering again is what makes the recovery's reads mean anything. A
+/// publication that cannot register cannot look, so it does not leave an
+/// envelope standing for blobs a collector may already have taken.
+#[tokio::test]
+async fn a_publication_that_cannot_register_again_does_not_leave_its_artifact() {
+    let request = publication("ci/unregistrable");
+    let prepared = super::prepare_publication("acme", &request).unwrap();
+    let variant = format!(".pnpr-artifacts/v0/{}", prepared.variant_path);
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: None,
+        fail_slot_read_after_first: None,
+        publish_overlapping_after_create: None,
+        fail_reads_of: None,
+        fail_scope_writes: false,
+        fail_only: Some(FailOnly::RegistrationAfter(variant.clone())),
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    let prepared = super::PreparedPublication {
+        started: Instant::now().checked_sub(super::ACTIVE_PUBLICATION_EXPIRY).unwrap(),
+        ..prepared
+    };
+    let mut reclamation_needed = false;
+    let mut created = Vec::new();
+
+    let error = store
+        .publish_reserving(prepared, "a-publication", &mut reclamation_needed, &mut created)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RegistryError::ObjectStore(_)), "{error:?}");
+    assert!(
+        backend.head(&ObjectPath::from(variant.as_str())).await.is_err(),
+        "the artifact it could not vouch for is taken back out",
+    );
+}
+
 /// Writing off a publication that is merely slow lets reclamation give back
 /// scopes it is still holding. Its artifact is stored all the same, so it takes
 /// them back rather than being left reaching machines nothing says it reaches.
@@ -1324,6 +1376,61 @@ async fn a_publication_whose_scope_went_elsewhere_takes_its_artifact_back_out() 
     assert!(
         store.read_object_bounded(&variant, 4096).await.unwrap().is_none(),
         "and its artifact does not stay beside the one that holds the scope",
+    );
+}
+
+/// The artifact goes out before the scopes it retook, so that a store error
+/// between the two never leaves it resolvable while holding nothing.
+#[tokio::test]
+async fn a_recovery_that_cannot_remove_its_artifact_keeps_the_scopes_it_retook() {
+    let tags = ["pnpm:v1:linux-arm64-node22-glibc2.17", "pnpm:v1:linux-x64-node22-glibc2.17"];
+    let ours = publication_tagged("ci/ours", &tags);
+    let (payload, _) = ours.envelope.decode_payload().unwrap();
+    let owner = super::owner_key("acme", &payload.owner).unwrap();
+    let entry = super::entry_digest(&ours.key, &payload.subject);
+    let slot = super::compatibility_slot(&payload.compatibility);
+    let variant = format!("{owner}/entries/{entry}/{slot}.json");
+    let backend: Arc<dyn ObjectStore> = Arc::new(FailArtifactWrites {
+        inner: InMemory::new(),
+        commit_before_error: false,
+        fail_deletes: false,
+        fail_next_quota_write: None,
+        claim_slot_first: None,
+        fail_slot_read_after_first: None,
+        publish_overlapping_after_create: None,
+        fail_reads_of: None,
+        fail_scope_writes: false,
+        fail_only: Some(FailOnly::DeleteOf(format!(".pnpr-artifacts/v0/{variant}"))),
+    });
+    let config =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&backend), prefix: String::new() };
+    let scratch = TempDir::new().unwrap();
+    let store = SharedArtifactStore::new(&config, scratch.path()).unwrap();
+    store.create_object(&variant, serde_json::to_vec(&ours.envelope).unwrap()).await.unwrap();
+    // Taken while this publication was written off, so the recovery loses — but
+    // only after retaking the scope that sorts before it.
+    store
+        .create_object(
+            &format!("{owner}/entries/{entry}/scopes/linux-x64-node22"),
+            b"an artifact published meanwhile".to_vec(),
+        )
+        .await
+        .unwrap();
+
+    let error = store
+        .recover_after_expiry(&owner, &entry, &variant, &payload, &ours.envelope.digest().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, RegistryError::ObjectStore(_)), "{error:?}");
+    assert_eq!(
+        store
+            .read_object_bounded(&format!("{owner}/entries/{entry}/scopes/linux-arm64-node22"), 128)
+            .await
+            .unwrap()
+            .as_deref(),
+        Some(ours.envelope.digest().unwrap().as_bytes()),
+        "the artifact that is still there still holds the scope it retook",
     );
 }
 
@@ -1722,6 +1829,19 @@ struct FailArtifactWrites {
     /// through by default, so a test injecting a failure reaches the envelope
     /// or blob it is aimed at rather than stopping at the claim.
     fail_scope_writes: bool,
+    /// Lets every operation through except the one named, so a test can put a
+    /// failure exactly where it means it.
+    fail_only: Option<FailOnly>,
+}
+
+#[derive(Debug)]
+enum FailOnly {
+    /// The quota write that follows this path being stored — the registration a
+    /// publication takes again once its artifact is durable, rather than the
+    /// reservation that precedes it.
+    RegistrationAfter(String),
+    /// Deletes of this path.
+    DeleteOf(String),
 }
 
 impl fmt::Display for FailArtifactWrites {
@@ -1748,6 +1868,18 @@ impl ObjectStore for FailArtifactWrites {
                 path: location.to_string(),
                 source: std::io::Error::other("slot claimed by another publication").into(),
             });
+        }
+        if let Some(fail) = self.fail_only.as_ref() {
+            if let FailOnly::RegistrationAfter(stored) = fail
+                && location.as_ref().ends_with("/quota.json")
+                && self.inner.head(&ObjectPath::from(stored.as_str())).await.is_ok()
+            {
+                return Err(object_store::Error::Generic {
+                    store: "test",
+                    source: std::io::Error::other("injected registration failure").into(),
+                });
+            }
+            return self.inner.put_opts(location, payload, options).await;
         }
         if !self.fail_scope_writes && location.as_ref().contains("/scopes/") {
             return self.inner.put_opts(location, payload, options).await;
@@ -1822,6 +1954,26 @@ impl ObjectStore for FailArtifactWrites {
         &self,
         locations: BoxStream<'static, object_store::Result<ObjectPath>>,
     ) -> BoxStream<'static, object_store::Result<ObjectPath>> {
+        if let Some(FailOnly::DeleteOf(failing)) = self.fail_only.as_ref() {
+            let failing = failing.clone();
+            let inner = self.inner.clone();
+            return locations
+                .then(move |location| {
+                    let (failing, inner) = (failing.clone(), inner.clone());
+                    async move {
+                        let location = location?;
+                        if location.as_ref() == failing {
+                            return Err(object_store::Error::Generic {
+                                store: "test",
+                                source: std::io::Error::other("injected deletion failure").into(),
+                            });
+                        }
+                        inner.delete(&location).await?;
+                        Ok(location)
+                    }
+                })
+                .boxed();
+        }
         if self.fail_deletes {
             locations
                 .map(|location| {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14325.

A publication registers itself in the usage document before it writes anything and unregisters when it is done. `finish_publication` retries that last write `PUBLICATION_FINISH_RETRIES` times; if every attempt fails, the registration stays, and nothing removed it. Reclamation acquires only when no publication is in flight, so it never ran again, and enough stranded registrations reached `MAX_ACTIVE_PUBLICATIONS` and refused publications that could have run.

Both halves have been there since pnpm/pnpm#14310. What changed is the cost: pnpm/pnpm#14321 made scopes claimed by publications and given back by reclamation, so a gate held shut now also leaves scopes claimed that no artifact holds — refusing every later artifact reaching those machines, not merely accumulating unreferenced blobs.

Each registration now records when it was made, and one older than an hour is written off. Reclamation drops those as it acquires rather than merely disregarding them, so the check when it completes still catches a publication that genuinely began while it ran, rather than tripping over one this run decided to ignore.

Notes for reviewers:

- **The hour is deliberately long.** Expiring a live publication is the dangerous direction — it lets a collector run beside one — so the bound is far longer than a publication that is merely slow, and far shorter than "never".
- **Stores written before registrations carried a time** deserialize as having registered when they were read, not at the epoch. A publication in flight across an upgrade is not a stranded one, and reading it as expired would let a collector run beside it. A genuinely stranded one expires an interval after the first write that stamps it.
- **`@pnpm/pnpr` only.** No client, protocol, or format change beyond a field the old shape still deserializes into.

Three regression tests: reclamation running once a stranded registration is written off, a full set of them no longer refusing a publication, and a legacy document's registrations surviving the pass. The first two fail without the fix.

## Squash Commit Body

```text
A publication registers before it writes anything and unregisters when it is
done. If every attempt at that last write fails, the registration stays, and
nothing removed it: reclamation acquires only when none is in flight, so it
never ran again, and enough of them reached the limit on publications in flight
and refused ones that could have run.

Reclamation matters more than it did. It collects unreferenced blobs, and since
scopes are claimed by publications and given back by reclamation, a gate held
shut also leaves scopes claimed that no artifact holds, refusing every later
artifact reaching those machines.

Record when each publication registered and write off one that registered longer
ago than a publication can plausibly take. Reclamation drops those as it
acquires rather than merely disregarding them, so the check when it completes
still catches a publication that began while it ran.

A registration read from a store written before times were kept counts as
beginning when it was read: a publication in flight across an upgrade is not a
stranded one, and expiring it would let a collector run beside it.

Closes pnpm/pnpm#14325.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  *(Registry-side only; no client change.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790605761&installation_model_id=426870&pr_number=14326&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14326&signature=f3cf901a50e3a04c5a0fa984562837440f038152147fab6971fd2541c10018b9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Automatically renews active publication registrations every five minutes to prevent valid, long-running publications from being abandoned.
  - Expires registrations that remain inactive for over one hour.
  - Reclaims registry storage, compatibility scopes, and in-flight publication capacity from stalled workflows.
  - Restores scope protection and safely recovers or removes artifacts after publication expiry.
  - Detects conflicts across supported scope types and prevents duplicate or unservable artifacts.
  - Correctly accounts for storage usage during scope backfill and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->