### PR TITLE
fix(peers): resolve workspace catalog peer ranges

### DIFF
--- a/.changeset/friendly-catalog-peers.md
+++ b/.changeset/friendly-catalog-peers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `catalog:` ranges in workspace package peer dependencies being reported as unmet [pnpm/pnpm#14361](https://github.com/pnpm/pnpm/issues/14361).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4646,6 +4646,8 @@ dependencies = [
  "dunce",
  "node-semver",
  "owo-colors",
+ "pnpm-catalogs-resolver",
+ "pnpm-catalogs-types",
  "pnpm-config",
  "pnpm-lockfile",
  "pnpm-package-manifest",

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -79,6 +79,8 @@ impl PeersArgs {
         .into_diagnostic()
         .wrap_err("load lockfile")?;
         let catalogs = configured_catalogs(config)?;
+        let catalogs =
+            (config.workspace_dir.is_some() || config.catalogs.is_some()).then_some(&catalogs);
 
         // A missing lockfile yields empty issues, mirroring pnpm's
         // `checkPeerDependencies`, so both output modes stay on the common
@@ -88,7 +90,7 @@ impl PeersArgs {
                 lockfile,
                 lockfile_dir,
                 &project_dirs,
-                &catalogs,
+                catalogs,
             )?,
             None => IssuesByProjects::new(),
         };

--- a/pnpm/crates/cli/src/cli_args/peers.rs
+++ b/pnpm/crates/cli/src/cli_args/peers.rs
@@ -7,8 +7,9 @@ use pnpm_deps_inspection_peers::{
 };
 use pnpm_lockfile::Lockfile;
 
-use crate::cli_args::recursive::{
-    AutoExcludeRoot, discover_workspace_projects, select_recursive_projects,
+use crate::cli_args::{
+    catalogs::configured_catalogs,
+    recursive::{AutoExcludeRoot, discover_workspace_projects, select_recursive_projects},
 };
 
 #[derive(Debug, Args)]
@@ -77,14 +78,18 @@ impl PeersArgs {
         }
         .into_diagnostic()
         .wrap_err("load lockfile")?;
+        let catalogs = configured_catalogs(config)?;
 
         // A missing lockfile yields empty issues, mirroring pnpm's
         // `checkPeerDependencies`, so both output modes stay on the common
         // path (`{}` for `--json`, "No peer dependency issues found" otherwise).
         let issues = match &lockfile {
-            Some(lockfile) => {
-                check_peer_dependencies_from_lockfile(lockfile, lockfile_dir, &project_dirs)
-            }
+            Some(lockfile) => check_peer_dependencies_from_lockfile(
+                lockfile,
+                lockfile_dir,
+                &project_dirs,
+                &catalogs,
+            )?,
             None => IssuesByProjects::new(),
         };
         let issues = filter_peer_issues(issues, &config.peer_dependency_rules);

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -343,6 +343,59 @@ fn strict_peer_dependencies_fails_on_a_linked_workspace_packages_unmet_peer() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn catalog_peer_of_a_linked_workspace_package_is_resolved() {
+    assert_catalog_peer_of_workspace_package_is_resolved(false);
+}
+
+#[test]
+fn catalog_peer_of_an_injected_workspace_package_is_resolved() {
+    assert_catalog_peer_of_workspace_package_is_resolved(true);
+}
+
+fn assert_catalog_peer_of_workspace_package_is_resolved(injected: bool) {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\ncatalog:\n  '@pnpm.e2e/foo': 1.0.0\nstrictPeerDependencies: true\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the workspace library");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write the library manifest");
+
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    let mut manifest = serde_json::json!({
+        "name": "app",
+        "version": "1.0.0",
+        "dependencies": { "lib": "workspace:*", "@pnpm.e2e/foo": "catalog:" },
+    });
+    if injected {
+        manifest["dependenciesMeta"] = serde_json::json!({ "lib": { "injected": true } });
+    }
+    fs::write(app.join("package.json"), manifest.to_string()).expect("write the app manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let _ = run_peers(&workspace, &["peers", "check", "--lockfile-only", "--json"]);
+
+    drop((root, mock_instance));
+}
+
 /// A `--filter`ed install acts only on the projects it selected, so its
 /// verdict covers only those. The lockfile still holds the unselected
 /// importers, and an unrelated project's unmet peer must not fail a run

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -442,6 +442,60 @@ fn standalone_install_does_not_require_catalogs_for_linked_peers() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn workspace_without_catalogs_does_not_reject_an_injected_catalog_peer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nsharedWorkspaceLockfile: false\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "version": "1.0.0" }"#)
+        .expect("write root manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the workspace library");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write the library manifest");
+
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*", "@pnpm.e2e/foo": "1.0.0" },
+            "dependenciesMeta": { "lib": { "injected": true } },
+        })
+        .to_string(),
+    )
+    .expect("write the app manifest");
+
+    let output = pacquet
+        .with_args(["--filter", "app", "install"])
+        .output()
+        .expect("install workspace package");
+    assert!(
+        output.status.success(),
+        "install must report rather than reject the raw range: {output:?}",
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains(PEERS_CHECK_HINT), "stdout:\n{stdout}");
+
+    drop((root, mock_instance));
+}
+
 fn assert_catalog_peer_of_workspace_package_is_resolved(injected: bool) {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -353,6 +353,54 @@ fn catalog_peer_of_an_injected_workspace_package_is_resolved() {
     assert_catalog_peer_of_workspace_package_is_resolved(true);
 }
 
+#[test]
+fn ignored_workspace_does_not_require_workspace_catalogs_for_peer_inspection() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\ncatalog:\n  '@pnpm.e2e/foo': 1.0.0\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*", "@pnpm.e2e/foo": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write root manifest");
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the workspace library");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write the library manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["--ignore-workspace", "peers", "check", "--lockfile-only", "--json"])
+        .output()
+        .expect("inspect peers without workspace configuration");
+    assert_eq!(output.status.code(), Some(1), "the raw catalog range remains unmet: {output:?}");
+    assert!(output.stderr.is_empty(), "inspection must not fail with a diagnostic: {output:?}");
+    let issues: Value = serde_json::from_slice(&output.stdout).expect("parse peers JSON");
+    assert_eq!(issues["."]["bad"]["@pnpm.e2e/foo"][0]["wantedRange"], "catalog:");
+
+    drop((root, mock_instance));
+}
+
 fn assert_catalog_peer_of_workspace_package_is_resolved(injected: bool) {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -401,6 +401,47 @@ fn ignored_workspace_does_not_require_workspace_catalogs_for_peer_inspection() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn standalone_install_does_not_require_catalogs_for_linked_peers() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::remove_file(workspace.join("pnpm-workspace.yaml"))
+        .expect("remove the mock registry's workspace manifest");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "link:./lib", "@pnpm.e2e/foo": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write app manifest");
+    let lib = workspace.join("lib");
+    fs::create_dir_all(&lib).expect("create linked library");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write linked library manifest");
+
+    let output = pacquet.with_arg("install").output().expect("install standalone project");
+    assert!(
+        output.status.success(),
+        "install must report rather than reject the raw range: {output:?}",
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains(PEERS_CHECK_HINT), "stdout:\n{stdout}");
+
+    drop((root, mock_instance));
+}
+
 fn assert_catalog_peer_of_workspace_package_is_resolved(injected: bool) {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/deps-inspection-peers/Cargo.toml
+++ b/pnpm/crates/deps-inspection-peers/Cargo.toml
@@ -11,6 +11,8 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+pnpm-catalogs-resolver                 = { workspace = true }
+pnpm-catalogs-types                    = { workspace = true }
 pnpm-config                            = { workspace = true }
 pnpm-lockfile                          = { workspace = true }
 pnpm-package-manifest                  = { workspace = true }

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -130,7 +130,7 @@ pub fn peer_issues_for_lockfile(
     lockfile_dir: &Path,
     importer_ids: &[String],
     rules: &PeerDependencyRules,
-    catalogs: &Catalogs,
+    catalogs: Option<&Catalogs>,
 ) -> Result<Option<PeerIssuesReport>, CatalogResolutionError> {
     let issues = filter_peer_issues(
         check_peer_dependencies_of_importers(lockfile, lockfile_dir, importer_ids, catalogs)?,
@@ -150,7 +150,7 @@ pub fn check_peer_dependencies_from_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &Path,
     project_dirs: &[PathBuf],
-    catalogs: &Catalogs,
+    catalogs: Option<&Catalogs>,
 ) -> Result<IssuesByProjects, CatalogResolutionError> {
     let mut importer_ids: Vec<String> = project_dirs
         .iter()
@@ -169,7 +169,7 @@ pub fn check_peer_dependencies_of_importers(
     lockfile: &Lockfile,
     lockfile_dir: &Path,
     importer_ids: &[String],
-    catalogs: &Catalogs,
+    catalogs: Option<&Catalogs>,
 ) -> Result<IssuesByProjects, CatalogResolutionError> {
     let empty_packages = HashMap::new();
     let empty_snapshots = HashMap::new();
@@ -255,7 +255,7 @@ struct LinkedPackagePeers<'a> {
     manifest: &'a PackageManifest,
     alias: &'a str,
     linked_version: &'a str,
-    catalogs: &'a Catalogs,
+    catalogs: Option<&'a Catalogs>,
     issues: &'a mut PeerIssues,
 }
 
@@ -350,8 +350,9 @@ fn check_linked_package_peers(
 fn resolve_peer_range(
     peer_name: &str,
     peer_range: &str,
-    catalogs: &Catalogs,
+    catalogs: Option<&Catalogs>,
 ) -> Result<String, CatalogResolutionError> {
+    let Some(catalogs) = catalogs else { return Ok(peer_range.to_string()) };
     let wanted =
         WantedDependency { alias: peer_name.to_string(), bare_specifier: peer_range.to_string() };
     match resolve_from_catalog(catalogs, &wanted) {
@@ -364,7 +365,7 @@ fn resolve_peer_range(
 struct PeerWalkContext<'a> {
     lockfile: &'a Lockfile,
     lockfile_dir: &'a Path,
-    catalogs: &'a Catalogs,
+    catalogs: Option<&'a Catalogs>,
 }
 
 fn collect_initial_keys(

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -25,6 +25,10 @@ use node_semver::{Range, Version};
 use owo_colors::{OwoColorize, Stream};
 use serde::Serialize;
 
+use pnpm_catalogs_resolver::{
+    CatalogResolutionError, CatalogResolutionResult, WantedDependency, resolve_from_catalog,
+};
+use pnpm_catalogs_types::Catalogs;
 use pnpm_config::PeerDependencyRules;
 use pnpm_lockfile::{Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
 use pnpm_package_manifest::PackageManifest;
@@ -121,15 +125,15 @@ impl PeerIssuesReport {
 /// `peerDependencyRules`, for the given importers.
 ///
 /// Returns `None` when there is nothing worth acting on.
-#[must_use]
 pub fn peer_issues_for_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &Path,
     importer_ids: &[String],
     rules: &PeerDependencyRules,
-) -> Option<PeerIssuesReport> {
+    catalogs: &Catalogs,
+) -> Result<Option<PeerIssuesReport>, CatalogResolutionError> {
     let issues = filter_peer_issues(
-        check_peer_dependencies_of_importers(lockfile, lockfile_dir, importer_ids),
+        check_peer_dependencies_of_importers(lockfile, lockfile_dir, importer_ids, catalogs)?,
         rules,
     );
     let has_missing_peer = issues.values().any(|project_issues| {
@@ -137,17 +141,17 @@ pub fn peer_issues_for_lockfile(
     });
     let has_issues =
         has_missing_peer || issues.values().any(|project_issues| !project_issues.bad.is_empty());
-    has_issues.then_some(PeerIssuesReport { issues, has_missing_peer })
+    Ok(has_issues.then_some(PeerIssuesReport { issues, has_missing_peer }))
 }
 
 /// The issues reachable from the given project directories, for the
 /// commands that inspect a selection rather than the whole workspace.
-#[must_use]
 pub fn check_peer_dependencies_from_lockfile(
     lockfile: &Lockfile,
     lockfile_dir: &Path,
     project_dirs: &[PathBuf],
-) -> IssuesByProjects {
+    catalogs: &Catalogs,
+) -> Result<IssuesByProjects, CatalogResolutionError> {
     let mut importer_ids: Vec<String> = project_dirs
         .iter()
         .map(|project_dir| pnpm_workspace::importer_id_from_root_dir(lockfile_dir, project_dir))
@@ -155,22 +159,23 @@ pub fn check_peer_dependencies_from_lockfile(
         .collect();
     importer_ids.sort();
     importer_ids.dedup();
-    check_peer_dependencies_of_importers(lockfile, lockfile_dir, &importer_ids)
+    check_peer_dependencies_of_importers(lockfile, lockfile_dir, &importer_ids, catalogs)
 }
 
 /// Walk the named importers, collecting every peer a package requires
 /// but the recorded graph does not satisfy. Unfiltered — the caller
 /// applies [`filter_peer_issues`].
-#[must_use]
 pub fn check_peer_dependencies_of_importers(
     lockfile: &Lockfile,
     lockfile_dir: &Path,
     importer_ids: &[String],
-) -> IssuesByProjects {
+    catalogs: &Catalogs,
+) -> Result<IssuesByProjects, CatalogResolutionError> {
     let empty_packages = HashMap::new();
     let empty_snapshots = HashMap::new();
     let packages = lockfile.packages.as_ref().unwrap_or(&empty_packages);
     let snapshots = lockfile.snapshots.as_ref().unwrap_or(&empty_snapshots);
+    let context = PeerWalkContext { lockfile, lockfile_dir, catalogs };
 
     let mut result: IssuesByProjects = BTreeMap::new();
     // Shared across importers so each package is evaluated once, matching
@@ -190,13 +195,12 @@ pub fn check_peer_dependencies_of_importers(
         let mut visited_importers = HashSet::new();
         collect_initial_keys(
             importer_id,
-            lockfile,
-            lockfile_dir,
+            &context,
             &[],
             &mut initial_keys,
             &mut visited_importers,
             &mut issues,
-        );
+        )?;
 
         walk_snapshot(
             initial_keys,
@@ -214,7 +218,7 @@ pub fn check_peer_dependencies_of_importers(
         result.insert(importer_id.clone(), issues);
     }
 
-    result
+    Ok(result)
 }
 
 fn path_is_within(path: &Path, base: &Path) -> bool {
@@ -251,10 +255,13 @@ struct LinkedPackagePeers<'a> {
     manifest: &'a PackageManifest,
     alias: &'a str,
     linked_version: &'a str,
+    catalogs: &'a Catalogs,
     issues: &'a mut PeerIssues,
 }
 
-fn check_linked_package_peers(inputs: LinkedPackagePeers<'_>) {
+fn check_linked_package_peers(
+    inputs: LinkedPackagePeers<'_>,
+) -> Result<(), CatalogResolutionError> {
     let LinkedPackagePeers {
         importer,
         importer_dir,
@@ -262,12 +269,13 @@ fn check_linked_package_peers(inputs: LinkedPackagePeers<'_>) {
         manifest,
         alias,
         linked_version,
+        catalogs,
         issues,
     } = inputs;
     let Some(peer_deps) =
         manifest.value().get("peerDependencies").and_then(|deps_val| deps_val.as_object())
     else {
-        return;
+        return Ok(());
     };
 
     let current_parents =
@@ -275,7 +283,8 @@ fn check_linked_package_peers(inputs: LinkedPackagePeers<'_>) {
 
     for (peer_name, peer_range_val) in peer_deps {
         let Some(peer_range) = peer_range_val.as_str() else { continue };
-        let peer_range = get_peer_version_range(peer_range);
+        let peer_range = resolve_peer_range(peer_name, peer_range, catalogs)?;
+        let peer_range = get_peer_version_range(&peer_range);
         let is_optional = manifest
             .value()
             .get("peerDependenciesMeta")
@@ -335,22 +344,42 @@ fn check_linked_package_peers(inputs: LinkedPackagePeers<'_>) {
             }
         }
     }
+    Ok(())
+}
+
+fn resolve_peer_range(
+    peer_name: &str,
+    peer_range: &str,
+    catalogs: &Catalogs,
+) -> Result<String, CatalogResolutionError> {
+    let wanted =
+        WantedDependency { alias: peer_name.to_string(), bare_specifier: peer_range.to_string() };
+    match resolve_from_catalog(catalogs, &wanted) {
+        CatalogResolutionResult::Found(found) => Ok(found.resolution.specifier),
+        CatalogResolutionResult::Unused => Ok(peer_range.to_string()),
+        CatalogResolutionResult::Misconfiguration(misconfiguration) => Err(misconfiguration.error),
+    }
+}
+
+struct PeerWalkContext<'a> {
+    lockfile: &'a Lockfile,
+    lockfile_dir: &'a Path,
+    catalogs: &'a Catalogs,
 }
 
 fn collect_initial_keys(
     importer_id: &str,
-    lockfile: &Lockfile,
-    lockfile_dir: &Path,
+    context: &PeerWalkContext<'_>,
     parents: &[ParentPkg],
     initial_keys: &mut Vec<(PkgNameVerPeer, Vec<ParentPkg>)>,
     visited_importers: &mut HashSet<String>,
     issues: &mut PeerIssues,
-) {
+) -> Result<(), CatalogResolutionError> {
     if !visited_importers.insert(importer_id.to_string()) {
-        return;
+        return Ok(());
     }
-    let Some(importer) = lockfile.importers.get(importer_id) else { return };
-    let importer_dir = lockfile_dir.join(importer_id);
+    let Some(importer) = context.lockfile.importers.get(importer_id) else { return Ok(()) };
+    let importer_dir = context.lockfile_dir.join(importer_id);
 
     let groups =
         [&importer.dependencies, &importer.dev_dependencies, &importer.optional_dependencies];
@@ -366,7 +395,7 @@ fn collect_initial_keys(
                 // recursion all need the same two answers, and this walk
                 // now runs on the install path.
                 let linked_dir = importer_dir.join(link_target);
-                if !path_is_within(&linked_dir, lockfile_dir) {
+                if !path_is_within(&linked_dir, context.lockfile_dir) {
                     continue;
                 }
                 let linked_manifest =
@@ -383,28 +412,29 @@ fn collect_initial_keys(
                     check_linked_package_peers(LinkedPackagePeers {
                         importer,
                         importer_dir: &importer_dir,
-                        lockfile_dir,
+                        lockfile_dir: context.lockfile_dir,
                         manifest: linked_manifest,
                         alias: &alias.to_string(),
                         linked_version: &linked_version,
+                        catalogs: context.catalogs,
                         issues,
-                    });
+                    })?;
                 }
 
                 let linked_importer_id =
-                    pnpm_workspace::importer_id_from_root_dir(lockfile_dir, &linked_dir);
+                    pnpm_workspace::importer_id_from_root_dir(context.lockfile_dir, &linked_dir);
                 collect_initial_keys(
                     &linked_importer_id,
-                    lockfile,
-                    lockfile_dir,
+                    context,
                     &next_parents,
                     initial_keys,
                     visited_importers,
                     issues,
-                );
+                )?;
             }
         }
     }
+    Ok(())
 }
 
 fn walk_snapshot(

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -11,6 +11,7 @@ use miette::Diagnostic;
 use pnpm_catalogs_config::{
     InvalidCatalogsConfigurationError, get_catalogs_from_workspace_manifest,
 };
+use pnpm_catalogs_resolver::CatalogResolutionError;
 use pnpm_catalogs_types::Catalogs;
 use pnpm_cmd_shim::LinkBinsError;
 use pnpm_config::{Config, NodeLinker, PNPM_VERSION};
@@ -773,6 +774,9 @@ pub enum InstallError {
     /// `catalogs.default`).
     #[diagnostic(transparent)]
     InvalidCatalogsConfiguration(#[error(source)] InvalidCatalogsConfigurationError),
+
+    #[diagnostic(transparent)]
+    CatalogResolution(#[error(source)] CatalogResolutionError),
 
     #[diagnostic(transparent)]
     FindWorkspaceProjects(#[error(source)] pnpm_workspace::FindWorkspaceProjectsError),

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -22,6 +22,7 @@ struct ResolveOnlyCompletionInputs<'a> {
     fresh_lockfile: Option<&'a Lockfile>,
     prefix: &'a str,
     config: &'static Config,
+    catalogs: &'a Catalogs,
     workspace_root: &'a Path,
     installed_importer_ids: &'a HashSet<String>,
 }
@@ -55,6 +56,7 @@ fn complete_resolve_only<Reporter: self::Reporter>(
             inputs.installed_importer_ids,
             inputs.workspace_root,
             inputs.config,
+            inputs.catalogs,
         )?;
     }
     Reporter::emit(&LogEvent::Summary(SummaryLog {
@@ -587,6 +589,7 @@ fn run_materialized_project_scripts<Reporter: self::Reporter>(
 
 struct ReportInstallCompletionInputs<'a> {
     config: &'static Config,
+    catalogs: &'a Catalogs,
     workspace_root: &'a Path,
     workspace_manifest_dir: &'a Path,
     prefix: String,
@@ -605,6 +608,7 @@ fn report_install_completion<Reporter: self::Reporter>(
 ) -> Result<(), InstallError> {
     let ReportInstallCompletionInputs {
         config,
+        catalogs,
         workspace_root,
         workspace_manifest_dir,
         prefix,
@@ -623,6 +627,7 @@ fn report_install_completion<Reporter: self::Reporter>(
         installed_importer_ids,
         workspace_root,
         config,
+        catalogs,
     )?;
     // `pnpm:summary` closes the install and lets the reporter render
     // the accumulated `pnpm:root` events as a "+N -M" block. Must
@@ -814,6 +819,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         fresh_lockfile: fresh_lockfile.as_ref(),
         prefix: &prefix,
         config,
+        catalogs: &catalogs,
         workspace_root: &workspace_root,
         installed_importer_ids,
     })? {
@@ -913,6 +919,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
 
     report_install_completion::<Reporter>(ReportInstallCompletionInputs {
         config,
+        catalogs: &catalogs,
         workspace_root: &workspace_root,
         workspace_manifest_dir: &workspace_manifest_dir,
         prefix,

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -22,7 +22,7 @@ struct ResolveOnlyCompletionInputs<'a> {
     fresh_lockfile: Option<&'a Lockfile>,
     prefix: &'a str,
     config: &'static Config,
-    catalogs: &'a Catalogs,
+    catalogs: Option<&'a Catalogs>,
     workspace_root: &'a Path,
     installed_importer_ids: &'a HashSet<String>,
 }
@@ -589,7 +589,7 @@ fn run_materialized_project_scripts<Reporter: self::Reporter>(
 
 struct ReportInstallCompletionInputs<'a> {
     config: &'static Config,
-    catalogs: &'a Catalogs,
+    catalogs: Option<&'a Catalogs>,
     workspace_root: &'a Path,
     workspace_manifest_dir: &'a Path,
     prefix: String,
@@ -756,6 +756,7 @@ pub(super) struct ApplyMaterializationInputs<'a, 'selection> {
     pub(super) selection: Option<WorkspaceInstallSelection<'selection>>,
     pub(super) supported_architectures: Option<pnpm_package_is_installable::SupportedArchitectures>,
     pub(super) catalogs: Catalogs,
+    pub(super) catalog_context_present: bool,
     pub(super) verified_file_integrity_baseline: VerifiedFileIntegrity,
 }
 
@@ -800,8 +801,10 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         selection,
         supported_architectures,
         catalogs,
+        catalog_context_present,
         verified_file_integrity_baseline,
     } = inputs;
+    let peer_catalogs = catalog_context_present.then_some(&catalogs);
     let modules_manifest = modules_manifest.as_ref();
     // What this run installed: a `--filter`ed install acts only on its
     // selection, every other one on the whole workspace. The lockfile
@@ -819,7 +822,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
         fresh_lockfile: fresh_lockfile.as_ref(),
         prefix: &prefix,
         config,
-        catalogs: &catalogs,
+        catalogs: peer_catalogs,
         workspace_root: &workspace_root,
         installed_importer_ids,
     })? {
@@ -919,7 +922,7 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
 
     report_install_completion::<Reporter>(ReportInstallCompletionInputs {
         config,
-        catalogs: &catalogs,
+        catalogs: peer_catalogs,
         workspace_root: &workspace_root,
         workspace_manifest_dir: &workspace_manifest_dir,
         prefix,

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -199,6 +199,9 @@ where
                 .map_err(InstallError::ReadWorkspaceManifest)?,
             None => None,
         };
+        let catalog_context_present = catalogs_override.is_some()
+            || config.catalogs.is_some()
+            || (!config.ignore_workspace && workspace_dir_opt.is_some());
         // Prefer a caller-supplied in-memory catalogs set
         // (`catalogs_override`, e.g. `pacquet update --latest --no-save`
         // resolving a bumped `catalog:` entry that is not written to disk),
@@ -1207,6 +1210,7 @@ where
             selection,
             supported_architectures,
             catalogs,
+            catalog_context_present,
             verified_file_integrity_baseline,
         })
         .await?;

--- a/pnpm/crates/package-manager/src/peer_dependency_issues.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues.rs
@@ -31,13 +31,17 @@ use crate::InstallError;
 /// acted on. A `--filter`ed install leaves every unselected importer in
 /// the lockfile untouched, and pnpm reports only on the projects that
 /// took part in the resolution.
+///
+/// `catalogs` is `None` when the install has no catalog context. Raw
+/// `catalog:` peer ranges in externally linked packages then remain peer
+/// issues instead of becoming catalog-configuration errors.
 pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
     resolved_lockfile: Option<&Lockfile>,
     peer_issue_importer_ids: &HashSet<String>,
     installed_importer_ids: &HashSet<String>,
     lockfile_dir: &Path,
     config: &Config,
-    catalogs: &Catalogs,
+    catalogs: Option<&Catalogs>,
 ) -> Result<(), InstallError> {
     let Some(lockfile) = resolved_lockfile else { return Ok(()) };
     let mut importer_ids: Vec<String> = peer_issue_importer_ids
@@ -54,7 +58,7 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
         lockfile_dir,
         &importer_ids,
         &config.peer_dependency_rules,
-        Some(catalogs),
+        catalogs,
     )
     .map_err(InstallError::CatalogResolution)?
     else {

--- a/pnpm/crates/package-manager/src/peer_dependency_issues.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues.rs
@@ -54,7 +54,7 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
         lockfile_dir,
         &importer_ids,
         &config.peer_dependency_rules,
-        catalogs,
+        Some(catalogs),
     )
     .map_err(InstallError::CatalogResolution)?
     else {

--- a/pnpm/crates/package-manager/src/peer_dependency_issues.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues.rs
@@ -8,6 +8,7 @@
 //! reports nothing, so `pnpm peers check` is what answers for a tree
 //! nobody re-resolved.
 
+use pnpm_catalogs_types::Catalogs;
 use pnpm_config::Config;
 use pnpm_deps_inspection_peers::peer_issues_for_lockfile;
 use pnpm_lockfile::Lockfile;
@@ -36,6 +37,7 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
     installed_importer_ids: &HashSet<String>,
     lockfile_dir: &Path,
     config: &Config,
+    catalogs: &Catalogs,
 ) -> Result<(), InstallError> {
     let Some(lockfile) = resolved_lockfile else { return Ok(()) };
     let mut importer_ids: Vec<String> = peer_issue_importer_ids
@@ -52,7 +54,10 @@ pub(crate) fn report_peer_dependency_issues<Reporter: pnpm_reporter::Reporter>(
         lockfile_dir,
         &importer_ids,
         &config.peer_dependency_rules,
-    ) else {
+        catalogs,
+    )
+    .map_err(InstallError::CatalogResolution)?
+    else {
         return Ok(());
     };
     if config.strict_peer_dependencies {

--- a/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
@@ -51,7 +51,7 @@ snapshots:
         &HashSet::from([".".to_string()]),
         lockfile_dir.path(),
         &config,
-        &catalogs,
+        Some(&catalogs),
     )
     .expect("a clean resolver candidate set must skip the lockfile walk");
     assert_eq!(EVENTS.lock().unwrap().len(), 0);
@@ -62,7 +62,7 @@ snapshots:
         &HashSet::from([".".to_string()]),
         lockfile_dir.path(),
         &config,
-        &catalogs,
+        Some(&catalogs),
     )
     .expect_err("a resolver candidate with a missing peer must fail in strict mode");
     assert!(matches!(error, InstallError::PeerDependencyIssues));

--- a/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
+++ b/pnpm/crates/package-manager/src/peer_dependency_issues/tests.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashSet, sync::Mutex};
 
+use pnpm_catalogs_types::Catalogs;
 use pnpm_config::Config;
 use pnpm_lockfile::Lockfile;
 use pnpm_reporter::{LogEvent, Reporter};
@@ -42,6 +43,7 @@ snapshots:
     let lockfile_dir = tempfile::tempdir().expect("create lockfile directory");
     let mut config = Config::new();
     config.strict_peer_dependencies = true;
+    let catalogs = Catalogs::new();
 
     report_peer_dependency_issues::<RecordingReporter>(
         Some(&lockfile),
@@ -49,6 +51,7 @@ snapshots:
         &HashSet::from([".".to_string()]),
         lockfile_dir.path(),
         &config,
+        &catalogs,
     )
     .expect("a clean resolver candidate set must skip the lockfile walk");
     assert_eq!(EVENTS.lock().unwrap().len(), 0);
@@ -59,6 +62,7 @@ snapshots:
         &HashSet::from([".".to_string()]),
         lockfile_dir.path(),
         &config,
+        &catalogs,
     )
     .expect_err("a resolver candidate with a missing peer must fail in strict mode");
     assert!(matches!(error, InstallError::PeerDependencyIssues));

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -2,6 +2,7 @@
 //! `pkgIdWithPatchHash`, its child specs, its peer dependencies, its
 //! leaf classification, and its deprecation notice.
 
+use pnpm_catalogs_types::Catalogs;
 use pnpm_package_manifest::engines_runtime_dependencies;
 use pnpm_patching::get_patch_info;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
@@ -11,8 +12,8 @@ use std::collections::BTreeMap;
 use crate::resolved_tree::PeerDep;
 
 use super::{
-    Deprecation, ResolveDependencyTreeError, dependency_is_injected, lock_recoverable,
-    tree_ctx::TreeCtx, workspace_ctx::ChildSpec,
+    Deprecation, ResolveDependencyTreeError, catalogs::resolve_catalog_specifier,
+    dependency_is_injected, lock_recoverable, tree_ctx::TreeCtx, workspace_ctx::ChildSpec,
 };
 
 /// Compute the `pkgIdWithPatchHash` for a freshly-resolved package:
@@ -224,14 +225,16 @@ fn render_parent(result: &pnpm_resolving_resolver_base::ResolveResult) -> String
 /// without a matching `peerDependencies` entry only counts when
 /// `optional: true` — it is treated as an optional `"*"` peer exactly
 /// like an explicitly declared one, and non-optional meta-only entries
-/// are ignored.
+/// are ignored. When [`Catalogs`] are supplied, `catalog:` ranges are
+/// dereferenced before they enter peer resolution.
 ///
 /// [`peer_shadowed_dependencies`]: crate::parent_pkg_aliases::peer_shadowed_dependencies
 pub(super) fn extract_peer_dependencies(
     result: &pnpm_resolving_resolver_base::ResolveResult,
     peer_shadowed: &HashSet<String>,
-) -> BTreeMap<String, PeerDep> {
-    let Some(manifest) = result.manifest.as_ref() else { return BTreeMap::new() };
+    catalogs: Option<&Catalogs>,
+) -> Result<BTreeMap<String, PeerDep>, ResolveDependencyTreeError> {
+    let Some(manifest) = result.manifest.as_ref() else { return Ok(BTreeMap::new()) };
     let mut peers: BTreeMap<String, PeerDep> = BTreeMap::new();
 
     let dep_names = |key| {
@@ -253,10 +256,13 @@ pub(super) fn extract_peer_dependencies(
                 continue;
             }
             if let Some(range_str) = range.as_str() {
-                peers.insert(
-                    name.clone(),
-                    PeerDep { version: range_str.to_string(), optional: false },
-                );
+                let version = match catalogs {
+                    Some(catalogs) => {
+                        resolve_catalog_specifier(name.clone(), range_str.to_string(), catalogs)?.1
+                    }
+                    None => range_str.to_string(),
+                };
+                peers.insert(name.clone(), PeerDep { version, optional: false });
             }
         }
     }
@@ -275,7 +281,7 @@ pub(super) fn extract_peer_dependencies(
         }
     }
 
-    peers
+    Ok(peers)
 }
 
 /// `true` when the package has no `dependencies`, `optionalDependencies`,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/reuse.rs
@@ -588,7 +588,7 @@ where
     // A reused node's children come from the snapshot rather than from
     // a manifest, so no `dependencies` entry of its synthesized
     // manifest can be peer-shadowed.
-    let peer_dependencies = extract_peer_dependencies(&result, &HashSet::default());
+    let peer_dependencies = extract_peer_dependencies(&result, &HashSet::default(), None)?;
     let child_refs = snapshot_child_refs(snapshot, &peer_dependencies);
     let is_leaf = child_refs.is_empty() && peer_dependencies.is_empty();
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -9,6 +9,7 @@
 use async_recursion::async_recursion;
 use futures_util::future;
 use pipe_trait::Pipe;
+use pnpm_catalogs_types::Catalogs;
 use pnpm_lockfile::{LockfileResolution, PkgNameVerPeer, TarballRevision};
 use pnpm_resolving_resolver_base::{
     CurrentPkg, GitResolveError, NoMatchingVersionError, PreferredVersionsOverlay,
@@ -506,7 +507,7 @@ where
             extract_peer_dependencies(
                 &result,
                 &peer_shadowed,
-                resolves_children_through_catalogs.then_some(&ctx.catalogs),
+                catalogs_for_children(ctx, resolves_children_through_catalogs),
             )?
         };
         register_peer_dep_names(ctx, &peer_dependencies);
@@ -758,7 +759,7 @@ fn install_owner_peer_dependencies(
     let peer_dependencies = extract_peer_dependencies(
         &pending.result,
         &claim.peer_shadowed,
-        pending.resolves_children_through_catalogs.then_some(&ctx.catalogs),
+        catalogs_for_children(ctx, pending.resolves_children_through_catalogs),
     )?;
     let mut packages = lock_recoverable(&ctx.workspace.packages);
     let Some(existing) = packages.get_mut(pending.id.as_str()) else { return Ok(()) };
@@ -983,18 +984,10 @@ where
             .collect::<Vec<ChildSpec>>()
             .pipe(Arc::new)
     };
-    let child_specs = if pending.resolves_children_through_catalogs {
-        child_specs
-            .iter()
-            .map(|(name, range, optional, injected)| {
-                resolve_catalog_specifier(name.clone(), range.clone(), &ctx.catalogs)
-                    .map(|(name, range)| (name, range, *optional, *injected))
-            })
-            .collect::<Result<Vec<ChildSpec>, ResolveDependencyTreeError>>()?
-            .pipe(Arc::new)
-    } else {
-        child_specs
-    };
+    let child_specs = resolve_catalog_child_specs(
+        child_specs,
+        catalogs_for_children(ctx, pending.resolves_children_through_catalogs),
+    )?;
     // An *updated* parent (one that landed on a different version than
     // the lockfile recorded, or a new dep) discards its
     // `resolvedDependencies` child refs, forcing its subtree to
@@ -1483,11 +1476,21 @@ pub(super) async fn warm_children_resolutions<Chain>(
         return;
     }
     let Ok(specs) = extract_children(&pending.result) else { return };
+    let specs = specs
+        .into_iter()
+        .filter(|(name, _, optional, _)| *optional || !pending.peer_shadowed.contains(name))
+        .collect::<Vec<ChildSpec>>()
+        .pipe(Arc::new);
+    let Ok(specs) = resolve_catalog_child_specs(
+        specs,
+        catalogs_for_children(ctx, pending.resolves_children_through_catalogs),
+    ) else {
+        return;
+    };
     let opts = ctx.opts_for_depth(pending.depth + 1);
     let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
     specs
         .iter()
-        .filter(|(name, _, optional, _)| *optional || !pending.peer_shadowed.contains(name))
         .map(|(name, range, optional, injected)| {
             let wanted = WantedDependency {
                 alias: Some(name.clone()),
@@ -1537,6 +1540,28 @@ fn resolves_children_through_catalogs(
     result: &pnpm_resolving_resolver_base::ResolveResult,
 ) -> bool {
     result.resolved_via == "workspace" && result.id.as_str().starts_with("file:")
+}
+
+fn catalogs_for_children(
+    ctx: &TreeCtx,
+    resolves_children_through_catalogs: bool,
+) -> Option<&Catalogs> {
+    (resolves_children_through_catalogs && !ctx.catalogs.is_empty()).then_some(&ctx.catalogs)
+}
+
+fn resolve_catalog_child_specs(
+    child_specs: Arc<Vec<ChildSpec>>,
+    catalogs: Option<&Catalogs>,
+) -> Result<Arc<Vec<ChildSpec>>, ResolveDependencyTreeError> {
+    let Some(catalogs) = catalogs else { return Ok(child_specs) };
+    child_specs
+        .iter()
+        .map(|(name, range, optional, injected)| {
+            resolve_catalog_specifier(name.clone(), range.clone(), catalogs)
+                .map(|(name, range)| (name, range, *optional, *injected))
+        })
+        .collect::<Result<Vec<ChildSpec>, ResolveDependencyTreeError>>()
+        .map(Arc::new)
 }
 
 /// The install aliases one resolved level contributes to its

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -501,7 +501,11 @@ where
         let peer_dependencies = if is_link {
             BTreeMap::new()
         } else {
-            extract_peer_dependencies(&result, &peer_shadowed)
+            extract_peer_dependencies(
+                &result,
+                &peer_shadowed,
+                resolves_children_through_catalogs(&result).then_some(&ctx.catalogs),
+            )?
         };
         register_peer_dep_names(ctx, &peer_dependencies);
         ctx.workspace.record_package_write(&id);
@@ -667,7 +671,7 @@ pub(super) async fn walk_from_seeds<Chain>(
 where
     Chain: Resolver + ?Sized,
 {
-    assign_level_owners(ctx, seeds.iter_mut());
+    assign_level_owners(ctx, seeds.iter_mut())?;
     let direct: Vec<DirectDep> = seeds.iter().filter_map(seeded_dep).collect();
     let mut frontier = settle_seeds(ctx, seeds, children_overlay.as_ref(), &children_pkg_aliases);
     while !frontier.is_empty() {
@@ -676,7 +680,7 @@ where
             .map(|node| seed_node_children(ctx, resolver, node))
             .pipe(future::try_join_all)
             .await?;
-        frontier = settle_level(ctx, seeded);
+        frontier = settle_level(ctx, seeded)?;
     }
     Ok(direct)
 }
@@ -689,7 +693,10 @@ where
 /// sorts first. Only that one claims: the losers cannot win against a
 /// standing owner either, since they do not even outrank their own
 /// level's winner.
-fn assign_level_owners<'seed>(ctx: &TreeCtx, seeds: impl Iterator<Item = &'seed mut NodeSeed>) {
+fn assign_level_owners<'seed>(
+    ctx: &TreeCtx,
+    seeds: impl Iterator<Item = &'seed mut NodeSeed>,
+) -> Result<(), ResolveDependencyTreeError> {
     // Linked nodes resolve their dependencies as their own importer,
     // so they never own children here.
     let mut level: Vec<&mut Box<PendingNode>> = seeds
@@ -726,9 +733,10 @@ fn assign_level_owners<'seed>(ctx: &TreeCtx, seeds: impl Iterator<Item = &'seed 
             &pending.parent_ancestors,
             peer_shadowed,
         );
-        install_owner_peer_dependencies(ctx, pending, &claim);
+        install_owner_peer_dependencies(ctx, pending, &claim)?;
         pending.claim = Some(claim);
     }
+    Ok(())
 }
 
 /// Split the package's envelope into children and peers the way its
@@ -740,20 +748,25 @@ fn install_owner_peer_dependencies(
     ctx: &TreeCtx,
     pending: &PendingNode,
     claim: &ChildrenOwnerClaim,
-) {
+) -> Result<(), ResolveDependencyTreeError> {
     if pending.is_link || !claim.owns_children {
-        return;
+        return Ok(());
     }
-    let peer_dependencies = extract_peer_dependencies(&pending.result, &claim.peer_shadowed);
+    let peer_dependencies = extract_peer_dependencies(
+        &pending.result,
+        &claim.peer_shadowed,
+        resolves_children_through_catalogs(&pending.result).then_some(&ctx.catalogs),
+    )?;
     let mut packages = lock_recoverable(&ctx.workspace.packages);
-    let Some(existing) = packages.get_mut(pending.id.as_str()) else { return };
+    let Some(existing) = packages.get_mut(pending.id.as_str()) else { return Ok(()) };
     if existing.peer_dependencies == peer_dependencies {
-        return;
+        return Ok(());
     }
     existing.peer_dependencies = peer_dependencies.clone();
     drop(packages);
     register_peer_dep_names(ctx, &peer_dependencies);
     ctx.workspace.record_package_write(&pending.id);
+    Ok(())
 }
 
 /// Give every occurrence of a settled level its tree node, and collect
@@ -809,8 +822,11 @@ fn settle_seeds(
 
 /// Record what each occurrence of a seeded level resolved for its
 /// children, and settle that level's own seeds into the next frontier.
-fn settle_level(ctx: &TreeCtx, mut seeded: Vec<SeededNode>) -> Vec<FrontierNode> {
-    assign_level_owners(ctx, seeded.iter_mut().flat_map(|node| node.seeds.iter_mut()));
+fn settle_level(
+    ctx: &TreeCtx,
+    mut seeded: Vec<SeededNode>,
+) -> Result<Vec<FrontierNode>, ResolveDependencyTreeError> {
+    assign_level_owners(ctx, seeded.iter_mut().flat_map(|node| node.seeds.iter_mut()))?;
     let mut frontier = Vec::new();
     for node in seeded {
         let SeededNode {
@@ -835,7 +851,7 @@ fn settle_level(ctx: &TreeCtx, mut seeded: Vec<SeededNode>) -> Vec<FrontierNode>
             &grandchild_pkg_aliases,
         ));
     }
-    frontier
+    Ok(frontier)
 }
 
 /// Publish the child edges one occurrence resolved, and report the

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -123,6 +123,7 @@ pub(super) struct PendingNode {
     alias: String,
     node_id: NodeId,
     is_link: bool,
+    resolves_children_through_catalogs: bool,
     parent_ancestors: Arc<Vec<String>>,
     next_ancestors: Arc<Vec<String>>,
     /// The dependency names this occurrence's own `peerDependencies`
@@ -474,6 +475,7 @@ where
     // id is collapsed to a leaf so every reference to the same workspace
     // path shares one [`NodeId`].
     let is_link = id.starts_with("link:");
+    let resolves_children_through_catalogs = resolves_children_through_catalogs(&result);
     let is_leaf = is_link || pkg_is_leaf(&result);
     let node_id = if is_leaf { NodeId::leaf(&id) } else { NodeId::next() };
 
@@ -504,7 +506,7 @@ where
             extract_peer_dependencies(
                 &result,
                 &peer_shadowed,
-                resolves_children_through_catalogs(&result).then_some(&ctx.catalogs),
+                resolves_children_through_catalogs.then_some(&ctx.catalogs),
             )?
         };
         register_peer_dep_names(ctx, &peer_dependencies);
@@ -538,6 +540,7 @@ where
         alias,
         node_id,
         is_link,
+        resolves_children_through_catalogs,
         parent_ancestors: Arc::clone(ancestor_ids),
         next_ancestors,
         peer_shadowed,
@@ -755,7 +758,7 @@ fn install_owner_peer_dependencies(
     let peer_dependencies = extract_peer_dependencies(
         &pending.result,
         &claim.peer_shadowed,
-        resolves_children_through_catalogs(&pending.result).then_some(&ctx.catalogs),
+        pending.resolves_children_through_catalogs.then_some(&ctx.catalogs),
     )?;
     let mut packages = lock_recoverable(&ctx.workspace.packages);
     let Some(existing) = packages.get_mut(pending.id.as_str()) else { return Ok(()) };
@@ -803,7 +806,7 @@ fn settle_seeds(
             insert_walked_node(ctx, &pending, children);
             continue;
         };
-        if !resolves_children_through_catalogs(&pending.result)
+        if !pending.resolves_children_through_catalogs
             && recorded_children_match(ctx, &pending.id, &children_context(ctx, &pending, &claim))
         {
             let children = lazy_children(&pending.parent_ancestors);
@@ -980,7 +983,7 @@ where
             .collect::<Vec<ChildSpec>>()
             .pipe(Arc::new)
     };
-    let child_specs = if resolves_children_through_catalogs(&pending.result) {
+    let child_specs = if pending.resolves_children_through_catalogs {
         child_specs
             .iter()
             .map(|(name, range, optional, injected)| {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -984,10 +984,18 @@ where
             .collect::<Vec<ChildSpec>>()
             .pipe(Arc::new)
     };
-    let child_specs = resolve_catalog_child_specs(
-        child_specs,
-        catalogs_for_children(ctx, pending.resolves_children_through_catalogs),
-    )?;
+    let child_specs = if let Some(catalogs) =
+        catalogs_for_children(ctx, pending.resolves_children_through_catalogs)
+    {
+        child_specs
+            .iter()
+            .cloned()
+            .collect::<Vec<ChildSpec>>()
+            .pipe(|specs| resolve_catalog_child_specs(specs, catalogs))?
+            .pipe(Arc::new)
+    } else {
+        child_specs
+    };
     // An *updated* parent (one that landed on a different version than
     // the lockfile recorded, or a new dep) discards its
     // `resolvedDependencies` child refs, forcing its subtree to
@@ -1476,16 +1484,21 @@ pub(super) async fn warm_children_resolutions<Chain>(
         return;
     }
     let Ok(specs) = extract_children(&pending.result) else { return };
-    let specs = specs
-        .into_iter()
-        .filter(|(name, _, optional, _)| *optional || !pending.peer_shadowed.contains(name))
-        .collect::<Vec<ChildSpec>>()
-        .pipe(Arc::new);
-    let Ok(specs) = resolve_catalog_child_specs(
-        specs,
-        catalogs_for_children(ctx, pending.resolves_children_through_catalogs),
-    ) else {
-        return;
+    let specs = if pending.peer_shadowed.is_empty() {
+        specs
+    } else {
+        specs
+            .into_iter()
+            .filter(|(name, _, optional, _)| *optional || !pending.peer_shadowed.contains(name))
+            .collect()
+    };
+    let specs = if let Some(catalogs) =
+        catalogs_for_children(ctx, pending.resolves_children_through_catalogs)
+    {
+        let Ok(specs) = resolve_catalog_child_specs(specs, catalogs) else { return };
+        specs
+    } else {
+        specs
     };
     let opts = ctx.opts_for_depth(pending.depth + 1);
     let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
@@ -1550,18 +1563,16 @@ fn catalogs_for_children(
 }
 
 fn resolve_catalog_child_specs(
-    child_specs: Arc<Vec<ChildSpec>>,
-    catalogs: Option<&Catalogs>,
-) -> Result<Arc<Vec<ChildSpec>>, ResolveDependencyTreeError> {
-    let Some(catalogs) = catalogs else { return Ok(child_specs) };
+    child_specs: Vec<ChildSpec>,
+    catalogs: &Catalogs,
+) -> Result<Vec<ChildSpec>, ResolveDependencyTreeError> {
     child_specs
-        .iter()
+        .into_iter()
         .map(|(name, range, optional, injected)| {
-            resolve_catalog_specifier(name.clone(), range.clone(), catalogs)
-                .map(|(name, range)| (name, range, *optional, *injected))
+            resolve_catalog_specifier(name, range, catalogs)
+                .map(|(name, range)| (name, range, optional, injected))
         })
-        .collect::<Result<Vec<ChildSpec>, ResolveDependencyTreeError>>()
-        .map(Arc::new)
+        .collect()
 }
 
 /// The install aliases one resolved level contributes to its


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14361 for the Rust pnpm CLI by resolving `catalog:` ranges in
workspace package peer dependencies before peer matching.

This covers both linked workspace dependencies and injected workspace
dependencies. The TypeScript CLI already resolves these ranges correctly, so
the change restores parity without requiring a TypeScript implementation
change.

## Squash Commit Body

```text
Resolve workspace package peer ranges through the effective workspace
catalogs before checking whether their consumers provide compatible versions.

Thread those catalogs through install-time and explicit peer inspection, and
apply them while constructing injected workspace dependency peer metadata.
Registry package peer ranges remain untouched.

Add regression coverage for linked and injected workspace packages.

Fixes pnpm/pnpm#14361.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14368"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790779871&installation_model_id=426870&pr_number=14368&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14368&signature=0edb0688bcc026f90a45d74f4ad36309ca67c607e9f56677007321e496791004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm peers check` incorrectly reporting `catalog:` peer dependencies as unmet.
  * Catalog-based peer dependencies now resolve correctly for linked and injected workspace packages.
  * Improved handling of unresolved catalog configuration.
  * Standalone and ignored-workspace checks no longer require unavailable workspace catalogs.

* **Tests**
  * Added coverage for catalog peer dependencies across workspace, linked-package, injected-package, and standalone scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->