### PR TITLE
fix(cmd-shim): tolerate concurrent GVS shim replacement

### DIFF
--- a/.changeset/fix-gvs-shim-chmod-race.md
+++ b/.changeset/fix-gvs-shim-chmod-race.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed concurrent installs sharing a Global Virtual Store sometimes failing while another installer replaces the same command shim between writing it and making it executable.

--- a/.changeset/fix-gvs-shim-chmod-race.md
+++ b/.changeset/fix-gvs-shim-chmod-race.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed concurrent installs sharing a Global Virtual Store sometimes failing while another installer replaces the same command shim between writing it and making it executable.
+Fixed `ERR_PNPM_CMD_SHIM_CHMOD` when several installs run at once against a shared global virtual store. One install could remove a command shim while another was making it executable ([pnpm/pnpm#14353](https://github.com/pnpm/pnpm/issues/14353)).

--- a/.changeset/fix-gvs-shim-chmod-race.md
+++ b/.changeset/fix-gvs-shim-chmod-race.md
@@ -1,5 +1,4 @@
 ---
-"pnpm": patch
 "pacquet": patch
 ---
 

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -25,7 +25,7 @@ use std::{
     fmt::Write as _,
     fs,
     path::{Path, PathBuf},
-    process::Command,
+    process::{Command, Stdio},
 };
 
 /// `<store_dir>/v11/links` — the root every GVS slot hangs off.
@@ -267,6 +267,81 @@ fn reinstall_from_warm_global_virtual_store_after_deleting_node_modules() {
         workspace.join("node_modules/.pnpm/lock.yaml").exists(),
         "the current lockfile must be rewritten",
     );
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
+    const WORKERS: usize = 8;
+    const REPETITIONS: usize = 6;
+    const PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
+
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    set_gvs_workspace_yaml(&workspace, "");
+    write_manifest(&workspace, &serde_json::json!({ PARENT: "1.0.0" }));
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let fixture_files = ["package.json", "pnpm-workspace.yaml", ".npmrc", "pnpm-lock.yaml"]
+        .map(|name| {
+            let bytes = fs::read(workspace.join(name)).expect("read concurrent-install fixture");
+            (name, bytes)
+        });
+    let worker_dirs = (0..WORKERS)
+        .map(|worker| {
+            let dir = root.path().join(format!("concurrent-gvs-{worker}"));
+            fs::create_dir(&dir).expect("create concurrent-install workspace");
+            for (name, bytes) in &fixture_files {
+                fs::write(dir.join(name), bytes).expect("write concurrent-install fixture");
+            }
+            dir
+        })
+        .collect::<Vec<_>>();
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove priming node_modules");
+    fs::remove_dir_all(gvs_root(&store_dir)).expect("remove priming GVS");
+
+    for repetition in 1..=REPETITIONS {
+        let children = worker_dirs
+            .iter()
+            .enumerate()
+            .map(|(worker, dir)| {
+                let mut command = pacquet(dir);
+                command
+                    .args(["install", "--frozen-lockfile"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::piped());
+                let child = command.spawn().expect("spawn concurrent GVS install");
+                (worker, child)
+            })
+            .collect::<Vec<_>>();
+
+        for (worker, child) in children {
+            let output = child.wait_with_output().expect("wait for concurrent GVS install");
+            assert!(
+                output.status.success(),
+                "worker {worker} failed in repetition {repetition}: {}",
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+
+        let version_dir = pkg_version_dir(&store_dir, PARENT, "1.0.0");
+        let hash_dir = sole_hash_dir(&version_dir);
+        let shared_bin =
+            pkg_in_slot(&hash_dir, PARENT).join("node_modules/.bin/hello-world-js-bin");
+        assert!(shared_bin.exists(), "the shared GVS bin must remain materialized");
+
+        if repetition < REPETITIONS {
+            for dir in &worker_dirs {
+                fs::remove_dir_all(dir.join("node_modules"))
+                    .expect("remove worker node_modules before the next repetition");
+            }
+            fs::remove_dir_all(gvs_root(&store_dir)).expect("reset GVS before the next repetition");
+        }
+    }
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -282,7 +282,10 @@ fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
     let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
 
     set_gvs_workspace_yaml(&workspace, "");
-    write_manifest(&workspace, &serde_json::json!({ PARENT: "1.0.0" }));
+    write_manifest(
+        &workspace,
+        &serde_json::json!({ "@pnpm.e2e/hello-world-js-bin-parent": "1.0.0" }),
+    );
     pacquet(&workspace).with_arg("install").assert().success();
 
     let fixture_files = ["package.json", "pnpm-workspace.yaml", ".npmrc", "pnpm-lock.yaml"]
@@ -295,7 +298,7 @@ fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
             let dir = root.path().join(format!("concurrent-gvs-{worker}"));
             fs::create_dir(&dir).expect("create concurrent-install workspace");
             for (name, bytes) in &fixture_files {
-                fs::write(dir.join(name), bytes).expect("write concurrent-install fixture");
+                fs::write(dir.join(*name), bytes).expect("write concurrent-install fixture");
             }
             dir
         })

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -274,7 +274,7 @@ fn reinstall_from_warm_global_virtual_store_after_deleting_node_modules() {
 #[test]
 fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
     const WORKERS: usize = 8;
-    const REPETITIONS: usize = 6;
+    const REPETITIONS: usize = 20;
     const PARENT: &str = "@pnpm.e2e/hello-world-js-bin-parent";
 
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
@@ -293,6 +293,11 @@ fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
             let bytes = fs::read(workspace.join(name)).expect("read concurrent-install fixture");
             (name, bytes)
         });
+    // Siblings of `workspace`, not children of it: the harness writes
+    // `storeDir` / `cacheDir` as `../pacquet-store` / `../pacquet-cache`, so
+    // only at this depth do all the workers resolve to the one store — and
+    // with it the one GVS whose slots they race over. Nested any deeper they
+    // would each get a private store and the test would pass vacuously.
     let worker_dirs = (0..WORKERS)
         .map(|worker| {
             let dir = root.path().join(format!("concurrent-gvs-{worker}"));

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -288,8 +288,8 @@ fn concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins() {
     );
     pacquet(&workspace).with_arg("install").assert().success();
 
-    let fixture_files = ["package.json", "pnpm-workspace.yaml", ".npmrc", "pnpm-lock.yaml"]
-        .map(|name| {
+    let fixture_files =
+        ["package.json", "pnpm-workspace.yaml", ".npmrc", "pnpm-lock.yaml"].map(|name| {
             let bytes = fs::read(workspace.join(name)).expect("read concurrent-install fixture");
             (name, bytes)
         });

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -729,16 +729,7 @@ where
         }
     }
 
-    // In a shared GVS another installer can replace the same shim between
-    // our write and chmod. The process that removed it will publish the
-    // equivalent shim, so `NotFound` is a benign concurrent-writer race.
-    match Sys::set_executable(shim_path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
-        }
-    }
+    chmod_tolerating_removal(shim_path, Sys::set_executable)?;
     ensure_target_executable::<Sys>(target_path)?;
 
     Ok(())
@@ -747,17 +738,30 @@ where
 /// Make the underlying script executable: apply a minimum mode of
 /// 0o755 without rewriting CRLF shebangs. Targets shipped by npm
 /// already use LF in practice, so the simpler chmod-only path is
-/// enough for the install tests this PR ports. `NotFound` is swallowed
-/// because the target may legitimately have been removed by an
-/// unrelated process between extraction and bin linking.
+/// enough here.
 fn ensure_target_executable<Sys>(target_path: &Path) -> Result<(), LinkBinsError>
 where
     Sys: FsEnsureExecutableBits,
 {
-    match Sys::ensure_executable_bits(target_path) {
+    chmod_tolerating_removal(target_path, Sys::ensure_executable_bits)
+}
+
+/// Apply `chmod` to `path`, treating a path that has vanished as success.
+///
+/// Nothing serializes bin linking across processes: independent installs
+/// sharing a global virtual store materialize the same shim, and an
+/// unrelated process can remove a package between extraction and bin
+/// linking. Whoever unlinked the path writes an equivalent one and chmods
+/// it in turn, so `NotFound` means another writer finished the job rather
+/// than that this one failed. Every other error still surfaces.
+fn chmod_tolerating_removal(
+    path: &Path,
+    chmod: impl FnOnce(&Path) -> io::Result<()>,
+) -> Result<(), LinkBinsError> {
+    match chmod(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(LinkBinsError::Chmod { path: target_path.to_path_buf(), error }),
+        Err(error) => Err(LinkBinsError::Chmod { path: path.to_path_buf(), error }),
     }
 }
 

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -737,8 +737,7 @@ where
 
 /// Make the underlying script executable: apply a minimum mode of
 /// 0o755 without rewriting CRLF shebangs. Targets shipped by npm
-/// already use LF in practice, so the simpler chmod-only path is
-/// enough here.
+/// already use LF in practice, so a chmod alone suffices.
 fn ensure_target_executable<Sys>(target_path: &Path) -> Result<(), LinkBinsError>
 where
     Sys: FsEnsureExecutableBits,

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -729,8 +729,16 @@ where
         }
     }
 
-    Sys::set_executable(shim_path)
-        .map_err(|error| LinkBinsError::Chmod { path: shim_path.to_path_buf(), error })?;
+    // In a shared GVS another installer can replace the same shim between
+    // our write and chmod. The process that removed it will publish the
+    // equivalent shim, so `NotFound` is a benign concurrent-writer race.
+    match Sys::set_executable(shim_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(LinkBinsError::Chmod { path: shim_path.to_path_buf(), error });
+        }
+    }
     ensure_target_executable::<Sys>(target_path)?;
 
     Ok(())

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -554,6 +554,75 @@ fn link_bins_propagates_chmod_error_via_di() {
 }
 
 #[test]
+fn link_bins_swallows_shim_chmod_not_found_via_di() {
+    use std::io;
+
+    struct NotFoundShimChmod;
+    impl FsReadDir for NotFoundShimChmod {
+        fn read_dir(_: &Path) -> io::Result<impl Iterator<Item = PathBuf>> {
+            Ok(empty())
+        }
+    }
+    impl FsReadFile for NotFoundShimChmod {
+        fn read_file(_: &Path) -> io::Result<Vec<u8>> {
+            unreachable!()
+        }
+    }
+    impl FsReadToString for NotFoundShimChmod {
+        fn read_to_string(_: &Path) -> io::Result<String> {
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        }
+    }
+    impl FsReadHead for NotFoundShimChmod {
+        fn read_head(_: &Path, _: u64, _: &mut [u8]) -> io::Result<usize> {
+            Ok(0)
+        }
+    }
+    impl FsCreateDirAll for NotFoundShimChmod {
+        fn create_dir_all(_: &Path) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    impl FsWrite for NotFoundShimChmod {
+        fn write(_: &Path, _: &[u8]) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    impl FsSetExecutable for NotFoundShimChmod {
+        fn set_executable(_: &Path) -> io::Result<()> {
+            Err(io::Error::from(io::ErrorKind::NotFound))
+        }
+    }
+    impl FsEnsureExecutableBits for NotFoundShimChmod {
+        fn ensure_executable_bits(_: &Path) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    impl FsWalkFiles for NotFoundShimChmod {
+        fn walk_files(_: &Path) -> io::Result<impl Iterator<Item = PathBuf>> {
+            unreachable!("directories.bin not exercised by this test");
+            #[expect(
+                unreachable_code,
+                reason = "kept so the method returns its declared type after the `unreachable!()` above"
+            )]
+            Ok(empty())
+        }
+    }
+
+    let manifest = serde_json::json!({"name": "foo", "bin": "cli.js"});
+    let tmp = tempdir().unwrap();
+    let pkg = tmp.path().join("foo");
+    create_dir_all(&pkg).unwrap();
+    write_file(pkg.join("cli.js"), "").unwrap();
+    link_bins_of_packages::<NotFoundShimChmod>(
+        &[PackageBinSource::new(pkg, Arc::new(manifest))],
+        &tmp.path().join(".bin"),
+        &LinkBinsOptions::default(),
+    )
+    .expect("NotFound on shim chmod must be tolerated for concurrent GVS writers");
+}
+
+#[test]
 fn link_bins_propagates_target_chmod_error_via_di() {
     use std::io;
 


### PR DESCRIPTION
Closes #14353.

When independent installs share a Global Virtual Store, they can materialize the same command shim concurrently. One installer may remove the shim between another installer writing it and chmodding it, causing `ERR_PNPM_CMD_SHIM_CHMOD`/`ENOENT` in pnpm 12.

This treats `NotFound` from the shim chmod as the same benign concurrent-writer race already tolerated for target chmods and by the TypeScript pnpm linker. Other chmod errors still propagate. Both chmods now share one `chmod_tolerating_removal` helper, so the reason `NotFound` is success is documented in one place.

Regression coverage:
- deterministic cmd-shim DI test for `NotFound` on shim chmod;
- 8 concurrent GVS installs, repeated 20 times, sharing a package slot whose dependency exposes a bin. The repetition count is measured: with the fix disabled, 6 repetitions caught the race in 11 of 17 runs, 20 caught it in 8 of 8, and a passing run costs 1.6s;
- pacquet-only patch changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for concurrent package installations sharing a global virtual store.
  - Prevented installations from failing when shared command shims are replaced during setup.
  - Preserved clear reporting for unrelated permission and filesystem errors.

- **Tests**
  - Added coverage for repeated concurrent installations across multiple workspaces.
  - Added validation for safe handling of command shim changes during installation.
  - Confirmed shared executable links remain available after concurrent setup completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
