### PR TITLE
perf(workspace): discover workspace projects concurrently

### DIFF
--- a/.changeset/spicy-donuts-discover.md
+++ b/.changeset/spicy-donuts-discover.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up workspace project discovery in large monorepos: workspace patterns are now probed concurrently and the discovered projects' `package.json` files are read in parallel [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5904,6 +5904,7 @@ dependencies = [
  "pnpm-package-manifest",
  "pnpm-workspace-projects-graph",
  "pretty_assertions",
+ "rayon",
  "serde",
  "serde-saphyr",
  "tempfile",

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -112,7 +112,10 @@ async fn update_config_can_set_extra_env() {
     )
     .expect("write pnpmfile");
     let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
-    assert!(config.extra_env.is_empty());
+    // `current::<Host>` reads the developer's real global config, which
+    // may seed `extra_env` (a global virtual store adds `NODE_PATH`), so
+    // assert only on the entry the hook adds.
+    assert_eq!(config.extra_env.get("npm_config_nodedir"), None);
 
     run_update_config_hooks::<SilentReporter>(&mut config, root.path())
         .await

--- a/pnpm/crates/workspace/Cargo.toml
+++ b/pnpm/crates/workspace/Cargo.toml
@@ -19,6 +19,7 @@ derive_more  = { workspace = true }
 indexmap     = { workspace = true }
 miette       = { workspace = true }
 pathdiff     = { workspace = true }
+rayon        = { workspace = true }
 serde        = { workspace = true }
 serde-saphyr = { workspace = true }
 wax          = { workspace = true }

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -18,6 +18,7 @@ use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manif
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
+use rayon::prelude::*;
 use std::{
     collections::BTreeSet,
     fs::{self, DirEntry},
@@ -164,85 +165,26 @@ pub fn find_workspace_projects_no_check(
             message: err.to_string(),
         })?;
 
-    // `NotFound` is the one error kind this enumeration absorbs, in both
-    // the walk below and the manifest read after it: a pattern whose
-    // directory is absent matches nothing, and a file may vanish between
-    // being listed and being read. Every other kind — parse failures,
-    // permission denials, "is a directory" — must propagate, so a
-    // malformed `package.json` surfaces as a diagnostic instead of being
-    // silently dropped from the workspace.
+    // Each pattern's probe touches its own directories, so the patterns
+    // fan out across the rayon pool and their per-pattern sets merge in
+    // list order afterwards — the merged set, and which pattern's error
+    // wins when several fail, both stay a function of the pattern list
+    // alone.
+    let pattern_sets: Vec<Result<BTreeSet<PathBuf>, FindWorkspaceProjectsError>> = include_patterns
+        .par_iter()
+        .map(|pattern| {
+            collect_pattern_manifests(
+                pattern,
+                workspace_root,
+                &ignore_template,
+                &dot_pruning_ignore_template,
+                &user_negations,
+            )
+        })
+        .collect();
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
-    for pattern in include_patterns {
-        match specialized_pattern(pattern) {
-            Some(SpecializedPattern::ChildrenOf(parent)) => {
-                collect_manifests_in_children(
-                    &workspace_root.join(parent),
-                    workspace_root,
-                    &ignore_template,
-                    &user_negations,
-                    &mut manifest_paths,
-                )?;
-                continue;
-            }
-            Some(SpecializedPattern::Literal(directory)) => {
-                collect_literal_manifests_in(
-                    &workspace_root.join(directory),
-                    workspace_root,
-                    &ignore_template,
-                    &user_negations,
-                    &mut manifest_paths,
-                );
-                continue;
-            }
-            None => {}
-        }
-
-        for normalized in normalize_manifest_patterns(pattern) {
-            let Some((walk_root, normalized)) = split_parent_prefix(workspace_root, &normalized)
-            else {
-                continue;
-            };
-            if is_literal_pattern(normalized) && !walk_root.join(normalized).is_file() {
-                continue;
-            }
-            let glob =
-                Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                    pattern: pattern.to_string(),
-                    message: err.to_string(),
-                })?;
-
-            let invalid_glob = |err: wax::BuildError| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.to_string(),
-                message: err.to_string(),
-            };
-            match positional_dot_ignores(normalized) {
-                None => collect_walk_manifests(
-                    glob.walk(walk_root)
-                        .not(dot_pruning_ignore_template.clone())
-                        .map_err(invalid_glob)?,
-                    walk_root,
-                    workspace_root,
-                    &user_negations,
-                    &mut manifest_paths,
-                )?,
-                Some(dot_ignores) => {
-                    let ignores = wax::any(
-                        IGNORE_PATTERNS
-                            .iter()
-                            .copied()
-                            .chain(dot_ignores.iter().map(String::as_str)),
-                    )
-                    .map_err(invalid_glob)?;
-                    collect_walk_manifests(
-                        glob.walk(walk_root).not(ignores).map_err(invalid_glob)?,
-                        walk_root,
-                        workspace_root,
-                        &user_negations,
-                        &mut manifest_paths,
-                    )?;
-                }
-            }
-        }
+    for set in pattern_sets {
+        manifest_paths.extend(set?);
     }
 
     for basename in PROJECT_MANIFEST_BASENAMES {
@@ -260,13 +202,126 @@ pub fn find_workspace_projects_no_check(
         dir_left.cmp(dir_right)
     });
 
-    let mut projects = Vec::with_capacity(sorted.len());
-    let mut seen_roots = BTreeSet::new();
+    // One group per project root, candidates in manifest-precedence
+    // order (`package.json` before `package.yaml` — the sort above is
+    // stable and ties keep the set's full-path order). Grouping before
+    // the reads keeps "first readable manifest wins" intact while the
+    // roots read concurrently: a candidate that vanishes mid-run still
+    // hands its root to the next candidate, never to a skipped root.
+    let mut root_groups: Vec<(PathBuf, Vec<PathBuf>)> = Vec::new();
     for manifest_path in sorted {
         let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();
-        if seen_roots.contains(&root_dir) {
+        match root_groups.last_mut() {
+            Some((last_root, candidates)) if *last_root == root_dir => {
+                candidates.push(manifest_path);
+            }
+            _ => root_groups.push((root_dir, vec![manifest_path])),
+        }
+    }
+
+    let read_results: Vec<Result<Option<Project>, FindWorkspaceProjectsError>> = root_groups
+        .into_par_iter()
+        .map(|(root_dir, candidates)| read_first_project_manifest(root_dir, candidates))
+        .collect();
+    let mut projects = Vec::with_capacity(read_results.len());
+    for result in read_results {
+        if let Some(project) = result? {
+            projects.push(project);
+        }
+    }
+
+    Ok(projects)
+}
+
+/// Expand one include pattern into the manifest paths it matches. The
+/// contract [`find_workspace_projects_no_check`] states — which error
+/// kinds are absorbed, how the fast paths and the generic walk divide
+/// the pattern space — lives there; this is its per-pattern body.
+fn collect_pattern_manifests(
+    pattern: &str,
+    workspace_root: &Path,
+    ignore_template: &wax::Any<'_>,
+    dot_pruning_ignore_template: &wax::Any<'_>,
+    user_negations: &wax::Any<'_>,
+) -> Result<BTreeSet<PathBuf>, FindWorkspaceProjectsError> {
+    let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
+    match specialized_pattern(pattern) {
+        Some(SpecializedPattern::ChildrenOf(parent)) => {
+            collect_manifests_in_children(
+                &workspace_root.join(parent),
+                workspace_root,
+                ignore_template,
+                user_negations,
+                &mut manifest_paths,
+            )?;
+            return Ok(manifest_paths);
+        }
+        Some(SpecializedPattern::Literal(directory)) => {
+            collect_literal_manifests_in(
+                &workspace_root.join(directory),
+                workspace_root,
+                ignore_template,
+                user_negations,
+                &mut manifest_paths,
+            );
+            return Ok(manifest_paths);
+        }
+        None => {}
+    }
+
+    for normalized in normalize_manifest_patterns(pattern) {
+        let Some((walk_root, normalized)) = split_parent_prefix(workspace_root, &normalized) else {
+            continue;
+        };
+        if is_literal_pattern(normalized) && !walk_root.join(normalized).is_file() {
             continue;
         }
+        let glob =
+            Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                pattern: pattern.to_string(),
+                message: err.to_string(),
+            })?;
+
+        let invalid_glob = |err: wax::BuildError| FindWorkspaceProjectsError::InvalidGlob {
+            pattern: pattern.to_string(),
+            message: err.to_string(),
+        };
+        match positional_dot_ignores(normalized) {
+            None => collect_walk_manifests(
+                glob.walk(walk_root)
+                    .not(dot_pruning_ignore_template.clone())
+                    .map_err(invalid_glob)?,
+                walk_root,
+                workspace_root,
+                user_negations,
+                &mut manifest_paths,
+            )?,
+            Some(dot_ignores) => {
+                let ignores = wax::any(
+                    IGNORE_PATTERNS.iter().copied().chain(dot_ignores.iter().map(String::as_str)),
+                )
+                .map_err(invalid_glob)?;
+                collect_walk_manifests(
+                    glob.walk(walk_root).not(ignores).map_err(invalid_glob)?,
+                    walk_root,
+                    workspace_root,
+                    user_negations,
+                    &mut manifest_paths,
+                )?;
+            }
+        }
+    }
+    Ok(manifest_paths)
+}
+
+/// Read `root_dir`'s project from the first readable candidate.
+/// `Ok(None)` when every candidate is gone or names no importer
+/// manifest — the root then simply isn't a project.
+fn read_first_project_manifest(
+    root_dir: PathBuf,
+    candidates: Vec<PathBuf>,
+) -> Result<Option<Project>, FindWorkspaceProjectsError> {
+    for manifest_path in candidates {
         let manifest = match read_exact_project_manifest(&manifest_path) {
             Ok(m) => m,
             Err(ReadProjectManifestError::Read(PackageManifestError::Io(err)))
@@ -284,11 +339,9 @@ pub fn find_workspace_projects_no_check(
             ))) => continue,
             Err(err) => return Err(FindWorkspaceProjectsError::ReadManifest(err)),
         };
-        seen_roots.insert(root_dir.clone());
-        projects.push(Project { root_dir, manifest, dependency_manifest: None });
+        return Ok(Some(Project { root_dir, manifest, dependency_manifest: None }));
     }
-
-    Ok(projects)
+    Ok(None)
 }
 
 /// Hardcoded ignore patterns. Enumerating a real workspace excludes

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -165,27 +165,34 @@ pub fn find_workspace_projects_no_check(
             message: err.to_string(),
         })?;
 
-    // Each pattern's probe touches its own directories, so the patterns
-    // fan out across the rayon pool and their per-pattern sets merge in
-    // list order afterwards — the merged set, and which pattern's error
-    // wins when several fail, both stay a function of the pattern list
-    // alone.
-    let pattern_sets: Vec<Result<BTreeSet<PathBuf>, FindWorkspaceProjectsError>> = include_patterns
+    // Each pattern's set folds into the shared merge as it completes,
+    // so peak memory stays one merged set plus the in-flight patterns —
+    // overlapping patterns don't multiply it. Set union commutes and
+    // the first error *in pattern-list order* wins, keeping the result
+    // and the reported failure a function of the pattern list alone.
+    let merged_manifest_paths: std::sync::Mutex<BTreeSet<PathBuf>> = std::sync::Mutex::default();
+    let pattern_errors: Vec<Option<FindWorkspaceProjectsError>> = include_patterns
         .par_iter()
         .map(|pattern| {
-            collect_pattern_manifests(
+            match collect_pattern_manifests(
                 pattern,
                 workspace_root,
                 &ignore_template,
                 &dot_pruning_ignore_template,
                 &user_negations,
-            )
+            ) {
+                Ok(set) => {
+                    merged_manifest_paths.lock().expect("merge lock never poisoned").extend(set);
+                    None
+                }
+                Err(error) => Some(error),
+            }
         })
         .collect();
-    let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
-    for set in pattern_sets {
-        manifest_paths.extend(set?);
+    if let Some(error) = pattern_errors.into_iter().flatten().next() {
+        return Err(error);
     }
+    let mut manifest_paths = merged_manifest_paths.into_inner().expect("merge lock never poisoned");
 
     for basename in PROJECT_MANIFEST_BASENAMES {
         let root_manifest = workspace_root.join(basename);
@@ -202,12 +209,12 @@ pub fn find_workspace_projects_no_check(
         dir_left.cmp(dir_right)
     });
 
-    // One group per project root, candidates in manifest-precedence
-    // order (`package.json` before `package.yaml` — the sort above is
-    // stable and ties keep the set's full-path order). Grouping before
-    // the reads keeps "first readable manifest wins" intact while the
-    // roots read concurrently: a candidate that vanishes mid-run still
-    // hands its root to the next candidate, never to a skipped root.
+    // A root's candidates stay in manifest-precedence order —
+    // `package.json` before `package.yaml`, because the sort above is
+    // stable and ties keep the set's full-path order — and share one
+    // read task, so "first readable manifest wins" holds under
+    // concurrency: a candidate that vanishes mid-run hands its root to
+    // the next candidate, never to a skipped root.
     let mut root_groups: Vec<(PathBuf, Vec<PathBuf>)> = Vec::new();
     for manifest_path in sorted {
         let root_dir = manifest_path.parent().unwrap_or(workspace_root).to_path_buf();

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -165,6 +165,25 @@ pub fn find_workspace_projects_no_check(
             message: err.to_string(),
         })?;
 
+    // Parse-check the generic-walk patterns up front, so a malformed
+    // glob fails before any pattern pays for a workspace walk. The fast
+    // paths accept only meta-character-free patterns, which cannot fail
+    // to parse.
+    for pattern in &include_patterns {
+        if specialized_pattern(pattern).is_some() {
+            continue;
+        }
+        for normalized in normalize_manifest_patterns(pattern) {
+            let Some((_, normalized)) = split_parent_prefix(workspace_root, &normalized) else {
+                continue;
+            };
+            Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
+                pattern: (*pattern).to_string(),
+                message: err.to_string(),
+            })?;
+        }
+    }
+
     // Each pattern's set folds into the shared merge as it completes,
     // so peak memory stays one merged set plus the in-flight patterns —
     // overlapping patterns don't multiply it. Set union commutes and

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -711,3 +711,35 @@ fn a_named_dot_directory_does_not_exempt_a_recursive_wildcard() {
     let names = find_project_names(tmp.path(), &[".config/**"]);
     assert_eq!(names, vec!["root".to_string(), "plain-lib".to_string()]);
 }
+
+/// A manifest that fails to parse must fail the discovery, and with
+/// several broken the reported one is a function of the project list —
+/// the first in root order — not of read scheduling.
+#[test]
+fn a_malformed_manifest_fails_discovery_deterministically() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    let broken = tmp.path().join("packages/broken");
+    fs::create_dir_all(&broken).unwrap();
+    fs::write(broken.join("package.json"), "{ not json").unwrap();
+    let broken_late = tmp.path().join("packages/zeta");
+    fs::create_dir_all(&broken_late).unwrap();
+    fs::write(broken_late.join("package.json"), "{ not json either").unwrap();
+
+    let result = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts { patterns: Some(vec!["packages/*".to_string()]) },
+    );
+
+    // `expect_err` would need `Project: Debug`, which it deliberately is not.
+    let Err(FindWorkspaceProjectsError::ReadManifest(source)) = result else {
+        panic!("a malformed manifest must surface as ReadManifest, not be dropped");
+    };
+    let message = source.to_string();
+    dbg!(&message);
+    assert!(
+        message.contains(&broken.join("package.json").display().to_string()),
+        "the reported manifest must be the first broken project in root order",
+    );
+}

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -743,3 +743,23 @@ fn a_malformed_manifest_fails_discovery_deterministically() {
         "the reported manifest must be the first broken project in root order",
     );
 }
+
+#[test]
+fn an_invalid_glob_pattern_fails_and_names_the_pattern() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    let result = find_workspace_projects(
+        tmp.path(),
+        &FindWorkspaceProjectsOpts {
+            patterns: Some(vec!["packages/*".to_string(), "packages/[invalid".to_string()]),
+        },
+    );
+
+    // `expect_err` would need `Project: Debug`, which it deliberately is not.
+    let Err(FindWorkspaceProjectsError::InvalidGlob { pattern, .. }) = result else {
+        panic!("an invalid glob must fail discovery");
+    };
+    assert_eq!(pattern, "packages/[invalid");
+}

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -720,10 +720,12 @@ fn a_malformed_manifest_fails_discovery_deterministically() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");
     make_project(tmp.path(), "packages/alpha", "alpha");
-    let broken = tmp.path().join("packages/broken");
+    // Component-wise joins, so the expected path below carries native
+    // separators like the discovery walk's error message does.
+    let broken = tmp.path().join("packages").join("broken");
     fs::create_dir_all(&broken).unwrap();
     fs::write(broken.join("package.json"), "{ not json").unwrap();
-    let broken_late = tmp.path().join("packages/zeta");
+    let broken_late = tmp.path().join("packages").join("zeta");
     fs::create_dir_all(&broken_late).unwrap();
     fs::write(broken_late.join("package.json"), "{ not json either").unwrap();
 

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -747,21 +747,26 @@ fn a_malformed_manifest_fails_discovery_deterministically() {
 }
 
 #[test]
-fn an_invalid_glob_pattern_fails_and_names_the_pattern() {
+fn an_invalid_glob_pattern_fails_before_any_walk() {
     let tmp = TempDir::new().unwrap();
     make_project(tmp.path(), ".", "root");
-    make_project(tmp.path(), "packages/alpha", "alpha");
+    // Walking the *earlier* pattern would fail with `Walk`: `packages`
+    // is a file, and the non-terminal star keeps the pattern off the
+    // specialized paths. Errors are otherwise selected in pattern-list
+    // order, so `InvalidGlob` winning proves the malformed pattern is
+    // rejected by the up-front parse check, before any pattern walks.
+    fs::write(tmp.path().join("packages"), "not a directory").unwrap();
 
     let result = find_workspace_projects(
         tmp.path(),
         &FindWorkspaceProjectsOpts {
-            patterns: Some(vec!["packages/*".to_string(), "packages/[invalid".to_string()]),
+            patterns: Some(vec!["packages/*/lib".to_string(), "nodes/[invalid".to_string()]),
         },
     );
 
     // `expect_err` would need `Project: Debug`, which it deliberately is not.
     let Err(FindWorkspaceProjectsError::InvalidGlob { pattern, .. }) = result else {
-        panic!("an invalid glob must fail discovery");
+        panic!("an invalid glob must fail discovery before any walk");
     };
-    assert_eq!(pattern, "packages/[invalid");
+    assert_eq!(pattern, "nodes/[invalid");
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352 (pnpm 12 slower than Yarn 4 on warm lockfile-only updates in large monorepos).

With the previously landed pnpm/pnpm#14262 (workspace-scoping fast paths), pnpm/pnpm#14266 (shared workspace resolutions), and pnpm/pnpm#14360 (summary regression), a profile of the issue's 6,833-project reproduction shows the largest remaining single block is workspace discovery, and that the whole warm update runs effectively single-threaded. Discovery spends its time in serial syscalls: each of the 784 include patterns probes its directories one after another, then all 6,833 `package.json` files are read one at a time.

This PR fans both stages out across the rayon pool:

- **Patterns expand concurrently.** Each pattern collects into its own set; the sets merge in pattern-list order, so the discovered set — and which pattern's error surfaces when several fail — stays a function of the pattern list alone.
- **Manifest reads run one task per project root.** Candidates for a root (`package.json` before `package.yaml`) are grouped *before* the fan-out, so the first readable manifest still wins and a candidate that vanishes mid-run still hands its root to the next candidate rather than dropping the project.

Observable behavior is unchanged: same discovered set, same ordering, same error precedence, same absorbed `NotFound` semantics. All 66 pre-existing discovery tests pass unchanged; a new test locks in that a malformed manifest still fails discovery and that the reported manifest is deterministic (verified to fail when the error is swallowed).

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, 784 patterns; M-series Mac, warm FS cache, warm non-noop lockfile-only update per the repo's README protocol):

| Metric | before | after |
| --- | ---: | ---: |
| discovery alone (in-process harness, median) | ~650 ms | ~225 ms |
| reporter-visible scoping span (process start → `pnpm:scope`, median) | ~700 ms | ~395 ms |
| whole warm update (`pnpm:execution-time`, median) | ~2.43 s | ~2.15 s |

### Remaining headroom (follow-ups, not in this PR)

The same profile budgets the rest of the ~2.4 s warm update roughly as: resolver tree walk ~490 ms (dominated by allocator traffic and `Path`-keyed hashing/`lexical_normalize` — the known `TreeCtx` follow-up noted in `resolve_workspace.rs`), wanted-lockfile YAML parse ~250 ms, lockfile build+serialize ~250 ms, peer pass ~150 ms, workspace-cycle check ~110 ms.

The second commit fixes `update_config_can_set_extra_env`, which failed on any machine whose real global config seeds `extra_env` (e.g. `enable-global-virtual-store=true` adds `NODE_PATH`): it now asserts the entry the hook adds instead of requiring an empty baseline.

## Squash Commit Body

```text
Workspace discovery ran serially: every include pattern probed its
directories one after another, then every discovered project's manifest
was read one file at a time. On a workspace with thousands of projects
the scoping phase is dominated by these serial syscalls.

Both stages now fan out across the rayon pool:

- Include patterns expand concurrently. Each pattern collects into its
  own set and the sets merge in pattern-list order, so the discovered
  set - and which pattern's error surfaces when several fail - remain
  a function of the pattern list alone.
- Manifest reads run one task per project root. Candidates for a root
  (package.json before package.yaml) are grouped before the fan-out so
  the first readable manifest still wins and a candidate that vanishes
  mid-run still hands its root to the next one.

On the 6,833-project reproduction from pnpm/pnpm#14352 (M-series Mac,
warm cache), discovery alone drops from ~650 ms to ~225 ms, and the
reporter-visible scoping span of a warm lockfile-only install drops
from ~700 ms to ~395 ms (median).

Also fixes the machine-dependent update_config_can_set_extra_env
assertion, which failed wherever the developer's real global config
seeds extra_env (a global virtual store adds NODE_PATH).

Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14379"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790794261&installation_model_id=426870&pr_number=14379&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14379&signature=2cadc098691d746220c474b6b94c9183dd7c53bd3e4aaa45689b0df76b99a4b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Accelerated workspace project discovery in large monorepos by processing workspace patterns and project manifests concurrently.
  - Preserved discovery order and error-reporting behavior.

- **Bug Fixes**
  - Invalid workspace patterns are detected earlier with more consistent error reporting.
  - Improved consistency when reporting malformed project manifests.

- **Release**
  - Includes a patch release for the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->