### PR TITLE
fix(cli): handle bare repo package names

### DIFF
--- a/.changeset/tidy-pandas-browse.md
+++ b/.changeset/tidy-pandas-browse.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm repo <package>` crashing when the package name omits a version.

--- a/.changeset/tidy-pandas-browse.md
+++ b/.changeset/tidy-pandas-browse.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm repo <package>` crashing when the package name omits a version.
+Fixed `pnpm repo <package>` and `pnpm docs <package>` resolving bare package names through the `latest` tag, and prevented malformed package ranges from crashing registry selection.

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -22,7 +22,7 @@ impl DocsArgs {
 
         let parsed = parse_wanted_dependency(raw_spec);
         let name = parsed.alias.as_deref().unwrap_or(raw_spec);
-        let bare = parsed.bare_specifier.as_deref().unwrap_or(name);
+        let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
         let (resolved_name, _range) = PackageManifest::resolve_registry_dependency(name, bare);
 
         let http_client = ThrottledClient::for_installs(

--- a/pnpm/crates/cli/src/cli_args/repo.rs
+++ b/pnpm/crates/cli/src/cli_args/repo.rs
@@ -111,7 +111,7 @@ async fn get_repo_url_from_registry(
 ) -> miette::Result<String> {
     let parsed = parse_wanted_dependency(raw_spec);
     let name = parsed.alias.as_deref().unwrap_or(raw_spec);
-    let bare = parsed.bare_specifier.as_deref().unwrap_or(name);
+    let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
     let (resolved_name, range) = PackageManifest::resolve_registry_dependency(name, bare);
 
     let registry = pick_registry_for_package(registries, resolved_name, Some(bare));

--- a/pnpm/crates/cli/src/cli_args/repo/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/repo/tests.rs
@@ -20,6 +20,12 @@ async fn test_registry_package_name_defaults_to_latest() {
                 "version": "1.0.0",
                 "dist": { "tarball": "https://registry.example/acme-1.0.0.tgz" },
                 "repository": "https://github.com/acme/repo.git"
+            },
+            "2.0.0": {
+                "name": "acme",
+                "version": "2.0.0",
+                "dist": { "tarball": "https://registry.example/acme-2.0.0.tgz" },
+                "repository": "https://github.com/acme/next.git"
             }
         }
     })

--- a/pnpm/crates/cli/src/cli_args/repo/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/repo/tests.rs
@@ -1,4 +1,60 @@
-use super::{get_repo_url_from_current_project, pick_repo_url, redact_url, repository_to_web_url};
+use std::collections::HashMap;
+
+use pnpm_config::Config;
+use pnpm_network::{RetryOpts, ThrottledClient};
+
+use super::{
+    get_repo_url_from_current_project, get_repo_url_from_registry, pick_repo_url, redact_url,
+    repository_to_web_url,
+};
+
+#[tokio::test]
+async fn test_registry_package_name_defaults_to_latest() {
+    let mut server = mockito::Server::new_async().await;
+    let body = serde_json::json!({
+        "name": "acme",
+        "dist-tags": { "latest": "1.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": { "tarball": "https://registry.example/acme-1.0.0.tgz" },
+                "repository": "https://github.com/acme/repo.git"
+            }
+        }
+    })
+    .to_string();
+    let mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(body)
+        .expect(1)
+        .create_async()
+        .await;
+    let config = Config { registry: format!("{}/", server.url()), ..Config::default() };
+    let http_client = ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &config.network_settings(),
+    )
+    .expect("create HTTP client");
+    let registries = config.resolved_registries().into_iter().collect::<HashMap<_, _>>();
+
+    let url = get_repo_url_from_registry(
+        &config,
+        "acme",
+        &http_client,
+        &registries,
+        &RetryOpts::default(),
+    )
+    .await
+    .expect("resolve repository URL");
+
+    assert_eq!(url, "https://github.com/acme/repo");
+    mock.assert_async().await;
+}
 
 #[test]
 fn test_opens_repository_url_from_local_manifest() {

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -234,7 +234,7 @@ impl Package {
 
     #[must_use]
     pub fn pinned_version(&self, version_range: &str) -> Option<Arc<PackageVersion>> {
-        let range: node_semver::Range = version_range.parse().unwrap(); // TODO: this step should have happened in PackageManifest
+        let range: node_semver::Range = version_range.parse().ok()?;
         // Match on the version *strings* so only winning manifests
         // hydrate from their raw fragments.
         let mut satisfying = self

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -158,6 +158,12 @@ fn pinned_version_returns_none_when_no_match() {
 }
 
 #[test]
+fn pinned_version_returns_none_for_invalid_range() {
+    let pkg = package_with_versions("acme", &["1.0.0", "1.2.0"], "1.2.0");
+    assert!(pkg.pinned_version("not-a-range").is_none());
+}
+
+#[test]
 fn package_deserializes_full_provenance_packument() {
     let body = r#"{
         "name": "acme",


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes the Rust pnpm CLI's `repo` registry lookup for bare package names by defaulting the missing version to `latest`, matching the existing TypeScript behavior. It also makes registry range selection return no match for malformed ranges instead of panicking.

The same default is applied to the Rust `docs` command, which shared the faulty package-spec fallback. The TypeScript CLI is unaffected because its implementations already handle bare names correctly.

Closes pnpm/pnpm#14378.

## Squash Commit Body

```text
Treat bare registry package names passed to `pnpm repo` and `pnpm docs` as `latest`. Harden registry range selection so malformed user input returns no match instead of panicking.

Closes pnpm/pnpm#14378.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790796645&installation_model_id=426870&pr_number=14380&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14380&signature=68a6b1ac3c31f13b212e970524e7b50523dee1714d950587dd15984234eeecc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm repo <package>` and `pnpm docs <package>` so packages without an explicit version or tag resolve against the `latest` release.
  * Prevented invalid version ranges from causing crashes during package metadata processing.
  * Improved repository URL resolution for packages using registry metadata.

* **Tests**
  * Added coverage for omitted package versions and invalid version ranges to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->