### PR TITLE
test(workspace): cover the generic walk's non-NotFound failure

### DIFF
--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -526,6 +526,26 @@ fn non_notfound_walk_failure_still_errors() {
     );
 }
 
+#[test]
+fn non_notfound_walk_failure_still_errors_on_the_generic_path() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    fs::write(tmp.path().join("packages"), "not a directory").unwrap();
+
+    // A non-terminal star keeps this off the specialized paths, which reach
+    // the filesystem through their own enumeration.
+    let result = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*/lib".to_string()]) },
+    );
+
+    let Err(FindWorkspaceProjectsError::Walk { source, .. }) = result else {
+        panic!("a non-NotFound walk failure must surface as Walk, not an empty match");
+    };
+    dbg!(&source);
+    assert_ne!(source.kind(), ErrorKind::NotFound);
+}
+
 /// A `packages:` entry may point outside the workspace root, and the
 /// declared project has to be enumerated all the same, or the install
 /// later rejects its lockfile importer as untrusted (pnpm/pnpm#13880).


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14262, which added specialized discovery paths for literal and terminal-star workspace patterns.

`non_notfound_walk_failure_still_errors` uses `packages/*`. That pattern is now claimed by the terminal-star fast path, so the test exercises the specialized enumeration's error mapping and no longer reaches the generic `wax` walk at all. The generic walk's own non-`NotFound` error return was left with no test covering it.

This adds a counterpart on a non-terminal star, `packages/*/lib`, which stays on the generic path. Both tests now assert the same contract on the path each one actually takes.

Verified against `main`: swallowing the generic walk's `Walk` error return fails only the new test, and no other test in the crate.

Tests only. No behavior change, so no changeset.

## Squash Commit Body

```text
`non_notfound_walk_failure_still_errors` uses `packages/*`, which the terminal
star fast path added in pnpm/pnpm#14262 now claims. It therefore exercises the
specialized enumeration's error mapping and no longer reaches the generic walk
at all, leaving that error return untested.

Add a counterpart on a non-terminal star, which stays on the generic path.
Swallowing the walk error there fails only the new test.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Tests only, and the affected code is the Rust `pnpm/` port. The
  TypeScript CLI has no counterpart to this `wax` traversal.
- [x] No changeset: no published package changes behavior.
- [x] Added or updated tests.
- [x] No documentation change needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790762859&installation_model_id=426870&pr_number=14363&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14363&signature=2add76dfbfa8c367ae8dd8835217b4ede06c57e5bd8e44850ce37562fe22b38d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace project discovery when an expected directory is replaced by a file.
  * Such filesystem errors are now reported correctly instead of being treated as an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->