### PR TITLE
fix(patching): honor zero-context insertion positions

### DIFF
--- a/.changeset/fix-zero-context-insertions.md
+++ b/.changeset/fix-zero-context-insertions.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Apply pure insertions in zero-context patches at the correct line instead of one line early.

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -232,7 +232,7 @@ fn applies_a_zero_context_insertion_that_ends_the_file_without_a_newline() {
     let hunk = text_block_fnl! {
         "@@ -2,0 +3 @@"
         "+added"
-        "\\ No newline at end of file"
+        r"\ No newline at end of file"
     };
     let expected = text_block! {
         "one"
@@ -247,7 +247,7 @@ fn applies_a_zero_context_insertion_without_a_newline_to_an_empty_file() {
     let hunk = text_block_fnl! {
         "@@ -0,0 +1 @@"
         "+added"
-        "\\ No newline at end of file"
+        r"\ No newline at end of file"
     };
     assert_eq!(applied_hunk("", hunk), "added");
 }

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -54,6 +54,25 @@ fn write_patch(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
     path
 }
 
+/// Apply a patch whose sole file operation is `hunk` against a `file.txt`
+/// holding `original`, and return what the file holds afterwards. The
+/// `diff --git` header the hunk needs is supplied here so a caller only
+/// spells out the coordinates under test.
+fn applied_hunk(original: &str, hunk: &str) -> String {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("file.txt");
+    fs::write(&target, original).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        &format!("diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n{hunk}"),
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    fs::read_to_string(&target).unwrap()
+}
+
 #[test]
 fn applies_modify_against_existing_file() {
     let patched = tempdir().unwrap();
@@ -68,54 +87,62 @@ fn applies_modify_against_existing_file() {
 }
 
 #[test]
-fn applies_insertions_with_and_without_context() {
-    for (name, original, hunk, expected) in [
-        (
-            "context on both sides",
-            "one\ntwo\n",
-            "@@ -1,2 +1,3 @@\n one\n+added\n two\n",
-            "one\nadded\ntwo\n",
-        ),
-        ("bof", "one\ntwo\n", "@@ -0,0 +1 @@\n+added\n", "added\none\ntwo\n"),
-        ("empty file", "", "@@ -0,0 +1 @@\n+added\n", "added\n"),
-        ("after line one", "one\ntwo\n", "@@ -1,0 +2 @@\n+added\n", "one\nadded\ntwo\n"),
-        (
-            "middle",
-            "one\ntwo\nthree\nfour\n",
-            "@@ -2,0 +3,2 @@\n+first\n+second\n",
-            "one\ntwo\nfirst\nsecond\nthree\nfour\n",
-        ),
-        ("eof", "one\ntwo\n", "@@ -2,0 +3 @@\n+added\n", "one\ntwo\nadded\n"),
-        ("crlf", "one\r\ntwo\r\n", "@@ -1,0 +2 @@\n+added\n", "one\r\nadded\ntwo\r\n"),
-        ("no final newline", "one\ntwo", "@@ -1,0 +2 @@\n+added\n", "one\nadded\ntwo"),
-        (
-            "inserted eof without newline",
-            "one\ntwo\n",
-            "@@ -2,0 +3 @@\n+added\n\\ No newline at end of file\n",
-            "one\ntwo\nadded",
-        ),
-        (
-            "empty file without newline",
-            "",
-            "@@ -0,0 +1 @@\n+added\n\\ No newline at end of file\n",
-            "added",
-        ),
-    ] {
-        let patched = tempdir().unwrap();
-        let target = patched.path().join("file.txt");
-        fs::write(&target, original).unwrap();
-        let patch_dir = tempdir().unwrap();
-        let patch = write_patch(
-            patch_dir.path(),
-            &format!("diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n{hunk}"),
-        );
+fn applies_an_insertion_with_context_on_both_sides() {
+    assert_eq!(
+        applied_hunk("one\ntwo\n", "@@ -1,2 +1,3 @@\n one\n+added\n two\n"),
+        "one\nadded\ntwo\n"
+    );
+}
 
-        apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+#[test]
+fn applies_a_zero_context_insertion_at_the_start_of_the_file() {
+    assert_eq!(applied_hunk("one\ntwo\n", "@@ -0,0 +1 @@\n+added\n"), "added\none\ntwo\n");
+}
 
-        let after = fs::read(&target).unwrap();
-        eprintln!("{name}: {:?}", String::from_utf8_lossy(&after));
-        assert_eq!(after, expected.as_bytes(), "{name}");
-    }
+#[test]
+fn applies_a_zero_context_insertion_to_an_empty_file() {
+    assert_eq!(applied_hunk("", "@@ -0,0 +1 @@\n+added\n"), "added\n");
+}
+
+#[test]
+fn applies_a_zero_context_insertion_after_the_first_line() {
+    assert_eq!(applied_hunk("one\ntwo\n", "@@ -1,0 +2 @@\n+added\n"), "one\nadded\ntwo\n");
+}
+
+#[test]
+fn applies_a_multi_line_zero_context_insertion_in_the_middle_of_the_file() {
+    assert_eq!(
+        applied_hunk("one\ntwo\nthree\nfour\n", "@@ -2,0 +3,2 @@\n+first\n+second\n"),
+        "one\ntwo\nfirst\nsecond\nthree\nfour\n",
+    );
+}
+
+#[test]
+fn applies_a_zero_context_insertion_at_the_end_of_the_file() {
+    assert_eq!(applied_hunk("one\ntwo\n", "@@ -2,0 +3 @@\n+added\n"), "one\ntwo\nadded\n");
+}
+
+#[test]
+fn applies_a_zero_context_insertion_to_a_crlf_file() {
+    assert_eq!(applied_hunk("one\r\ntwo\r\n", "@@ -1,0 +2 @@\n+added\n"), "one\r\nadded\ntwo\r\n");
+}
+
+#[test]
+fn applies_a_zero_context_insertion_to_a_file_without_a_final_newline() {
+    assert_eq!(applied_hunk("one\ntwo", "@@ -1,0 +2 @@\n+added\n"), "one\nadded\ntwo");
+}
+
+#[test]
+fn applies_a_zero_context_insertion_that_ends_the_file_without_a_newline() {
+    assert_eq!(
+        applied_hunk("one\ntwo\n", "@@ -2,0 +3 @@\n+added\n\\ No newline at end of file\n"),
+        "one\ntwo\nadded",
+    );
+}
+
+#[test]
+fn applies_a_zero_context_insertion_without_a_newline_to_an_empty_file() {
+    assert_eq!(applied_hunk("", "@@ -0,0 +1 @@\n+added\n\\ No newline at end of file\n"), "added");
 }
 
 #[test]

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -107,7 +107,9 @@ fn applies_an_insertion_with_context_on_both_sides() {
         "added"
         "two"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -125,7 +127,9 @@ fn applies_a_zero_context_insertion_at_the_start_of_the_file() {
         "one"
         "two"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -152,7 +156,9 @@ fn applies_a_zero_context_insertion_after_the_first_line() {
         "added"
         "two"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -176,7 +182,9 @@ fn applies_a_multi_line_zero_context_insertion_in_the_middle_of_the_file() {
         "three"
         "four"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -194,7 +202,9 @@ fn applies_a_zero_context_insertion_at_the_end_of_the_file() {
         "two"
         "added"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -205,7 +215,9 @@ fn applies_a_zero_context_insertion_to_a_crlf_file() {
         "+added"
     };
     let expected = concat!("one\r\n", "added\n", "two\r\n");
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -223,7 +235,9 @@ fn applies_a_zero_context_insertion_to_a_file_without_a_final_newline() {
         "added"
         "two"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
@@ -242,7 +256,9 @@ fn applies_a_zero_context_insertion_that_ends_the_file_without_a_newline() {
         "two"
         "added"
     };
-    assert_eq!(applied_hunk(original, hunk), expected);
+    let after = applied_hunk(original, hunk);
+    eprintln!("AFTER:\n{after}\n");
+    assert_eq!(after, expected);
 }
 
 #[test]

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -2,7 +2,7 @@ use crate::apply::{PatchApplyError, apply_patch_to_dir};
 use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::tempdir;
-use text_block_macros::text_block_fnl;
+use text_block_macros::{text_block, text_block_fnl};
 
 /// An `is-positive` patch: a single-hunk Modify on `index.js`.
 const IS_POSITIVE_PATCH: &str = "\
@@ -88,61 +88,168 @@ fn applies_modify_against_existing_file() {
 
 #[test]
 fn applies_an_insertion_with_context_on_both_sides() {
-    assert_eq!(
-        applied_hunk("one\ntwo\n", "@@ -1,2 +1,3 @@\n one\n+added\n two\n"),
-        "one\nadded\ntwo\n"
-    );
+    let original = text_block_fnl! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -1,2 +1,3 @@"
+        " one"
+        "+added"
+        " two"
+    };
+    let expected = text_block_fnl! {
+        "one"
+        "added"
+        "two"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_zero_context_insertion_at_the_start_of_the_file() {
-    assert_eq!(applied_hunk("one\ntwo\n", "@@ -0,0 +1 @@\n+added\n"), "added\none\ntwo\n");
+    let original = text_block_fnl! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -0,0 +1 @@"
+        "+added"
+    };
+    let expected = text_block_fnl! {
+        "added"
+        "one"
+        "two"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_zero_context_insertion_to_an_empty_file() {
-    assert_eq!(applied_hunk("", "@@ -0,0 +1 @@\n+added\n"), "added\n");
+    let hunk = text_block_fnl! {
+        "@@ -0,0 +1 @@"
+        "+added"
+    };
+    assert_eq!(applied_hunk("", hunk), "added\n");
 }
 
 #[test]
 fn applies_a_zero_context_insertion_after_the_first_line() {
-    assert_eq!(applied_hunk("one\ntwo\n", "@@ -1,0 +2 @@\n+added\n"), "one\nadded\ntwo\n");
+    let original = text_block_fnl! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -1,0 +2 @@"
+        "+added"
+    };
+    let expected = text_block_fnl! {
+        "one"
+        "added"
+        "two"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_multi_line_zero_context_insertion_in_the_middle_of_the_file() {
-    assert_eq!(
-        applied_hunk("one\ntwo\nthree\nfour\n", "@@ -2,0 +3,2 @@\n+first\n+second\n"),
-        "one\ntwo\nfirst\nsecond\nthree\nfour\n",
-    );
+    let original = text_block_fnl! {
+        "one"
+        "two"
+        "three"
+        "four"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -2,0 +3,2 @@"
+        "+first"
+        "+second"
+    };
+    let expected = text_block_fnl! {
+        "one"
+        "two"
+        "first"
+        "second"
+        "three"
+        "four"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_zero_context_insertion_at_the_end_of_the_file() {
-    assert_eq!(applied_hunk("one\ntwo\n", "@@ -2,0 +3 @@\n+added\n"), "one\ntwo\nadded\n");
+    let original = text_block_fnl! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -2,0 +3 @@"
+        "+added"
+    };
+    let expected = text_block_fnl! {
+        "one"
+        "two"
+        "added"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
+/// The CRLF fixtures stay escaped literals: a text block joins its lines with
+/// `\n`, so the endings under test would have to hide as trailing `\r` inside
+/// the quotes.
 #[test]
 fn applies_a_zero_context_insertion_to_a_crlf_file() {
-    assert_eq!(applied_hunk("one\r\ntwo\r\n", "@@ -1,0 +2 @@\n+added\n"), "one\r\nadded\ntwo\r\n");
+    let hunk = text_block_fnl! {
+        "@@ -1,0 +2 @@"
+        "+added"
+    };
+    assert_eq!(applied_hunk("one\r\ntwo\r\n", hunk), "one\r\nadded\ntwo\r\n");
 }
 
 #[test]
 fn applies_a_zero_context_insertion_to_a_file_without_a_final_newline() {
-    assert_eq!(applied_hunk("one\ntwo", "@@ -1,0 +2 @@\n+added\n"), "one\nadded\ntwo");
+    let original = text_block! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -1,0 +2 @@"
+        "+added"
+    };
+    let expected = text_block! {
+        "one"
+        "added"
+        "two"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_zero_context_insertion_that_ends_the_file_without_a_newline() {
-    assert_eq!(
-        applied_hunk("one\ntwo\n", "@@ -2,0 +3 @@\n+added\n\\ No newline at end of file\n"),
-        "one\ntwo\nadded",
-    );
+    let original = text_block_fnl! {
+        "one"
+        "two"
+    };
+    let hunk = text_block_fnl! {
+        "@@ -2,0 +3 @@"
+        "+added"
+        "\\ No newline at end of file"
+    };
+    let expected = text_block! {
+        "one"
+        "two"
+        "added"
+    };
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]
 fn applies_a_zero_context_insertion_without_a_newline_to_an_empty_file() {
-    assert_eq!(applied_hunk("", "@@ -0,0 +1 @@\n+added\n\\ No newline at end of file\n"), "added");
+    let hunk = text_block_fnl! {
+        "@@ -0,0 +1 @@"
+        "+added"
+        "\\ No newline at end of file"
+    };
+    assert_eq!(applied_hunk("", hunk), "added");
 }
 
 #[test]

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -54,19 +54,23 @@ fn write_patch(dir: &std::path::Path, body: &str) -> std::path::PathBuf {
     path
 }
 
+/// The single-file header [`applied_hunk`] prepends to every hunk it is given.
+const FILE_TXT_PATCH_HEADER: &str = text_block_fnl! {
+    "diff --git a/file.txt b/file.txt"
+    "--- a/file.txt"
+    "+++ b/file.txt"
+};
+
 /// Apply a patch whose sole file operation is `hunk` against a `file.txt`
-/// holding `original`, and return what the file holds afterwards. The
-/// `diff --git` header the hunk needs is supplied here so a caller only
-/// spells out the coordinates under test.
+/// holding `original`, and return what the file holds afterwards.
+/// [`FILE_TXT_PATCH_HEADER`] is supplied here so a caller only spells out the
+/// coordinates under test.
 fn applied_hunk(original: &str, hunk: &str) -> String {
     let patched = tempdir().unwrap();
     let target = patched.path().join("file.txt");
     fs::write(&target, original).unwrap();
     let patch_dir = tempdir().unwrap();
-    let patch = write_patch(
-        patch_dir.path(),
-        &format!("diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n{hunk}"),
-    );
+    let patch = write_patch(patch_dir.path(), &format!("{FILE_TXT_PATCH_HEADER}{hunk}"));
 
     apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
 
@@ -193,16 +197,15 @@ fn applies_a_zero_context_insertion_at_the_end_of_the_file() {
     assert_eq!(applied_hunk(original, hunk), expected);
 }
 
-/// The CRLF fixtures stay escaped literals: a text block joins its lines with
-/// `\n`, so the endings under test would have to hide as trailing `\r` inside
-/// the quotes.
 #[test]
 fn applies_a_zero_context_insertion_to_a_crlf_file() {
+    let original = concat!("one\r\n", "two\r\n");
     let hunk = text_block_fnl! {
         "@@ -1,0 +2 @@"
         "+added"
     };
-    assert_eq!(applied_hunk("one\r\ntwo\r\n", hunk), "one\r\nadded\ntwo\r\n");
+    let expected = concat!("one\r\n", "added\n", "two\r\n");
+    assert_eq!(applied_hunk(original, hunk), expected);
 }
 
 #[test]

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -68,6 +68,57 @@ fn applies_modify_against_existing_file() {
 }
 
 #[test]
+fn applies_insertions_with_and_without_context() {
+    for (name, original, hunk, expected) in [
+        (
+            "context on both sides",
+            "one\ntwo\n",
+            "@@ -1,2 +1,3 @@\n one\n+added\n two\n",
+            "one\nadded\ntwo\n",
+        ),
+        ("bof", "one\ntwo\n", "@@ -0,0 +1 @@\n+added\n", "added\none\ntwo\n"),
+        ("empty file", "", "@@ -0,0 +1 @@\n+added\n", "added\n"),
+        ("after line one", "one\ntwo\n", "@@ -1,0 +2 @@\n+added\n", "one\nadded\ntwo\n"),
+        (
+            "middle",
+            "one\ntwo\nthree\nfour\n",
+            "@@ -2,0 +3,2 @@\n+first\n+second\n",
+            "one\ntwo\nfirst\nsecond\nthree\nfour\n",
+        ),
+        ("eof", "one\ntwo\n", "@@ -2,0 +3 @@\n+added\n", "one\ntwo\nadded\n"),
+        ("crlf", "one\r\ntwo\r\n", "@@ -1,0 +2 @@\n+added\n", "one\r\nadded\ntwo\r\n"),
+        ("no final newline", "one\ntwo", "@@ -1,0 +2 @@\n+added\n", "one\nadded\ntwo"),
+        (
+            "inserted eof without newline",
+            "one\ntwo\n",
+            "@@ -2,0 +3 @@\n+added\n\\ No newline at end of file\n",
+            "one\ntwo\nadded",
+        ),
+        (
+            "empty file without newline",
+            "",
+            "@@ -0,0 +1 @@\n+added\n\\ No newline at end of file\n",
+            "added",
+        ),
+    ] {
+        let patched = tempdir().unwrap();
+        let target = patched.path().join("file.txt");
+        fs::write(&target, original).unwrap();
+        let patch_dir = tempdir().unwrap();
+        let patch = write_patch(
+            patch_dir.path(),
+            &format!("diff --git a/file.txt b/file.txt\n--- a/file.txt\n+++ b/file.txt\n{hunk}"),
+        );
+
+        apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+        let after = fs::read(&target).unwrap();
+        eprintln!("{name}: {:?}", String::from_utf8_lossy(&after));
+        assert_eq!(after, expected.as_bytes(), "{name}");
+    }
+}
+
+#[test]
 fn missing_patch_file_errors_patch_not_found() {
     let patched = tempdir().unwrap();
     let missing = patched.path().join("does-not-exist.patch");

--- a/pnpm/crates/patching/src/apply/tolerant.rs
+++ b/pnpm/crates/patching/src/apply/tolerant.rs
@@ -36,11 +36,11 @@ pub(super) fn apply(original: &str, patch: &Patch<'_, str>) -> Result<String, St
     let mut modifications = Vec::new();
     for (index, hunk) in patch.hunks().iter().enumerate() {
         let parts = split_into_parts(hunk.lines());
-        let start = to_isize(hunk.old_range().start());
+        let old_range = hunk.old_range();
+        // Empty ranges name the gap after the line; nonempty ranges are one-based.
+        let start = to_isize(old_range.start()) - isize::from(!old_range.is_empty());
         let matched = fuzzing_offsets()
-            .find_map(|offset| {
-                evaluate_hunk(&parts, &lines, start - 1 + offset, hunk.old_range().len())
-            })
+            .find_map(|offset| evaluate_hunk(&parts, &lines, start + offset, old_range.len()))
             .ok_or_else(|| format!("error applying hunk #{}", index + 1))?;
         modifications.extend(matched);
     }

--- a/pnpm/crates/patching/src/apply/tolerant/tests.rs
+++ b/pnpm/crates/patching/src/apply/tolerant/tests.rs
@@ -153,3 +153,52 @@ fn applies_several_hunks_against_the_same_baseline() {
 ";
     assert_eq!(applied(original, patch), "a\nA\nb\nc\nd\ne\nf\ng\nh\ni\nj\nK\nl\n");
 }
+
+#[test]
+fn applies_several_zero_context_insertions_against_the_same_baseline() {
+    let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
+    let patch = "\
+--- a/file.txt
++++ b/file.txt
+@@ -0,0 +1 @@
++START
+@@ -1,0 +3 @@
++A
+@@ -6,0 +9 @@
++F
+@@ -12,0 +16 @@
++END
+";
+    let after = applied(original, patch);
+    eprintln!("{after}");
+    assert_eq!(after, "START\na\nA\nb\nc\nd\ne\nf\nF\ng\nh\ni\nj\nk\nl\nEND\n");
+}
+
+#[test]
+fn applies_zero_context_insertions_after_deletion_and_replacement_shifts() {
+    let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
+    let patch = "\
+--- a/file.txt
++++ b/file.txt
+@@ -1,2 +0,0 @@
+-a
+-b
+@@ -3,0 +2 @@
++C
+@@ -5 +4,2 @@
+-e
++E1
++E2
+@@ -7,0 +8,2 @@
++G1
++G2
+@@ -10 +12 @@
+-j
++J
+@@ -12,0 +15 @@
++END
+";
+    let after = applied(original, patch);
+    eprintln!("{after}");
+    assert_eq!(after, "c\nC\nd\nE1\nE2\nf\ng\nG1\nG2\nh\ni\nJ\nk\nl\nEND\n");
+}

--- a/pnpm/crates/patching/src/apply/tolerant/tests.rs
+++ b/pnpm/crates/patching/src/apply/tolerant/tests.rs
@@ -1,6 +1,7 @@
 use super::apply;
 use diffy::Patch;
 use pretty_assertions::assert_eq;
+use text_block_macros::text_block_fnl;
 
 fn applied(original: &str, patch: &str) -> String {
     let patch = Patch::from_str(patch).expect("parse patch");
@@ -157,18 +158,18 @@ fn applies_several_hunks_against_the_same_baseline() {
 #[test]
 fn applies_several_zero_context_insertions_against_the_same_baseline() {
     let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
-    let patch = "\
---- a/file.txt
-+++ b/file.txt
-@@ -0,0 +1 @@
-+START
-@@ -1,0 +3 @@
-+A
-@@ -6,0 +9 @@
-+F
-@@ -12,0 +16 @@
-+END
-";
+    let patch = text_block_fnl! {
+        "--- a/file.txt"
+        "+++ b/file.txt"
+        "@@ -0,0 +1 @@"
+        "+START"
+        "@@ -1,0 +3 @@"
+        "+A"
+        "@@ -6,0 +9 @@"
+        "+F"
+        "@@ -12,0 +16 @@"
+        "+END"
+    };
     let after = applied(original, patch);
     eprintln!("{after}");
     assert_eq!(after, "START\na\nA\nb\nc\nd\ne\nf\nF\ng\nh\ni\nj\nk\nl\nEND\n");
@@ -177,27 +178,27 @@ fn applies_several_zero_context_insertions_against_the_same_baseline() {
 #[test]
 fn applies_zero_context_insertions_after_deletion_and_replacement_shifts() {
     let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
-    let patch = "\
---- a/file.txt
-+++ b/file.txt
-@@ -1,2 +0,0 @@
--a
--b
-@@ -3,0 +2 @@
-+C
-@@ -5 +4,2 @@
--e
-+E1
-+E2
-@@ -7,0 +8,2 @@
-+G1
-+G2
-@@ -10 +12 @@
--j
-+J
-@@ -12,0 +15 @@
-+END
-";
+    let patch = text_block_fnl! {
+        "--- a/file.txt"
+        "+++ b/file.txt"
+        "@@ -1,2 +0,0 @@"
+        "-a"
+        "-b"
+        "@@ -3,0 +2 @@"
+        "+C"
+        "@@ -5 +4,2 @@"
+        "-e"
+        "+E1"
+        "+E2"
+        "@@ -7,0 +8,2 @@"
+        "+G1"
+        "+G2"
+        "@@ -10 +12 @@"
+        "-j"
+        "+J"
+        "@@ -12,0 +15 @@"
+        "+END"
+    };
     let after = applied(original, patch);
     eprintln!("{after}");
     assert_eq!(after, "c\nC\nd\nE1\nE2\nf\ng\nG1\nG2\nh\ni\nJ\nk\nl\nEND\n");

--- a/pnpm/crates/patching/src/apply/tolerant/tests.rs
+++ b/pnpm/crates/patching/src/apply/tolerant/tests.rs
@@ -157,7 +157,20 @@ fn applies_several_hunks_against_the_same_baseline() {
 
 #[test]
 fn applies_several_zero_context_insertions_against_the_same_baseline() {
-    let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
+    let original = text_block_fnl! {
+        "a"
+        "b"
+        "c"
+        "d"
+        "e"
+        "f"
+        "g"
+        "h"
+        "i"
+        "j"
+        "k"
+        "l"
+    };
     let patch = text_block_fnl! {
         "--- a/file.txt"
         "+++ b/file.txt"
@@ -170,14 +183,45 @@ fn applies_several_zero_context_insertions_against_the_same_baseline() {
         "@@ -12,0 +16 @@"
         "+END"
     };
+    let expected = text_block_fnl! {
+        "START"
+        "a"
+        "A"
+        "b"
+        "c"
+        "d"
+        "e"
+        "f"
+        "F"
+        "g"
+        "h"
+        "i"
+        "j"
+        "k"
+        "l"
+        "END"
+    };
     let after = applied(original, patch);
     eprintln!("{after}");
-    assert_eq!(after, "START\na\nA\nb\nc\nd\ne\nf\nF\ng\nh\ni\nj\nk\nl\nEND\n");
+    assert_eq!(after, expected);
 }
 
 #[test]
 fn applies_zero_context_insertions_after_deletion_and_replacement_shifts() {
-    let original = "a\nb\nc\nd\ne\nf\ng\nh\ni\nj\nk\nl\n";
+    let original = text_block_fnl! {
+        "a"
+        "b"
+        "c"
+        "d"
+        "e"
+        "f"
+        "g"
+        "h"
+        "i"
+        "j"
+        "k"
+        "l"
+    };
     let patch = text_block_fnl! {
         "--- a/file.txt"
         "+++ b/file.txt"
@@ -199,7 +243,24 @@ fn applies_zero_context_insertions_after_deletion_and_replacement_shifts() {
         "@@ -12,0 +15 @@"
         "+END"
     };
+    let expected = text_block_fnl! {
+        "c"
+        "C"
+        "d"
+        "E1"
+        "E2"
+        "f"
+        "g"
+        "G1"
+        "G2"
+        "h"
+        "i"
+        "J"
+        "k"
+        "l"
+        "END"
+    };
     let after = applied(original, patch);
     eprintln!("{after}");
-    assert_eq!(after, "c\nC\nd\nE1\nE2\nf\ng\nG1\nG2\nh\ni\nJ\nk\nl\nEND\n");
+    assert_eq!(after, expected);
 }


### PR DESCRIPTION
## Summary

Fix the Rust patch applier placing valid zero-context pure insertions one line early. The published pnpm 12.0.0 binary can report a successful install, including `--frozen-lockfile`, while producing incorrect package files.

An old range such as `-2,0` identifies the gap **after** the second original line. The tolerant applier subtracted one from every old-range start, as though every hunk consumed an existing line. A pure insertion has no original lines to match, so the incorrect earlier position was silently accepted.

Normalize the old-range coordinate according to whether it is empty, then use the existing baseline-owned hunk matching and cumulative splice offsets. Contextual fuzzing, CRLF/trailing-whitespace tolerances, and final-newline handling are unchanged. The production delta is net zero lines; regression coverage adds three tests in the existing test modules.

### Minimal example

Given `first\nsecond\nthird\n`, this valid hunk:

```diff
@@ -2,0 +3 @@
+inserted
```

must produce `first\nsecond\ninserted\nthird\n`. The affected applier instead produced `first\ninserted\nsecond\nthird\n`.

### Validation

- Before the owner change: 84 patching tests passed and the three new regressions failed for incorrect insertion positions.
- After the change: all 87 patching tests passed.
- Formatting, focused Clippy with warnings denied, and a native CLI build passed.
- Actual `install` → `patch` → `patch-commit` → fresh-workspace, fresh-store frozen-install workflows passed all 11 synthetic file scenarios with both zero and ordinary context. Patch generation used process-local Git `diff.context`; `git apply --unidiff-zero` independently verified the intended bytes.
- A four-file runtime regression was replayed through the same real CLI flow. All four output hashes now match the intended files, and a duplicate `const` declaration produced by the affected binary is eliminated.
- Independent review found no P0 blockers.

The complete, unfiltered `just ready` gate passed: **9,613 tests passed**, with five existing default skips. Nextest also reported 57 slow and four passing-but-leaky tests. Initial attempts exposed isolated-checkout setup issues (bootstrap store/npmrc overrides and an absent checkout-local fixture directory); correcting that setup required no additional source changes or test/gate configuration changes.

`pnpm run compile-only` and `pnpm run lint --quiet` also passed for the TypeScript workspace. The complete Rust pre-push script passed with all checks enabled: formatting, workspace Clippy, all-feature/private-item rustdoc, Dylint, spelling, and TOML formatting.

Full workspace gate, with task bootstrap overrides removed so fixtures own their configuration:

```bash
env -u PNPM_CONFIG_STORE_DIR -u npm_config_userconfig -u npm_config_globalconfig -u npm_config_cache just ready
```

Focused commands:

```bash
cargo test --locked -p pnpm-patching
```

```bash
cargo fmt -p pnpm-patching -- --check
```

```bash
cargo clippy --locked -p pnpm-patching --all-targets -- --deny warnings
```

```bash
cargo build --locked -p pnpm-cli --bin pnpm
```

### TypeScript parity

The TypeScript CLI delegates patch application to the separately published `@pnpm/patch-package@0.0.1` dependency, which has the same coordinate defect. That dependency-owner repair remains a follow-up. This PR fixes the Rust owner directly; it does not add a TypeScript consumer workaround, rewrite patch artifacts, or alter dependency versions/overrides.

## Squash Commit Body

```text
Treat an empty unified-diff old range as the gap after its recorded line,
rather than converting it like a one-based nonempty range. Keep every hunk
located against the original file and retain the existing cumulative
splice offsets and contextual matching tolerances.

Add file-boundary coverage for insertions with and without context,
including BOF, EOF, empty files, CRLF and missing final newlines. Cover
multiple insertion hunks and insertion positions following earlier
deletions and replacements.

The TypeScript patch-package dependency needs the corresponding owner
repair separately; no consumer workaround is introduced here.
```

## Checklist

- [x] Searched existing issues and pull requests for an equivalent fix.
- [x] The description notes the remaining TypeScript dependency-owner work.
- [x] Added a short user-facing changeset for the Rust CLI package.
- [x] Added regression tests and demonstrated that they fail before the fix.
- [x] No configuration or documented command behavior changes are required.

---
Written by an agent (Claude Code, Codex).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790645013&installation_model_id=426870&pr_number=14343&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14343&signature=5270fb819b3eb50fc54284e5916d3ff01ca5a4726dd0d83ae3a2336b30d18db2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed zero-context insertions being applied one line too early.
  * Improved insertion handling across empty files, file boundaries, varied line endings, and files without a final newline.
  * Preserved correct insertion positions when patches combine deletions, replacements, and multiple insertions.

* **Tests**
  * Expanded coverage for zero-context and mixed patch scenarios, including file boundaries and different newline formats.
  * Added validation for files with and without final newlines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->