### PR TITLE
fix(config): read globalDir and globalBinDir from the global config file

### DIFF
--- a/.changeset/global-dirs-from-the-global-config-file.md
+++ b/.changeset/global-dirs-from-the-global-config-file.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/config.reader": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). A leading `~/` in either value is expanded, and a project's `pnpm-workspace.yaml` still cannot set them.
+`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). A leading `~/` in either value is expanded before the global package and bin directories are derived from it, and a project's `pnpm-workspace.yaml` still cannot set them.

--- a/.changeset/global-dirs-from-the-global-config-file.md
+++ b/.changeset/global-dirs-from-the-global-config-file.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). Both settings were only read from `PNPM_CONFIG_GLOBAL_DIR` / `PNPM_CONFIG_GLOBAL_BIN_DIR`. A project's `pnpm-workspace.yaml` still cannot set them.

--- a/.changeset/global-dirs-from-the-global-config-file.md
+++ b/.changeset/global-dirs-from-the-global-config-file.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). Both settings were only read from `PNPM_CONFIG_GLOBAL_DIR` / `PNPM_CONFIG_GLOBAL_BIN_DIR`. A project's `pnpm-workspace.yaml` still cannot set them.
+`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). A leading `~/` in either value is expanded, and a project's `pnpm-workspace.yaml` still cannot set them.

--- a/.changeset/global-dirs-from-the-global-config-file.md
+++ b/.changeset/global-dirs-from-the-global-config-file.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-`globalDir` and `globalBinDir` set in the global `config.yaml` are honored again, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). A leading `~/` in either value is expanded before the global package and bin directories are derived from it, and a project's `pnpm-workspace.yaml` still cannot set them.
+`globalDir` and `globalBinDir` are honored wherever they are set, so `pnpm add -g` no longer fails with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` after `pnpm config set -g global-bin-dir` [#14336](https://github.com/pnpm/pnpm/issues/14336). The global `config.yaml` is read again, `PNPM_CONFIG_GLOBAL_DIR` / `PNPM_CONFIG_GLOBAL_BIN_DIR` reach the directories derived from them, and a leading `~/` is expanded before that derivation. A project's `pnpm-workspace.yaml` still cannot set either key.

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -175,6 +175,8 @@ impl WorkspaceSettings {
         json_field!(enable_modules_dir, "ENABLE_MODULES_DIR");
         json_field!(global_shims, "GLOBAL_SHIMS");
         string_field!(global_virtual_store_dir, "GLOBAL_VIRTUAL_STORE_DIR");
+        string_field!(global_dir, "GLOBAL_DIR");
+        string_field!(global_bin_dir, "GLOBAL_BIN_DIR");
         enum_field!(package_import_method, "PACKAGE_IMPORT_METHOD", PackageImportMethod);
         json_field!(modules_cache_max_age, "MODULES_CACHE_MAX_AGE");
         json_field!(virtual_store_dir_max_length, "VIRTUAL_STORE_DIR_MAX_LENGTH");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3540,7 +3540,7 @@ impl Config {
             collect_explicit_settings(&mut self.explicit_settings, &global_settings);
             let configured_state_dir = global_settings.state_dir.take();
             let saved_workspace_dir = self.workspace_dir.take();
-            global_settings.expand_home_prefixes::<Sys>();
+            global_settings.expand_global_dir_home_prefixes::<Sys>();
             global_settings.apply_to(&mut self, start_dir);
             self.workspace_dir = saved_workspace_dir;
             if let Some(configured_state_dir) =
@@ -3672,7 +3672,7 @@ impl Config {
         let bootstrap = &mut self.package_manager_bootstrap;
         env_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         let saved_workspace_dir = self.workspace_dir.clone();
-        env_settings.expand_home_prefixes::<Sys>();
+        env_settings.expand_global_dir_home_prefixes::<Sys>();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         self.apply_remote_side_effects_cache_env::<Sys>();

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3609,6 +3609,11 @@ impl Config {
                 settings.ci = None;
                 settings.state_dir = None;
                 settings.scope = None;
+                // Where the machine keeps its globally installed packages and
+                // their shims is not a repository's to choose; pnpm's
+                // project-manifest key filter drops both keys.
+                settings.global_dir = None;
+                settings.global_bin_dir = None;
                 // `|=` rather than `=` so an `enableGlobalVirtualStore` /
                 // `virtualStoreDir` set in the global `config.yaml` still
                 // counts as "explicitly set" when the workspace yaml
@@ -3739,13 +3744,6 @@ impl Config {
         // Resolve the global install directories:
         // `globalPkgDir = (globalDir ?? <pnpm-home>/global)/v11` and
         // `bin = globalBinDir ?? <pnpm-home>/bin`.
-        if self.global_dir.is_none() {
-            self.global_dir = read_pnpm_env::<Sys>("global_dir", "GLOBAL_DIR").map(PathBuf::from);
-        }
-        if self.global_bin_dir.is_none() {
-            self.global_bin_dir =
-                read_pnpm_env::<Sys>("global_bin_dir", "GLOBAL_BIN_DIR").map(PathBuf::from);
-        }
         let pnpm_home_dir = default_pnpm_home_dir::<Sys>();
         let global_dir_root = self
             .global_dir

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3540,6 +3540,7 @@ impl Config {
             collect_explicit_settings(&mut self.explicit_settings, &global_settings);
             let configured_state_dir = global_settings.state_dir.take();
             let saved_workspace_dir = self.workspace_dir.take();
+            global_settings.expand_home_prefixes::<Sys>();
             global_settings.apply_to(&mut self, start_dir);
             self.workspace_dir = saved_workspace_dir;
             if let Some(configured_state_dir) =
@@ -3609,9 +3610,6 @@ impl Config {
                 settings.ci = None;
                 settings.state_dir = None;
                 settings.scope = None;
-                // Where the machine keeps its globally installed packages and
-                // their shims is not a repository's to choose; pnpm's
-                // project-manifest key filter drops both keys.
                 settings.global_dir = None;
                 settings.global_bin_dir = None;
                 // `|=` rather than `=` so an `enableGlobalVirtualStore` /
@@ -3674,6 +3672,7 @@ impl Config {
         let bootstrap = &mut self.package_manager_bootstrap;
         env_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         let saved_workspace_dir = self.workspace_dir.clone();
+        env_settings.expand_home_prefixes::<Sys>();
         env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         self.apply_remote_side_effects_cache_env::<Sys>();

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3,7 +3,7 @@ use super::{
     NodeLinker, NodePackageMapType, PackageImportMethod, TrustPolicy, WorkspaceSettings,
     default_ci, fs,
 };
-use crate::defaults::{default_state_dir, default_store_dir};
+use crate::defaults::{GLOBAL_LAYOUT_VERSION, default_state_dir, default_store_dir};
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::env_guard::EnvGuard;
 use pretty_assertions::assert_eq;
@@ -369,6 +369,47 @@ pub fn state_dir_uses_only_trusted_config_sources() {
     ]);
     let config = load_with_fake_env(project.path());
     assert!(config.state_dir.as_os_str().is_empty());
+}
+
+#[test]
+pub fn global_dirs_use_only_trusted_config_sources() {
+    fake_env!(load_with_fake_env);
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(
+        config_dir.join("config.yaml"),
+        "globalDir: from-global\nglobalBinDir: from-global-bin\n",
+    )
+    .expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    fs::write(
+        project.path().join("pnpm-workspace.yaml"),
+        "globalDir: from-project\nglobalBinDir: from-project-bin\n",
+    )
+    .expect("write workspace yaml");
+
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(project.path());
+    assert_eq!(
+        config.global_pkg_dir,
+        Some(project.path().join("from-global").join(GLOBAL_LAYOUT_VERSION)),
+    );
+    assert_eq!(config.global_bin, Some(project.path().join("from-global-bin")));
+    assert_eq!(config.workspace_key_issues.refused, ["globalDir", "globalBinDir"]);
+
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        ("PNPM_CONFIG_GLOBAL_DIR", "from-env"),
+        ("PNPM_CONFIG_GLOBAL_BIN_DIR", "from-env-bin"),
+    ]);
+    let config = load_with_fake_env(project.path());
+    assert_eq!(
+        config.global_pkg_dir,
+        Some(project.path().join("from-env").join(GLOBAL_LAYOUT_VERSION)),
+    );
+    assert_eq!(config.global_bin, Some(project.path().join("from-env-bin")));
 }
 
 #[test]

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -410,6 +410,50 @@ pub fn global_dirs_use_only_trusted_config_sources() {
         Some(project.path().join("from-env").join(GLOBAL_LAYOUT_VERSION)),
     );
     assert_eq!(config.global_bin, Some(project.path().join("from-env-bin")));
+    assert_eq!(
+        config.explicit_settings.get("globalBinDir"),
+        Some(&serde_json::Value::String("from-env-bin".to_string())),
+    );
+}
+
+#[test]
+pub fn global_dirs_expand_a_leading_tilde() {
+    let home = tempdir().expect("home tempdir");
+    static HOME_PATH: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
+    HOME_PATH.set(home.path().to_path_buf()).expect("set once");
+    let config_dir = home.path().join("xdg").join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.yaml"), "globalDir: ~/global\nglobalBinDir: ~/bin\n")
+        .expect("write global config.yaml");
+
+    struct HostWithHome;
+    impl EnvVar for HostWithHome {
+        fn var(name: &str) -> Option<String> {
+            if name == "XDG_CONFIG_HOME" {
+                let xdg = HOME_PATH.get().expect("home path").join("xdg");
+                return Some(xdg.to_str().expect("utf-8 home path").to_string());
+            }
+            safe_host_var(name)
+        }
+    }
+    impl EnvVarOs for HostWithHome {
+        fn var_os(_: &str) -> Option<OsString> {
+            None
+        }
+    }
+    impl GetHomeDir for HostWithHome {
+        fn home_dir() -> Option<PathBuf> {
+            HOME_PATH.get().cloned()
+        }
+    }
+    inert_link_probe!(HostWithHome);
+    host_current_dir!(HostWithHome);
+
+    let project = tempdir().expect("project tempdir");
+    let config =
+        Config::new().current::<HostWithHome>(project.path()).expect("global config.yaml loads");
+    assert_eq!(config.global_pkg_dir, Some(home.path().join("global").join(GLOBAL_LAYOUT_VERSION)));
+    assert_eq!(config.global_bin, Some(home.path().join("bin")));
 }
 
 #[test]
@@ -4145,8 +4189,7 @@ pub fn global_config_yaml_schema_directive_is_silent() {
 pub fn global_config_yaml_key_pnpm_honors_stays_silent() {
     let config_dir = tempdir().expect("config tempdir");
     let config_file = config_dir.path().join("config.yaml");
-    fs::write(&config_file, "globalBinDir: /usr/local/pnpm-bin\n")
-        .expect("write global config.yaml");
+    fs::write(&config_file, "globalPath: /usr/local/pnpm\n").expect("write global config.yaml");
 
     let warnings = capture_warnings(|| {
         WorkspaceSettings::load_global(config_dir.path())

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -3,7 +3,7 @@ use crate::{
     NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode, RuntimeOnFail,
     SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun,
     VirtualStoreType,
-    api::EnvVar,
+    api::{EnvVar, GetHomeDir},
     config_types::is_config_file_key,
     known_settings::{SCHEMA_DIRECTIVE_KEY, annotate_unknown_setting, is_known_setting_key},
     naming_cases::{is_camel_case, to_camel_case, to_kebab_case},
@@ -357,13 +357,17 @@ pub struct WorkspaceSettings {
     /// against the workspace dir like the other path-valued fields.
     /// When set, overrides the derived `<store_dir>/links` path.
     pub global_virtual_store_dir: Option<String>,
-    /// `globalDir` from the global `config.yaml`. Resolved like the other
-    /// path-valued fields; a project manifest does not contribute it (see
-    /// [`crate::refused_keys`]). See [`Config::global_dir`].
+    /// `globalDir` from the global `config.yaml`. Resolved against the
+    /// workspace dir like the other path-valued fields. See
+    /// [`Config::global_dir`].
+    ///
+    /// No repo-committed file may set it — see [`crate::refused_keys`].
     pub global_dir: Option<String>,
-    /// `globalBinDir` from the global `config.yaml`. Resolved like the other
-    /// path-valued fields; a project manifest does not contribute it (see
-    /// [`crate::refused_keys`]). See [`Config::global_bin_dir`].
+    /// `globalBinDir` from the global `config.yaml`. Resolved against the
+    /// workspace dir like the other path-valued fields. See
+    /// [`Config::global_bin_dir`].
+    ///
+    /// No repo-committed file may set it — see [`crate::refused_keys`].
     pub global_bin_dir: Option<String>,
     pub package_import_method: Option<PackageImportMethod>,
     pub modules_cache_max_age: Option<u64>,
@@ -1836,6 +1840,29 @@ impl WorkspaceSettings {
         }
     }
 
+    /// Rewrite a leading `~/` in `globalDir` / `globalBinDir` into the home
+    /// directory, as pnpm's `transformPathKeys` does. A shell expands the
+    /// tilde before `pnpm config set` sees it, but a hand-written
+    /// `config.yaml` carries it verbatim.
+    ///
+    /// Call this before [`Self::apply_to`], which would otherwise take the
+    /// tilde for an ordinary relative path segment.
+    pub fn expand_home_prefixes<Sys: GetHomeDir>(&mut self) {
+        for dir in [&mut self.global_dir, &mut self.global_bin_dir] {
+            let Some(relative) = dir
+                .as_deref()
+                .and_then(|dir| dir.strip_prefix("~/").or_else(|| dir.strip_prefix(r"~\")))
+            else {
+                continue;
+            };
+            if let Some(expanded) = Sys::home_dir()
+                .and_then(|home_dir| home_dir.join(relative).into_os_string().into_string().ok())
+            {
+                *dir = Some(expanded);
+            }
+        }
+    }
+
     fn substitute_env_scalars<Sys: EnvVar>(&mut self) {
         substitute_optional_string::<Sys>(&mut self.scope);
         substitute_optional_string::<Sys>(&mut self.store_dir);
@@ -2037,6 +2064,12 @@ impl WorkspaceSettings {
         if let Some(v) = self.global_virtual_store_dir {
             config.global_virtual_store_dir = resolve(base_dir, &v);
         }
+        if let Some(v) = self.global_dir {
+            config.global_dir = Some(resolve(base_dir, &v));
+        }
+        if let Some(v) = self.global_bin_dir {
+            config.global_bin_dir = Some(resolve(base_dir, &v));
+        }
         // Last of the path-valued settings: pinning the lockfile dir
         // re-resolves `modulesDir` / `virtualStoreDir` against it, so it
         // must see whatever this layer just set.
@@ -2045,12 +2078,6 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.store_dir {
             config.store_dir = StoreDir::from(resolve(base_dir, &v));
-        }
-        if let Some(v) = self.global_dir {
-            config.global_dir = Some(resolve(base_dir, &v));
-        }
-        if let Some(v) = self.global_bin_dir {
-            config.global_bin_dir = Some(resolve(base_dir, &v));
         }
         let mut declared_prefixes = false;
         if let Some(entries) = self.registries {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -357,6 +357,14 @@ pub struct WorkspaceSettings {
     /// against the workspace dir like the other path-valued fields.
     /// When set, overrides the derived `<store_dir>/links` path.
     pub global_virtual_store_dir: Option<String>,
+    /// `globalDir` from the global `config.yaml`. Resolved like the other
+    /// path-valued fields; a project manifest does not contribute it (see
+    /// [`crate::refused_keys`]). See [`Config::global_dir`].
+    pub global_dir: Option<String>,
+    /// `globalBinDir` from the global `config.yaml`. Resolved like the other
+    /// path-valued fields; a project manifest does not contribute it (see
+    /// [`crate::refused_keys`]). See [`Config::global_bin_dir`].
+    pub global_bin_dir: Option<String>,
     pub package_import_method: Option<PackageImportMethod>,
     pub modules_cache_max_age: Option<u64>,
     pub virtual_store_dir_max_length: Option<u64>,
@@ -1835,6 +1843,8 @@ impl WorkspaceSettings {
         substitute_optional_string::<Sys>(&mut self.modules_dir);
         substitute_optional_string::<Sys>(&mut self.virtual_store_dir);
         substitute_optional_string::<Sys>(&mut self.global_virtual_store_dir);
+        substitute_optional_string::<Sys>(&mut self.global_dir);
+        substitute_optional_string::<Sys>(&mut self.global_bin_dir);
         substitute_optional_string::<Sys>(&mut self.user_agent);
         substitute_optional_string::<Sys>(&mut self.npmrc_auth_file);
         substitute_optional_string::<Sys>(&mut self.lockfile_dir);
@@ -2035,6 +2045,12 @@ impl WorkspaceSettings {
         }
         if let Some(v) = self.store_dir {
             config.store_dir = StoreDir::from(resolve(base_dir, &v));
+        }
+        if let Some(v) = self.global_dir {
+            config.global_dir = Some(resolve(base_dir, &v));
+        }
+        if let Some(v) = self.global_bin_dir {
+            config.global_bin_dir = Some(resolve(base_dir, &v));
         }
         let mut declared_prefixes = false;
         if let Some(entries) = self.registries {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1852,15 +1852,11 @@ impl WorkspaceSettings {
             let Some(relative) = dir
                 .as_deref()
                 .and_then(|dir| dir.strip_prefix("~/").or_else(|| dir.strip_prefix(r"~\")))
-                // Without the trim, `~//bin` joins as an absolute path and
-                // lands on `/bin`; without the normalize, `~/../bin` keeps
-                // the parent segment pnpm's `path.join` collapses.
-                .map(|relative| relative.trim_start_matches(['/', '\\']))
             else {
                 continue;
             };
             if let Some(expanded) = Sys::home_dir()
-                .map(|home_dir| pnpm_fs::lexical_normalize(&home_dir.join(relative)))
+                .map(|home_dir| join_home_relative(&home_dir, relative))
                 .and_then(|expanded| expanded.into_os_string().into_string().ok())
             {
                 *dir = Some(expanded);
@@ -2415,6 +2411,19 @@ fn substitute_optional_inner_string<Sys: EnvVar>(value: &mut Option<Option<Strin
 
 fn normalize_registry_url(registry: &str) -> String {
     if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
+}
+
+/// Join a `~/`-relative suffix onto the home directory the way pnpm's
+/// `path.join` does: concatenate with the separator, then normalize. Node
+/// treats every argument after the first as a fragment, so `Path::join` is
+/// the wrong primitive here — it lets a suffix that parses as rooted
+/// (`~//bin`) replace the home directory outright, which is how the tilde
+/// would end up naming somewhere else entirely.
+fn join_home_relative(home: &Path, relative: &str) -> PathBuf {
+    let mut joined = home.as_os_str().to_os_string();
+    joined.push(std::path::MAIN_SEPARATOR_STR);
+    joined.push(relative);
+    pnpm_fs::lexical_normalize(Path::new(&joined))
 }
 
 fn resolve(base: &Path, value: &str) -> PathBuf {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -357,15 +357,15 @@ pub struct WorkspaceSettings {
     /// against the workspace dir like the other path-valued fields.
     /// When set, overrides the derived `<store_dir>/links` path.
     pub global_virtual_store_dir: Option<String>,
-    /// `globalDir` from the global `config.yaml`. Resolved against the
-    /// workspace dir like the other path-valued fields. See
-    /// [`Config::global_dir`].
+    /// `globalDir` from the global `config.yaml` or the environment. A
+    /// relative value resolves against the directory pnpm runs in, which
+    /// is where pnpm itself resolves it. See [`Config::global_dir`].
     ///
     /// No repo-committed file may set it — see [`crate::refused_keys`].
     pub global_dir: Option<String>,
-    /// `globalBinDir` from the global `config.yaml`. Resolved against the
-    /// workspace dir like the other path-valued fields. See
-    /// [`Config::global_bin_dir`].
+    /// `globalBinDir` from the global `config.yaml` or the environment. A
+    /// relative value resolves against the directory pnpm runs in, which
+    /// is where pnpm itself resolves it. See [`Config::global_bin_dir`].
     ///
     /// No repo-committed file may set it — see [`crate::refused_keys`].
     pub global_bin_dir: Option<String>,
@@ -1841,13 +1841,13 @@ impl WorkspaceSettings {
     }
 
     /// Rewrite a leading `~/` in `globalDir` / `globalBinDir` into the home
-    /// directory, as pnpm's `transformPathKeys` does. A shell expands the
-    /// tilde before `pnpm config set` sees it, but a hand-written
+    /// directory, as pnpm's `transformGlobalDirKeys` does. A shell expands
+    /// the tilde before `pnpm config set` sees it, but a hand-written
     /// `config.yaml` carries it verbatim.
     ///
     /// Call this before [`Self::apply_to`], which would otherwise take the
     /// tilde for an ordinary relative path segment.
-    pub fn expand_home_prefixes<Sys: GetHomeDir>(&mut self) {
+    pub(crate) fn expand_global_dir_home_prefixes<Sys: GetHomeDir>(&mut self) {
         for dir in [&mut self.global_dir, &mut self.global_bin_dir] {
             let Some(relative) = dir
                 .as_deref()

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1852,11 +1852,16 @@ impl WorkspaceSettings {
             let Some(relative) = dir
                 .as_deref()
                 .and_then(|dir| dir.strip_prefix("~/").or_else(|| dir.strip_prefix(r"~\")))
+                // Without the trim, `~//bin` joins as an absolute path and
+                // lands on `/bin`; without the normalize, `~/../bin` keeps
+                // the parent segment pnpm's `path.join` collapses.
+                .map(|relative| relative.trim_start_matches(['/', '\\']))
             else {
                 continue;
             };
             if let Some(expanded) = Sys::home_dir()
-                .and_then(|home_dir| home_dir.join(relative).into_os_string().into_string().ok())
+                .map(|home_dir| pnpm_fs::lexical_normalize(&home_dir.join(relative)))
+                .and_then(|expanded| expanded.into_os_string().into_string().ok())
             {
                 *dir = Some(expanded);
             }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3457,7 +3457,7 @@ fn expanding_a_home_prefix_joins_the_way_pnpm_does() {
         assert_eq!(
             settings.global_dir.as_deref().map(Path::new),
             expected,
-            "globalDir {configured}"
+            "globalDir {configured}",
         );
         assert_eq!(
             settings.global_bin_dir.as_deref().map(Path::new),

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3439,11 +3439,13 @@ fn expanding_a_home_prefix_joins_the_way_pnpm_does() {
         }
     }
 
+    // Compared as paths, not strings: the join separator is `\\` on Windows.
+    let home = PathBuf::from("/home/example");
     for (configured, expected) in [
-        ("~/bin", "/home/example/bin"),
-        ("~//bin", "/home/example/bin"),
-        ("~/../bin", "/home/bin"),
-        ("~/nested/../bin", "/home/example/bin"),
+        ("~/bin", home.join("bin")),
+        ("~//bin", home.join("bin")),
+        ("~/../bin", PathBuf::from("/home").join("bin")),
+        ("~/nested/../bin", home.join("bin")),
     ] {
         let mut settings = WorkspaceSettings {
             global_dir: Some(configured.to_string()),
@@ -3451,8 +3453,17 @@ fn expanding_a_home_prefix_joins_the_way_pnpm_does() {
             ..WorkspaceSettings::default()
         };
         settings.expand_global_dir_home_prefixes::<FakeHome>();
-        assert_eq!(settings.global_dir.as_deref(), Some(expected), "globalDir {configured}");
-        assert_eq!(settings.global_bin_dir.as_deref(), Some(expected), "globalBinDir {configured}");
+        let expected = Some(expected.as_path());
+        assert_eq!(
+            settings.global_dir.as_deref().map(Path::new),
+            expected,
+            "globalDir {configured}"
+        );
+        assert_eq!(
+            settings.global_bin_dir.as_deref().map(Path::new),
+            expected,
+            "globalBinDir {configured}",
+        );
     }
 }
 

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -6,14 +6,19 @@ use super::{
 use crate::{
     AuditLevel, CatalogMode, ColorMode, Config, GlobalShims, GlobalShimsSetting, HoistingLimits,
     LinkWorkspacePackages, NodeLinker, NodePackageMapType, ResolutionMode, ScriptsPrependNodePath,
-    ShimPolicy, TrustPolicy, api::EnvVar,
+    ShimPolicy, TrustPolicy,
+    api::{EnvVar, GetHomeDir},
 };
 use pipe_trait::Pipe;
 use pnpm_lockfile::{RegistryOptions, RegistryServerType};
 use pnpm_store_dir::StoreDir;
 use pnpm_workspace_state::{ConfigDependency, ConfigDependencyDetail};
 use pretty_assertions::assert_eq;
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 #[test]
 fn parses_common_settings_from_yaml() {
@@ -3420,4 +3425,54 @@ fn rejects_string_task_concurrency_as_an_invalid_setting() {
         LoadWorkspaceYamlError::InvalidTaskConcurrency { ref task, ref concurrency }
             if task == "build" && concurrency == r#""2""#
     ));
+}
+
+/// The odd suffixes pnpm's `path.join(homedir, rest)` swallows: a doubled
+/// separator must not turn the value absolute, and a parent segment must
+/// collapse rather than survive into the resolved path.
+#[test]
+fn expanding_a_home_prefix_joins_the_way_pnpm_does() {
+    struct FakeHome;
+    impl GetHomeDir for FakeHome {
+        fn home_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/home/example"))
+        }
+    }
+
+    for (configured, expected) in [
+        ("~/bin", "/home/example/bin"),
+        ("~//bin", "/home/example/bin"),
+        ("~/../bin", "/home/bin"),
+        ("~/nested/../bin", "/home/example/bin"),
+    ] {
+        let mut settings = WorkspaceSettings {
+            global_dir: Some(configured.to_string()),
+            global_bin_dir: Some(configured.to_string()),
+            ..WorkspaceSettings::default()
+        };
+        settings.expand_global_dir_home_prefixes::<FakeHome>();
+        assert_eq!(settings.global_dir.as_deref(), Some(expected), "globalDir {configured}");
+        assert_eq!(settings.global_bin_dir.as_deref(), Some(expected), "globalBinDir {configured}");
+    }
+}
+
+/// A tilde that names no home-relative path is an ordinary value: pnpm's
+/// `/^~[/\\]/` does not match it either.
+#[test]
+fn a_tilde_without_a_separator_is_left_alone() {
+    struct FakeHome;
+    impl GetHomeDir for FakeHome {
+        fn home_dir() -> Option<PathBuf> {
+            Some(PathBuf::from("/home/example"))
+        }
+    }
+
+    let mut settings = WorkspaceSettings {
+        global_dir: Some("~backup/global".to_string()),
+        global_bin_dir: Some("bin/~/nested".to_string()),
+        ..WorkspaceSettings::default()
+    };
+    settings.expand_global_dir_home_prefixes::<FakeHome>();
+    assert_eq!(settings.global_dir.as_deref(), Some("~backup/global"));
+    assert_eq!(settings.global_bin_dir.as_deref(), Some("bin/~/nested"));
 }

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -51,7 +51,7 @@ import {
   overrideSupportedArchitecturesWithCLI,
 } from './overrideSupportedArchitecturesWithCLI.js'
 import { quoteAndJoin } from './quoteAndJoin.js'
-import { transformPathKeys } from './transformPath.js'
+import { transformGlobalDirKeys, transformPathKeys } from './transformPath.js'
 import { types } from './types.js'
 import { isKnownSettingKey, quoteAndAnnotateUnknown } from './unknownSettings.js'
 export { types }
@@ -429,6 +429,7 @@ export async function getConfig (opts: {
     }
   }
   pnpmConfig.pnpmHomeDir = getDataDir({ env, platform: process.platform })
+  transformGlobalDirKeys(pnpmConfig, os.homedir())
   let globalDirRoot
   if (pnpmConfig.globalDir) {
     globalDirRoot = pnpmConfig.globalDir

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -429,6 +429,20 @@ export async function getConfig (opts: {
     }
   }
   pnpmConfig.pnpmHomeDir = getDataDir({ env, platform: process.platform })
+  // `globalPkgDir` and `bin` are derived just below, and `globalPkgDir` is
+  // read again further down, both before the full `PNPM_CONFIG_*` pass runs.
+  // The two settings they are built from therefore have to come off the
+  // environment here; that pass sets them again to the same values. The CLI
+  // outranks the environment, exactly as it does there.
+  for (const { key, value } of parseEnvVars(
+    schemaKey => schemaKey === 'global-dir' || schemaKey === 'global-bin-dir' ? types[schemaKey] : undefined,
+    env
+  )) {
+    if ((key !== 'globalDir' && key !== 'globalBinDir') || typeof value !== 'string') continue
+    if (Object.hasOwn(cliOptions, key) || Object.hasOwn(cliOptions, kebabCase(key))) continue
+    pnpmConfig[key] = value
+    explicitlySetKeys.add(key)
+  }
   transformGlobalDirKeys(pnpmConfig, os.homedir())
   let globalDirRoot
   if (pnpmConfig.globalDir) {

--- a/pnpm11/config/reader/src/transformPath.ts
+++ b/pnpm11/config/reader/src/transformPath.ts
@@ -7,16 +7,38 @@ const REGEX = /^~[/\\]/
 export const transformPath = (path: string, homedir: string): string =>
   REGEX.test(path) ? join(homedir, path.replace(REGEX, '')) : path
 
-const PATH_KEYS = [
-  'cacheDir',
+const GLOBAL_DIR_KEYS = [
   'globalBinDir',
   'globalDir',
+] as const satisfies Array<keyof Config>
+
+const PATH_KEYS = [
+  'cacheDir',
+  ...GLOBAL_DIR_KEYS,
   'pnpmHomeDir',
   'storeDir',
 ] as const satisfies Array<keyof Config>
 
-export function transformPathKeys (config: Partial<Pick<Config, typeof PATH_KEYS[number]>>, homedir: string): void {
-  for (const key of PATH_KEYS) {
+type PathKey = typeof PATH_KEYS[number]
+
+type PathConfig = Partial<Pick<Config, PathKey>>
+
+/**
+ * Expand a leading `~/` in the two settings `globalPkgDir` and `bin` are
+ * derived from, before that derivation runs — a tilde left in place would
+ * become a directory literally named `~`. The `transformPathKeys` pass at
+ * the end of `getConfig` reaches these two again, by then a no-op.
+ */
+export function transformGlobalDirKeys (config: PathConfig, homedir: string): void {
+  transformKeys(config, homedir, GLOBAL_DIR_KEYS)
+}
+
+export function transformPathKeys (config: PathConfig, homedir: string): void {
+  transformKeys(config, homedir, PATH_KEYS)
+}
+
+function transformKeys (config: PathConfig, homedir: string, keys: readonly PathKey[]): void {
+  for (const key of keys) {
     if (config[key]) {
       config[key] = transformPath(config[key], homedir)
     }

--- a/pnpm11/config/reader/test/globalBinDir.test.ts
+++ b/pnpm11/config/reader/test/globalBinDir.test.ts
@@ -5,6 +5,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { getConfig } from '@pnpm/config.reader'
+import { GLOBAL_LAYOUT_VERSION } from '@pnpm/constants'
 import { tempDir } from '@pnpm/prepare'
 import pathName from 'path-name'
 import { symlinkDir } from 'symlink-dir'
@@ -89,4 +90,23 @@ test('the global directory may be a symlink to a directory that is in PATH', asy
     },
   })
   expect(config.bin).toBe(globalBinDirSymlink)
+})
+
+test('a leading ~ is expanded before the global directories are derived', async () => {
+  const { config } = await getConfig({
+    cliOptions: {
+      global: true,
+      'global-bin-dir': '~/.local/pnpm',
+      'global-dir': '~/.local/share/pnpm-global',
+    },
+    env: {
+      [pathName]: `${globalBinDir}${path.delimiter}${process.env[pathName]!}`,
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.bin).toBe(globalBinDir)
+  expect(config.globalPkgDir).toBe(path.join(homedir(), '.local', 'share', 'pnpm-global', GLOBAL_LAYOUT_VERSION))
 })

--- a/pnpm11/config/reader/test/globalBinDir.test.ts
+++ b/pnpm11/config/reader/test/globalBinDir.test.ts
@@ -110,3 +110,48 @@ test('a leading ~ is expanded before the global directories are derived', async 
   expect(config.bin).toBe(globalBinDir)
   expect(config.globalPkgDir).toBe(path.join(homedir(), '.local', 'share', 'pnpm-global', GLOBAL_LAYOUT_VERSION))
 })
+
+test('PNPM_CONFIG_GLOBAL_BIN_DIR and PNPM_CONFIG_GLOBAL_DIR reach the derived directories', async () => {
+  const tmp = tempDir()
+  const envBinDir = path.join(tmp, 'env-bin')
+  fs.mkdirSync(envBinDir, { recursive: true })
+  const { config } = await getConfig({
+    cliOptions: {
+      global: true,
+      dir: import.meta.dirname,
+    },
+    env: {
+      [pathName]: `${envBinDir}${path.delimiter}${process.env[pathName]!}`,
+      PNPM_CONFIG_GLOBAL_BIN_DIR: envBinDir,
+      PNPM_CONFIG_GLOBAL_DIR: path.join(tmp, 'env-global'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.bin).toBe(envBinDir)
+  expect(config.globalPkgDir).toBe(path.join(tmp, 'env-global', GLOBAL_LAYOUT_VERSION))
+})
+
+test('a global-bin-dir on the command line outranks PNPM_CONFIG_GLOBAL_BIN_DIR', async () => {
+  const tmp = tempDir()
+  const cliBinDir = path.join(tmp, 'cli-bin')
+  fs.mkdirSync(cliBinDir, { recursive: true })
+  const { config } = await getConfig({
+    cliOptions: {
+      global: true,
+      'global-bin-dir': cliBinDir,
+      dir: import.meta.dirname,
+    },
+    env: {
+      [pathName]: `${cliBinDir}${path.delimiter}${process.env[pathName]!}`,
+      PNPM_CONFIG_GLOBAL_BIN_DIR: path.join(tmp, 'env-bin'),
+    },
+    packageManager: {
+      name: 'pnpm',
+      version: '1.0.0',
+    },
+  })
+  expect(config.bin).toBe(cliBinDir)
+})

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4796,6 +4796,39 @@ describe('global config.yaml', () => {
     expect(config.dangerouslyAllowAllBuilds).toBeDefined()
   })
 
+  // The scenario the reporter hit: `pnpm config set -g global-bin-dir` writes
+  // the key into this file, and `pnpm add -g` has to install into it.
+  test('globalDir and globalBinDir from the global config.yaml reach the derived directories', async () => {
+    prepareEmpty()
+
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', {
+      globalBinDir: '~/pnpm-bin',
+      globalDir: '~/pnpm-global',
+    })
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+    const home = path.resolve('user-home')
+    const binDir = path.join(home, 'pnpm-bin')
+    const homedirSpy = jest.spyOn(os, 'homedir').mockReturnValue(home)
+    try {
+      const { config } = await getConfig({
+        cliOptions: { global: true },
+        env: {
+          [PATH]: `${binDir}${path.delimiter}${process.env[PATH]!}`,
+        },
+        packageManager: {
+          name: 'pnpm',
+          version: '1.0.0',
+        },
+      })
+      expect(config.globalPkgDir).toBe(path.join(home, 'pnpm-global', GLOBAL_LAYOUT_VERSION))
+      expect(config.bin).toBe(binDir)
+    } finally {
+      homedirSpy.mockRestore()
+    }
+  })
+
   test('warns about a kebab-case key in the global config.yaml', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
## Summary

`pnpm config set -g global-bin-dir <path>` writes `globalBinDir` into the global `config.yaml`, but pnpm 12 never read it back: `pnpm add -g` kept using the derived `<pnpm-home>/bin` and failed with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`. The global file is parsed into `WorkspaceSettings`, which had no `globalDir` / `globalBinDir` fields, so serde dropped both keys, and `Config` filled the two settings from `PNPM_CONFIG_GLOBAL_DIR` / `PNPM_CONFIG_GLOBAL_BIN_DIR` alone. Exporting the env var was the only way to get the configured directory back, which is what the reporter found.

Both settings are now fields of `WorkspaceSettings`, so they come off the global `config.yaml` through the same path every other machine-level setting takes, and the env vars go through the ordinary `PNPM_CONFIG_*` overlay instead of their own late special case. A leading `~/` is expanded against the home directory before the global package and bin directories are derived from it — without that a hand-written `config.yaml` would resolve the tilde as a directory name. A project's `pnpm-workspace.yaml` still cannot set either key: pnpm's project-manifest filter refuses both, so they are cleared with `stateDir` and `scope` before the workspace layer is applied.

The reporter notes other config-file keys are missing too. The rest of `pnpmConfigFileKeys` that pacquet does not read — `fetchingConcurrency`, `globalPath`, `loglevel`, `npmPath`, `reporter` — have no `Config` field either, so each is a setting to implement rather than a key to wire up, and none of them is this bug.

The TypeScript CLI already reads both keys from that file, so the missing
setting is pacquet-side only. The tilde is not: `transformPathKeys` runs at
the end of `getConfig`, long after `globalPkgDir` and `bin` have been built
from `globalDir` / `globalBinDir`, so pnpm `mkdir`s a `globalBinDir: ~/bin`
as a directory literally named `~` under the cwd and then fails
`checkGlobalBinDir` with `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH` — the same
error, from the same setting. The two global directory keys are split out
of the path-key pass so they can be expanded where they are read; the later
pass reaches them again as a no-op.

The same review turned up the mirror of the reported bug on the TypeScript
side: `PNPM_CONFIG_GLOBAL_DIR` / `PNPM_CONFIG_GLOBAL_BIN_DIR` set the two
settings, but the `parseEnvVars` pass that reads them runs after
`globalPkgDir` and `bin` are derived from them (and after `globalPkgDir` is
consumed at `index.ts:561`), so `PNPM_CONFIG_GLOBAL_BIN_DIR=<dir> pnpm add -g`
installed into `<pnpm-home>/bin`. It predates this PR, but pacquet routes both
vars through its env overlay before deriving, so leaving it would ship the two
stacks disagreeing about the same setting. The two keys are taken off the
environment before the derivation, with the CLI still outranking them.

Fixes pnpm/pnpm#14336

## Squash Commit Body

```text
The global config.yaml is parsed into WorkspaceSettings, which had no
globalDir / globalBinDir fields, so serde dropped both keys and the two
settings reached Config only from PNPM_CONFIG_GLOBAL_DIR /
PNPM_CONFIG_GLOBAL_BIN_DIR, read in a late special case of their own.
A user who ran `pnpm config set -g global-bin-dir` therefore got
ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH from `pnpm add -g` unless they also
exported the environment variable.

Both are fields of WorkspaceSettings now, resolved against the base dir
like the other path-valued settings, which puts them on the ordinary
cascade: the global file, then PNPM_CONFIG_* through the shared env
overlay, with the special case removed. Two side effects of joining that
overlay: ${VAR} is expanded in the values, and PNPM_CONFIG_GLOBAL_DIR now
wins over pnpm_config_global_dir rather than the other way round, both of
which match every other setting. A leading ~/ is expanded before the
paths are resolved, mirroring transformPathKeys, since resolving one as a
relative path would produce a directory literally named "~".

pnpm's project-manifest key filter refuses both keys, so
pnpm-workspace.yaml has them cleared alongside stateDir and scope and
still cannot point the machine's global directories anywhere.

On the TypeScript side the tilde had the same bug from the other end:
transformPathKeys ran after globalPkgDir and bin were derived from the two
settings, so a `~/` in globalBinDir became a directory literally named "~"
under the cwd and then failed checkGlobalBinDir with the same error code.
The two keys are now expanded before that derivation, which is also what
keeps the stacks agreeing about the tilde.

PNPM_CONFIG_GLOBAL_DIR / PNPM_CONFIG_GLOBAL_BIN_DIR had the same shape of
problem there: the parseEnvVars pass that reads them runs after the
derivation, so the env vars never reached globalPkgDir or bin. They are
taken off the environment before it now, the CLI still outranking them.

Closes pnpm/pnpm#14336
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global installation directories configured in the global `config.yaml` are honored again.
  * Fixed errors when installing packages globally with a custom global binary directory.
  * Workspace settings can no longer override machine-wide global installation directories.
  * Environment-based global directory settings are applied correctly.
  * Leading `~/` paths in global directory settings now expand to the home directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
The TypeScript half of the tilde fix and this description update were written by an agent (Claude Code, claude-opus-5).

