### PR TITLE
perf(install): limit peer reporting to resolver candidates

### DIFF
--- a/.changeset/peer-report-candidate-scope.md
+++ b/.changeset/peer-report-candidate-scope.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Avoid walking every workspace importer a second time when a resolving install reports peer-dependency issues.
+Fixed a slowdown at the end of a resolving install in a large workspace. The peer-dependency report now inspects only the projects the resolution flagged, rather than every project in the lockfile ([pnpm/pnpm#14359](https://github.com/pnpm/pnpm/issues/14359)).

--- a/.changeset/peer-report-candidate-scope.md
+++ b/.changeset/peer-report-candidate-scope.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Avoid walking every workspace importer a second time when a resolving install reports peer-dependency issues.

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -269,6 +269,80 @@ fn write_peer_conflict_manifest(project_dir: &std::path::Path, name: &str) {
     .expect("write package.json");
 }
 
+/// A workspace project's own `peerDependencies` are checked against the
+/// dependencies of the projects that link to it. Peer resolution never
+/// sees them — a `link:` node's peers belong to the linked importer —
+/// so the consuming importer reaches the report by a route of its own.
+fn write_linked_peer_workspace(workspace: &std::path::Path) {
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the linked project");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the linked manifest");
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*", "@pnpm.e2e/foo": "2.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the consuming manifest");
+}
+
+#[test]
+fn a_linked_workspace_packages_unmet_peer_is_warned_about() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_linked_peer_workspace(&workspace);
+
+    let output = pacquet.with_arg("install").output().expect("run pnpm install");
+    assert!(output.status.success(), "install must succeed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains(PEERS_CHECK_HINT), "stdout:\n{stdout}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn strict_peer_dependencies_fails_on_a_linked_workspace_packages_unmet_peer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_linked_peer_workspace(&workspace);
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nstrictPeerDependencies: true\n",
+    )
+    .expect("rewrite workspace manifest");
+
+    let output = pacquet.with_arg("install").output().expect("run pnpm install");
+    assert!(!output.status.success(), "install must fail: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(
+        stdout.contains("[ERR_PNPM_PEER_DEP_ISSUES] Unmet peer dependencies"),
+        "stdout:\n{stdout}",
+    );
+    assert!(stdout.contains("unmet peer @pnpm.e2e/foo"), "stdout:\n{stdout}");
+
+    drop((root, mock_instance));
+}
+
 /// A `--filter`ed install acts only on the projects it selected, so its
 /// verdict covers only those. The lockfile still holds the unselected
 /// importers, and an unrelated project's unmet peer must not fail a run

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -133,6 +133,32 @@ fn a_resolving_install_warns_about_peer_dependency_issues() {
     drop((root, mock_instance));
 }
 
+/// The resolve-only install path carries the resolver's peer-issue
+/// candidates through its separate completion plumbing without
+/// materializing `node_modules`.
+#[test]
+fn a_lockfile_only_install_warns_about_peer_dependency_issues() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_peer_conflict_manifest(&workspace, "peer-conflict");
+
+    let output = pacquet
+        .with_args(["install", "--lockfile-only"])
+        .output()
+        .expect("run pnpm install --lockfile-only");
+    assert!(output.status.success(), "lockfile-only install must succeed: {output:?}");
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains(PEERS_CHECK_HINT), "stdout:\n{stdout}");
+    assert!(workspace.join("pnpm-lock.yaml").exists(), "the lockfile must be written");
+    assert!(
+        !workspace.join("node_modules").exists(),
+        "lockfile-only install must not materialize node_modules",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// `strictPeerDependencies` turns the same verdict into
 /// `ERR_PNPM_PEER_DEP_ISSUES`. pnpm fails after the artifacts are
 /// written, so `node_modules` is still there for the user to inspect

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -133,9 +133,9 @@ fn a_resolving_install_warns_about_peer_dependency_issues() {
     drop((root, mock_instance));
 }
 
-/// The resolve-only install path carries the resolver's peer-issue
-/// candidates through its separate completion plumbing without
-/// materializing `node_modules`.
+/// `--lockfile-only` finishes through its own completion path, which
+/// has to carry the resolver's peer-issue candidates just like the
+/// materializing one.
 #[test]
 fn a_lockfile_only_install_warns_about_peer_dependency_issues() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -18,6 +18,7 @@ struct ResolveOnlyCompletionInputs<'a> {
     dry_run: bool,
     peer_issues_sink_is_none: bool,
     existing_wanted_lockfile: Option<&'a Lockfile>,
+    peer_issue_importer_ids: &'a HashSet<String>,
     fresh_lockfile: Option<&'a Lockfile>,
     prefix: &'a str,
     config: &'static Config,
@@ -50,6 +51,7 @@ fn complete_resolve_only<Reporter: self::Reporter>(
     if inputs.peer_issues_sink_is_none {
         report_peer_dependency_issues::<Reporter>(
             inputs.fresh_lockfile,
+            inputs.peer_issue_importer_ids,
             inputs.installed_importer_ids,
             inputs.workspace_root,
             inputs.config,
@@ -594,6 +596,7 @@ struct ReportInstallCompletionInputs<'a> {
     /// resolution — which is what decides whether peer-dependency
     /// issues are reported at all.
     resolved_lockfile: Option<&'a Lockfile>,
+    peer_issue_importer_ids: &'a HashSet<String>,
     installed_importer_ids: &'a HashSet<String>,
 }
 
@@ -608,6 +611,7 @@ fn report_install_completion<Reporter: self::Reporter>(
         ignored_builds,
         verified_file_integrity_baseline,
         resolved_lockfile,
+        peer_issue_importer_ids,
         installed_importer_ids,
     } = inputs;
     // Reported before the summary and before the ignored-builds
@@ -615,6 +619,7 @@ fn report_install_completion<Reporter: self::Reporter>(
     // the install, first among the ways it can still fail.
     report_peer_dependency_issues::<Reporter>(
         resolved_lockfile,
+        peer_issue_importer_ids,
         installed_importer_ids,
         workspace_root,
         config,
@@ -713,6 +718,7 @@ pub(super) struct ApplyMaterializationInputs<'a, 'selection> {
     pub(super) dry_run: bool,
     pub(super) peer_issues_sink_is_none: bool,
     pub(super) existing_wanted_lockfile: Option<&'a Lockfile>,
+    pub(super) peer_issue_importer_ids: HashSet<String>,
     pub(super) fresh_lockfile: Option<Lockfile>,
     pub(super) prefix: String,
     pub(super) lockfile: Option<&'a Lockfile>,
@@ -756,6 +762,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         dry_run,
         peer_issues_sink_is_none,
         existing_wanted_lockfile,
+        peer_issue_importer_ids,
         fresh_lockfile,
         prefix,
         lockfile,
@@ -803,6 +810,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         dry_run,
         peer_issues_sink_is_none,
         existing_wanted_lockfile,
+        peer_issue_importer_ids: &peer_issue_importer_ids,
         fresh_lockfile: fresh_lockfile.as_ref(),
         prefix: &prefix,
         config,
@@ -911,6 +919,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         ignored_builds,
         verified_file_integrity_baseline,
         resolved_lockfile: fresh_lockfile.as_ref(),
+        peer_issue_importer_ids: &peer_issue_importer_ids,
         installed_importer_ids,
     })
 }

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -82,6 +82,7 @@ pub(super) struct MaterializationOutput {
     pub(super) hoisted_dependencies: HoistedDependencies,
     pub(super) hoisted_locations: BTreeMap<String, Vec<String>>,
     pub(super) install_skipped: crate::SkippedSnapshots,
+    pub(super) peer_issue_importer_ids: HashSet<String>,
     pub(super) fresh_lockfile: Option<Lockfile>,
     /// The store-index writer task, already winding down (both install
     /// paths dropped every writer handle before returning). The caller
@@ -149,6 +150,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
     let ignored_builds: Vec<String>;
     let deferred_builds: Vec<String>;
     let injected_deps: BTreeMap<String, Vec<String>>;
+    let peer_issue_importer_ids: HashSet<String>;
     let effective_node_version = super::effective_node_version(config, manifest);
     let (
         hoisted_dependencies,
@@ -307,6 +309,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         ignored_builds = frozen_result.ignored_builds;
         deferred_builds = frozen_result.deferred_builds;
         injected_deps = frozen_result.injected_deps;
+        peer_issue_importer_ids = HashSet::new();
         (
             frozen_result.hoisted_dependencies,
             frozen_result.hoisted_locations,
@@ -443,6 +446,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         ignored_builds = fresh_result.ignored_builds;
         deferred_builds = fresh_result.deferred_builds;
         injected_deps = fresh_result.injected_deps;
+        peer_issue_importer_ids = fresh_result.peer_issue_importer_ids;
         (
             fresh_result.hoisted_dependencies,
             fresh_result.hoisted_locations,
@@ -459,6 +463,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         hoisted_dependencies,
         hoisted_locations,
         install_skipped,
+        peer_issue_importer_ids,
         fresh_lockfile,
         store_index_teardown,
     })

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -82,6 +82,10 @@ pub(super) struct MaterializationOutput {
     pub(super) hoisted_dependencies: HoistedDependencies,
     pub(super) hoisted_locations: BTreeMap<String, Vec<String>>,
     pub(super) install_skipped: crate::SkippedSnapshots,
+    /// See
+    /// [`crate::InstallWithFreshLockfileResult::peer_issue_importer_ids`].
+    /// Empty on the frozen path, which resolves nothing and so also
+    /// leaves `fresh_lockfile` `None`.
     pub(super) peer_issue_importer_ids: HashSet<String>,
     pub(super) fresh_lockfile: Option<Lockfile>,
     /// The store-index writer task, already winding down (both install

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -1110,6 +1110,7 @@ where
             hoisted_dependencies,
             hoisted_locations,
             install_skipped,
+            peer_issue_importer_ids,
             fresh_lockfile,
             store_index_teardown,
         } = materialize::<Reporter>(MaterializationInputs {
@@ -1173,6 +1174,7 @@ where
             dry_run,
             peer_issues_sink_is_none,
             existing_wanted_lockfile,
+            peer_issue_importer_ids,
             fresh_lockfile,
             prefix,
             lockfile,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1954,8 +1954,8 @@ fn build_extra_env(
 /// workspace whose projects declare no peers costs one pass over the
 /// declared dependencies and no I/O. Over-approximates — a
 /// `workspace:` dependency the lockfile records as an injected
-/// directory rather than a link still counts — which only widens the
-/// walk.
+/// directory rather than a link still counts, as does a target this
+/// cannot name — which only widens the walk.
 fn importers_consuming_linked_peers(
     importer_manifests: &BTreeMap<String, &PackageManifest>,
     lockfile_dir: &Path,
@@ -1984,20 +1984,24 @@ fn importers_consuming_linked_peers(
     for (importer_id, manifest) in importer_manifests {
         let importer_dir = lockfile_dir.join(importer_id);
         let groups = [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
-        for (alias, bare_specifier) in manifest.dependencies(groups) {
-            let linked_id = if bare_specifier.starts_with("workspace:") {
-                ids_by_name.get(alias).copied().map(ToOwned::to_owned)
-            } else if let Some(relative) = bare_specifier
-                .strip_prefix("link:")
-                .or_else(|| bare_specifier.strip_prefix("file:"))
-            {
-                Some(pnpm_workspace::importer_id_from_root_dir(
-                    lockfile_dir,
-                    &importer_dir.join(relative),
-                ))
-            } else {
-                continue;
-            };
+        for (entry_key, bare_specifier) in manifest.dependencies(groups) {
+            let linked_id =
+                if let Some(spec) = pnpm_workspace_spec::WorkspaceSpec::parse(bare_specifier) {
+                    // `workspace:<name>@<range>` names the project it links
+                    // to; the bare form takes that name from the entry key.
+                    let project_name = spec.alias.as_deref().unwrap_or(entry_key);
+                    ids_by_name.get(project_name).copied().map(ToOwned::to_owned)
+                } else if let Some(relative) = bare_specifier
+                    .strip_prefix("link:")
+                    .or_else(|| bare_specifier.strip_prefix("file:"))
+                {
+                    Some(pnpm_workspace::importer_id_from_root_dir(
+                        lockfile_dir,
+                        &importer_dir.join(relative),
+                    ))
+                } else {
+                    continue;
+                };
             // A target outside the workspace has a manifest the walk
             // still reads, so it counts without being inspectable here.
             let declares = linked_id.as_deref().is_none_or(|linked_id| {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2007,6 +2007,9 @@ fn importers_consuming_linked_peers(
             } else if let Some(relative) = bare_specifier
                 .strip_prefix("link:")
                 .or_else(|| bare_specifier.strip_prefix("file:"))
+                // A `file:` tarball resolves to a package, not to a
+                // directory the lockfile records as a `link:` entry.
+                .filter(|_| !pnpm_resolving_local_resolver::is_tarball_filename(bare_specifier))
             {
                 let linked_id = pnpm_workspace::importer_id_from_root_dir(
                     lockfile_dir,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -701,6 +701,11 @@ pub struct InstallWithFreshLockfileResult {
     /// see [`crate::collect_injected_deps`]. Empty on the
     /// `lockfile_only` path, which never materializes.
     pub injected_deps: BTreeMap<String, Vec<String>>,
+    /// Importers whose fresh resolution found peer-dependency issues.
+    /// The install completion path uses this as a candidate set when
+    /// rendering the final issue report from [`Self::wanted_lockfile`],
+    /// avoiding a second walk of every clean workspace importer.
+    pub peer_issue_importer_ids: HashSet<String>,
     /// `Some` when the install resolved a graph that was written to
     /// `pnpm-lock.yaml`; `None` when the write was skipped (today: only
     /// `config.lockfile=false`). The caller mirrors the same gate when
@@ -1192,6 +1197,8 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             }
         }
         let total_nodes = workspace_result.peers.graph.len();
+        let peer_issue_importer_ids =
+            workspace_result.peers.peer_dependency_issues_by_importer.keys().cloned().collect();
         // Hand the per-importer issues to the programmatic caller
         // before the graph is consumed below.
         if let Some(sink) = &peer_issues_sink {
@@ -1305,6 +1312,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             }
             return finish_lockfile_only::<Reporter>(LockfileOnlyOptions {
                 built_lockfile,
+                peer_issue_importer_ids,
                 config,
                 lockfile_dir,
                 requester,
@@ -1765,6 +1773,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             hoisted_dependencies,
             hoisted_locations,
             injected_deps,
+            peer_issue_importer_ids,
             wanted_lockfile,
             can_record_lockfile_verification,
             ignored_builds,
@@ -1928,6 +1937,7 @@ fn build_extra_env(
 
 struct LockfileOnlyOptions<'a> {
     built_lockfile: Lockfile,
+    peer_issue_importer_ids: HashSet<String>,
     config: &'a Config,
     lockfile_dir: &'a Path,
     requester: &'a str,
@@ -1964,6 +1974,7 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
 ) -> Result<InstallWithFreshLockfileResult, InstallWithFreshLockfileError> {
     let LockfileOnlyOptions {
         built_lockfile,
+        peer_issue_importer_ids,
         config,
         lockfile_dir,
         requester,
@@ -2004,6 +2015,7 @@ async fn finish_lockfile_only<Reporter: self::Reporter>(
         hoisted_dependencies: HoistedDependencies::new(),
         hoisted_locations: BTreeMap::new(),
         injected_deps: BTreeMap::new(),
+        peer_issue_importer_ids,
         wanted_lockfile,
         can_record_lockfile_verification,
         ignored_builds: Vec::new(),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -701,10 +701,11 @@ pub struct InstallWithFreshLockfileResult {
     /// see [`crate::collect_injected_deps`]. Empty on the
     /// `lockfile_only` path, which never materializes.
     pub injected_deps: BTreeMap<String, Vec<String>>,
-    /// Importers whose fresh resolution found peer-dependency issues.
-    /// The install completion path uses this as a candidate set when
-    /// rendering the final issue report from [`Self::wanted_lockfile`],
-    /// avoiding a second walk of every clean workspace importer.
+    /// Importers the resolution left a peer-dependency issue under.
+    /// Install completion renders its report from
+    /// [`Self::wanted_lockfile`] — which carries the resolved versions
+    /// the resolver's parent chains leave out — but walks only these
+    /// importers.
     pub peer_issue_importer_ids: HashSet<String>,
     /// `Some` when the install resolved a graph that was written to
     /// `pnpm-lock.yaml`; `None` when the write was skipped (today: only

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1972,44 +1972,51 @@ fn importers_consuming_linked_peers(
         .filter(|(_, manifest)| declares_peers(manifest))
         .map(|(importer_id, _)| importer_id.as_str())
         .collect();
-    let ids_by_name: HashMap<&str, &str> = importer_manifests
-        .iter()
-        .filter_map(|(importer_id, manifest)| {
-            let name = manifest.value().get("name")?.as_str()?;
-            Some((name, importer_id.as_str()))
-        })
+    fn project_name(manifest: &PackageManifest) -> Option<&str> {
+        manifest.value().get("name")?.as_str()
+    }
+    let peer_declaring_names: HashSet<&str> = importer_manifests
+        .values()
+        .filter(|manifest| declares_peers(manifest))
+        .filter_map(|manifest| project_name(manifest))
         .collect();
+    let project_names: HashSet<&str> =
+        importer_manifests.values().filter_map(|manifest| project_name(manifest)).collect();
 
     let mut consumers = HashSet::new();
     for (importer_id, manifest) in importer_manifests {
         let importer_dir = lockfile_dir.join(importer_id);
         let groups = [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
         for (entry_key, bare_specifier) in manifest.dependencies(groups) {
-            let linked_id =
-                if let Some(spec) = pnpm_workspace_spec::WorkspaceSpec::parse(bare_specifier) {
-                    // `workspace:<name>@<range>` names the project it links
-                    // to; the bare form takes that name from the entry key.
-                    let project_name = spec.alias.as_deref().unwrap_or(entry_key);
-                    ids_by_name.get(project_name).copied().map(ToOwned::to_owned)
-                } else if let Some(relative) = bare_specifier
-                    .strip_prefix("link:")
-                    .or_else(|| bare_specifier.strip_prefix("file:"))
-                {
-                    Some(pnpm_workspace::importer_id_from_root_dir(
-                        lockfile_dir,
-                        &importer_dir.join(relative),
-                    ))
-                } else {
-                    continue;
-                };
-            // Not a workspace project, so its peers are unknown here.
-            // The walk reads such a manifest when the target resolves
-            // inside the lockfile directory and skips one that escapes;
-            // symlinks decide which, so both count.
-            let declares = linked_id.as_deref().is_none_or(|linked_id| {
-                peer_declaring_ids.contains(linked_id)
-                    || !importer_manifests.contains_key(linked_id)
-            });
+            // A target whose peers are unknown here counts. The walk
+            // reads such a manifest when it resolves inside the lockfile
+            // directory and skips one that escapes; symlinks decide
+            // which, so both count.
+            let declares = if let Some(spec) =
+                pnpm_workspace_spec::WorkspaceSpec::parse(bare_specifier)
+            {
+                // `workspace:<name>@<range>` names the project it links
+                // to; the bare form takes that name from the entry key.
+                // The range picks among the projects sharing that name,
+                // so any one of them declaring a peer counts — reaching
+                // for the picked version would duplicate
+                // `resolve_workspace_range` to narrow an answer that is
+                // only ever "walk this importer too".
+                let linked_name = spec.alias.as_deref().unwrap_or(entry_key);
+                peer_declaring_names.contains(linked_name) || !project_names.contains(linked_name)
+            } else if let Some(relative) = bare_specifier
+                .strip_prefix("link:")
+                .or_else(|| bare_specifier.strip_prefix("file:"))
+            {
+                let linked_id = pnpm_workspace::importer_id_from_root_dir(
+                    lockfile_dir,
+                    &importer_dir.join(relative),
+                );
+                peer_declaring_ids.contains(linked_id.as_str())
+                    || !importer_manifests.contains_key(&linked_id)
+            } else {
+                continue;
+            };
             if declares {
                 consumers.insert(importer_id.clone());
                 break;

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2004,13 +2004,15 @@ fn importers_consuming_linked_peers(
                 // only ever "walk this importer too".
                 let linked_name = spec.alias.as_deref().unwrap_or(entry_key);
                 peer_declaring_names.contains(linked_name) || !project_names.contains(linked_name)
-            } else if let Some(relative) = bare_specifier
-                .strip_prefix("link:")
-                .or_else(|| bare_specifier.strip_prefix("file:"))
-                // A `file:` tarball resolves to a package, not to a
-                // directory the lockfile records as a `link:` entry.
-                .filter(|_| !pnpm_resolving_local_resolver::is_tarball_filename(bare_specifier))
-            {
+            } else if let Some(relative) = bare_specifier.strip_prefix("link:").or_else(|| {
+                // Only `file:` reads the name: it resolves to a package
+                // when that names a tarball, and only its directory form
+                // becomes the `link:` entry the walk inspects. A `link:`
+                // is a directory whatever it is called.
+                bare_specifier
+                    .strip_prefix("file:")
+                    .filter(|_| !pnpm_resolving_local_resolver::is_tarball_filename(bare_specifier))
+            }) {
                 let linked_id = pnpm_workspace::importer_id_from_root_dir(
                     lockfile_dir,
                     &importer_dir.join(relative),

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -2002,8 +2002,10 @@ fn importers_consuming_linked_peers(
                 } else {
                     continue;
                 };
-            // A target outside the workspace has a manifest the walk
-            // still reads, so it counts without being inspectable here.
+            // Not a workspace project, so its peers are unknown here.
+            // The walk reads such a manifest when the target resolves
+            // inside the lockfile directory and skips one that escapes;
+            // symlinks decide which, so both count.
             let declares = linked_id.as_deref().is_none_or(|linked_id| {
                 peer_declaring_ids.contains(linked_id)
                     || !importer_manifests.contains_key(linked_id)

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1198,8 +1198,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             }
         }
         let total_nodes = workspace_result.peers.graph.len();
-        let peer_issue_importer_ids =
+        let mut peer_issue_importer_ids: HashSet<String> =
             workspace_result.peers.peer_dependency_issues_by_importer.keys().cloned().collect();
+        peer_issue_importer_ids
+            .extend(importers_consuming_linked_peers(&importer_manifests, lockfile_dir));
         // Hand the per-importer issues to the programmatic caller
         // before the graph is consumed below.
         if let Some(sink) = &peer_issues_sink {
@@ -1934,6 +1936,81 @@ fn build_extra_env(
         );
     }
     env
+}
+
+/// Importers whose linked workspace dependency declares
+/// `peerDependencies`.
+///
+/// The lockfile walk that renders the report reads a linked project's
+/// manifest and checks its peers against the *consuming* importer's
+/// dependencies. Peer resolution has no counterpart for that check — a
+/// `link:` node's own peers are the linked importer's business — so
+/// these importers never reach
+/// `peer_dependency_issues_by_importer` and have to join the report's
+/// candidate set on their own. Only the direct consumer is needed: it
+/// is the importer whose dependencies the check compares against.
+///
+/// Answered from the manifests the install already parsed, so a
+/// workspace whose projects declare no peers costs one pass over the
+/// declared dependencies and no I/O. Over-approximates — a
+/// `workspace:` dependency the lockfile records as an injected
+/// directory rather than a link still counts — which only widens the
+/// walk.
+fn importers_consuming_linked_peers(
+    importer_manifests: &BTreeMap<String, &PackageManifest>,
+    lockfile_dir: &Path,
+) -> HashSet<String> {
+    let declares_peers = |manifest: &PackageManifest| {
+        manifest
+            .value()
+            .get("peerDependencies")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|peers| !peers.is_empty())
+    };
+    let peer_declaring_ids: HashSet<&str> = importer_manifests
+        .iter()
+        .filter(|(_, manifest)| declares_peers(manifest))
+        .map(|(importer_id, _)| importer_id.as_str())
+        .collect();
+    let ids_by_name: HashMap<&str, &str> = importer_manifests
+        .iter()
+        .filter_map(|(importer_id, manifest)| {
+            let name = manifest.value().get("name")?.as_str()?;
+            Some((name, importer_id.as_str()))
+        })
+        .collect();
+
+    let mut consumers = HashSet::new();
+    for (importer_id, manifest) in importer_manifests {
+        let importer_dir = lockfile_dir.join(importer_id);
+        let groups = [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional];
+        for (alias, bare_specifier) in manifest.dependencies(groups) {
+            let linked_id = if bare_specifier.starts_with("workspace:") {
+                ids_by_name.get(alias).copied().map(ToOwned::to_owned)
+            } else if let Some(relative) = bare_specifier
+                .strip_prefix("link:")
+                .or_else(|| bare_specifier.strip_prefix("file:"))
+            {
+                Some(pnpm_workspace::importer_id_from_root_dir(
+                    lockfile_dir,
+                    &importer_dir.join(relative),
+                ))
+            } else {
+                continue;
+            };
+            // A target outside the workspace has a manifest the walk
+            // still reads, so it counts without being inspectable here.
+            let declares = linked_id.as_deref().is_none_or(|linked_id| {
+                peer_declaring_ids.contains(linked_id)
+                    || !importer_manifests.contains_key(linked_id)
+            });
+            if declares {
+                consumers.insert(importer_id.clone());
+                break;
+            }
+        }
+    }
+    consumers
 }
 
 struct LockfileOnlyOptions<'a> {

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -265,18 +265,33 @@ fn an_aliased_workspace_dependency_resolves_through_its_specifier() {
     );
 }
 
-/// A `link:` target outside the workspace has a manifest the report's
-/// walk still reads, so it counts without being inspectable here.
+/// A `link:` target that is not a workspace project counts either way:
+/// the report's walk reads its manifest when it resolves inside the
+/// lockfile directory, and a symlink decides whether one that escapes
+/// lexically still does.
 #[test]
-fn a_link_outside_the_workspace_is_treated_as_peer_declaring() {
-    assert_eq!(
-        linked_peer_consumers(&[
-            (".", serde_json::json!({ "name": "root" })),
-            (
-                "packages/app",
-                serde_json::json!({ "name": "app", "dependencies": { "vendored": "link:../../vendored" } }),
-            ),
-        ]),
-        vec!["packages/app".to_string()],
-    );
+fn a_link_to_a_non_project_target_is_treated_as_peer_declaring() {
+    let inside = linked_peer_consumers(&[
+        (".", serde_json::json!({ "name": "root" })),
+        (
+            "packages/app",
+            serde_json::json!({
+                "name": "app",
+                "dependencies": { "vendored": "link:../../vendor/thing" },
+            }),
+        ),
+    ]);
+    assert_eq!(inside, vec!["packages/app".to_string()]);
+
+    let escaping = linked_peer_consumers(&[
+        (".", serde_json::json!({ "name": "root" })),
+        (
+            "packages/app",
+            serde_json::json!({
+                "name": "app",
+                "dependencies": { "vendored": "link:../../../outside" },
+            }),
+        ),
+    ]);
+    assert_eq!(escaping, vec!["packages/app".to_string()]);
 }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -291,6 +291,28 @@ fn same_named_workspace_projects_count_when_any_version_declares_a_peer() {
     );
 }
 
+/// A `file:` tarball resolves to a package rather than to a directory,
+/// so it never becomes the `link:` entry the report's walk inspects.
+#[test]
+fn a_file_tarball_dependency_adds_no_candidate() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({
+                    "name": "app",
+                    "dependencies": {
+                        "packed": "file:../../vendor/packed-1.0.0.tgz",
+                        "archived": "file:../../vendor/archived.tar.gz",
+                    },
+                }),
+            ),
+        ]),
+        Vec::<String>::new(),
+    );
+}
+
 /// A `link:` target that is not a workspace project counts either way:
 /// the report's walk reads its manifest when it resolves inside the
 /// lockfile directory, and a symlink decides whether one that escapes

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -291,6 +291,26 @@ fn same_named_workspace_projects_count_when_any_version_declares_a_peer() {
     );
 }
 
+/// `link:` names a directory whatever it is called, so a tarball-looking
+/// name must not exclude it the way the same name excludes a `file:`.
+#[test]
+fn a_link_to_a_tarball_named_directory_still_counts() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({ "name": "app", "dependencies": { "lib": "link:../lib.tgz" } }),
+            ),
+            (
+                "packages/lib.tgz",
+                serde_json::json!({ "name": "lib", "peerDependencies": { "react": "^18.0.0" } }),
+            ),
+        ]),
+        vec!["packages/app".to_string()],
+    );
+}
+
 /// A `file:` tarball resolves to a package rather than to a directory,
 /// so it never becomes the `link:` entry the report's walk inspects.
 #[test]

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -241,6 +241,30 @@ fn only_the_importers_linking_to_a_peer_declaring_project_become_candidates() {
     );
 }
 
+/// `workspace:<name>@<range>` links to the project the specifier names,
+/// not to the one the entry key happens to match.
+#[test]
+fn an_aliased_workspace_dependency_resolves_through_its_specifier() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({
+                    "name": "app",
+                    "dependencies": { "decoy": "workspace:lib@*" },
+                }),
+            ),
+            ("packages/decoy", serde_json::json!({ "name": "decoy" })),
+            (
+                "packages/lib",
+                serde_json::json!({ "name": "lib", "peerDependencies": { "react": "^18.0.0" } }),
+            ),
+        ]),
+        vec!["packages/app".to_string()],
+    );
+}
+
 /// A `link:` target outside the workspace has a manifest the report's
 /// walk still reads, so it counts without being inspectable here.
 #[test]

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     ImporterUpdateSeedPolicy, UpdateSeedPolicy, compute_package_extensions_checksum,
-    full_resolution_required, include_transitive_optional_dependencies,
-    is_partial_workspace_selection, update_reuse_scopes, verify_merged_repair,
+    full_resolution_required, importers_consuming_linked_peers,
+    include_transitive_optional_dependencies, is_partial_workspace_selection, update_reuse_scopes,
+    verify_merged_repair,
 };
 use pnpm_config::{Config, PackageExtension};
 use pnpm_lockfile::Lockfile;
@@ -166,4 +167,92 @@ fn importer_scoped_update_absent_importer_keeps_all_reuse() {
     assert_eq!(default_scope, UpdateReuseScope::All);
     assert_eq!(scopes.get("selected"), Some(&UpdateReuseScope::None));
     assert!(!scopes.contains_key("unselected"));
+}
+
+fn workspace_manifests(
+    projects: &[(&str, serde_json::Value)],
+) -> std::collections::BTreeMap<String, pnpm_package_manifest::PackageManifest> {
+    projects
+        .iter()
+        .map(|(importer_id, manifest)| {
+            let path = std::path::PathBuf::from("/repo").join(importer_id).join("package.json");
+            (
+                (*importer_id).to_string(),
+                pnpm_package_manifest::PackageManifest::from_value(path, manifest.clone()),
+            )
+        })
+        .collect()
+}
+
+fn linked_peer_consumers(projects: &[(&str, serde_json::Value)]) -> Vec<String> {
+    let owned = workspace_manifests(projects);
+    let borrowed = owned.iter().map(|(id, manifest)| (id.clone(), manifest)).collect();
+    let mut consumers: Vec<String> =
+        importers_consuming_linked_peers(&borrowed, std::path::Path::new("/repo"))
+            .into_iter()
+            .collect();
+    consumers.sort();
+    consumers
+}
+
+/// The candidate set stays empty when nothing in the workspace declares
+/// a peer — the case the report's cost is scoped for.
+#[test]
+fn a_workspace_without_peer_declarations_adds_no_candidates() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({
+                    "name": "app",
+                    "dependencies": { "lib": "workspace:*", "is-positive": "1.0.0" },
+                }),
+            ),
+            ("packages/lib", serde_json::json!({ "name": "lib" })),
+        ]),
+        Vec::<String>::new(),
+    );
+}
+
+#[test]
+fn only_the_importers_linking_to_a_peer_declaring_project_become_candidates() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({ "name": "app", "dependencies": { "lib": "workspace:*" } }),
+            ),
+            (
+                "packages/relative",
+                serde_json::json!({ "name": "relative", "dependencies": { "lib": "link:../lib" } }),
+            ),
+            (
+                "packages/unrelated",
+                serde_json::json!({ "name": "unrelated", "dependencies": { "app": "workspace:*" } }),
+            ),
+            (
+                "packages/lib",
+                serde_json::json!({ "name": "lib", "peerDependencies": { "react": "^18.0.0" } }),
+            ),
+        ]),
+        vec!["packages/app".to_string(), "packages/relative".to_string()],
+    );
+}
+
+/// A `link:` target outside the workspace has a manifest the report's
+/// walk still reads, so it counts without being inspectable here.
+#[test]
+fn a_link_outside_the_workspace_is_treated_as_peer_declaring() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({ "name": "app", "dependencies": { "vendored": "link:../../vendored" } }),
+            ),
+        ]),
+        vec!["packages/app".to_string()],
+    );
 }

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/tests.rs
@@ -265,6 +265,32 @@ fn an_aliased_workspace_dependency_resolves_through_its_specifier() {
     );
 }
 
+/// A workspace can hold several projects under one package name, with
+/// the `workspace:` range picking between them, so any one of them
+/// declaring a peer has to put the consumer in the candidate set.
+#[test]
+fn same_named_workspace_projects_count_when_any_version_declares_a_peer() {
+    assert_eq!(
+        linked_peer_consumers(&[
+            (".", serde_json::json!({ "name": "root" })),
+            (
+                "packages/app",
+                serde_json::json!({ "name": "app", "dependencies": { "lib": "workspace:*" } }),
+            ),
+            (
+                "packages/lib-v1",
+                serde_json::json!({
+                    "name": "lib",
+                    "version": "1.0.0",
+                    "peerDependencies": { "react": "^18.0.0" },
+                }),
+            ),
+            ("packages/lib-v2", serde_json::json!({ "name": "lib", "version": "2.0.0" })),
+        ]),
+        vec!["packages/app".to_string()],
+    );
+}
+
 /// A `link:` target that is not a workspace project counts either way:
 /// the report's walk reads its manifest when it resolves inside the
 /// lockfile directory, and a symlink decides whether one that escapes

--- a/pnpm/crates/package-manager/src/peer_dependency_issues.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues.rs
@@ -20,13 +20,16 @@ use crate::InstallError;
 /// resolved. `None` — every install that skipped resolution — reports
 /// nothing.
 ///
-/// `peer_issue_importer_ids` identifies importers for which the resolver found peer issues.
-/// This function checks only those importers against the final lockfile.
+/// `peer_issue_importer_ids` is the resolution's own verdict: the
+/// importers it left an issue under. Only those are walked, so a
+/// workspace the resolution found clean costs nothing here. The
+/// lockfile stays the report's source — it carries the resolved
+/// versions the resolver's parent chains leave out.
 ///
-/// Resolver parent chains omit package versions.
-/// The final lockfile supplies those versions to the report.
-/// `installed_importer_ids` prevents a filtered install from reporting
-/// issues for unselected projects.
+/// `installed_importer_ids` scopes the verdict to the projects this run
+/// acted on. A `--filter`ed install leaves every unselected importer in
+/// the lockfile untouched, and pnpm reports only on the projects that
+/// took part in the resolution.
 pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
     resolved_lockfile: Option<&Lockfile>,
     peer_issue_importer_ids: &HashSet<String>,
@@ -43,9 +46,6 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
         })
         .cloned()
         .collect();
-    if importer_ids.is_empty() {
-        return Ok(());
-    }
     importer_ids.sort();
     let Some(report) = peer_issues_for_lockfile(
         lockfile,

--- a/pnpm/crates/package-manager/src/peer_dependency_issues.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues.rs
@@ -20,23 +20,32 @@ use crate::InstallError;
 /// resolved. `None` — every install that skipped resolution — reports
 /// nothing.
 ///
-/// `installed_importer_ids` scopes the verdict to the projects this run
-/// acted on. A `--filter`ed install leaves every unselected importer in
-/// the lockfile untouched, and pnpm reports only on the projects that
-/// took part in the resolution.
+/// `peer_issue_importer_ids` identifies importers for which the resolver found peer issues.
+/// This function checks only those importers against the final lockfile.
+///
+/// Resolver parent chains omit package versions.
+/// The final lockfile supplies those versions to the report.
+/// `installed_importer_ids` prevents a filtered install from reporting
+/// issues for unselected projects.
 pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
     resolved_lockfile: Option<&Lockfile>,
+    peer_issue_importer_ids: &HashSet<String>,
     installed_importer_ids: &HashSet<String>,
     lockfile_dir: &Path,
     config: &Config,
 ) -> Result<(), InstallError> {
     let Some(lockfile) = resolved_lockfile else { return Ok(()) };
-    let mut importer_ids: Vec<String> = lockfile
-        .importers
-        .keys()
-        .filter(|importer_id| installed_importer_ids.contains(*importer_id))
+    let mut importer_ids: Vec<String> = peer_issue_importer_ids
+        .iter()
+        .filter(|importer_id| {
+            installed_importer_ids.contains(*importer_id)
+                && lockfile.importers.contains_key(*importer_id)
+        })
         .cloned()
         .collect();
+    if importer_ids.is_empty() {
+        return Ok(());
+    }
     importer_ids.sort();
     let Some(report) = peer_issues_for_lockfile(
         lockfile,
@@ -62,3 +71,6 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
     }));
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
@@ -61,7 +61,6 @@ snapshots:
         &config,
     )
     .expect_err("a resolver candidate with a missing peer must fail in strict mode");
-    eprintln!("ERROR:\n{error}\n");
     assert!(matches!(error, InstallError::PeerDependencyIssues));
     let events = EVENTS.lock().unwrap();
     assert!(matches!(events.as_slice(), [LogEvent::Global(_)]), "unexpected events: {events:?}");

--- a/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
@@ -1,0 +1,68 @@
+use std::{collections::HashSet, sync::Mutex};
+
+use pnpm_config::Config;
+use pnpm_lockfile::Lockfile;
+use pnpm_reporter::{LogEvent, Reporter};
+
+use super::report_peer_dependency_issues;
+use crate::InstallError;
+
+#[test]
+fn only_resolver_issue_candidates_are_walked() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().unwrap().clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      peer-user:
+        specifier: 1.0.0
+        version: 1.0.0
+packages:
+  peer-user@1.0.0:
+    resolution:
+      integrity: sha512-deadbeef
+    peerDependencies:
+      peer-provider: ^1.0.0
+snapshots:
+  peer-user@1.0.0: {}
+",
+    )
+    .expect("parse lockfile fixture");
+    let lockfile_dir = tempfile::tempdir().expect("create lockfile directory");
+    let mut config = Config::new();
+    config.strict_peer_dependencies = true;
+
+    report_peer_dependency_issues::<RecordingReporter>(
+        Some(&lockfile),
+        &HashSet::new(),
+        &HashSet::from([".".to_string()]),
+        lockfile_dir.path(),
+        &config,
+    )
+    .expect("a clean resolver candidate set must skip the lockfile walk");
+    assert_eq!(EVENTS.lock().unwrap().len(), 0);
+
+    let error = report_peer_dependency_issues::<RecordingReporter>(
+        Some(&lockfile),
+        &HashSet::from([".".to_string()]),
+        &HashSet::from([".".to_string()]),
+        lockfile_dir.path(),
+        &config,
+    )
+    .expect_err("a resolver candidate with a missing peer must fail in strict mode");
+    eprintln!("ERROR:\n{error}\n");
+    assert!(matches!(error, InstallError::PeerDependencyIssues));
+    let events = EVENTS.lock().unwrap();
+    assert!(matches!(events.as_slice(), [LogEvent::Global(_)]), "unexpected events: {events:?}");
+}

--- a/pnpm/crates/resolving-local-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-local-resolver/src/lib.rs
@@ -32,4 +32,6 @@ pub use local_resolver::{
     LocalResolverUpdate, LocalSpecError, ResolveLocalError, resolve_from_local_path,
     resolve_from_local_scheme, resolve_latest_from_local,
 };
-pub use parse_bare_specifier::{PathProtocolNotSupportedError, WantedLocalDependency};
+pub use parse_bare_specifier::{
+    PathProtocolNotSupportedError, WantedLocalDependency, is_tarball_filename,
+};

--- a/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
@@ -311,7 +311,11 @@ fn strip_tilde_prefix(spec: &str) -> Option<&str> {
     spec.strip_prefix("~/")
 }
 
-fn is_tarball_filename(bare: &str) -> bool {
+/// Whether a local specifier names a package tarball rather than a
+/// directory. A `file:` specifier resolves to one or the other, and only
+/// the directory form becomes a `link:` entry in the lockfile.
+#[must_use]
+pub fn is_tarball_filename(bare: &str) -> bool {
     let lower = bare.to_ascii_lowercase();
     lower.ends_with(".tgz") || lower.ends_with(".tar.gz") || lower.ends_with(".tar")
 }


### PR DESCRIPTION
<!-- Maintainers will start the review after CodeRabbit approves the PR and CI passes. -->

## Summary

Commit [`a5effe488d`](https://github.com/pnpm/pnpm/commit/a5effe488d91c84f0ac8dbe37521f5930a5081fe) added peer dependency reporting to resolving installs. This feature reports warnings and enforces `strictPeerDependencies` after resolution.

The new completion step used the final lockfile to render the issue report. It checked every installed importer, including importers without peer issues.

This second check caused the regression. On a dependency update with no peer issues, `pnpm:summary` took approximately five seconds.

This PR carries the resolver's candidate importer IDs to install completion. The final lockfile check processes only those candidates.

Filtered installs also intersect the candidates with their selected importers. Frozen installs keep the existing behavior and do not report new issues.

The final lockfile remains the report source. It contains resolved versions that the resolver's intermediate parent chains omit.

Closes #14359

## Benchmark

The [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) contains 6,833 projects. The benchmark added one workspace dependency to a leaf project.

Each binary ran one warm-up. Five measured runs then alternated the binary order. Each run started with the same lockfile.

```console
pnpm install --lockfile-only --trust-lockfile --offline --ignore-scripts --reporter=ndjson
```

| Binary | Summary median | Summary range | Total median | Total range |
| --- | ---: | ---: | ---: | ---: |
| pnpm 12.1.0 | 4,930 ms | 4,880–5,020 ms | 9,530 ms | 9,440–10,420 ms |
| This PR | 30 ms | 30–40 ms | 4,610 ms | 4,560–4,660 ms |

The median summary time decreased by 99.39%. The pnpm 12.1.0 binary and this PR produced byte-identical lockfiles.

## Validation

- All 10 peer CLI tests passed. The tests cover resolving, lockfile-only, strict, filtered, rules, and up-to-date installs.
- The focused package-manager regression test passed.
- Workspace Cargo check, Clippy, rustfmt, typo, and diff checks passed.
- The low-concurrency suite passed 9,613 tests. One unrelated `pnpm-cmd-shim` signal test timed out and also timed out alone.

## Squash Commit Body

```text
Resolving installs checked every installed importer again when they reported peer dependency issues. This added about five seconds on a 6,833-project workspace.

Carry the affected importer IDs to install completion. Check only those importers against the final lockfile.

Keep filtered installs scoped to their selected importers.
```

## Checklist

- [x] Issue #14359 tracks this regression.
- [x] This change affects only the Rust install pipeline. The TypeScript implementation does not use this path.
- [x] I added a patch changeset for `pacquet`.
- [x] I added package-manager and CLI coverage. The CLI coverage includes `install --lockfile-only`.
- [x] Peer reporting behavior does not change. This PR does not require documentation changes.

---

Written by an agent (Codex).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer-dependency reporting during installation by checking only relevant projects, reducing slowdowns in large workspaces.
  * `--lockfile-only` installs now report peer-dependency issues while writing the lockfile without creating `node_modules`.
  * Improved detection of peer-dependency issues involving linked workspace and external projects.
  * Strict peer-dependency mode now more reliably reports installation failures.

* **Tests**
  * Added coverage for targeted reporting, lockfile-only installs, and linked peer dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->