### PR TITLE
fix: link runtimes before dependency scripts

### DIFF
--- a/.changeset/calm-runtimes-build.md
+++ b/.changeset/calm-runtimes-build.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/building.during-install": patch
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-restorer": patch
+"pnpm": patch
+---
+
+Made downloaded runtimes available to dependency lifecycle scripts during installation.

--- a/.changeset/calm-runtimes-build.md
+++ b/.changeset/calm-runtimes-build.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/building.during-install": patch
+"@pnpm/building.during-install": minor
 "@pnpm/installing.deps-installer": patch
 "@pnpm/installing.deps-restorer": patch
 "pnpm": patch

--- a/pnpm/crates/cli/tests/suite/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/suite/install_runtimes.rs
@@ -269,6 +269,61 @@ fn devengines_runtime_with_download_is_installed() {
     assert_installed(&workspace, std::slice::from_ref(&fixture));
 }
 
+#[cfg(unix)]
+#[test]
+fn downloaded_node_runtime_is_available_to_dependency_lifecycle_scripts() {
+    let root = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new();
+    let version = "24.0.0-rc.4";
+    let _mocks = mock_node_release(&mut server, version);
+    let workspace = prepare_workspace(
+        &root,
+        format!(
+            "nodeDownloadMirrors:\n  rc: '{}/'\nallowBuilds:\n  'dependency@file:dependency': true\n",
+            server.url(),
+        )
+        .as_str(),
+    );
+    let dependency = workspace.join("dependency");
+    fs::create_dir(&dependency).unwrap();
+    fs::write(
+        dependency.join("package.json"),
+        json!({
+            "name": "dependency",
+            "version": "1.0.0",
+            "scripts": { "install": "node && printf ran > lifecycle-ran" },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "dependencies": { "dependency": "file:dependency" },
+            "devEngines": {
+                "runtime": { "name": "node", "version": version, "onFail": "download" },
+            },
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let empty_path = root.path().join("empty-path");
+    fs::create_dir(&empty_path).unwrap();
+    std::os::unix::fs::symlink("/bin/sh", empty_path.join("sh")).unwrap();
+
+    command(&workspace).with_env("PATH", &empty_path).with_arg("install").assert().success();
+    let lifecycle_marker = workspace.join("node_modules/dependency/lifecycle-ran");
+    assert!(lifecycle_marker.exists(), "missing lifecycle marker: {lifecycle_marker:?}");
+
+    fs::remove_dir_all(workspace.join("node_modules")).unwrap();
+    command(&workspace)
+        .with_env("PATH", empty_path)
+        .with_args(["install", "--frozen-lockfile", "--offline"])
+        .assert()
+        .success();
+    assert!(lifecycle_marker.exists(), "missing lifecycle marker: {lifecycle_marker:?}");
+}
+
 #[test]
 fn devengines_runtime_without_download_is_not_installed() {
     let root = tempfile::tempdir().unwrap();

--- a/pnpm11/building/during-install/src/index.ts
+++ b/pnpm11/building/during-install/src/index.ts
@@ -7,6 +7,7 @@ import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
 import { getWorkspaceConcurrency } from '@pnpm/config.reader'
 import { skippedOptionalDependencyLogger } from '@pnpm/core-loggers'
 import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
+import { isRuntimeDepPath } from '@pnpm/deps.path'
 import { PnpmError } from '@pnpm/error'
 import { runPostinstallHooks } from '@pnpm/exec.lifecycle'
 import { logger } from '@pnpm/logger'
@@ -423,4 +424,21 @@ export async function linkBinsOfDependencies<T extends string> (
       warn: opts.warn,
     })
   }
+}
+
+export async function linkBinsOfRuntimeDependencies<T extends string> (
+  depNodes: Array<DependenciesGraphNode<T> | undefined>,
+  binPath: string,
+  opts: {
+    extraNodePaths?: string[]
+    preferSymlinkedExecutables?: boolean
+  }
+): Promise<void> {
+  const runtimeNodes = depNodes.filter((dep): dep is DependenciesGraphNode<T> => dep != null && isRuntimeDepPath(dep.depPath))
+  if (runtimeNodes.length === 0) return
+  const pkgs = await Promise.all(runtimeNodes.map(async (dep) => ({
+    location: dep.dir,
+    manifest: ((await dep.fetching?.())?.bundledManifest ?? (await safeReadPackageJsonFromDir(dep.dir))) as DependencyManifest ?? {},
+  })))
+  await linkBinsOfPackages(pkgs, binPath, opts)
 }

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
 import { buildSelectedPkgs } from '@pnpm/building.after-install'
-import { buildModules, type DepsStateCache, linkBinsOfDependencies } from '@pnpm/building.during-install'
+import { buildModules, type DepsStateCache, linkBinsOfDependencies, linkBinsOfRuntimeDependencies } from '@pnpm/building.during-install'
 import { createAllowBuildFunction, isBuildExplicitlyDisallowed } from '@pnpm/building.policy'
 import { mergeCatalogs } from '@pnpm/catalogs.config'
 import { parseCatalogProtocol } from '@pnpm/catalogs.protocol-parser'
@@ -2231,6 +2231,15 @@ const _installInContext: InstallFunction = async (projects, ctx, opts) => {
             ...makeNodePackageMapOption(path.join(ctx.rootModulesDir, PACKAGE_MAP_FILENAME), extraEnv),
           }
         }
+        if (!opts.ignoreScripts && !opts.virtualStoreOnly) {
+          await linkRuntimeBinsOfImporters({
+            dependenciesByProjectId,
+            dependenciesGraph,
+            extraNodePaths: ctx.extraNodePaths,
+            preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+            projects,
+          })
+        }
         // Dependency lifecycle scripts must not run on an unverified lockfile.
         await opts.verifyLockfile?.()
         const ignoredBuildsFromBuild = (await buildModules(dependenciesGraph, rootNodes, {
@@ -2740,6 +2749,25 @@ const installInContext: InstallFunction = async (projects, ctx, opts) => {
 }
 
 const limitLinking = pLimit(16)
+
+async function linkRuntimeBinsOfImporters (opts: {
+  dependenciesByProjectId: Record<string, Map<string, DepPath>>
+  dependenciesGraph: DependenciesGraph
+  extraNodePaths?: string[]
+  preferSymlinkedExecutables?: boolean
+  projects: Array<Pick<ImporterToUpdate, 'binsDir' | 'id'>>
+}): Promise<void> {
+  await Promise.all(opts.projects.map(async (project) => {
+    await linkBinsOfRuntimeDependencies(
+      Array.from(opts.dependenciesByProjectId[project.id].values()).map((depPath) => opts.dependenciesGraph[depPath]),
+      project.binsDir,
+      {
+        extraNodePaths: opts.extraNodePaths,
+        preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+      }
+    )
+  }))
+}
 
 async function linkAllBins (
   depNodes: DependenciesGraphNode[],

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -2756,9 +2756,10 @@ async function linkRuntimeBinsOfImporters (opts: {
   extraNodePaths?: string[]
   preferSymlinkedExecutables?: boolean
   projects: Array<Pick<ImporterToUpdate, 'binsDir' | 'id'>>
-}): Promise<void> {
-  await Promise.all(opts.projects.map(async (project) => {
-    await linkBinsOfRuntimeDependencies(
+}
+): Promise<void> {
+  await Promise.all(opts.projects.map((project) => limitLinking(() =>
+    linkBinsOfRuntimeDependencies(
       Array.from(opts.dependenciesByProjectId[project.id].values()).map((depPath) => opts.dependenciesGraph[depPath]),
       project.binsDir,
       {
@@ -2766,7 +2767,7 @@ async function linkRuntimeBinsOfImporters (opts: {
         preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
       }
     )
-  }))
+  )))
 }
 
 async function linkAllBins (

--- a/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
+++ b/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
@@ -454,31 +454,6 @@ test('installing Node.js runtime, when it is set via the engines field of a depe
   expect(fs.readFileSync('node_modules/@pnpm.e2e/cli-with-node-engine/node-version', 'utf8')).toBe('v22.19.0')
 })
 
-test('downloaded Node.js runtime is available to dependency lifecycle scripts', async () => {
-  const project = prepareEmpty()
-  const manifest = {
-    dependencies: {
-      '@pnpm.e2e/install-script-example': '1.0.0',
-    },
-    devDependencies: {
-      node: 'runtime:22.0.0',
-    },
-  }
-  const opts = {
-    allowBuilds: { '@pnpm.e2e/install-script-example': true },
-    extraEnv: { PATH: '' },
-    fastUnpack: false,
-    scriptShell: process.platform === 'win32' ? process.env.ComSpec : '/bin/sh',
-  }
-
-  await install(manifest, testDefaults(opts))
-  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
-
-  rimrafSync('node_modules')
-  await install(manifest, testDefaults({ ...opts, frozenLockfile: true }))
-  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
-})
-
 test('update --latest keeps a Node.js runtime dependency on the runtime resolver', async () => {
   prepareEmpty()
   const manifest = {

--- a/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
+++ b/pnpm11/installing/deps-installer/test/install/nodeRuntime.ts
@@ -454,6 +454,31 @@ test('installing Node.js runtime, when it is set via the engines field of a depe
   expect(fs.readFileSync('node_modules/@pnpm.e2e/cli-with-node-engine/node-version', 'utf8')).toBe('v22.19.0')
 })
 
+test('downloaded Node.js runtime is available to dependency lifecycle scripts', async () => {
+  const project = prepareEmpty()
+  const manifest = {
+    dependencies: {
+      '@pnpm.e2e/install-script-example': '1.0.0',
+    },
+    devDependencies: {
+      node: 'runtime:22.0.0',
+    },
+  }
+  const opts = {
+    allowBuilds: { '@pnpm.e2e/install-script-example': true },
+    extraEnv: { PATH: '' },
+    fastUnpack: false,
+    scriptShell: process.platform === 'win32' ? process.env.ComSpec : '/bin/sh',
+  }
+
+  await install(manifest, testDefaults(opts))
+  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
+
+  rimrafSync('node_modules')
+  await install(manifest, testDefaults({ ...opts, frozenLockfile: true }))
+  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
+})
+
 test('update --latest keeps a Node.js runtime dependency on the runtime resolver', async () => {
   prepareEmpty()
   const manifest = {

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -2,7 +2,7 @@ import { promises as fs } from 'node:fs'
 import path from 'node:path'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
-import { buildModules } from '@pnpm/building.during-install'
+import { buildModules, linkBinsOfRuntimeDependencies } from '@pnpm/building.during-install'
 import { createAllowBuildFunction, isBuildExplicitlyDisallowed } from '@pnpm/building.policy'
 import {
   LAYOUT_VERSION,
@@ -674,6 +674,15 @@ export async function headlessInstall (opts: HeadlessOptions): Promise<Installat
         ...makeNodePackageMapOption(path.join(rootModulesDir, PACKAGE_MAP_FILENAME), extraEnv),
       }
     }
+    if (!opts.ignoreScripts && !opts.virtualStoreOnly) {
+      await linkRuntimeBinsOfImporters({
+        directDependenciesByImporterId,
+        extraNodePaths: opts.extraNodePaths,
+        graph,
+        preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+        projects: selectedProjects,
+      })
+    }
     // Dependency lifecycle scripts must not run on an unverified lockfile.
     await opts.verifyLockfile?.()
     ignoredBuilds = (await buildModules(graph, Array.from(directNodes), {
@@ -919,6 +928,25 @@ async function linkBinsOfImporter (
     projectManifest: manifest,
     warn,
   })
+}
+
+async function linkRuntimeBinsOfImporters (opts: {
+  directDependenciesByImporterId: DirectDependenciesByImporterId
+  extraNodePaths?: string[]
+  graph: DependenciesGraph
+  preferSymlinkedExecutables?: boolean
+  projects: Project[]
+}): Promise<void> {
+  await Promise.all(opts.projects.map(async (project) => {
+    await linkBinsOfRuntimeDependencies(
+      Object.values(opts.directDependenciesByImporterId[project.id]).map((location) => opts.graph[location]),
+      project.binsDir,
+      {
+        extraNodePaths: opts.extraNodePaths,
+        preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
+      }
+    )
+  }))
 }
 
 async function getRootPackagesToLink (

--- a/pnpm11/installing/deps-restorer/src/index.ts
+++ b/pnpm11/installing/deps-restorer/src/index.ts
@@ -936,9 +936,10 @@ async function linkRuntimeBinsOfImporters (opts: {
   graph: DependenciesGraph
   preferSymlinkedExecutables?: boolean
   projects: Project[]
-}): Promise<void> {
-  await Promise.all(opts.projects.map(async (project) => {
-    await linkBinsOfRuntimeDependencies(
+}
+): Promise<void> {
+  await Promise.all(opts.projects.map((project) => limitLinking(() =>
+    linkBinsOfRuntimeDependencies(
       Object.values(opts.directDependenciesByImporterId[project.id]).map((location) => opts.graph[location]),
       project.binsDir,
       {
@@ -946,7 +947,7 @@ async function linkRuntimeBinsOfImporters (opts: {
         preferSymlinkedExecutables: opts.preferSymlinkedExecutables,
       }
     )
-  }))
+  )))
 }
 
 async function getRootPackagesToLink (

--- a/pnpm11/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm11/pnpm/test/install/nodeRuntime.ts
@@ -16,6 +16,35 @@ test('installing a CLI tool that requires a specific version of Node.js to be in
   expect(fs.readFileSync('node-version', 'utf8')).toBe('v22.19.0')
 })
 
+test('downloaded runtime is available to dependency lifecycle scripts without a system Node.js', async () => {
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/install-script-example': '1.0.0',
+    },
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '22.0.0',
+        onFail: 'download',
+      },
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', {
+    allowBuilds: {
+      '@pnpm.e2e/install-script-example': true,
+    },
+    scriptShell: process.platform === 'win32' ? process.env.ComSpec : '/bin/sh',
+  })
+  const opts = { env: { PATH: '' } }
+
+  await execPnpm(['install'], opts)
+  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
+
+  fs.rmSync('node_modules', { force: true, recursive: true })
+  await execPnpm(['install', '--frozen-lockfile'], opts)
+  project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
+})
+
 test('a devEngines.runtime is never promoted into a catalog under catalogMode=strict', async () => {
   const project = prepare({
     devEngines: {

--- a/pnpm11/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm11/pnpm/test/install/nodeRuntime.ts
@@ -37,15 +37,15 @@ test('downloaded runtime is available to dependency lifecycle scripts without a 
   })
   const opts = { env: { PATH: '' } }
 
-  await execPnpm(['install', '--ignore-scripts'])
+  await execPnpm(['install', '--ignore-scripts', '--virtual-store-dir=.pnpm'])
   fs.rmSync('node_modules', { force: true, recursive: true })
   fs.rmSync('pnpm-lock.yaml', { force: true })
 
-  await execPnpm(['install'], opts)
+  await execPnpm(['install', '--prefer-offline', '--virtual-store-dir=.pnpm'], opts)
   project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
 
   fs.rmSync('node_modules', { force: true, recursive: true })
-  await execPnpm(['install', '--frozen-lockfile'], opts)
+  await execPnpm(['install', '--frozen-lockfile', '--prefer-offline', '--virtual-store-dir=.pnpm'], opts)
   project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
 })
 

--- a/pnpm11/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm11/pnpm/test/install/nodeRuntime.ts
@@ -37,6 +37,10 @@ test('downloaded runtime is available to dependency lifecycle scripts without a 
   })
   const opts = { env: { PATH: '' } }
 
+  await execPnpm(['install', '--ignore-scripts'])
+  fs.rmSync('node_modules', { force: true, recursive: true })
+  fs.rmSync('pnpm-lock.yaml', { force: true })
+
   await execPnpm(['install'], opts)
   project.has('@pnpm.e2e/install-script-example/generated-by-install.js')
 

--- a/pnpm11/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm11/pnpm/test/install/nodeRuntime.ts
@@ -24,7 +24,7 @@ test('downloaded runtime is available to dependency lifecycle scripts without a 
     devEngines: {
       runtime: {
         name: 'node',
-        version: '22.0.0',
+        version: '22.19.0',
         onFail: 'download',
       },
     },

--- a/pnpm11/pnpm/test/install/nodeRuntime.ts
+++ b/pnpm11/pnpm/test/install/nodeRuntime.ts
@@ -7,6 +7,8 @@ import { writeYamlFileSync } from 'write-yaml-file'
 
 import { execPnpm } from '../utils/index.js'
 
+const skipOnWindows = process.platform === 'win32' ? test.skip : test
+
 test('installing a CLI tool that requires a specific version of Node.js to be installed alongside it', async () => {
   prepare()
   fs.writeFileSync('pnpm-workspace.yaml', 'allowBuilds: { "@pnpm.e2e/cli-with-node-engine@1.0.0": true }', 'utf8')
@@ -16,7 +18,7 @@ test('installing a CLI tool that requires a specific version of Node.js to be in
   expect(fs.readFileSync('node-version', 'utf8')).toBe('v22.19.0')
 })
 
-test('downloaded runtime is available to dependency lifecycle scripts without a system Node.js', async () => {
+skipOnWindows('downloaded runtime is available to dependency lifecycle scripts without a system Node.js', async () => {
   const project = prepare({
     dependencies: {
       '@pnpm.e2e/install-script-example': '1.0.0',


### PR DESCRIPTION
## Summary

- Link downloaded runtime binaries into each importer before dependency lifecycle scripts run in both fresh and frozen TypeScript install paths.
- Add Node-free lifecycle-script regressions for the TypeScript CLI and pacquet. Pacquet already had the required ordering, so it needs test coverage only.
- Add a minor changeset for the newly exported building API and patch changesets for the installers and CLI.

Fixes pnpm/pnpm#14358.

## Squash Commit Body

```text
The pnpm container image intentionally omits a system Node.js installation and relies on project-pinned downloaded runtimes. The TypeScript installer imported the runtime package before dependency builds but linked its binary into the importer only after those builds, so sibling lifecycle scripts could fail with `node: not found`.

Link only direct runtime dependency bins before scheduling dependency lifecycle scripts. Apply the same ordering to fresh and frozen installs while leaving the normal final bin-linking pass unchanged. Pacquet already links importer bins before dependency builds; add an equivalent regression to preserve parity.

Fixes pnpm/pnpm#14358.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users; it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790786228&installation_model_id=426870&pr_number=14371&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14371&signature=62bbc84b5661e7e0c7481abe9f14987280d336dd062f24ca22ae218a0c58901c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Downloaded Node.js runtimes are now available to dependency lifecycle scripts during installation, even when Node.js is not present on the system `PATH`.
  * Runtime-provided executables are correctly linked for dependency installation scripts.
  * Reinstallations using a frozen lockfile retain access to downloaded runtimes.

* **Tests**
  * Added coverage for fresh and offline reinstall scenarios involving downloaded Node.js runtimes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->