### PR TITLE
fix(ci): pin Jest to 30.4

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,8 +132,8 @@ catalogs:
       specifier: ^8.7.0
       version: 8.7.0
     '@jest/globals':
-      specifier: 30.5.0
-      version: 30.5.0
+      specifier: 30.4.1
+      version: 30.4.1
     '@npm/types':
       specifier: ^2.1.0
       version: 2.1.0
@@ -522,11 +522,11 @@ catalogs:
       specifier: 4.0.0
       version: 4.0.0
     jest:
-      specifier: ^30.5.0
-      version: 30.5.0
+      specifier: 30.4.2
+      version: 30.4.2
     jest-diff:
-      specifier: ^30.5.0
-      version: 30.5.0
+      specifier: 30.4.1
+      version: 30.4.1
     js-yaml:
       specifier: npm:@zkochan/js-yaml@0.0.11
       version: 0.0.11
@@ -950,7 +950,7 @@ importers:
         version: 9.1.7
       jest:
         specifier: 'catalog:'
-        version: 30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
+        version: 30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
       keyv:
         specifier: 'catalog:'
         version: 5.6.0
@@ -1059,7 +1059,7 @@ importers:
     dependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-store':
         specifier: workspace:*
         version: link:../assert-store
@@ -1114,7 +1114,7 @@ importers:
     dependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: link:../../store/cafs
@@ -1173,7 +1173,7 @@ importers:
         version: 8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint-plugin-jest:
         specifier: 'catalog:'
-        version: 29.16.5(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(jest@30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
+        version: 29.16.5(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(jest@30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
 
   pnpm11/__utils__/get-release-text:
     dependencies:
@@ -1201,7 +1201,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/get-release-text':
         specifier: workspace:*
         version: 'link:'
@@ -1238,7 +1238,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/jest-config':
         specifier: workspace:*
         version: 'link:'
@@ -1318,7 +1318,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/jest-config':
         specifier: workspace:*
         version: link:../jest-config
@@ -1355,7 +1355,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/prepare':
         specifier: workspace:*
         version: link:../prepare
@@ -1413,7 +1413,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/auth.commands':
         specifier: workspace:*
         version: 'link:'
@@ -1474,7 +1474,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/bins.linker':
         specifier: workspace:*
         version: 'link:'
@@ -1557,7 +1557,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/bins.resolver':
         specifier: workspace:*
         version: 'link:'
@@ -1745,7 +1745,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../../__utils__/assert-project
@@ -1866,7 +1866,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/building.during-install':
         specifier: workspace:*
         version: 'link:'
@@ -1901,7 +1901,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/building.policy':
         specifier: workspace:*
         version: 'link:'
@@ -1966,7 +1966,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/cache.commands':
         specifier: workspace:*
         version: 'link:'
@@ -1997,7 +1997,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/catalogs.config':
         specifier: workspace:*
         version: 'link:'
@@ -2012,7 +2012,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/catalogs.protocol-parser':
         specifier: workspace:*
         version: 'link:'
@@ -2028,7 +2028,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/catalogs.resolver':
         specifier: workspace:*
         version: 'link:'
@@ -2096,7 +2096,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/cli.commands':
         specifier: workspace:*
         version: 'link:'
@@ -2178,7 +2178,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/cli.default-reporter':
         specifier: workspace:*
         version: 'link:'
@@ -2215,7 +2215,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/cli.meta':
         specifier: workspace:*
         version: 'link:'
@@ -2237,7 +2237,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/cli.parse-cli-args':
         specifier: workspace:*
         version: 'link:'
@@ -2332,7 +2332,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.commands':
         specifier: workspace:*
         version: 'link:'
@@ -2360,7 +2360,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.matcher':
         specifier: workspace:*
         version: 'link:'
@@ -2382,7 +2382,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.normalize-registries':
         specifier: workspace:*
         version: 'link:'
@@ -2422,7 +2422,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.package-is-installable':
         specifier: workspace:*
         version: 'link:'
@@ -2453,7 +2453,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.parse-overrides':
         specifier: workspace:*
         version: 'link:'
@@ -2469,7 +2469,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.normalize-registries':
         specifier: workspace:*
         version: link:../normalize-registries
@@ -2581,7 +2581,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.reader':
         specifier: workspace:*
         version: 'link:'
@@ -2614,7 +2614,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.registry-auth-key':
         specifier: workspace:*
         version: 'link:'
@@ -2636,7 +2636,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.version-policy':
         specifier: workspace:*
         version: 'link:'
@@ -2684,7 +2684,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/error':
         specifier: workspace:*
         version: 'link:'
@@ -2700,7 +2700,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: 'link:'
@@ -2722,7 +2722,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/crypto.hash':
         specifier: workspace:*
         version: 'link:'
@@ -2747,7 +2747,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/crypto.integrity':
         specifier: workspace:*
         version: 'link:'
@@ -2763,7 +2763,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/crypto.object-hasher':
         specifier: workspace:*
         version: 'link:'
@@ -2791,7 +2791,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@openpgp/web-stream-tools':
         specifier: 'catalog:'
         version: 0.3.1(@types/node@22.19.19)(typescript@6.0.3)
@@ -2837,7 +2837,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../../core/constants
@@ -2970,7 +2970,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.compliance.commands':
         specifier: workspace:*
         version: 'link:'
@@ -3021,7 +3021,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.compliance.license-resolver':
         specifier: workspace:*
         version: 'link:'
@@ -3079,7 +3079,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.normalize-registries':
         specifier: workspace:*
         version: link:../../../config/normalize-registries
@@ -3158,7 +3158,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.compliance.sbom':
         specifier: workspace:*
         version: 'link:'
@@ -3201,7 +3201,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.github-actions':
         specifier: workspace:*
         version: 'link:'
@@ -3268,7 +3268,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.graph-builder':
         specifier: workspace:*
         version: 'link:'
@@ -3308,7 +3308,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.graph-hasher':
         specifier: workspace:*
         version: 'link:'
@@ -3317,7 +3317,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.graph-sequencer':
         specifier: workspace:*
         version: 'link:'
@@ -3429,7 +3429,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../../core/constants
@@ -3508,7 +3508,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.inspection.list':
         specifier: workspace:*
         version: 'link:'
@@ -3575,7 +3575,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.inspection.outdated':
         specifier: workspace:*
         version: 'link:'
@@ -3627,7 +3627,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.inspection.peers-checker':
         specifier: workspace:*
         version: 'link:'
@@ -3649,7 +3649,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.inspection.peers-issues-renderer':
         specifier: workspace:*
         version: 'link:'
@@ -3722,7 +3722,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../../core/constants
@@ -3753,7 +3753,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.path':
         specifier: workspace:*
         version: 'link:'
@@ -3791,7 +3791,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.security.signatures':
         specifier: workspace:*
         version: 'link:'
@@ -3861,7 +3861,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/deps.status':
         specifier: workspace:*
         version: 'link:'
@@ -3985,7 +3985,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../../core/constants
@@ -4083,7 +4083,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/engine.runtime.commands':
         specifier: workspace:*
         version: 'link:'
@@ -4166,7 +4166,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/engine.runtime.node-resolver':
         specifier: workspace:*
         version: 'link:'
@@ -4194,7 +4194,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/engine.runtime.system-version':
         specifier: workspace:*
         version: 'link:'
@@ -4327,7 +4327,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/engine.runtime.system-version':
         specifier: workspace:*
         version: link:../../engine/runtime/system-version
@@ -4372,7 +4372,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/exec.esm-node-path-loader':
         specifier: workspace:*
         version: 'link:'
@@ -4424,7 +4424,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/exec.lifecycle':
         specifier: workspace:*
         version: 'link:'
@@ -4489,7 +4489,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/exec.prepare-package':
         specifier: workspace:*
         version: 'link:'
@@ -4544,7 +4544,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.binary-fetcher':
         specifier: workspace:*
         version: 'link:'
@@ -4581,7 +4581,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.directory-fetcher':
         specifier: workspace:*
         version: 'link:'
@@ -4649,7 +4649,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.git-fetcher':
         specifier: workspace:*
         version: 'link:'
@@ -4692,7 +4692,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.pick-fetcher':
         specifier: workspace:*
         version: 'link:'
@@ -4762,7 +4762,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.tarball-fetcher':
         specifier: workspace:*
         version: 'link:'
@@ -4840,7 +4840,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fs.hard-link-dir':
         specifier: workspace:*
         version: 'link:'
@@ -4889,7 +4889,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fs.indexed-pkg-importer':
         specifier: workspace:*
         version: 'link:'
@@ -4907,7 +4907,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fs.is-empty-dir-or-nothing':
         specifier: workspace:*
         version: 'link:'
@@ -4955,7 +4955,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fs.symlink-dependency':
         specifier: workspace:*
         version: 'link:'
@@ -5037,7 +5037,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/global.commands':
         specifier: workspace:*
         version: 'link:'
@@ -5102,7 +5102,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.fetcher-base':
         specifier: workspace:*
         version: link:../../fetching/fetcher-base
@@ -5151,7 +5151,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/hooks.read-package-hook':
         specifier: workspace:*
         version: 'link:'
@@ -5188,7 +5188,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/hooks.types':
         specifier: workspace:*
         version: 'link:'
@@ -5246,7 +5246,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/fetching.fetcher-base':
         specifier: workspace:*
         version: link:../../fetching/fetcher-base
@@ -5490,7 +5490,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../../__utils__/assert-project
@@ -5550,7 +5550,7 @@ importers:
         version: 7.0.0
       jest-diff:
         specifier: 'catalog:'
-        version: 30.5.0
+        version: 30.4.1
       path-name:
         specifier: 'catalog:'
         version: 1.0.0
@@ -5620,7 +5620,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.context':
         specifier: workspace:*
         version: 'link:'
@@ -5648,7 +5648,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.dedupe.check':
         specifier: workspace:*
         version: 'link:'
@@ -5667,7 +5667,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.dedupe.issues-renderer':
         specifier: workspace:*
         version: 'link:'
@@ -5887,7 +5887,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../../__utils__/assert-project
@@ -6122,7 +6122,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.deps-resolver':
         specifier: workspace:*
         version: 'link:'
@@ -6255,7 +6255,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../../__utils__/assert-project
@@ -6406,7 +6406,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.env-installer':
         specifier: workspace:*
         version: 'link:'
@@ -6575,7 +6575,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.linking.real-hoist':
         specifier: workspace:*
         version: 'link:'
@@ -6609,7 +6609,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.modules-yaml':
         specifier: workspace:*
         version: 'link:'
@@ -6700,7 +6700,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.client':
         specifier: workspace:*
         version: link:../client
@@ -6826,7 +6826,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.filtering':
         specifier: workspace:*
         version: 'link:'
@@ -6905,7 +6905,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.fs':
         specifier: workspace:*
         version: 'link:'
@@ -6975,7 +6975,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.make-dedicated-lockfile':
         specifier: workspace:*
         version: 'link:'
@@ -7009,7 +7009,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.merger':
         specifier: workspace:*
         version: 'link:'
@@ -7040,7 +7040,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.preferred-versions':
         specifier: workspace:*
         version: 'link:'
@@ -7068,7 +7068,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.pruner':
         specifier: workspace:*
         version: 'link:'
@@ -7102,7 +7102,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.settings-checker':
         specifier: workspace:*
         version: 'link:'
@@ -7142,7 +7142,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.to-pnp':
         specifier: workspace:*
         version: 'link:'
@@ -7207,7 +7207,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/lockfile.utils':
         specifier: workspace:*
         version: 'link:'
@@ -7274,7 +7274,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../core/constants
@@ -7357,7 +7357,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/constants':
         specifier: workspace:*
         version: link:../../core/constants
@@ -7389,7 +7389,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/network.auth-header':
         specifier: workspace:*
         version: 'link:'
@@ -7429,7 +7429,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -7448,7 +7448,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/network.git-utils':
         specifier: workspace:*
         version: 'link:'
@@ -7470,7 +7470,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/network.web-auth':
         specifier: workspace:*
         version: 'link:'
@@ -7489,7 +7489,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/object.key-sorting':
         specifier: workspace:*
         version: 'link:'
@@ -7502,7 +7502,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/object.property-path':
         specifier: workspace:*
         version: 'link:'
@@ -7518,7 +7518,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -7633,7 +7633,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -7694,7 +7694,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/patching.config':
         specifier: workspace:*
         version: 'link:'
@@ -7731,7 +7731,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/pkg-manifest.commands':
         specifier: workspace:*
         version: 'link:'
@@ -7756,7 +7756,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/pkg-manifest.reader':
         specifier: workspace:*
         version: 'link:'
@@ -7787,7 +7787,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -7812,7 +7812,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../__utils__/assert-project
@@ -8149,7 +8149,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/exe':
         specifier: workspace:*
         version: 'link:'
@@ -8312,7 +8312,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -8544,7 +8544,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-project':
         specifier: workspace:*
         version: link:../../__utils__/assert-project
@@ -8647,7 +8647,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/catalogs.config':
         specifier: workspace:*
         version: link:../../catalogs/config
@@ -8702,7 +8702,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/releasing.versioning':
         specifier: workspace:*
         version: 'link:'
@@ -8757,7 +8757,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/config.normalize-registries':
         specifier: workspace:*
         version: link:../../config/normalize-registries
@@ -8809,7 +8809,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/resolving.git-resolver':
         specifier: workspace:*
         version: 'link:'
@@ -8837,7 +8837,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/resolving.jsr-specifier-parser':
         specifier: workspace:*
         version: 'link:'
@@ -8868,7 +8868,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -8989,7 +8989,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -9051,7 +9051,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../../core/logger
@@ -9080,7 +9080,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/resolving.resolver-base':
         specifier: workspace:*
         version: 'link:'
@@ -9096,7 +9096,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/network.fetch':
         specifier: workspace:*
         version: link:../../network/fetch
@@ -9115,7 +9115,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/resolving.tarball-url':
         specifier: workspace:*
         version: 'link:'
@@ -9128,7 +9128,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/shell.path':
         specifier: workspace:*
         version: 'link:'
@@ -9174,7 +9174,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/store.cafs':
         specifier: workspace:*
         version: 'link:'
@@ -9298,7 +9298,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/assert-store':
         specifier: workspace:*
         version: link:../../__utils__/assert-store
@@ -9386,7 +9386,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -9453,7 +9453,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/installing.client':
         specifier: workspace:*
         version: link:../../installing/client
@@ -9546,7 +9546,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/store.index':
         specifier: workspace:*
         version: 'link:'
@@ -9586,7 +9586,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/store.path':
         specifier: workspace:*
         version: 'link:'
@@ -9617,7 +9617,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/store.pkg-finder':
         specifier: workspace:*
         version: 'link:'
@@ -9691,7 +9691,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.comments-parser':
         specifier: workspace:*
         version: 'link:'
@@ -9700,7 +9700,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.naming-cases':
         specifier: workspace:*
         version: 'link:'
@@ -9709,7 +9709,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.ordinal-comparator':
         specifier: workspace:*
         version: 'link:'
@@ -9718,7 +9718,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.sanitize':
         specifier: workspace:*
         version: 'link:'
@@ -9727,7 +9727,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/text.tree-renderer':
         specifier: workspace:*
         version: 'link:'
@@ -9779,7 +9779,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../core/logger
@@ -9837,7 +9837,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/prepare':
         specifier: workspace:*
         version: link:../../__utils__/prepare
@@ -9898,7 +9898,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -9965,7 +9965,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/test-fixtures':
         specifier: workspace:*
         version: link:../../__utils__/test-fixtures
@@ -10002,7 +10002,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.project-manifest-writer':
         specifier: workspace:*
         version: 'link:'
@@ -10048,7 +10048,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types
@@ -10100,7 +10100,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.projects-graph':
         specifier: workspace:*
         version: 'link:'
@@ -10137,7 +10137,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -10159,7 +10159,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.projects-sorter':
         specifier: workspace:*
         version: 'link:'
@@ -10172,7 +10172,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.range-resolver':
         specifier: workspace:*
         version: 'link:'
@@ -10191,7 +10191,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.root-finder':
         specifier: workspace:*
         version: 'link:'
@@ -10200,7 +10200,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.spec-parser':
         specifier: workspace:*
         version: 'link:'
@@ -10225,7 +10225,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -10259,7 +10259,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/logger':
         specifier: workspace:*
         version: link:../../core/logger
@@ -10284,7 +10284,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/workspace.workspace-manifest-reader':
         specifier: workspace:*
         version: 'link:'
@@ -10333,7 +10333,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/prepare':
         specifier: workspace:*
         version: link:../../__utils__/prepare
@@ -10367,7 +10367,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/yaml.document-sync':
         specifier: workspace:*
         version: 'link:'
@@ -10407,7 +10407,7 @@ importers:
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
-        version: 30.5.0(supports-color@10.2.2)
+        version: 30.4.1(supports-color@10.2.2)
       '@pnpm/pnpr.client':
         specifier: workspace:*
         version: 'link:'
@@ -11359,12 +11359,12 @@ packages:
     resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
     engines: {node: '>=8'}
 
-  '@jest/console@30.5.0':
-    resolution: {integrity: sha512-BI1DpOedrJqbrYVi9yNhDWGjqphR/+gsM4STmg2+VaeXm7851hvpBDyKOZGMXATTrGEnFuEseQvLCtrrRmG0GQ==}
+  '@jest/console@30.4.1':
+    resolution: {integrity: sha512-v3bhyxUh9Hgmo5p6hAOXe14/R3ZxZDOsvHleh4B07z3m/x4/ngPUXEm9XwK4sF4u+f+P2ORb0Ge+MgpaqRMVDA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/core@30.5.0':
-    resolution: {integrity: sha512-DLjRME+NY//j+UDTSfWnjoP0srrdR3DrJRy7yFZktGIwzpN2iVy2vMo0jziZ5c2Ij7bOwlJRXKVWtxZusazOJg==}
+  '@jest/core@30.4.2':
+    resolution: {integrity: sha512-TZJA6cPJUFxoWhxaLo8t0VX/MZX2wPWr0uIDvLSHIvN4gu9h02vSzqI2kBADG1ExqQlC+cY09xKMSreivvrChQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -11372,40 +11372,56 @@ packages:
       node-notifier:
         optional: true
 
+  '@jest/diff-sequences@30.4.0':
+    resolution: {integrity: sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/diff-sequences@30.5.0':
     resolution: {integrity: sha512-OsqBjHXCn8cadasoAZBP6nWYvMsRhpMzGXTpxJ5aO04NlbdhIz+FVe3q49l0AwVhsz/cEmIpBes6gAFl1/dWQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/environment@30.5.0':
-    resolution: {integrity: sha512-HUaqexIauIh69IQ4NTuPDEUCB8g8T4TOPSIzQOS18mwI/KEHKQk1j013K2o6ra031szZE2t5jGmVx3xbzdjgKA==}
+  '@jest/environment@30.4.1':
+    resolution: {integrity: sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/expect-utils@30.4.1':
+    resolution: {integrity: sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/expect-utils@30.5.0':
     resolution: {integrity: sha512-5j0ztPxSy3McUJihjkDdCyCfjvT2hxykFTWsgEBZKB8qsw9ALdCiGTpTRH5gnf/d+qI4SflYUJ0dWNbzjQCWbA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/expect@30.5.0':
-    resolution: {integrity: sha512-jEmgmgJEobJ3zEhDOGp1VAJ6JkoVelpS8uZ1ae1Ul/5lP78UKJKmmU0lciJwd6JdnqOXHaaS/QCKwbf1dHI9MA==}
+  '@jest/expect@30.4.1':
+    resolution: {integrity: sha512-ginrj6TMgh2GshLUGCjO94Ptx9HhdZA/I6A9iUfyeLKFtdAjnKzHDgzgP9HYQgbxM1lbXScQ2eUBz2lGeVDPWA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/fake-timers@30.5.0':
-    resolution: {integrity: sha512-sg8xIbYwe5GdB/vT3/0qrDIpO7Ov9mazHi++M95uynmDKEZ70G1r169AWct73H07VrTZhrz1SJEfLtjYv8tE3A==}
+  '@jest/fake-timers@30.4.1':
+    resolution: {integrity: sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/get-type@30.1.0':
+    resolution: {integrity: sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/get-type@30.5.0':
     resolution: {integrity: sha512-9/2VUPitAjmBzbvDvqrxmvB7BzWsBW0WmkkojX1ODuxX1NLGxx9gfaZpHB0z8DtJ9uhGNmZG/VXBhf8uO0OV8Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/globals@30.5.0':
-    resolution: {integrity: sha512-h7eJx534czwL8lQMYB0hwLT4/HquO8EX/RtYL7RNUHyUyWWVciYjoudN4Ns5JmNvn2/jh0Vm9UstZjEzJJ5EsQ==}
+  '@jest/globals@30.4.1':
+    resolution: {integrity: sha512-ZbuY4cmXC8DkxYjfvT2DbcHWL2T6vmsMhXCDcmTB2T0y0gaezBI77ufq5ZAIdcRkYZ7NEQEDg1xFeKbxUJ5v5Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/pattern@30.5.0':
     resolution: {integrity: sha512-HdNQYSdRTEBNrginaqzQtTjG0HRMfrra/z6Ok7uL3S87vSlarIVohEsJsSj5edu3MiHoHjAkvPROz5ZjoKai+w==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/reporters@30.5.0':
-    resolution: {integrity: sha512-FEAuusWm+PUOn9ydjaHhpOpyPmS6IbGE04HaKTuUI4zd8eqYZiXiNLoCsdCog/l2XnNj53E9pFy64UltcvfJKg==}
+  '@jest/reporters@30.4.1':
+    resolution: {integrity: sha512-/SnkPCzEQpUaBH81kjdEdDdo2WZl5hxw+BmLDGWjRkm8o7XlhjwsU36cqwe5PGBE5WYpBvDzRSdXx9rbGuJtNA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -11417,33 +11433,41 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   '@jest/schemas@30.5.0':
     resolution: {integrity: sha512-/hunigyNpc4RCjC0VaW3f5RCUZVM2+WQ65qP7z083Gmvac7or2LI50XVNOtE4YPgBpV0yxYiAgorAPGniCoJmg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/snapshot-utils@30.5.0':
-    resolution: {integrity: sha512-iWQtIsi2dRsO2oWzVceOeynuRJiYTW8gsDVp5wFQ02ipHluQsNgBpasWSHiawVxukIlsGLdCtCSbIEK7fPtpvQ==}
+  '@jest/snapshot-utils@30.4.1':
+    resolution: {integrity: sha512-ObY4ljvQ95mt6iwKtVLetR/4yXiAgl3H4nJxhztr0MTjrN97TwDYrnCp/kF60Ec9HdhkWTHSu+Hg05aXfngpOA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/source-map@30.5.0':
-    resolution: {integrity: sha512-xWpTJP9D0bDFGbPGT8XuWSwwha/iHADyyKzUnMx4UbdgnHugxrDaQFO4RZ8x4ZsFzRP6pNii8uvlgKCDxCIuDg==}
+  '@jest/source-map@30.0.1':
+    resolution: {integrity: sha512-MIRWMUUR3sdbP36oyNyhbThLHyJ2eEDClPCiHVbrYAe5g3CHRArIVpBw7cdSB5fr+ofSfIb2Tnsw8iEHL0PYQg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-result@30.5.0':
-    resolution: {integrity: sha512-9IlPqUzUMkVDmoDqSSrVVLroVotgN3hTUPWPwq24XWXhh1Zpg915RXZ5pgRJ/7j4YE/kng5nqjSn4p3S68SZJA==}
+  '@jest/test-result@30.4.1':
+    resolution: {integrity: sha512-/ZG7pgEiOmmWkN9TplKbOu4id2N5lh7FHwRwlkgBVAzGdRH+OkkQ8wX/kIxg4zmd3ZQvAL1RwL2yWsvNYYECTw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/test-sequencer@30.5.0':
-    resolution: {integrity: sha512-TXlvSDIVv482b83hD8A8WtxDJEmGF47f60W6jRXOQL0Isfs3hKtk4rZIm9R/jLzAibg8+c56y+Q00BQs8R7Xcg==}
+  '@jest/test-sequencer@30.4.1':
+    resolution: {integrity: sha512-PeYE+4td5rKjoRPxztObrXU+H8hsjZfxKMXOcmrr34JerSyB/ROOxbbicz8B7A5j9R9VayDnVPvBmedqCsFCdw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  '@jest/transform@30.5.0':
-    resolution: {integrity: sha512-n1cYhoByyULEIXi64wbT4Lq91qeT1E6bwpM//sprFXhw955qaiHTdAmy1c1rNFGB6fCf1J+nxDUSf3RGwgZP5A==}
+  '@jest/transform@30.4.1':
+    resolution: {integrity: sha512-Wz0LyktlTvRefoymh+n64hQ84KNXsRGcwdoZ8CSa0Ea+fgYcHZlnk+hDP7v2MS7il2bQ5uTEIxf4/NNfhMN4KQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@29.6.3':
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/types@30.5.0':
     resolution: {integrity: sha512-s1N+79S4Yp9ZgklCauZXi+YPJdCdtStNYQT32stuD6EeQaIBGHoUfyj2P0YWy8RmuQfaJboO+ulxEvEheR/POQ==}
@@ -11574,88 +11598,6 @@ packages:
         optional: true
       typescript:
         optional: true
-
-  '@parcel/watcher-android-arm64@2.6.0':
-    resolution: {integrity: sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-
-  '@parcel/watcher-darwin-arm64@2.6.0':
-    resolution: {integrity: sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@parcel/watcher-darwin-x64@2.6.0':
-    resolution: {integrity: sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@parcel/watcher-freebsd-x64@2.6.0':
-    resolution: {integrity: sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@parcel/watcher-linux-arm-glibc@2.6.0':
-    resolution: {integrity: sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@parcel/watcher-linux-arm-musl@2.6.0':
-    resolution: {integrity: sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-    libc: [musl]
-
-  '@parcel/watcher-linux-arm64-glibc@2.6.0':
-    resolution: {integrity: sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@parcel/watcher-linux-arm64-musl@2.6.0':
-    resolution: {integrity: sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@parcel/watcher-linux-x64-glibc@2.6.0':
-    resolution: {integrity: sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@parcel/watcher-linux-x64-musl@2.6.0':
-    resolution: {integrity: sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@parcel/watcher-win32-arm64@2.6.0':
-    resolution: {integrity: sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@parcel/watcher-win32-x64@2.6.0':
-    resolution: {integrity: sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@parcel/watcher@2.6.0':
-    resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
-    engines: {node: '>= 10.0.0'}
 
   '@pkgr/core@0.3.6':
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
@@ -13084,18 +13026,18 @@ packages:
       react-native-b4a:
         optional: true
 
-  babel-jest@30.5.0:
-    resolution: {integrity: sha512-PrhPHlKC+MsLnuNzgIH/y1dkz1f6cSfKWaQeaG8WxLMuG44dYWQ8E9uRrsBbAGCU/3+BEFYPN4d6G3Zc5Y+waA==}
+  babel-jest@30.4.1:
+    resolution: {integrity: sha512-fATAbM8piYxkiXQp3RBXmZHxZVNJZAVXXfyeyCN2Tida3+qJ8ea9UxhiJ2y4fLO90ZImKt6k9FlcH2+rLkJGhw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-0
 
-  babel-plugin-istanbul@8.0.0:
-    resolution: {integrity: sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==}
-    engines: {node: '>=18'}
+  babel-plugin-istanbul@7.0.1:
+    resolution: {integrity: sha512-D8Z6Qm8jCvVXtIRkBnqNHX0zJ37rQcFJ9u8WOS6tkYOsRdHBzypCstaxWiu5ZIlqQtviRYbgnRLSoCEvjqcqbA==}
+    engines: {node: '>=12'}
 
-  babel-plugin-jest-hoist@30.5.0:
-    resolution: {integrity: sha512-gtGo1B+u14jrZQv6TdSWIWkTqclboo7Qn+dFAGUOIuXLFuJKAdg3U5MIWzZnW4vfUb4dX9skmAMiby86e/SF4A==}
+  babel-plugin-jest-hoist@30.4.0:
+    resolution: {integrity: sha512-9EdtWM/sSfXLOGLwSn+GS6pIXyBnL07/8gyJlwFXjWy4DxMOyItqyUT29d4lQiS380EZwYlX7/At4PgBS+m2aA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   babel-preset-current-node-syntax@1.2.0:
@@ -13103,11 +13045,11 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0 || ^8.0.0-0
 
-  babel-preset-jest@30.5.0:
-    resolution: {integrity: sha512-ZGPn5ClP4lBDpuOK8W1yQIOy359HmbnZv3suucAlIe+SEE9yDsxV4S2PjSbH2Vc97U+WmzYD7vw3kr8NsQ/i6w==}
+  babel-preset-jest@30.4.0:
+    resolution: {integrity: sha512-lBY4jxsNmCnSiu7kquw8ZC9F4+XLMOKypT3RnNHPvU2Kpd4W0xaPuLr5ZkRyOsvLYAY4yaW1ZwTW4xB7NIiZzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
-      '@babel/core': ^7.11.0 || ^8.0.0-beta.1 || ^8.0.0
+      '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -13205,6 +13147,9 @@ packages:
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -13848,9 +13793,6 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
-  es-module-lexer@2.3.2:
-    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
-
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
@@ -14057,6 +13999,10 @@ packages:
   exit-x@0.2.2:
     resolution: {integrity: sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect@30.4.1:
+    resolution: {integrity: sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   expect@30.5.0:
     resolution: {integrity: sha512-8fiMWcEjPU7B9nErC4FtFcCzf2tC6I75Qf7m8wzBAWC2taZmcno3yAFEjIQL34SwoGZNgPf63UDiJLyh4SMPaw==}
@@ -14905,16 +14851,16 @@ packages:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
 
-  jest-changed-files@30.5.0:
-    resolution: {integrity: sha512-dq1x8JiEnHkJDxxOrF6UJDivBRAQMwAa5tzr+VX3um0SfyMFseUPQUbe51wLwggfoa5h/EmOtSpdJxxkzSlNRQ==}
+  jest-changed-files@30.4.1:
+    resolution: {integrity: sha512-IuctmYrxi21iOSOaIXpJWalHyPAsVv0GeBHKDn8C1CA4W5htHn7INL+wdnL4Bo0+olEndvAFkmb++tIQJG+vvg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-circus@30.5.0:
-    resolution: {integrity: sha512-T3v7uM4wwCu+RQicjsAWCgoL3CiyuX3THSKwv2uMb9N2bMUgb+HfwDWEUma85vOGbvQNQ/YfoCXF1OCZot0ZEw==}
+  jest-circus@30.4.2:
+    resolution: {integrity: sha512-rvHH7VlY6LgbJXJTQ87GW62g1FntOtbhh0zT+v04kC+pgL6aBKyYINXxWukCpj3dcIBMw5/XUbtDS9dU9JTXeQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-cli@30.5.0:
-    resolution: {integrity: sha512-QHZMiy32x2K+NzJ1AuuoCAVc1Y5co0VXib3R7kD9MWcWFflzsD1eJN0wR+mkNlM+ts7C+Bjz0oOoFE5IiHylCg==}
+  jest-cli@30.4.2:
+    resolution: {integrity: sha512-jfA2ocvVHMXS2QijrJ0d31ektP+d/W0T5RpcTX2Pq+3sVqHlsXVCM2+FmwpL+bdY8OfHpIg9xMxLF17Zg0U49Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -14923,8 +14869,8 @@ packages:
       node-notifier:
         optional: true
 
-  jest-config@30.5.0:
-    resolution: {integrity: sha512-gYQl2FqYgiVpyuB7DutBIbJRWaq5VcHdzOXJJ51HNa8J5JrsZehIlzNFW0/9s5uvvcbzM5/LTUizYSbsFErv+w==}
+  jest-config@30.4.2:
+    resolution: {integrity: sha512-rNHAShJQqQwFNoL0hbf3BphSBOWnpOUAKvidLS/AjNVLPfoj5mSf4jQMfW3cYOs6hXeZC7nF7mDHaBnbxELOzg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     peerDependencies:
       '@types/node': '*'
@@ -14938,20 +14884,24 @@ packages:
       ts-node:
         optional: true
 
+  jest-diff@30.4.1:
+    resolution: {integrity: sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-diff@30.5.0:
     resolution: {integrity: sha512-QjCfDMwdPFvLxTQmS4/Dswx3PUCiqmSXVLGljMC3SU7YG1qHVoR6b86IH/O2G9k9OMyKXz2vS2Q60VnAozNDwA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-docblock@30.5.0:
-    resolution: {integrity: sha512-NwDqcxtoZi33RhuW+zJS/RVA3rmheQ8BnwpYZuc/Eruaz6seQb7+aoCeDZu/3X7W2XmD8DbSo9Pn72DbKsBFYw==}
+  jest-docblock@30.4.0:
+    resolution: {integrity: sha512-ZPMabUZCx5MpbZ2eBYSvZ0J8fvo3dR9oM+eeUpb3aKNQFuS2tu3Duw1TNlMoP8k3WQgKGJuhcMFvwcVuq6T7oA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-each@30.5.0:
-    resolution: {integrity: sha512-NiMFNhRygJEFqYNt8pnkxppUF6CR486GEpt9rSU6lPBf7KeccaOL0zbjxG8fgJgD//6e7zYdssnlt6j+1kI31A==}
+  jest-each@30.4.1:
+    resolution: {integrity: sha512-/8MJbH6fuj48TstjrMf+u/pd06Qezz5xOXvZA6442heNOWr8bdeoGZX2d9fCn028CoMgYmroH9//zky5GfyYmA==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-environment-node@30.5.0:
-    resolution: {integrity: sha512-bTc79ywKLz0ogbT3JIYuEhgWV4Ffd/cJe06co4v8CyRtlmju8x5gokMlGFR8ARWhmk5SnbDRxmf50XWnlZVhDg==}
+  jest-environment-node@30.4.1:
+    resolution: {integrity: sha512-4FZYVOk85hz2AyT6BbarKy9u37g6DbrDyCdFhsnDdXqyrueYQvB+0zO4f/kqLCRD0BsPRXPMNJeQwihKZV8naw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-get-type@29.6.3:
@@ -14962,20 +14912,32 @@ packages:
     resolution: {integrity: sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-haste-map@30.5.0:
-    resolution: {integrity: sha512-0FStogBslBVOEqTOJr4oXMtFitmrWp9WscG6Gbns88i0YAuMXijCT2G5VMfg/HCR4QAnL+OF2C2ednag+HlDuA==}
+  jest-haste-map@30.4.1:
+    resolution: {integrity: sha512-rFrcONd8jeFsyw+Z9CrScJgglRf2+NFmNam8dKu7n+SoHqNYT47mn0DdEcVUZJpvh7Iz6/si7f7yUH7GJHVgnw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-leak-detector@30.5.0:
-    resolution: {integrity: sha512-Mq11ceAkNR250Iv45RoOwuG9fb4kYbJ02qoyL7A0nCI8FV5+aG/THmcEUx5uR2dNSa4KOtz+xBKrJ8cZPhPpuQ==}
+  jest-leak-detector@30.4.1:
+    resolution: {integrity: sha512-IpmyiioeHxiWDhesHnUFmOxcTzwCwKpgACgWajtAP+nYQXiY7DakTxB6Bx9JFiRMljr0AX1PvnQdaU1KFoz6NQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-matcher-utils@30.4.1:
+    resolution: {integrity: sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-matcher-utils@30.5.0:
     resolution: {integrity: sha512-EfaYMC9f9ds7fahB/LYFTgd1Z2RS9Vpm2e46gazij0onkpoQG7Daq+MLm8/gQVqWwRVjL/RNDggbFx9MsrJEmQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-message-util@30.4.1:
+    resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-message-util@30.5.0:
     resolution: {integrity: sha512-dBYMhplGfspKaCnVk9TUy1cZnknWubpuPNEputjz0YJk1G/92R45rn45BvbPMPMtC5LVcIdxJGPOaOSQTiuzJw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
+  jest-mock@30.4.1:
+    resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-mock@30.5.0:
@@ -14995,37 +14957,45 @@ packages:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   jest-regex-util@30.5.0:
     resolution: {integrity: sha512-Mg0WK7A6xRHLSA1udJ8y9f3lM0uUhFTBnLKzwPmqB9AylvpleJ6BLemR8K9dK27DY+cesDryoA7yLZCAHsPG1A==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-resolve-dependencies@30.5.0:
-    resolution: {integrity: sha512-TnSBAp3wGOnqXBmLT3OXtJkugw6Vj2KU0IPde2EJmbGns/QMoNlkauJ7jZ8KYaxONSpx0o4pUvi+u1Q/LSk3Pg==}
+  jest-resolve-dependencies@30.4.2:
+    resolution: {integrity: sha512-gDiVh1I+GxYzz9oXlyw+1wv6VOYX1WYxMOfjsA3iGKePV2oxmbHhwxfkALxNxYy1ciw6APWwkW2zZONwP97aEQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-resolve@29.7.0:
     resolution: {integrity: sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-resolve@30.5.0:
-    resolution: {integrity: sha512-NFvQWJ4G7e2kN5712iG+12Xr325NRFGAIhovrwLfgq5Oqd4bFHITw4CzcFkZGp1GTCqemC4v1l8/yZzedKZkjw==}
+  jest-resolve@30.4.1:
+    resolution: {integrity: sha512-Zry8Yq/yJcNAZ7dJ5F2heic8AheXvbFZ7XI5V+h28nrYZ7Qoyy4dItq8OodjnYD270mvX+ZudmrNV9cysqhW5Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runner@30.5.0:
-    resolution: {integrity: sha512-Q6Yt+1LvXvEstvru6sQLT7OQYC77VNl6dK0KEvBkeOHgThmXDqNp3Ox9TglDWFHU85pemqTNdKwxfnmO3vgrdA==}
+  jest-runner@30.4.2:
+    resolution: {integrity: sha512-2dw0PslVYXxffXGpLo+Ejad+KcI1Qkjn7f4X4619gf21oCUmL+SPfjqIa/losUem3yEOvfNZe/F1HWUcNpODcg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-runtime@30.5.0:
-    resolution: {integrity: sha512-VTRz0sRIw2EISeHigx1O+CMuwoG4+RKJjF8dp8okzFaDNQEcv5Mw0h5QW8VJXgb2CRF4gZIjSEBb2jdzXPagFQ==}
+  jest-runtime@30.4.2:
+    resolution: {integrity: sha512-3/5e8iPz2k/VLqlr8DgTftYyLUv8Su3FkCAO2/Od81UsUTpSxOrS6O5x5KkoQwyUjmpYyDJKeyAvg2T2nvpNkQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-snapshot@30.5.0:
-    resolution: {integrity: sha512-pZWETdcqmKve9MDTE/AX6RaeAbRhzKhhAXGozAW8Pg2FfOSdUrQ/7D+VdwE3fLQsqjpITXJVQvYVZoMEzrUl0Q==}
+  jest-snapshot@30.4.1:
+    resolution: {integrity: sha512-tEOkkfOMppUyeiHwjZswOQ3lcnoTnws/q5FnGIaeIh/jmoU0ZlgMYRR8sTlTj+nNGCoJ0RDq6SfxGxCsyMTPmw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  jest-util@30.4.1:
+    resolution: {integrity: sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-util@30.5.0:
     resolution: {integrity: sha512-lzU4aGUWaS+2X/B0CmgheDasfnsVlRfZh/rNQxB9b9s8cSYUq5BcqdQA95ld+KqJXBUVVt1sqnMQ2T3OxIalmg==}
@@ -15035,24 +15005,24 @@ packages:
     resolution: {integrity: sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-validate@30.5.0:
-    resolution: {integrity: sha512-N/hsPYKgBSzBeVZ2RHCs3yvBbTZNPX7Be8q33zhyo/yeFneBL1swzly31LYU4LJ3zJM9e8TxSM8IYLo2SDJZYQ==}
+  jest-validate@30.4.1:
+    resolution: {integrity: sha512-PDWi4SOwLnwqNDfHZjOcsEFyZ4fc/2W2gVL3DEoyqnB6jCQMLRtfBong8s6omIw3lI0HWOus12xfnFmQtjW3fw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-watcher@30.5.0:
-    resolution: {integrity: sha512-ujjnEoL4Uu+Swu3WRwYenWMB9JMEiD2T3OypnveMJ64S/1r/5G8eC4OQ1wEOgYWQqMi+mT+buzccflCHr/XJ9Q==}
+  jest-watcher@30.4.1:
+    resolution: {integrity: sha512-/l9UonmvCwjHH7d2h3iAwIloLc1H0S8mJZ/LNK3i86hqwPAz8otUJjP9MfYtz9Tt77Su5FD2xGjZn8d31IZHlw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-worker@29.7.0:
     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-worker@30.5.0:
-    resolution: {integrity: sha512-7kFk/607EoynNHLJa20daivkElM+c9PrCLduYy6AlMkYrXbh5TmVtW1BLXE05Y8baAFsJHMoC3xs2QRRTotwLw==}
+  jest-worker@30.4.1:
+    resolution: {integrity: sha512-SHynN/q/QD++iNyvMdy+WMmbCGk8jIsNcRxycXbWubSOhvo6T+j2afcfUSl+3hYsiBebOTo0cT7c2H7CXugu1g==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest@30.5.0:
-    resolution: {integrity: sha512-HeFeOUEKh5gjnp1rjuSCse8Dhj0Y3KA8lsZ3azr4Wnq1nCxwMBu35MDc9mp8iblZxmeAz6wV4P241tyUB7J2Ew==}
+  jest@30.4.2:
+    resolution: {integrity: sha512-Yi1jqNC/Oq0N4hBgNH/YvBpP1P57QqundgytzYqy3yqAa7NZPNjSoi4SGbRAXDMdBzNE6xBCi5U7RgfrvMEUVQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -15562,9 +15532,6 @@ packages:
     resolution: {integrity: sha512-DjLCuKmAP5OEPOn7H/UyigDSj0DeUO6qcrrSo2Y5jPTYbdKXqNpLafEFGoNNhH9v+ChBLlmc5CRN1YVvZIQsOQ==}
     engines: {node: '>=10'}
     hasBin: true
-
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
   node-gyp-build-optional-packages@5.2.2:
     resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
@@ -16183,6 +16150,10 @@ packages:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  pretty-format@30.4.1:
+    resolution: {integrity: sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==}
+    engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
+
   pretty-format@30.5.0:
     resolution: {integrity: sha512-mzNzBErpHwM0zpmWS7ExOv62yhQhvd546nUuFqVR0dmnJB59tfrw9sjDF0DJknwsr59OXP0buwJ7PaKguczHSg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -16698,6 +16669,9 @@ packages:
     resolution: {integrity: sha512-w7xWRu8U9MneKNna8ptG194jp9PLtbd/Rl6gwrmbK4yUeKbE66a64rHgl0iKTBBDr/hpanx7zMGP1Qo8MRkc/w==}
     engines: {node: '>=20'}
 
+  source-map-support@0.5.13:
+    resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
+
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -16931,9 +16905,9 @@ packages:
     resolution: {integrity: sha512-qFAy10MTMwjzjU8U16YS4YoZD+NQLHzLssFMNqgravjbvIPNiqkGFR4yjhJfmY9R5OFU7+yHxc6y+uGHkKwLRA==}
     engines: {node: '>=20'}
 
-  test-exclude@7.0.2:
-    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
-    engines: {node: '>=18'}
+  test-exclude@6.0.0:
+    resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
+    engines: {node: '>=8'}
 
   test-exclude@8.0.0:
     resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
@@ -18351,44 +18325,44 @@ snapshots:
 
   '@istanbuljs/schema@0.1.6': {}
 
-  '@jest/console@30.5.0':
+  '@jest/console@30.4.1':
     dependencies:
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       chalk: 4.1.2
-      jest-message-util: 30.5.0
-      jest-util: 30.5.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
       slash: 3.0.0
 
-  '@jest/core@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)':
+  '@jest/core@30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)':
     dependencies:
-      '@jest/console': 30.5.0
-      '@jest/pattern': 30.5.0
-      '@jest/reporters': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/test-result': 30.5.0
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/console': 30.4.1
+      '@jest/pattern': 30.4.0
+      '@jest/reporters': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-changed-files: 30.5.0
-      jest-config: 30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
-      jest-haste-map: 30.5.0
-      jest-message-util: 30.5.0
-      jest-regex-util: 30.5.0
-      jest-resolve: 30.5.0
-      jest-resolve-dependencies: 30.5.0(supports-color@10.2.2)
-      jest-runner: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-runtime: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-snapshot: 30.5.0(supports-color@10.2.2)
-      jest-util: 30.5.0
-      jest-validate: 30.5.0
-      jest-watcher: 30.5.0
-      pretty-format: 30.5.0
+      jest-changed-files: 30.4.1
+      jest-config: 30.4.2(@babel/types@7.29.8)(@types/node@26.4.0)(supports-color@10.2.2)
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-resolve-dependencies: 30.4.2(supports-color@10.2.2)
+      jest-runner: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-runtime: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-snapshot: 30.4.1(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      jest-watcher: 30.4.1
+      pretty-format: 30.4.1
       slash: 3.0.0
     transitivePeerDependencies:
       - '@babel/types'
@@ -18397,73 +18371,86 @@ snapshots:
       - supports-color
       - ts-node
 
+  '@jest/diff-sequences@30.4.0': {}
+
   '@jest/diff-sequences@30.5.0': {}
 
-  '@jest/environment@30.5.0':
+  '@jest/environment@30.4.1':
     dependencies:
-      '@jest/fake-timers': 30.5.0
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
-      jest-mock: 30.5.0
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
+      jest-mock: 30.4.1
+
+  '@jest/expect-utils@30.4.1':
+    dependencies:
+      '@jest/get-type': 30.1.0
 
   '@jest/expect-utils@30.5.0':
     dependencies:
       '@jest/get-type': 30.5.0
 
-  '@jest/expect@30.5.0(supports-color@10.2.2)':
+  '@jest/expect@30.4.1(supports-color@10.2.2)':
     dependencies:
-      expect: 30.5.0
-      jest-snapshot: 30.5.0(supports-color@10.2.2)
+      expect: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/fake-timers@30.5.0':
+  '@jest/fake-timers@30.4.1':
     dependencies:
-      '@jest/types': 30.5.0
+      '@jest/types': 30.4.1
       '@sinonjs/fake-timers': 15.4.0
-      '@types/node': 22.19.19
-      jest-message-util: 30.5.0
-      jest-mock: 30.5.0
-      jest-util: 30.5.0
+      '@types/node': 26.4.0
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+
+  '@jest/get-type@30.1.0': {}
 
   '@jest/get-type@30.5.0': {}
 
-  '@jest/globals@30.5.0(supports-color@10.2.2)':
+  '@jest/globals@30.4.1(supports-color@10.2.2)':
     dependencies:
-      '@jest/environment': 30.5.0
-      '@jest/expect': 30.5.0(supports-color@10.2.2)
-      '@jest/types': 30.5.0
-      jest-mock: 30.5.0
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@10.2.2)
+      '@jest/types': 30.4.1
+      jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
+
+  '@jest/pattern@30.4.0':
+    dependencies:
+      '@types/node': 26.4.0
+      jest-regex-util: 30.4.0
 
   '@jest/pattern@30.5.0':
     dependencies:
       '@types/node': 22.19.19
       jest-regex-util: 30.5.0
 
-  '@jest/reporters@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)':
+  '@jest/reporters@30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
-      '@jest/console': 30.5.0
-      '@jest/test-result': 30.5.0
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
+      '@jest/console': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.19.19
+      '@types/node': 26.4.0
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
-      glob: 13.0.6
+      glob: 11.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-instrument: 6.0.3(@babel/types@7.29.8)(supports-color@10.2.2)
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.6(supports-color@10.2.2)
       istanbul-reports: '@zkochan/istanbul-reports@3.0.2'
-      jest-message-util: 30.5.0
-      jest-util: 30.5.0
-      jest-worker: 30.5.0
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       slash: 3.0.0
       string-length: 4.0.2
       v8-to-istanbul: 9.3.0
@@ -18475,51 +18462,54 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.12
 
+  '@jest/schemas@30.4.1':
+    dependencies:
+      '@sinclair/typebox': 0.34.52
+
   '@jest/schemas@30.5.0':
     dependencies:
       '@sinclair/typebox': 0.34.52
 
-  '@jest/snapshot-utils@30.5.0':
+  '@jest/snapshot-utils@30.4.1':
     dependencies:
-      '@jest/types': 30.5.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       natural-compare: 1.4.0
 
-  '@jest/source-map@30.5.0':
+  '@jest/source-map@30.0.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       callsites: 3.1.0
-      convert-source-map: 2.0.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
 
-  '@jest/test-result@30.5.0':
+  '@jest/test-result@30.4.1':
     dependencies:
-      '@jest/console': 30.5.0
-      '@jest/types': 30.5.0
+      '@jest/console': 30.4.1
+      '@jest/types': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       collect-v8-coverage: 1.0.3
 
-  '@jest/test-sequencer@30.5.0':
+  '@jest/test-sequencer@30.4.1':
     dependencies:
-      '@jest/test-result': 30.5.0
+      '@jest/test-result': 30.4.1
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-haste-map: 30.5.0
+      jest-haste-map: 30.4.1
       slash: 3.0.0
 
-  '@jest/transform@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)':
+  '@jest/transform@30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@jest/types': 30.5.0
+      '@jest/types': 30.4.1
       '@jridgewell/trace-mapping': 0.3.31
-      babel-plugin-istanbul: 8.0.0(@babel/types@7.29.8)(supports-color@10.2.2)
+      babel-plugin-istanbul: 7.0.1(@babel/types@7.29.8)(supports-color@10.2.2)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-haste-map: 30.5.0
-      jest-regex-util: 30.5.0
-      jest-util: 30.5.0
+      jest-haste-map: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
       pirates: 4.0.7
       slash: 3.0.0
       write-file-atomic: 5.0.1
@@ -18530,6 +18520,16 @@ snapshots:
   '@jest/types@29.6.3':
     dependencies:
       '@jest/schemas': 29.6.3
+      '@types/istanbul-lib-coverage': 2.0.6
+      '@types/istanbul-reports': 3.0.4
+      '@types/node': 26.4.0
+      '@types/yargs': 17.0.35
+      chalk: 4.1.2
+
+  '@jest/types@30.4.1':
+    dependencies:
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 26.4.0
@@ -18677,62 +18677,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.19
       typescript: 6.0.3
-
-  '@parcel/watcher-android-arm64@2.6.0':
-    optional: true
-
-  '@parcel/watcher-darwin-arm64@2.6.0':
-    optional: true
-
-  '@parcel/watcher-darwin-x64@2.6.0':
-    optional: true
-
-  '@parcel/watcher-freebsd-x64@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-arm-glibc@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-arm-musl@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-glibc@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-musl@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-x64-glibc@2.6.0':
-    optional: true
-
-  '@parcel/watcher-linux-x64-musl@2.6.0':
-    optional: true
-
-  '@parcel/watcher-win32-arm64@2.6.0':
-    optional: true
-
-  '@parcel/watcher-win32-x64@2.6.0':
-    optional: true
-
-  '@parcel/watcher@2.6.0':
-    dependencies:
-      detect-libc: 2.1.2
-      is-glob: 4.0.3
-      node-addon-api: 7.1.1
-      picomatch: 4.0.7
-    optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.6.0
-      '@parcel/watcher-darwin-arm64': 2.6.0
-      '@parcel/watcher-darwin-x64': 2.6.0
-      '@parcel/watcher-freebsd-x64': 2.6.0
-      '@parcel/watcher-linux-arm-glibc': 2.6.0
-      '@parcel/watcher-linux-arm-musl': 2.6.0
-      '@parcel/watcher-linux-arm64-glibc': 2.6.0
-      '@parcel/watcher-linux-arm64-musl': 2.6.0
-      '@parcel/watcher-linux-x64-glibc': 2.6.0
-      '@parcel/watcher-linux-x64-musl': 2.6.0
-      '@parcel/watcher-win32-arm64': 2.6.0
-      '@parcel/watcher-win32-x64': 2.6.0
 
   '@pkgr/core@0.3.6': {}
 
@@ -20707,13 +20651,13 @@ snapshots:
 
   b4a@1.8.1: {}
 
-  babel-jest@30.5.0(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.8)(supports-color@10.2.2):
+  babel-jest@30.4.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.8)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 8.0.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      babel-preset-jest: 30.5.0(@babel/core@7.29.7(supports-color@10.2.2))
+      babel-plugin-istanbul: 7.0.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      babel-preset-jest: 30.4.0(@babel/core@7.29.7(supports-color@10.2.2))
       chalk: 4.1.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       slash: 3.0.0
@@ -20721,18 +20665,18 @@ snapshots:
       - '@babel/types'
       - supports-color
 
-  babel-plugin-istanbul@8.0.0(@babel/types@7.29.8)(supports-color@10.2.2):
+  babel-plugin-istanbul@7.0.1(@babel/types@7.29.8)(supports-color@10.2.2):
     dependencies:
       '@babel/helper-plugin-utils': 7.29.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-instrument: 6.0.3(@babel/types@7.29.8)(supports-color@10.2.2)
-      test-exclude: 7.0.2
+      test-exclude: 6.0.0
     transitivePeerDependencies:
       - '@babel/types'
       - supports-color
 
-  babel-plugin-jest-hoist@30.5.0:
+  babel-plugin-jest-hoist@30.4.0:
     dependencies:
       '@types/babel__core': 7.20.5
 
@@ -20755,10 +20699,10 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7(supports-color@10.2.2))
 
-  babel-preset-jest@30.5.0(@babel/core@7.29.7(supports-color@10.2.2)):
+  babel-preset-jest@30.4.0(@babel/core@7.29.7(supports-color@10.2.2)):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      babel-plugin-jest-hoist: 30.5.0
+      babel-plugin-jest-hoist: 30.4.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@10.2.2))
 
   bail@2.0.2: {}
@@ -20867,6 +20811,8 @@ snapshots:
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
+
+  buffer-from@1.1.2: {}
 
   buffer@5.7.1:
     dependencies:
@@ -21570,8 +21516,6 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.3.2: {}
-
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
@@ -21669,13 +21613,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jest@29.16.5(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(jest@30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
+  eslint-plugin-jest@29.16.5(@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(jest@30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/utils': 8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
       eslint: 10.9.1(jiti@2.6.1)(supports-color@10.2.2)
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.68.0(@typescript-eslint/parser@8.68.0(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3))(eslint@10.9.1(jiti@2.6.1)(supports-color@10.2.2))(supports-color@10.2.2)(typescript@6.0.3)
-      jest: 30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
+      jest: 30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -21842,6 +21786,15 @@ snapshots:
   exists-link@2.0.0: {}
 
   exit-x@0.2.2: {}
+
+  expect@30.4.1:
+    dependencies:
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
 
   expect@30.5.0:
     dependencies:
@@ -22730,31 +22683,31 @@ snapshots:
     dependencies:
       '@isaacs/cliui': 9.0.0
 
-  jest-changed-files@30.5.0:
+  jest-changed-files@30.4.1:
     dependencies:
       execa: 5.1.1
-      jest-util: 30.5.0
+      jest-util: 30.4.1
       p-limit: 3.1.0
 
-  jest-circus@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2):
+  jest-circus@30.4.2(@babel/types@7.29.8)(supports-color@10.2.2):
     dependencies:
-      '@jest/environment': 30.5.0
-      '@jest/expect': 30.5.0(supports-color@10.2.2)
-      '@jest/test-result': 30.5.0
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/environment': 30.4.1
+      '@jest/expect': 30.4.1(supports-color@10.2.2)
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
       is-generator-fn: 2.1.0
-      jest-each: 30.5.0
-      jest-matcher-utils: 30.5.0
-      jest-message-util: 30.5.0
-      jest-runtime: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-snapshot: 30.5.0(supports-color@10.2.2)
-      jest-util: 30.5.0
+      jest-each: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-runtime: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-snapshot: 30.4.1(supports-color@10.2.2)
+      jest-util: 30.4.1
       p-limit: 3.1.0
-      pretty-format: 30.5.0
+      pretty-format: 30.4.1
       pure-rand: 7.0.1
       slash: 3.0.0
       stack-utils: 2.0.6
@@ -22763,17 +22716,17 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
+  jest-cli@30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
     dependencies:
-      '@jest/core': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/test-result': 30.5.0
-      '@jest/types': 30.5.0
+      '@jest/core': 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
-      jest-util: 30.5.0
-      jest-validate: 30.5.0
+      jest-config: 30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       yargs: 17.7.3
     transitivePeerDependencies:
       - '@babel/types'
@@ -22783,29 +22736,29 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
+  jest-config@30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@jest/get-type': 30.5.0
-      '@jest/pattern': 30.5.0
-      '@jest/test-sequencer': 30.5.0
-      '@jest/types': 30.5.0
-      babel-jest: 30.5.0(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.8)(supports-color@10.2.2)
       chalk: 4.1.2
       ci-info: 4.4.0
       deepmerge: 4.3.1
-      glob: 13.0.6
+      glob: 11.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-circus: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-docblock: 30.5.0
-      jest-environment-node: 30.5.0
-      jest-regex-util: 30.5.0
-      jest-resolve: 30.5.0
-      jest-runner: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-util: 30.5.0
-      jest-validate: 30.5.0
+      jest-circus: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       parse-json: 5.2.0
-      pretty-format: 30.5.0
+      pretty-format: 30.4.1
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
@@ -22815,6 +22768,45 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.4.2(@babel/types@7.29.8)(@types/node@26.4.0)(supports-color@10.2.2):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@jest/get-type': 30.1.0
+      '@jest/pattern': 30.4.0
+      '@jest/test-sequencer': 30.4.1
+      '@jest/types': 30.4.1
+      babel-jest: 30.4.1(@babel/core@7.29.7(supports-color@10.2.2))(@babel/types@7.29.8)(supports-color@10.2.2)
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      deepmerge: 4.3.1
+      glob: 11.1.0
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      jest-circus: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-runner: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
+      parse-json: 5.2.0
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 26.4.0
+    transitivePeerDependencies:
+      - '@babel/types'
+      - babel-plugin-macros
+      - supports-color
+
+  jest-diff@30.4.1:
+    dependencies:
+      '@jest/diff-sequences': 30.4.0
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      pretty-format: 30.4.1
+
   jest-diff@30.5.0:
     dependencies:
       '@jest/diff-sequences': 30.5.0
@@ -22822,27 +22814,27 @@ snapshots:
       chalk: 4.1.2
       pretty-format: 30.5.0
 
-  jest-docblock@30.5.0:
+  jest-docblock@30.4.0:
     dependencies:
       detect-newline: 3.1.0
 
-  jest-each@30.5.0:
+  jest-each@30.4.1:
     dependencies:
-      '@jest/get-type': 30.5.0
-      '@jest/types': 30.5.0
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
       chalk: 4.1.2
-      jest-util: 30.5.0
-      pretty-format: 30.5.0
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
 
-  jest-environment-node@30.5.0:
+  jest-environment-node@30.4.1:
     dependencies:
-      '@jest/environment': 30.5.0
-      '@jest/fake-timers': 30.5.0
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
-      jest-mock: 30.5.0
-      jest-util: 30.5.0
-      jest-validate: 30.5.0
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
+      jest-mock: 30.4.1
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
 
   jest-get-type@29.6.3: {}
 
@@ -22862,24 +22854,32 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  jest-haste-map@30.5.0:
+  jest-haste-map@30.4.1:
     dependencies:
-      '@jest/types': 30.5.0
-      '@parcel/watcher': 2.6.0
-      '@types/node': 22.19.19
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       anymatch: 3.1.3
       fb-watchman: 2.0.2
-      fdir: 6.5.0(picomatch@4.0.7)
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-regex-util: 30.5.0
-      jest-util: 30.5.0
-      jest-worker: 30.5.0
+      jest-regex-util: 30.4.0
+      jest-util: 30.4.1
+      jest-worker: 30.4.1
       picomatch: 4.0.7
+      walker: 1.0.8
+    optionalDependencies:
+      fsevents: 2.3.3
 
-  jest-leak-detector@30.5.0:
+  jest-leak-detector@30.4.1:
     dependencies:
-      '@jest/get-type': 30.5.0
-      pretty-format: 30.5.0
+      '@jest/get-type': 30.1.0
+      pretty-format: 30.4.1
+
+  jest-matcher-utils@30.4.1:
+    dependencies:
+      '@jest/get-type': 30.1.0
+      chalk: 4.1.2
+      jest-diff: 30.4.1
+      pretty-format: 30.4.1
 
   jest-matcher-utils@30.5.0:
     dependencies:
@@ -22887,6 +22887,19 @@ snapshots:
       chalk: 4.1.2
       jest-diff: 30.5.0
       pretty-format: 30.5.0
+
+  jest-message-util@30.4.1:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@jest/types': 30.4.1
+      '@types/stack-utils': 2.0.3
+      chalk: 4.1.2
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      jest-util: 30.4.1
+      picomatch: 4.0.7
+      pretty-format: 30.4.1
+      slash: 3.0.0
+      stack-utils: 2.0.6
 
   jest-message-util@30.5.0:
     dependencies:
@@ -22901,6 +22914,12 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
+      jest-util: 30.4.1
+
   jest-mock@30.5.0:
     dependencies:
       '@jest/expect-utils': 30.5.0
@@ -22912,14 +22931,20 @@ snapshots:
     optionalDependencies:
       jest-resolve: 29.7.0
 
+  jest-pnp-resolver@1.2.3(jest-resolve@30.4.1):
+    optionalDependencies:
+      jest-resolve: 30.4.1
+
   jest-regex-util@29.6.3: {}
+
+  jest-regex-util@30.4.0: {}
 
   jest-regex-util@30.5.0: {}
 
-  jest-resolve-dependencies@30.5.0(supports-color@10.2.2):
+  jest-resolve-dependencies@30.4.2(supports-color@10.2.2):
     dependencies:
-      jest-regex-util: 30.5.0
-      jest-snapshot: 30.5.0(supports-color@10.2.2)
+      jest-regex-util: 30.4.0
+      jest-snapshot: 30.4.1(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -22935,94 +22960,94 @@ snapshots:
       resolve.exports: 2.0.3
       slash: 3.0.0
 
-  jest-resolve@30.5.0:
+  jest-resolve@30.4.1:
     dependencies:
       chalk: 4.1.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-haste-map: 30.5.0
-      jest-util: 30.5.0
-      jest-validate: 30.5.0
+      jest-haste-map: 30.4.1
+      jest-pnp-resolver: 1.2.3(jest-resolve@30.4.1)
+      jest-util: 30.4.1
+      jest-validate: 30.4.1
       slash: 3.0.0
       unrs-resolver: 1.12.2
 
-  jest-runner@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2):
+  jest-runner@30.4.2(@babel/types@7.29.8)(supports-color@10.2.2):
     dependencies:
-      '@jest/console': 30.5.0
-      '@jest/environment': 30.5.0
-      '@jest/source-map': 30.5.0
-      '@jest/test-result': 30.5.0
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/console': 30.4.1
+      '@jest/environment': 30.4.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-docblock: 30.5.0
-      jest-environment-node: 30.5.0
-      jest-haste-map: 30.5.0
-      jest-leak-detector: 30.5.0
-      jest-message-util: 30.5.0
-      jest-resolve: 30.5.0
-      jest-runtime: 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      jest-util: 30.5.0
-      jest-watcher: 30.5.0
-      jest-worker: 30.5.0
+      jest-docblock: 30.4.0
+      jest-environment-node: 30.4.1
+      jest-haste-map: 30.4.1
+      jest-leak-detector: 30.4.1
+      jest-message-util: 30.4.1
+      jest-resolve: 30.4.1
+      jest-runtime: 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      jest-util: 30.4.1
+      jest-watcher: 30.4.1
+      jest-worker: 30.4.1
       p-limit: 3.1.0
+      source-map-support: 0.5.13
     transitivePeerDependencies:
       - '@babel/types'
       - supports-color
 
-  jest-runtime@30.5.0(@babel/types@7.29.8)(supports-color@10.2.2):
+  jest-runtime@30.4.2(@babel/types@7.29.8)(supports-color@10.2.2):
     dependencies:
-      '@jest/environment': 30.5.0
-      '@jest/fake-timers': 30.5.0
-      '@jest/globals': 30.5.0(supports-color@10.2.2)
-      '@jest/source-map': 30.5.0
-      '@jest/test-result': 30.5.0
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/environment': 30.4.1
+      '@jest/fake-timers': 30.4.1
+      '@jest/globals': 30.4.1(supports-color@10.2.2)
+      '@jest/source-map': 30.0.1
+      '@jest/test-result': 30.4.1
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       chalk: 4.1.2
       cjs-module-lexer: 2.2.1
       collect-v8-coverage: 1.0.3
-      es-module-lexer: 2.3.2
-      glob: 13.0.6
+      glob: 11.1.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-haste-map: 30.5.0
-      jest-message-util: 30.5.0
-      jest-mock: 30.5.0
-      jest-regex-util: 30.5.0
-      jest-resolve: 30.5.0
-      jest-snapshot: 30.5.0(supports-color@10.2.2)
-      jest-util: 30.5.0
+      jest-haste-map: 30.4.1
+      jest-message-util: 30.4.1
+      jest-mock: 30.4.1
+      jest-regex-util: 30.4.0
+      jest-resolve: 30.4.1
+      jest-snapshot: 30.4.1(supports-color@10.2.2)
+      jest-util: 30.4.1
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - '@babel/types'
       - supports-color
 
-  jest-snapshot@30.5.0(supports-color@10.2.2):
+  jest-snapshot@30.4.1(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
       '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/types': 7.29.8
-      '@jest/expect-utils': 30.5.0
-      '@jest/get-type': 30.5.0
-      '@jest/snapshot-utils': 30.5.0
-      '@jest/transform': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
+      '@jest/expect-utils': 30.4.1
+      '@jest/get-type': 30.1.0
+      '@jest/snapshot-utils': 30.4.1
+      '@jest/transform': 30.4.1(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.7(supports-color@10.2.2))
       chalk: 4.1.2
-      expect: 30.5.0
+      expect: 30.4.1
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
-      jest-diff: 30.5.0
-      jest-matcher-utils: 30.5.0
-      jest-message-util: 30.5.0
-      jest-util: 30.5.0
-      pretty-format: 30.5.0
+      jest-diff: 30.4.1
+      jest-matcher-utils: 30.4.1
+      jest-message-util: 30.4.1
+      jest-util: 30.4.1
+      pretty-format: 30.4.1
       semver: 7.8.5
       synckit: 0.11.13
     transitivePeerDependencies:
@@ -23036,6 +23061,15 @@ snapshots:
       ci-info: 3.9.0
       graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
       picomatch: 2.3.2
+
+  jest-util@30.4.1:
+    dependencies:
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
+      chalk: 4.1.2
+      ci-info: 4.4.0
+      graceful-fs: 4.2.11(patch_hash=68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1)
+      picomatch: 4.0.7
 
   jest-util@30.5.0:
     dependencies:
@@ -23055,24 +23089,24 @@ snapshots:
       leven: 3.1.0
       pretty-format: 29.7.0
 
-  jest-validate@30.5.0:
+  jest-validate@30.4.1:
     dependencies:
-      '@jest/get-type': 30.5.0
-      '@jest/types': 30.5.0
+      '@jest/get-type': 30.1.0
+      '@jest/types': 30.4.1
       camelcase: 6.3.0
       chalk: 4.1.2
       leven: 3.1.0
-      pretty-format: 30.5.0
+      pretty-format: 30.4.1
 
-  jest-watcher@30.5.0:
+  jest-watcher@30.4.1:
     dependencies:
-      '@jest/test-result': 30.5.0
-      '@jest/types': 30.5.0
-      '@types/node': 22.19.19
+      '@jest/test-result': 30.4.1
+      '@jest/types': 30.4.1
+      '@types/node': 26.4.0
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
-      jest-util: 30.5.0
+      jest-util: 30.4.1
       string-length: 4.0.2
 
   jest-worker@29.7.0:
@@ -23082,20 +23116,20 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest-worker@30.5.0:
+  jest-worker@30.4.1:
     dependencies:
-      '@types/node': 22.19.19
+      '@types/node': 26.4.0
       '@ungap/structured-clone': 1.4.0
-      jest-util: 30.5.0
+      jest-util: 30.4.1
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
+  jest@30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2):
     dependencies:
-      '@jest/core': 30.5.0(@babel/types@7.29.8)(supports-color@10.2.2)
-      '@jest/types': 30.5.0
+      '@jest/core': 30.4.2(@babel/types@7.29.8)(supports-color@10.2.2)
+      '@jest/types': 30.4.1
       import-local: 3.2.0
-      jest-cli: 30.5.0(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
+      jest-cli: 30.4.2(@babel/types@7.29.8)(@types/node@22.19.19)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@babel/types'
       - '@types/node'
@@ -23708,8 +23742,6 @@ snapshots:
       pretty-bytes: 4.0.2
       walk-filtered: 0.9.3
 
-  node-addon-api@7.1.1: {}
-
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
       detect-libc: 2.1.2
@@ -24188,6 +24220,13 @@ snapshots:
       '@jest/schemas': 29.6.3
       ansi-styles: 5.2.0
       react-is: 18.3.1
+
+  pretty-format@30.4.1:
+    dependencies:
+      '@jest/schemas': 30.4.1
+      ansi-styles: 5.2.0
+      react-is-18: react-is@18.3.1
+      react-is-19: react-is@19.2.8
 
   pretty-format@30.5.0:
     dependencies:
@@ -24765,6 +24804,11 @@ snapshots:
     dependencies:
       is-plain-obj: 4.1.0
 
+  source-map-support@0.5.13:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
   source-map@0.6.1: {}
 
   spawn-command@0.0.2: {}
@@ -25032,11 +25076,11 @@ snapshots:
       ansi-escapes: 7.3.0
       supports-hyperlinks: 4.5.0
 
-  test-exclude@7.0.2:
+  test-exclude@6.0.0:
     dependencies:
       '@istanbuljs/schema': 0.1.6
-      glob: 11.1.0
-      minimatch: 10.2.6
+      glob: 7.2.3
+      minimatch: 3.1.5
 
   test-exclude@8.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -108,7 +108,8 @@ catalog:
   '@cyclonedx/cyclonedx-library': 10.2.0
   '@eslint/js': ^10.0.1
   '@inquirer/prompts': ^8.7.0
-  '@jest/globals': 30.5.0
+  # Jest 30.5.0 breaks ESM package imports in the Jest runtime.
+  '@jest/globals': 30.4.1
   '@npm/types': ^2.1.0
   '@pnpm/byline': ^1.0.0
   '@pnpm/colorize-semver-diff': ^2.0.0
@@ -251,8 +252,8 @@ catalog:
   is-subdir: ^2.0.0
   is-windows: ^1.0.2
   isexe: 4.0.0
-  jest: ^30.5.0
-  jest-diff: ^30.5.0
+  jest: 30.4.2
+  jest-diff: 30.4.1
   human-id: ^4.2.1
   js-yaml: npm:@zkochan/js-yaml@0.0.11
   json5: ^2.2.3
@@ -543,12 +544,15 @@ update:
   ignoreDeps:
     - '@babel/core'
     - '@babel/plugin-transform-explicit-resource-management'
+    - '@jest/globals'
     - '@types/node'
     - bin-links
     - bole
     - cspell
     - eslint-plugin-regexp
     - ini
+    - jest
+    - jest-diff
     - libnpmpublish
     - node-gyp
     - normalize-package-data


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Jest 30.5.0 regressed ESM module resolution in the TS test suite. The first test package fails while loading `vfile` because Jest resolves its `#minurl` package import to a module namespace without the expected `isUrl` export.

Pin `@jest/globals`, `jest`, and `jest-diff` to the last working 30.4.x releases and add them to `update.ignoreDeps` so the scheduled lockfile update does not recreate the failure.

Related workflow run: https://github.com/pnpm/pnpm/actions/runs/33258072799/job/99115350706

## Squash Commit Body

```text
Jest 30.5.0 regresses ESM package-import resolution and prevents the TypeScript test suite from starting. Keep the Jest toolchain on the last working 30.4.x releases and exclude it from automated dependency updates until the upstream regression is resolved.
```

## Checklist

- [x] Verified the previously failing get-release-text suite and the shared Jest configuration suite locally.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790606937&installation_model_id=426870&pr_number=14330&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14330&signature=80317163e2308f4093daf56ef5ae08cf6969b1f03f8ae7eca6eb5961da5f2210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned testing tool versions for more consistent development and verification.
  * Prevented automated dependency updates from changing these testing tools unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->