### PR TITLE
fix(graph-hasher): handle build cycles consistently

### DIFF
--- a/.changeset/fix-cyclic-build-hashes.md
+++ b/.changeset/fix-cyclic-build-hashes.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.graph-hasher": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Fixed global virtual store hashes for dependency cycles. Every package that transitively depends on an allowed build now includes the engine in its store path, independent of traversal order [pnpm/pnpm#14341](https://github.com/pnpm/pnpm/issues/14341).

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -173,9 +173,8 @@ impl VirtualStoreLayout {
     /// `allow_build_policy` drives engine-agnostic gating. When
     /// `Some`, the constructor walks `snapshots` once to collect
     /// every key whose `(name, version)` passes
-    /// [`AllowBuildPolicy::check`] returning `Some(true)`, then
-    /// passes that set as `built_dep_paths` to
-    /// [`calc_graph_node_hash`]. Pure-JS subgraphs hash with
+    /// [`AllowBuildPolicy::check`] returning `Some(true)`, then expands
+    /// that set to every transitive parent. Pure-JS subgraphs hash with
     /// `engine = null` so their GVS directories survive Node.js
     /// upgrades. When `None`, every snapshot keeps the engine in
     /// its hash payload.
@@ -266,22 +265,18 @@ impl VirtualStoreLayout {
         // Build the engine-agnostic gating set once per install.
         // `None` here disables gating so every snapshot still hashes
         // with its engine string.
-        let built_dep_paths: Option<HashSet<String>> = allow_build_policy.map(|policy| {
-            snapshots
+        let build_required_dep_paths: Option<HashSet<String>> = allow_build_policy.map(|policy| {
+            let built_dep_paths = snapshots
                 .keys()
                 .filter(|key| policy.check(&key.without_peer().to_string()) == Some(true))
                 .map(ToString::to_string)
-                .collect()
+                .collect();
+            pnpm_graph_hasher::build_required_dep_paths(&graph, &built_dep_paths)
         });
         let mut cache: DepsStateCache<String> = HashMap::new();
-        // Install-scoped memoization for the `transitivelyRequiresBuild`
-        // walk; shared across every snapshot's hash computation so
-        // diamond-shaped subgraphs only get visited once. Untouched
-        // when `built_dep_paths` is `None`.
-        let mut build_required_cache: HashMap<String, bool> = HashMap::new();
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
         // Lockfile key order, not `HashMap` order: `calc_graph_node_hash`
-        // memoizes into `cache` / `build_required_cache`, and for a
+        // memoizes into `cache`, and for a
         // snapshot inside a dependency cycle the digest that lands there
         // depends on which snapshot the walk reached it from.
         for (snapshot_key, snapshot) in crate::deps_graph::in_lockfile_order(snapshots) {
@@ -307,8 +302,7 @@ impl VirtualStoreLayout {
                 &mut cache,
                 &graph_key,
                 snapshot_engine,
-                built_dep_paths.as_ref(),
-                &mut build_required_cache,
+                build_required_dep_paths.as_ref(),
                 project,
             );
             let name = metadata_key.name.to_string();

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -276,9 +276,9 @@ impl VirtualStoreLayout {
         let mut cache: DepsStateCache<String> = HashMap::new();
         let mut gvs_suffixes: HashMap<PackageKey, String> = HashMap::with_capacity(snapshots.len());
         // Lockfile key order, not `HashMap` order: `calc_graph_node_hash`
-        // memoizes into `cache`, and for a
-        // snapshot inside a dependency cycle the digest that lands there
-        // depends on which snapshot the walk reached it from.
+        // memoizes into `cache`, and for a snapshot inside a dependency
+        // cycle the digest that lands there depends on which snapshot the
+        // walk reached it from.
         for (snapshot_key, snapshot) in crate::deps_graph::in_lockfile_order(snapshots) {
             // Per-snapshot engine resolution: a snapshot that declares
             // its own `engines.runtime` carries the desugared

--- a/pnpm/crates/graph-hasher/src/dep_state.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state.rs
@@ -213,7 +213,7 @@ pub fn warm_deps_state_cache<'a, Key>(
     }
 }
 
-/// Return every graph node that is, or transitively depends on, a node
+/// Return every node that is, or transitively depends on, a node
 /// in `built_dep_paths`.
 ///
 /// The result controls whether [`crate::calc_graph_node_hash`] includes
@@ -232,26 +232,26 @@ where
         return HashSet::new();
     }
 
-    let mut parents_by_child: HashMap<Key, Vec<Key>> = HashMap::new();
+    let mut parents_by_child: HashMap<&Key, Vec<&Key>> = HashMap::new();
     for (parent, node) in graph {
         for child in node.children.values() {
-            parents_by_child.entry(child.clone()).or_default().push(parent.clone());
+            parents_by_child.entry(child).or_default().push(parent);
         }
     }
 
-    let mut build_required = built_dep_paths.clone();
-    let mut pending: Vec<Key> = built_dep_paths.iter().cloned().collect();
+    let mut build_required: HashSet<&Key> = built_dep_paths.iter().collect();
+    let mut pending: Vec<&Key> = built_dep_paths.iter().collect();
     while let Some(child) = pending.pop() {
-        let Some(parents) = parents_by_child.get(&child) else {
+        let Some(parents) = parents_by_child.get(child) else {
             continue;
         };
         for parent in parents {
-            if build_required.insert(parent.clone()) {
-                pending.push(parent.clone());
+            if build_required.insert(parent) {
+                pending.push(parent);
             }
         }
     }
-    build_required
+    build_required.into_iter().cloned().collect()
 }
 
 #[cfg(test)]

--- a/pnpm/crates/graph-hasher/src/dep_state.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state.rs
@@ -213,74 +213,45 @@ pub fn warm_deps_state_cache<'a, Key>(
     }
 }
 
-/// Recursive helper used by [`crate::calc_graph_node_hash`] to decide
-/// whether a snapshot's engine string should contribute to its global-
-/// virtual-store hash.
+/// Return every graph node that is, or transitively depends on, a node
+/// in `built_dep_paths`.
 ///
-/// Returns `true` if `dep_path` is either in `built_dep_paths`
-/// directly, or transitively depends on a snapshot that is. The
-/// returned boolean drives whether the engine is included in
-/// [`crate::calc_graph_node_hash`] — pure-JS leaves (and their pure-JS
-/// ancestors) get `engine = null`, so their GVS hashes survive Node.js
-/// upgrades and architecture moves. Snapshots that *might* run a
-/// postinstall script keep `engine = ENGINE_NAME` so the hash
-/// partitions them by host environment.
-///
-/// The cycle guard uses `dep_path` itself, not `node.full_pkg_id`
-/// (unlike [`calc_dep_graph_hash`]), because the same pkg id reachable
-/// through two different peer contexts is two distinct nodes — once
-/// one is mid-walk we still want to recurse into the other.
-///
-/// On cycle hit (`parents.contains(dep_path)`) the function returns
-/// `false` *without* caching. The "false in this particular cycle
-/// rotation" answer isn't the canonical one — a sibling visit might
-/// still find a builder upstream, and caching `false` here would
-/// poison the next visit at the same key. A `false` *derived* from
-/// such a hit is still cached though, so — as in
-/// [`calc_dep_graph_hash`] — the answer a cycle member settles on
-/// depends on visit order, and the caller has to supply a
-/// deterministic one.
-///
-/// `cache` is install-scoped and threaded across every snapshot
-/// visited inside one [`crate::calc_graph_node_hash`] walk. `parents`
-/// is the per-walk cycle-tracking set — callers always pass a fresh
-/// empty `HashSet`, the function inserts/removes `dep_path` around
-/// the recursion.
-pub(crate) fn transitively_requires_build<Key>(
+/// The result controls whether [`crate::calc_graph_node_hash`] includes
+/// the engine in a global-virtual-store hash. It is computed as one
+/// graph-wide fixed point so dependency cycles cannot produce different
+/// answers for different entry points.
+#[must_use]
+pub fn build_required_dep_paths<Key>(
     graph: &HashMap<Key, DepsGraphNode<Key>>,
     built_dep_paths: &HashSet<Key>,
-    cache: &mut HashMap<Key, bool>,
-    dep_path: &Key,
-    parents: &mut HashSet<Key>,
-) -> bool
+) -> HashSet<Key>
 where
     Key: Clone + Eq + std::hash::Hash,
 {
-    if let Some(&cached) = cache.get(dep_path) {
-        return cached;
+    if built_dep_paths.is_empty() {
+        return HashSet::new();
     }
-    if built_dep_paths.contains(dep_path) {
-        cache.insert(dep_path.clone(), true);
-        return true;
-    }
-    let Some(node) = graph.get(dep_path) else {
-        cache.insert(dep_path.clone(), false);
-        return false;
-    };
-    if parents.contains(dep_path) {
-        return false;
-    }
-    parents.insert(dep_path.clone());
-    let mut result = false;
-    for child in node.children.values() {
-        if transitively_requires_build(graph, built_dep_paths, cache, child, parents) {
-            result = true;
-            break;
+
+    let mut parents_by_child: HashMap<Key, Vec<Key>> = HashMap::new();
+    for (parent, node) in graph {
+        for child in node.children.values() {
+            parents_by_child.entry(child.clone()).or_default().push(parent.clone());
         }
     }
-    parents.remove(dep_path);
-    cache.insert(dep_path.clone(), result);
-    result
+
+    let mut build_required = built_dep_paths.clone();
+    let mut pending: Vec<Key> = built_dep_paths.iter().cloned().collect();
+    while let Some(child) = pending.pop() {
+        let Some(parents) = parents_by_child.get(&child) else {
+            continue;
+        };
+        for parent in parents {
+            if build_required.insert(parent.clone()) {
+                pending.push(parent.clone());
+            }
+        }
+    }
+    build_required
 }
 
 #[cfg(test)]

--- a/pnpm/crates/graph-hasher/src/dep_state.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state.rs
@@ -220,6 +220,10 @@ pub fn warm_deps_state_cache<'a, Key>(
 /// the engine in a global-virtual-store hash. It is computed as one
 /// graph-wide fixed point so dependency cycles cannot produce different
 /// answers for different entry points.
+///
+/// A key with no node in `graph` is kept and still marks whatever depends
+/// on it: the built set comes from the allow-build policy rather than the
+/// graph, so the two can disagree.
 #[must_use]
 pub fn build_required_dep_paths<Key>(
     graph: &HashMap<Key, DepsGraphNode<Key>>,

--- a/pnpm/crates/graph-hasher/src/dep_state/tests.rs
+++ b/pnpm/crates/graph-hasher/src/dep_state/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    CalcDepStateOptions, DepsGraphNode, calc_dep_graph_hash, calc_dep_state,
-    calc_dep_state_input_key, transitively_requires_build, warm_deps_state_cache,
+    CalcDepStateOptions, DepsGraphNode, build_required_dep_paths, calc_dep_graph_hash,
+    calc_dep_state, calc_dep_state_input_key, warm_deps_state_cache,
 };
 use crate::hash_object;
 use indexmap::IndexMap;
@@ -259,171 +259,56 @@ fn shared_input_keys_isolate_cyclic_roots() {
 }
 
 #[test]
-fn transitively_requires_build_self_in_built_set() {
-    let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    graph.insert(
-        "builder@1.0.0".to_string(),
+fn build_required_dep_paths_reaches_every_parent_across_a_cycle() {
+    let graph = HashMap::from([
+        (
+            "a".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "a".to_string(),
+                children: IndexMap::from([
+                    ("b".to_string(), "b".to_string()),
+                    ("builder".to_string(), "builder".to_string()),
+                ]),
+            },
+        ),
+        (
+            "b".to_string(),
+            DepsGraphNode {
+                full_pkg_id: "b".to_string(),
+                children: IndexMap::from([("a".to_string(), "a".to_string())]),
+            },
+        ),
+        (
+            "builder".to_string(),
+            DepsGraphNode { full_pkg_id: "builder".to_string(), children: IndexMap::new() },
+        ),
+        (
+            "unrelated".to_string(),
+            DepsGraphNode { full_pkg_id: "unrelated".to_string(), children: IndexMap::new() },
+        ),
+    ]);
+
+    assert_eq!(
+        build_required_dep_paths(&graph, &HashSet::from(["builder".to_string()])),
+        HashSet::from(["a".to_string(), "b".to_string(), "builder".to_string()]),
+    );
+}
+
+#[test]
+fn build_required_dep_paths_handles_empty_and_missing_builders() {
+    let graph = HashMap::from([(
+        "root".to_string(),
         DepsGraphNode {
-            full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
-            children: IndexMap::new(),
+            full_pkg_id: "root".to_string(),
+            children: IndexMap::from([("missing".to_string(), "missing".to_string())]),
         },
-    );
-    let built: std::collections::HashSet<String> =
-        std::iter::once("builder@1.0.0".to_string()).collect();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"builder@1.0.0".to_string(),
-        &mut parents
-    ));
-    assert_eq!(cache.get("builder@1.0.0"), Some(&true));
-}
+    )]);
 
-#[test]
-fn transitively_requires_build_walks_to_descendant_builder() {
-    let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = IndexMap::new();
-    root_children.insert("dep".to_string(), "builder@1.0.0".to_string());
-    graph.insert(
-        "root@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "root@1.0.0:sha512-r".to_string(), children: root_children },
+    assert!(build_required_dep_paths(&graph, &HashSet::new()).is_empty());
+    assert_eq!(
+        build_required_dep_paths(&graph, &HashSet::from(["missing".to_string()])),
+        HashSet::from(["root".to_string(), "missing".to_string()]),
     );
-    graph.insert(
-        "builder@1.0.0".to_string(),
-        DepsGraphNode {
-            full_pkg_id: "builder@1.0.0:sha512-b".to_string(),
-            children: IndexMap::new(),
-        },
-    );
-    let built: std::collections::HashSet<String> =
-        std::iter::once("builder@1.0.0".to_string()).collect();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"root@1.0.0".to_string(),
-        &mut parents
-    ));
-    assert_eq!(cache.get("root@1.0.0"), Some(&true));
-    assert_eq!(cache.get("builder@1.0.0"), Some(&true));
-}
-
-#[test]
-fn transitively_requires_build_returns_false_for_unrelated_tree() {
-    let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut root_children = IndexMap::new();
-    root_children.insert("dep".to_string(), "leaf@1.0.0".to_string());
-    graph.insert(
-        "root@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "root@1.0.0:sha512-r".to_string(), children: root_children },
-    );
-    graph.insert(
-        "leaf@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-l".to_string(), children: IndexMap::new() },
-    );
-    let built: std::collections::HashSet<String> =
-        std::iter::once("builder@9.9.9".to_string()).collect();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(!transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"root@1.0.0".to_string(),
-        &mut parents
-    ));
-    assert_eq!(cache.get("root@1.0.0"), Some(&false));
-    assert_eq!(cache.get("leaf@1.0.0"), Some(&false));
-}
-
-/// The install-time graph build can drop entries for resolutions the
-/// linker rejects later, so the walker must not panic on missing keys.
-#[test]
-fn transitively_requires_build_caches_false_for_missing_node() {
-    let graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let built: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(!transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"ghost@1.0.0".to_string(),
-        &mut parents
-    ));
-    assert_eq!(cache.get("ghost@1.0.0"), Some(&false));
-}
-
-#[test]
-fn transitively_requires_build_cycle_terminates() {
-    let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    let mut a_children = IndexMap::new();
-    a_children.insert("b".to_string(), "b@1.0.0".to_string());
-    graph.insert(
-        "a@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
-    );
-    let mut b_children = IndexMap::new();
-    b_children.insert("a".to_string(), "a@1.0.0".to_string());
-    graph.insert(
-        "b@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "b@1.0.0:sha512-b".to_string(), children: b_children },
-    );
-    let built: std::collections::HashSet<String> = std::collections::HashSet::new();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(!transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"a@1.0.0".to_string(),
-        &mut parents
-    ));
-    assert_eq!(cache.get("a@1.0.0"), Some(&false));
-    assert_eq!(cache.get("b@1.0.0"), Some(&false));
-    assert!(parents.is_empty(), "parents set must be restored to empty");
-}
-
-#[test]
-fn transitively_requires_build_cycle_does_not_mask_sibling_builder() {
-    let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
-    // Two children so child iteration order can take either path.
-    let mut a_children = IndexMap::new();
-    a_children.insert("b".to_string(), "b@1.0.0".to_string());
-    a_children.insert("c".to_string(), "builder@1.0.0".to_string());
-    graph.insert(
-        "a@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "a@1.0.0:sha512-a".to_string(), children: a_children },
-    );
-    let mut b_children = IndexMap::new();
-    b_children.insert("a".to_string(), "a@1.0.0".to_string());
-    graph.insert(
-        "b@1.0.0".to_string(),
-        DepsGraphNode { full_pkg_id: "b@1.0.0:sha512-b".to_string(), children: b_children },
-    );
-    graph.insert(
-        "builder@1.0.0".to_string(),
-        DepsGraphNode {
-            full_pkg_id: "builder@1.0.0:sha512-x".to_string(),
-            children: IndexMap::new(),
-        },
-    );
-    let built: std::collections::HashSet<String> =
-        std::iter::once("builder@1.0.0".to_string()).collect();
-    let mut cache = HashMap::new();
-    let mut parents = std::collections::HashSet::new();
-    assert!(transitively_requires_build(
-        &graph,
-        &built,
-        &mut cache,
-        &"a@1.0.0".to_string(),
-        &mut parents
-    ));
 }
 
 /// `a` sits in two cycles at once — `a` ↔ `b` and `a` ↔ `m` — so the

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path.rs
@@ -1,21 +1,18 @@
 //! Global-virtual-store directory naming — the GVS hash computation
 //! and path formatting.
 //!
-//! The engine string contribution is gated by
-//! `transitively_requires_build` (private to this crate): when the
-//! caller supplies a `built_dep_paths` set (derived from
-//! `allowBuilds` / `dangerouslyAllowAllBuilds`), only snapshots
-//! that themselves run a build script — or that transitively
-//! depend on one — keep the engine in the GVS hash payload.
+//! The engine string contribution is gated by a precomputed
+//! `build_required_dep_paths` set: only snapshots that themselves run
+//! a build script — or that transitively depend on one — keep the
+//! engine in the GVS hash payload.
 //! Pure-JS leaves and their pure-JS ancestors hash with
 //! `engine = null`, so their GVS directories survive Node.js
 //! upgrades and architecture moves. Passing `None` for
-//! `built_dep_paths` reproduces the always-include behaviour (the
-//! `built_dep_paths === undefined` branch).
+//! `build_required_dep_paths` reproduces the always-include behaviour.
 
 use crate::{
     HashEncoding,
-    dep_state::{DepsGraphNode, DepsStateCache, calc_dep_graph_hash, transitively_requires_build},
+    dep_state::{DepsGraphNode, DepsStateCache, calc_dep_graph_hash},
     hash_object, hash_object_without_sorting,
 };
 use serde_json::{Value, json};
@@ -41,16 +38,9 @@ use std::{
 /// pure-JS subgraphs hash with `engine = null` so their GVS
 /// directories survive Node.js upgrades. The gating is driven by:
 ///
-/// - `built_dep_paths`: when `Some`, the set of snapshot keys whose
-///   `allowBuilds` entry evaluates to `true` (or every snapshot when
-///   `dangerouslyAllowAllBuilds` is on). `None` disables the gating
-///   and forces `include_engine = true` — the
-///   `built_dep_paths === undefined` branch.
-/// - `build_required_cache`: install-scoped memoization for the
-///   gating walk. Allocated once at the call site and reused across
-///   every snapshot in the install. Untouched when `built_dep_paths`
-///   is `None`; callers that don't care can hold a throwaway
-///   `let mut cache = HashMap::new();` and pass `&mut cache`.
+/// - `build_required_dep_paths`: when `Some`, the fixed set returned by
+///   [`crate::build_required_dep_paths`]. `None` disables the gating and
+///   forces `include_engine = true`.
 ///
 /// `project` scopes the slot to one project instead of sharing it
 /// across every project in the store. Callers pass `Some(lockfile_dir)`
@@ -62,23 +52,13 @@ pub fn calc_graph_node_hash<Key>(
     cache: &mut DepsStateCache<Key>,
     dep_path: &Key,
     engine: Option<&str>,
-    built_dep_paths: Option<&HashSet<Key>>,
-    build_required_cache: &mut HashMap<Key, bool>,
+    build_required_dep_paths: Option<&HashSet<Key>>,
     project: Option<&str>,
 ) -> String
 where
     Key: Clone + Eq + std::hash::Hash,
 {
-    let include_engine = match built_dep_paths {
-        None => true,
-        Some(set) => transitively_requires_build(
-            graph,
-            set,
-            build_required_cache,
-            dep_path,
-            &mut HashSet::new(),
-        ),
-    };
+    let include_engine = build_required_dep_paths.is_none_or(|set| set.contains(dep_path));
     let engine_value = if include_engine {
         match engine {
             Some(s) => Value::String(s.to_owned()),

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
@@ -3,7 +3,7 @@ use super::{
     calc_leaf_global_virtual_store_path, format_global_virtual_store_path,
     join_global_virtual_store_path,
 };
-use crate::dep_state::DepsGraphNode;
+use crate::{build_required_dep_paths, dep_state::DepsGraphNode};
 use indexmap::IndexMap;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
@@ -53,15 +53,12 @@ fn identical_leaves_hash_identically() {
     );
     let mut cache_a = HashMap::new();
     let mut cache_b = HashMap::new();
-    let mut br_a = HashMap::new();
-    let mut br_b = HashMap::new();
     let first = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"leaf@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br_a,
         None,
     );
     let second = calc_graph_node_hash(
@@ -70,7 +67,6 @@ fn identical_leaves_hash_identically() {
         &"leaf@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br_b,
         None,
     );
     assert_eq!(first, second, "deterministic for same input");
@@ -85,38 +81,26 @@ fn engine_string_changes_hash() {
         DepsGraphNode { full_pkg_id: "leaf@1.0.0:sha512-x".to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
-    let mut br = HashMap::new();
     let with_engine = calc_graph_node_hash(
         &graph,
         &mut cache,
         &"leaf@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br,
         None,
     );
     let mut cache_other = HashMap::new();
-    let mut br_other = HashMap::new();
     let with_other_engine = calc_graph_node_hash(
         &graph,
         &mut cache_other,
         &"leaf@1.0.0".to_string(),
         Some("linux-x64-node22"),
         None,
-        &mut br_other,
         None,
     );
     let mut cache_null = HashMap::new();
-    let mut br_null = HashMap::new();
-    let with_null = calc_graph_node_hash(
-        &graph,
-        &mut cache_null,
-        &"leaf@1.0.0".to_string(),
-        None,
-        None,
-        &mut br_null,
-        None,
-    );
+    let with_null =
+        calc_graph_node_hash(&graph, &mut cache_null, &"leaf@1.0.0".to_string(), None, None, None);
     assert_ne!(with_engine, with_other_engine);
     assert_ne!(with_engine, with_null);
     assert_ne!(with_other_engine, with_null);
@@ -132,32 +116,29 @@ fn engine_agnostic_when_subtree_has_no_builders() {
             children: IndexMap::new(),
         },
     );
-    let built: HashSet<String> = std::iter::once("someone-else@1.0.0".to_string()).collect();
+    let build_required: HashSet<String> =
+        std::iter::once("someone-else@1.0.0".to_string()).collect();
     let mut cache_a = HashMap::new();
-    let mut br_a = HashMap::new();
     let darwin = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"pure-js@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
-        Some(&built),
-        &mut br_a,
+        Some(&build_required),
         None,
     );
     let mut cache_b = HashMap::new();
-    let mut br_b = HashMap::new();
     let linux = calc_graph_node_hash(
         &graph,
         &mut cache_b,
         &"pure-js@1.0.0".to_string(),
         Some("linux-x64-node22"),
-        Some(&built),
-        &mut br_b,
+        Some(&build_required),
         None,
     );
     assert_eq!(
         darwin, linux,
-        "pure-js subtree must hash engine-agnostically when gated by builtDepPaths",
+        "pure-js subtree must hash engine-agnostically when build gating is enabled",
     );
 }
 
@@ -171,27 +152,23 @@ fn engine_included_when_self_in_built_set() {
             children: IndexMap::new(),
         },
     );
-    let built: HashSet<String> = std::iter::once("native@1.0.0".to_string()).collect();
+    let build_required: HashSet<String> = std::iter::once("native@1.0.0".to_string()).collect();
     let mut cache_a = HashMap::new();
-    let mut br_a = HashMap::new();
     let darwin = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"native@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
-        Some(&built),
-        &mut br_a,
+        Some(&build_required),
         None,
     );
     let mut cache_b = HashMap::new();
-    let mut br_b = HashMap::new();
     let linux = calc_graph_node_hash(
         &graph,
         &mut cache_b,
         &"native@1.0.0".to_string(),
         Some("linux-x64-node22"),
-        Some(&built),
-        &mut br_b,
+        Some(&build_required),
         None,
     );
     assert_ne!(darwin, linux, "builder must partition by engine string");
@@ -214,33 +191,94 @@ fn engine_included_for_ancestor_of_builder() {
         },
     );
     let built: HashSet<String> = std::iter::once("native@1.0.0".to_string()).collect();
+    let build_required = build_required_dep_paths(&graph, &built);
     let mut cache_a = HashMap::new();
-    let mut br_a = HashMap::new();
     let darwin = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"root@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
-        Some(&built),
-        &mut br_a,
+        Some(&build_required),
         None,
     );
     let mut cache_b = HashMap::new();
-    let mut br_b = HashMap::new();
     let linux = calc_graph_node_hash(
         &graph,
         &mut cache_b,
         &"root@1.0.0".to_string(),
         Some("linux-x64-node22"),
-        Some(&built),
-        &mut br_b,
+        Some(&build_required),
         None,
     );
     assert_ne!(darwin, linux, "ancestor of a builder must partition by engine string");
 }
 
 #[test]
-fn none_built_dep_paths_disables_gating() {
+fn engine_included_for_every_cycle_member_that_reaches_builder() {
+    let cycle_a = "a@1.0.0".to_string();
+    let cycle_b = "b@1.0.0".to_string();
+    let builder = "builder@1.0.0".to_string();
+    let pure_js = "pure-js@1.0.0".to_string();
+    let graph = HashMap::from([
+        (
+            cycle_a.clone(),
+            DepsGraphNode {
+                full_pkg_id: "a@1.0.0:sha512-a".to_string(),
+                children: IndexMap::from([
+                    ("b".to_string(), cycle_b.clone()),
+                    ("builder".to_string(), builder.clone()),
+                ]),
+            },
+        ),
+        (
+            cycle_b.clone(),
+            DepsGraphNode {
+                full_pkg_id: "b@1.0.0:sha512-b".to_string(),
+                children: IndexMap::from([("a".to_string(), cycle_a.clone())]),
+            },
+        ),
+        (
+            builder.clone(),
+            DepsGraphNode {
+                full_pkg_id: "builder@1.0.0:sha512-builder".to_string(),
+                children: IndexMap::new(),
+            },
+        ),
+        (
+            pure_js.clone(),
+            DepsGraphNode {
+                full_pkg_id: "pure-js@1.0.0:sha512-pure".to_string(),
+                children: IndexMap::new(),
+            },
+        ),
+    ]);
+    let built = HashSet::from([builder]);
+    let build_required = build_required_dep_paths(&graph, &built);
+
+    let hashes_for = |engine| {
+        let mut dep_state_cache = HashMap::new();
+        [cycle_a.clone(), cycle_b.clone(), pure_js.clone()].map(|dep_path| {
+            calc_graph_node_hash(
+                &graph,
+                &mut dep_state_cache,
+                &dep_path,
+                Some(engine),
+                Some(&build_required),
+                None,
+            )
+        })
+    };
+
+    let darwin = hashes_for("darwin-arm64-node20");
+    let linux = hashes_for("linux-x64-node22");
+
+    assert_ne!(darwin[0], linux[0], "first cycle member must partition by engine string");
+    assert_ne!(darwin[1], linux[1], "second cycle member must partition by engine string");
+    assert_eq!(darwin[2], linux[2], "disconnected pure-JS package stays engine-agnostic");
+}
+
+#[test]
+fn no_build_required_set_disables_gating() {
     let mut graph: HashMap<String, DepsGraphNode<String>> = HashMap::new();
     graph.insert(
         "pure-js@1.0.0".to_string(),
@@ -250,28 +288,24 @@ fn none_built_dep_paths_disables_gating() {
         },
     );
     let mut cache_a = HashMap::new();
-    let mut br_a = HashMap::new();
     let darwin = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"pure-js@1.0.0".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br_a,
         None,
     );
     let mut cache_b = HashMap::new();
-    let mut br_b = HashMap::new();
     let linux = calc_graph_node_hash(
         &graph,
         &mut cache_b,
         &"pure-js@1.0.0".to_string(),
         Some("linux-x64-node22"),
         None,
-        &mut br_b,
         None,
     );
-    assert_ne!(darwin, linux, "without builtDepPaths gating, engine is always part of the hash");
+    assert_ne!(darwin, linux, "without build gating, engine is always part of the hash");
 }
 
 #[test]
@@ -292,25 +326,21 @@ fn different_children_change_hash() {
         DepsGraphNode { full_pkg_id: "root@1.0.0:sha512-r".to_string(), children: IndexMap::new() },
     );
     let mut cache_a = HashMap::new();
-    let mut br_a = HashMap::new();
     let with_dep = calc_graph_node_hash(
         &graph,
         &mut cache_a,
         &"root@1.0.0(a)".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br_a,
         None,
     );
     let mut cache_b = HashMap::new();
-    let mut br_b = HashMap::new();
     let without_dep = calc_graph_node_hash(
         &graph,
         &mut cache_b,
         &"root@1.0.0(b)".to_string(),
         Some("darwin-arm64-node20"),
         None,
-        &mut br_b,
         None,
     );
     assert_ne!(with_dep, without_dep, "same root, different children must not collide on GVS hash");
@@ -325,16 +355,8 @@ fn leaf_matches_single_node_graph_hash() {
         DepsGraphNode { full_pkg_id: full.to_string(), children: IndexMap::new() },
     );
     let mut cache = HashMap::new();
-    let mut br = HashMap::new();
-    let digest = calc_graph_node_hash(
-        &graph,
-        &mut cache,
-        &"leaf@1.0.0".to_string(),
-        None,
-        None,
-        &mut br,
-        None,
-    );
+    let digest =
+        calc_graph_node_hash(&graph, &mut cache, &"leaf@1.0.0".to_string(), None, None, None);
     assert_eq!(
         calc_leaf_global_virtual_store_path(full, "leaf", "1.0.0"),
         format_global_virtual_store_path("leaf", "1.0.0", &digest),

--- a/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
+++ b/pnpm/crates/graph-hasher/src/global_virtual_store_path/tests.rs
@@ -255,13 +255,13 @@ fn engine_included_for_every_cycle_member_that_reaches_builder() {
     let built = HashSet::from([builder]);
     let build_required = build_required_dep_paths(&graph, &built);
 
-    let hashes_for = |engine| {
+    let hashes_for = |engine, dep_paths: [&String; 3]| {
         let mut dep_state_cache = HashMap::new();
-        [cycle_a.clone(), cycle_b.clone(), pure_js.clone()].map(|dep_path| {
+        dep_paths.map(|dep_path| {
             calc_graph_node_hash(
                 &graph,
                 &mut dep_state_cache,
-                &dep_path,
+                dep_path,
                 Some(engine),
                 Some(&build_required),
                 None,
@@ -269,12 +269,26 @@ fn engine_included_for_every_cycle_member_that_reaches_builder() {
         })
     };
 
-    let darwin = hashes_for("darwin-arm64-node20");
-    let linux = hashes_for("linux-x64-node22");
+    let darwin = hashes_for("darwin-arm64-node20", [&cycle_a, &cycle_b, &pure_js]);
+    let linux = hashes_for("linux-x64-node22", [&cycle_a, &cycle_b, &pure_js]);
+    let darwin_reverse = hashes_for("darwin-arm64-node20", [&cycle_b, &cycle_a, &pure_js]);
+    let linux_reverse = hashes_for("linux-x64-node22", [&cycle_b, &cycle_a, &pure_js]);
 
     assert_ne!(darwin[0], linux[0], "first cycle member must partition by engine string");
     assert_ne!(darwin[1], linux[1], "second cycle member must partition by engine string");
     assert_eq!(darwin[2], linux[2], "disconnected pure-JS package stays engine-agnostic");
+    assert_ne!(
+        darwin_reverse[0], linux_reverse[0],
+        "second cycle member must partition by engine string when visited first",
+    );
+    assert_ne!(
+        darwin_reverse[1], linux_reverse[1],
+        "first cycle member must partition by engine string when visited second",
+    );
+    assert_eq!(
+        darwin_reverse[2], linux_reverse[2],
+        "disconnected pure-JS package stays engine-agnostic in reverse order",
+    );
 }
 
 #[test]

--- a/pnpm/crates/graph-hasher/src/lib.rs
+++ b/pnpm/crates/graph-hasher/src/lib.rs
@@ -18,7 +18,7 @@ mod object_hasher;
 
 pub use dep_state::{
     CalcDepStateOptions, DEPENDENCY_SIDE_EFFECTS_INPUT_KEY_PREFIX, DepsGraphNode, DepsStateCache,
-    calc_dep_state, calc_dep_state_input_key, warm_deps_state_cache,
+    build_required_dep_paths, calc_dep_state, calc_dep_state_input_key, warm_deps_state_cache,
 };
 pub use engine_name::{
     detect_node_major, detect_node_version, engine_name, host_arch, host_libc, host_platform,

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -280,14 +280,11 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
   pkgMetaIterator: PkgMetaIterator<T>,
   opts: GraphNodeHashOptions = {}
 ): IterableIterator<HashedDepPath<T>> {
-  let builtDepPaths: Set<DepPath> | undefined
-  let buildRequiredCache: Record<string, boolean> | undefined
+  let buildRequiredDepPaths: Set<DepPath> | undefined
   let entries: Iterable<T>
   if (opts.allowBuild != null) {
     const pkgMetaList = Array.from(pkgMetaIterator)
-    builtDepPaths = computeBuiltDepPaths(pkgMetaList, opts.allowBuild)
-    buildRequiredCache = {}
-    prepareBuildRequiredCache(graph, builtDepPaths, buildRequiredCache)
+    buildRequiredDepPaths = computeBuildRequiredDepPaths(graph, computeBuiltDepPaths(pkgMetaList, opts.allowBuild))
     entries = pkgMetaList
   } else {
     entries = pkgMetaIterator
@@ -295,8 +292,7 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
   const ctx = {
     graph,
     cache: {},
-    builtDepPaths,
-    buildRequiredCache,
+    buildRequiredDepPaths,
     supportedArchitectures: opts.supportedArchitectures,
     nodeVersion: opts.nodeVersion,
     lockfileDir: opts.lockfileDir,
@@ -310,11 +306,11 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
 }
 
 export function calcGraphNodeHash<T extends PkgMeta> (
-  { graph, cache, builtDepPaths, buildRequiredCache, supportedArchitectures, nodeVersion, lockfileDir }: {
+  { graph, cache, buildRequiredDepPaths, supportedArchitectures, nodeVersion, lockfileDir }: {
     graph: DepsGraph<DepPath>
     cache: DepsStateCache
-    builtDepPaths?: Set<DepPath>
-    buildRequiredCache?: Record<string, boolean>
+    /** See {@link computeBuildRequiredDepPaths}. */
+    buildRequiredDepPaths?: Set<DepPath>
     supportedArchitectures?: SupportedArchitectures
     /** See {@link GraphNodeHashOptions.nodeVersion}. */
     nodeVersion?: string
@@ -324,17 +320,12 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   pkgMeta: T
 ): string {
   const { name, version, depPath } = pkgMeta
-  // When builtDepPaths is provided (derived from the allowBuilds config),
-  // we only include the engine name for packages that are allowed to build
-  // or transitively depend on a package that is allowed to build.
+  // When buildRequiredDepPaths is provided (derived from the allowBuilds
+  // config), we only include the engine name for packages that are allowed
+  // to build or transitively depend on a package that is allowed to build.
   // This makes GVS hashes engine-agnostic for pure-JS packages,
   // so they survive Node.js upgrades and architecture changes.
-  let includeEngine = true
-  if (builtDepPaths !== undefined) {
-    buildRequiredCache ??= {}
-    prepareBuildRequiredCache(graph, builtDepPaths, buildRequiredCache)
-    includeEngine = buildRequiredCache[depPath] === true
-  }
+  const includeEngine = buildRequiredDepPaths === undefined || buildRequiredDepPaths.has(depPath)
   // A snapshot that declares `engines.runtime` carries the desugared
   // `node@runtime:<version>` pin as a child; that's the Node the bin
   // linker spawns for its lifecycle scripts, so it has to drive the
@@ -507,34 +498,35 @@ function computeBuiltDepPaths (
   return builtDepPaths
 }
 
-const BUILD_REQUIRED_CACHE_READY = Symbol('buildRequiredCacheReady')
-
-type PreparedBuildRequiredCache = Record<string, boolean> & {
-  [BUILD_REQUIRED_CACHE_READY]?: true
-}
-
-function prepareBuildRequiredCache (
+/**
+ * Expand `builtDepPaths` to every node that is, or transitively depends
+ * on, one of them.
+ *
+ * The result gates the engine string in {@link calcGraphNodeHash}: only a
+ * package that may run a build script — or that depends on one — keeps the
+ * engine in its GVS hash. It is computed as one graph-wide reverse closure,
+ * so a package inside a dependency cycle gets the same answer no matter
+ * which node the hasher reaches it from.
+ */
+export function computeBuildRequiredDepPaths (
   graph: DepsGraph<DepPath>,
-  builtDepPaths: Set<DepPath>,
-  cache: Record<string, boolean>
-): void {
-  const preparedCache = cache as PreparedBuildRequiredCache
-  if (preparedCache[BUILD_REQUIRED_CACHE_READY] === true) return
-  if (builtDepPaths.size === 0) {
-    preparedCache[BUILD_REQUIRED_CACHE_READY] = true
-    return
-  }
+  builtDepPaths: Set<DepPath>
+): Set<DepPath> {
+  const buildRequiredDepPaths = new Set(builtDepPaths)
+  if (builtDepPaths.size === 0) return buildRequiredDepPaths
 
   const parentsByChild = new Map<DepPath, DepPath[]>()
   for (const parent of Object.keys(graph) as DepPath[]) {
     for (const child of Object.values(graph[parent].children)) {
-      const parents = parentsByChild.get(child) ?? []
-      parents.push(parent)
-      parentsByChild.set(child, parents)
+      const parents = parentsByChild.get(child)
+      if (parents == null) {
+        parentsByChild.set(child, [parent])
+      } else {
+        parents.push(parent)
+      }
     }
   }
 
-  const buildRequiredDepPaths = new Set(builtDepPaths)
   const pending = Array.from(builtDepPaths)
   while (pending.length > 0) {
     const child = pending.pop()!
@@ -545,10 +537,7 @@ function prepareBuildRequiredCache (
       }
     }
   }
-  for (const depPath of buildRequiredDepPaths) {
-    cache[depPath] = true
-  }
-  preparedCache[BUILD_REQUIRED_CACHE_READY] = true
+  return buildRequiredDepPaths
 }
 
 function lockfileDepsToGraphChildren (

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -281,10 +281,13 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
   opts: GraphNodeHashOptions = {}
 ): IterableIterator<HashedDepPath<T>> {
   let builtDepPaths: Set<DepPath> | undefined
+  let buildRequiredCache: Record<string, boolean> | undefined
   let entries: Iterable<T>
   if (opts.allowBuild != null) {
     const pkgMetaList = Array.from(pkgMetaIterator)
     builtDepPaths = computeBuiltDepPaths(pkgMetaList, opts.allowBuild)
+    buildRequiredCache = {}
+    prepareBuildRequiredCache(graph, builtDepPaths, buildRequiredCache)
     entries = pkgMetaList
   } else {
     entries = pkgMetaIterator
@@ -293,7 +296,7 @@ export function * iterateHashedGraphNodes<T extends PkgMeta> (
     graph,
     cache: {},
     builtDepPaths,
-    buildRequiredCache: builtDepPaths !== undefined ? {} : undefined,
+    buildRequiredCache,
     supportedArchitectures: opts.supportedArchitectures,
     nodeVersion: opts.nodeVersion,
     lockfileDir: opts.lockfileDir,
@@ -326,8 +329,12 @@ export function calcGraphNodeHash<T extends PkgMeta> (
   // or transitively depend on a package that is allowed to build.
   // This makes GVS hashes engine-agnostic for pure-JS packages,
   // so they survive Node.js upgrades and architecture changes.
-  const includeEngine = builtDepPaths === undefined ||
-    transitivelyRequiresBuild(graph, builtDepPaths, buildRequiredCache ??= {}, depPath, new Set())
+  let includeEngine = true
+  if (builtDepPaths !== undefined) {
+    buildRequiredCache ??= {}
+    prepareBuildRequiredCache(graph, builtDepPaths, buildRequiredCache)
+    includeEngine = buildRequiredCache[depPath] === true
+  }
   // A snapshot that declares `engines.runtime` carries the desugared
   // `node@runtime:<version>` pin as a child; that's the Node the bin
   // linker spawns for its lifecycle scripts, so it has to drive the
@@ -500,35 +507,48 @@ function computeBuiltDepPaths (
   return builtDepPaths
 }
 
-function transitivelyRequiresBuild<T extends string> (
-  graph: DepsGraph<T>,
-  builtDepPaths: Set<T>,
-  cache: Record<string, boolean>,
-  depPath: T,
-  parents: Set<T>
-): boolean {
-  if (depPath in cache) return cache[depPath]
-  if (builtDepPaths.has(depPath)) {
-    cache[depPath] = true
-    return true
+const BUILD_REQUIRED_CACHE_READY = Symbol('buildRequiredCacheReady')
+
+type PreparedBuildRequiredCache = Record<string, boolean> & {
+  [BUILD_REQUIRED_CACHE_READY]?: true
+}
+
+function prepareBuildRequiredCache (
+  graph: DepsGraph<DepPath>,
+  builtDepPaths: Set<DepPath>,
+  cache: Record<string, boolean>
+): void {
+  const preparedCache = cache as PreparedBuildRequiredCache
+  if (preparedCache[BUILD_REQUIRED_CACHE_READY] === true) return
+  if (builtDepPaths.size === 0) {
+    preparedCache[BUILD_REQUIRED_CACHE_READY] = true
+    return
   }
-  const node = graph[depPath]
-  if (!node) {
-    cache[depPath] = false
-    return false
-  }
-  if (parents.has(depPath)) {
-    return false
-  }
-  const nextParents = new Set([...parents, depPath])
-  for (const childDepPath of Object.values(node.children) as T[]) {
-    if (transitivelyRequiresBuild(graph, builtDepPaths, cache, childDepPath, nextParents)) {
-      cache[depPath] = true
-      return true
+
+  const parentsByChild = new Map<DepPath, DepPath[]>()
+  for (const parent of Object.keys(graph) as DepPath[]) {
+    for (const child of Object.values(graph[parent].children)) {
+      const parents = parentsByChild.get(child) ?? []
+      parents.push(parent)
+      parentsByChild.set(child, parents)
     }
   }
-  cache[depPath] = false
-  return false
+
+  const buildRequiredDepPaths = new Set(builtDepPaths)
+  const pending = Array.from(builtDepPaths)
+  while (pending.length > 0) {
+    const child = pending.pop()!
+    for (const parent of parentsByChild.get(child) ?? []) {
+      if (!buildRequiredDepPaths.has(parent)) {
+        buildRequiredDepPaths.add(parent)
+        pending.push(parent)
+      }
+    }
+  }
+  for (const depPath of buildRequiredDepPaths) {
+    cache[depPath] = true
+  }
+  preparedCache[BUILD_REQUIRED_CACHE_READY] = true
 }
 
 function lockfileDepsToGraphChildren (

--- a/pnpm11/deps/graph-hasher/src/index.ts
+++ b/pnpm11/deps/graph-hasher/src/index.ts
@@ -507,6 +507,10 @@ function computeBuiltDepPaths (
  * engine in its GVS hash. It is computed as one graph-wide reverse closure,
  * so a package inside a dependency cycle gets the same answer no matter
  * which node the hasher reaches it from.
+ *
+ * A path with no node in `graph` is kept and still marks whatever depends on
+ * it: the built set comes from the allowBuild policy rather than the graph,
+ * so the two can disagree.
  */
 export function computeBuildRequiredDepPaths (
   graph: DepsGraph<DepPath>,

--- a/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
+++ b/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from '@jest/globals'
-import { iterateHashedGraphNodes } from '@pnpm/deps.graph-hasher'
+import { type DepsGraph, iterateHashedGraphNodes } from '@pnpm/deps.graph-hasher'
 import type { AllowBuild, DepPath } from '@pnpm/types'
 
 it('gates built dep paths through the allowBuild policy by depPath', () => {
@@ -38,4 +38,48 @@ it('gates built dep paths through the allowBuild policy by depPath', () => {
   ))
 
   expect(checkedDepPaths).toStrictEqual([registryDepPath, directTarballDepPath])
+})
+
+it('includes the engine for every cycle member that reaches a builder', () => {
+  const a = 'a@1.0.0' as DepPath
+  const b = 'b@1.0.0' as DepPath
+  const builder = 'builder@1.0.0' as DepPath
+  const pureJs = 'pure-js@1.0.0' as DepPath
+  const graph: DepsGraph<DepPath> = {
+    [a]: {
+      children: { b, builder },
+      fullPkgId: 'a@1.0.0:sha512-a',
+    },
+    [b]: {
+      children: { a },
+      fullPkgId: 'b@1.0.0:sha512-b',
+    },
+    [builder]: {
+      children: {},
+      fullPkgId: 'builder@1.0.0:sha512-builder',
+    },
+    [pureJs]: {
+      children: {},
+      fullPkgId: 'pure-js@1.0.0:sha512-pure',
+    },
+  }
+  const pkgMeta = [
+    { depPath: a, name: 'a', version: '1.0.0' },
+    { depPath: b, name: 'b', version: '1.0.0' },
+    { depPath: builder, name: 'builder', version: '1.0.0' },
+    { depPath: pureJs, name: 'pure-js', version: '1.0.0' },
+  ]
+  const hashesFor = (nodeVersion: string): Map<DepPath, string> => new Map(
+    Array.from(iterateHashedGraphNodes(graph, pkgMeta.values(), {
+      allowBuild: (depPath) => depPath === builder,
+      nodeVersion,
+    })).map(({ hash, pkgMeta }) => [pkgMeta.depPath, hash])
+  )
+
+  const node20 = hashesFor('20.0.0')
+  const node22 = hashesFor('22.0.0')
+
+  expect(node20.get(a)).not.toBe(node22.get(a))
+  expect(node20.get(b)).not.toBe(node22.get(b))
+  expect(node20.get(pureJs)).toBe(node22.get(pureJs))
 })

--- a/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
+++ b/pnpm11/deps/graph-hasher/test/allowBuildIdentity.test.ts
@@ -69,17 +69,23 @@ it('includes the engine for every cycle member that reaches a builder', () => {
     { depPath: builder, name: 'builder', version: '1.0.0' },
     { depPath: pureJs, name: 'pure-js', version: '1.0.0' },
   ]
-  const hashesFor = (nodeVersion: string): Map<DepPath, string> => new Map(
-    Array.from(iterateHashedGraphNodes(graph, pkgMeta.values(), {
-      allowBuild: (depPath) => depPath === builder,
-      nodeVersion,
-    })).map(({ hash, pkgMeta }) => [pkgMeta.depPath, hash])
-  )
+  const reversePkgMeta = [pkgMeta[1], pkgMeta[0], pkgMeta[2], pkgMeta[3]]
 
-  const node20 = hashesFor('20.0.0')
-  const node22 = hashesFor('22.0.0')
+  for (const orderedPkgMeta of [pkgMeta, reversePkgMeta]) {
+    const node20 = hashesFor('20.0.0', orderedPkgMeta)
+    const node22 = hashesFor('22.0.0', orderedPkgMeta)
 
-  expect(node20.get(a)).not.toBe(node22.get(a))
-  expect(node20.get(b)).not.toBe(node22.get(b))
-  expect(node20.get(pureJs)).toBe(node22.get(pureJs))
+    expect(node20.get(a)).not.toBe(node22.get(a))
+    expect(node20.get(b)).not.toBe(node22.get(b))
+    expect(node20.get(pureJs)).toBe(node22.get(pureJs))
+  }
+
+  function hashesFor (nodeVersion: string, orderedPkgMeta: typeof pkgMeta): Map<DepPath, string> {
+    return new Map(
+      Array.from(iterateHashedGraphNodes(graph, orderedPkgMeta.values(), {
+        allowBuild: (depPath) => depPath === builder,
+        nodeVersion,
+      })).map(({ hash, pkgMeta }) => [pkgMeta.depPath, hash])
+    )
+  }
 })

--- a/pnpm11/deps/graph-hasher/test/index.ts
+++ b/pnpm11/deps/graph-hasher/test/index.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from '@jest/globals'
 import { hashObject, hashObjectWithoutSorting } from '@pnpm/crypto.object-hasher'
-import { calcDepState, calcDepStateInputKey, calcGraphNodeHash, findRuntimeNodeVersion, readSnapshotRuntimePin } from '@pnpm/deps.graph-hasher'
+import { calcDepState, calcDepStateInputKey, calcGraphNodeHash, computeBuildRequiredDepPaths, findRuntimeNodeVersion, readSnapshotRuntimePin } from '@pnpm/deps.graph-hasher'
 import { engineName } from '@pnpm/engine.runtime.system-version'
 import type { DepPath, PkgIdWithPatchHash } from '@pnpm/types'
 
@@ -202,7 +202,7 @@ describe('calcGraphNodeHash', () => {
     },
   } as Record<DepPath, { children: Record<string, DepPath>, pkgIdWithPatchHash: PkgIdWithPatchHash, resolution: { integrity: string } }>
 
-  test('includes ENGINE_NAME when builtDepPaths is not provided', () => {
+  test('includes ENGINE_NAME when build gating is disabled', () => {
     const hash = calcGraphNodeHash(
       { graph: graphNodeGraph, cache: {} },
       { depPath: 'foo@1.0.0' as DepPath, name: 'foo', version: '1.0.0' }
@@ -225,7 +225,7 @@ describe('calcGraphNodeHash', () => {
   test('omits ENGINE_NAME for pure-JS packages when builtDepPaths is provided', () => {
     const builtDepPaths = new Set<DepPath>(['native@1.0.0' as DepPath])
     const hash = calcGraphNodeHash(
-      { graph: graphNodeGraph, cache: {}, builtDepPaths, buildRequiredCache: {} },
+      { graph: graphNodeGraph, cache: {}, buildRequiredDepPaths: computeBuildRequiredDepPaths(graphNodeGraph, builtDepPaths) },
       { depPath: 'foo@1.0.0' as DepPath, name: 'foo', version: '1.0.0' }
     )
     const depsHash = hashObject({
@@ -244,7 +244,7 @@ describe('calcGraphNodeHash', () => {
   test('includes ENGINE_NAME for packages that require a build', () => {
     const builtDepPaths = new Set<DepPath>(['native@1.0.0' as DepPath])
     const hash = calcGraphNodeHash(
-      { graph: graphNodeGraph, cache: {}, builtDepPaths, buildRequiredCache: {} },
+      { graph: graphNodeGraph, cache: {}, buildRequiredDepPaths: computeBuildRequiredDepPaths(graphNodeGraph, builtDepPaths) },
       { depPath: 'native@1.0.0' as DepPath, name: 'native', version: '1.0.0' }
     )
     const depsHash = hashObject({ id: 'native@1.0.0:002', deps: {} })
@@ -258,7 +258,7 @@ describe('calcGraphNodeHash', () => {
   test('includes ENGINE_NAME for packages that transitively depend on a built package', () => {
     const builtDepPaths = new Set<DepPath>(['native@1.0.0' as DepPath])
     const hash = calcGraphNodeHash(
-      { graph: graphNodeGraph, cache: {}, builtDepPaths, buildRequiredCache: {} },
+      { graph: graphNodeGraph, cache: {}, buildRequiredDepPaths: computeBuildRequiredDepPaths(graphNodeGraph, builtDepPaths) },
       { depPath: 'depends-on-native@1.0.0' as DepPath, name: 'depends-on-native', version: '1.0.0' }
     )
     const depsHash = hashObject({
@@ -277,7 +277,7 @@ describe('calcGraphNodeHash', () => {
   test('omits ENGINE_NAME when builtDepPaths is empty', () => {
     const builtDepPaths = new Set<DepPath>()
     const hash = calcGraphNodeHash(
-      { graph: graphNodeGraph, cache: {}, builtDepPaths, buildRequiredCache: {} },
+      { graph: graphNodeGraph, cache: {}, buildRequiredDepPaths: computeBuildRequiredDepPaths(graphNodeGraph, builtDepPaths) },
       { depPath: 'foo@1.0.0' as DepPath, name: 'foo', version: '1.0.0' }
     )
     const depsHash = hashObject({

--- a/pnpm11/deps/graph-hasher/test/lockfileToDepGraph.test.ts
+++ b/pnpm11/deps/graph-hasher/test/lockfileToDepGraph.test.ts
@@ -158,8 +158,7 @@ describe('lockfileToDepGraph link target hashing', () => {
     return calcGraphNodeHash({
       graph,
       cache: {},
-      builtDepPaths: new Set(),
-      buildRequiredCache: {},
+      buildRequiredDepPaths: new Set(),
     }, parentPkgMeta)
   }
 
@@ -225,8 +224,7 @@ describe('lockfileToDepGraph link hash parity with pacquet', () => {
     expect(calcGraphNodeHash({
       graph,
       cache: {},
-      builtDepPaths: new Set(),
-      buildRequiredCache: {},
+      buildRequiredDepPaths: new Set(),
     }, {
       depPath: fixturePackage.key,
       name: fixturePackage.name,


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14341.

- Calculate build requirements as a graph-wide reverse closure before global virtual store hashes are calculated.
- Make every dependency-cycle member that reaches an allowed builder include the engine in its store path.
- Apply the same behavior to the TypeScript CLI and the Rust `pnpm/` client, with the same API on both sides: the expanded set is computed once per install (`computeBuildRequiredDepPaths` / `build_required_dep_paths`) and passed to the hasher, replacing the `builtDepPaths` + `buildRequiredCache` option pair on `calcGraphNodeHash`.

## Squash Commit Body

```text
Compute build requirements as a graph-wide reverse closure before global virtual store hashes are calculated.

This prevents cycle members from keeping a false result caused by traversal order. Apply the same behavior to the TypeScript and Rust clients.

Fixes pnpm/pnpm#14341.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790632564&installation_model_id=426870&pr_number=14342&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14342&signature=349b37bd639ae7e1fae7a24221873faf3a91e9f6afc7e8ffd24fdd2c1bb285ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dependency-cycle virtual-store hashes to consistently include the runtime engine when packages transitively depend on an allowed build.
  * Ensured hash results remain consistent regardless of dependency traversal order.
  * Improved hash differentiation across runtime versions for affected dependency cycles while preserving stable hashes for unaffected packages.

* **Tests**
  * Added coverage for cyclic dependencies, transitive build requirements, and runtime-version-sensitive hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
