### PR TITLE
chore: unblock lockfile update workflow

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -77,6 +77,7 @@ versioning:
     '@pnpm/pnpr': alpha
 
 allowBuilds:
+  '@parcel/watcher': false
   core-js: false
   esbuild: true
   fuse-native: true
@@ -524,6 +525,7 @@ trustPolicy: no-downgrade
 trustPolicyExclude:
   - '@pnpm/*'
   - '@yarnpkg/libzip@3.2.2'
+  - fastq@1.20.2
   - pnpm
   - rxjs@7.8.2
   - tinyexec@1.2.2


### PR DESCRIPTION
## Summary

The lockfile update workflow stopped on a trust downgrade for `fastq@1.20.2`: the two preceding releases used npm trusted publishing, while this release was published manually by the package maintainer without provenance.

- Add an exact `fastq@1.20.2` trust-policy exception after verifying that its npm `gitHead` matches the maintainer-authored upstream tag and reviewing the package diff.
- Classify `@parcel/watcher` as `allowBuilds: false`. Jest 30.5 introduces it through `jest-haste-map`; its install script only builds from source when explicitly requested, so the automated update does not need to execute it.
- Restore the failing [Update Lockfile run](https://github.com/pnpm/pnpm/actions/runs/33238148384/job/99062687579) without weakening trust checks for other versions or allowing a new lifecycle script.

This changes repository automation policy only, so it does not require TypeScript/Rust parity, documentation, or a changeset.

## Squash Commit Body

```text
The daily lockfile updater could not resolve fastq 1.20.2 because that
release was manually published without the trusted-publisher evidence found
on earlier versions. Review the upstream tag and npm package contents, then
exclude only that exact version from the no-downgrade check.

Once resolution continued, Jest 30.5 introduced @parcel/watcher and pnpm
required an explicit build policy. Its install script is unnecessary when
the packaged platform binary is used, so classify the script as denied.
```

## Checklist

- [x] Confirmed the workspace configuration parses both policy entries.
- [x] Completed a fresh `pnpm update --latest --include-github-actions --no-changeset` resolution and install.
- [x] Passed the pre-push TypeScript compile, lint, spelling, and metadata checks.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14327"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790605861&installation_model_id=426870&pr_number=14327&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14327&signature=697fb822ef6eede9f729654d7085e191349f386c0419efaa4b5bea6cc7fe9cfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation settings to support required build handling.
  * Added an approved package version to the trust policy exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->