### PR TITLE
fix(cli): preserve detached children after success

### DIFF
--- a/.changeset/calm-jobs-survive.md
+++ b/.changeset/calm-jobs-survive.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed detached child processes being terminated after successful commands on Windows.

--- a/pnpm/crates/cli/src/job_control.rs
+++ b/pnpm/crates/cli/src/job_control.rs
@@ -1,23 +1,61 @@
-//! Best-effort process-tree cleanup, mirroring Cargo and Bun.
+//! Best-effort process-tree cleanup for failed and interrupted commands.
 //!
 //! Windows has no POSIX signals or process groups, so terminating a child
-//! reaches only the direct child — a grandchild spawned by a lifecycle script
-//! that outlives a failed or interrupted command would be orphaned. Assigning
-//! the pacquet process to a Job Object with `KILL_ON_JOB_CLOSE` ties every
-//! descendant's lifetime to ours: when pacquet exits — cleanly, on error, or
-//! when killed — the OS terminates the whole tree. On Unix the kernel's
-//! process-group and signal model already provides this, so setup is a no-op.
+//! reaches only the direct child. Assigning pacquet to a Job Object with
+//! `KILL_ON_JOB_CLOSE` lets the OS terminate the whole process tree after an
+//! error, panic, or interrupt. Successful commands disarm the job so a process
+//! deliberately detached by a script can outlive pacquet. On Unix the kernel's
+//! process-group and signal model already provides cleanup, so setup is a no-op.
 //!
 //! [`setup`] returns a guard to bind for the lifetime of the process.
 
-/// Marker that process-tree cleanup has been installed; hold it for the
-/// lifetime of the process.
+/// Process-tree cleanup armed for the lifetime of a command.
 ///
-/// On Windows it stands for a Job Object whose handle is intentionally kept
-/// open for the whole run: the OS closes it at exit, which is what fires
-/// `KILL_ON_JOB_CLOSE`. On Unix the kernel's process-group and signal model
-/// already tears down descendants, so the guard is inert.
-pub struct JobGuard;
+/// Call [`Self::disarm`] after a successful command to let detached descendants
+/// survive. Otherwise the operating system closes the armed Job Object at
+/// process exit and terminates its remaining processes. The guard is inert on
+/// Unix.
+pub struct JobGuard {
+    #[cfg(windows)]
+    job: windows_sys::Win32::Foundation::HANDLE,
+}
+
+impl JobGuard {
+    /// Disable process-tree cleanup after a successful command.
+    #[cfg(windows)]
+    pub fn disarm(self) {
+        use core::mem::{size_of, zeroed};
+        use core::ptr;
+        use windows_sys::Win32::Foundation::CloseHandle;
+        use windows_sys::Win32::System::JobObjects::{
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+            SetInformationJobObject,
+        };
+
+        // SAFETY: `self.job` is the valid handle created by [`setup`]. The
+        // information pointer refers to a stack local that outlives the call.
+        // Clear the kill limit before closing the handle; if clearing fails,
+        // leave the armed handle for the operating system to close at exit.
+        unsafe {
+            let info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = zeroed();
+            let set = SetInformationJobObject(
+                self.job,
+                JobObjectExtendedLimitInformation,
+                ptr::addr_of!(info).cast(),
+                size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            );
+            if set != 0 {
+                CloseHandle(self.job);
+            }
+        }
+    }
+
+    /// Disable the inert process-tree cleanup guard on Unix.
+    #[cfg(not(windows))]
+    pub fn disarm(self) {
+        let Self {} = self;
+    }
+}
 
 #[cfg(windows)]
 pub fn setup() -> Option<JobGuard> {
@@ -61,11 +99,11 @@ pub fn setup() -> Option<JobGuard> {
         // Deliberately do not close `job`: it must stay open until the process
         // exits so `KILL_ON_JOB_CLOSE` fires then. Closing it now would also
         // terminate this process, since it is assigned to the job.
-        Some(JobGuard)
+        Some(JobGuard { job })
     }
 }
 
 #[cfg(not(windows))]
 pub fn setup() -> Option<JobGuard> {
-    Some(JobGuard)
+    Some(JobGuard {})
 }

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -169,10 +169,8 @@ fn run_cli() -> miette::Result<()> {
     if args.run_completion_if_requested()? {
         return Ok(());
     }
-    // Tie any child pacquet spawns (lifecycle scripts and their descendants)
-    // to this process so none are orphaned on Windows. Held until `main`
-    // returns; see `job_control`.
-    let _job_guard = job_control::setup();
+    // Arm Windows process-tree cleanup until the command succeeds.
+    let job_guard = job_control::setup();
     configure_rayon_pool();
     // `block_on` polls the command future on the calling thread, and the
     // install pipeline has a deep synchronous call chain whose stack frames
@@ -180,7 +178,14 @@ fn run_cli() -> miette::Result<()> {
     // default to 8 MiB, so the limit trips on Windows first). Run it on a
     // thread with a generous, platform-uniform stack instead of the OS
     // default main-thread stack.
-    block_on_runtime("pacquet-main", args.run(&config_overrides, builtin_command_forced))
+    let result =
+        block_on_runtime("pacquet-main", args.run(&config_overrides, builtin_command_forced));
+    if result.is_ok()
+        && let Some(job_guard) = job_guard
+    {
+        job_guard.disarm();
+    }
+    result
 }
 
 /// Stack size for the thread the command runs on. Generous headroom over

--- a/pnpm/crates/cli/tests/suite/exec.rs
+++ b/pnpm/crates/cli/tests/suite/exec.rs
@@ -17,7 +17,7 @@ fn write_executable(path: &std::path::Path, body: &str) {
     fs::set_permissions(path, perms).expect("chmod executable");
 }
 
-fn spawn_detached_node_script(marker_path: &Path, parent_exit_code: i32) -> String {
+fn make_detached_node_script(marker_path: &Path, parent_exit_code: i32) -> String {
     let marker_json = serde_json::to_string(&marker_path.to_string_lossy()).expect("quote marker");
     let detached_script =
         format!("setTimeout(() => require('fs').writeFileSync({marker_json}, 'survived'), 500)");
@@ -25,6 +25,46 @@ fn spawn_detached_node_script(marker_path: &Path, parent_exit_code: i32) -> Stri
     format!(
         "const {{ spawn }} = require('child_process'); const child = spawn(process.execPath, ['-e', {detached_script_json}], {{ detached: true, stdio: 'ignore' }}); child.unref(); process.exit({parent_exit_code})",
     )
+}
+
+#[cfg(target_os = "windows")]
+fn make_long_lived_detached_node_script(pid_path: &Path) -> String {
+    let pid_path_json = serde_json::to_string(&pid_path.to_string_lossy()).expect("quote PID path");
+    let detached_script = format!(
+        "const fs = require('fs'); fs.writeFileSync({pid_path_json}, String(process.pid)); setTimeout(() => {{}}, 60000)",
+    );
+    let detached_script_json = serde_json::to_string(&detached_script).expect("quote script");
+    format!(
+        "const {{ spawn }} = require('child_process'); const fs = require('fs'); const child = spawn(process.execPath, ['-e', {detached_script_json}], {{ detached: true, stdio: 'ignore' }}); child.unref(); while (!fs.existsSync({pid_path_json})) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10); process.exit(1)",
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn assert_process_exits(pid: u32) {
+    use windows_sys::Win32::{
+        Foundation::{CloseHandle, WAIT_OBJECT_0, WAIT_TIMEOUT},
+        System::Threading::{
+            OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess,
+            WaitForSingleObject,
+        },
+    };
+
+    // SAFETY: the PID came from the detached child. A non-null handle is valid
+    // until it is closed below, and the requested access rights only wait for
+    // or terminate that child if the regression leaves it running.
+    unsafe {
+        let process = OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, 0, pid);
+        if process.is_null() {
+            return;
+        }
+        let wait = WaitForSingleObject(process, 10_000);
+        if wait == WAIT_TIMEOUT {
+            TerminateProcess(process, 1);
+            WaitForSingleObject(process, 10_000);
+        }
+        CloseHandle(process);
+        assert_eq!(wait, WAIT_OBJECT_0, "the detached process should be cleaned up");
+    }
 }
 
 /// `pacquet exec <command>` resolves the command against the project's
@@ -161,7 +201,7 @@ fn exec_preserves_a_detached_process_after_success() {
         .with_arg("exec")
         .with_arg("node")
         .with_arg("-e")
-        .with_arg(spawn_detached_node_script(&marker_path, 0))
+        .with_arg(make_detached_node_script(&marker_path, 0))
         .assert()
         .success();
 
@@ -176,27 +216,25 @@ fn exec_preserves_a_detached_process_after_success() {
     drop(root);
 }
 
+#[cfg(target_os = "windows")]
 #[test]
-#[cfg_attr(
-    not(target_os = "windows"),
-    ignore = "only Windows Job Objects kill detached descendants"
-)]
 fn exec_cleans_up_a_detached_process_after_failure() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    let marker_path = workspace.join("detached-marker.txt");
+    let pid_path = workspace.join("detached-pid.txt");
 
     pacquet
         .with_arg("exec")
         .with_arg("node")
         .with_arg("-e")
-        .with_arg(spawn_detached_node_script(&marker_path, 1))
+        .with_arg(make_long_lived_detached_node_script(&pid_path))
         .assert()
         .failure();
 
-    thread::sleep(Duration::from_secs(2));
-    let marker_exists = marker_path.exists();
-    eprintln!("DETACHED MARKER EXISTS: {marker_exists}");
-    assert!(!marker_exists, "the detached process should be cleaned up after a failed pnpm exec");
+    let pid = fs::read_to_string(&pid_path)
+        .expect("read detached process PID")
+        .parse()
+        .expect("parse detached process PID");
+    assert_process_exits(pid);
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/exec.rs
+++ b/pnpm/crates/cli/tests/suite/exec.rs
@@ -28,42 +28,46 @@ fn make_detached_node_script(marker_path: &Path, parent_exit_code: i32) -> Strin
 }
 
 #[cfg(target_os = "windows")]
-fn make_long_lived_detached_node_script(pid_path: &Path) -> String {
-    let pid_path_json = serde_json::to_string(&pid_path.to_string_lossy()).expect("quote PID path");
+fn make_connected_detached_node_script(ready_path: &Path, port: u16) -> String {
+    let ready_path_json =
+        serde_json::to_string(&ready_path.to_string_lossy()).expect("quote ready path");
     let detached_script = format!(
-        "const fs = require('fs'); fs.writeFileSync({pid_path_json}, String(process.pid)); setTimeout(() => {{}}, 60000)",
+        "const fs = require('fs'); const socket = require('net').createConnection({{ host: '127.0.0.1', port: {port} }}, () => fs.writeFileSync({ready_path_json}, 'ready')); socket.on('data', () => process.exit(0))",
     );
     let detached_script_json = serde_json::to_string(&detached_script).expect("quote script");
     format!(
-        "const {{ spawn }} = require('child_process'); const fs = require('fs'); const child = spawn(process.execPath, ['-e', {detached_script_json}], {{ detached: true, stdio: 'ignore' }}); child.unref(); while (!fs.existsSync({pid_path_json})) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10); process.exit(1)",
+        "const {{ spawn }} = require('child_process'); const fs = require('fs'); const child = spawn(process.execPath, ['-e', {detached_script_json}], {{ detached: true, stdio: 'ignore' }}); child.unref(); const deadline = Date.now() + 10000; while (!fs.existsSync({ready_path_json}) && Date.now() < deadline) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10); process.exit(fs.existsSync({ready_path_json}) ? 1 : 42)",
     )
 }
 
 #[cfg(target_os = "windows")]
-fn assert_process_exits(pid: u32) {
-    use windows_sys::Win32::{
-        Foundation::{CloseHandle, WAIT_OBJECT_0, WAIT_TIMEOUT},
-        System::Threading::{
-            OpenProcess, PROCESS_SYNCHRONIZE, PROCESS_TERMINATE, TerminateProcess,
-            WaitForSingleObject,
-        },
-    };
+fn assert_connection_closes(mut connection: std::net::TcpStream) {
+    use std::io::{ErrorKind, Read, Write};
 
-    // SAFETY: the PID came from the detached child. A non-null handle is valid
-    // until it is closed below, and the requested access rights only wait for
-    // or terminate that child if the regression leaves it running.
-    unsafe {
-        let process = OpenProcess(PROCESS_SYNCHRONIZE | PROCESS_TERMINATE, 0, pid);
-        if process.is_null() {
-            return;
+    connection
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .expect("set detached child connection timeout");
+    let mut byte = [0];
+    let process_exited = match connection.read(&mut byte) {
+        Ok(0) => true,
+        Ok(_) => false,
+        Err(err)
+            if matches!(
+                err.kind(),
+                ErrorKind::BrokenPipe
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::ConnectionReset
+                    | ErrorKind::NotConnected,
+            ) =>
+        {
+            true
         }
-        let wait = WaitForSingleObject(process, 10_000);
-        if wait == WAIT_TIMEOUT {
-            TerminateProcess(process, 1);
-            WaitForSingleObject(process, 10_000);
-        }
-        CloseHandle(process);
-        assert_eq!(wait, WAIT_OBJECT_0, "the detached process should be cleaned up");
+        Err(err) if matches!(err.kind(), ErrorKind::TimedOut | ErrorKind::WouldBlock) => false,
+        Err(err) => panic!("read detached child connection: {err}"),
+    };
+    if !process_exited {
+        let _ = connection.write_all(b"exit");
+        panic!("the detached process should be cleaned up");
     }
 }
 
@@ -219,22 +223,40 @@ fn exec_preserves_a_detached_process_after_success() {
 #[cfg(target_os = "windows")]
 #[test]
 fn exec_cleans_up_a_detached_process_after_failure() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    let pid_path = workspace.join("detached-pid.txt");
+    use std::{io::ErrorKind, net::TcpListener};
 
-    pacquet
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let ready_path = workspace.join("detached-ready.txt");
+    let listener = TcpListener::bind(("127.0.0.1", 0)).expect("listen for detached child");
+    listener.set_nonblocking(true).expect("set listener nonblocking");
+    let port = listener.local_addr().expect("read listener address").port();
+
+    let mut pacquet_process = pacquet
         .with_arg("exec")
         .with_arg("node")
         .with_arg("-e")
-        .with_arg(make_long_lived_detached_node_script(&pid_path))
-        .assert()
-        .failure();
+        .with_arg(make_connected_detached_node_script(&ready_path, port))
+        .spawn()
+        .expect("spawn pacquet exec");
 
-    let pid = fs::read_to_string(&pid_path)
-        .expect("read detached process PID")
-        .parse()
-        .expect("parse detached process PID");
-    assert_process_exits(pid);
+    let deadline = Instant::now() + Duration::from_secs(12);
+    let connection = loop {
+        match listener.accept() {
+            Ok((connection, _)) => break connection,
+            Err(err) if err.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                let _ = pacquet_process.kill();
+                let _ = pacquet_process.wait();
+                panic!("the detached process did not connect before the deadline");
+            }
+            Err(err) => panic!("accept detached child connection: {err}"),
+        }
+    };
+    let status = pacquet_process.wait().expect("wait for pacquet exec");
+    assert_eq!(status.code(), Some(1), "the fixture must reach its intentional failure");
+    assert_connection_closes(connection);
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/exec.rs
+++ b/pnpm/crates/cli/tests/suite/exec.rs
@@ -1,9 +1,12 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::CommandTempCwd;
-
-#[cfg(unix)]
-use std::fs;
+use std::{
+    fs,
+    path::Path,
+    thread,
+    time::{Duration, Instant},
+};
 
 #[cfg(unix)]
 fn write_executable(path: &std::path::Path, body: &str) {
@@ -12,6 +15,16 @@ fn write_executable(path: &std::path::Path, body: &str) {
     let mut perms = fs::metadata(path).expect("stat executable").permissions();
     perms.set_mode(0o755);
     fs::set_permissions(path, perms).expect("chmod executable");
+}
+
+fn spawn_detached_node_script(marker_path: &Path, parent_exit_code: i32) -> String {
+    let marker_json = serde_json::to_string(&marker_path.to_string_lossy()).expect("quote marker");
+    let detached_script =
+        format!("setTimeout(() => require('fs').writeFileSync({marker_json}, 'survived'), 500)");
+    let detached_script_json = serde_json::to_string(&detached_script).expect("quote script");
+    format!(
+        "const {{ spawn }} = require('child_process'); const child = spawn(process.execPath, ['-e', {detached_script_json}], {{ detached: true, stdio: 'ignore' }}); child.unref(); process.exit({parent_exit_code})",
+    )
 }
 
 /// `pacquet exec <command>` resolves the command against the project's
@@ -135,6 +148,55 @@ fn exec_shell_mode_preserves_embedded_quotes() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(output.status.success(), "shell-mode command must exit 0, got: {output:?}");
     assert!(stdout.contains("shell-quote-ok"), "embedded quotes must survive; stdout: {stdout:?}");
+
+    drop(root);
+}
+
+#[test]
+fn exec_preserves_a_detached_process_after_success() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker_path = workspace.join("detached-marker.txt");
+
+    pacquet
+        .with_arg("exec")
+        .with_arg("node")
+        .with_arg("-e")
+        .with_arg(spawn_detached_node_script(&marker_path, 0))
+        .assert()
+        .success();
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while !marker_path.exists() && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(50));
+    }
+    let marker_exists = marker_path.exists();
+    eprintln!("DETACHED MARKER EXISTS: {marker_exists}");
+    assert!(marker_exists, "the detached process should survive a successful pnpm exec");
+
+    drop(root);
+}
+
+#[test]
+#[cfg_attr(
+    not(target_os = "windows"),
+    ignore = "only Windows Job Objects kill detached descendants"
+)]
+fn exec_cleans_up_a_detached_process_after_failure() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker_path = workspace.join("detached-marker.txt");
+
+    pacquet
+        .with_arg("exec")
+        .with_arg("node")
+        .with_arg("-e")
+        .with_arg(spawn_detached_node_script(&marker_path, 1))
+        .assert()
+        .failure();
+
+    thread::sleep(Duration::from_secs(2));
+    let marker_exists = marker_path.exists();
+    eprintln!("DETACHED MARKER EXISTS: {marker_exists}");
+    assert!(!marker_exists, "the detached process should be cleaned up after a failed pnpm exec");
 
     drop(root);
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

- Disarm pnpm's Windows Job Object after a command finishes successfully so intentionally detached descendants can continue running.
- Keep `KILL_ON_JOB_CLOSE` armed for errors, panics, and interrupts, preserving process-tree cleanup on unsuccessful execution.
- Add end-to-end coverage for the successful and failed detached-child paths.

Fixes pnpm/pnpm#14356.

The TypeScript CLI already preserves detached children after successful commands and does not use this Job Object mechanism, so this is a Rust-only parity fix.

## Squash Commit Body

```text
The Windows Rust CLI process was assigned to a Job Object with KILL_ON_JOB_CLOSE for its entire lifetime. This reliably cleaned up descendants on failure and interruption, but also killed processes deliberately detached by successful exec and run commands.

Keep the Job Object armed while a command runs, then clear the kill-on-close limit and close the handle only after a successful result. Error returns, nonzero child exits, panics, and interrupts continue to leave the job armed for process-tree cleanup.

Add end-to-end tests for detached descendants on both successful and failed exec paths.

Fixes pnpm/pnpm#14356.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790777779&installation_model_id=426870&pr_number=14365&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14365&signature=214a5c69941ba79d982eeef249e9093a1b7cbd4488459d9300a31a133fad4197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a Windows issue where detached child processes were terminated after successful commands.
  - Detached processes now remain running after successful execution while still being cleaned up when commands fail.
  - Improved process handling for commands that launch long-running detached tasks.

- **Tests**
  - Added coverage verifying detached process behavior for both successful and failed commands on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->