### PR TITLE
fix(deps-restorer): report imported packages from the hoisted linker

### DIFF
--- a/.changeset/hoisted-linker-added-counter.md
+++ b/.changeset/hoisted-linker-added-counter.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed the install progress line reporting `added 0` under `nodeLinker: hoisted`, even when packages were linked into `node_modules` [#14348](https://github.com/pnpm/pnpm/issues/14348).

--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -128,6 +128,30 @@ fn installing_with_hoisted_node_linker() {
     drop((root, mock_instance));
 }
 
+/// The `added` counter on the progress line is fed by
+/// `pnpm:progress imported`, which under `nodeLinker: hoisted` only
+/// the hoisted linker emits — an install that materializes packages
+/// must move it off zero (pnpm/pnpm#14348).
+#[test]
+fn the_progress_line_counts_the_packages_the_hoisted_linker_added() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_manifest(&workspace, serde_json::json!({ "@pnpm.e2e/pkg-with-1-dep": "100.0.0" }));
+    write_workspace_yaml(&workspace, "nodeLinker: hoisted\n");
+
+    let output = pacquet_at(&workspace).with_args(["install"]).output().expect("run pnpm install");
+    assert!(output.status.success(), "install failed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(
+        stdout.contains("Progress: resolved 2, reused 0, downloaded 2, added 2, done"),
+        "stdout:\n{stdout}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// With `lockfile: false` the hoisted install still materializes a
 /// real directory and writes no `pnpm-lock.yaml`.
 #[test]

--- a/pnpm/crates/deps-restorer/src/link_hoisted_modules.rs
+++ b/pnpm/crates/deps-restorer/src/link_hoisted_modules.rs
@@ -304,7 +304,9 @@ fn import_node<Reporter: self::Reporter>(
 
     // `pnpm:progress imported` — see the matching emit in
     // `create_virtual_dir_by_snapshot::run` for the rationale on the
-    // optimistic `method` value. `to` is the node's hoisted directory.
+    // optimistic `method` value. Under `nodeLinker: hoisted` that emit
+    // never runs (no virtual-store slot is written), so this is the
+    // only source of the reporter's `added` counter.
     Reporter::emit(&LogEvent::Progress(ProgressLog {
         level: LogLevel::Debug,
         message: ProgressMessage::Imported {

--- a/pnpm/crates/deps-restorer/src/link_hoisted_modules.rs
+++ b/pnpm/crates/deps-restorer/src/link_hoisted_modules.rs
@@ -26,7 +26,9 @@ use miette::Diagnostic;
 use pnpm_cmd_shim::{Host, LinkBinsError, LinkBinsOptions, link_bins};
 use pnpm_config::PackageImportMethod;
 use pnpm_lockfile::PkgIdWithPatchHash;
-use pnpm_reporter::{LogEvent, LogLevel, Reporter, StatsLog, StatsMessage};
+use pnpm_reporter::{
+    LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter, StatsLog, StatsMessage,
+};
 use rayon::prelude::*;
 use std::{
     collections::HashMap,
@@ -298,7 +300,21 @@ fn import_node<Reporter: self::Reporter>(
             ..ImportIndexedDirOpts::default()
         },
     )
-    .map_err(LinkHoistedModulesError::ImportIndexedDir)
+    .map_err(LinkHoistedModulesError::ImportIndexedDir)?;
+
+    // `pnpm:progress imported` — see the matching emit in
+    // `create_virtual_dir_by_snapshot::run` for the rationale on the
+    // optimistic `method` value. `to` is the node's hoisted directory.
+    Reporter::emit(&LogEvent::Progress(ProgressLog {
+        level: LogLevel::Debug,
+        message: ProgressMessage::Imported {
+            method: crate::optimistic_wire_method(opts.import_method),
+            requester: opts.requester.to_owned(),
+            to: node.dir.to_string_lossy().into_owned(),
+        },
+    }));
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/pnpm/crates/deps-restorer/src/link_hoisted_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_hoisted_modules/tests.rs
@@ -420,6 +420,9 @@ fn hierarchy_entry_missing_from_graph_errors() {
     }
 }
 
+/// One `pnpm:progress imported` per imported node — the event the
+/// default reporter counts as `added`, and the only source of that
+/// counter under `nodeLinker: hoisted`.
 #[test]
 fn import_pass_emits_one_imported_event_per_node() {
     static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());

--- a/pnpm/crates/deps-restorer/src/link_hoisted_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_hoisted_modules/tests.rs
@@ -8,13 +8,15 @@ use pnpm_cmd_shim::LinkBinsOptions;
 use pnpm_config::PackageImportMethod;
 use pnpm_lockfile::{DirectoryResolution, LockfileResolution, PkgIdWithPatchHash};
 use pnpm_modules_yaml::DepPath;
-use pnpm_reporter::SilentReporter;
+use pnpm_reporter::{
+    LogEvent, PackageImportMethod as WireImportMethod, ProgressMessage, Reporter, SilentReporter,
+};
 use pretty_assertions::assert_eq;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fs,
     path::{Path, PathBuf},
-    sync::atomic::AtomicU8,
+    sync::{Mutex, atomic::AtomicU8},
 };
 
 fn sample_resolution() -> LockfileResolution {
@@ -416,4 +418,76 @@ fn hierarchy_entry_missing_from_graph_errors() {
         }
         other => panic!("expected MissingGraphNode, got {other:?}"),
     }
+}
+
+#[test]
+fn import_pass_emits_one_imported_event_per_node() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cas_root = tmp.path().join("cas");
+    let lockfile_dir = tmp.path().join("repo");
+    let (graph, hierarchy, cas_paths) = flat_layout(
+        &lockfile_dir,
+        &cas_root,
+        &[
+            ("a", "a@1.0.0", "a@1.0.0", &[("package/index.js", b"module.exports = 1;")]),
+            ("b", "b@1.0.0", "b@1.0.0", &[("package/index.js", b"module.exports = 2;")]),
+        ],
+    );
+
+    let logged = AtomicU8::new(0);
+    let opts = LinkHoistedModulesOpts {
+        graph: &graph,
+        prev_graph: None,
+        hierarchy: &hierarchy,
+        cas_paths_by_pkg_id: &cas_paths,
+        import_method: PackageImportMethod::Hardlink,
+        logged_methods: &logged,
+        requester: lockfile_dir.to_str().expect("requester"),
+        link_options: &LinkBinsOptions::default(),
+        confine_root: &lockfile_dir,
+    };
+    EVENTS.lock().unwrap().clear();
+    link_hoisted_modules::<RecordingReporter>(&opts).expect("linker succeeds");
+
+    let captured = EVENTS.lock().unwrap();
+    let mut imported: Vec<(WireImportMethod, String, String)> = captured
+        .iter()
+        .filter_map(|event| match event {
+            LogEvent::Progress(log) => match &log.message {
+                ProgressMessage::Imported { method, requester, to } => {
+                    Some((*method, requester.clone(), to.clone()))
+                }
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    imported.sort_by(|left, right| left.2.cmp(&right.2));
+
+    let modules = lockfile_dir.join("node_modules");
+    let requester = lockfile_dir.to_str().expect("requester").to_string();
+    assert_eq!(
+        imported,
+        vec![
+            (
+                WireImportMethod::Hardlink,
+                requester.clone(),
+                modules.join("a").to_string_lossy().into_owned(),
+            ),
+            (
+                WireImportMethod::Hardlink,
+                requester,
+                modules.join("b").to_string_lossy().into_owned(),
+            ),
+        ],
+    );
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Under `nodeLinker: hoisted` the install summary always ended with `added 0`, even on a clean install that linked hundreds of packages. The `added` counter is driven by `pnpm:progress imported`, and the hoisted linker never fired it: `import_node()` called `import_indexed_dir()` and returned, while the isolated linker emits the event after its own CAFS import. This adds the missing emit, with the same `requester`/`to` fields the TypeScript `linkHoistedModules` already reports per node.

Fixes pnpm/pnpm#14348

## Squash Commit Body

```text
The hoisted linker imported each graph node through import_indexed_dir()
without emitting pnpm:progress imported, so the default reporter's
`added` counter stayed at zero for the whole install while the isolated
linker's counter worked. LinkHoistedModulesOpts::requester was already
threaded in for this event.

The emit mirrors the TypeScript reportPackageImported() call in
linkHoistedModules: one event per successfully imported node, with the
node's hoisted directory as `to`. Optional nodes with no CAS entry
return before the import and stay unreported, as they do today.

Fixes pnpm/pnpm#14348
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790675146&installation_model_id=426870&pr_number=14350&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14350&signature=c7d15250290837678e94bf8799c059f90a161f326f3c2071145fc54f1d7bae95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed install progress reporting for hoisted linking so packages are correctly counted as added.
  * Progress updates now accurately reflect each package linked into `node_modules`.

* **Tests**
  * Added coverage to verify that one import progress event is reported for each linked package.
  * Added end-to-end coverage for accurate resolved, downloaded, and added package counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->