### PR TITLE
fix(cli): honor side-effects cache overrides

### DIFF
--- a/.changeset/side-effects-cache-boolean-keeps-remote-tier.md
+++ b/.changeset/side-effects-cache-boolean-keeps-remote-tier.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+Fixed `--side-effects-cache`/`--no-side-effects-cache` and `PNPM_CONFIG_SIDE_EFFECTS_CACHE` discarding a remote side-effects cache declared under the object form of `sideEffectsCache` in `pnpm-workspace.yaml`. The boolean now switches only the local cache off or on, as it already does when a config file declares it.

--- a/.changeset/side-effects-cache-cli-override.md
+++ b/.changeset/side-effects-cache-cli-override.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed command-line `--side-effects-cache` overrides being ignored when `pnpm-workspace.yaml` uses the object form of `sideEffectsCache` [pnpm/pnpm#14338](https://github.com/pnpm/pnpm/issues/14338).

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -581,6 +581,8 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.side_effects_cache {
             config.side_effects_cache = value;
+            config.side_effects_cache_read_setting = None;
+            config.side_effects_cache_write_setting = None;
             config.explicit_settings.insert("sideEffectsCache".to_string(), value.into());
         }
         if let Some(value) = self.side_effects_cache_readonly {

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -580,9 +580,7 @@ impl ConfigOverrides {
             config.explicit_settings.insert("strictPeerDependencies".to_string(), value.into());
         }
         if let Some(value) = self.side_effects_cache {
-            config.side_effects_cache = value;
-            config.side_effects_cache_read_setting = None;
-            config.side_effects_cache_write_setting = None;
+            config.apply_side_effects_cache_shorthand(value);
             config.explicit_settings.insert("sideEffectsCache".to_string(), value.into());
         }
         if let Some(value) = self.side_effects_cache_readonly {

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -750,6 +750,26 @@ fn a_boolean_setting_claims_the_next_token_only_when_it_spells_a_boolean() {
 }
 
 #[test]
+fn side_effects_cache_cli_override_replaces_object_setting() {
+    for (flag, object_setting, expected) in
+        [("--no-side-effects-cache", true, false), ("--side-effects-cache", false, true)]
+    {
+        let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", "install", flag]));
+        assert_eq!(remaining, argv(["pacquet", "install"]));
+
+        let mut config = Config {
+            side_effects_cache_read_setting: Some(object_setting),
+            side_effects_cache_write_setting: Some(object_setting),
+            ..Config::default()
+        };
+        overrides.apply(&mut config, Path::new("/workspace"));
+
+        assert_eq!(config.side_effects_cache_read(), expected);
+        assert_eq!(config.side_effects_cache_write(), expected);
+    }
+}
+
+#[test]
 fn a_repeated_list_setting_accumulates_its_values() {
     let (overrides, _) = ConfigOverrides::extract(argv([
         "pacquet",

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use pnpm_config::{
     ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker,
-    PackageImportMethod, PmOnFail, RuntimeOnFail, TrustPolicy,
+    PackageImportMethod, PmOnFail, RemoteSideEffectsCacheSettings, RuntimeOnFail, TrustPolicy,
 };
 use pnpm_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
@@ -750,22 +750,30 @@ fn a_boolean_setting_claims_the_next_token_only_when_it_spells_a_boolean() {
 }
 
 #[test]
-fn side_effects_cache_cli_override_replaces_object_setting() {
-    for (flag, object_setting, expected) in
+fn a_side_effects_cache_flag_replaces_the_object_form_and_keeps_its_remote_tier() {
+    for (flag, declared_gates, expected) in
         [("--no-side-effects-cache", true, false), ("--side-effects-cache", false, true)]
     {
         let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", "install", flag]));
         assert_eq!(remaining, argv(["pacquet", "install"]));
 
         let mut config = Config {
-            side_effects_cache_read_setting: Some(object_setting),
-            side_effects_cache_write_setting: Some(object_setting),
+            side_effects_cache_read_setting: Some(declared_gates),
+            side_effects_cache_write_setting: Some(declared_gates),
+            remote_side_effects_cache: Some(RemoteSideEffectsCacheSettings {
+                org: "acme".to_string(),
+                ..RemoteSideEffectsCacheSettings::default()
+            }),
             ..Config::default()
         };
         overrides.apply(&mut config, Path::new("/workspace"));
 
         assert_eq!(config.side_effects_cache_read(), expected);
         assert_eq!(config.side_effects_cache_write(), expected);
+        assert_eq!(
+            config.remote_side_effects_cache.map(|remote| remote.org),
+            Some("acme".to_string()),
+        );
     }
 }
 

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -1,9 +1,10 @@
 use super::{WorkspaceSettings, parse_json_or_string, parse_tri_array};
 use crate::{
-    ColorMode, NodeLinker, NodePackageMapType, SaveWorkspaceProtocol, ScriptsPrependNodePath,
-    TrustPolicy, VirtualStoreType, api::EnvVar,
+    ColorMode, Config, NodeLinker, NodePackageMapType, SaveWorkspaceProtocol,
+    ScriptsPrependNodePath, TrustPolicy, VirtualStoreType, api::EnvVar,
 };
 use pretty_assertions::assert_eq;
+use std::path::Path;
 
 #[test]
 fn bool_env_var_only_accepts_lowercase_true_false() {
@@ -270,4 +271,36 @@ fn virtual_store_type_env_var_parses_its_two_values() {
         Some(VirtualStoreType::Project),
     );
     assert_eq!(WorkspaceSettings::from_pnpm_config_env::<EnvNonsense>().virtual_store_type, None);
+}
+
+/// The environment can only spell the boolean, so it reaches the same
+/// shorthand arm a yaml layer's boolean does: the object form's gates give way
+/// to it and the remote tier it says nothing about survives.
+#[test]
+fn a_side_effects_cache_env_var_replaces_the_object_form() {
+    struct EnvSideEffectsCacheOff;
+    impl EnvVar for EnvSideEffectsCacheOff {
+        fn var(name: &str) -> Option<String> {
+            (name == "PNPM_CONFIG_SIDE_EFFECTS_CACHE").then(|| "false".to_owned())
+        }
+    }
+    let declared: WorkspaceSettings = serde_saphyr::from_str(
+        r"
+sideEffectsCache:
+  read: true
+  write: true
+  remote:
+    org: acme
+",
+    )
+    .unwrap();
+
+    let mut config = Config::new();
+    declared.apply_to(&mut config, Path::new("/workspace"));
+    WorkspaceSettings::from_pnpm_config_env::<EnvSideEffectsCacheOff>()
+        .apply_to(&mut config, Path::new("/workspace"));
+
+    assert!(!config.side_effects_cache_read());
+    assert!(!config.side_effects_cache_write());
+    assert_eq!(config.remote_side_effects_cache.expect("shared cache config").org, "acme");
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2772,6 +2772,21 @@ impl Config {
         registries
     }
 
+    /// Apply a boolean `sideEffectsCache` declaration, which turns the
+    /// local read and write gates on or off together.
+    ///
+    /// [`Config::side_effects_cache_read`] and
+    /// [`Config::side_effects_cache_write`] prefer the object form's
+    /// fields, so a layer spelling the setting as a boolean has to clear
+    /// what an earlier layer's object left behind to beat it. The remote
+    /// tier is a separate declaration the boolean says nothing about, so
+    /// it survives untouched.
+    pub fn apply_side_effects_cache_shorthand(&mut self, enabled: bool) {
+        self.side_effects_cache = enabled;
+        self.side_effects_cache_read_setting = None;
+        self.side_effects_cache_write_setting = None;
+    }
+
     /// Whether the install should consult the side-effects cache
     /// (`sideEffectsCacheRead = sideEffectsCache ?? sideEffectsCacheReadonly`).
     ///

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2065,12 +2065,7 @@ impl WorkspaceSettings {
         // supplies the signing key, and neither may drop the other's fields.
         match self.side_effects_cache {
             Some(SideEffectsCacheSetting::Enabled(enabled)) => {
-                config.side_effects_cache = enabled;
-                // A later layer saying `sideEffectsCache: false` has to beat an
-                // earlier layer's object, and the helpers prefer these when set,
-                // so the shorthand must clear what the object left behind.
-                config.side_effects_cache_read_setting = None;
-                config.side_effects_cache_write_setting = None;
+                config.apply_side_effects_cache_shorthand(enabled);
             }
             Some(SideEffectsCacheSetting::Settings(settings)) => {
                 config.side_effects_cache_read_setting = Some(settings.read.unwrap_or(true));

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -670,6 +670,14 @@ export async function getConfig (opts: {
       continue
     }
 
+    // The environment can only spell the boolean, and a plain assignment
+    // would drop a remote tier a config file declared under the object form.
+    if (key === 'sideEffectsCache') {
+      applySideEffectsCacheDeclaration(pnpmConfig, value)
+      explicitlySetKeys.add(key)
+      continue
+    }
+
     // @ts-expect-error
     pnpmConfig[key] = value
     explicitlySetKeys.add(key)
@@ -1616,7 +1624,9 @@ function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config & ConfigCo
   workspaceManifest: WorkspaceManifest
 }): void {
   const skipped: ReadonlySet<string> | undefined = skipSettings
-  const newSettings = Object.assign(getOptionsFromPnpmSettings(workspaceDir, workspaceManifest, { manifest: projectManifest, expandRequestDestinationEnv, trustedSource }), configFromCliOpts)
+  const settingsFromManifest = getOptionsFromPnpmSettings(workspaceDir, workspaceManifest, { manifest: projectManifest, expandRequestDestinationEnv, trustedSource })
+  const sideEffectsCacheFromManifest = settingsFromManifest.sideEffectsCache
+  const newSettings = Object.assign(settingsFromManifest, configFromCliOpts)
   for (const [key, value] of Object.entries(newSettings)) {
     if (!isCamelCase(key)) continue
     if (CONFIG_CONTEXT_KEY_SET.has(key)) continue
@@ -1639,30 +1649,14 @@ function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config & ConfigCo
       continue
     }
     if (key === 'sideEffectsCache') {
-      const previous = typeof pnpmConfig.sideEffectsCache === 'object' && pnpmConfig.sideEffectsCache != null
-        ? pnpmConfig.sideEffectsCache
-        : undefined
-      if (typeof value === 'boolean') {
-        // A boolean says whether to read and write. It says nothing about the
-        // remote tier, so one declared by an earlier source survives it — but
-        // it has to survive as a remote tier rather than by turning the
-        // boolean into an object, which would move the whole declaration onto
-        // the object branch of the resolver and take it out of reach of
-        // `sideEffectsCacheReadonly`.
-        if (previous?.remote != null) {
-          pnpmConfig.remoteSideEffectsCache = {
-            ...pnpmConfig.remoteSideEffectsCache,
-            ...withCanonicalOrg(previous.remote),
-          }
-        }
-        pnpmConfig.sideEffectsCache = value
-      } else if (value != null) {
-        const declared = value as SideEffectsCacheSettings
-        const remote = previous?.remote != null || declared.remote != null
-          ? { ...previous?.remote, ...withCanonicalOrg(declared.remote) }
-          : undefined
-        pnpmConfig.sideEffectsCache = { ...previous, ...declared, remote }
+      // The command line is a layer on top of the manifest, not a substitute
+      // for it: applying only the value that won the merge above would drop a
+      // remote tier the manifest declared, which the boolean says nothing
+      // about.
+      if (sideEffectsCacheFromManifest != null && sideEffectsCacheFromManifest !== value) {
+        applySideEffectsCacheDeclaration(pnpmConfig, sideEffectsCacheFromManifest)
       }
+      applySideEffectsCacheDeclaration(pnpmConfig, value)
       pnpmConfig.explicitlySetKeys.add(key)
       continue
     }
@@ -1679,6 +1673,38 @@ function addSettingsFromWorkspaceManifestToConfig (pnpmConfig: Config & ConfigCo
     pnpmConfig.verifyDepsBeforeRun = process.env.pnpm_config_verify_deps_before_run as VerifyDepsBeforeRun
   }
   pnpmConfig.catalogs = getCatalogsFromWorkspaceManifest(workspaceManifest)
+}
+
+/**
+ * Merge one source's `sideEffectsCache` declaration into the config, later
+ * sources landing on top of earlier ones.
+ *
+ * A boolean says whether to read and write. It says nothing about the remote
+ * tier, so one declared by an earlier source survives it — but it has to
+ * survive as a remote tier rather than by turning the boolean into an object,
+ * which would move the whole declaration onto the object branch of
+ * {@link resolveSideEffectsCache} and take it out of reach of
+ * `sideEffectsCacheReadonly`.
+ */
+function applySideEffectsCacheDeclaration (pnpmConfig: Config, value: unknown): void {
+  const previous = typeof pnpmConfig.sideEffectsCache === 'object' && pnpmConfig.sideEffectsCache != null
+    ? pnpmConfig.sideEffectsCache
+    : undefined
+  if (typeof value === 'boolean') {
+    if (previous?.remote != null) {
+      pnpmConfig.remoteSideEffectsCache = {
+        ...pnpmConfig.remoteSideEffectsCache,
+        ...withCanonicalOrg(previous.remote),
+      }
+    }
+    pnpmConfig.sideEffectsCache = value
+  } else if (value != null) {
+    const declared = value as SideEffectsCacheSettings
+    const remote = previous?.remote != null || declared.remote != null
+      ? { ...previous?.remote, ...withCanonicalOrg(declared.remote) }
+      : undefined
+    pnpmConfig.sideEffectsCache = { ...previous, ...declared, remote }
+  }
 }
 
 /**

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -5894,6 +5894,47 @@ test('getConfig() resolves the canonical sideEffectsCache declaration', async ()
   expect(config.remoteSideEffectsCache).toStrictEqual({ org: 'acme', packages: ['native-addon'] })
 })
 
+test('getConfig() lets a command-line boolean replace a declared sideEffectsCache object', async () => {
+  const resolveWith = async (declared: object, cliValue: boolean): Promise<Config> => {
+    prepareEmpty()
+    writeYamlFileSync('pnpm-workspace.yaml', { sideEffectsCache: declared })
+    const { config } = await getConfig({
+      cliOptions: { 'side-effects-cache': cliValue },
+      packageManager: { name: 'pnpm', version: '1.0.0' },
+      workspaceDir: process.cwd(),
+    })
+    return config
+  }
+
+  const disabled = await resolveWith({ read: true, write: true, remote: { org: 'acme' } }, false)
+  expect(disabled.sideEffectsCacheRead).toBe(false)
+  expect(disabled.sideEffectsCacheWrite).toBe(false)
+  // The boolean says nothing about the remote tier, so the object's survives it.
+  expect(disabled.remoteSideEffectsCache).toStrictEqual({ org: 'acme' })
+
+  const enabled = await resolveWith({ read: false, write: false }, true)
+  expect(enabled.sideEffectsCacheRead).toBe(true)
+  expect(enabled.sideEffectsCacheWrite).toBe(true)
+})
+
+test('getConfig() lets PNPM_CONFIG_SIDE_EFFECTS_CACHE replace a declared sideEffectsCache object', async () => {
+  prepareEmpty()
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    sideEffectsCache: { read: true, write: true, remote: { org: 'acme' } },
+  })
+
+  const { config } = await getConfig({
+    cliOptions: {},
+    env: { PNPM_CONFIG_SIDE_EFFECTS_CACHE: 'false' },
+    packageManager: { name: 'pnpm', version: '1.0.0' },
+    workspaceDir: process.cwd(),
+  })
+
+  expect(config.sideEffectsCacheRead).toBe(false)
+  expect(config.sideEffectsCacheWrite).toBe(false)
+  expect(config.remoteSideEffectsCache).toStrictEqual({ org: 'acme' })
+})
+
 test('getConfig() defaults read and write when only the remote tier is declared', async () => {
   // Naming the remote tier says nothing about the local one, and the local one
   // was on by default before this setting grew an object form. Reading `remote`


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14338.

The Rust CLI now lets the command-line `--side-effects-cache` value replace the
local read and write settings derived from the object form in
`pnpm-workspace.yaml`. This restores command-line precedence for both the
positive and negative flags. The workspace yaml already cleared those settings
for a boolean of its own, so both sources now share one
`Config::apply_side_effects_cache_shorthand`.

Writing the matching parity coverage turned up a related bug on the TypeScript
side. A boolean `sideEffectsCache` is meant to switch only the *local* cache,
leaving a `remote` tier an earlier source declared under the object form — and
that held between config files, but not for the command line or the
environment. `--no-side-effects-cache` (or `PNPM_CONFIG_SIDE_EFFECTS_CACHE`)
merged over the workspace object before it was ever applied, so the remote tier
was dropped and pnpm silently stopped using the shared cache. The declarations
are now applied in layer order through one function, matching the Rust CLI.

## Squash Commit Body

```text
Pacquet kept sideEffectsCache.read and sideEffectsCache.write in separate
resolved fields. A later command-line boolean changed only the fallback field,
so the earlier object values still controlled cache reads and writes. Clear the
object-derived local gates when the CLI boolean is applied, through the same
Config method the workspace yaml uses for its own shorthand.

A boolean says nothing about the remote tier, so one an earlier source declared
survives it. In the TypeScript CLI that held only between config files: the
command line was merged into the workspace settings before they were applied,
and the environment assigned the boolean directly, so in both cases the object
was gone before anything could carry its remote tier across. Apply each
source's declaration in turn, the workspace manifest's before the command
line's.

Add regression coverage in both stacks for enabling and disabling the cache
over opposite workspace object settings, and for the remote tier surviving.

Fixes pnpm/pnpm#14338.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).
Updated by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14340"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790628647&installation_model_id=426870&pr_number=14340&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14340&signature=88cd56597812ee4b8fd48d3780ce7378bf57e9b3c313c7e3fa0ef432d4638a6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `--side-effects-cache` and `--no-side-effects-cache` so they correctly override local read and write cache settings from `pnpm-workspace.yaml`.
  * Preserved remote side-effects cache settings when using command-line flags or `PNPM_CONFIG_SIDE_EFFECTS_CACHE`.
  * Ensured boolean overrides consistently enable or disable the local cache without discarding remote caching.

* **Tests**
  * Added coverage for command-line and environment-variable overrides with object-based cache settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
