### PR TITLE
fix(pnpr): regenerate conflicted lockfiles

### DIFF
--- a/.changeset/pnpr-broken-lockfile-recovery.md
+++ b/.changeset/pnpr-broken-lockfile-recovery.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed non-frozen installs through a pnpr server failing instead of regenerating a conflicted lockfile.

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -878,6 +878,10 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         return Err(FrozenStoreIncompatibleWithPnpr.into());
     }
 
+    let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
+        state.manifest.path().parent().expect("manifest path always has a parent dir")
+    });
+
     // Borrowed from the shared state, not cloned: the frozen branch
     // below never needs an owned lockfile, so the exchange-free paths
     // pay no deep copy. The server-exchange paths clone at the point a
@@ -885,11 +889,31 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
     let previous_wanted: Option<&Lockfile> = if link.use_state_lockfile {
         let loaded =
             if link.fix_lockfile { state.lockfile.get_for_fix() } else { state.lockfile.get() };
-        loaded.map_err(|err| miette::Report::new(err).wrap_err("load the lockfile"))?
+        match loaded {
+            Ok(lockfile) => lockfile,
+            Err(error) if !link.frozen_lockfile => {
+                <Reporter as pnpm_reporter::Reporter>::emit(&pnpm_reporter::LogEvent::Pnpm(
+                    pnpm_reporter::PnpmLog {
+                        level: pnpm_reporter::LogLevel::Warn,
+                        message: format!(
+                            "Ignoring broken lockfile at {}: {error}",
+                            lockfile_dir.display(),
+                        ),
+                        prefix: lockfile_dir.to_string_lossy().into_owned(),
+                    },
+                ));
+                None
+            }
+            Err(error) => {
+                return Err(miette::Report::new(error).wrap_err("load the lockfile"));
+            }
+        }
     } else {
         None
     };
-    let merge_wanted = if link.fix_lockfile && link.use_state_lockfile {
+    let merge_wanted = if previous_wanted.is_none() {
+        None
+    } else if link.fix_lockfile && link.use_state_lockfile {
         MaybeLazyLockfile::Repair(&state.lockfile).get_for_merge().map_err(|err| {
             miette::Report::new(err).wrap_err("load the lockfile for filtered merge")
         })?
@@ -974,9 +998,6 @@ async fn install_via_pnpr_inner<Reporter: self::Reporter + 'static>(
         PnprBenchmarkRegistryOverride::resolve_registry,
     );
 
-    let lockfile_dir = link.lockfile_path.and_then(|path| path.parent()).unwrap_or_else(|| {
-        state.manifest.path().parent().expect("manifest path always has a parent dir")
-    });
     let pnpmfile_hook = if state.config.ignore_pnpmfile {
         None
     } else {

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -27,6 +27,7 @@ use std::{
     thread,
     time::Duration,
 };
+use text_block_macros::text_block_fnl;
 
 const IS_POSITIVE_PATCH: &str = include_str!(
     "../../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0.patch"
@@ -439,8 +440,13 @@ fn install_via_pnpr_links_node_modules() {
 
 #[test]
 fn install_via_pnpr_replaces_a_conflicted_lockfile() {
-    const CONFLICTED_LOCKFILE: &str =
-        "<<<<<<< HEAD\nlockfileVersion: '9.0'\n=======\nlockfileVersion: '9.0'\n>>>>>>> branch\n";
+    const CONFLICTED_LOCKFILE: &str = text_block_fnl! {
+        "<<<<<<< HEAD"
+        "lockfileVersion: '9.0'"
+        "======="
+        "lockfileVersion: '9.0'"
+        ">>>>>>> branch"
+    };
 
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -438,6 +438,48 @@ fn install_via_pnpr_links_node_modules() {
 }
 
 #[test]
+fn install_via_pnpr_replaces_a_conflicted_lockfile() {
+    const CONFLICTED_LOCKFILE: &str =
+        "<<<<<<< HEAD\nlockfileVersion: '9.0'\n=======\nlockfileVersion: '9.0'\n>>>>>>> branch\n";
+
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { npmrc_path, mock_instance, .. } = npmrc_info;
+    let (pnpr_url, token) = start_pnpr(&mock_instance.url());
+    configure_pnpr_auth(&npmrc_path, &pnpr_url, &token);
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@foo/no-deps": "1.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    fs::write(workspace.join("pnpm-lock.yaml"), CONFLICTED_LOCKFILE)
+        .expect("write conflicted lockfile");
+
+    pacquet
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+
+    let lockfile = read_workspace_lockfile(&workspace);
+    assert_eq!(workspace_importer_version(&lockfile, ".", "@foo/no-deps"), "1.0.0");
+    assert!(is_symlink_or_junction(&workspace.join("node_modules/@foo/no-deps")).unwrap());
+
+    fs::write(workspace.join("pnpm-lock.yaml"), CONFLICTED_LOCKFILE)
+        .expect("rewrite conflicted lockfile");
+    pacquet_at(&workspace)
+        .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .with_args(["install", "--fix-lockfile", "--pnpr-server", &pnpr_url])
+        .assert()
+        .success();
+    let repaired = read_workspace_lockfile(&workspace);
+    assert_eq!(workspace_importer_version(&repaired, ".", "@foo/no-deps"), "1.0.0");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn patched_dependencies_resolve_via_pnpr() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Make non-frozen pnpr installs recover from unreadable wanted lockfiles, including files containing Git conflict markers. The client now warns, resolves from the manifests without sending the malformed lockfile, and writes a clean replacement.

Frozen installs remain strict. The TypeScript CLI already recovers from unreadable lockfiles, so this brings the Rust pnpr path into parity without requiring a TypeScript change.

## Squash Commit Body

```text
Treat an unreadable wanted lockfile as regenerable state during non-frozen
pnpr installs, matching local install behavior. Warn before resolving from
the manifests and omit the malformed lockfile from the pnpr request.

Keep frozen installs strict, and prevent --fix-lockfile from retrying the
same malformed lockfile during lockfile merging.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users because it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (OpenCode, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790606241&installation_model_id=426870&pr_number=14329&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14329&signature=6dbb4b3e5c45800be1efb0362de3541d0044b44f1cb19762d1c0828d1cb75fab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-frozen installs through a pnpr server now recover from conflicted or unreadable lockfiles by regenerating them instead of failing.
  * Frozen installs continue to report an error when the lockfile is invalid, preserving strict installation behavior.
  * Lockfile repair now works correctly with the `--fix-lockfile` option, allowing affected installations to complete successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->