### PR TITLE
fix(lockfile): publish env document updates through the hardened writer

### DIFF
--- a/.changeset/harden-env-lockfile-writes.md
+++ b/.changeset/harden-env-lockfile-writes.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/lockfile.fs": patch
+"pnpm": patch
+---
+
+Writes that replace the env document of `pnpm-lock.yaml` — the leading document recording config dependencies — now publish through the same hardened writer as the rest of the lockfile, so a symlink appearing at the lockfile's path while the write is in flight can no longer redirect it onto the link's target.

--- a/.changeset/harden-env-lockfile-writes.md
+++ b/.changeset/harden-env-lockfile-writes.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-Writes that replace the env document of `pnpm-lock.yaml` — the leading document recording config dependencies — now publish through the same hardened writer as the rest of the lockfile, so a symlink appearing at the lockfile's path while the write is in flight can no longer redirect it onto the link's target.
+`pnpm install` no longer lets a symlink swapped into the path of `pnpm-lock.yaml` during a config dependency update redirect the lockfile write to the symlink target [pnpm/pnpm#14322](https://github.com/pnpm/pnpm/issues/14322).

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -3,11 +3,16 @@ import path from 'node:path'
 import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
 import type { EnvLockfile } from '@pnpm/lockfile.types'
 import yaml from 'js-yaml'
-import writeFileAtomic from 'write-file-atomic'
 
 import { sortLockfileKeys } from './sortLockfileKeys.js'
-import { lockfileYamlDump } from './write.js'
-import { extractMainDocument, readLockfileToStringNoFollow, streamReadFirstYamlDocument } from './yamlDocuments.js'
+import { lockfileYamlDump, writeWantedLockfileAtomic } from './write.js'
+import {
+  extractMainDocument,
+  readLockfileToStringNoFollow,
+  streamReadFirstYamlDocument,
+  YAML_DOCUMENT_SEPARATOR,
+  YAML_DOCUMENT_START,
+} from './yamlDocuments.js'
 
 export function createEnvLockfile (): EnvLockfile {
   return {
@@ -54,6 +59,12 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
   return envLockfile
 }
 
+/**
+ * Replaces the env document that leads `pnpm-lock.yaml`, preserving the main
+ * document after it. Publishes through the same writer as the main document, so
+ * a symlink appearing at the path between the read below and the write cannot
+ * redirect it onto the link's target.
+ */
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)
   const sorted = sortLockfileKeys(lockfile)
@@ -62,6 +73,6 @@ export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile):
   const existing = await readLockfileToStringNoFollow(lockfilePath)
   const mainDoc = existing == null ? '' : extractMainDocument(existing)
 
-  const combined = `---\n${envYaml}\n---\n${mainDoc}`
-  return writeFileAtomic(lockfilePath, combined)
+  const combined = `${YAML_DOCUMENT_START}${envYaml}${YAML_DOCUMENT_SEPARATOR}${mainDoc}`
+  await writeWantedLockfileAtomic(lockfilePath, combined)
 }

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -60,10 +60,10 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
 }
 
 /**
- * Replaces the env document that leads `pnpm-lock.yaml`, preserving the main
- * document after it. Publishes through the same writer as the main document, so
- * a symlink appearing at the path between the read below and the write cannot
- * redirect it onto the link's target.
+ * Replaces the env document that leads `pnpm-lock.yaml` and keeps the main
+ * document after it; a missing lockfile gets an env-only document. Refuses a
+ * symlinked lockfile with `LOCKFILE_IS_SYMLINK`, both when reading the main
+ * document and again when publishing through {@link writeWantedLockfileAtomic}.
  */
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -60,10 +60,8 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
 }
 
 /**
- * Replaces the env document that leads `pnpm-lock.yaml` and keeps the main
- * document after it; a missing lockfile gets an env-only document. Refuses a
- * symlinked lockfile with `LOCKFILE_IS_SYMLINK`, both when reading the main
- * document and again when publishing through {@link writeWantedLockfileAtomic}.
+ * Replaces the env document that leads `pnpm-lock.yaml` while preserving its
+ * main document. Refuses to replace a symlinked lockfile.
  */
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -102,9 +102,15 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
 }
 
 /**
+ * Replaces the file at `lockfilePath` with `content`: the bytes go to a
+ * temporary file in the same directory, which inherits the mode and ownership
+ * of the file it replaces and is removed again if publishing fails. Rejects
+ * with `LOCKFILE_IS_SYMLINK` when the path is a symlink, checked up front and
+ * again right before publishing.
+ *
  * Publishes with `rename`, not the `write-file-atomic` used elsewhere here:
  * `rename` never resolves the final path component, so a symlink swapped in
- * after {@link ensureLockfileIsNotSymlink} cannot redirect the write.
+ * after the last check cannot redirect the write.
  */
 export async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -102,15 +102,9 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
 }
 
 /**
- * Replaces the file at `lockfilePath` with `content`: the bytes go to a
- * temporary file in the same directory, which inherits the mode and ownership
- * of the file it replaces and is removed again if publishing fails. Rejects
- * with `LOCKFILE_IS_SYMLINK` when the path is a symlink, checked up front and
- * again right before publishing.
- *
  * Publishes with `rename`, not the `write-file-atomic` used elsewhere here:
  * `rename` never resolves the final path component, so a symlink swapped in
- * after the last check cannot redirect the write.
+ * after {@link ensureLockfileIsNotSymlink} cannot redirect the write.
  */
 export async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)

--- a/pnpm11/lockfile/fs/src/write.ts
+++ b/pnpm11/lockfile/fs/src/write.ts
@@ -106,7 +106,7 @@ async function writeLockfileDoc (lockfilePath: string, lockfileName: string, mai
  * `rename` never resolves the final path component, so a symlink swapped in
  * after {@link ensureLockfileIsNotSymlink} cannot redirect the write.
  */
-async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
+export async function writeWantedLockfileAtomic (lockfilePath: string, content: string): Promise<void> {
   await ensureLockfileIsNotSymlink(lockfilePath)
   const targetStat = await fs.lstat(lockfilePath).catch((error: NodeJS.ErrnoException) => {
     if (error.code === 'ENOENT') return undefined

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -41,8 +41,8 @@ test('writeEnvLockfile keeps the main document after the env document it replace
   await writeEnvLockfile(dir, envLockfileWithConfigDep())
 
   const written = fs.readFileSync(lockfilePath, 'utf8')
-  // Pins both document markers this writer emits: `extractMainDocument` only
-  // returns the tail when the separator sits where it did before.
+  // `extractMainDocument` returns the tail only when a separator follows the
+  // env document, so the two assertions pin both markers this writer emits.
   expect(written.startsWith('---\n')).toBe(true)
   expect(extractMainDocument(written)).toBe(mainDoc)
   expect(written).toContain('my-config')

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { createEnvLockfile, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
+import { createEnvLockfile, extractMainDocument, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { temporaryDirectory } from 'tempy'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
@@ -30,4 +30,53 @@ testOnNonWindows('writeEnvLockfile rejects a symlinked lockfile without touching
 
   expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true)
   expect(fs.readFileSync(realLockfile, 'utf8')).toBe('target content')
+})
+
+function envLockfileWithConfigDep () {
+  const lockfile = createEnvLockfile()
+  lockfile.importers['.'].configDependencies = {
+    'my-config': { specifier: '^1.0.0', version: '1.0.0' },
+  }
+  return lockfile
+}
+
+test('writeEnvLockfile keeps the main document after the env document it replaces', async () => {
+  const dir = temporaryDirectory()
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  const mainDoc = "lockfileVersion: '9.0'\nsettings:\n  autoInstallPeers: true\n"
+  fs.writeFileSync(lockfilePath, `---\nlockfileVersion: '9.0'\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n\n---\n${mainDoc}`)
+
+  await writeEnvLockfile(dir, envLockfileWithConfigDep())
+
+  const written = fs.readFileSync(lockfilePath, 'utf8')
+  expect(extractMainDocument(written)).toBe(mainDoc)
+  expect(written).toContain('my-config')
+  await expect(readEnvLockfile(dir)).resolves.toMatchObject({
+    importers: { '.': { configDependencies: { 'my-config': { version: '1.0.0' } } } },
+  })
+})
+
+test('writeEnvLockfile leaves no temporary file behind', async () => {
+  const dir = temporaryDirectory()
+
+  await writeEnvLockfile(dir, envLockfileWithConfigDep())
+
+  expect(fs.readdirSync(dir)).toStrictEqual([WANTED_LOCKFILE])
+})
+
+// The replacement is a fresh file, so its mode has to be restored explicitly:
+// creating it honours the umask, which would strip bits the lockfile carried.
+testOnNonWindows('writeEnvLockfile preserves the lockfile mode against the umask', async () => {
+  const dir = temporaryDirectory()
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  await writeEnvLockfile(dir, createEnvLockfile())
+  fs.chmodSync(lockfilePath, 0o666)
+  const previousUmask = process.umask(0o022)
+  try {
+    await writeEnvLockfile(dir, envLockfileWithConfigDep())
+  } finally {
+    process.umask(previousUmask)
+  }
+
+  expect(fs.statSync(lockfilePath).mode & 0o777).toBe(0o666)
 })

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -32,14 +32,6 @@ testOnNonWindows('writeEnvLockfile rejects a symlinked lockfile without touching
   expect(fs.readFileSync(realLockfile, 'utf8')).toBe('target content')
 })
 
-function envLockfileWithConfigDep () {
-  const lockfile = createEnvLockfile()
-  lockfile.importers['.'].configDependencies = {
-    'my-config': { specifier: '^1.0.0', version: '1.0.0' },
-  }
-  return lockfile
-}
-
 test('writeEnvLockfile keeps the main document after the env document it replaces', async () => {
   const dir = temporaryDirectory()
   const lockfilePath = path.join(dir, WANTED_LOCKFILE)
@@ -80,3 +72,11 @@ testOnNonWindows('writeEnvLockfile preserves the lockfile mode against the umask
 
   expect(fs.statSync(lockfilePath).mode & 0o777).toBe(0o666)
 })
+
+function envLockfileWithConfigDep () {
+  const lockfile = createEnvLockfile()
+  lockfile.importers['.'].configDependencies = {
+    'my-config': { specifier: '^1.0.0', version: '1.0.0' },
+  }
+  return lockfile
+}

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -41,6 +41,9 @@ test('writeEnvLockfile keeps the main document after the env document it replace
   await writeEnvLockfile(dir, envLockfileWithConfigDep())
 
   const written = fs.readFileSync(lockfilePath, 'utf8')
+  // Pins both document markers this writer emits: `extractMainDocument` only
+  // returns the tail when the separator sits where it did before.
+  expect(written.startsWith('---\n')).toBe(true)
   expect(extractMainDocument(written)).toBe(mainDoc)
   expect(written).toContain('my-config')
   await expect(readEnvLockfile(dir)).resolves.toMatchObject({

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -1,9 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { createEnvLockfile, extractMainDocument, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
+import { createEnvLockfile, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { temporaryDirectory } from 'tempy'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
@@ -32,6 +32,34 @@ testOnNonWindows('writeEnvLockfile rejects a symlinked lockfile without touching
   expect(fs.readFileSync(realLockfile, 'utf8')).toBe('target content')
 })
 
+testOnNonWindows('writeEnvLockfile rejects a symlink inserted while writing without touching the target', async () => {
+  const dir = temporaryDirectory()
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  const originalLockfile = path.join(dir, 'original-lockfile.yaml')
+  const symlinkTarget = path.join(dir, 'symlink-target.yaml')
+  fs.writeFileSync(lockfilePath, "lockfileVersion: '9.0'\n")
+  fs.writeFileSync(symlinkTarget, 'target content')
+  const open = fs.promises.open
+  const openSpy = jest.spyOn(fs.promises, 'open').mockImplementation(async (filePath, flags, mode) => {
+    const fileHandle = await open(filePath, flags, mode)
+    if (String(filePath).endsWith('.tmp')) {
+      fs.renameSync(lockfilePath, originalLockfile)
+      fs.symlinkSync(symlinkTarget, lockfilePath, 'file')
+    }
+    return fileHandle
+  })
+
+  try {
+    await expect(writeEnvLockfile(dir, createEnvLockfile())).rejects.toThrow(/symlinked lockfile/)
+  } finally {
+    openSpy.mockRestore()
+  }
+
+  expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(symlinkTarget, 'utf8')).toBe('target content')
+  expect(fs.readdirSync(dir).some((name) => name.endsWith('.tmp'))).toBe(false)
+})
+
 test('writeEnvLockfile keeps the main document after the env document it replaces', async () => {
   const dir = temporaryDirectory()
   const lockfilePath = path.join(dir, WANTED_LOCKFILE)
@@ -41,11 +69,23 @@ test('writeEnvLockfile keeps the main document after the env document it replace
   await writeEnvLockfile(dir, envLockfileWithConfigDep())
 
   const written = fs.readFileSync(lockfilePath, 'utf8')
-  // `extractMainDocument` returns the tail only when a separator follows the
-  // env document, so the two assertions pin both markers this writer emits.
-  expect(written.startsWith('---\n')).toBe(true)
-  expect(extractMainDocument(written)).toBe(mainDoc)
-  expect(written).toContain('my-config')
+  expect(written).toBe(`---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies:
+      my-config:
+        specifier: ^1.0.0
+        version: 1.0.0
+
+packages: {}
+
+snapshots: {}
+
+---
+${mainDoc}`)
   await expect(readEnvLockfile(dir)).resolves.toMatchObject({
     importers: { '.': { configDependencies: { 'my-config': { version: '1.0.0' } } } },
   })
@@ -59,8 +99,6 @@ test('writeEnvLockfile leaves no temporary file behind', async () => {
   expect(fs.readdirSync(dir)).toStrictEqual([WANTED_LOCKFILE])
 })
 
-// The replacement is a fresh file, so its mode has to be restored explicitly:
-// creating it honours the umask, which would strip bits the lockfile carried.
 testOnNonWindows('writeEnvLockfile preserves the lockfile mode against the umask', async () => {
   const dir = temporaryDirectory()
   const lockfilePath = path.join(dir, WANTED_LOCKFILE)


### PR DESCRIPTION
## Summary

`writeEnvLockfile()` read `pnpm-lock.yaml` without following a symlink, but then passed the combined YAML to `write-file-atomic`. That package resolves the target with `realpath`, so a symlink swapped into the lockfile path after the read could redirect the write to the link target.

This PR routes env document updates through the hardened writer already used for main lockfile updates. The writer checks the path again immediately before publishing and uses `rename`, which replaces the final path entry without following it. The YAML document markers now use the shared constants without changing the emitted bytes.

A deterministic regression test swaps in a symlink after the temporary file is opened. It verifies that publication rejects, leaves the symlink target untouched, and removes the temporary file.

No pnpm v12 change is needed. `EnvLockfile::write` already uses `pnpm_fs::write_atomic`, which publishes a same-directory temporary file with `rename` and does not follow the final symlink.

Closes pnpm/pnpm#14322

## Squash Commit Body

```text
writeEnvLockfile() handed the combined YAML to write-file-atomic, which
resolves the final path component with realpath. A symlink appearing at
the lockfile path after the no-follow read could therefore redirect the
write to the link target.

Use writeWantedLockfileAtomic(), which is already used for main lockfile
document updates. It checks the path again immediately before publishing
and then renames a same-directory temporary file over the path. Rename
replaces the final path entry without following it.

Use the shared YAML document marker constants without changing the emitted
bytes. Add deterministic coverage for the symlink-swap window, complete
serialized output, metadata preservation, and temporary-file cleanup.

No pnpm v12 port is needed because EnvLockfile::write already publishes
through pnpm_fs::write_atomic.

Closes pnpm/pnpm#14322
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

## Testing

- `pnpm --filter @pnpm/lockfile.fs test`: 9 suites and 80 tests passed.
- Pre-push TypeScript compilation, v11 CLI bundling, lint, spellcheck, and metadata validation passed.

---
Written by an agent (Codex, GPT-5).
