### PR TITLE
fix(lockfile): pair repair views

### DIFF
--- a/.changeset/calm-lockfiles-share.md
+++ b/.changeset/calm-lockfiles-share.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install --fix-lockfile` to derive its repair and filtered-merge views from one lockfile snapshot.

--- a/pnpm/crates/lockfile/src/lazy_lockfile.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile.rs
@@ -1,5 +1,6 @@
 use crate::{
-    LoadLockfileError, LoadedWantedLockfile, Lockfile, ProjectSnapshot, WantedLockfileSelection,
+    LoadLockfileError, LoadedRepairLockfile, LoadedWantedLockfile, Lockfile, ProjectSnapshot,
+    WantedLockfileSelection,
 };
 use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
 
@@ -16,8 +17,7 @@ use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
 pub struct LazyLockfile {
     source: Option<(PathBuf, WantedLockfileSelection)>,
     cell: OnceLock<LoadedWantedLockfile>,
-    fix_cell: OnceLock<LoadedWantedLockfile>,
-    fix_merge_cell: OnceLock<LoadedWantedLockfile>,
+    fix_cell: OnceLock<LoadedRepairLockfile>,
 }
 
 impl LazyLockfile {
@@ -29,7 +29,6 @@ impl LazyLockfile {
             source: Some((dir, selection)),
             cell: OnceLock::new(),
             fix_cell: OnceLock::new(),
-            fix_merge_cell: OnceLock::new(),
         }
     }
 
@@ -38,12 +37,7 @@ impl LazyLockfile {
     /// config.
     #[must_use]
     pub fn disabled() -> Self {
-        LazyLockfile {
-            source: None,
-            cell: OnceLock::new(),
-            fix_cell: OnceLock::new(),
-            fix_merge_cell: OnceLock::new(),
-        }
+        LazyLockfile { source: None, cell: OnceLock::new(), fix_cell: OnceLock::new() }
     }
 
     /// A lockfile that is already in memory; [`Self::get`] returns it
@@ -53,12 +47,7 @@ impl LazyLockfile {
         let cell = OnceLock::new();
         cell.set(LoadedWantedLockfile { lockfile, pre_merge_importers: None })
             .expect("a fresh OnceLock accepts the first set");
-        LazyLockfile {
-            source: None,
-            cell,
-            fix_cell: OnceLock::new(),
-            fix_merge_cell: OnceLock::new(),
-        }
+        LazyLockfile { source: None, cell, fix_cell: OnceLock::new() }
     }
 
     /// The parsed wanted lockfile, loading it on first call. `None`
@@ -71,11 +60,11 @@ impl LazyLockfile {
 
     /// Load after discarding fields that a repairing resolution regenerates.
     pub fn get_for_fix(&self) -> Result<Option<&Lockfile>, LoadLockfileError> {
-        Ok(self.load_for_fix()?.lockfile.as_ref())
+        Ok(self.load_for_fix()?.seed())
     }
 
     fn get_for_fix_merge(&self) -> Result<Option<&Lockfile>, LoadLockfileError> {
-        Ok(self.load_for_fix_merge()?.lockfile.as_ref())
+        Ok(self.load_for_fix()?.merge())
     }
 
     /// The importers the branch-lockfile fold started from, loading the
@@ -90,7 +79,7 @@ impl LazyLockfile {
     fn pre_merge_importers_for_fix(
         &self,
     ) -> Result<Option<&HashMap<String, ProjectSnapshot>>, LoadLockfileError> {
-        Ok(self.load_for_fix()?.pre_merge_importers.as_ref())
+        Ok(self.load_for_fix()?.pre_merge_importers())
     }
 
     fn load(&self) -> Result<&LoadedWantedLockfile, LoadLockfileError> {
@@ -104,32 +93,16 @@ impl LazyLockfile {
         Ok(self.cell.get_or_init(|| loaded))
     }
 
-    fn load_for_fix(&self) -> Result<&LoadedWantedLockfile, LoadLockfileError> {
+    fn load_for_fix(&self) -> Result<&LoadedRepairLockfile, LoadLockfileError> {
         if let Some(loaded) = self.fix_cell.get() {
             return Ok(loaded);
         }
         let loaded = if let Some((dir, selection)) = self.source.as_ref() {
             Lockfile::load_wanted_detailed_for_fix(dir, selection)?
         } else {
-            let mut loaded = self.cell.get().cloned().unwrap_or_default();
-            if let Some(lockfile) = loaded.lockfile.as_mut() {
-                lockfile.prepare_for_fix();
-            }
-            loaded
+            LoadedRepairLockfile::from_loaded(self.cell.get().cloned().unwrap_or_default())
         };
         Ok(self.fix_cell.get_or_init(|| loaded))
-    }
-
-    fn load_for_fix_merge(&self) -> Result<&LoadedWantedLockfile, LoadLockfileError> {
-        if let Some(loaded) = self.fix_merge_cell.get() {
-            return Ok(loaded);
-        }
-        let loaded = if let Some((dir, selection)) = self.source.as_ref() {
-            Lockfile::load_wanted_detailed_for_fix_merge(dir, selection)?
-        } else {
-            self.cell.get().cloned().unwrap_or_default()
-        };
-        Ok(self.fix_merge_cell.get_or_init(|| loaded))
     }
 
     /// Whether a wanted lockfile is known to be available: the parsed
@@ -140,10 +113,11 @@ impl LazyLockfile {
     /// the repeat-install fast path.
     #[must_use]
     pub fn is_loaded_or_on_disk(&self) -> bool {
-        if let Some(loaded) =
-            self.cell.get().or_else(|| self.fix_cell.get()).or_else(|| self.fix_merge_cell.get())
-        {
+        if let Some(loaded) = self.cell.get() {
             return loaded.lockfile.is_some();
+        }
+        if let Some(loaded) = self.fix_cell.get() {
+            return loaded.seed().is_some();
         }
         self.source
             .as_ref()
@@ -178,7 +152,7 @@ impl<'a> MaybeLazyLockfile<'a> {
         match self {
             MaybeLazyLockfile::Loaded(lockfile) => Ok(lockfile),
             MaybeLazyLockfile::Lazy(lazy) => lazy.get(),
-            MaybeLazyLockfile::Repair(lazy) => lazy.get().or_else(|_| lazy.get_for_fix_merge()),
+            MaybeLazyLockfile::Repair(lazy) => lazy.get_for_fix_merge(),
         }
     }
 

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -16,6 +16,41 @@ fn preloaded_returns_the_stored_lockfile_without_io() {
 }
 
 #[test]
+fn preloaded_repair_preserves_the_merge_view() {
+    let lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "packages:"
+        "  pkg@1.0.0:"
+        "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+        "    deprecated: stale"
+    })
+    .expect("parse preloaded lockfile");
+    let lazy = LazyLockfile::preloaded(Some(lockfile));
+    let package_key = "pkg@1.0.0".parse().expect("package key");
+
+    let seed = lazy.get_for_fix().expect("repair load succeeds").expect("repair lockfile");
+    assert!(
+        seed.packages
+            .as_ref()
+            .and_then(|packages| packages.get(&package_key))
+            .is_some_and(|metadata| metadata.deprecated.is_none()),
+    );
+
+    let merge = MaybeLazyLockfile::Repair(&lazy)
+        .get_for_merge()
+        .expect("merge load succeeds")
+        .expect("merge lockfile");
+    assert_eq!(
+        merge
+            .packages
+            .as_ref()
+            .and_then(|packages| packages.get(&package_key))
+            .and_then(|metadata| metadata.deprecated.as_deref()),
+        Some("stale"),
+    );
+}
+
+#[test]
 fn preloaded_none_reports_absent() {
     let lazy = LazyLockfile::preloaded(None);
     assert!(lazy.get().expect("preloaded lockfile loads infallibly").is_none());
@@ -43,6 +78,8 @@ fn deferred_loads_from_the_given_dir_not_the_process_cwd() {
     let lazy =
         LazyLockfile::deferred(empty.path().to_path_buf(), WantedLockfileSelection::default());
     assert!(!lazy.is_loaded_or_on_disk());
+    assert!(lazy.get_for_fix().expect("absent repair load succeeds").is_none());
+    assert!(!lazy.is_loaded_or_on_disk(), "the empty repair cache must report no lockfile");
     assert!(lazy.get().expect("absent lockfile loads as None").is_none());
 }
 

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -163,6 +163,109 @@ fn repair_merge_preserves_valid_metadata_when_strict_parsing_fails() {
 }
 
 #[test]
+fn repair_views_stay_on_the_same_file_generation() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    fs::write(
+        &path,
+        text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .: {}"
+            "packages:"
+            "  pkg@1.0.0:"
+            "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+            "    deprecated: first generation"
+        },
+    )
+    .expect("write first lockfile generation");
+
+    let lazy = LazyLockfile::deferred(dir.path().to_path_buf(), WantedLockfileSelection::default());
+    lazy.get_for_fix().expect("repair load succeeds").expect("repair lockfile");
+
+    fs::write(
+        path,
+        text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .: {}"
+            "packages:"
+            "  pkg@1.0.0:"
+            "    resolution: {integrity: sha512-TIE61hcgbI/SlJh/0c1sT1SZbBlpg7WiZcs65WPJhoIZQPhH1SCpcGA7LgrVXT15lwN3HV4GQM/MJ9aKEn3Qfg==}"
+            "    deprecated: second generation"
+        },
+    )
+    .expect("write second lockfile generation");
+
+    let merge = MaybeLazyLockfile::Repair(&lazy)
+        .get_for_merge()
+        .expect("merge load succeeds")
+        .expect("merge lockfile");
+    let package_key = "pkg@1.0.0".parse().expect("package key");
+    assert_eq!(
+        merge
+            .packages
+            .as_ref()
+            .and_then(|packages| packages.get(&package_key))
+            .and_then(|metadata| metadata.deprecated.as_deref()),
+        Some("first generation"),
+    );
+}
+
+#[test]
+fn repair_views_fold_branch_lockfiles_together() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(
+        dir.path().join(Lockfile::FILE_NAME),
+        text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .: {}"
+            "snapshots:"
+            "  base@1.0.0:"
+            "    optional: true"
+        },
+    )
+    .expect("write base lockfile");
+    fs::write(
+        dir.path().join(Lockfile::git_branch_file_name("feature")),
+        text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  packages/branch: {}"
+            "snapshots:"
+            "  branch@1.0.0:"
+            "    optional: true"
+        },
+    )
+    .expect("write branch lockfile");
+
+    let selection = WantedLockfileSelection {
+        merge_git_branch_lockfiles: true,
+        ..WantedLockfileSelection::default()
+    };
+    let lazy = LazyLockfile::deferred(dir.path().to_path_buf(), selection);
+    let seed = lazy.get_for_fix().expect("repair load succeeds").expect("repair lockfile");
+    let merge = MaybeLazyLockfile::Repair(&lazy)
+        .get_for_merge()
+        .expect("merge load succeeds")
+        .expect("merge lockfile");
+    let pre_merge_importers = MaybeLazyLockfile::Repair(&lazy)
+        .pre_merge_importers()
+        .expect("pre-merge importers load")
+        .expect("branch merge records base importers");
+    let branch_key = "branch@1.0.0".parse().expect("branch package key");
+    let seed_branch = &seed.snapshots.as_ref().expect("seed snapshots")[&branch_key];
+    let merge_branch = &merge.snapshots.as_ref().expect("merge snapshots")[&branch_key];
+
+    dbg!(seed_branch, merge_branch, pre_merge_importers);
+    assert!(!seed_branch.optional);
+    assert!(merge_branch.optional);
+    assert!(pre_merge_importers.contains_key("."));
+    assert!(!pre_merge_importers.contains_key("packages/branch"));
+}
+
+#[test]
 fn empty_and_env_only_files_count_as_absent() {
     let dir = tempfile::tempdir().expect("tempdir");
     let path = dir.path().join(Lockfile::FILE_NAME);

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -1,5 +1,5 @@
 use super::{LazyLockfile, MaybeLazyLockfile};
-use crate::{Lockfile, WantedLockfileSelection};
+use crate::{LoadLockfileError, Lockfile, WantedLockfileSelection};
 use std::fs;
 use text_block_macros::text_block;
 
@@ -247,6 +247,29 @@ fn repair_views_stay_on_the_same_file_generation() {
             .and_then(|metadata| metadata.deprecated.as_deref()),
         Some("first generation"),
     );
+}
+
+#[test]
+fn a_failed_repair_load_is_retried_rather_than_cached() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    fs::write(&path, "lockfileVersion: '9.0'\nimporters: [\n").expect("write broken lockfile");
+
+    let lazy = LazyLockfile::deferred(dir.path().to_path_buf(), WantedLockfileSelection::default());
+    let error = lazy.get_for_fix().expect_err("a repair load cannot parse broken YAML");
+    eprintln!("ERROR:\n{error}\n");
+    assert!(matches!(error, LoadLockfileError::ParseYaml { .. }));
+
+    fs::write(
+        path,
+        text_block! {
+            "lockfileVersion: '9.0'"
+            "importers:"
+            "  .: {}"
+        },
+    )
+    .expect("write repaired lockfile");
+    assert!(lazy.get_for_fix().expect("the failed load was not cached").is_some());
 }
 
 #[test]

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -55,6 +55,36 @@ fn format_yaml_error(error: &serde_saphyr::Error) -> String {
     }
 }
 
+/// The parsing budgets for a lockfile document of `document_len` bytes.
+///
+/// Every size-proportional budget is raised to the document's byte length:
+/// none of these dimensions can exceed the size of an input that is already
+/// in memory, so a valid lockfile must never trip them, however large. The
+/// remaining defaults (aliases, anchors, depth, documents) bound YAML shapes
+/// the lockfile emitter never produces and stay as security caps.
+fn yaml_parse_options(document_len: usize) -> serde_saphyr::Options {
+    serde_saphyr::options! {
+        budget: serde_saphyr::budget! {
+            max_events: document_len.max(DEFAULT_YAML_MAX_EVENTS),
+            max_nodes: document_len.max(DEFAULT_YAML_MAX_NODES),
+            max_total_scalar_bytes: document_len.max(DEFAULT_YAML_MAX_SCALAR_BYTES),
+            max_total_comment_bytes: document_len.max(DEFAULT_YAML_MAX_SCALAR_BYTES),
+            max_reader_input_bytes: Some(document_len.max(DEFAULT_YAML_MAX_READER_INPUT_BYTES)),
+        },
+    }
+}
+
+/// The text of a lockfile file, or `None` when it is absent. Every other
+/// read failure is an error: an existing-but-unreadable lockfile must not
+/// be mistaken for a missing one.
+fn read_lockfile_text(file_path: &Path) -> Result<Option<String>, LoadLockfileError> {
+    match fs::read_to_string(file_path) {
+        Ok(content) => Ok(Some(content)),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
+        Err(error) => error.pipe(LoadLockfileError::ReadFile).pipe(Err),
+    }
+}
+
 impl Lockfile {
     /// Load lockfile from the current directory.
     pub fn load_from_current_dir() -> Result<Option<Self>, LoadLockfileError> {
@@ -127,6 +157,9 @@ impl Lockfile {
         Ok(LoadedWantedLockfile::default())
     }
 
+    /// [`Self::load_wanted_detailed`] for a repairing install: each file
+    /// it reads is read once and yields both of the views the repair
+    /// needs. See [`LoadedRepairLockfile`] for why they must be paired.
     pub(crate) fn load_wanted_detailed_for_fix(
         dir: &Path,
         selection: &WantedLockfileSelection,
@@ -190,29 +223,12 @@ impl Lockfile {
         if main.trim().is_empty() {
             return Ok(None);
         }
-        serde_saphyr::from_str_with_options::<Self>(
-            &main,
-            serde_saphyr::options! {
-                // Every size-proportional budget is raised to the document's
-                // byte length: none of these dimensions can exceed the size of
-                // an input that is already in memory, so a valid lockfile must
-                // never trip them, however large. The remaining defaults
-                // (aliases, anchors, depth, documents) bound YAML shapes the
-                // lockfile emitter never produces and stay as security caps.
-                budget: serde_saphyr::budget! {
-                    max_events: main.len().max(DEFAULT_YAML_MAX_EVENTS),
-                    max_nodes: main.len().max(DEFAULT_YAML_MAX_NODES),
-                    max_total_scalar_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
-                    max_total_comment_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
-                    max_reader_input_bytes: Some(main.len().max(DEFAULT_YAML_MAX_READER_INPUT_BYTES)),
-                },
-            },
-        )
-        .map(|mut lockfile| {
-            lockfile.reconstruct_missing_directory_resolutions();
-            Some(lockfile)
-        })
-        .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
+        serde_saphyr::from_str_with_options::<Self>(&main, yaml_parse_options(main.len()))
+            .map(|mut lockfile| {
+                lockfile.reconstruct_missing_directory_resolutions();
+                Some(lockfile)
+            })
+            .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
     }
 
     fn parse_repair_views(
@@ -225,15 +241,7 @@ impl Lockfile {
         }
         let mut value = serde_saphyr::from_str_with_options::<serde_json::Value>(
             &main,
-            serde_saphyr::options! {
-                budget: serde_saphyr::budget! {
-                    max_events: main.len().max(DEFAULT_YAML_MAX_EVENTS),
-                    max_nodes: main.len().max(DEFAULT_YAML_MAX_NODES),
-                    max_total_scalar_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
-                    max_total_comment_bytes: main.len().max(DEFAULT_YAML_MAX_SCALAR_BYTES),
-                    max_reader_input_bytes: Some(main.len().max(DEFAULT_YAML_MAX_READER_INPUT_BYTES)),
-                },
-            },
+            yaml_parse_options(main.len()),
         )
         .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))?;
         prepare_value_for_fix(&mut value);
@@ -254,22 +262,16 @@ impl Lockfile {
     /// file is absent or its main document is empty, the same absence
     /// rules the directory-addressed loaders use.
     pub fn load_from_path(file_path: &Path) -> Result<Option<Self>, LoadLockfileError> {
-        let content = match fs::read_to_string(file_path) {
-            Ok(content) => content,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-            Err(error) => return error.pipe(LoadLockfileError::ReadFile).pipe(Err),
-        };
+        let Some(content) = read_lockfile_text(file_path)? else { return Ok(None) };
         Self::parse(&content, file_path)
     }
 
+    /// [`Self::load_from_path`] deriving both repair views from the
+    /// single read.
     fn load_repair_views_from_path(
         file_path: &Path,
     ) -> Result<Option<RepairLockfileViews>, LoadLockfileError> {
-        let content = match fs::read_to_string(file_path) {
-            Ok(content) => content,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-            Err(error) => return error.pipe(LoadLockfileError::ReadFile).pipe(Err),
-        };
+        let Some(content) = read_lockfile_text(file_path)? else { return Ok(None) };
         Self::parse_repair_views(&content, file_path)
     }
 }
@@ -290,13 +292,23 @@ pub struct LoadedWantedLockfile {
     pub pre_merge_importers: Option<HashMap<String, ProjectSnapshot>>,
 }
 
-#[derive(Debug, Default, Clone)]
+/// The views a repairing install reads the wanted lockfile for, and the
+/// importers the branch-lockfile fold started from — see
+/// [`LoadedWantedLockfile`] for why the caller needs those.
+///
+/// The views are held as one value because they are one file generation
+/// seen two ways: caching them separately lets a repair resolve from one
+/// generation and restore the projects outside its filter from another.
+#[derive(Debug, Default)]
 pub(crate) struct LoadedRepairLockfile {
     views: Option<RepairLockfileViews>,
     pre_merge_importers: Option<HashMap<String, ProjectSnapshot>>,
 }
 
 impl LoadedRepairLockfile {
+    /// Derive both views from a lockfile that is already in memory,
+    /// for the sources [`Lockfile::load_wanted_detailed_for_fix`] never
+    /// reads.
     pub(crate) fn from_loaded(loaded: LoadedWantedLockfile) -> Self {
         let views = loaded.lockfile.map(|merge| {
             let mut seed = merge.clone();
@@ -319,7 +331,10 @@ impl LoadedRepairLockfile {
     }
 }
 
-#[derive(Debug, Clone)]
+/// One wanted-lockfile generation seen two ways: `seed` has the fields a
+/// repairing resolution regenerates cleared, `merge` is intact so the
+/// projects a filtered repair did not select keep what they had.
+#[derive(Debug)]
 struct RepairLockfileViews {
     seed: Lockfile,
     merge: Lockfile,
@@ -368,6 +383,8 @@ fn merge_git_branch_lockfiles(base: Lockfile, dir: &Path) -> Result<Lockfile, Lo
     Ok(merged)
 }
 
+/// [`merge_git_branch_lockfiles`] folding each branch lockfile into both
+/// repair views, so a branch file too is read once for the pair.
 fn merge_git_branch_lockfile_repairs(
     mut base: RepairLockfileViews,
     dir: &Path,

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -110,41 +110,12 @@ impl Lockfile {
         dir: &Path,
         selection: &WantedLockfileSelection,
     ) -> Result<LoadedWantedLockfile, LoadLockfileError> {
-        Self::load_wanted_detailed_with(dir, selection, WantedLockfileLoadMode::Strict)
-    }
-
-    pub(crate) fn load_wanted_detailed_for_fix(
-        dir: &Path,
-        selection: &WantedLockfileSelection,
-    ) -> Result<LoadedWantedLockfile, LoadLockfileError> {
-        Self::load_wanted_detailed_with(dir, selection, WantedLockfileLoadMode::RepairSeed)
-    }
-
-    pub(crate) fn load_wanted_detailed_for_fix_merge(
-        dir: &Path,
-        selection: &WantedLockfileSelection,
-    ) -> Result<LoadedWantedLockfile, LoadLockfileError> {
-        Self::load_wanted_detailed_with(dir, selection, WantedLockfileLoadMode::RepairMerge)
-    }
-
-    fn load_wanted_detailed_with(
-        dir: &Path,
-        selection: &WantedLockfileSelection,
-        mode: WantedLockfileLoadMode,
-    ) -> Result<LoadedWantedLockfile, LoadLockfileError> {
         for file_name in selection.read_order() {
             let path = dir.join(file_name);
-            let loaded = match mode {
-                WantedLockfileLoadMode::Strict => Self::load_from_path(&path),
-                WantedLockfileLoadMode::RepairSeed => Self::load_from_path_for_fix(&path, true),
-                WantedLockfileLoadMode::RepairMerge => Self::load_from_path_for_fix(&path, false),
-            }?;
-            let Some(lockfile) = loaded else {
-                continue;
-            };
+            let Some(lockfile) = Self::load_from_path(&path)? else { continue };
             return if selection.merge_git_branch_lockfiles {
                 let pre_merge_importers = lockfile.importers.clone();
-                let merged = merge_git_branch_lockfiles(lockfile, dir, mode)?;
+                let merged = merge_git_branch_lockfiles(lockfile, dir)?;
                 Ok(LoadedWantedLockfile {
                     lockfile: Some(merged),
                     pre_merge_importers: Some(pre_merge_importers),
@@ -154,6 +125,27 @@ impl Lockfile {
             };
         }
         Ok(LoadedWantedLockfile::default())
+    }
+
+    pub(crate) fn load_wanted_detailed_for_fix(
+        dir: &Path,
+        selection: &WantedLockfileSelection,
+    ) -> Result<LoadedRepairLockfile, LoadLockfileError> {
+        for file_name in selection.read_order() {
+            let path = dir.join(file_name);
+            let Some(views) = Self::load_repair_views_from_path(&path)? else { continue };
+            return if selection.merge_git_branch_lockfiles {
+                let pre_merge_importers = views.seed.importers.clone();
+                let views = merge_git_branch_lockfile_repairs(views, dir)?;
+                Ok(LoadedRepairLockfile {
+                    views: Some(views),
+                    pre_merge_importers: Some(pre_merge_importers),
+                })
+            } else {
+                Ok(LoadedRepairLockfile { views: Some(views), pre_merge_importers: None })
+            };
+        }
+        Ok(LoadedRepairLockfile::default())
     }
 
     /// Whether `<dir>/pnpm-lock.yaml` would load as `Some`: the file
@@ -223,11 +215,10 @@ impl Lockfile {
         .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))
     }
 
-    fn parse_for_fix(
+    fn parse_repair_views(
         content: &str,
         file_path: &Path,
-        prepare: bool,
-    ) -> Result<Option<Self>, LoadLockfileError> {
+    ) -> Result<Option<RepairLockfileViews>, LoadLockfileError> {
         let main = extract_main_document(content);
         if main.trim().is_empty() {
             return Ok(None);
@@ -247,12 +238,11 @@ impl Lockfile {
         .map_err(|source| LoadLockfileError::parse_yaml(file_path, &source))?;
         prepare_value_for_fix(&mut value);
         serde_json::from_value::<Self>(value)
-            .map(|mut lockfile| {
-                lockfile.reconstruct_missing_directory_resolutions();
-                if prepare {
-                    lockfile.prepare_for_fix();
-                }
-                Some(lockfile)
+            .map(|mut merge| {
+                merge.reconstruct_missing_directory_resolutions();
+                let mut seed = merge.clone();
+                seed.prepare_for_fix();
+                Some(RepairLockfileViews { seed, merge })
             })
             .map_err(|source| LoadLockfileError::ParseYaml {
                 path: file_path.to_path_buf(),
@@ -272,16 +262,15 @@ impl Lockfile {
         Self::parse(&content, file_path)
     }
 
-    fn load_from_path_for_fix(
+    fn load_repair_views_from_path(
         file_path: &Path,
-        prepare: bool,
-    ) -> Result<Option<Self>, LoadLockfileError> {
+    ) -> Result<Option<RepairLockfileViews>, LoadLockfileError> {
         let content = match fs::read_to_string(file_path) {
             Ok(content) => content,
             Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
             Err(error) => return error.pipe(LoadLockfileError::ReadFile).pipe(Err),
         };
-        Self::parse_for_fix(&content, file_path, prepare)
+        Self::parse_repair_views(&content, file_path)
     }
 }
 
@@ -299,6 +288,41 @@ mod tests;
 pub struct LoadedWantedLockfile {
     pub lockfile: Option<Lockfile>,
     pub pre_merge_importers: Option<HashMap<String, ProjectSnapshot>>,
+}
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct LoadedRepairLockfile {
+    views: Option<RepairLockfileViews>,
+    pre_merge_importers: Option<HashMap<String, ProjectSnapshot>>,
+}
+
+impl LoadedRepairLockfile {
+    pub(crate) fn from_loaded(loaded: LoadedWantedLockfile) -> Self {
+        let views = loaded.lockfile.map(|merge| {
+            let mut seed = merge.clone();
+            seed.prepare_for_fix();
+            RepairLockfileViews { seed, merge }
+        });
+        LoadedRepairLockfile { views, pre_merge_importers: loaded.pre_merge_importers }
+    }
+
+    pub(crate) fn seed(&self) -> Option<&Lockfile> {
+        self.views.as_ref().map(|views| &views.seed)
+    }
+
+    pub(crate) fn merge(&self) -> Option<&Lockfile> {
+        self.views.as_ref().map(|views| &views.merge)
+    }
+
+    pub(crate) fn pre_merge_importers(&self) -> Option<&HashMap<String, ProjectSnapshot>> {
+        self.pre_merge_importers.as_ref()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RepairLockfileViews {
+    seed: Lockfile,
+    merge: Lockfile,
 }
 
 /// Which wanted-lockfile file an install reads and writes, and whether the
@@ -332,32 +356,31 @@ impl WantedLockfileSelection {
     }
 }
 
-fn merge_git_branch_lockfiles(
-    base: Lockfile,
-    dir: &Path,
-    mode: WantedLockfileLoadMode,
-) -> Result<Lockfile, LoadLockfileError> {
+fn merge_git_branch_lockfiles(base: Lockfile, dir: &Path) -> Result<Lockfile, LoadLockfileError> {
     let branch_lockfiles =
         Lockfile::git_branch_lockfiles(dir).map_err(LoadLockfileError::ReadFile)?;
     let mut merged = base;
     for path in branch_lockfiles {
-        let branch_lockfile = match mode {
-            WantedLockfileLoadMode::Strict => Lockfile::load_from_path(&path),
-            WantedLockfileLoadMode::RepairSeed => Lockfile::load_from_path_for_fix(&path, true),
-            WantedLockfileLoadMode::RepairMerge => Lockfile::load_from_path_for_fix(&path, false),
-        }?;
-        if let Some(branch_lockfile) = branch_lockfile {
+        if let Some(branch_lockfile) = Lockfile::load_from_path(&path)? {
             merged = merge_lockfile_changes(&merged, &branch_lockfile);
         }
     }
     Ok(merged)
 }
 
-#[derive(Clone, Copy)]
-enum WantedLockfileLoadMode {
-    Strict,
-    RepairSeed,
-    RepairMerge,
+fn merge_git_branch_lockfile_repairs(
+    mut base: RepairLockfileViews,
+    dir: &Path,
+) -> Result<RepairLockfileViews, LoadLockfileError> {
+    let branch_lockfiles =
+        Lockfile::git_branch_lockfiles(dir).map_err(LoadLockfileError::ReadFile)?;
+    for path in branch_lockfiles {
+        if let Some(branch) = Lockfile::load_repair_views_from_path(&path)? {
+            base.seed = merge_lockfile_changes(&base.seed, &branch.seed);
+            base.merge = merge_lockfile_changes(&base.merge, &branch.merge);
+        }
+    }
+    Ok(base)
 }
 
 fn prepare_value_for_fix(value: &mut serde_json::Value) {

--- a/pnpm/crates/lockfile/src/load_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    DirectoryResolution, ImporterDepVersion, LazyLockfile, Lockfile, LockfileResolution,
-    PackageKey, PkgName, SnapshotDepRef, WantedLockfileSelection,
+    DirectoryResolution, ImporterDepVersion, LazyLockfile, LoadLockfileError, Lockfile,
+    LockfileResolution, PackageKey, PkgName, SnapshotDepRef, WantedLockfileSelection,
 };
 use pnpm_diagnostics::miette::Diagnostic;
 use pretty_assertions::assert_eq;
@@ -66,6 +66,22 @@ fn write_lockfile(content: &str) -> tempfile::TempDir {
     std::fs::write(virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME), content)
         .expect("write lock.yaml");
     tmp
+}
+
+#[test]
+fn an_unreadable_lockfile_is_an_error_for_both_the_strict_and_the_repair_loader() {
+    let tmp = tempdir().expect("create tempdir");
+    let path = tmp.path().join(Lockfile::FILE_NAME);
+    std::fs::create_dir(&path).expect("put a directory where the lockfile belongs");
+
+    let strict = Lockfile::load_from_path(&path).expect_err("a directory is not readable text");
+    eprintln!("STRICT:\n{strict}\n");
+    assert!(matches!(strict, LoadLockfileError::ReadFile(_)));
+
+    let lazy = LazyLockfile::deferred(tmp.path().to_path_buf(), WantedLockfileSelection::default());
+    let repair = lazy.get_for_fix().expect_err("the repair loader reads the same file");
+    eprintln!("REPAIR:\n{repair}\n");
+    assert!(matches!(repair, LoadLockfileError::ReadFile(_)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14333.

The Rust lockfile loader now derives the repair seed and filtered-merge baseline from one wanted-lockfile read. It caches these views as one pair, so an install cannot combine data from different file generations.

Branch lockfiles use the same model. Each branch file is read once, then its paired views are folded in the existing deterministic order.

The strict loader and the public lockfile interfaces do not change. The TypeScript CLI already derives its repair state from one read, so it needs no matching change. This PR adds a patch changeset for `pacquet`.

## Squash Commit Body

```text
Derive the repair seed and filtered-merge baseline from one wanted-lockfile read.
Cache both views as one pair and fold branch lockfiles through the same paired path,
so one repair cannot combine data from different file generations.

Fixes pnpm/pnpm#14333.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14335"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790610607&installation_model_id=426870&pr_number=14335&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14335&signature=5b9207f5ff57f92aa8c44094d28e55a3dd4bf6c59ebfec768236626e8dea71a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved `pnpm install --fix-lockfile` consistency across repairs and filtered merges.
  - Repair operations remain stable when the lockfile changes during installation.
  - Git branch lockfiles are correctly included when branch merging is enabled.
  - Improved handling and retry behavior when lockfiles are missing or temporarily unavailable.

- **Tests**
  - Added coverage for lockfile stability, repair caching, error handling, and branch lockfile merging.

- **Release**
  - Included in a patch release of `pacquet`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->