### PR TITLE
fix(package-manager): keep global excludes out of manifests

### DIFF
--- a/.changeset/fresh-plums-stay-local.md
+++ b/.changeset/fresh-plums-stay-local.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer writes global `minimumReleaseAgeExclude` entries to the project's `pnpm-workspace.yaml` [pnpm/pnpm#14347](https://github.com/pnpm/pnpm/issues/14347).

--- a/pnpm/crates/cli/src/cli_args/audit/fix.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/fix.rs
@@ -120,7 +120,7 @@ pub(crate) async fn fix_override(
         let added =
             resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)?;
         if !added.is_empty() {
-            write_age_excludes(settings_dir, config, &added)?;
+            write_age_excludes(settings_dir, &added)?;
             let note = format!(
                 "\n\n{} entries were added to minimumReleaseAgeExclude to allow installing the patched versions:\n{}",
                 added.len(),
@@ -284,24 +284,23 @@ pub(crate) fn minimum_release_age_excludes(
     pnpm_config::version_policy::merge_package_version_specs(&specs).map_err(miette::Report::new)
 }
 
-/// Merge `added` into the existing `minimumReleaseAgeExclude` and persist the
-/// canonical result. Mirrors pnpm's `writeSettings` re-merge of
+/// Merge `added` into the project-local `minimumReleaseAgeExclude` and persist
+/// the canonical result. Mirrors pnpm's `writeSettings` re-merge of
 /// `[...existing, ...added]`.
 pub(crate) fn write_age_excludes(
     settings_dir: &std::path::Path,
-    config: &Config,
     added: &[String],
 ) -> miette::Result<()> {
-    let mut all = config.minimum_release_age_exclude.clone().unwrap_or_default();
-    all.extend(added.iter().cloned());
-    let merged = pnpm_config::version_policy::merge_package_version_specs(&all)
-        .map_err(miette::Report::new)?;
-    pnpm_workspace_manifest_writer::set_minimum_release_age_excludes(settings_dir, &merged).map_err(
-        |err| {
-            miette::Report::new(err)
-                .wrap_err("write minimumReleaseAgeExclude to pnpm-workspace.yaml")
+    pnpm_workspace_manifest_writer::update_workspace_manifest(
+        settings_dir,
+        &pnpm_workspace_manifest_writer::UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: added,
+            ..Default::default()
         },
     )
+    .map_err(|err| {
+        miette::Report::new(err).wrap_err("write minimumReleaseAgeExclude to pnpm-workspace.yaml")
+    })
 }
 
 /// Merge the requested ignores into `auditConfig.ignoreGhsas` and persist
@@ -505,7 +504,7 @@ pub(crate) async fn fix_with_update<Reporter: self::Reporter + 'static>(
         let added =
             resolve_minimum_release_age_excludes(advisories, publish_infos, minimum_release_age)?;
         if !added.is_empty() {
-            write_age_excludes(settings_dir, state.config, &added)?;
+            write_age_excludes(settings_dir, &added)?;
         }
         added
     } else {

--- a/pnpm/crates/package-manager/src/minimum_release_age.rs
+++ b/pnpm/crates/package-manager/src/minimum_release_age.rs
@@ -9,7 +9,7 @@ use pnpm_config::{
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, PromptAction, PromptLog, Reporter};
 use pnpm_resolving_resolver_base::ResolutionPolicyViolation;
 use pnpm_workspace_manifest_writer::{
-    UpdateWorkspaceManifestError, set_minimum_release_age_excludes,
+    UpdateWorkspaceManifestError, UpdateWorkspaceManifestOptions, update_workspace_manifest,
 };
 
 use pnpm_resolving_npm_resolver::MINIMUM_RELEASE_AGE_VIOLATION_CODE;
@@ -127,7 +127,6 @@ where
 
     if !strict {
         return persist_and_report_excludes::<ReporterImpl>(
-            config,
             workspace_dir,
             &immature,
             "(set minimumReleaseAgeStrict to true to gate these updates with a prompt)",
@@ -158,7 +157,6 @@ where
         return Ok(());
     }
     persist_and_report_excludes::<ReporterImpl>(
-        config,
         workspace_dir,
         &immature,
         "(approved at the prompt)",
@@ -166,7 +164,6 @@ where
 }
 
 fn persist_and_report_excludes<ReporterImpl: Reporter>(
-    config: &Config,
     workspace_dir: &Path,
     immature: &[&ResolutionPolicyViolation],
     reason: &str,
@@ -175,14 +172,16 @@ fn persist_and_report_excludes<ReporterImpl: Reporter>(
         .iter()
         .map(|violation| format!("{}@{}", violation.name, violation.version))
         .collect();
-    let merged = merge_package_version_specs(
-        config.minimum_release_age_exclude.iter().flatten().chain(&added),
-    )
-    .map_err(MinimumReleaseAgeError::VersionPolicy)?;
     let added =
         merge_package_version_specs(&added).map_err(MinimumReleaseAgeError::VersionPolicy)?;
-    set_minimum_release_age_excludes(workspace_dir, &merged)
-        .map_err(MinimumReleaseAgeError::WriteWorkspaceManifest)?;
+    update_workspace_manifest(
+        workspace_dir,
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .map_err(MinimumReleaseAgeError::WriteWorkspaceManifest)?;
 
     ReporterImpl::emit(&LogEvent::Pnpm(PnpmLog {
         level: LogLevel::Info,

--- a/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
+++ b/pnpm/crates/package-manager/src/minimum_release_age/tests.rs
@@ -237,6 +237,38 @@ async fn loose_mode_persists_excludes_without_prompting() {
 }
 
 #[tokio::test]
+async fn global_excludes_are_not_persisted_to_the_workspace_manifest() {
+    let dir = tempdir().expect("temp dir");
+    fs::write(
+        dir.path().join("pnpm-workspace.yaml"),
+        "minimumReleaseAgeExclude:\n  - local@1.0.0\n",
+    )
+    .expect("write workspace manifest");
+    let mut config = Config::new();
+    config.minimum_release_age = Some(60);
+    config.minimum_release_age_exclude =
+        Some(vec!["global-only".to_string(), "local@1.0.0".to_string()]);
+    let mut prompt = FakePrompt::default();
+
+    handle_minimum_release_age_violations_with::<SilentReporter, _>(
+        &config,
+        dir.path(),
+        &[violation("local", "2.0.0", "MINIMUM_RELEASE_AGE_VIOLATION")],
+        true,
+        true,
+        &mut prompt,
+    )
+    .await
+    .expect("loose mode always proceeds");
+
+    assert_eq!(
+        fs::read_to_string(dir.path().join("pnpm-workspace.yaml"))
+            .expect("read workspace manifest"),
+        "minimumReleaseAgeExclude:\n  - local@1.0.0 || 2.0.0\n",
+    );
+}
+
+#[tokio::test]
 async fn strict_approval_without_persistence_proceeds_but_leaves_the_workspace_manifest_unchanged()
 {
     recording_reporter!(reset_events, prompt_actions);

--- a/pnpm/crates/workspace-manifest-writer/src/lib.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/lib.rs
@@ -99,6 +99,9 @@ pub enum UpdateWorkspaceManifestError {
     )]
     #[diagnostic(code(ERR_PNPM_WORKSPACE_MANIFEST_WRITER_INVALID_CONTROL_CHARACTER))]
     InvalidControlCharacter { path: std::path::PathBuf, value: String },
+
+    #[diagnostic(transparent)]
+    VersionPolicy(#[error(source)] pnpm_config::version_policy::VersionPolicyError),
 }
 
 /// Whether `value` holds a character YAML treats as a line break: a
@@ -152,12 +155,14 @@ pub struct UpdateWorkspaceManifestOptions<'a> {
     pub resolved_package_versions: Option<&'a ResolvedPackageVersions>,
     pub prune_minimum_release_age_excludes: bool,
     pub prune_allow_builds: bool,
+    /// Entries to merge into the project-local `minimumReleaseAgeExclude`
+    /// list after its cleanup pass.
+    pub added_minimum_release_age_excludes: &'a [String],
 }
 
-/// Merge `opts.updated_catalogs` into `dir`'s `pnpm-workspace.yaml` and run
-/// the `catalogPrune` pass when requested, writing the file back
-/// only when something actually changed (and removing it when the edits
-/// empty the document).
+/// Apply the requested merges and cleanup passes to `dir`'s
+/// `pnpm-workspace.yaml`, writing the file back only when something actually
+/// changed (and removing it when the edits empty the document).
 pub fn update_workspace_manifest(
     dir: &Path,
     opts: &UpdateWorkspaceManifestOptions<'_>,
@@ -185,6 +190,11 @@ pub fn update_workspace_manifest(
             return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
         }
     }
+    if !opts.added_minimum_release_age_excludes.is_empty()
+        && let Some(key) = unsupported_inline_key(manifest.text(), &[&["minimumReleaseAgeExclude"]])
+    {
+        return Err(UpdateWorkspaceManifestError::UnsupportedInlineBlock { path, key });
+    }
 
     let mut changed = match opts.updated_catalogs {
         Some(updated_catalogs) => {
@@ -211,6 +221,23 @@ pub fn update_workspace_manifest(
         if opts.prune_allow_builds {
             changed |= edit::prune_allow_builds(&mut manifest, resolved);
         }
+    }
+    if !opts.added_minimum_release_age_excludes.is_empty() {
+        let merged = pnpm_config::version_policy::merge_package_version_specs(
+            manifest
+                .minimum_release_age_exclude
+                .iter()
+                .flatten()
+                .chain(opts.added_minimum_release_age_excludes),
+        )
+        .map_err(UpdateWorkspaceManifestError::VersionPolicy)?;
+        if let Some(bad) = merged.iter().find(|exclude| has_control_char(exclude)) {
+            return Err(UpdateWorkspaceManifestError::InvalidControlCharacter {
+                path,
+                value: bad.clone(),
+            });
+        }
+        changed |= edit::set_minimum_release_age_excludes(&mut manifest, &merged);
     }
     if !changed {
         return Ok(());

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -968,6 +968,21 @@ fn minimum_release_age_exclude_empty_removes_the_block() {
 }
 
 #[test]
+fn minimum_release_age_excludes_are_added_to_the_local_manifest_values() {
+    let added = ["local@2.0.0".to_string()];
+    let out = run_with(
+        Some("minimumReleaseAgeExclude:\n  - local@1.0.0\n"),
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .expect("written");
+
+    assert_eq!(out, "minimumReleaseAgeExclude:\n  - local@1.0.0 || 2.0.0\n");
+}
+
+#[test]
 fn set_overrides_refuses_to_clobber_a_non_scalar_value() {
     let dir = TempDir::new().expect("temp dir");
     let path = dir.path().join(WORKSPACE_MANIFEST_FILENAME);


### PR DESCRIPTION
## Summary

- Merge newly approved `minimumReleaseAgeExclude` entries with the project-local `pnpm-workspace.yaml` values instead of the fully cascaded config.
- Use the same local merge for audit fixes, preventing user-global exclusions from leaking through that write path too.
- Keep global exclusions active during resolution; this change only prevents them from being serialized into a project.
- The TypeScript CLI already has this behavior, so this brings the Rust `pnpm` implementation back into parity.

Fixes pnpm/pnpm#14347.

## Squash Commit Body

```text
Merge newly approved minimumReleaseAgeExclude entries in the workspace-manifest writer, where the project-local values are available, instead of merging against the fully cascaded Config. This prevents user-global exclusions from being serialized into project manifests while preserving their effect during resolution. Route audit-fix persistence through the same local merge.

Fixes pnpm/pnpm#14347.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The TypeScript CLI already implements the correct local merge; this change restores parity in the Rust `pnpm` port.
- [x] Added a `pacquet` patch changeset.
- [x] Added regression coverage at the package-manager and workspace-manifest-writer layers.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790785072&installation_model_id=426870&pr_number=14370&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14370&signature=585b372da0559994b2cd4f3a5f47a417380341390492e364ea3578769af9b872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented global `minimumReleaseAgeExclude` entries from being written to the workspace manifest during installation and audit fixes.
  - Preserved project-local exclusions while correctly merging newly added package version rules.

- **Tests**
  - Added coverage verifying that global exclusions are omitted and local exclusions are retained in the workspace manifest.

- **Documentation**
  - Documented the corrected workspace manifest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->