### PR TITLE
fix(cmd-shim): use native dispatcher on WSL2

### DIFF
--- a/.changeset/fix-wsl2-context-shims.md
+++ b/.changeset/fix-wsl2-context-shims.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed context-aware global shims on WSL2 so native Linux installations dispatch through the project runtime.

--- a/pnpm/crates/cmd-shim/src/shim.rs
+++ b/pnpm/crates/cmd-shim/src/shim.rs
@@ -299,21 +299,23 @@ pub fn generate_sh_shim(
     };
 
     if style == ShimStyle::ContextAware {
-        // The dispatcher receives the target as data, not as a path the
-        // shell resolves, so hand it the `$basedir_win` flavor: identical
-        // to `$basedir` everywhere except MSYS/WSL, where the pnpm
-        // Windows executable needs the Windows spelling.
         let quoted_name = sh_single_quote(shim_name(shim_path));
-        // Adjacent quoting: the `$basedir_win` expansion stays inside
+        // Adjacent quoting: the `$dispatcher_basedir` expansion stays inside
         // double quotes while the manifest-controlled file name is
         // single-quoted, so it can never be command-substituted.
-        let quoted_shim_win =
-            format!(r#""$basedir_win/"{}"#, sh_single_quote(shim_name(shim_path)));
-        writeln!(
-            sh,
-            "if [ -z \"$PNPM_SHIM_BYPASS\" ] && [ -x \"$basedir/{CONTEXT_AWARE_DISPATCHER_NAME}$exe\" ]; then\n  exec \"$basedir/{CONTEXT_AWARE_DISPATCHER_NAME}$exe\" --shim {quoted_name} {quoted_shim_win} {quoted_target_win} -- \"$@\"\nfi",
-        )
-        .unwrap();
+        let quoted_shim =
+            format!(r#""$dispatcher_basedir/"{}"#, sh_single_quote(shim_name(shim_path)));
+        let quoted_dispatch_target = if Path::new(&sh_target).is_absolute() {
+            format!(r#""{sh_target}""#)
+        } else {
+            format!(r#""$dispatcher_basedir/{sh_target}""#)
+        };
+        write_context_aware_sh_dispatch(
+            &mut sh,
+            &quoted_name,
+            &quoted_shim,
+            &quoted_dispatch_target,
+        );
     }
 
     match runtime {
@@ -646,6 +648,19 @@ esac
 
 "#;
 
+fn write_context_aware_sh_dispatch(
+    sh: &mut String,
+    quoted_name: &str,
+    quoted_shim: &str,
+    quoted_target: &str,
+) {
+    writeln!(
+        sh,
+        "if [ -z \"$PNPM_SHIM_BYPASS\" ]; then\n  dispatcher=\"$basedir/{CONTEXT_AWARE_DISPATCHER_NAME}\"\n  dispatcher_basedir=\"$basedir\"\n  if [ -n \"$msys\" ] && [ -x \"$dispatcher$exe\" ]; then\n    dispatcher=\"$dispatcher$exe\"\n    dispatcher_basedir=\"$basedir_win\"\n  elif [ ! -x \"$dispatcher\" ] && [ -n \"$exe\" ] && [ -x \"$dispatcher$exe\" ]; then\n    dispatcher=\"$dispatcher$exe\"\n    dispatcher_basedir=\"$basedir_win\"\n  fi\n  if [ -x \"$dispatcher\" ]; then\n    exec \"$dispatcher\" --shim {quoted_name} {quoted_shim} {quoted_target} -- \"$@\"\n  fi\nfi",
+    )
+    .unwrap();
+}
+
 fn indent_shell_block(script: &str) -> String {
     script
         .split('\n')
@@ -705,14 +720,10 @@ pub fn generate_virtual_sh_shim(package: &str, shim_path: &Path) -> String {
     let mut sh = String::from(SH_SHIM_HEADER);
     let bin = shim_name(shim_path);
     let quoted_name = sh_single_quote(bin);
-    let quoted_shim_win = format!(r#""$basedir_win/"{}"#, sh_single_quote(bin));
+    let quoted_shim = format!(r#""$dispatcher_basedir/"{}"#, sh_single_quote(bin));
     let target = virtual_shim_target(package);
     let quoted_target = sh_single_quote(&target);
-    writeln!(
-        sh,
-        "if [ -z \"$PNPM_SHIM_BYPASS\" ] && [ -x \"$basedir/{CONTEXT_AWARE_DISPATCHER_NAME}$exe\" ]; then\n  exec \"$basedir/{CONTEXT_AWARE_DISPATCHER_NAME}$exe\" --shim {quoted_name} {quoted_shim_win} {quoted_target} -- \"$@\"\nfi",
-    )
-    .unwrap();
+    write_context_aware_sh_dispatch(&mut sh, &quoted_name, &quoted_shim, &quoted_target);
     writeln!(sh, "echo {} >&2", sh_single_quote(&no_target_message(bin, package))).unwrap();
     writeln!(sh, "exit 1").unwrap();
     writeln!(sh, "# {CONTEXT_AWARE_MARKER}").unwrap();

--- a/pnpm/crates/cmd-shim/src/shim/tests.rs
+++ b/pnpm/crates/cmd-shim/src/shim/tests.rs
@@ -653,7 +653,7 @@ fn context_aware_sh_shim_dispatches_through_versioned_binary_then_falls_back() {
     let runtime = ScriptRuntime { prog: Some("node".to_string()), args: String::new() };
     let body = generate_sh_shim(target, shim, Some(&runtime), &[], ShimStyle::ContextAware);
     assert!(
-        body.contains(r#"exec "$basedir/.pnpm-shim-v1$exe" --shim 'tool' "$basedir_win/"'tool' "$basedir_win/../global/v11/x/node_modules/pkg/cli.js" -- "$@""#),
+        body.contains(r#"exec "$dispatcher" --shim 'tool' "$dispatcher_basedir/"'tool' "$dispatcher_basedir/../global/v11/x/node_modules/pkg/cli.js" -- "$@""#),
         "body was:\n{body}",
     );
     assert!(body.contains(r#"[ -z "$PNPM_SHIM_BYPASS" ]"#), "body was:\n{body}");
@@ -661,6 +661,50 @@ fn context_aware_sh_shim_dispatches_through_versioned_binary_then_falls_back() {
     assert!(body.contains(r#""$basedir/node""#), "body was:\n{body}");
     assert!(is_context_aware_shim(&body));
     assert!(is_shim_pointing_at(&body, target));
+}
+
+#[cfg(unix)]
+#[test]
+fn context_aware_sh_shim_uses_native_dispatcher_paths_on_wsl2() {
+    use std::{env, fs, os::unix::fs::PermissionsExt, process::Command};
+
+    let root = tempfile::tempdir().unwrap();
+    let global_bin = root.path().join("bin");
+    let tools_bin = root.path().join("tools");
+    let target = root.path().join("global/node_modules/pkg/cli.js");
+    let dispatched_target = global_bin.join("../global/node_modules/pkg/cli.js");
+    let shim = global_bin.join("tool");
+    let dispatcher = global_bin.join(".pnpm-shim-v1");
+    let uname = tools_bin.join("uname");
+    let wslpath = tools_bin.join("wslpath");
+    fs::create_dir_all(&global_bin).unwrap();
+    fs::create_dir_all(&tools_bin).unwrap();
+    fs::create_dir_all(target.parent().unwrap()).unwrap();
+    fs::write(&shim, generate_sh_shim(&target, &shim, None, &[], ShimStyle::ContextAware)).unwrap();
+    fs::write(&dispatcher, "#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n").unwrap();
+    fs::write(&uname, "#!/bin/sh\nprintf 'Linux test WSL2\\n'\n").unwrap();
+    fs::write(&wslpath, "#!/bin/sh\nprintf 'C:\\\\converted\\n'\n").unwrap();
+    for executable in [&shim, &dispatcher, &uname, &wslpath] {
+        fs::set_permissions(executable, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let path = env::join_paths(
+        std::iter::once(tools_bin).chain(env::split_paths(&env::var_os("PATH").unwrap())),
+    )
+    .unwrap();
+
+    let output = Command::new(&shim).env("PATH", path).arg("forwarded").output().unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert!(output.status.success(), "stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    assert_eq!(
+        stdout,
+        format!(
+            "<--shim>\n<tool>\n<{}>\n<{}>\n<-->\n<forwarded>\n",
+            shim.display(),
+            dispatched_target.display(),
+        ),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cmd-shim/src/shim/tests.rs
+++ b/pnpm/crates/cmd-shim/src/shim/tests.rs
@@ -208,6 +208,15 @@ fn generate_sh_shim_uses_absolute_target_when_no_common_prefix() {
         body.contains(r#""/abs/elsewhere/cli""#),
         "absolute-target branch must skip $basedir prefix, body:\n{body}",
     );
+
+    let context_aware_body =
+        generate_sh_shim(target, shim, Some(&runtime), &[], ShimStyle::ContextAware);
+    assert!(
+        context_aware_body.contains(
+            r#"exec "$dispatcher" --shim 'local-shim' "$dispatcher_basedir/"'local-shim' "/abs/elsewhere/cli" -- "$@""#,
+        ),
+        "context-aware dispatch must skip $dispatcher_basedir for an absolute target, body:\n{context_aware_body}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Prefer the native `.pnpm-shim-v1` dispatcher and POSIX paths when a context-aware shell shim runs under WSL2.
- Keep `.exe` dispatch and converted paths for shims backed by a Windows dispatcher, including MSYS/Cygwin.
- Share the dispatcher selection between installed and virtual shell shims, and add an executable WSL2 regression test.

This is pacquet-only because context-aware global shims are a pnpm v12 Rust feature with no TypeScript v11 counterpart.

Fixes pnpm/pnpm#14364.

## Squash Commit Body

```text
WSL2 reports itself through `uname`, so the shell shim header enables its
Windows interoperability path. Context-aware shims consequently looked only
for `.pnpm-shim-v1.exe`; a native Linux installation provides
`.pnpm-shim-v1`, so dispatch was skipped. Supplying an executable alias still
failed because the Linux dispatcher received paths converted by `wslpath`.

Select the native dispatcher with its POSIX base directory whenever it exists.
Retain the `.exe` dispatcher and converted base directory when the shim is
actually backed by a Windows executable, preferring that form on MSYS/Cygwin.
Use the same dispatch generator for installed and virtual shims.

Add a regression test that simulates WSL2's `uname` and `wslpath`, executes a
generated shim, and verifies that the native dispatcher receives POSIX shim
and target paths.

Fixes pnpm/pnpm#14364.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779700&installation_model_id=426870&pr_number=14367&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14367&signature=2eb4350c71d4a294a80dc0b1e5586af930a7cd2410a1b59b945e8e98bab654a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context-aware command shims on WSL2 so native Linux installations correctly dispatch commands through the project runtime.
  * Improved dispatcher path detection across native Unix, MSYS, and WSL environments.
  * Preserved correct forwarding of command targets and arguments.

* **Release**
  * Prepared a patch release for the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->