### PR TITLE
fix(cmd-shim): tolerate concurrent GVS shim replacement

### DIFF
--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -283,7 +283,7 @@ fn concurrent_installs_can_share_global_virtual_store_bins() {
     set_gvs_workspace_yaml(&workspace, "");
     write_manifest(
         &workspace,
-        &serde_json::json!({ ".e2e/hello-world-js-bin-parent": "1.0.0" }),
+        &serde_json::json!({ "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" }),
     );
 
     // Prime the content-addressed store and lockfile once. Each repetition
@@ -331,11 +331,11 @@ fn concurrent_installs_can_share_global_virtual_store_bins() {
 
         let parent_slot = sole_hash_dir(&pkg_version_dir(
             &store_dir,
-            ".e2e/hello-world-js-bin-parent",
+            "@pnpm.e2e/hello-world-js-bin-parent",
             "1.0.0",
         ));
         assert!(
-            pkg_in_slot(&parent_slot, ".e2e/hello-world-js-bin-parent")
+            pkg_in_slot(&parent_slot, "@pnpm.e2e/hello-world-js-bin-parent")
                 .join("node_modules/.bin/hello-world-js-bin")
                 .exists(),
             "the shared GVS dependency shim must exist after repetition {repetition}",

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -25,7 +25,7 @@ use std::{
     fmt::Write as _,
     fs,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 /// `<store_dir>/v11/links` — the root every GVS slot hangs off.
@@ -267,6 +267,84 @@ fn reinstall_from_warm_global_virtual_store_after_deleting_node_modules() {
         workspace.join("node_modules/.pnpm/lock.yaml").exists(),
         "the current lockfile must be rewritten",
     );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn concurrent_installs_can_share_global_virtual_store_bins() {
+    const WORKERS: usize = 8;
+    const REPETITIONS: usize = 10;
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "");
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ ".e2e/hello-world-js-bin-parent": "1.0.0" }),
+    );
+
+    // Prime the content-addressed store and lockfile once. Each repetition
+    // then deletes only the shared GVS projection, so the concurrent work is
+    // isolated to materializing the same package slot and its dependency bin.
+    pacquet(&workspace).with_arg("install").assert().success();
+    let fixture_files = [".npmrc", "package.json", "pnpm-workspace.yaml", "pnpm-lock.yaml"];
+
+    for repetition in 1..=REPETITIONS {
+        if gvs_root(&store_dir).exists() {
+            fs::remove_dir_all(gvs_root(&store_dir)).expect("reset GVS projection");
+        }
+
+        let mut worker_dirs = Vec::with_capacity(WORKERS);
+        for worker in 1..=WORKERS {
+            let worker_dir = root.path().join(format!("gvs-concurrent-{repetition}-{worker}"));
+            fs::create_dir(&worker_dir).expect("create concurrent workspace");
+            for file in fixture_files {
+                fs::copy(workspace.join(file), worker_dir.join(file))
+                    .unwrap_or_else(|err| panic!("copy {file} into {worker_dir:?}: {err}"));
+            }
+            worker_dirs.push(worker_dir);
+        }
+
+        let mut children = Vec::with_capacity(WORKERS);
+        for worker_dir in &worker_dirs {
+            let mut command = pacquet(worker_dir);
+            command
+                .args(["install", "--frozen-lockfile", "--ignore-scripts"])
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            children.push(command.spawn().expect("spawn concurrent GVS install"));
+        }
+
+        for (worker, child) in children.into_iter().enumerate() {
+            let output = child.wait_with_output().expect("wait for concurrent GVS install");
+            assert!(
+                output.status.success(),
+                "concurrent GVS install failed at repetition {repetition}, worker {}\nstdout:\n{}\nstderr:\n{}",
+                worker + 1,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+
+        let parent_slot = sole_hash_dir(&pkg_version_dir(
+            &store_dir,
+            ".e2e/hello-world-js-bin-parent",
+            "1.0.0",
+        ));
+        assert!(
+            pkg_in_slot(&parent_slot, ".e2e/hello-world-js-bin-parent")
+                .join("node_modules/.bin/hello-world-js-bin")
+                .exists(),
+            "the shared GVS dependency shim must exist after repetition {repetition}",
+        );
+
+        for worker_dir in worker_dirs {
+            fs::remove_dir_all(worker_dir).expect("remove concurrent workspace");
+        }
+    }
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -211,26 +211,16 @@ impl FsWrite for Host {
     fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
         #[cfg(unix)]
         {
-            use std::{
-                ffi::OsString,
-                io::Write as _,
-                sync::atomic::{AtomicU64, Ordering},
-            };
+            use std::{io::Write as _, sync::atomic::{AtomicU64, Ordering}};
 
             static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
             let parent = path.parent().ok_or_else(|| {
                 io::Error::new(io::ErrorKind::InvalidInput, "atomic replacement needs a parent")
             })?;
-            let file_name = path.file_name().ok_or_else(|| {
-                io::Error::new(io::ErrorKind::InvalidInput, "atomic replacement needs a file name")
-            })?;
-
             for _ in 0..64 {
                 let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
-                let mut temp_name = OsString::from(".");
-                temp_name.push(file_name);
-                temp_name.push(format!(".pnpm-tmp-{}-{sequence}", std::process::id()));
-                let temp_path = parent.join(temp_name);
+                let temp_path =
+                    parent.join(format!(".pnpm-tmp-{}-{sequence}", std::process::id()));
                 let mut temp = match std::fs::OpenOptions::new()
                     .write(true)
                     .create_new(true)

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -119,7 +119,9 @@ pub trait FsWrite {
     /// The production host prepares a secure sibling tempfile, sets its final
     /// mode, then renames it over the destination. The non-Unix implementation
     /// is a direct write because this operation is only used by POSIX shims.
-    fn atomic_replace_executable(path: &Path, bytes: &[u8]) -> io::Result<()>;
+    fn atomic_replace_executable(path: &Path, bytes: &[u8]) -> io::Result<()> {
+        Self::write(path, bytes)
+    }
 }
 
 /// Replace the permission bits at `path` with `0o755`. Used to chmod

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -211,7 +211,10 @@ impl FsWrite for Host {
     fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
         #[cfg(unix)]
         {
-            use std::{io::Write as _, sync::atomic::{AtomicU64, Ordering}};
+            use std::{
+                io::Write as _,
+                sync::atomic::{AtomicU64, Ordering},
+            };
 
             static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
             let parent = path.parent().ok_or_else(|| {
@@ -219,21 +222,17 @@ impl FsWrite for Host {
             })?;
             for _ in 0..64 {
                 let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
-                let temp_path =
-                    parent.join(format!(".pnpm-tmp-{}-{sequence}", std::process::id()));
-                let mut temp = match std::fs::OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(&temp_path)
-                {
-                    Ok(temp) => temp,
-                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-                    Err(error) => return Err(error),
-                };
+                let temp_path = parent.join(format!(".pnpm-tmp-{}-{sequence}", std::process::id()));
+                let mut temp =
+                    match std::fs::OpenOptions::new().write(true).create_new(true).open(&temp_path)
+                    {
+                        Ok(temp) => temp,
+                        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                        Err(error) => return Err(error),
+                    };
 
-                if let Err(error) = temp
-                    .write_all(bytes)
-                    .and_then(|()| std::fs::rename(&temp_path, path))
+                if let Err(error) =
+                    temp.write_all(bytes).and_then(|()| std::fs::rename(&temp_path, path))
                 {
                     let _ = std::fs::remove_file(&temp_path);
                     return Err(error);

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -106,17 +106,12 @@ pub trait FsCreateDirAll {
 /// exists. Used to write the three shim flavors (`.sh`, `.cmd`,
 /// `.ps1`).
 ///
-/// **Not atomic.** This trait is the moral equivalent of
-/// `std::fs::write`: it opens (or creates and truncates) the file,
-/// writes `bytes`, and closes. No tempfile + rename guard, no
-/// `fsync`. A SIGINT or crash mid-write can leave a truncated file
-/// on disk. Number of syscalls is up to the impl — `std::fs::write`
-/// itself is open/(truncate)/write/close, and a fake might loop.
-/// If a future caller needs atomic write semantics, build it on top
-/// of this trait by writing to a sibling tempfile and then
-/// renaming. Hiding that algorithm inside the capability would
-/// obscure what each callsite inherits; keeping the trait minimal
-/// lets every callsite see exactly what guarantees it gets.
+/// [`FsWrite::write`] is deliberately non-atomic and mirrors `std::fs::write`.
+/// [`FsWrite::atomic_replace`] is the explicit stronger operation used by
+/// POSIX command-shim materialization: the production host writes a secure
+/// sibling tempfile and renames it over the destination, so readers never
+/// observe the unlink/write gap of an in-place replacement. Neither operation
+/// calls `fsync`.
 pub trait FsWrite {
     fn write(path: &Path, bytes: &[u8]) -> io::Result<()>;
 

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -119,6 +119,12 @@ pub trait FsCreateDirAll {
 /// lets every callsite see exactly what guarantees it gets.
 pub trait FsWrite {
     fn write(path: &Path, bytes: &[u8]) -> io::Result<()>;
+
+    /// Atomically replace `path` with `bytes` on Unix by writing a secure
+    /// sibling temporary file and renaming it over the destination. The
+    /// non-Unix implementation is a direct write because the only current
+    /// atomic-replacement caller is the POSIX command-shim path.
+    fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()>;
 }
 
 /// Replace the permission bits at `path` with `0o755`. Used to chmod
@@ -205,6 +211,60 @@ impl FsCreateDirAll for Host {
 impl FsWrite for Host {
     fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
         std::fs::write(path, bytes)
+    }
+
+    fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            use std::{
+                ffi::OsString,
+                io::Write as _,
+                sync::atomic::{AtomicU64, Ordering},
+            };
+
+            static NEXT_TEMP: AtomicU64 = AtomicU64::new(0);
+            let parent = path.parent().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "atomic replacement needs a parent")
+            })?;
+            let file_name = path.file_name().ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "atomic replacement needs a file name")
+            })?;
+
+            for _ in 0..64 {
+                let sequence = NEXT_TEMP.fetch_add(1, Ordering::Relaxed);
+                let mut temp_name = OsString::from(".");
+                temp_name.push(file_name);
+                temp_name.push(format!(".pnpm-tmp-{}-{sequence}", std::process::id()));
+                let temp_path = parent.join(temp_name);
+                let mut temp = match std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&temp_path)
+                {
+                    Ok(temp) => temp,
+                    Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                    Err(error) => return Err(error),
+                };
+
+                if let Err(error) = temp
+                    .write_all(bytes)
+                    .and_then(|()| std::fs::rename(&temp_path, path))
+                {
+                    let _ = std::fs::remove_file(&temp_path);
+                    return Err(error);
+                }
+                return Ok(());
+            }
+
+            Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "could not allocate a sibling temporary shim file",
+            ))
+        }
+        #[cfg(not(unix))]
+        {
+            std::fs::write(path, bytes)
+        }
     }
 }
 

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -115,11 +115,11 @@ pub trait FsCreateDirAll {
 pub trait FsWrite {
     fn write(path: &Path, bytes: &[u8]) -> io::Result<()>;
 
-    /// Atomically replace `path` with `bytes` on Unix by writing a secure
-    /// sibling temporary file and renaming it over the destination. The
-    /// non-Unix implementation is a direct write because the only current
-    /// atomic-replacement caller is the POSIX command-shim path.
-    fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()>;
+    /// Atomically replace `path` on Unix with a fully-written executable file.
+    /// The production host prepares a secure sibling tempfile, sets its final
+    /// mode, then renames it over the destination. The non-Unix implementation
+    /// is a direct write because this operation is only used by POSIX shims.
+    fn atomic_replace_executable(path: &Path, bytes: &[u8]) -> io::Result<()>;
 }
 
 /// Replace the permission bits at `path` with `0o755`. Used to chmod
@@ -208,11 +208,12 @@ impl FsWrite for Host {
         std::fs::write(path, bytes)
     }
 
-    fn atomic_replace(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    fn atomic_replace_executable(path: &Path, bytes: &[u8]) -> io::Result<()> {
         #[cfg(unix)]
         {
             use std::{
                 io::Write as _,
+                os::unix::fs::PermissionsExt as _,
                 sync::atomic::{AtomicU64, Ordering},
             };
 
@@ -231,8 +232,12 @@ impl FsWrite for Host {
                         Err(error) => return Err(error),
                     };
 
-                if let Err(error) =
-                    temp.write_all(bytes).and_then(|()| std::fs::rename(&temp_path, path))
+                if let Err(error) = temp
+                    .write_all(bytes)
+                    .and_then(|()| {
+                        temp.set_permissions(std::fs::Permissions::from_mode(0o755))
+                    })
+                    .and_then(|()| std::fs::rename(&temp_path, path))
                 {
                     let _ = std::fs::remove_file(&temp_path);
                     return Err(error);

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -234,9 +234,7 @@ impl FsWrite for Host {
 
                 if let Err(error) = temp
                     .write_all(bytes)
-                    .and_then(|()| {
-                        temp.set_permissions(std::fs::Permissions::from_mode(0o755))
-                    })
+                    .and_then(|()| temp.set_permissions(std::fs::Permissions::from_mode(0o755)))
                     .and_then(|()| std::fs::rename(&temp_path, path))
                 {
                     let _ = std::fs::remove_file(&temp_path);

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -735,6 +735,11 @@ where
         }
     }
 
+    // Unix shims are already mode 0o755 before their atomic publish. Avoid a
+    // path-based chmod after publication: in a writable shared bin directory,
+    // another process could replace the final dirent with a symlink and turn
+    // that chmod into a permission-changing TOCTOU on an unrelated target.
+    #[cfg(not(unix))]
     Sys::set_executable(shim_path)
         .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })?;
     ensure_target_executable::<Sys>(target_path)?;

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -709,14 +709,20 @@ where
     let already_correct = sh_marker_ok && windows_ok;
 
     if !already_correct {
-        // Unlink any pre-existing entry before writing. `Sys::write` opens
-        // through a symlink, so without this a symlink planted at the bin
-        // path (e.g. in a shared/writable global bin dir) would redirect the
-        // write and clobber an arbitrary target. Removing first guarantees we
-        // create a fresh regular file.
-        remove_stale_bin(shim_path)?;
-        Sys::write(shim_path, sh_body.as_bytes())
+        // POSIX rename atomically replaces the destination dirent. Building the
+        // shim in a secure sibling tempfile therefore avoids both the symlink-
+        // clobber hazard of truncate-in-place and the shared-GVS unlink/write
+        // window that allowed another installer to make this path disappear.
+        #[cfg(unix)]
+        Sys::atomic_replace(shim_path, sh_body.as_bytes())
             .map_err(|error| LinkBinsError::WriteShim { path: shim_path.to_path_buf(), error })?;
+        #[cfg(not(unix))]
+        {
+            remove_stale_bin(shim_path)?;
+            Sys::write(shim_path, sh_body.as_bytes()).map_err(|error| {
+                LinkBinsError::WriteShim { path: shim_path.to_path_buf(), error }
+            })?;
+        }
         if let Some((cmd_path, cmd_body, powershell_shim)) = &windows_shims {
             remove_stale_bin(cmd_path)?;
             Sys::write(cmd_path, cmd_body.as_bytes())
@@ -729,35 +735,11 @@ where
         }
     }
 
-    set_shim_executable::<Sys>(shim_path)?;
+    Sys::set_executable(shim_path)
+        .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })?;
     ensure_target_executable::<Sys>(target_path)?;
 
     Ok(())
-}
-
-/// Set the shim executable bit, tolerating only a transient disappearance.
-///
-/// Independent installs sharing a GVS can race when one writer unlinks the
-/// shim between another writer's write and chmod. Give that competing writer
-/// a short bounded window to finish, but never report success while the shim
-/// remains absent. Non-`NotFound` chmod failures stay fatal.
-fn set_shim_executable<Sys>(shim_path: &Path) -> Result<(), LinkBinsError>
-where
-    Sys: FsSetExecutable,
-{
-    for delay_ms in [1, 2, 4, 8, 16] {
-        match Sys::set_executable(shim_path) {
-            Ok(()) => return Ok(()),
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {
-                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
-            }
-            Err(error) => {
-                return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
-            }
-        }
-    }
-    Sys::set_executable(shim_path)
-        .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })
 }
 
 /// Make the underlying script executable: apply a minimum mode of

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -714,7 +714,7 @@ where
         // clobber hazard of truncate-in-place and the shared-GVS unlink/write
         // window that allowed another installer to make this path disappear.
         #[cfg(unix)]
-        Sys::atomic_replace(shim_path, sh_body.as_bytes())
+        Sys::atomic_replace_executable(shim_path, sh_body.as_bytes())
             .map_err(|error| LinkBinsError::WriteShim { path: shim_path.to_path_buf(), error })?;
         #[cfg(not(unix))]
         {

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -729,8 +729,17 @@ where
         }
     }
 
-    Sys::set_executable(shim_path)
-        .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })?;
+    match Sys::set_executable(shim_path) {
+        Ok(()) => {}
+        // Independent installs can materialize the same GVS shim concurrently.
+        // If another writer unlinks this path between our write and chmod, it
+        // owns completing the shared shim; match the TypeScript linker and
+        // treat that ENOENT as benign. Other chmod failures remain fatal.
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
+        }
+    }
     ensure_target_executable::<Sys>(target_path)?;
 
     Ok(())

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -729,20 +729,35 @@ where
         }
     }
 
-    match Sys::set_executable(shim_path) {
-        Ok(()) => {}
-        // Independent installs can materialize the same GVS shim concurrently.
-        // If another writer unlinks this path between our write and chmod, it
-        // owns completing the shared shim; match the TypeScript linker and
-        // treat that ENOENT as benign. Other chmod failures remain fatal.
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
-        }
-    }
+    set_shim_executable::<Sys>(shim_path)?;
     ensure_target_executable::<Sys>(target_path)?;
 
     Ok(())
+}
+
+/// Set the shim executable bit, tolerating only a transient disappearance.
+///
+/// Independent installs sharing a GVS can race when one writer unlinks the
+/// shim between another writer's write and chmod. Give that competing writer
+/// a short bounded window to finish, but never report success while the shim
+/// remains absent. Non-`NotFound` chmod failures stay fatal.
+fn set_shim_executable<Sys>(shim_path: &Path) -> Result<(), LinkBinsError>
+where
+    Sys: FsSetExecutable,
+{
+    for delay_ms in [1, 2, 4, 8, 16] {
+        match Sys::set_executable(shim_path) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                std::thread::sleep(std::time::Duration::from_millis(delay_ms));
+            }
+            Err(error) => {
+                return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
+            }
+        }
+    }
+    Sys::set_executable(shim_path)
+        .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })
 }
 
 /// Make the underlying script executable: apply a minimum mode of

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -485,6 +485,7 @@ fn link_bins_propagates_write_shim_error_via_di() {
     assert!(matches!(err, LinkBinsError::WriteShim { .. }));
 }
 
+#[cfg(not(unix))]
 #[test]
 fn link_bins_propagates_chmod_error_via_di() {
     use std::io;

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -375,7 +375,7 @@ fn link_bins_propagates_create_bin_dir_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }
@@ -452,7 +452,7 @@ fn link_bins_propagates_write_shim_error_via_di() {
             Err(io::Error::from(io::ErrorKind::PermissionDenied))
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             Err(io::Error::from(io::ErrorKind::PermissionDenied))
         }
     }
@@ -526,7 +526,7 @@ fn link_bins_propagates_chmod_error_via_di() {
             Ok(())
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -576,11 +576,13 @@ fn atomic_shim_replace_does_not_follow_existing_symlink() {
     write_file(&target, "do not touch").unwrap();
     symlink(&target, &shim).unwrap();
 
-    <Host as FsWrite>::atomic_replace(&shim, b"replacement").unwrap();
+    <Host as FsWrite>::atomic_replace_executable(&shim, b"replacement").unwrap();
 
     assert_eq!(std::fs::read_to_string(&target).unwrap(), "do not touch");
     assert_eq!(std::fs::read_to_string(&shim).unwrap(), "replacement");
     assert!(!std::fs::symlink_metadata(&shim).unwrap().file_type().is_symlink());
+    use std::os::unix::fs::PermissionsExt as _;
+    assert_eq!(std::fs::metadata(&shim).unwrap().permissions().mode() & 0o777, 0o755);
 }
 
 #[test]
@@ -618,7 +620,7 @@ fn link_bins_propagates_target_chmod_error_via_di() {
             Ok(())
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -692,7 +694,7 @@ fn link_bins_swallows_target_chmod_not_found_via_di() {
             Ok(())
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -765,7 +767,7 @@ fn link_bins_propagates_probe_shim_source_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }
@@ -838,7 +840,7 @@ fn link_bins_propagates_read_manifest_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }
@@ -953,7 +955,7 @@ fn link_bins_propagates_modules_dir_read_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -374,6 +374,10 @@ fn link_bins_propagates_create_bin_dir_error_via_di() {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+            unreachable!()
+        }
     }
     impl FsSetExecutable for FailingCreateDir {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -447,6 +451,10 @@ fn link_bins_propagates_write_shim_error_via_di() {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
             Err(io::Error::from(io::ErrorKind::PermissionDenied))
         }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::PermissionDenied))
+        }
     }
     impl FsSetExecutable for FailingWrite {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -517,6 +525,10 @@ fn link_bins_propagates_chmod_error_via_di() {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+            Ok(())
+        }
     }
     impl FsSetExecutable for FailingChmod {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -553,48 +565,22 @@ fn link_bins_propagates_chmod_error_via_di() {
     assert!(matches!(err, LinkBinsError::Chmod { .. }));
 }
 
+#[cfg(unix)]
 #[test]
-fn shim_chmod_retries_transient_not_found_via_di() {
-    use std::{
-        io,
-        sync::atomic::{AtomicUsize, Ordering},
-    };
+fn atomic_shim_replace_does_not_follow_existing_symlink() {
+    use std::os::unix::fs::symlink;
 
-    static CALLS: AtomicUsize = AtomicUsize::new(0);
-    struct TransientMissingShim;
-    impl FsSetExecutable for TransientMissingShim {
-        fn set_executable(path: &Path) -> io::Result<()> {
-            if CALLS.fetch_add(1, Ordering::Relaxed) == 0 {
-                return Err(io::Error::from(io::ErrorKind::NotFound));
-            }
-            <Host as FsSetExecutable>::set_executable(path)
-        }
-    }
-
-    CALLS.store(0, Ordering::Relaxed);
     let tmp = tempdir().unwrap();
+    let target = tmp.path().join("target");
     let shim = tmp.path().join("shim");
-    write_file(&shim, "#!/usr/bin/env node\n").unwrap();
+    write_file(&target, "do not touch").unwrap();
+    symlink(&target, &shim).unwrap();
 
-    super::set_shim_executable::<TransientMissingShim>(&shim)
-        .expect("a transient missing shim must be retried");
-    assert_eq!(CALLS.load(Ordering::Relaxed), 2);
-}
+    <Host as FsWrite>::atomic_replace(&shim, b"replacement").unwrap();
 
-#[test]
-fn shim_chmod_propagates_persistent_not_found_via_di() {
-    use std::io;
-
-    struct PersistentlyMissingShim;
-    impl FsSetExecutable for PersistentlyMissingShim {
-        fn set_executable(_: &Path) -> io::Result<()> {
-            Err(io::Error::from(io::ErrorKind::NotFound))
-        }
-    }
-
-    let err = super::set_shim_executable::<PersistentlyMissingShim>(Path::new("missing-shim"))
-        .expect_err("a persistently missing shim must not report success");
-    assert!(matches!(err, LinkBinsError::Chmod { .. }));
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "do not touch");
+    assert_eq!(std::fs::read_to_string(&shim).unwrap(), "replacement");
+    assert!(!std::fs::symlink_metadata(&shim).unwrap().file_type().is_symlink());
 }
 
 #[test]
@@ -629,6 +615,10 @@ fn link_bins_propagates_target_chmod_error_via_di() {
     }
     impl FsWrite for FailingTargetChmod {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
+            Ok(())
+        }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
     }
@@ -701,6 +691,10 @@ fn link_bins_swallows_target_chmod_not_found_via_di() {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
             Ok(())
         }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+            Ok(())
+        }
     }
     impl FsSetExecutable for NotFoundTargetChmod {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -770,6 +764,10 @@ fn link_bins_propagates_probe_shim_source_error_via_di() {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
+            unreachable!()
+        }
     }
     impl FsSetExecutable for FailingProbe {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -837,6 +835,10 @@ fn link_bins_propagates_read_manifest_error_via_di() {
     }
     impl FsWrite for DenyManifestRead {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
+            unreachable!()
+        }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }
@@ -948,6 +950,10 @@ fn link_bins_propagates_modules_dir_read_error_via_di() {
     }
     impl FsWrite for FailingModulesRead {
         fn write(_: &Path, _: &[u8]) -> io::Result<()> {
+            unreachable!()
+        }
+
+        fn atomic_replace(_: &Path, _: &[u8]) -> io::Result<()> {
             unreachable!()
         }
     }

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -375,9 +375,6 @@ fn link_bins_propagates_create_bin_dir_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            unreachable!()
-        }
     }
     impl FsSetExecutable for FailingCreateDir {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -452,9 +449,6 @@ fn link_bins_propagates_write_shim_error_via_di() {
             Err(io::Error::from(io::ErrorKind::PermissionDenied))
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            Err(io::Error::from(io::ErrorKind::PermissionDenied))
-        }
     }
     impl FsSetExecutable for FailingWrite {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -526,9 +520,6 @@ fn link_bins_propagates_chmod_error_via_di() {
             Ok(())
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            Ok(())
-        }
     }
     impl FsSetExecutable for FailingChmod {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -620,9 +611,6 @@ fn link_bins_propagates_target_chmod_error_via_di() {
             Ok(())
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            Ok(())
-        }
     }
     impl FsSetExecutable for FailingTargetChmod {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -694,9 +682,6 @@ fn link_bins_swallows_target_chmod_not_found_via_di() {
             Ok(())
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            Ok(())
-        }
     }
     impl FsSetExecutable for NotFoundTargetChmod {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -767,9 +752,6 @@ fn link_bins_propagates_probe_shim_source_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            unreachable!()
-        }
     }
     impl FsSetExecutable for FailingProbe {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -840,9 +822,6 @@ fn link_bins_propagates_read_manifest_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            unreachable!()
-        }
     }
     impl FsSetExecutable for DenyManifestRead {
         fn set_executable(_: &Path) -> io::Result<()> {
@@ -955,9 +934,6 @@ fn link_bins_propagates_modules_dir_read_error_via_di() {
             unreachable!()
         }
 
-        fn atomic_replace_executable(_: &Path, _: &[u8]) -> io::Result<()> {
-            unreachable!()
-        }
     }
     impl FsSetExecutable for FailingModulesRead {
         fn set_executable(_: &Path) -> io::Result<()> {

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -590,7 +590,14 @@ fn link_bins_swallows_missing_shim_chmod_via_di() {
     let shim = tmp.path().join(".bin/foo");
     create_dir_all(shim.parent().unwrap()).unwrap();
 
-    super::write_shim::<MissingShimChmod>(&target, &shim, &[], super::ShimStyle::Direct)
+    super::write_shim::<MissingShimChmod>(
+        &target,
+        &shim,
+        &[],
+        false,
+        super::ShimStyle::Direct,
+        false,
+    )
         .expect("NotFound on the shared shim chmod must be tolerated");
 }
 

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -554,6 +554,47 @@ fn link_bins_propagates_chmod_error_via_di() {
 }
 
 #[test]
+fn link_bins_swallows_missing_shim_chmod_via_di() {
+    use std::io;
+
+    struct MissingShimChmod;
+    impl FsReadToString for MissingShimChmod {
+        fn read_to_string(path: &Path) -> io::Result<String> {
+            <Host as FsReadToString>::read_to_string(path)
+        }
+    }
+    impl FsReadHead for MissingShimChmod {
+        fn read_head(path: &Path, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
+            <Host as FsReadHead>::read_head(path, offset, buf)
+        }
+    }
+    impl FsWrite for MissingShimChmod {
+        fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+            <Host as FsWrite>::write(path, bytes)
+        }
+    }
+    impl FsSetExecutable for MissingShimChmod {
+        fn set_executable(_: &Path) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        }
+    }
+    impl FsEnsureExecutableBits for MissingShimChmod {
+        fn ensure_executable_bits(path: &Path) -> io::Result<()> {
+            <Host as FsEnsureExecutableBits>::ensure_executable_bits(path)
+        }
+    }
+
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("cli.js");
+    write_file(&target, "#!/usr/bin/env node\n").unwrap();
+    let shim = tmp.path().join(".bin/foo");
+    create_dir_all(shim.parent().unwrap()).unwrap();
+
+    super::write_shim::<MissingShimChmod>(&target, &shim, &[], super::ShimStyle::Direct)
+        .expect("NotFound on the shared shim chmod must be tolerated");
+}
+
+#[test]
 fn link_bins_propagates_target_chmod_error_via_di() {
     use std::io;
 

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -598,7 +598,7 @@ fn link_bins_swallows_missing_shim_chmod_via_di() {
         super::ShimStyle::Direct,
         false,
     )
-        .expect("NotFound on the shared shim chmod must be tolerated");
+    .expect("NotFound on the shared shim chmod must be tolerated");
 }
 
 #[test]

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -554,51 +554,47 @@ fn link_bins_propagates_chmod_error_via_di() {
 }
 
 #[test]
-fn link_bins_swallows_missing_shim_chmod_via_di() {
+fn shim_chmod_retries_transient_not_found_via_di() {
+    use std::{
+        io,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    static CALLS: AtomicUsize = AtomicUsize::new(0);
+    struct TransientMissingShim;
+    impl FsSetExecutable for TransientMissingShim {
+        fn set_executable(path: &Path) -> io::Result<()> {
+            if CALLS.fetch_add(1, Ordering::Relaxed) == 0 {
+                return Err(io::Error::from(io::ErrorKind::NotFound));
+            }
+            <Host as FsSetExecutable>::set_executable(path)
+        }
+    }
+
+    CALLS.store(0, Ordering::Relaxed);
+    let tmp = tempdir().unwrap();
+    let shim = tmp.path().join("shim");
+    write_file(&shim, "#!/usr/bin/env node\n").unwrap();
+
+    super::set_shim_executable::<TransientMissingShim>(&shim)
+        .expect("a transient missing shim must be retried");
+    assert_eq!(CALLS.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn shim_chmod_propagates_persistent_not_found_via_di() {
     use std::io;
 
-    struct MissingShimChmod;
-    impl FsReadToString for MissingShimChmod {
-        fn read_to_string(path: &Path) -> io::Result<String> {
-            <Host as FsReadToString>::read_to_string(path)
-        }
-    }
-    impl FsReadHead for MissingShimChmod {
-        fn read_head(path: &Path, offset: u64, buf: &mut [u8]) -> io::Result<usize> {
-            <Host as FsReadHead>::read_head(path, offset, buf)
-        }
-    }
-    impl FsWrite for MissingShimChmod {
-        fn write(path: &Path, bytes: &[u8]) -> io::Result<()> {
-            <Host as FsWrite>::write(path, bytes)
-        }
-    }
-    impl FsSetExecutable for MissingShimChmod {
+    struct PersistentlyMissingShim;
+    impl FsSetExecutable for PersistentlyMissingShim {
         fn set_executable(_: &Path) -> io::Result<()> {
             Err(io::Error::from(io::ErrorKind::NotFound))
         }
     }
-    impl FsEnsureExecutableBits for MissingShimChmod {
-        fn ensure_executable_bits(path: &Path) -> io::Result<()> {
-            <Host as FsEnsureExecutableBits>::ensure_executable_bits(path)
-        }
-    }
 
-    let tmp = tempdir().unwrap();
-    let target = tmp.path().join("cli.js");
-    write_file(&target, "#!/usr/bin/env node\n").unwrap();
-    let shim = tmp.path().join(".bin/foo");
-    create_dir_all(shim.parent().unwrap()).unwrap();
-
-    super::write_shim::<MissingShimChmod>(
-        &target,
-        &shim,
-        &[],
-        false,
-        super::ShimStyle::Direct,
-        false,
-    )
-    .expect("NotFound on the shared shim chmod must be tolerated");
+    let err = super::set_shim_executable::<PersistentlyMissingShim>(Path::new("missing-shim"))
+        .expect_err("a persistently missing shim must not report success");
+    assert!(matches!(err, LinkBinsError::Chmod { .. }));
 }
 
 #[test]


### PR DESCRIPTION
Superseded by #14355.

This was an earlier atomic-replacement exploration. The accepted implementation is #14355, which follows the upstream triage direction and has the clean validation/review path.

Closed to keep a single canonical implementation PR.