### PR TITLE
fix: authenticate node.js mirror downloads

### DIFF
--- a/.changeset/authenticated-node-mirrors.md
+++ b/.changeset/authenticated-node-mirrors.md
@@ -5,6 +5,7 @@
 "@pnpm/fetching.binary-fetcher": patch
 "@pnpm/fetching.tarball-fetcher": patch
 "@pnpm/installing.client": patch
+"@pnpm/network.fetch": patch
 "@pnpm/resolving.default-resolver": patch
 "pacquet": patch
 "pnpm": patch

--- a/.changeset/authenticated-node-mirrors.md
+++ b/.changeset/authenticated-node-mirrors.md
@@ -1,8 +1,9 @@
 ---
 "@pnpm/crypto.shasums-file": patch
 "@pnpm/engine.runtime.commands": patch
-"@pnpm/engine.runtime.node-resolver": patch
+"@pnpm/engine.runtime.node-resolver": minor
 "@pnpm/fetching.binary-fetcher": patch
+"@pnpm/fetching.tarball-fetcher": patch
 "@pnpm/installing.client": patch
 "@pnpm/resolving.default-resolver": patch
 "pacquet": patch

--- a/.changeset/authenticated-node-mirrors.md
+++ b/.changeset/authenticated-node-mirrors.md
@@ -1,4 +1,5 @@
 ---
+"@pnpm/crypto.shasums-file": patch
 "@pnpm/engine.runtime.commands": patch
 "@pnpm/engine.runtime.node-resolver": patch
 "@pnpm/fetching.binary-fetcher": patch

--- a/.changeset/authenticated-node-mirrors.md
+++ b/.changeset/authenticated-node-mirrors.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/engine.runtime.commands": patch
+"@pnpm/engine.runtime.node-resolver": patch
+"@pnpm/fetching.binary-fetcher": patch
+"@pnpm/installing.client": patch
+"@pnpm/resolving.default-resolver": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Authenticate Node.js runtime downloads from `nodeDownloadMirrors` with URL-scoped npm registry credentials, including bearer tokens, basic auth, and `tokenHelper` [pnpm/pnpm#14334](https://github.com/pnpm/pnpm/issues/14334).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4071,6 +4071,9 @@ importers:
       '@pnpm/exec.pnpm-cli-runner':
         specifier: workspace:*
         version: link:../../../exec/pnpm-cli-runner
+      '@pnpm/network.auth-header':
+        specifier: workspace:*
+        version: link:../../../network/auth-header
       '@pnpm/network.fetch':
         specifier: workspace:*
         version: link:../../../network/fetch

--- a/pnpm/crates/cli/src/cli_args/env.rs
+++ b/pnpm/crates/cli/src/cli_args/env.rs
@@ -7,7 +7,7 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::Config;
 use pnpm_engine_runtime_node_resolver::{
-    get_node_mirror, parse_node_specifier, resolve_node_versions,
+    get_node_mirror, parse_node_specifier, resolve_node_versions_with_auth,
 };
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::{Reporter, emit_global_warning};
@@ -150,8 +150,9 @@ impl EnvArgs {
         let mirror =
             get_node_mirror(Some(&config.node_download_mirrors), &specifier.release_channel);
         let http_client = build_registry_client(config)?;
-        let mut versions = resolve_node_versions(
+        let mut versions = resolve_node_versions_with_auth(
             &http_client,
+            &config.auth_headers,
             Some(specifier.version_specifier.as_str()),
             Some(&mirror),
         )

--- a/pnpm/crates/cli/tests/suite/install_runtimes.rs
+++ b/pnpm/crates/cli/tests/suite/install_runtimes.rs
@@ -132,6 +132,29 @@ fn installs_node_runtime_from_the_rc_channel() {
     assert!(fs::read_to_string(workspace.join("pnpm-lock.yaml")).unwrap().contains(version));
 }
 
+#[test]
+fn installs_node_runtime_from_an_authenticated_mirror() {
+    let root = tempfile::tempdir().unwrap();
+    let mut server = mockito::Server::new();
+    let version = "24.0.0-rc.4";
+    let _mocks = mock_node_release_with_auth(&mut server, version, Some("Bearer mirror-token"));
+    let workspace = prepare_workspace(
+        &root,
+        format!("nodeDownloadMirrors:\n  rc: '{}/'\n", server.url()).as_str(),
+    );
+    let server_url = server.url();
+    let authority = server_url.trim_start_matches("http:");
+    fs::write(workspace.join(".npmrc"), format!("{authority}/:_authToken=mirror-token\n")).unwrap();
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "dependencies": { "node": format!("runtime:{version}") } }).to_string(),
+    )
+    .unwrap();
+
+    command(&workspace).with_arg("install").assert().success();
+    assert!(workspace.join("node_modules/node/package.json").exists());
+}
+
 /// The registry mock knows no package named "node", so resolving the alias
 /// name there instead of leaving the dependency to the runtime resolver
 /// fails the update.
@@ -616,6 +639,14 @@ fn node_archive_name(version: &str, platform: &str, arch: &str) -> String {
 }
 
 pub(crate) fn mock_node_release(server: &mut mockito::Server, version: &str) -> [mockito::Mock; 3] {
+    mock_node_release_with_auth(server, version, None)
+}
+
+fn mock_node_release_with_auth(
+    server: &mut mockito::Server,
+    version: &str,
+    authorization: Option<&str>,
+) -> [mockito::Mock; 3] {
     let archive_name = node_archive_name(version, host_platform(), host_arch());
     let archive = if host_platform() == "win32" {
         let prefix = archive_name.strip_suffix(".zip").unwrap();
@@ -624,22 +655,30 @@ pub(crate) fn mock_node_release(server: &mut mockito::Server, version: &str) -> 
         build_tarball("node", version, true)
     };
     let digest = format!("{:x}", Sha256::digest(&archive));
-    let index = server
+    let mut index = server
         .mock("GET", "/index.json")
         .with_status(200)
-        .with_body(format!(r#"[{{"version":"v{version}","lts":false}}]"#))
-        .create();
-    let shasums = server
+        .with_body(format!(r#"[{{"version":"v{version}","lts":false}}]"#));
+    if let Some(authorization) = authorization {
+        index = index.match_header("authorization", authorization);
+    }
+    let index = index.create();
+    let mut shasums = server
         .mock("GET", format!("/v{version}/SHASUMS256.txt").as_str())
         .with_status(200)
-        .with_body(format!("{digest}  {archive_name}\n"))
-        .create();
-    let archive = server
+        .with_body(format!("{digest}  {archive_name}\n"));
+    if let Some(authorization) = authorization {
+        shasums = shasums.match_header("authorization", authorization);
+    }
+    let shasums = shasums.create();
+    let mut archive = server
         .mock("GET", format!("/v{version}/{archive_name}").as_str())
         .with_status(200)
-        .with_body(archive)
-        .create();
-    [index, shasums, archive]
+        .with_body(archive);
+    if let Some(authorization) = authorization {
+        archive = archive.match_header("authorization", authorization);
+    }
+    [index, shasums, archive.create()]
 }
 
 fn command(workspace: &Path) -> Command {

--- a/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
+++ b/pnpm/crates/crypto-shasums-file/src/disk_cache.rs
@@ -24,6 +24,8 @@
 //!   before the cache existed), and the musl list's download URLs are
 //!   derived from the hardcoded unofficial-builds base, never from the
 //!   cached body.
+//! - Authenticated responses bypass this cache because the URL does not
+//!   identify the credential context that produced the body.
 //!
 //! The `<trust>` path segment keeps the two classes in disjoint
 //! subtrees so their read policies cannot be confused.

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -237,8 +237,8 @@ pub async fn fetch_verified_node_shasums_file_cached(
 
 /// Like [`fetch_verified_node_shasums_file_cached`], selecting URL-scoped
 /// authorization independently for the body and detached signature.
-/// Authenticated responses bypass the URL-keyed cache so metadata cannot cross
-/// credential boundaries.
+/// Auth-aware fetches bypass the URL-keyed cache so redirects cannot move
+/// metadata across credential boundaries.
 pub async fn fetch_verified_node_shasums_file_cached_with_auth_headers(
     http_client: &ThrottledClient,
     shasums_url: &str,
@@ -261,11 +261,7 @@ async fn fetch_verified_node_shasums_file_cached_inner(
     auth_headers: Option<&AuthHeaders>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
     let signature_url = format!("{shasums_url}.sig");
-    let authenticated = auth_headers.is_some_and(|headers| {
-        headers.for_secure_url(shasums_url).is_some()
-            || headers.for_secure_url(&signature_url).is_some()
-    });
-    let cache_dir = if authenticated { None } else { cache_dir };
+    let cache_dir = if auth_headers.is_some() { None } else { cache_dir };
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
         && let Some(signature) =
             read_cached_bytes(cache_dir, ShasumsTrust::Verified, &signature_url)
@@ -294,8 +290,8 @@ pub async fn fetch_shasums_file_cached(
 }
 
 /// Like [`fetch_shasums_file_cached`], selecting URL-scoped authorization for
-/// the request. Authenticated responses bypass the URL-keyed cache so metadata
-/// cannot cross credential boundaries.
+/// the request. Auth-aware fetches bypass the URL-keyed cache so redirects
+/// cannot move metadata across credential boundaries.
 pub async fn fetch_shasums_file_cached_with_auth_headers(
     http_client: &ThrottledClient,
     shasums_url: &str,
@@ -311,9 +307,7 @@ async fn fetch_shasums_file_cached_inner(
     cache_dir: Option<&Path>,
     auth_headers: Option<&AuthHeaders>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
-    let authenticated =
-        auth_headers.is_some_and(|headers| headers.for_secure_url(shasums_url).is_some());
-    let cache_dir = if authenticated { None } else { cache_dir };
+    let cache_dir = if auth_headers.is_some() { None } else { cache_dir };
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -29,7 +29,7 @@ use pgp::{
     composed::{Deserializable, DetachedSignature, SignedPublicKey},
     types::KeyDetails,
 };
-use pnpm_network::ThrottledClient;
+use pnpm_network::{AuthHeaders, ThrottledClient};
 
 use disk_cache::{ShasumsTrust, read_cached_bytes, read_cached_shasums, write_cached_shasums};
 use node_release_keys::{NODE_RELEASE_KEYS, NodeReleaseKey};
@@ -176,7 +176,7 @@ pub async fn fetch_verified_node_shasums(
     shasums_url: &str,
 ) -> Result<String, FetchVerifiedNodeShasumsError> {
     let (body, _signature) =
-        fetch_verified_node_shasums_with_signature(http_client, shasums_url, None).await?;
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url, None, None).await?;
     Ok(body)
 }
 
@@ -186,14 +186,20 @@ pub async fn fetch_verified_node_shasums(
 async fn fetch_verified_node_shasums_with_signature(
     http_client: &ThrottledClient,
     shasums_url: &str,
-    authorization: Option<&str>,
+    shasums_authorization: Option<&str>,
+    signature_authorization: Option<&str>,
 ) -> Result<(String, Vec<u8>), FetchVerifiedNodeShasumsError> {
     let shasums_bytes =
-        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt", authorization).await?;
-    let signature_url = format!("{shasums_url}.sig");
-    let signature_bytes =
-        fetch_node_shasums_bytes(http_client, &signature_url, "SHASUMS256.txt.sig", authorization)
+        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt", shasums_authorization)
             .await?;
+    let signature_url = format!("{shasums_url}.sig");
+    let signature_bytes = fetch_node_shasums_bytes(
+        http_client,
+        &signature_url,
+        "SHASUMS256.txt.sig",
+        signature_authorization,
+    )
+    .await?;
 
     if !is_signed_by_trusted_node_release_key(&shasums_bytes, &signature_bytes)? {
         return Err(FetchVerifiedNodeShasumsError::SignatureInvalid {
@@ -232,20 +238,45 @@ pub async fn fetch_verified_node_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    fetch_verified_node_shasums_file_cached_with_auth(http_client, shasums_url, cache_dir, None)
+    fetch_verified_node_shasums_file_cached_inner(http_client, shasums_url, cache_dir, None, None)
         .await
 }
 
-/// Like [`fetch_verified_node_shasums_file_cached`], sending the supplied
-/// authorization value. Authenticated responses bypass the URL-keyed cache so
-/// metadata cannot cross credential boundaries.
-pub async fn fetch_verified_node_shasums_file_cached_with_auth(
+/// Like [`fetch_verified_node_shasums_file_cached`], selecting URL-scoped
+/// authorization independently for the body and detached signature.
+/// Authenticated responses bypass the URL-keyed cache so metadata cannot cross
+/// credential boundaries.
+pub async fn fetch_verified_node_shasums_file_cached_with_auth_headers(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
-    authorization: Option<&str>,
+    auth_headers: &AuthHeaders,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    let cache_dir = if authorization.is_some() { None } else { cache_dir };
+    let signature_url = format!("{shasums_url}.sig");
+    let shasums_authorization = auth_headers.for_secure_url(shasums_url);
+    let signature_authorization = auth_headers.for_secure_url(&signature_url);
+    fetch_verified_node_shasums_file_cached_inner(
+        http_client,
+        shasums_url,
+        cache_dir,
+        shasums_authorization.as_deref(),
+        signature_authorization.as_deref(),
+    )
+    .await
+}
+
+async fn fetch_verified_node_shasums_file_cached_inner(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+    shasums_authorization: Option<&str>,
+    signature_authorization: Option<&str>,
+) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
+    let cache_dir = if shasums_authorization.is_some() || signature_authorization.is_some() {
+        None
+    } else {
+        cache_dir
+    };
     let signature_url = format!("{shasums_url}.sig");
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
         && let Some(signature) =
@@ -254,8 +285,13 @@ pub async fn fetch_verified_node_shasums_file_cached_with_auth(
     {
         return Ok(parse_shasums_file(&body));
     }
-    let (body, signature) =
-        fetch_verified_node_shasums_with_signature(http_client, shasums_url, authorization).await?;
+    let (body, signature) = fetch_verified_node_shasums_with_signature(
+        http_client,
+        shasums_url,
+        shasums_authorization,
+        signature_authorization,
+    )
+    .await?;
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, body.as_bytes());
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, &signature_url, &signature);
     Ok(parse_shasums_file(&body))
@@ -271,13 +307,24 @@ pub async fn fetch_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
-    fetch_shasums_file_cached_with_auth(http_client, shasums_url, cache_dir, None).await
+    fetch_shasums_file_cached_inner(http_client, shasums_url, cache_dir, None).await
 }
 
-/// Like [`fetch_shasums_file_cached`], sending the supplied authorization
-/// value. Authenticated responses bypass the URL-keyed cache so metadata
+/// Like [`fetch_shasums_file_cached`], selecting URL-scoped authorization for
+/// the request. Authenticated responses bypass the URL-keyed cache so metadata
 /// cannot cross credential boundaries.
-pub async fn fetch_shasums_file_cached_with_auth(
+pub async fn fetch_shasums_file_cached_with_auth_headers(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+    auth_headers: &AuthHeaders,
+) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
+    let authorization = auth_headers.for_secure_url(shasums_url);
+    fetch_shasums_file_cached_inner(http_client, shasums_url, cache_dir, authorization.as_deref())
+        .await
+}
+
+async fn fetch_shasums_file_cached_inner(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -237,13 +237,15 @@ pub async fn fetch_verified_node_shasums_file_cached(
 }
 
 /// Like [`fetch_verified_node_shasums_file_cached`], sending the supplied
-/// authorization value when the cache misses.
+/// authorization value. Authenticated responses bypass the URL-keyed cache so
+/// metadata cannot cross credential boundaries.
 pub async fn fetch_verified_node_shasums_file_cached_with_auth(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
     authorization: Option<&str>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
+    let cache_dir = if authorization.is_some() { None } else { cache_dir };
     let signature_url = format!("{shasums_url}.sig");
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
         && let Some(signature) =
@@ -273,13 +275,15 @@ pub async fn fetch_shasums_file_cached(
 }
 
 /// Like [`fetch_shasums_file_cached`], sending the supplied authorization
-/// value when the cache misses.
+/// value. Authenticated responses bypass the URL-keyed cache so metadata
+/// cannot cross credential boundaries.
 pub async fn fetch_shasums_file_cached_with_auth(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
     authorization: Option<&str>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
+    let cache_dir = if authorization.is_some() { None } else { cache_dir };
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -176,7 +176,7 @@ pub async fn fetch_verified_node_shasums(
     shasums_url: &str,
 ) -> Result<String, FetchVerifiedNodeShasumsError> {
     let (body, _signature) =
-        fetch_verified_node_shasums_with_signature(http_client, shasums_url, None, None).await?;
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url, None).await?;
     Ok(body)
 }
 
@@ -186,20 +186,14 @@ pub async fn fetch_verified_node_shasums(
 async fn fetch_verified_node_shasums_with_signature(
     http_client: &ThrottledClient,
     shasums_url: &str,
-    shasums_authorization: Option<&str>,
-    signature_authorization: Option<&str>,
+    auth_headers: Option<&AuthHeaders>,
 ) -> Result<(String, Vec<u8>), FetchVerifiedNodeShasumsError> {
     let shasums_bytes =
-        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt", shasums_authorization)
-            .await?;
+        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt", auth_headers).await?;
     let signature_url = format!("{shasums_url}.sig");
-    let signature_bytes = fetch_node_shasums_bytes(
-        http_client,
-        &signature_url,
-        "SHASUMS256.txt.sig",
-        signature_authorization,
-    )
-    .await?;
+    let signature_bytes =
+        fetch_node_shasums_bytes(http_client, &signature_url, "SHASUMS256.txt.sig", auth_headers)
+            .await?;
 
     if !is_signed_by_trusted_node_release_key(&shasums_bytes, &signature_bytes)? {
         return Err(FetchVerifiedNodeShasumsError::SignatureInvalid {
@@ -238,8 +232,7 @@ pub async fn fetch_verified_node_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    fetch_verified_node_shasums_file_cached_inner(http_client, shasums_url, cache_dir, None, None)
-        .await
+    fetch_verified_node_shasums_file_cached_inner(http_client, shasums_url, cache_dir, None).await
 }
 
 /// Like [`fetch_verified_node_shasums_file_cached`], selecting URL-scoped
@@ -252,15 +245,11 @@ pub async fn fetch_verified_node_shasums_file_cached_with_auth_headers(
     cache_dir: Option<&Path>,
     auth_headers: &AuthHeaders,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    let signature_url = format!("{shasums_url}.sig");
-    let shasums_authorization = auth_headers.for_secure_url(shasums_url);
-    let signature_authorization = auth_headers.for_secure_url(&signature_url);
     fetch_verified_node_shasums_file_cached_inner(
         http_client,
         shasums_url,
         cache_dir,
-        shasums_authorization.as_deref(),
-        signature_authorization.as_deref(),
+        Some(auth_headers),
     )
     .await
 }
@@ -269,15 +258,14 @@ async fn fetch_verified_node_shasums_file_cached_inner(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
-    shasums_authorization: Option<&str>,
-    signature_authorization: Option<&str>,
+    auth_headers: Option<&AuthHeaders>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
-    let cache_dir = if shasums_authorization.is_some() || signature_authorization.is_some() {
-        None
-    } else {
-        cache_dir
-    };
     let signature_url = format!("{shasums_url}.sig");
+    let authenticated = auth_headers.is_some_and(|headers| {
+        headers.for_secure_url(shasums_url).is_some()
+            || headers.for_secure_url(&signature_url).is_some()
+    });
+    let cache_dir = if authenticated { None } else { cache_dir };
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
         && let Some(signature) =
             read_cached_bytes(cache_dir, ShasumsTrust::Verified, &signature_url)
@@ -285,13 +273,8 @@ async fn fetch_verified_node_shasums_file_cached_inner(
     {
         return Ok(parse_shasums_file(&body));
     }
-    let (body, signature) = fetch_verified_node_shasums_with_signature(
-        http_client,
-        shasums_url,
-        shasums_authorization,
-        signature_authorization,
-    )
-    .await?;
+    let (body, signature) =
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url, auth_headers).await?;
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, body.as_bytes());
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, &signature_url, &signature);
     Ok(parse_shasums_file(&body))
@@ -319,22 +302,22 @@ pub async fn fetch_shasums_file_cached_with_auth_headers(
     cache_dir: Option<&Path>,
     auth_headers: &AuthHeaders,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
-    let authorization = auth_headers.for_secure_url(shasums_url);
-    fetch_shasums_file_cached_inner(http_client, shasums_url, cache_dir, authorization.as_deref())
-        .await
+    fetch_shasums_file_cached_inner(http_client, shasums_url, cache_dir, Some(auth_headers)).await
 }
 
 async fn fetch_shasums_file_cached_inner(
     http_client: &ThrottledClient,
     shasums_url: &str,
     cache_dir: Option<&Path>,
-    authorization: Option<&str>,
+    auth_headers: Option<&AuthHeaders>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
-    let cache_dir = if authorization.is_some() { None } else { cache_dir };
+    let authenticated =
+        auth_headers.is_some_and(|headers| headers.for_secure_url(shasums_url).is_some());
+    let cache_dir = if authenticated { None } else { cache_dir };
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }
-    let body = fetch_shasums_file_raw_with_auth(http_client, shasums_url, authorization).await?;
+    let body = fetch_shasums_file_raw_with_auth(http_client, shasums_url, auth_headers).await?;
     write_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url, body.as_bytes());
     Ok(parse_shasums_file(&body))
 }
@@ -352,58 +335,83 @@ pub async fn fetch_shasums_file_raw(
 async fn fetch_shasums_file_raw_with_auth(
     http_client: &ThrottledClient,
     shasums_url: &str,
-    authorization: Option<&str>,
+    auth_headers: Option<&AuthHeaders>,
 ) -> Result<String, FetchShasumsFileError> {
-    let mut request = http_client.acquire_for_url(shasums_url).await.get(shasums_url);
-    if let Some(authorization) = authorization {
-        request = request.header("authorization", authorization);
-    }
-    let response = request.send().await.map_err(|error| FetchShasumsFileError::Network {
-        url: shasums_url.to_string(),
-        error: Arc::new(error),
-    })?;
-    if !response.status().is_success() {
+    let (status, body) = if let Some(auth_headers) = auth_headers {
+        let response = http_client
+            .get_bytes_with_secure_auth_headers(shasums_url, auth_headers)
+            .await
+            .map_err(|error| FetchShasumsFileError::Network {
+                url: shasums_url.to_string(),
+                error: Arc::new(error),
+            })?;
+        (response.status, response.body)
+    } else {
+        let response =
+            http_client.acquire_for_url(shasums_url).await.get(shasums_url).send().await.map_err(
+                |error| FetchShasumsFileError::Network {
+                    url: shasums_url.to_string(),
+                    error: Arc::new(error),
+                },
+            )?;
+        let status = response.status();
+        let body = response.bytes().await.map_err(|error| FetchShasumsFileError::Network {
+            url: shasums_url.to_string(),
+            error: Arc::new(error),
+        })?;
+        (status, body.to_vec())
+    };
+    if !status.is_success() {
         return Err(FetchShasumsFileError::StatusNotOk {
             url: shasums_url.to_string(),
-            status: response.status().as_u16(),
+            status: status.as_u16(),
         });
     }
-    response.text().await.map_err(|error| FetchShasumsFileError::Network {
-        url: shasums_url.to_string(),
-        error: Arc::new(error),
-    })
+    Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
 async fn fetch_node_shasums_bytes(
     http_client: &ThrottledClient,
     url: &str,
     what: &'static str,
-    authorization: Option<&str>,
+    auth_headers: Option<&AuthHeaders>,
 ) -> Result<Vec<u8>, FetchVerifiedNodeShasumsError> {
-    let mut request = http_client.acquire_for_url(url).await.get(url);
-    if let Some(authorization) = authorization {
-        request = request.header("authorization", authorization);
-    }
-    let response =
-        request.send().await.map_err(|error| FetchVerifiedNodeShasumsError::Network {
-            what,
-            url: url.to_string(),
-            error: Arc::new(error),
-        })?;
-    if !response.status().is_success() {
+    let (status, body) = if let Some(auth_headers) = auth_headers {
+        let response = http_client
+            .get_bytes_with_secure_auth_headers(url, auth_headers)
+            .await
+            .map_err(|error| FetchVerifiedNodeShasumsError::Network {
+                what,
+                url: url.to_string(),
+                error: Arc::new(error),
+            })?;
+        (response.status, response.body)
+    } else {
+        let response =
+            http_client.acquire_for_url(url).await.get(url).send().await.map_err(|error| {
+                FetchVerifiedNodeShasumsError::Network {
+                    what,
+                    url: url.to_string(),
+                    error: Arc::new(error),
+                }
+            })?;
+        let status = response.status();
+        let body =
+            response.bytes().await.map_err(|error| FetchVerifiedNodeShasumsError::Network {
+                what,
+                url: url.to_string(),
+                error: Arc::new(error),
+            })?;
+        (status, body.to_vec())
+    };
+    if !status.is_success() {
         return Err(FetchVerifiedNodeShasumsError::StatusNotOk {
             what,
             url: url.to_string(),
-            status: response.status().as_u16(),
+            status: status.as_u16(),
         });
     }
-    response.bytes().await.map(|bytes| bytes.to_vec()).map_err(|error| {
-        FetchVerifiedNodeShasumsError::Network {
-            what,
-            url: url.to_string(),
-            error: Arc::new(error),
-        }
-    })
+    Ok(body)
 }
 
 fn is_signed_by_trusted_node_release_key(

--- a/pnpm/crates/crypto-shasums-file/src/lib.rs
+++ b/pnpm/crates/crypto-shasums-file/src/lib.rs
@@ -176,7 +176,7 @@ pub async fn fetch_verified_node_shasums(
     shasums_url: &str,
 ) -> Result<String, FetchVerifiedNodeShasumsError> {
     let (body, _signature) =
-        fetch_verified_node_shasums_with_signature(http_client, shasums_url).await?;
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url, None).await?;
     Ok(body)
 }
 
@@ -186,12 +186,14 @@ pub async fn fetch_verified_node_shasums(
 async fn fetch_verified_node_shasums_with_signature(
     http_client: &ThrottledClient,
     shasums_url: &str,
+    authorization: Option<&str>,
 ) -> Result<(String, Vec<u8>), FetchVerifiedNodeShasumsError> {
     let shasums_bytes =
-        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt").await?;
+        fetch_node_shasums_bytes(http_client, shasums_url, "SHASUMS256.txt", authorization).await?;
     let signature_url = format!("{shasums_url}.sig");
     let signature_bytes =
-        fetch_node_shasums_bytes(http_client, &signature_url, "SHASUMS256.txt.sig").await?;
+        fetch_node_shasums_bytes(http_client, &signature_url, "SHASUMS256.txt.sig", authorization)
+            .await?;
 
     if !is_signed_by_trusted_node_release_key(&shasums_bytes, &signature_bytes)? {
         return Err(FetchVerifiedNodeShasumsError::SignatureInvalid {
@@ -230,6 +232,18 @@ pub async fn fetch_verified_node_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
+    fetch_verified_node_shasums_file_cached_with_auth(http_client, shasums_url, cache_dir, None)
+        .await
+}
+
+/// Like [`fetch_verified_node_shasums_file_cached`], sending the supplied
+/// authorization value when the cache misses.
+pub async fn fetch_verified_node_shasums_file_cached_with_auth(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+    authorization: Option<&str>,
+) -> Result<Vec<ShasumsFileItem>, FetchVerifiedNodeShasumsError> {
     let signature_url = format!("{shasums_url}.sig");
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url)
         && let Some(signature) =
@@ -239,7 +253,7 @@ pub async fn fetch_verified_node_shasums_file_cached(
         return Ok(parse_shasums_file(&body));
     }
     let (body, signature) =
-        fetch_verified_node_shasums_with_signature(http_client, shasums_url).await?;
+        fetch_verified_node_shasums_with_signature(http_client, shasums_url, authorization).await?;
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, shasums_url, body.as_bytes());
     write_cached_shasums(cache_dir, ShasumsTrust::Verified, &signature_url, &signature);
     Ok(parse_shasums_file(&body))
@@ -255,10 +269,21 @@ pub async fn fetch_shasums_file_cached(
     shasums_url: &str,
     cache_dir: Option<&Path>,
 ) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
+    fetch_shasums_file_cached_with_auth(http_client, shasums_url, cache_dir, None).await
+}
+
+/// Like [`fetch_shasums_file_cached`], sending the supplied authorization
+/// value when the cache misses.
+pub async fn fetch_shasums_file_cached_with_auth(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    cache_dir: Option<&Path>,
+    authorization: Option<&str>,
+) -> Result<Vec<ShasumsFileItem>, FetchShasumsFileError> {
     if let Some(body) = read_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url) {
         return Ok(parse_shasums_file(&body));
     }
-    let body = fetch_shasums_file_raw(http_client, shasums_url).await?;
+    let body = fetch_shasums_file_raw_with_auth(http_client, shasums_url, authorization).await?;
     write_cached_shasums(cache_dir, ShasumsTrust::Unverified, shasums_url, body.as_bytes());
     Ok(parse_shasums_file(&body))
 }
@@ -270,13 +295,22 @@ pub async fn fetch_shasums_file_raw(
     http_client: &ThrottledClient,
     shasums_url: &str,
 ) -> Result<String, FetchShasumsFileError> {
-    let response =
-        http_client.acquire_for_url(shasums_url).await.get(shasums_url).send().await.map_err(
-            |error| FetchShasumsFileError::Network {
-                url: shasums_url.to_string(),
-                error: Arc::new(error),
-            },
-        )?;
+    fetch_shasums_file_raw_with_auth(http_client, shasums_url, None).await
+}
+
+async fn fetch_shasums_file_raw_with_auth(
+    http_client: &ThrottledClient,
+    shasums_url: &str,
+    authorization: Option<&str>,
+) -> Result<String, FetchShasumsFileError> {
+    let mut request = http_client.acquire_for_url(shasums_url).await.get(shasums_url);
+    if let Some(authorization) = authorization {
+        request = request.header("authorization", authorization);
+    }
+    let response = request.send().await.map_err(|error| FetchShasumsFileError::Network {
+        url: shasums_url.to_string(),
+        error: Arc::new(error),
+    })?;
     if !response.status().is_success() {
         return Err(FetchShasumsFileError::StatusNotOk {
             url: shasums_url.to_string(),
@@ -293,14 +327,17 @@ async fn fetch_node_shasums_bytes(
     http_client: &ThrottledClient,
     url: &str,
     what: &'static str,
+    authorization: Option<&str>,
 ) -> Result<Vec<u8>, FetchVerifiedNodeShasumsError> {
+    let mut request = http_client.acquire_for_url(url).await.get(url);
+    if let Some(authorization) = authorization {
+        request = request.header("authorization", authorization);
+    }
     let response =
-        http_client.acquire_for_url(url).await.get(url).send().await.map_err(|error| {
-            FetchVerifiedNodeShasumsError::Network {
-                what,
-                url: url.to_string(),
-                error: Arc::new(error),
-            }
+        request.send().await.map_err(|error| FetchVerifiedNodeShasumsError::Network {
+            what,
+            url: url.to_string(),
+            error: Arc::new(error),
         })?;
     if !response.status().is_success() {
         return Err(FetchVerifiedNodeShasumsError::StatusNotOk {

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -225,6 +225,52 @@ async fn authenticated_verified_fetch_bypasses_the_cache() {
     signature.assert_async().await;
 }
 
+#[tokio::test]
+async fn authenticated_verified_fetch_reselects_auth_after_redirects() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums_redirect = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(302)
+        .with_header("location", "/public/SHASUMS256.txt")
+        .create_async()
+        .await;
+    let shasums = server
+        .mock("GET", "/public/SHASUMS256.txt")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .create_async()
+        .await;
+    let signature_redirect = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(302)
+        .with_header("location", "/public/SHASUMS256.txt.sig")
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/public/SHASUMS256.txt.sig")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(node_22_11_0_signature())
+        .create_async()
+        .await;
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+    let auth_headers =
+        AuthHeaders::from_creds_map([(nerf_dart(&url), "Bearer mirror-token".to_string())]);
+
+    fetch_verified_node_shasums_file_cached_with_auth_headers(&client, &url, None, &auth_headers)
+        .await
+        .expect("fetch redirected checksums and signature");
+
+    shasums_redirect.assert_async().await;
+    shasums.assert_async().await;
+    signature_redirect.assert_async().await;
+    signature.assert_async().await;
+}
+
 /// A body that fails signature verification must not be cached: the
 /// retry after the failure still refetches.
 #[tokio::test]
@@ -322,6 +368,36 @@ async fn authenticated_plain_fetch_ignores_and_preserves_the_url_cache() {
         read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, &url).as_deref(),
         Some(cached_body),
     );
+    shasums.assert_async().await;
+}
+
+#[tokio::test]
+async fn authenticated_plain_fetch_reselects_auth_after_redirects() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/download/v1.2.3/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(302)
+        .with_header("location", "/public/SHASUMS256.txt")
+        .create_async()
+        .await;
+    let shasums = server
+        .mock("GET", "/public/SHASUMS256.txt")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body("ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  foo.tar.gz\n")
+        .create_async()
+        .await;
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/v1.2.3/SHASUMS256.txt", server.url());
+    let auth_headers =
+        AuthHeaders::from_creds_map([(nerf_dart(&url), "Bearer mirror-token".to_string())]);
+
+    fetch_shasums_file_cached_with_auth_headers(&client, &url, None, &auth_headers)
+        .await
+        .expect("fetch redirected checksums");
+
+    redirect.assert_async().await;
     shasums.assert_async().await;
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -1,11 +1,11 @@
 use pretty_assertions::assert_eq;
 
 use super::{
-    FetchVerifiedNodeShasumsError, PickFileChecksumError, ShasumsFileItem,
-    fetch_shasums_file_cached, fetch_verified_node_shasums,
+    FetchVerifiedNodeShasumsError, PickFileChecksumError, ShasumsFileItem, ShasumsTrust,
+    fetch_shasums_file_cached, fetch_shasums_file_cached_with_auth, fetch_verified_node_shasums,
     fetch_verified_node_shasums_file_cached, fetch_verified_node_shasums_file_cached_with_auth,
     is_signed_by_trusted_node_release_key, parse_shasums_file,
-    pick_file_checksum_from_shasums_file,
+    pick_file_checksum_from_shasums_file, read_cached_shasums, write_cached_shasums,
 };
 
 #[test]
@@ -153,7 +153,6 @@ async fn verified_fetch_caches_the_body_after_verification() {
     let mut server = mockito::Server::new_async().await;
     let shasums = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
-        .match_header("authorization", "Bearer mirror-token")
         .with_status(200)
         .with_body(NODE_22_11_0_SHASUMS)
         .expect(1)
@@ -161,7 +160,6 @@ async fn verified_fetch_caches_the_body_after_verification() {
         .await;
     let signature = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
-        .match_header("authorization", "Bearer mirror-token")
         .with_status(200)
         .with_body(node_22_11_0_signature())
         .expect(1)
@@ -171,19 +169,52 @@ async fn verified_fetch_caches_the_body_after_verification() {
     let client = pnpm_network::ThrottledClient::new_for_installs();
     let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
 
-    let fetched = fetch_verified_node_shasums_file_cached_with_auth(
-        &client,
-        &url,
-        Some(cache_dir.path()),
-        Some("Bearer mirror-token"),
-    )
-    .await
-    .expect("fetch and verify");
+    let fetched = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
+        .await
+        .expect("fetch and verify");
     let cached = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
         .await
         .expect("serve from cache");
 
     assert_eq!(fetched, cached);
+    shasums.assert_async().await;
+    signature.assert_async().await;
+}
+
+#[tokio::test]
+async fn authenticated_verified_fetch_bypasses_the_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .expect(2)
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(node_22_11_0_signature())
+        .expect(2)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+
+    for _ in 0..2 {
+        fetch_verified_node_shasums_file_cached_with_auth(
+            &client,
+            &url,
+            Some(cache_dir.path()),
+            Some("Bearer mirror-token"),
+        )
+        .await
+        .expect("fetch and verify");
+    }
+
     shasums.assert_async().await;
     signature.assert_async().await;
 }
@@ -241,6 +272,48 @@ async fn plain_fetch_caches_the_body() {
 
     assert_eq!(fetched, cached);
     assert_eq!(fetched.len(), 1);
+    shasums.assert_async().await;
+}
+
+#[tokio::test]
+async fn authenticated_plain_fetch_ignores_and_preserves_the_url_cache() {
+    let mut server = mockito::Server::new_async().await;
+    let fresh_body =
+        "be127be1d98cad94c56f46245d0f2de89934d300028694456861a6d5ac558bf3  fresh.tar.gz\n";
+    let shasums = server
+        .mock("GET", "/download/v1.2.3/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(fresh_body)
+        .expect(1)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/download/v1.2.3/SHASUMS256.txt", server.url());
+    let cached_body =
+        "ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  cached.tar.gz\n";
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Unverified,
+        &url,
+        cached_body.as_bytes(),
+    );
+
+    let fetched = fetch_shasums_file_cached_with_auth(
+        &client,
+        &url,
+        Some(cache_dir.path()),
+        Some("Bearer mirror-token"),
+    )
+    .await
+    .expect("fetch authenticated body");
+
+    assert_eq!(fetched[0].file_name, "fresh.tar.gz");
+    assert_eq!(
+        read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, &url).as_deref(),
+        Some(cached_body),
+    );
     shasums.assert_async().await;
 }
 

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -3,8 +3,9 @@ use pretty_assertions::assert_eq;
 use super::{
     FetchVerifiedNodeShasumsError, PickFileChecksumError, ShasumsFileItem,
     fetch_shasums_file_cached, fetch_verified_node_shasums,
-    fetch_verified_node_shasums_file_cached, is_signed_by_trusted_node_release_key,
-    parse_shasums_file, pick_file_checksum_from_shasums_file,
+    fetch_verified_node_shasums_file_cached, fetch_verified_node_shasums_file_cached_with_auth,
+    is_signed_by_trusted_node_release_key, parse_shasums_file,
+    pick_file_checksum_from_shasums_file,
 };
 
 #[test]
@@ -152,6 +153,7 @@ async fn verified_fetch_caches_the_body_after_verification() {
     let mut server = mockito::Server::new_async().await;
     let shasums = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
         .with_status(200)
         .with_body(NODE_22_11_0_SHASUMS)
         .expect(1)
@@ -159,6 +161,7 @@ async fn verified_fetch_caches_the_body_after_verification() {
         .await;
     let signature = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
+        .match_header("authorization", "Bearer mirror-token")
         .with_status(200)
         .with_body(node_22_11_0_signature())
         .expect(1)
@@ -168,9 +171,14 @@ async fn verified_fetch_caches_the_body_after_verification() {
     let client = pnpm_network::ThrottledClient::new_for_installs();
     let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
 
-    let fetched = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
-        .await
-        .expect("fetch and verify");
+    let fetched = fetch_verified_node_shasums_file_cached_with_auth(
+        &client,
+        &url,
+        Some(cache_dir.path()),
+        Some("Bearer mirror-token"),
+    )
+    .await
+    .expect("fetch and verify");
     let cached = fetch_verified_node_shasums_file_cached(&client, &url, Some(cache_dir.path()))
         .await
         .expect("serve from cache");

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -2,11 +2,13 @@ use pretty_assertions::assert_eq;
 
 use super::{
     FetchVerifiedNodeShasumsError, PickFileChecksumError, ShasumsFileItem, ShasumsTrust,
-    fetch_shasums_file_cached, fetch_shasums_file_cached_with_auth, fetch_verified_node_shasums,
-    fetch_verified_node_shasums_file_cached, fetch_verified_node_shasums_file_cached_with_auth,
+    fetch_shasums_file_cached, fetch_shasums_file_cached_with_auth_headers,
+    fetch_verified_node_shasums, fetch_verified_node_shasums_file_cached,
+    fetch_verified_node_shasums_file_cached_with_auth_headers,
     is_signed_by_trusted_node_release_key, parse_shasums_file,
     pick_file_checksum_from_shasums_file, read_cached_shasums, write_cached_shasums,
 };
+use pnpm_network::{AuthHeaders, nerf_dart};
 
 #[test]
 fn parses_rows_into_sri_encoded_integrities() {
@@ -186,7 +188,7 @@ async fn authenticated_verified_fetch_bypasses_the_cache() {
     let mut server = mockito::Server::new_async().await;
     let shasums = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt")
-        .match_header("authorization", "Bearer mirror-token")
+        .match_header("authorization", "Bearer shasums-token")
         .with_status(200)
         .with_body(NODE_22_11_0_SHASUMS)
         .expect(2)
@@ -194,7 +196,7 @@ async fn authenticated_verified_fetch_bypasses_the_cache() {
         .await;
     let signature = server
         .mock("GET", "/download/release/v22.11.0/SHASUMS256.txt.sig")
-        .match_header("authorization", "Bearer mirror-token")
+        .match_header("authorization", "Bearer signature-token")
         .with_status(200)
         .with_body(node_22_11_0_signature())
         .expect(2)
@@ -203,13 +205,17 @@ async fn authenticated_verified_fetch_bypasses_the_cache() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let client = pnpm_network::ThrottledClient::new_for_installs();
     let url = format!("{}/download/release/v22.11.0/SHASUMS256.txt", server.url());
+    let auth_headers = AuthHeaders::from_creds_map([
+        (nerf_dart(&format!("{url}/")), "Bearer shasums-token".to_string()),
+        (nerf_dart(&format!("{url}.sig/")), "Bearer signature-token".to_string()),
+    ]);
 
     for _ in 0..2 {
-        fetch_verified_node_shasums_file_cached_with_auth(
+        fetch_verified_node_shasums_file_cached_with_auth_headers(
             &client,
             &url,
             Some(cache_dir.path()),
-            Some("Bearer mirror-token"),
+            &auth_headers,
         )
         .await
         .expect("fetch and verify");
@@ -291,6 +297,8 @@ async fn authenticated_plain_fetch_ignores_and_preserves_the_url_cache() {
     let cache_dir = tempfile::tempdir().expect("create temp cache dir");
     let client = pnpm_network::ThrottledClient::new_for_installs();
     let url = format!("{}/download/v1.2.3/SHASUMS256.txt", server.url());
+    let auth_headers =
+        AuthHeaders::from_creds_map([(nerf_dart(&url), "Bearer mirror-token".to_string())]);
     let cached_body =
         "ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  cached.tar.gz\n";
     write_cached_shasums(
@@ -300,11 +308,11 @@ async fn authenticated_plain_fetch_ignores_and_preserves_the_url_cache() {
         cached_body.as_bytes(),
     );
 
-    let fetched = fetch_shasums_file_cached_with_auth(
+    let fetched = fetch_shasums_file_cached_with_auth_headers(
         &client,
         &url,
         Some(cache_dir.path()),
-        Some("Bearer mirror-token"),
+        &auth_headers,
     )
     .await
     .expect("fetch authenticated body");

--- a/pnpm/crates/crypto-shasums-file/src/tests.rs
+++ b/pnpm/crates/crypto-shasums-file/src/tests.rs
@@ -271,6 +271,73 @@ async fn authenticated_verified_fetch_reselects_auth_after_redirects() {
     signature.assert_async().await;
 }
 
+#[tokio::test]
+async fn auth_aware_verified_fetch_bypasses_cache_before_authenticated_redirect() {
+    let mut server = mockito::Server::new_async().await;
+    let shasums_redirect = server
+        .mock("GET", "/public/SHASUMS256.txt")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(302)
+        .with_header("location", "/private/SHASUMS256.txt")
+        .create_async()
+        .await;
+    let shasums = server
+        .mock("GET", "/private/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(NODE_22_11_0_SHASUMS)
+        .create_async()
+        .await;
+    let signature_redirect = server
+        .mock("GET", "/public/SHASUMS256.txt.sig")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(302)
+        .with_header("location", "/private/SHASUMS256.txt.sig")
+        .create_async()
+        .await;
+    let signature = server
+        .mock("GET", "/private/SHASUMS256.txt.sig")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(node_22_11_0_signature())
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/public/SHASUMS256.txt", server.url());
+    let signature_url = format!("{url}.sig");
+    let auth_headers = AuthHeaders::from_creds_map([(
+        nerf_dart(&format!("{}/private/", server.url())),
+        "Bearer mirror-token".to_string(),
+    )]);
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Verified,
+        &url,
+        NODE_22_11_0_SHASUMS.as_bytes(),
+    );
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Verified,
+        &signature_url,
+        &node_22_11_0_signature(),
+    );
+
+    fetch_verified_node_shasums_file_cached_with_auth_headers(
+        &client,
+        &url,
+        Some(cache_dir.path()),
+        &auth_headers,
+    )
+    .await
+    .expect("fetch authenticated redirects instead of cached metadata");
+
+    shasums_redirect.assert_async().await;
+    shasums.assert_async().await;
+    signature_redirect.assert_async().await;
+    signature.assert_async().await;
+}
+
 /// A body that fails signature verification must not be cached: the
 /// retry after the failure still refetches.
 #[tokio::test]
@@ -397,6 +464,59 @@ async fn authenticated_plain_fetch_reselects_auth_after_redirects() {
         .await
         .expect("fetch redirected checksums");
 
+    redirect.assert_async().await;
+    shasums.assert_async().await;
+}
+
+#[tokio::test]
+async fn auth_aware_plain_fetch_bypasses_cache_before_authenticated_redirect() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/public/SHASUMS256.txt")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(302)
+        .with_header("location", "/private/SHASUMS256.txt")
+        .create_async()
+        .await;
+    let fresh_body =
+        "be127be1d98cad94c56f46245d0f2de89934d300028694456861a6d5ac558bf3  fresh.tar.gz\n";
+    let shasums = server
+        .mock("GET", "/private/SHASUMS256.txt")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(fresh_body)
+        .create_async()
+        .await;
+    let cache_dir = tempfile::tempdir().expect("create temp cache dir");
+    let client = pnpm_network::ThrottledClient::new_for_installs();
+    let url = format!("{}/public/SHASUMS256.txt", server.url());
+    let auth_headers = AuthHeaders::from_creds_map([(
+        nerf_dart(&format!("{}/private/", server.url())),
+        "Bearer mirror-token".to_string(),
+    )]);
+    let cached_body =
+        "ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  cached.tar.gz\n";
+    write_cached_shasums(
+        Some(cache_dir.path()),
+        ShasumsTrust::Unverified,
+        &url,
+        cached_body.as_bytes(),
+    );
+
+    let fetched = fetch_shasums_file_cached_with_auth_headers(
+        &client,
+        &url,
+        Some(cache_dir.path()),
+        &auth_headers,
+    )
+    .await
+    .expect("fetch authenticated redirect instead of cached metadata");
+
+    assert_eq!(fetched[0].file_name, "fresh.tar.gz");
+    assert_eq!(
+        read_cached_shasums(Some(cache_dir.path()), ShasumsTrust::Unverified, &url).as_deref(),
+        Some(cached_body),
+    );
     redirect.assert_async().await;
     shasums.assert_async().await;
 }

--- a/pnpm/crates/engine-runtime-node-resolver/src/lib.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/lib.rs
@@ -39,5 +39,5 @@ pub use normalize_arch::get_normalized_arch;
 pub use parse_node_specifier::{NodeSpecifier, ParseNodeSpecifierError, parse_node_specifier};
 pub use resolve_node_version::{
     NODE_EXTRAS_IGNORE_PATTERN, ResolveNodeVersionError, resolve_node_version,
-    resolve_node_versions,
+    resolve_node_version_with_auth, resolve_node_versions, resolve_node_versions_with_auth,
 };

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -16,8 +16,9 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
 use pnpm_crypto_shasums_file::{
-    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file_cached_with_auth,
-    fetch_verified_node_shasums_file_cached_with_auth,
+    FetchShasumsFileError, FetchVerifiedNodeShasumsError,
+    fetch_shasums_file_cached_with_auth_headers,
+    fetch_verified_node_shasums_file_cached_with_auth_headers,
 };
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, LockfileResolution, PlatformAssetResolution,
@@ -451,22 +452,21 @@ async fn read_node_assets_from_mirror(
     // The URL is pinned to one released version, which is what makes it
     // eligible for the SHASUMS disk cache.
     let integrities_url = format!("{node_mirror_base_url}v{version}/SHASUMS256.txt");
-    let authorization = auth_headers.for_url(&integrities_url);
     let items = if verify_signature {
-        fetch_verified_node_shasums_file_cached_with_auth(
+        fetch_verified_node_shasums_file_cached_with_auth_headers(
             http_client,
             &integrities_url,
             cache_dir,
-            authorization.as_deref(),
+            auth_headers,
         )
         .await
         .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
     } else {
-        fetch_shasums_file_cached_with_auth(
+        fetch_shasums_file_cached_with_auth_headers(
             http_client,
             &integrities_url,
             cache_dir,
-            authorization.as_deref(),
+            auth_headers,
         )
         .await
         .map_err(NodeResolverError::FetchShasumsFile)?

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -16,14 +16,14 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
 use pnpm_crypto_shasums_file::{
-    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file_cached,
-    fetch_verified_node_shasums_file_cached,
+    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file_cached_with_auth,
+    fetch_verified_node_shasums_file_cached_with_auth,
 };
 use pnpm_lockfile::{
     BinaryArchive, BinaryResolution, BinarySpec, LockfileResolution, PlatformAssetResolution,
     PlatformAssetTarget, VariationsResolution,
 };
-use pnpm_network::ThrottledClient;
+use pnpm_network::{AuthHeaders, ThrottledClient};
 use pnpm_resolving_resolver_base::{
     LatestInfo, LatestQuery, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
     ResolveResult, Resolver, WantedDependency,
@@ -36,7 +36,7 @@ use crate::{
         DEFAULT_NODE_MIRROR_BASE_URL, UNOFFICIAL_NODE_MIRROR_BASE_URL, get_node_mirror,
     },
     parse_node_specifier::{NodeSpecifier, ParseNodeSpecifierError, parse_node_specifier},
-    resolve_node_version::{ResolveNodeVersionError, resolve_node_version},
+    resolve_node_version::{ResolveNodeVersionError, resolve_node_version_with_auth},
 };
 
 const RESOLVED_VIA: &str = "nodejs.org";
@@ -93,6 +93,7 @@ pub enum NodeResolverError {
 /// to time out behind a proxy.
 pub struct NodeResolver {
     pub http_client: Arc<ThrottledClient>,
+    pub auth_headers: Arc<AuthHeaders>,
     pub node_download_mirrors: HashMap<String, String>,
     pub offline: bool,
     /// The pnpm cache directory backing the per-version SHASUMS disk
@@ -104,7 +105,21 @@ pub struct NodeResolver {
 impl NodeResolver {
     #[must_use]
     pub fn new(http_client: Arc<ThrottledClient>) -> Self {
-        Self { http_client, node_download_mirrors: HashMap::new(), offline: false, cache_dir: None }
+        Self::new_with_auth(http_client, Arc::new(AuthHeaders::default()))
+    }
+
+    #[must_use]
+    pub fn new_with_auth(
+        http_client: Arc<ThrottledClient>,
+        auth_headers: Arc<AuthHeaders>,
+    ) -> Self {
+        Self {
+            http_client,
+            auth_headers,
+            node_download_mirrors: HashMap::new(),
+            offline: false,
+            cache_dir: None,
+        }
     }
 }
 
@@ -159,8 +174,9 @@ impl NodeResolver {
             // raises for a nonexistent version; any other outcome
             // re-raises the asset error unchanged.
             Err(error) if picked.resolved_without_index => {
-                let error = match resolve_node_version(
+                let error = match resolve_node_version_with_auth(
                     &self.http_client,
+                    &self.auth_headers,
                     &picked.version,
                     Some(&picked.mirror),
                 )
@@ -227,13 +243,15 @@ impl NodeResolver {
                 resolved_without_index: true,
             });
         }
-        let version =
-            resolve_node_version(&self.http_client, &parsed.version_specifier, Some(&mirror))
-                .await
-                .map_err(NodeResolverError::FetchReleaseIndex)?
-                .ok_or_else(|| NodeResolverError::VersionNotFound {
-                    spec: version_spec.to_string(),
-                })?;
+        let version = resolve_node_version_with_auth(
+            &self.http_client,
+            &self.auth_headers,
+            &parsed.version_specifier,
+            Some(&mirror),
+        )
+        .await
+        .map_err(NodeResolverError::FetchReleaseIndex)?
+        .ok_or_else(|| NodeResolverError::VersionNotFound { spec: version_spec.to_string() })?;
         Ok(PickedNodeVersion {
             version,
             mirror,
@@ -288,12 +306,14 @@ impl NodeResolver {
             Box::new(NodeResolverError::InvalidReleaseChannel(err)) as ResolveError
         })?;
         let mirror = get_node_mirror(Some(&self.node_download_mirrors), &parsed.release_channel);
-        let version =
-            resolve_node_version(&self.http_client, &parsed.version_specifier, Some(&mirror))
-                .await
-                .map_err(|err| {
-                    Box::new(NodeResolverError::FetchReleaseIndex(err)) as ResolveError
-                })?;
+        let version = resolve_node_version_with_auth(
+            &self.http_client,
+            &self.auth_headers,
+            &parsed.version_specifier,
+            Some(&mirror),
+        )
+        .await
+        .map_err(|err| Box::new(NodeResolverError::FetchReleaseIndex(err)) as ResolveError)?;
         let Some(version) = version else {
             return Ok(Some(LatestInfo::default()));
         };
@@ -321,6 +341,7 @@ impl NodeResolver {
     ) -> Result<Vec<PlatformAssetResolution>, NodeResolverError> {
         let mut assets = read_node_assets_from_mirror(
             &self.http_client,
+            &self.auth_headers,
             mirror,
             version,
             /* musl_only */ false,
@@ -331,6 +352,7 @@ impl NodeResolver {
         if mirror == DEFAULT_NODE_MIRROR_BASE_URL
             && let Ok(mut musl_assets) = read_node_assets_from_mirror(
                 &self.http_client,
+                &self.auth_headers,
                 UNOFFICIAL_NODE_MIRROR_BASE_URL,
                 version,
                 /* musl_only */ true,
@@ -419,6 +441,7 @@ fn normalize_node_runtime_version_specifier(
 /// caller asked for.
 async fn read_node_assets_from_mirror(
     http_client: &ThrottledClient,
+    auth_headers: &AuthHeaders,
     node_mirror_base_url: &str,
     version: &str,
     musl_only: bool,
@@ -428,14 +451,25 @@ async fn read_node_assets_from_mirror(
     // The URL is pinned to one released version, which is what makes it
     // eligible for the SHASUMS disk cache.
     let integrities_url = format!("{node_mirror_base_url}v{version}/SHASUMS256.txt");
+    let authorization = auth_headers.for_url(&integrities_url);
     let items = if verify_signature {
-        fetch_verified_node_shasums_file_cached(http_client, &integrities_url, cache_dir)
-            .await
-            .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
+        fetch_verified_node_shasums_file_cached_with_auth(
+            http_client,
+            &integrities_url,
+            cache_dir,
+            authorization.as_deref(),
+        )
+        .await
+        .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
     } else {
-        fetch_shasums_file_cached(http_client, &integrities_url, cache_dir)
-            .await
-            .map_err(NodeResolverError::FetchShasumsFile)?
+        fetch_shasums_file_cached_with_auth(
+            http_client,
+            &integrities_url,
+            cache_dir,
+            authorization.as_deref(),
+        )
+        .await
+        .map_err(NodeResolverError::FetchShasumsFile)?
     };
     let mut assets = Vec::new();
     for item in items {

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver.rs
@@ -16,8 +16,8 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::Version;
 use pnpm_crypto_shasums_file::{
-    FetchShasumsFileError, FetchVerifiedNodeShasumsError,
-    fetch_shasums_file_cached_with_auth_headers,
+    FetchShasumsFileError, FetchVerifiedNodeShasumsError, fetch_shasums_file_cached,
+    fetch_shasums_file_cached_with_auth_headers, fetch_verified_node_shasums_file_cached,
     fetch_verified_node_shasums_file_cached_with_auth_headers,
 };
 use pnpm_lockfile::{
@@ -453,14 +453,24 @@ async fn read_node_assets_from_mirror(
     // eligible for the SHASUMS disk cache.
     let integrities_url = format!("{node_mirror_base_url}v{version}/SHASUMS256.txt");
     let items = if verify_signature {
-        fetch_verified_node_shasums_file_cached_with_auth_headers(
-            http_client,
-            &integrities_url,
-            cache_dir,
-            auth_headers,
-        )
-        .await
-        .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
+        if auth_headers.is_empty() {
+            fetch_verified_node_shasums_file_cached(http_client, &integrities_url, cache_dir)
+                .await
+                .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
+        } else {
+            fetch_verified_node_shasums_file_cached_with_auth_headers(
+                http_client,
+                &integrities_url,
+                cache_dir,
+                auth_headers,
+            )
+            .await
+            .map_err(NodeResolverError::FetchVerifiedNodeShasums)?
+        }
+    } else if auth_headers.is_empty() {
+        fetch_shasums_file_cached(http_client, &integrities_url, cache_dir)
+            .await
+            .map_err(NodeResolverError::FetchShasumsFile)?
     } else {
         fetch_shasums_file_cached_with_auth_headers(
             http_client,

--- a/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/node_resolver/tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use pnpm_network::ThrottledClient;
+use pnpm_network::{AuthHeaders, ThrottledClient};
 use pnpm_resolving_resolver_base::{ResolveOptions, Resolver, WantedDependency};
 use pretty_assertions::assert_eq;
 
@@ -194,6 +194,7 @@ async fn release_asset_reader_requires_signature_when_requested() {
         .await;
     let err = read_node_assets_from_mirror(
         &ThrottledClient::new_for_installs(),
+        &AuthHeaders::default(),
         &format!("{}/download/release/", server.url()),
         "22.11.0",
         false,
@@ -217,6 +218,7 @@ async fn prerelease_asset_reader_does_not_require_signature() {
         .await;
     let assets = read_node_assets_from_mirror(
         &ThrottledClient::new_for_installs(),
+        &AuthHeaders::default(),
         &format!("{}/download/rc/", server.url()),
         "22.11.0",
         false,
@@ -346,6 +348,7 @@ async fn asset_reader_serves_repeat_reads_from_the_cache() {
 
     let fetched = read_node_assets_from_mirror(
         &client,
+        &AuthHeaders::default(),
         &mirror,
         "22.11.0",
         false,
@@ -356,6 +359,7 @@ async fn asset_reader_serves_repeat_reads_from_the_cache() {
     .expect("fetch the asset list");
     let cached = read_node_assets_from_mirror(
         &client,
+        &AuthHeaders::default(),
         &mirror,
         "22.11.0",
         false,

--- a/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
@@ -54,6 +54,10 @@ pub enum ResolveNodeVersionError {
         error: Arc<reqwest::Error>,
     },
 
+    #[display("Failed to fetch Node.js release index at {url}: HTTP status {status}")]
+    #[diagnostic(code(ERR_PNPM_FETCH_NODE_INDEX_FAILED))]
+    FetchIndexStatus { url: String, status: u16 },
+
     #[display("Failed to decode Node.js release index at {url}")]
     #[diagnostic(code(ERR_PNPM_DECODE_NODE_INDEX_FAILED))]
     DecodeIndex {
@@ -155,19 +159,20 @@ async fn fetch_all_versions(
 ) -> Result<Vec<NodeVersion>, ResolveNodeVersionError> {
     let base = node_mirror_base_url.unwrap_or("https://nodejs.org/download/release/");
     let url = format!("{base}index.json");
-    let mut request = http_client.acquire_for_url(&url).await.get(&url);
-    if let Some(authorization) = auth_headers.for_secure_url(&url) {
-        request = request.header("authorization", authorization);
-    }
-    let response =
-        request.send().await.and_then(reqwest::Response::error_for_status).map_err(|error| {
-            ResolveNodeVersionError::FetchIndex { url: url.clone(), error: Arc::new(error) }
+    let response = http_client
+        .get_bytes_with_secure_auth_headers(&url, auth_headers)
+        .await
+        .map_err(|error| ResolveNodeVersionError::FetchIndex {
+            url: url.clone(),
+            error: Arc::new(error),
         })?;
-    let body = response.text().await.map_err(|error| ResolveNodeVersionError::FetchIndex {
-        url: url.clone(),
-        error: Arc::new(error),
-    })?;
-    let raw: Vec<RawNodeVersion> = serde_json::from_str(&body).map_err(|error| {
+    if !response.status.is_success() {
+        return Err(ResolveNodeVersionError::FetchIndexStatus {
+            url,
+            status: response.status.as_u16(),
+        });
+    }
+    let raw: Vec<RawNodeVersion> = serde_json::from_slice(&response.body).map_err(|error| {
         ResolveNodeVersionError::DecodeIndex { url: url.clone(), error: Arc::new(error) }
     })?;
     Ok(raw

--- a/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
@@ -156,7 +156,7 @@ async fn fetch_all_versions(
     let base = node_mirror_base_url.unwrap_or("https://nodejs.org/download/release/");
     let url = format!("{base}index.json");
     let mut request = http_client.acquire_for_url(&url).await.get(&url);
-    if let Some(authorization) = auth_headers.for_url(&url) {
+    if let Some(authorization) = auth_headers.for_secure_url(&url) {
         request = request.header("authorization", authorization);
     }
     let response =

--- a/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
-use pnpm_network::ThrottledClient;
+use pnpm_network::{AuthHeaders, ThrottledClient};
 use serde::Deserialize;
 
 /// Pattern matched against archive entries pacquet strips out of the
@@ -74,7 +74,24 @@ pub async fn resolve_node_version(
     version_spec: &str,
     node_mirror_base_url: Option<&str>,
 ) -> Result<Option<String>, ResolveNodeVersionError> {
-    let all_versions = fetch_all_versions(http_client, node_mirror_base_url).await?;
+    resolve_node_version_with_auth(
+        http_client,
+        &AuthHeaders::default(),
+        version_spec,
+        node_mirror_base_url,
+    )
+    .await
+}
+
+/// Like [`resolve_node_version`], authenticating the release-index request
+/// with the longest URL-prefix match from [`AuthHeaders`].
+pub async fn resolve_node_version_with_auth(
+    http_client: &ThrottledClient,
+    auth_headers: &AuthHeaders,
+    version_spec: &str,
+    node_mirror_base_url: Option<&str>,
+) -> Result<Option<String>, ResolveNodeVersionError> {
+    let all_versions = fetch_all_versions(http_client, auth_headers, node_mirror_base_url).await?;
     if is_latest_selector(version_spec) {
         return Ok(all_versions.first().map(|version| version.version.clone()));
     }
@@ -92,7 +109,24 @@ pub async fn resolve_node_versions(
     version_spec: Option<&str>,
     node_mirror_base_url: Option<&str>,
 ) -> Result<Vec<String>, ResolveNodeVersionError> {
-    let all_versions = fetch_all_versions(http_client, node_mirror_base_url).await?;
+    resolve_node_versions_with_auth(
+        http_client,
+        &AuthHeaders::default(),
+        version_spec,
+        node_mirror_base_url,
+    )
+    .await
+}
+
+/// Like [`resolve_node_versions`], authenticating the release-index request
+/// with the longest URL-prefix match from [`AuthHeaders`].
+pub async fn resolve_node_versions_with_auth(
+    http_client: &ThrottledClient,
+    auth_headers: &AuthHeaders,
+    version_spec: Option<&str>,
+    node_mirror_base_url: Option<&str>,
+) -> Result<Vec<String>, ResolveNodeVersionError> {
+    let all_versions = fetch_all_versions(http_client, auth_headers, node_mirror_base_url).await?;
     let Some(version_spec) = version_spec else {
         return Ok(all_versions.into_iter().map(|version| version.version).collect());
     };
@@ -116,20 +150,18 @@ pub async fn resolve_node_versions(
 
 async fn fetch_all_versions(
     http_client: &ThrottledClient,
+    auth_headers: &AuthHeaders,
     node_mirror_base_url: Option<&str>,
 ) -> Result<Vec<NodeVersion>, ResolveNodeVersionError> {
     let base = node_mirror_base_url.unwrap_or("https://nodejs.org/download/release/");
     let url = format!("{base}index.json");
-    let response = http_client
-        .acquire_for_url(&url)
-        .await
-        .get(&url)
-        .send()
-        .await
-        .and_then(reqwest::Response::error_for_status)
-        .map_err(|error| ResolveNodeVersionError::FetchIndex {
-            url: url.clone(),
-            error: Arc::new(error),
+    let mut request = http_client.acquire_for_url(&url).await.get(&url);
+    if let Some(authorization) = auth_headers.for_url(&url) {
+        request = request.header("authorization", authorization);
+    }
+    let response =
+        request.send().await.and_then(reqwest::Response::error_for_status).map_err(|error| {
+            ResolveNodeVersionError::FetchIndex { url: url.clone(), error: Arc::new(error) }
         })?;
     let body = response.text().await.map_err(|error| ResolveNodeVersionError::FetchIndex {
         url: url.clone(),

--- a/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
@@ -1,8 +1,11 @@
 use pretty_assertions::assert_eq;
 
-use pnpm_network::ThrottledClient;
+use pnpm_network::{AuthHeaders, ThrottledClient, nerf_dart};
 
-use super::{NodeVersion, filter_versions, resolve_node_version, resolve_node_versions};
+use super::{
+    NodeVersion, filter_versions, resolve_node_version, resolve_node_version_with_auth,
+    resolve_node_versions,
+};
 
 fn make_versions() -> Vec<NodeVersion> {
     vec![
@@ -64,4 +67,54 @@ async fn empty_selector_picks_latest_version() {
 
     let picked = resolve_node_versions(&http_client, Some("  "), Some(&base_url)).await.unwrap();
     assert_eq!(picked, vec!["22.1.0"]);
+}
+
+#[tokio::test]
+async fn authenticated_version_resolve_uses_matching_mirror_credentials() {
+    let mut server = mockito::Server::new_async().await;
+    let index = server
+        .mock("GET", "/index.json")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(200)
+        .with_body(r#"[{ "version": "v22.1.0", "lts": false }]"#)
+        .create_async()
+        .await;
+    let base_url = format!("{}/", server.url());
+    let auth_headers =
+        AuthHeaders::from_creds_map([(nerf_dart(&base_url), "Bearer mirror-token".to_string())]);
+    let http_client = ThrottledClient::new_for_installs();
+
+    let picked =
+        resolve_node_version_with_auth(&http_client, &auth_headers, "latest", Some(&base_url))
+            .await
+            .unwrap();
+
+    assert_eq!(picked, Some("22.1.0".to_string()));
+    index.assert_async().await;
+}
+
+#[tokio::test]
+async fn authenticated_version_resolve_omits_unmatched_credentials() {
+    let mut server = mockito::Server::new_async().await;
+    let index = server
+        .mock("GET", "/index.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(r#"[{ "version": "v22.1.0", "lts": false }]"#)
+        .create_async()
+        .await;
+    let base_url = format!("{}/", server.url());
+    let auth_headers = AuthHeaders::from_creds_map([(
+        "//other.example/".to_string(),
+        "Bearer other-token".to_string(),
+    )]);
+    let http_client = ThrottledClient::new_for_installs();
+
+    let picked =
+        resolve_node_version_with_auth(&http_client, &auth_headers, "latest", Some(&base_url))
+            .await
+            .unwrap();
+
+    assert_eq!(picked, Some("22.1.0".to_string()));
+    index.assert_async().await;
 }

--- a/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
+++ b/pnpm/crates/engine-runtime-node-resolver/src/resolve_node_version/tests.rs
@@ -118,3 +118,35 @@ async fn authenticated_version_resolve_omits_unmatched_credentials() {
     assert_eq!(picked, Some("22.1.0".to_string()));
     index.assert_async().await;
 }
+
+#[tokio::test]
+async fn authenticated_version_resolve_reselects_credentials_after_redirects() {
+    let mut server = mockito::Server::new_async().await;
+    let redirect = server
+        .mock("GET", "/private/index.json")
+        .match_header("authorization", "Bearer mirror-token")
+        .with_status(302)
+        .with_header("location", "/public/index.json")
+        .create_async()
+        .await;
+    let index = server
+        .mock("GET", "/public/index.json")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body(r#"[{ "version": "v22.1.0", "lts": false }]"#)
+        .create_async()
+        .await;
+    let base_url = format!("{}/private/", server.url());
+    let auth_headers =
+        AuthHeaders::from_creds_map([(nerf_dart(&base_url), "Bearer mirror-token".to_string())]);
+    let http_client = ThrottledClient::new_for_installs();
+
+    let picked =
+        resolve_node_version_with_auth(&http_client, &auth_headers, "latest", Some(&base_url))
+            .await
+            .unwrap();
+
+    assert_eq!(picked, Some("22.1.0".to_string()));
+    redirect.assert_async().await;
+    index.assert_async().await;
+}

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -679,12 +679,20 @@ impl<'a> ParsedUrl<'a> {
             Some((user_info, host_port)) => (Some(user_info), host_port),
             None => (None, authority),
         };
-        let (host, port) = match host_port.rsplit_once(':') {
-            // Skip IPv6 brackets. Pnpm doesn't handle them either, and
-            // no npm registry we care about uses them. Documenting the
-            // limit here rather than silently misparsing.
-            Some((host, port)) if !host.contains('[') => (host, Some(port)),
-            _ => (host_port, None),
+        let (host, port) = if host_port.starts_with('[') {
+            match host_port.find(']') {
+                Some(closing_bracket) => {
+                    let host = &host_port[..=closing_bracket];
+                    let port = host_port[closing_bracket + 1..].strip_prefix(':');
+                    (host, port)
+                }
+                None => (host_port, None),
+            }
+        } else {
+            match host_port.rsplit_once(':') {
+                Some((host, port)) => (host, Some(port)),
+                None => (host_port, None),
+            }
         };
         Some(ParsedUrl { scheme, user_info, host, port, path })
     }

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -383,6 +383,24 @@ impl AuthHeaders {
         self.for_url_with_package(url, None)
     }
 
+    /// Resolve an `Authorization` header only when `url` uses TLS or targets
+    /// the local machine. The loopback exception keeps local registry proxies
+    /// usable without exposing credentials on a network link.
+    #[must_use]
+    pub fn for_secure_url(&self, url: &str) -> Option<String> {
+        self.for_secure_url_with_package(url, None)
+    }
+
+    /// Package-aware counterpart to [`Self::for_secure_url`].
+    #[must_use]
+    pub fn for_secure_url_with_package(&self, url: &str, pkg_name: Option<&str>) -> Option<String> {
+        let parsed = ParsedUrl::parse(url)?;
+        if !parsed.scheme.eq_ignore_ascii_case("https") && !is_loopback_host(parsed.host) {
+            return None;
+        }
+        self.for_url_with_package(url, pkg_name)
+    }
+
     /// Attach a server-side [`UpstreamRouteHook`] that takes over auth
     /// selection. The returned [`AuthHeaders`] keeps its
     /// client-forwarded credentials (so [`Self::to_by_scope`] still
@@ -719,6 +737,14 @@ impl<'a> ParsedUrl<'a> {
 
 fn is_default_port(scheme: &str, port: &str) -> bool {
     matches!((scheme, port), ("https", "443") | ("http", "80"))
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .trim_matches(['[', ']'])
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback())
 }
 
 /// Local base64 encode so this crate doesn't pull in `base64` just for

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -182,6 +182,13 @@ impl fmt::Debug for AuthHeaders {
 }
 
 impl AuthHeaders {
+    /// Whether no configured credential or route hook can provide
+    /// authorization for any URL.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_uri.is_empty() && self.scoped_by_scope.is_empty() && self.route_hook.is_none()
+    }
+
     /// Build an [`AuthHeaders`] from `(nerf_darted_uri, header_value)`
     /// pairs. Caller is responsible for nerf-darting and for choosing
     /// the right scheme (`Bearer ...` or `Basic ...`).

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -551,12 +551,18 @@ fn returns_none_for_unmatched_url_in_empty_map() {
 
 #[test]
 fn secure_lookup_rejects_plain_http_but_allows_loopback() {
-    let headers = build(&[("//reg.com/", "Bearer remote"), ("//127.0.0.1/", "Bearer local")]);
+    let headers = build(&[
+        ("//reg.com/", "Bearer remote"),
+        ("//127.0.0.1/", "Bearer local"),
+        ("//[::1]/", "Bearer ipv6-local"),
+    ]);
     assert_eq!(headers.for_secure_url("http://reg.com/pkg"), None);
     let remote = headers.for_secure_url("https://reg.com/pkg");
     assert_eq!(remote.as_deref(), Some("Bearer remote"));
     let local = headers.for_secure_url("http://127.0.0.1/pkg");
     assert_eq!(local.as_deref(), Some("Bearer local"));
+    let ipv6_local = headers.for_secure_url("http://[::1]:4873/pkg");
+    assert_eq!(ipv6_local.as_deref(), Some("Bearer ipv6-local"));
 }
 
 /// Specifically exercises the trailing-slash-append branch in

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -546,7 +546,9 @@ fn registry_with_pathname_matches_with_explicit_port() {
 
 #[test]
 fn returns_none_for_unmatched_url_in_empty_map() {
-    assert_eq!(AuthHeaders::default().for_url("http://reg.com"), None);
+    let headers = AuthHeaders::default();
+    assert!(headers.is_empty());
+    assert_eq!(headers.for_url("http://reg.com"), None);
 }
 
 #[test]
@@ -556,6 +558,7 @@ fn secure_lookup_rejects_plain_http_but_allows_loopback() {
         ("//127.0.0.1/", "Bearer local"),
         ("//[::1]/", "Bearer ipv6-local"),
     ]);
+    assert!(!headers.is_empty());
     assert_eq!(headers.for_secure_url("http://reg.com/pkg"), None);
     let remote = headers.for_secure_url("https://reg.com/pkg");
     assert_eq!(remote.as_deref(), Some("Bearer remote"));

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -549,6 +549,16 @@ fn returns_none_for_unmatched_url_in_empty_map() {
     assert_eq!(AuthHeaders::default().for_url("http://reg.com"), None);
 }
 
+#[test]
+fn secure_lookup_rejects_plain_http_but_allows_loopback() {
+    let headers = build(&[("//reg.com/", "Bearer remote"), ("//127.0.0.1/", "Bearer local")]);
+    assert_eq!(headers.for_secure_url("http://reg.com/pkg"), None);
+    let remote = headers.for_secure_url("https://reg.com/pkg");
+    assert_eq!(remote.as_deref(), Some("Bearer remote"));
+    let local = headers.for_secure_url("http://127.0.0.1/pkg");
+    assert_eq!(local.as_deref(), Some("Bearer local"));
+}
+
 /// Specifically exercises the trailing-slash-append branch in
 /// [`AuthHeaders::for_url`]: the URL ends without a `/` *and*
 /// names a path segment (`/scope`). Without the append,

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -625,6 +625,49 @@ impl ThrottledClient {
         self.acquire_for_url_with_priority_and_redirects(url, priority, false).await
     }
 
+    /// Send a GET whose URL-scoped credentials are re-evaluated for every
+    /// redirect target. Credentials are limited to TLS and loopback URLs by
+    /// [`AuthHeaders::for_secure_url`].
+    pub async fn get_bytes_with_secure_auth_headers(
+        &self,
+        url: &str,
+        auth_headers: &AuthHeaders,
+    ) -> Result<SecureAuthResponse, reqwest::Error> {
+        let mut current_url = url.to_string();
+        for redirect_count in 0..=MAX_REDIRECT_HOPS {
+            let client = self
+                .acquire_for_url_without_redirects_with_priority(&current_url, UNPRIORITIZED)
+                .await;
+            let mut request = client.get(&current_url);
+            if let Some(authorization) = auth_headers.for_secure_url(&current_url) {
+                request = request.header("authorization", authorization);
+            }
+            let response = request.send().await?;
+            if !is_redirect_status(response.status()) || redirect_count == MAX_REDIRECT_HOPS {
+                let status = response.status();
+                let body = response.bytes().await?.to_vec();
+                return Ok(SecureAuthResponse { status, body });
+            }
+            let Some(location) = response.headers().get(reqwest::header::LOCATION) else {
+                let status = response.status();
+                let body = response.bytes().await?.to_vec();
+                return Ok(SecureAuthResponse { status, body });
+            };
+            let Ok(location) = location.to_str() else {
+                let status = response.status();
+                let body = response.bytes().await?.to_vec();
+                return Ok(SecureAuthResponse { status, body });
+            };
+            let Ok(target) = response.url().join(location) else {
+                let status = response.status();
+                let body = response.bytes().await?.to_vec();
+                return Ok(SecureAuthResponse { status, body });
+            };
+            current_url = target.to_string();
+        }
+        unreachable!()
+    }
+
     async fn acquire_for_url_with_priority_and_redirects(
         &self,
         url: &str,
@@ -644,6 +687,11 @@ impl ThrottledClient {
         let client = clients.select(follow_redirects);
         ThrottledClientGuard { _permit: permit, _host_permit: host_permit, client }
     }
+}
+
+pub struct SecureAuthResponse {
+    pub status: reqwest::StatusCode,
+    pub body: Vec<u8>,
 }
 
 fn ignore_warning(_: &str) {}
@@ -706,6 +754,10 @@ fn allowlist_redirect_policy(guard: RedirectGuard) -> reqwest::redirect::Policy 
             attempt.follow()
         }
     })
+}
+
+fn is_redirect_status(status: reqwest::StatusCode) -> bool {
+    matches!(status.as_u16(), 301 | 302 | 303 | 307 | 308)
 }
 
 #[cfg(any(target_os = "macos", test))]

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -892,7 +892,10 @@ async fn resolve_added_dependency<'a>(
     ) {
         workspace_specifier
     } else if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
-        let mut node_resolver = NodeResolver::new(std::sync::Arc::clone(http_client_arc));
+        let mut node_resolver = NodeResolver::new_with_auth(
+            std::sync::Arc::clone(http_client_arc),
+            std::sync::Arc::clone(&config.auth_headers),
+        );
         node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
         node_resolver.offline = config.offline;
         node_resolver.cache_dir = Some(config.cache_dir.clone());

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -301,7 +301,8 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
     let local_ctx = LocalResolverContext { preserve_absolute_paths: false };
     let local_scheme_resolver = LocalSchemeResolver::new(local_ctx);
     let local_path_resolver = LocalPathResolver::new(local_ctx);
-    let mut node_resolver = NodeResolver::new(Arc::clone(http_client_arc));
+    let mut node_resolver =
+        NodeResolver::new_with_auth(Arc::clone(http_client_arc), Arc::clone(auth_headers));
     node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
     node_resolver.offline = config.offline;
     node_resolver.cache_dir = Some(config.cache_dir.clone());

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1909,7 +1909,10 @@ fn ensure_latest_resolver_chain<'chain>(
             create_configured_npm_resolver(ctx.config, Arc::clone(ctx.http_client_arc), &policy)
                 .map_err(UpdateError::InvalidNamedRegistry)?,
         );
-        let mut node_resolver = NodeResolver::new(Arc::clone(ctx.http_client_arc));
+        let mut node_resolver = NodeResolver::new_with_auth(
+            Arc::clone(ctx.http_client_arc),
+            Arc::clone(&ctx.config.auth_headers),
+        );
         node_resolver.node_download_mirrors.clone_from(&ctx.config.node_download_mirrors);
         node_resolver.offline = ctx.config.offline;
         node_resolver.cache_dir = Some(ctx.config.cache_dir.clone());

--- a/pnpm/crates/resolving-default-resolver/src/standalone.rs
+++ b/pnpm/crates/resolving-default-resolver/src/standalone.rs
@@ -111,7 +111,8 @@ pub fn build_standalone_chain(
     let local_scheme_resolver = LocalSchemeResolver::new(local_ctx);
     let local_path_resolver = LocalPathResolver::new(local_ctx);
 
-    let mut node_resolver = NodeResolver::new(Arc::clone(http_client));
+    let mut node_resolver =
+        NodeResolver::new_with_auth(Arc::clone(http_client), Arc::clone(&config.auth_headers));
     node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
     node_resolver.offline = config.offline;
     node_resolver.cache_dir = Some(config.cache_dir.clone());

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -7,9 +7,10 @@ use super::{
     Arc, Duration, GZIP_MAGIC, HashMap, HttpStatusError, IgnoreEntryFilter, Instant, NetworkError,
     PathBuf, PrefetchedCasPaths, STREAM_EXTRACT_COMPRESSED_THRESHOLD,
     STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, SharedReportedProgressKeys, TarballError,
-    VerifyChecksumError, allocate_tarball_buffer, body_chunk_channel, extract_gzipped_tarball,
-    local_file_tarball_path, non_gzip_body_error, open_local_tarball, post_download_semaphore,
-    read_local_tarball_buffer, stream_extract_gzipped_channel, streaming_extract_semaphore,
+    VerifyChecksumError, allocate_tarball_buffer, auth_header_for_package_download,
+    body_chunk_channel, extract_gzipped_tarball, local_file_tarball_path, non_gzip_body_error,
+    open_local_tarball, post_download_semaphore, read_local_tarball_buffer,
+    stream_extract_gzipped_channel, streaming_extract_semaphore,
 };
 use futures_util::{Stream, StreamExt};
 use pnpm_network::{
@@ -675,7 +676,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     // Resolve the per-URL auth header and attach it. Tarball hosts that
     // differ from the metadata host still pick up the header keyed at
     // the registry's nerf-darted URI.
-    if let Some(value) = auth_headers.for_url_with_package(package_url, Some(package_id)) {
+    if let Some(value) = auth_header_for_package_download(auth_headers, package_url, package_id) {
         request = request.header("authorization", value);
     }
 

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -49,6 +49,18 @@ use tokio::sync::{Notify, RwLock, Semaphore};
 /// still decodes in full.
 const MAX_UNTRUSTED_PREALLOC_BYTES: usize = 64 * 1024 * 1024;
 
+fn auth_header_for_package_download(
+    auth_headers: &AuthHeaders,
+    package_url: &str,
+    package_id: &str,
+) -> Option<String> {
+    if package_id.starts_with("node@runtime:") {
+        auth_headers.for_secure_url_with_package(package_url, Some(package_id))
+    } else {
+        auth_headers.for_url_with_package(package_url, Some(package_id))
+    }
+}
+
 /// Cap on concurrent post-download tarball work (SHA-512 of the whole
 /// tarball + gzip inflate + per-file SHA-512 + CAFS writes). The body is
 /// CPU-bound with some blocking FS I/O, and putting it on

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     FetchTarballForResolution, MAX_UNTRUSTED_PREALLOC_BYTES, MemCache, RetryOpts,
-    SharedReportedProgressKeys,
+    SharedReportedProgressKeys, auth_header_for_package_download,
     download::{
         DownloadTarballToStore, download_priority, fetch_and_extract_with_retry,
         is_transient_error, slow_download_warning,
@@ -40,6 +40,31 @@ use tempfile::{TempDir, tempdir};
 
 fn integrity(integrity_str: &str) -> Integrity {
     integrity_str.parse().expect("parse integrity string")
+}
+
+#[test]
+fn node_runtime_downloads_do_not_send_auth_over_remote_http() {
+    let auth_headers = AuthHeaders::from_creds_map([(
+        "//mirror.example/".to_string(),
+        "Bearer mirror-token".to_string(),
+    )]);
+    assert_eq!(
+        auth_header_for_package_download(
+            &auth_headers,
+            "http://mirror.example/node.tar.gz",
+            "node@runtime:22.0.0",
+        ),
+        None,
+    );
+    assert_eq!(
+        auth_header_for_package_download(
+            &auth_headers,
+            "https://mirror.example/node.tar.gz",
+            "node@runtime:22.0.0",
+        )
+        .as_deref(),
+        Some("Bearer mirror-token"),
+    );
 }
 
 #[test]

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -8,8 +8,9 @@ use super::{
     Arc, Component, Cursor, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant,
     NetworkError, PathBuf, PrefetchedCasPaths, Read, STREAM_ENTRY_BUFFER_MAX, TarballError,
     UNIX_EPOCH, VerifyChecksumError, allocate_tarball_buffer, apply_append_manifest,
-    apply_placeholder_manifest, emit_progress_found_in_store, is_transient_error,
-    load_cached_cas_paths, post_download_semaphore, tarball_error_to_request_retry,
+    apply_placeholder_manifest, auth_header_for_package_download, emit_progress_found_in_store,
+    is_transient_error, load_cached_cas_paths, post_download_semaphore,
+    tarball_error_to_request_retry,
 };
 use pnpm_fs::file_mode;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
@@ -300,7 +301,7 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
     // would 401 without this. Keeps parity with pnpm's binary
     // fetcher which goes through the same `fetchFromRegistry` /
     // auth-header plumbing.
-    if let Some(value) = auth_headers.for_url_with_package(package_url, Some(package_id)) {
+    if let Some(value) = auth_header_for_package_download(auth_headers, package_url, package_id) {
         request = request.header("authorization", value);
     }
 

--- a/pnpm11/crypto/shasums-file/src/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/src/diskCache.ts
@@ -26,6 +26,8 @@ import { threadId } from 'node:worker_threads'
  *   (their bodies were project-controllable before the cache existed), and
  *   the musl list's download URLs are derived from the hardcoded
  *   unofficial-builds base, never from the cached body.
+ * - Authenticated responses bypass this cache because the URL does not
+ *   identify the credential context that produced the body.
  *
  * The `<trust>` path segment keeps the two classes in disjoint subtrees so
  * their read policies cannot be confused.

--- a/pnpm11/crypto/shasums-file/src/index.ts
+++ b/pnpm11/crypto/shasums-file/src/index.ts
@@ -40,6 +40,7 @@ export async function fetchVerifiedNodeShasumsFile (
 
 export interface FetchShasumsFileCachedOpts {
   cacheDir?: string
+  skipCache?: boolean
 }
 
 export interface FetchVerifiedNodeShasumsFileCachedOpts extends FetchShasumsFileCachedOpts {
@@ -61,7 +62,7 @@ export async function fetchVerifiedNodeShasumsFileCached (
   shasumsUrl: string,
   opts?: FetchVerifiedNodeShasumsFileCachedOpts
 ): Promise<ShasumsFileItem[]> {
-  const cacheOpts = { cacheDir: opts?.cacheDir, trust: 'verified' as const }
+  const cacheOpts = { cacheDir: opts?.skipCache === true ? undefined : opts?.cacheDir, trust: 'verified' as const }
   const signatureUrl = `${shasumsUrl}.sig`
   const [cachedBody, cachedSignature] = await Promise.all([
     readCachedShasums(shasumsUrl, cacheOpts),
@@ -93,7 +94,7 @@ export async function fetchShasumsFileCached (
   shasumsUrl: string,
   opts?: FetchShasumsFileCachedOpts
 ): Promise<ShasumsFileItem[]> {
-  const cacheOpts = { cacheDir: opts?.cacheDir, trust: 'unverified' as const }
+  const cacheOpts = { cacheDir: opts?.skipCache === true ? undefined : opts?.cacheDir, trust: 'unverified' as const }
   const cached = await readCachedShasums(shasumsUrl, cacheOpts)
   if (cached != null) return parseShasumsFile(cached)
   const body = await fetchShasumsFileRaw(fetch, shasumsUrl)

--- a/pnpm11/crypto/shasums-file/test/diskCache.ts
+++ b/pnpm11/crypto/shasums-file/test/diskCache.ts
@@ -35,6 +35,23 @@ test('fetchShasumsFileCached() serves repeat reads from the cache', async () => 
   )).toBe(SHASUMS)
 })
 
+test('fetchShasumsFileCached() can bypass an existing URL cache entry', async () => {
+  const cacheDir = await temporaryDirectory()
+  let responseBody = SHASUMS
+  const { fetch, calls } = countingFetch({
+    [SHASUMS_URL]: () => new Response(responseBody),
+  })
+
+  const cachedContext = await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir })
+  responseBody = 'cafebabe'.repeat(8) + '  node-v22.11.0-linux-x64.tar.gz\n'
+  const isolatedContext = await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir, skipCache: true })
+  const stillCached = await fetchShasumsFileCached(fetch, SHASUMS_URL, { cacheDir })
+
+  expect(isolatedContext).not.toStrictEqual(cachedContext)
+  expect(stillCached).toStrictEqual(cachedContext)
+  expect(calls).toStrictEqual([SHASUMS_URL, SHASUMS_URL])
+})
+
 test('fetchVerifiedNodeShasumsFileCached() caches the body after verification and skips re-verification', async () => {
   const { signature, trustedKeys } = await signedShasums()
   const cacheDir = await temporaryDirectory()

--- a/pnpm11/engine/runtime/commands/package.json
+++ b/pnpm11/engine/runtime/commands/package.json
@@ -37,6 +37,7 @@
     "@pnpm/engine.runtime.node-resolver": "workspace:*",
     "@pnpm/error": "workspace:*",
     "@pnpm/exec.pnpm-cli-runner": "workspace:*",
+    "@pnpm/network.auth-header": "workspace:*",
     "@pnpm/network.fetch": "workspace:*",
     "@pnpm/types": "workspace:*",
     "render-help": "catalog:"

--- a/pnpm11/engine/runtime/commands/src/env/envList.ts
+++ b/pnpm11/engine/runtime/commands/src/env/envList.ts
@@ -1,4 +1,5 @@
 import { getNodeMirror, parseNodeSpecifier, resolveNodeVersions } from '@pnpm/engine.runtime.node-resolver'
+import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry } from '@pnpm/network.fetch'
 
 import type { NvmNodeCommandOptions } from './node.js'
@@ -13,5 +14,8 @@ async function listRemoteVersions (opts: NvmNodeCommandOptions, versionSpec?: st
   const fetch = createFetchFromRegistry(opts)
   const { releaseChannel, versionSpecifier } = versionSpec ? parseNodeSpecifier(versionSpec) : { releaseChannel: 'release', versionSpecifier: '' }
   const nodeMirrorBaseUrl = getNodeMirror(opts.nodeDownloadMirrors, releaseChannel)
-  return resolveNodeVersions(fetch, versionSpecifier, nodeMirrorBaseUrl)
+  return resolveNodeVersions(fetch, versionSpecifier, {
+    nodeMirrorBaseUrl,
+    getAuthHeader: createGetAuthHeaderByURI(opts.configByUri),
+  })
 }

--- a/pnpm11/engine/runtime/commands/tsconfig.json
+++ b/pnpm11/engine/runtime/commands/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "../../../exec/pnpm-cli-runner"
     },
     {
+      "path": "../../../network/auth-header"
+    },
+    {
       "path": "../../../network/fetch"
     },
     {

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -212,7 +212,8 @@ async function readNodeAssetsFromMirror (
   const integritiesFileUrl = `${nodeMirrorBaseUrl}v${version}/SHASUMS256.txt`
   const cacheOpts = {
     cacheDir: opts.cacheDir,
-    skipCache: getAuthHeader?.(integritiesFileUrl) != null,
+    skipCache: getSecureAuthHeader(getAuthHeader, integritiesFileUrl) != null ||
+      getSecureAuthHeader(getAuthHeader, `${integritiesFileUrl}.sig`) != null,
   }
   const shasumsFileItems = verifySignature
     ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, cacheOpts)
@@ -334,8 +335,20 @@ function createAuthenticatedFetch (fetch: FetchFromRegistry, getAuthHeader?: Get
   if (getAuthHeader == null) return fetch
   return (url, opts) => fetch(url, {
     ...opts,
-    authHeaderValue: getAuthHeader(url),
+    authHeaderValue: getSecureAuthHeader(getAuthHeader, url),
   })
+}
+
+function getSecureAuthHeader (getAuthHeader: GetAuthHeader | undefined, url: string): string | undefined {
+  const authHeaderValue = getAuthHeader?.(url)
+  if (authHeaderValue == null) return undefined
+  const parsed = new URL(url)
+  if (parsed.protocol === 'https:' || isLoopbackHost(parsed.hostname)) return authHeaderValue
+  return undefined
+}
+
+function isLoopbackHost (hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.')
 }
 
 function getNodeBinsForCurrentOS (platform: string = process.platform): Record<string, string> {

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net'
+
 import { fetchShasumsFileCached, fetchVerifiedNodeShasumsFileCached } from '@pnpm/crypto.shasums-file'
 import { PnpmError } from '@pnpm/error'
 import type { FetchFromRegistry, GetAuthHeader } from '@pnpm/fetching.types'
@@ -363,7 +365,7 @@ function getSecureAuthHeader (getAuthHeader: GetAuthHeader | undefined, url: str
 }
 
 function isLoopbackHost (hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.')
+  return hostname === 'localhost' || hostname === '[::1]' || (isIP(hostname) === 4 && hostname.startsWith('127.'))
 }
 
 function isRedirectStatus (status: number): boolean {

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -276,6 +276,8 @@ const SEMVER_OPTS = {
   loose: true,
 }
 
+const MAX_NODE_MIRROR_REDIRECTS = 20
+
 export async function resolveNodeVersion (
   fetch: FetchFromRegistry,
   versionSpec: string,
@@ -333,10 +335,23 @@ function normalizeNodeVersionFetchOptions (opts?: string | NodeVersionFetchOptio
 
 function createAuthenticatedFetch (fetch: FetchFromRegistry, getAuthHeader?: GetAuthHeader): FetchFromRegistry {
   if (getAuthHeader == null) return fetch
-  return (url, opts) => fetch(url, {
-    ...opts,
-    authHeaderValue: getSecureAuthHeader(getAuthHeader, url),
-  })
+  return async (url, opts) => {
+    let currentUrl = url
+    for (let redirectCount = 0; ; redirectCount++) {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(currentUrl, {
+        ...opts,
+        authHeaderValue: getSecureAuthHeader(getAuthHeader, currentUrl),
+        redirect: 'manual',
+      })
+      if (opts?.redirect === 'manual' || !isRedirectStatus(response.status) || redirectCount === MAX_NODE_MIRROR_REDIRECTS) {
+        return response
+      }
+      const location = response.headers.get('location')
+      if (location == null) return response
+      currentUrl = new URL(location, currentUrl).toString()
+    }
+  }
 }
 
 function getSecureAuthHeader (getAuthHeader: GetAuthHeader | undefined, url: string): string | undefined {
@@ -349,6 +364,10 @@ function getSecureAuthHeader (getAuthHeader: GetAuthHeader | undefined, url: str
 
 function isLoopbackHost (hostname: string): boolean {
   return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.')
+}
+
+function isRedirectStatus (status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308
 }
 
 function getNodeBinsForCurrentOS (platform: string = process.platform): Record<string, string> {

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -75,7 +75,7 @@ export async function resolveNodeRuntime (
   }
   let variants: PlatformAssetResolution[]
   try {
-    variants = await readNodeAssets(fetch, { nodeMirrorBaseUrl, version, releaseChannel, cacheDir: ctx.cacheDir })
+    variants = await readNodeAssets(fetch, { nodeMirrorBaseUrl, version, releaseChannel, cacheDir: ctx.cacheDir, getAuthHeader: ctx.getAuthHeader })
   } catch (err: unknown) {
     // The exact-specifier pick skipped the release index, so a failed asset
     // read is ambiguous: the version may simply not exist. Consult the index
@@ -168,15 +168,16 @@ async function readNodeAssets (
     version: string
     releaseChannel: string
     cacheDir?: string
+    getAuthHeader?: GetAuthHeader
   }
 ): Promise<PlatformAssetResolution[]> {
-  const { nodeMirrorBaseUrl, version, releaseChannel, cacheDir } = opts
+  const { nodeMirrorBaseUrl, version, releaseChannel, cacheDir, getAuthHeader } = opts
   // The mirror is repository-configurable, so the SHASUMS file's hashes are only
   // trustworthy once its OpenPGP signature is verified against the Node.js
   // release keys embedded in pnpm. Only the `release` channel publishes a signed
   // SHASUMS256.txt; pre-release channels (rc, nightly, …) are unsigned by Node,
   // so they cannot be verified this way.
-  const assets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl, version, muslOnly: false, verifySignature: releaseChannel === 'release', cacheDir })
+  const assets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl, version, muslOnly: false, verifySignature: releaseChannel === 'release', cacheDir, getAuthHeader })
 
   // When using the default mirror, also fetch musl variants from unofficial-builds.nodejs.org,
   // since musl builds are not available on the official mirror. That URL is hardcoded (not
@@ -184,7 +185,7 @@ async function readNodeAssets (
   // over TLS rather than verified against the official release keys.
   if (nodeMirrorBaseUrl === DEFAULT_NODE_MIRROR_BASE_URL) {
     try {
-      const muslAssets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl: UNOFFICIAL_NODE_MIRROR_BASE_URL, version, muslOnly: true, verifySignature: false, cacheDir })
+      const muslAssets = await readNodeAssetsFromMirror(fetch, { nodeMirrorBaseUrl: UNOFFICIAL_NODE_MIRROR_BASE_URL, version, muslOnly: true, verifySignature: false, cacheDir, getAuthHeader })
       assets.push(...muslAssets)
     } catch {
       // Musl variants may not be available for all Node.js versions (e.g. very old ones)
@@ -202,15 +203,20 @@ async function readNodeAssetsFromMirror (
     muslOnly: boolean
     verifySignature: boolean
     cacheDir?: string
+    getAuthHeader?: GetAuthHeader
   }
 ): Promise<PlatformAssetResolution[]> {
-  const { nodeMirrorBaseUrl, version, muslOnly, verifySignature, cacheDir } = opts
+  const { nodeMirrorBaseUrl, version, muslOnly, verifySignature, getAuthHeader } = opts
   // The URL is pinned to one released version, which is what makes it
   // eligible for the SHASUMS disk cache.
   const integritiesFileUrl = `${nodeMirrorBaseUrl}v${version}/SHASUMS256.txt`
+  const cacheOpts = {
+    cacheDir: opts.cacheDir,
+    skipCache: getAuthHeader?.(integritiesFileUrl) != null,
+  }
   const shasumsFileItems = verifySignature
-    ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, { cacheDir })
-    : await fetchShasumsFileCached(fetch, integritiesFileUrl, { cacheDir })
+    ? await fetchVerifiedNodeShasumsFileCached(fetch, integritiesFileUrl, cacheOpts)
+    : await fetchShasumsFileCached(fetch, integritiesFileUrl, cacheOpts)
   const escaped = version.replace(/\\/g, '\\\\').replace(/\./g, '\\.')
   // The second capture group uses [^.-]+ to stop at a dash, so that the optional
   // third group can capture the '-musl' suffix separately (e.g. 'x64' + '-musl').

--- a/pnpm11/engine/runtime/node-resolver/src/index.ts
+++ b/pnpm11/engine/runtime/node-resolver/src/index.ts
@@ -1,6 +1,6 @@
 import { fetchShasumsFileCached, fetchVerifiedNodeShasumsFileCached } from '@pnpm/crypto.shasums-file'
 import { PnpmError } from '@pnpm/error'
-import type { FetchFromRegistry } from '@pnpm/fetching.types'
+import type { FetchFromRegistry, GetAuthHeader } from '@pnpm/fetching.types'
 import type {
   BinaryResolution,
   LatestInfo,
@@ -39,6 +39,7 @@ export interface NodeRuntimeResolveResult extends ResolveResult {
 export async function resolveNodeRuntime (
   ctx: {
     fetchFromRegistry: FetchFromRegistry
+    getAuthHeader?: GetAuthHeader
     nodeDownloadMirrors?: Record<string, string>
     offline?: boolean
     cacheDir?: string
@@ -57,6 +58,7 @@ export async function resolveNodeRuntime (
   }
 
   if (ctx.offline) throw new PnpmError('NO_OFFLINE_NODEJS_RESOLUTION', 'Offline Node.js resolution is not supported')
+  const fetch = createAuthenticatedFetch(ctx.fetchFromRegistry, ctx.getAuthHeader)
   const versionSpec = normalizeRuntimeSpec(wantedDependency.bareSpecifier.substring('runtime:'.length))
   const { releaseChannel, versionSpecifier } = parseNodeSpecifier(versionSpec)
   const nodeMirrorBaseUrl = getNodeMirror(ctx.nodeDownloadMirrors, releaseChannel)
@@ -66,21 +68,21 @@ export async function resolveNodeRuntime (
   const exactVersion = exactReleaseVersion(releaseChannel, versionSpecifier)
   let version = exactVersion
   if (version == null) {
-    version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl) ?? undefined
+    version = await resolveNodeVersion(fetch, versionSpecifier, nodeMirrorBaseUrl) ?? undefined
     if (!version) {
       throw new PnpmError('NODEJS_VERSION_NOT_FOUND', `Could not find a Node.js version that satisfies ${versionSpec}`)
     }
   }
   let variants: PlatformAssetResolution[]
   try {
-    variants = await readNodeAssets(ctx.fetchFromRegistry, { nodeMirrorBaseUrl, version, releaseChannel, cacheDir: ctx.cacheDir })
+    variants = await readNodeAssets(fetch, { nodeMirrorBaseUrl, version, releaseChannel, cacheDir: ctx.cacheDir })
   } catch (err: unknown) {
     // The exact-specifier pick skipped the release index, so a failed asset
     // read is ambiguous: the version may simply not exist. Consult the index
     // now, purely to raise the same NODEJS_VERSION_NOT_FOUND the index-first
     // path raises for a nonexistent version; any other outcome re-raises the
     // asset error unchanged.
-    if (exactVersion != null && await versionMissingFromIndex(ctx.fetchFromRegistry, exactVersion, nodeMirrorBaseUrl)) {
+    if (exactVersion != null && await versionMissingFromIndex(fetch, exactVersion, nodeMirrorBaseUrl)) {
       throw new PnpmError('NODEJS_VERSION_NOT_FOUND', `Could not find a Node.js version that satisfies ${versionSpec}`)
     }
     throw err
@@ -103,7 +105,7 @@ export async function resolveNodeRuntime (
 }
 
 export async function resolveLatestNodeRuntime (
-  ctx: { fetchFromRegistry: FetchFromRegistry, nodeDownloadMirrors?: Record<string, string> },
+  ctx: { fetchFromRegistry: FetchFromRegistry, getAuthHeader?: GetAuthHeader, nodeDownloadMirrors?: Record<string, string> },
   query: LatestQuery,
   _opts: ResolveOptions
 ): Promise<LatestInfo | undefined> {
@@ -112,7 +114,10 @@ export async function resolveLatestNodeRuntime (
   const versionSpec = query.compatible ? normalizeRuntimeSpec(manifestSpec.substring('runtime:'.length)) : 'latest'
   const { releaseChannel, versionSpecifier } = parseNodeSpecifier(versionSpec)
   const nodeMirrorBaseUrl = getNodeMirror(ctx.nodeDownloadMirrors, releaseChannel)
-  const version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, nodeMirrorBaseUrl)
+  const version = await resolveNodeVersion(ctx.fetchFromRegistry, versionSpecifier, {
+    nodeMirrorBaseUrl,
+    getAuthHeader: ctx.getAuthHeader,
+  })
   if (!version) return {}
   return { latestManifest: { name: 'node', version } }
 }
@@ -267,9 +272,10 @@ const SEMVER_OPTS = {
 export async function resolveNodeVersion (
   fetch: FetchFromRegistry,
   versionSpec: string,
-  nodeMirrorBaseUrl?: string
+  opts?: string | NodeVersionFetchOptions
 ): Promise<string | null> {
-  const allVersions = await fetchAllVersions(fetch, nodeMirrorBaseUrl)
+  const { nodeMirrorBaseUrl, getAuthHeader } = normalizeNodeVersionFetchOptions(opts)
+  const allVersions = await fetchAllVersions(createAuthenticatedFetch(fetch, getAuthHeader), nodeMirrorBaseUrl)
   versionSpec = normalizeRuntimeSpec(versionSpec)
   if (versionSpec === 'latest') {
     return allVersions[0].version
@@ -281,9 +287,10 @@ export async function resolveNodeVersion (
 export async function resolveNodeVersions (
   fetch: FetchFromRegistry,
   versionSpec?: string,
-  nodeMirrorBaseUrl?: string
+  opts?: string | NodeVersionFetchOptions
 ): Promise<string[]> {
-  const allVersions = await fetchAllVersions(fetch, nodeMirrorBaseUrl)
+  const { nodeMirrorBaseUrl, getAuthHeader } = normalizeNodeVersionFetchOptions(opts)
+  const allVersions = await fetchAllVersions(createAuthenticatedFetch(fetch, getAuthHeader), nodeMirrorBaseUrl)
   if (versionSpec == null) {
     return allVersions.map(({ version }) => version)
   }
@@ -306,6 +313,23 @@ async function fetchAllVersions (fetch: FetchFromRegistry, nodeMirrorBaseUrl?: s
     version: version.substring(1),
     lts,
   }))
+}
+
+export interface NodeVersionFetchOptions {
+  nodeMirrorBaseUrl?: string
+  getAuthHeader?: GetAuthHeader
+}
+
+function normalizeNodeVersionFetchOptions (opts?: string | NodeVersionFetchOptions): NodeVersionFetchOptions {
+  return typeof opts === 'string' ? { nodeMirrorBaseUrl: opts } : opts ?? {}
+}
+
+function createAuthenticatedFetch (fetch: FetchFromRegistry, getAuthHeader?: GetAuthHeader): FetchFromRegistry {
+  if (getAuthHeader == null) return fetch
+  return (url, opts) => fetch(url, {
+    ...opts,
+    authHeaderValue: getAuthHeader(url),
+  })
 }
 
 function getNodeBinsForCurrentOS (platform: string = process.platform): Record<string, string> {

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -43,6 +43,28 @@ test.each([
   expect(resolution?.normalizedBareSpecifier).toBe(expected)
 })
 
+test('resolveNodeRuntime() authenticates release index and SHASUMS requests', async () => {
+  const requests: Array<{ url: string, authHeaderValue?: string }> = []
+  const authenticatedFetch: FetchFromRegistry = async (url, opts) => {
+    requests.push({ url, authHeaderValue: opts?.authHeaderValue })
+    return fetch(url)
+  }
+
+  await resolveNodeRuntime({
+    fetchFromRegistry: authenticatedFetch,
+    getAuthHeader: url => url.startsWith(MIRROR) ? 'Bearer mirror-token' : undefined,
+    nodeDownloadMirrors: { rc: MIRROR },
+  }, {
+    alias: 'node',
+    bareSpecifier: 'runtime:rc/22',
+  })
+
+  expect(requests).toEqual([
+    { url: `${MIRROR}index.json`, authHeaderValue: 'Bearer mirror-token' },
+    { url: `${MIRROR}v22.11.0/SHASUMS256.txt`, authHeaderValue: 'Bearer mirror-token' },
+  ])
+})
+
 const RELEASE_MIRROR = 'https://node.example/download/release/'
 
 // An exact-specifier resolve skips the release index, so a nonexistent

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -75,6 +75,35 @@ test('resolveNodeRuntime() authenticates release index and SHASUMS requests with
   }
 })
 
+test('resolveNodeRuntime() omits credentials for a remote HTTP mirror', async () => {
+  const mirror = 'http://node.example/download/rc/'
+  const requests: Array<{ url: string, authHeaderValue?: string }> = []
+  const httpFetch: FetchFromRegistry = async (url, opts) => {
+    requests.push({ url, authHeaderValue: opts?.authHeaderValue })
+    if (url === `${mirror}index.json`) {
+      return new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }]))
+    }
+    if (url === `${mirror}v22.11.0/SHASUMS256.txt`) {
+      return new Response('ed52239294ad517fbe91a268146d5d2aa8a17d2d62d64873e43219078ba71c4e  node-v22.11.0-linux-x64.tar.gz\n')
+    }
+    throw new Error(`Unexpected URL: ${url}`)
+  }
+
+  await resolveNodeRuntime({
+    fetchFromRegistry: httpFetch,
+    getAuthHeader: () => 'Bearer mirror-token',
+    nodeDownloadMirrors: { rc: mirror },
+  }, {
+    alias: 'node',
+    bareSpecifier: 'runtime:rc/22',
+  })
+
+  expect(requests).toEqual([
+    { url: `${mirror}index.json`, authHeaderValue: undefined },
+    { url: `${mirror}v22.11.0/SHASUMS256.txt`, authHeaderValue: undefined },
+  ])
+})
+
 const RELEASE_MIRROR = 'https://node.example/download/release/'
 
 // An exact-specifier resolve skips the release index, so a nonexistent

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -75,8 +75,10 @@ test('resolveNodeRuntime() authenticates release index and SHASUMS requests with
   }
 })
 
-test('resolveNodeRuntime() omits credentials for a remote HTTP mirror', async () => {
-  const mirror = 'http://node.example/download/rc/'
+test.each([
+  'http://node.example/download/rc/',
+  'http://127.attacker.example/download/rc/',
+])('resolveNodeRuntime() omits credentials for remote HTTP mirror %s', async (mirror) => {
   const requests: Array<{ url: string, authHeaderValue?: string }> = []
   const httpFetch: FetchFromRegistry = async (url, opts) => {
     requests.push({ url, authHeaderValue: opts?.authHeaderValue })

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -43,26 +43,36 @@ test.each([
   expect(resolution?.normalizedBareSpecifier).toBe(expected)
 })
 
-test('resolveNodeRuntime() authenticates release index and SHASUMS requests', async () => {
+test('resolveNodeRuntime() authenticates release index and SHASUMS requests without sharing cached metadata', async () => {
   const requests: Array<{ url: string, authHeaderValue?: string }> = []
   const authenticatedFetch: FetchFromRegistry = async (url, opts) => {
     requests.push({ url, authHeaderValue: opts?.authHeaderValue })
     return fetch(url)
   }
+  const cacheDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pnpm-node-resolver-auth-'))
+  try {
+    for (let run = 0; run < 2; run++) {
+      // eslint-disable-next-line no-await-in-loop
+      await resolveNodeRuntime({
+        fetchFromRegistry: authenticatedFetch,
+        getAuthHeader: url => url.startsWith(MIRROR) ? 'Bearer mirror-token' : undefined,
+        nodeDownloadMirrors: { rc: MIRROR },
+        cacheDir,
+      }, {
+        alias: 'node',
+        bareSpecifier: 'runtime:rc/22',
+      })
+    }
 
-  await resolveNodeRuntime({
-    fetchFromRegistry: authenticatedFetch,
-    getAuthHeader: url => url.startsWith(MIRROR) ? 'Bearer mirror-token' : undefined,
-    nodeDownloadMirrors: { rc: MIRROR },
-  }, {
-    alias: 'node',
-    bareSpecifier: 'runtime:rc/22',
-  })
-
-  expect(requests).toEqual([
-    { url: `${MIRROR}index.json`, authHeaderValue: 'Bearer mirror-token' },
-    { url: `${MIRROR}v22.11.0/SHASUMS256.txt`, authHeaderValue: 'Bearer mirror-token' },
-  ])
+    expect(requests).toEqual([
+      { url: `${MIRROR}index.json`, authHeaderValue: 'Bearer mirror-token' },
+      { url: `${MIRROR}v22.11.0/SHASUMS256.txt`, authHeaderValue: 'Bearer mirror-token' },
+      { url: `${MIRROR}index.json`, authHeaderValue: 'Bearer mirror-token' },
+      { url: `${MIRROR}v22.11.0/SHASUMS256.txt`, authHeaderValue: 'Bearer mirror-token' },
+    ])
+  } finally {
+    await fs.promises.rm(cacheDir, { recursive: true, force: true })
+  }
 })
 
 const RELEASE_MIRROR = 'https://node.example/download/release/'

--- a/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
+++ b/pnpm11/engine/runtime/node-resolver/test/resolveNodeRuntime.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { expect, test } from '@jest/globals'
 import type { FetchFromRegistry } from '@pnpm/fetching.types'
 
-import { resolveNodeRuntime } from '../lib/index.js'
+import { resolveNodeRuntime, resolveNodeVersion } from '../lib/index.js'
 
 const MIRROR = 'https://node.example/download/rc/'
 
@@ -101,6 +101,33 @@ test('resolveNodeRuntime() omits credentials for a remote HTTP mirror', async ()
   expect(requests).toEqual([
     { url: `${mirror}index.json`, authHeaderValue: undefined },
     { url: `${mirror}v22.11.0/SHASUMS256.txt`, authHeaderValue: undefined },
+  ])
+})
+
+test('resolveNodeVersion() selects credentials again after a redirect', async () => {
+  const startUrl = `${MIRROR}index.json`
+  const redirectedUrl = 'http://node.example/public/index.json'
+  const requests: Array<{ url: string, authHeaderValue?: string }> = []
+  const redirectingFetch: FetchFromRegistry = async (url, opts) => {
+    requests.push({ url, authHeaderValue: opts?.authHeaderValue })
+    if (url === startUrl) {
+      return new Response(null, { status: 302, headers: { location: redirectedUrl } })
+    }
+    if (url === redirectedUrl) {
+      return new Response(JSON.stringify([{ version: 'v22.11.0', lts: false }]))
+    }
+    throw new Error(`Unexpected URL: ${url}`)
+  }
+
+  const version = await resolveNodeVersion(redirectingFetch, 'latest', {
+    nodeMirrorBaseUrl: MIRROR,
+    getAuthHeader: url => url.startsWith(MIRROR) ? 'Bearer mirror-token' : undefined,
+  })
+
+  expect(version).toBe('22.11.0')
+  expect(requests).toEqual([
+    { url: startUrl, authHeaderValue: 'Bearer mirror-token' },
+    { url: redirectedUrl, authHeaderValue: undefined },
   ])
 })
 

--- a/pnpm11/fetching/binary-fetcher/src/index.ts
+++ b/pnpm11/fetching/binary-fetcher/src/index.ts
@@ -4,7 +4,7 @@ import util from 'node:util'
 
 import { PnpmError } from '@pnpm/error'
 import type { BinaryFetcher, FetchFunction, FetchResult } from '@pnpm/fetching.fetcher-base'
-import type { FetchFromRegistry } from '@pnpm/fetching.types'
+import type { FetchFromRegistry, GetAuthHeader } from '@pnpm/fetching.types'
 import type { StoreIndex } from '@pnpm/store.index'
 import { addFilesFromDir } from '@pnpm/worker'
 import AdmZip from 'adm-zip'
@@ -16,6 +16,7 @@ import { temporaryDirectory } from 'tempy'
 export interface CreateBinaryFetcherOptions {
   fetch: FetchFromRegistry
   fetchFromRemoteTarball: FetchFunction
+  getAuthHeader?: GetAuthHeader
   storeIndex: StoreIndex
   offline?: boolean
   /**
@@ -75,6 +76,7 @@ export function createBinaryFetcher (ctx: CreateBinaryFetcherOptions): { binary:
           url: resolution.url,
           integrity: resolution.integrity,
           basename: resolution.prefix ?? '',
+          authHeaderValue: ctx.getAuthHeader?.(resolution.url),
           ignoreEntry: archiveFilter?.regex,
         }, tempLocation)
         fetchResult = await addFilesFromDir({
@@ -106,6 +108,7 @@ export interface AssetInfo {
   url: string
   integrity: string
   basename: string
+  authHeaderValue?: string
   /**
    * Regex matched against each zip entry's path relative to the archive's top-level basename.
    * Matching entries are skipped during extraction.
@@ -146,10 +149,10 @@ export async function downloadAndUnpackZip (
  */
 async function downloadWithIntegrityCheck (
   fetchFromRegistry: FetchFromRegistry,
-  { url, integrity }: AssetInfo,
+  { url, integrity, authHeaderValue }: AssetInfo,
   tmpPath: string
 ): Promise<void> {
-  const response = await fetchFromRegistry(url)
+  const response = await fetchFromRegistry(url, { authHeaderValue })
 
   // Collect all chunks from the response
   const chunks: Buffer[] = []

--- a/pnpm11/fetching/binary-fetcher/src/index.ts
+++ b/pnpm11/fetching/binary-fetcher/src/index.ts
@@ -76,7 +76,7 @@ export function createBinaryFetcher (ctx: CreateBinaryFetcherOptions): { binary:
           url: resolution.url,
           integrity: resolution.integrity,
           basename: resolution.prefix ?? '',
-          authHeaderValue: ctx.getAuthHeader?.(resolution.url),
+          authHeaderValue: getSecureNodeMirrorAuthHeader(ctx.getAuthHeader, resolution.url, opts.pkg.name),
           ignoreEntry: archiveFilter?.regex,
         }, tempLocation)
         fetchResult = await addFilesFromDir({
@@ -102,6 +102,18 @@ export function createBinaryFetcher (ctx: CreateBinaryFetcherOptions): { binary:
   return {
     binary: fetchBinary,
   }
+}
+
+function getSecureNodeMirrorAuthHeader (
+  getAuthHeader: GetAuthHeader | undefined,
+  url: string,
+  packageName: string | undefined
+): string | undefined {
+  const authHeaderValue = getAuthHeader?.(url)
+  if (authHeaderValue == null || packageName !== 'node') return authHeaderValue
+  const parsed = new URL(url)
+  if (parsed.protocol === 'https:' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname.startsWith('127.')) return authHeaderValue
+  return undefined
 }
 
 export interface AssetInfo {

--- a/pnpm11/fetching/binary-fetcher/src/index.ts
+++ b/pnpm11/fetching/binary-fetcher/src/index.ts
@@ -1,4 +1,5 @@
 import fsPromises from 'node:fs/promises'
+import { isIP } from 'node:net'
 import path from 'node:path'
 import util from 'node:util'
 
@@ -112,8 +113,12 @@ function getSecureNodeMirrorAuthHeader (
   const authHeaderValue = getAuthHeader?.(url)
   if (authHeaderValue == null || packageName !== 'node') return authHeaderValue
   const parsed = new URL(url)
-  if (parsed.protocol === 'https:' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname.startsWith('127.')) return authHeaderValue
+  if (parsed.protocol === 'https:' || isLoopbackHost(parsed.hostname)) return authHeaderValue
   return undefined
+}
+
+function isLoopbackHost (hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '[::1]' || (isIP(hostname) === 4 && hostname.startsWith('127.'))
 }
 
 export interface AssetInfo {

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -373,6 +373,36 @@ describe('extractZipToTarget security', () => {
 })
 
 describe('createBinaryFetcher', () => {
+  it.each([
+    ['https://mirror.example/node.zip', 'Bearer mirror-token'],
+    ['http://mirror.example/node.zip', undefined],
+  ])('selects secure Node.js mirror auth for %s', async (url, expectedAuthHeaderValue) => {
+    const fetch = ((_url: string, opts?: { authHeaderValue?: string }) => {
+      expect(opts?.authHeaderValue).toBe(expectedAuthHeaderValue)
+      throw new Error('stop after request inspection')
+    }) as never
+    const binaryFetcher = createBinaryFetcher({
+      fetch,
+      fetchFromRemoteTarball: fetch,
+      getAuthHeader: () => 'Bearer mirror-token',
+      storeIndex: {} as never,
+    }).binary
+
+    await expect(binaryFetcher({
+      tempDir: async () => temporaryDirectory(),
+    } as never, {
+      type: 'binary',
+      archive: 'zip',
+      bin: { node: 'node.exe' },
+      integrity: 'sha512-unused',
+      url,
+    }, {
+      filesIndexFile: 'unused',
+      lockfileDir: 'unused',
+      pkg: { name: 'node', version: '22.0.0' },
+    })).rejects.toThrow('stop after request inspection')
+  })
+
   it('rejects an invalid archiveFilters regex at creation time', () => {
     const noop = (() => {
       throw new Error('should not be called')

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -376,6 +376,8 @@ describe('createBinaryFetcher', () => {
   it.each([
     ['https://mirror.example/node.zip', 'Bearer mirror-token'],
     ['http://mirror.example/node.zip', undefined],
+    ['http://127.attacker.example/node.zip', undefined],
+    ['http://127.0.0.1/node.zip', 'Bearer mirror-token'],
   ])('selects secure Node.js mirror auth for %s', async (url, expectedAuthHeaderValue) => {
     const fetch = ((_url: string, opts?: { authHeaderValue?: string }) => {
       expect(opts?.authHeaderValue).toBe(expectedAuthHeaderValue)

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -198,6 +198,29 @@ describe('extractZipToTarget security', () => {
       expect(fs.existsSync(path.join(targetDir, 'README.md'))).toBe(true)
     })
 
+    it('should authenticate the ZIP download', async () => {
+      const targetDir = temporaryDirectory()
+      const zip = new AdmZip()
+      zip.addFile('node-v20.0.0/bin/node', Buffer.from('binary'))
+      const zipBuffer = zip.toBuffer()
+      const integrity = ssri.fromData(zipBuffer).toString()
+      const fetch = (_url: string, opts?: { authHeaderValue?: string }) => {
+        expect(opts?.authHeaderValue).toBe('Bearer mirror-token')
+        return Promise.resolve({
+          body: (async function * () {
+            yield zipBuffer
+          })(),
+        })
+      }
+
+      await downloadAndUnpackZip(fetch as never, {
+        url: 'https://example.com/node.zip',
+        integrity,
+        basename: 'node-v20.0.0',
+        authHeaderValue: 'Bearer mirror-token',
+      }, targetDir)
+    })
+
     it('should handle empty basename correctly', async () => {
       const targetDir = temporaryDirectory()
       const zip = new AdmZip()

--- a/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from 'node:http'
+import { isIP } from 'node:net'
 import util from 'node:util'
 
 import { requestRetryLogger } from '@pnpm/core-loggers'
@@ -239,8 +240,12 @@ function getSecureNodeMirrorAuthHeader (
 ): string | undefined {
   if (authHeaderValue == null || appendedPackageName !== 'node') return authHeaderValue
   const parsed = new URL(url)
-  if (parsed.protocol === 'https:' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname.startsWith('127.')) return authHeaderValue
+  if (parsed.protocol === 'https:' || isLoopbackHost(parsed.hostname)) return authHeaderValue
   return undefined
+}
+
+function isLoopbackHost (hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '[::1]' || (isIP(hostname) === 4 && hostname.startsWith('127.'))
 }
 
 // Per RFC 9110 §8.4, Content-Encoding is a comma-separated list of codings.

--- a/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
+++ b/pnpm11/fetching/tarball-fetcher/src/remoteTarballFetcher.ts
@@ -67,7 +67,11 @@ export function createDownloader (
   const fetchMinSpeedKiBps = gotOpts.fetchMinSpeedKiBps ?? 50 // 50 KiB/s
 
   return async function download (url: string, opts: DownloadOptions): Promise<FetchResult> {
-    const authHeaderValue = opts.getAuthHeaderByURI(url, { pkgName: opts.pkg?.name })
+    const authHeaderValue = getSecureNodeMirrorAuthHeader(
+      opts.getAuthHeaderByURI(url, { pkgName: opts.pkg?.name }),
+      url,
+      opts.appendManifest?.name
+    )
 
     const downloadRetryOpts = { ...retryOpts, ...opts.retry }
     const op = retry.operation(downloadRetryOpts)
@@ -226,6 +230,17 @@ export function createDownloader (
       })
     }
   }
+}
+
+function getSecureNodeMirrorAuthHeader (
+  authHeaderValue: string | undefined,
+  url: string,
+  appendedPackageName: string | undefined
+): string | undefined {
+  if (authHeaderValue == null || appendedPackageName !== 'node') return authHeaderValue
+  const parsed = new URL(url)
+  if (parsed.protocol === 'https:' || parsed.hostname === 'localhost' || parsed.hostname === '[::1]' || parsed.hostname.startsWith('127.')) return authHeaderValue
+  return undefined
 }
 
 // Per RFC 9110 §8.4, Content-Encoding is a comma-separated list of codings.

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -747,15 +747,19 @@ test('does not require package name for tarball auth lookup', async () => {
   expect(calls).toContainEqual({ uri: resolution.tarball, pkgName: undefined })
 })
 
-test('does not send Node.js mirror credentials over remote HTTP', async () => {
+test.each([
+  ['http://example.com', undefined],
+  ['http://127.attacker.example', undefined],
+  ['http://127.0.0.1', 'Bearer mirror-token'],
+])('selects secure Node.js mirror auth for %s', async (origin, expectedAuthHeaderValue) => {
   const tarballContent = fs.readFileSync(tarballPath)
-  const mockPool = mockAgent.get(registry)
+  const mockPool = mockAgent.get(origin)
 
   mockPool.intercept({
     path: '/download/node.tgz',
     method: 'GET',
     headers: headers => {
-      expect(headers.authorization).toBeUndefined()
+      expect(headers.authorization).toBe(expectedAuthHeaderValue)
       return true
     },
   }).reply(200, tarballContent, {
@@ -771,7 +775,7 @@ test('does not send Node.js mirror credentials over remote HTTP', async () => {
       retries: 1,
     },
   })
-  const url = `${registry}/download/node.tgz`
+  const url = `${origin}/download/node.tgz`
 
   const index = await download(url, {
     getAuthHeaderByURI: () => 'Bearer mirror-token',

--- a/pnpm11/fetching/tarball-fetcher/test/fetch.ts
+++ b/pnpm11/fetching/tarball-fetcher/test/fetch.ts
@@ -747,6 +747,44 @@ test('does not require package name for tarball auth lookup', async () => {
   expect(calls).toContainEqual({ uri: resolution.tarball, pkgName: undefined })
 })
 
+test('does not send Node.js mirror credentials over remote HTTP', async () => {
+  const tarballContent = fs.readFileSync(tarballPath)
+  const mockPool = mockAgent.get(registry)
+
+  mockPool.intercept({
+    path: '/download/node.tgz',
+    method: 'GET',
+    headers: headers => {
+      expect(headers.authorization).toBeUndefined()
+      return true
+    },
+  }).reply(200, tarballContent, {
+    headers: { 'Content-Length': tarballSize.toString() },
+  })
+
+  process.chdir(temporaryDirectory())
+
+  const download = createDownloader(fetchFromRegistry, {
+    retry: {
+      maxTimeout: 100,
+      minTimeout: 0,
+      retries: 1,
+    },
+  })
+  const url = `${registry}/download/node.tgz`
+
+  const index = await download(url, {
+    getAuthHeaderByURI: () => 'Bearer mirror-token',
+    cafs,
+    storeIndex,
+    filesIndexFile,
+    integrity: tarballIntegrity,
+    appendManifest: { name: 'node', version: '22.0.0' },
+  })
+
+  expect(index).toBeTruthy()
+})
+
 async function getFileIntegrity (filename: string) {
   return (await ssri.fromStream(fs.createReadStream(filename))).toString()
 }

--- a/pnpm11/installing/client/src/index.ts
+++ b/pnpm11/installing/client/src/index.ts
@@ -150,6 +150,7 @@ function createFetchers (
     ...createBinaryFetcher({
       fetch: fetchFromRegistry,
       fetchFromRemoteTarball: tarballFetchers.remoteTarball,
+      getAuthHeader,
       offline: opts.offline,
       storeIndex: opts.storeIndex,
       archiveFilters: { node: NODE_EXTRAS_IGNORE_PATTERN },

--- a/pnpm11/network/fetch/src/fetchFromRegistry.ts
+++ b/pnpm11/network/fetch/src/fetchFromRegistry.ts
@@ -91,7 +91,7 @@ export function createFetchFromRegistry (defaultOpts: CreateFetchFromRegistryOpt
 
     let redirects = 0
     let urlObject = new URL(url)
-    const originalHost = urlObject.host
+    const originalOrigin = urlObject.origin
     /* eslint-disable no-await-in-loop */
     while (true) {
       const dispatcherOptions: DispatcherOptions = {
@@ -123,7 +123,7 @@ export function createFetchFromRegistry (defaultOpts: CreateFetchFromRegistryOpt
       // This is a workaround to remove authorization headers on redirect.
       // Related pnpm issue: https://github.com/pnpm/pnpm/issues/1815
       urlObject = resolveRedirectUrl(response, urlObject)
-      if (originalHost === urlObject.host) continue
+      if (originalOrigin === urlObject.origin) continue
       if (headers['authorization']) {
         delete headers.authorization
       }

--- a/pnpm11/network/fetch/test/fetchFromRegistry.test.ts
+++ b/pnpm11/network/fetch/test/fetchFromRegistry.test.ts
@@ -116,6 +116,38 @@ test('authorization headers are not removed before redirection if the target is 
   }
 })
 
+test('authorization headers are removed before a same-host HTTPS downgrade', async () => {
+  setupMockAgent()
+  try {
+    const securePool = getMockAgent().get('https://registry.pnpm.io')
+    securePool.intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: { authorization: 'Bearer 123' },
+    }).reply(302, '', { headers: { location: 'http://registry.pnpm.io/is-positive' } })
+
+    const plainPool = getMockAgent().get('http://registry.pnpm.io')
+    plainPool.intercept({
+      path: '/is-positive',
+      method: 'GET',
+      headers: headers => {
+        expect(headers.authorization).toBeUndefined()
+        return true
+      },
+    }).reply(200, { ok: true }, { headers: { 'content-type': 'application/json' } })
+
+    const fetchFromRegistry = createFetchFromRegistry({})
+    const res = await fetchFromRegistry(
+      'https://registry.pnpm.io/is-positive',
+      { authHeaderValue: 'Bearer 123' }
+    )
+
+    expect(await res.json()).toStrictEqual({ ok: true })
+  } finally {
+    await teardownMockAgent()
+  }
+})
+
 test('manual redirect mode returns the redirect response without following it', async () => {
   setupMockAgent()
   try {

--- a/pnpm11/resolving/default-resolver/src/index.ts
+++ b/pnpm11/resolving/default-resolver/src/index.ts
@@ -120,10 +120,10 @@ export function createResolver (
   const localCtx = { preserveAbsolutePaths: pnpmOpts.preserveAbsolutePaths }
   const _resolveFromLocalScheme = resolveFromLocalScheme.bind(null, localCtx)
   const _resolveFromLocalPath = resolveFromLocalPath.bind(null, localCtx)
-  const _resolveNodeRuntime = resolveNodeRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors, cacheDir: pnpmOpts.cacheDir })
+  const _resolveNodeRuntime = resolveNodeRuntime.bind(null, { fetchFromRegistry, getAuthHeader, offline: pnpmOpts.offline, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors, cacheDir: pnpmOpts.cacheDir })
   const _resolveDenoRuntime = resolveDenoRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, resolveFromNpm })
   const _resolveBunRuntime = resolveBunRuntime.bind(null, { fetchFromRegistry, offline: pnpmOpts.offline, resolveFromNpm })
-  const _resolveLatestNodeRuntime = resolveLatestNodeRuntime.bind(null, { fetchFromRegistry, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors })
+  const _resolveLatestNodeRuntime = resolveLatestNodeRuntime.bind(null, { fetchFromRegistry, getAuthHeader, nodeDownloadMirrors: pnpmOpts.nodeDownloadMirrors })
   const _resolveLatestDenoRuntime = resolveLatestDenoRuntime.bind(null, { resolveFromNpm })
   const _resolveLatestBunRuntime = resolveLatestBunRuntime.bind(null, { resolveFromNpm })
   const _resolveFromCustomResolvers = pnpmOpts.customResolvers


### PR DESCRIPTION
## Summary

- Reuse pnpm's existing URL-scoped registry credentials for Node.js mirror release indexes, checksum files and signatures, and runtime archives.
- Support bearer tokens, basic authentication, and `tokenHelper` without introducing another authentication setting.
- Preserve longest-path-prefix scoping and cross-origin redirect protections so credentials are only sent to explicitly configured mirror URLs.
- Bypass the URL-keyed checksum cache for authenticated requests so metadata cannot cross credential contexts.
- Keep the TypeScript CLI and Rust pnpm implementation in parity.

Closes pnpm/pnpm#14334.

## Squash Commit Body

```text
Reuse the existing URL-scoped registry credential lookup for every Node.js mirror request instead of introducing a separate authentication setting.

This covers release indexes, SHASUMS files and signatures, and runtime archives in both implementations while retaining longest-path-prefix scoping and cross-origin redirect protections. Authenticated checksum metadata bypasses the URL-keyed disk cache so it cannot cross credential contexts.

Closes pnpm/pnpm#14334.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Node.js runtime downloads from configured mirrors now support URL-scoped authentication.
  * Authentication applies to version checks, archives, and integrity metadata.
  * `env list` can discover versions from authenticated mirrors.

* **Bug Fixes**
  * Authenticated metadata bypasses shared disk caches.
  * Credentials are not sent to remote Node.js mirrors over plain HTTP, except recognized loopback hosts.
  * Redirects re-evaluate authentication and remove credentials when switching to an insecure or different origin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->