### PR TITLE
fix(pacquet): load config hooks before packing

### DIFF
--- a/.changeset/curvy-ravens-pack.md
+++ b/.changeset/curvy-ravens-pack.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Load pnpmfile `updateConfig` hooks before packing so hook-provided catalogs resolve in `pnpm pack`, `pnpm publish`, and `pnpm stage publish` [pnpm/pnpm#14377](https://github.com/pnpm/pnpm/issues/14377).

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -425,10 +425,17 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: PackArgs) -> miette::Result<Comma
     Ok(Box::pin(async move {
         let output = match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
+                run_update_config_for_packing::<DefaultReporter>(config, dir).await?;
                 args.run::<DefaultReporter>(dir, config, recursive).await?
             }
-            ReporterType::Ndjson => args.run::<NdjsonReporter>(dir, config, recursive).await?,
-            ReporterType::Silent => args.run::<SilentReporter>(dir, config, recursive).await?,
+            ReporterType::Ndjson => {
+                run_update_config_for_packing::<NdjsonReporter>(config, dir).await?;
+                args.run::<NdjsonReporter>(dir, config, recursive).await?
+            }
+            ReporterType::Silent => {
+                run_update_config_for_packing::<SilentReporter>(config, dir).await?;
+                args.run::<SilentReporter>(dir, config, recursive).await?
+            }
         };
         if !output.is_empty() {
             println!("{output}");
@@ -453,15 +460,24 @@ pub(super) fn publish<'a>(
     let dir = ctx.dir;
     let recursive = ctx.recursive;
     args.flags.report_summary |= ctx.recursive_report_summary;
+    async fn run<Reporter: pnpm_reporter::Reporter>(
+        args: PublishArgs,
+        dir: &std::path::Path,
+        config: &mut Config,
+        recursive: bool,
+    ) -> miette::Result<()> {
+        run_update_config_for_packing::<Reporter>(config, dir).await?;
+        args.run::<Reporter>(dir, config, recursive).await
+    }
     if args.flags.json {
-        return Ok(Box::pin(args.run::<SilentReporter>(dir, config, recursive)));
+        return Ok(Box::pin(run::<SilentReporter>(args, dir, config, recursive)));
     }
     Ok(match ctx.reporter {
         ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(dir, config, recursive))
+            Box::pin(run::<DefaultReporter>(args, dir, config, recursive))
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(dir, config, recursive)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>(dir, config, recursive)),
+        ReporterType::Ndjson => Box::pin(run::<NdjsonReporter>(args, dir, config, recursive)),
+        ReporterType::Silent => Box::pin(run::<SilentReporter>(args, dir, config, recursive)),
     })
 }
 
@@ -480,9 +496,12 @@ pub(super) fn stage<'a>(
     async fn print_output<Reporter: pnpm_reporter::Reporter>(
         args: StageArgs,
         dir: &std::path::Path,
-        config: &Config,
+        config: &mut Config,
         recursive: bool,
     ) -> miette::Result<()> {
+        if args.params.first().is_some_and(|subcommand| subcommand == "publish") {
+            run_update_config_for_packing::<Reporter>(config, dir).await?;
+        }
         if let Some(output) = args.run::<Reporter>(dir, config, recursive).await? {
             let output = super::sanitize::sanitize(&output);
             if !output.is_empty() {
@@ -502,6 +521,14 @@ pub(super) fn stage<'a>(
             Box::pin(print_output::<SilentReporter>(args, dir, config, recursive))
         }
     })
+}
+
+async fn run_update_config_for_packing<Reporter: pnpm_reporter::Reporter>(
+    config: &mut Config,
+    dir: &std::path::Path,
+) -> miette::Result<()> {
+    let config_root = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+    crate::config_deps::run_update_config_hooks::<Reporter>(config, &config_root).await
 }
 
 pub(super) fn bin<'a>(ctx: &RunCtx<'a>, args: BinArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -529,7 +529,13 @@ async fn run_update_config_for_packing<Reporter: pnpm_reporter::Reporter>(
     config: &mut Config,
     dir: &std::path::Path,
 ) -> miette::Result<Vec<std::sync::Arc<dyn pnpm_hooks::PnpmfileHooks>>> {
-    let config_root = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
+    let config_root = config.root_project_manifest_dir(dir).to_path_buf();
+    crate::config_deps::install_config_deps::<Reporter>(
+        config,
+        &config_root,
+        config.frozen_lockfile.unwrap_or(false),
+    )
+    .await?;
     crate::config_deps::run_update_config_hooks::<Reporter>(config, &config_root).await
 }
 

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -425,16 +425,16 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: PackArgs) -> miette::Result<Comma
     Ok(Box::pin(async move {
         let output = match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
-                run_update_config_for_packing::<DefaultReporter>(config, dir).await?;
-                args.run::<DefaultReporter>(dir, config, recursive).await?
+                let hooks = run_update_config_for_packing::<DefaultReporter>(config, dir).await?;
+                args.run::<DefaultReporter>(dir, config, recursive, hooks).await?
             }
             ReporterType::Ndjson => {
-                run_update_config_for_packing::<NdjsonReporter>(config, dir).await?;
-                args.run::<NdjsonReporter>(dir, config, recursive).await?
+                let hooks = run_update_config_for_packing::<NdjsonReporter>(config, dir).await?;
+                args.run::<NdjsonReporter>(dir, config, recursive, hooks).await?
             }
             ReporterType::Silent => {
-                run_update_config_for_packing::<SilentReporter>(config, dir).await?;
-                args.run::<SilentReporter>(dir, config, recursive).await?
+                let hooks = run_update_config_for_packing::<SilentReporter>(config, dir).await?;
+                args.run::<SilentReporter>(dir, config, recursive, hooks).await?
             }
         };
         if !output.is_empty() {
@@ -466,8 +466,8 @@ pub(super) fn publish<'a>(
         config: &mut Config,
         recursive: bool,
     ) -> miette::Result<()> {
-        run_update_config_for_packing::<Reporter>(config, dir).await?;
-        args.run::<Reporter>(dir, config, recursive).await
+        let hooks = run_update_config_for_packing::<Reporter>(config, dir).await?;
+        args.run::<Reporter>(dir, config, recursive, hooks).await
     }
     if args.flags.json {
         return Ok(Box::pin(run::<SilentReporter>(args, dir, config, recursive)));
@@ -499,10 +499,12 @@ pub(super) fn stage<'a>(
         config: &mut Config,
         recursive: bool,
     ) -> miette::Result<()> {
-        if args.params.first().is_some_and(|subcommand| subcommand == "publish") {
-            run_update_config_for_packing::<Reporter>(config, dir).await?;
-        }
-        if let Some(output) = args.run::<Reporter>(dir, config, recursive).await? {
+        let hooks = if args.params.first().is_some_and(|subcommand| subcommand == "publish") {
+            run_update_config_for_packing::<Reporter>(config, dir).await?
+        } else {
+            Vec::new()
+        };
+        if let Some(output) = args.run::<Reporter>(dir, config, recursive, hooks).await? {
             let output = super::sanitize::sanitize(&output);
             if !output.is_empty() {
                 println!("{output}");
@@ -526,7 +528,7 @@ pub(super) fn stage<'a>(
 async fn run_update_config_for_packing<Reporter: pnpm_reporter::Reporter>(
     config: &mut Config,
     dir: &std::path::Path,
-) -> miette::Result<()> {
+) -> miette::Result<Vec<std::sync::Arc<dyn pnpm_hooks::PnpmfileHooks>>> {
     let config_root = config.workspace_dir.clone().unwrap_or_else(|| dir.to_path_buf());
     crate::config_deps::run_update_config_hooks::<Reporter>(config, &config_root).await
 }

--- a/pnpm/crates/cli/src/cli_args/pack.rs
+++ b/pnpm/crates/cli/src/cli_args/pack.rs
@@ -87,20 +87,18 @@ impl PackArgs {
         dir: &Path,
         config: &Config,
         recursive: bool,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<String> {
         if recursive {
-            self.run_recursive::<Reporter>(dir, config).await
+            self.run_recursive::<Reporter>(dir, config, before_packing_hooks).await
         } else {
-            let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
             let mut options = self.pack_options(
                 dir.to_path_buf(),
                 config,
                 configured_catalogs(config)?,
                 self.out.clone(),
                 self.pack_destination.clone(),
-                crate::config_deps::load_before_packing_hooks(config, pnpmfile_root).map_err(
-                    |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
-                )?,
+                before_packing_hooks,
             );
             set_injected_changelog(&mut options, config, dir).await?;
             let result = api::<Reporter, Host>(&options)
@@ -117,6 +115,7 @@ impl PackArgs {
         &self,
         dir: &Path,
         config: &Config,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<String> {
         // `--out` and `--pack-destination` are mutually exclusive. The
         // single-project path enforces this inside `api`; the recursive
@@ -146,13 +145,6 @@ impl PackArgs {
         // of each project's own root.
         let (out, pack_destination) = self.resolve_recursive_destination(dir);
         let catalogs = configured_catalogs(config)?;
-        // Load the pnpmfiles once for the whole workspace (they live at the
-        // workspace root); cloning the Arcs into each project shares one
-        // worker per pnpmfile instead of re-spawning it per packed project.
-        let before_packing_hooks =
-            crate::config_deps::load_before_packing_hooks(config, workspace_root).map_err(
-                |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
-            )?;
         let output_can_change_while_packing = !before_packing_hooks.is_empty()
             || (!config.ignore_scripts
                 && graph.values().any(|node| {

--- a/pnpm/crates/cli/src/cli_args/publish.rs
+++ b/pnpm/crates/cli/src/cli_args/publish.rs
@@ -10,13 +10,14 @@
 
 mod recursive;
 
-use std::{collections::HashMap, path::Path};
+use std::{collections::HashMap, path::Path, sync::Arc};
 
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
 use pipe_trait::Pipe;
 use pnpm_config::Config;
 use pnpm_executor::{RunPostinstallHooks, ScriptsPrependNodePath, run_lifecycle_hook};
+use pnpm_hooks::PnpmfileHooks;
 use pnpm_pack::{Host as PackHost, PackOptions, PackResult, api as pack_api};
 use pnpm_publish::{
     Access, Host, OidcHttpOptions, PackedPkg, PublishNetwork, PublishPackedPkgOptions,
@@ -160,9 +161,17 @@ impl PublishArgs {
         dir: &Path,
         config: &Config,
         recursive: bool,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<()> {
-        let published =
-            self.publish_packages::<Reporter>(dir, config, recursive, /* stage */ false).await?;
+        let published = self
+            .publish_packages::<Reporter>(
+                dir,
+                config,
+                recursive,
+                /* stage */ false,
+                before_packing_hooks,
+            )
+            .await?;
         // Mirror `pnpm publish --json`: serialize only when asked. The
         // recursive path emits the array of per-package summaries (an empty
         // array when nothing was published).
@@ -189,6 +198,7 @@ impl PublishArgs {
         config: &Config,
         recursive: bool,
         stage: bool,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<PublishedPackages> {
         if self.flags.batch && !recursive {
             return Err(miette::miette!(
@@ -205,7 +215,8 @@ impl PublishArgs {
         run_git_checks::<Host>(dir, git_checks, publish_branch)?;
 
         if recursive {
-            let published = self.run_recursive::<Reporter>(dir, config, stage).await?;
+            let published =
+                self.run_recursive::<Reporter>(dir, config, stage, &before_packing_hooks).await?;
             return Ok(PublishedPackages::Recursive(published));
         }
 
@@ -219,7 +230,14 @@ impl PublishArgs {
                 self.publish_tarball::<Reporter>(package, &opts, &network).await?
             } else {
                 let project_dir = self.package.as_deref().map_or(dir, Path::new);
-                self.publish_directory::<Reporter>(project_dir, config, &opts, &network).await?
+                self.publish_directory::<Reporter>(
+                    project_dir,
+                    config,
+                    &opts,
+                    &network,
+                    &before_packing_hooks,
+                )
+                .await?
             };
         Ok(PublishedPackages::Single(Box::new(summary)))
     }
@@ -260,8 +278,10 @@ impl PublishArgs {
         config: &Config,
         opts: &PublishPackedPkgOptions,
         network: &PublishNetwork<'_>,
+        before_packing_hooks: &[Arc<dyn PnpmfileHooks>],
     ) -> miette::Result<PublishSummary> {
-        let packed = self.pack_directory::<Reporter>(project_dir, config).await?;
+        let packed =
+            self.pack_directory::<Reporter>(project_dir, config, before_packing_hooks).await?;
         let summary =
             publish_packed_pkg::<Host, Reporter>(&packed.packed_pkg(), opts, network).await?;
 
@@ -273,6 +293,7 @@ impl PublishArgs {
         &self,
         project_dir: &Path,
         config: &Config,
+        before_packing_hooks: &[Arc<dyn PnpmfileHooks>],
     ) -> miette::Result<PackedDirectory> {
         let manifest = pnpm_package_manifest::safe_read_package_json_from_dir(project_dir)
             .into_diagnostic()
@@ -295,8 +316,14 @@ impl PublishArgs {
         }
 
         let pack_destination = tempfile::tempdir().into_diagnostic().wrap_err("create temp dir")?;
-        let pack_result =
-            self.pack_for_publish::<Reporter>(project_dir, config, pack_destination.path()).await?;
+        let pack_result = self
+            .pack_for_publish::<Reporter>(
+                project_dir,
+                config,
+                pack_destination.path(),
+                before_packing_hooks,
+            )
+            .await?;
         let tarball_data = std::fs::read(&pack_result.tarball_path)
             .into_diagnostic()
             .wrap_err("read packed tarball")?;
@@ -344,12 +371,8 @@ impl PublishArgs {
         dir: &Path,
         config: &Config,
         pack_destination: &Path,
+        before_packing_hooks: &[Arc<dyn PnpmfileHooks>],
     ) -> miette::Result<PackResult> {
-        let pnpmfile_root = config.workspace_dir.as_deref().unwrap_or(dir);
-        let before_packing_hooks =
-            crate::config_deps::load_before_packing_hooks(config, pnpmfile_root).map_err(
-                |error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"),
-            )?;
         let mut options = PackOptions {
             dir: dir.to_path_buf(),
             catalogs: crate::cli_args::catalogs::configured_catalogs(config)?,
@@ -374,7 +397,7 @@ impl PublishArgs {
             dry_run: false,
             out: None,
             pack_destination: Some(pack_destination.to_string_lossy().into_owned()),
-            before_packing_hooks,
+            before_packing_hooks: before_packing_hooks.to_vec(),
             injected_files: Vec::new(),
             output_locks: None,
         };

--- a/pnpm/crates/cli/src/cli_args/publish/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/recursive.rs
@@ -8,13 +8,14 @@
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
-    sync::Mutex,
+    sync::{Arc, Mutex},
     time::Duration,
 };
 
 use miette::{Context, IntoDiagnostic};
 use pipe_trait::Pipe;
 use pnpm_config::Config;
+use pnpm_hooks::PnpmfileHooks;
 use pnpm_network::{RetryOpts, ThrottledClient};
 use pnpm_publish::{
     Host, PublishNetwork, PublishSummary, batch_publish_packed_pkgs, find_registry_info,
@@ -48,6 +49,7 @@ impl PublishArgs {
         dir: &Path,
         config: &Config,
         stage: bool,
+        before_packing_hooks: &[Arc<dyn PnpmfileHooks>],
     ) -> miette::Result<Vec<PublishSummary>> {
         let workspace_root = config.workspace_dir.as_deref().unwrap_or(dir);
         // `publish` is not in pnpm's root-auto-exclusion command set
@@ -132,7 +134,10 @@ impl PublishArgs {
                     .order
             {
                 if to_publish.contains(&root) {
-                    packed.push(self.pack_directory::<Reporter>(&root, config).await?);
+                    packed.push(
+                        self.pack_directory::<Reporter>(&root, config, before_packing_hooks)
+                            .await?,
+                    );
                 }
             }
             let packages = packed.iter().map(|package| package.packed_pkg()).collect::<Vec<_>>();
@@ -166,7 +171,16 @@ impl PublishArgs {
                 if !to_publish.contains(&root) {
                     return TaskCompletion::Passed;
                 }
-                match command.publish_directory::<Reporter>(&root, config, opts, network).await {
+                match command
+                    .publish_directory::<Reporter>(
+                        &root,
+                        config,
+                        opts,
+                        network,
+                        before_packing_hooks,
+                    )
+                    .await
+                {
                     Ok(summary) => {
                         published
                             .lock()

--- a/pnpm/crates/cli/src/cli_args/publish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/publish/tests.rs
@@ -87,7 +87,7 @@ async fn pack_for_publish_writes_a_tarball_and_returns_the_manifest() {
 
     let args = publish_args_with(PublishFlags { ignore_scripts: true, ..publish_flags() });
     let result = args
-        .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path())
+        .pack_for_publish::<SilentReporter>(dir.path(), &Config::default(), dest.path(), &[])
         .await
         .expect("packing succeeds");
 
@@ -150,7 +150,7 @@ async fn publish_directory_errors_when_no_manifest_is_present() {
     let network = PublishNetwork { client: &client, auth_headers: &auth_headers };
 
     let err = args
-        .publish_directory::<SilentReporter>(dir.path(), &config, &opts, &network)
+        .publish_directory::<SilentReporter>(dir.path(), &config, &opts, &network, &[])
         .await
         .expect_err("an empty directory has no package.json");
 
@@ -166,7 +166,7 @@ async fn publish_directory_errors_when_no_manifest_is_present() {
 async fn run_rejects_batch_without_recursive() {
     let args = publish_args_with(PublishFlags { batch: true, ..publish_flags() });
     let err = args
-        .run::<SilentReporter>(std::path::Path::new("."), &Config::default(), false)
+        .run::<SilentReporter>(std::path::Path::new("."), &Config::default(), false, Vec::new())
         .await
         .expect_err("--batch requires --recursive");
     assert_eq!(

--- a/pnpm/crates/cli/src/cli_args/stage.rs
+++ b/pnpm/crates/cli/src/cli_args/stage.rs
@@ -9,12 +9,13 @@
 mod approve;
 mod summarize_tarball;
 
-use std::{collections::HashMap, path::Path, time::Duration};
+use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
 
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
+use pnpm_hooks::PnpmfileHooks;
 use pnpm_network::{
     RetryOpts, ThrottledClient, read_limited_body, redact_url_credentials, send_with_retry,
 };
@@ -180,9 +181,12 @@ impl StageArgs {
         dir: &Path,
         config: &Config,
         recursive: bool,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<Option<String>> {
         match self.params.first().map(String::as_str) {
-            Some("publish") => self.stage_publish::<Reporter>(dir, config, recursive).await,
+            Some("publish") => {
+                self.stage_publish::<Reporter>(dir, config, recursive, before_packing_hooks).await
+            }
             Some("list") => self.stage_list(config).await,
             Some("view") => self.stage_view(config).await,
             Some("approve") => approve::stage_approve::<Reporter>(&self, config).await,
@@ -203,13 +207,21 @@ impl StageArgs {
         dir: &Path,
         config: &Config,
         recursive: bool,
+        before_packing_hooks: Vec<Arc<dyn PnpmfileHooks>>,
     ) -> miette::Result<Option<String>> {
         let StageArgs { params, flags, .. } = self;
         let json = flags.json;
         let dry_run = flags.dry_run;
         let publish = PublishArgs { package: params.get(1).cloned(), flags };
-        let published =
-            publish.publish_packages::<Reporter>(dir, config, recursive, /* stage */ true).await?;
+        let published = publish
+            .publish_packages::<Reporter>(
+                dir,
+                config,
+                recursive,
+                /* stage */ true,
+                before_packing_hooks,
+            )
+            .await?;
         let summaries = published.summaries();
         if json {
             let keyed = key_by_package_name(summaries);

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -420,7 +420,7 @@ impl EnvInstallerContext {
 /// clobbered. The `catalog:`/`catalogs:` blocks — which pacquet models
 /// outside `WorkspaceSettings` — are seeded into the hook input and, when
 /// a hook changes them, captured into [`Config::catalogs`] for the install
-/// to use.
+/// and packing commands to use.
 /// The pnpmfile paths that contribute hooks for `root_dir`, in
 /// application order: config-dependency plugin pnpmfiles (lexical
 /// order) first, then the workspace-root `.pnpmfile.{cjs,mjs}`. Shared

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -408,19 +408,6 @@ impl EnvInstallerContext {
     }
 }
 
-/// Run the `updateConfig` pnpmfile hooks contributed by config-dependency
-/// plugins (and the project's own pnpmfile), applying their result to
-/// `config`. Plugin pnpmfiles run before the project pnpmfile, each
-/// transforming the config object in turn.
-///
-/// Config round-trips through [`WorkspaceSettings`], so any settings key
-/// a hook changes is applied back the same way `pnpm-workspace.yaml` is.
-/// Only the keys a hook actually changed are applied, so values resolved
-/// from `.npmrc` / CLI flags that the hooks leave untouched are not
-/// clobbered. The `catalog:`/`catalogs:` blocks — which pacquet models
-/// outside `WorkspaceSettings` — are seeded into the hook input and, when
-/// a hook changes them, captured into [`Config::catalogs`] for the install
-/// and packing commands to use.
 /// The pnpmfile paths that contribute hooks for `root_dir`, in
 /// application order: config-dependency plugin pnpmfiles (lexical
 /// order) first, then the workspace-root `.pnpmfile.{cjs,mjs}`. Shared
@@ -468,14 +455,29 @@ pub fn load_before_packing_hooks(
         .collect())
 }
 
+/// Run the `updateConfig` pnpmfile hooks contributed by config-dependency
+/// plugins and the project's own pnpmfile, applying their result to `config`.
+/// The returned handles are the same loaded hook objects that ran
+/// `updateConfig`, so packing can retain the original hook set when the hook
+/// changes a hook-selection setting such as `ignorePnpmfile`.
+///
+/// Config round-trips through [`WorkspaceSettings`], so any settings key a
+/// hook changes is applied back the same way `pnpm-workspace.yaml` is. Only
+/// the keys a hook actually changed are applied, so values resolved from
+/// `.npmrc` or CLI flags that the hooks leave untouched are not clobbered.
+/// The `catalog:`/`catalogs:` blocks — which pacquet models outside
+/// `WorkspaceSettings` — are seeded into the hook input and, when changed,
+/// captured into [`Config::catalogs`] for install and packing commands.
 pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     config: &mut Config,
     root_dir: &Path,
-) -> Result<()> {
+) -> Result<Vec<Arc<dyn PnpmfileHooks>>> {
     let pnpmfiles = resolve_pnpmfile_paths(config, root_dir)
         .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))?;
+    let hooks: Vec<Arc<dyn PnpmfileHooks>> =
+        pnpmfiles.iter().cloned().map(finder::load_pnpmfile_at).collect();
     if pnpmfiles.is_empty() {
-        return Ok(());
+        return Ok(hooks);
     }
 
     let (base_dir, settings) = match WorkspaceSettings::find_and_load(root_dir).into_diagnostic()? {
@@ -521,17 +523,14 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     let prefix = root_dir.to_string_lossy().into_owned();
     let mut current = input.clone();
     let mut has_filter_log = false;
-    for pnpmfile in &pnpmfiles {
-        let hooks = finder::load_pnpmfile_at(pnpmfile.clone());
+    for (pnpmfile, hook) in pnpmfiles.iter().zip(&hooks) {
         let ctx = HookContext { log: hook_logger::<Reporter>(pnpmfile, &prefix), dir: None };
-        current = hooks
+        current = hook
             .update_config(current, ctx)
             .await
             .map_err(|err| miette::miette!("{err}"))
-            .wrap_err_with(|| {
-            format!("running updateConfig hook from {}", pnpmfile.display())
-        })?;
-        has_filter_log |= hooks.has_filter_log().await;
+            .wrap_err_with(|| format!("running updateConfig hook from {}", pnpmfile.display()))?;
+        has_filter_log |= hook.has_filter_log().await;
     }
     if has_filter_log {
         Reporter::emit(&LogEvent::Pnpm(PnpmLog {
@@ -564,7 +563,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
 
     let delta = config_delta(&input, &current);
     if delta.as_object().is_none_or(serde_json::Map::is_empty) {
-        return Ok(());
+        return Ok(hooks);
     }
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
     let changed_prefer_frozen_lockfile = delta.get("preferFrozenLockfile").cloned();
@@ -625,7 +624,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
             global_virtual_store_dir_explicit,
         );
     }
-    Ok(())
+    Ok(hooks)
 }
 
 /// The keys whose value the hooks changed between the serialized input

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -42,7 +42,7 @@ fn pack_uses_embed_readme_and_manifest_obfuscation_settings() {
 }
 
 #[test]
-fn update_config_hook_catalog_is_used_when_packing() {
+fn packing_reuses_the_hooks_that_updated_config() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     fs::write(
         workspace.join("package.json"),
@@ -60,7 +60,12 @@ fn update_config_hook_catalog_is_used_when_packing() {
   hooks: {
     updateConfig (config) {
       config.catalogs = { default: { 'is-odd': '3.0.1' } }
+      config.ignorePnpmfile = true
       return config
+    },
+    beforePacking (manifest) {
+      manifest.packedByHook = true
+      return manifest
     },
   },
 }
@@ -72,6 +77,7 @@ fn update_config_hook_catalog_is_used_when_packing() {
 
     let manifest = read_manifest_from_tarball(&workspace.join("pkg-1.0.0.tgz"));
     assert_eq!(manifest["devDependencies"]["is-odd"], "3.0.1");
+    assert_eq!(manifest["packedByHook"], json!(true));
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -41,6 +41,41 @@ fn pack_uses_embed_readme_and_manifest_obfuscation_settings() {
     drop(root);
 }
 
+#[test]
+fn update_config_hook_catalog_is_used_when_packing() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "devDependencies": { "is-odd": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        r"module.exports = {
+  hooks: {
+    updateConfig (config) {
+      config.catalogs = { default: { 'is-odd': '3.0.1' } }
+      return config
+    },
+  },
+}
+",
+    )
+    .expect("write .pnpmfile.cjs");
+
+    pacquet.with_arg("pack").assert().success();
+
+    let manifest = read_manifest_from_tarball(&workspace.join("pkg-1.0.0.tgz"));
+    assert_eq!(manifest["devDependencies"]["is-odd"], "3.0.1");
+
+    drop(root);
+}
+
 /// A `beforePacking` hook that deletes `devDependencies` and stamps a
 /// marker rewrites the manifest packed into the tarball.
 #[test]

--- a/pnpm/crates/cli/tests/suite/pack.rs
+++ b/pnpm/crates/cli/tests/suite/pack.rs
@@ -8,7 +8,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::CommandTempCwd;
+use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use serde_json::json;
 use std::{fs, path::Path};
 
@@ -80,6 +80,68 @@ fn packing_reuses_the_hooks_that_updated_config() {
     assert_eq!(manifest["packedByHook"], json!(true));
 
     drop(root);
+}
+
+#[test]
+fn external_lockfile_dir_supplies_packing_hooks() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "pkg",
+            "version": "1.0.0",
+            "dependencies": { "is-odd": "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "lockfileDir: ..\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        r"module.exports = {
+  hooks: {
+    updateConfig (config) {
+      config.catalogs = { default: { 'is-odd': '3.0.1' } }
+      return config
+    },
+  },
+}
+",
+    )
+    .expect("write lockfile-root pnpmfile");
+
+    pacquet.with_arg("pack").assert().success();
+
+    let manifest = read_manifest_from_tarball(&workspace.join("pkg-1.0.0.tgz"));
+    assert_eq!(manifest["dependencies"]["is-odd"], "3.0.1");
+
+    drop(root);
+}
+
+#[test]
+fn pack_installs_config_dependencies_before_loading_hooks() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("package.json"),
+        json!({ "name": "pkg", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write package.json");
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut settings = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    settings.push_str("\nconfigDependencies:\n  '@pnpm/plugin-pnpmfile': 1.0.0\n");
+    fs::write(workspace_yaml, settings).expect("write configDependencies");
+
+    pacquet.with_arg("pack").assert().success();
+
+    assert!(
+        workspace.join("node_modules/.pnpm-config/@pnpm/plugin-pnpmfile/pnpmfile.cjs").is_file(),
+        "pack must materialize config dependencies before loading their hooks",
+    );
+
+    drop((root, mock_instance));
 }
 
 /// A `beforePacking` hook that deletes `devDependencies` and stamps a

--- a/pnpm/crates/cli/tests/suite/publish.rs
+++ b/pnpm/crates/cli/tests/suite/publish.rs
@@ -116,8 +116,17 @@ fn dry_run_uploads_nothing() {
     write_project(
         dir.path(),
         &registry,
-        &json!({ "name": "test-publish-dry", "version": "1.0.0" }),
+        &json!({
+            "name": "test-publish-dry",
+            "version": "1.0.0",
+            "devDependencies": { "is-odd": "catalog:" },
+        }),
     );
+    fs::write(
+        dir.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig: config => ({ ...config, catalogs: { default: { 'is-odd': '3.0.1' } } }) } }",
+    )
+    .expect("write .pnpmfile.cjs");
 
     // Any PUT during a dry run is a failure: the mock expects zero hits.
     let mock = server.mock("PUT", Matcher::Any).expect(0).create();

--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -70,8 +70,17 @@ fn publish_dry_run_reports_that_the_package_would_be_staged() {
     write_project(
         dir.path(),
         &registry,
-        &json!({ "name": "@scope/stage-publish-dry-run", "version": "1.0.0" }),
+        &json!({
+            "name": "@scope/stage-publish-dry-run",
+            "version": "1.0.0",
+            "devDependencies": { "is-odd": "catalog:" },
+        }),
     );
+    fs::write(
+        dir.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig: config => ({ ...config, catalogs: { default: { 'is-odd': '3.0.1' } } }) } }",
+    )
+    .expect("write .pnpmfile.cjs");
     let mock = server.mock("POST", Matcher::Any).expect(0).create();
 
     let output =

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -1982,10 +1982,9 @@ pub struct Config {
     /// default. Not a `pnpm-workspace.yaml` key — the only way to
     /// populate it is an `updateConfig` pnpmfile hook that returns an
     /// `extraEnv` object, wired up in `pnpm_cli`'s
-    /// `run_update_config_hooks`. That hook runs only for the
-    /// install-family commands (install, deploy, dedupe, prune), so this
-    /// is non-empty only under those; other commands' spawn sites read it
-    /// too, but see an empty map until the hook broadens.
+    /// `run_update_config_hooks`. That hook runs for the install family
+    /// and commands that pack packages, making the returned environment
+    /// available to their lifecycle scripts.
     pub extra_env: HashMap<String, String>,
 
     /// `unsafePerm` from `pnpm-workspace.yaml`. When `false`,
@@ -2373,9 +2372,9 @@ pub struct Config {
     /// Catalogs injected by an `updateConfig` pnpmfile hook, seeded from
     /// `pnpm-workspace.yaml`'s `catalog:`/`catalogs:` and returned
     /// (possibly modified) by the hook. `None` when no hook changed
-    /// them, in which case the install reads catalogs straight from the
+    /// them, in which case consumers read catalogs straight from the
     /// workspace manifest. `Some` carries the complete catalog set the
-    /// hook produced (existing + injected), so the install uses it as-is
+    /// hook produced (existing + injected), so consumers use it as-is
     /// — the counterpart to pnpm's `config.catalogs` after the
     /// `updateConfig` pass.
     pub catalogs: Option<pnpm_catalogs_types::Catalogs>,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Run pnpmfile `updateConfig` hooks before the Rust CLI packs packages for `pnpm pack`, `pnpm publish`, and `pnpm stage publish`. This makes hook-provided catalogs and lifecycle configuration available during packing, matching the TypeScript CLI.

`pnpm stage` registry-only subcommands remain hook-free.

Closes pnpm/pnpm#14377.

## Squash Commit Body

```text
The Rust CLI loaded `beforePacking` hooks for packing commands but skipped
`updateConfig`, so catalogs injected by a pnpmfile were unavailable when the
packed manifest dereferenced `catalog:` specifiers.

Run `updateConfig` once before each packing entry point, using the workspace
root when available. Restrict the `stage` integration to `stage publish` so
registry-only stage operations do not evaluate project hooks.

Add end-to-end coverage for pack, publish dry-run, and stage publish dry-run.

Closes pnpm/pnpm#14377.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. The TypeScript CLI already loads `updateConfig` for these commands; this PR brings the Rust port into parity.
- [x] Added a changeset (`pnpm changeset`) because this PR changes a published
  package.
- [x] Added or updated tests.
- [x] Updated the documentation where needed.

---
Written by an agent (Codex, gpt-5.4).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790796758&installation_model_id=426870&pr_number=14381&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14381&signature=a079e2f190a951641a67b856bbe6f9d7fccf8836f671054b892f0bfbfb403f9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed catalog resolution during package packing and publishing when configured through `updateConfig` hooks.
  - Ensured catalog-based dependencies resolve correctly in `pack`, `publish`, and staged publishing workflows.
  - Ensured pnpmfile hooks and their dependencies are loaded before packing operations.
  - Improved dry-run behavior for packages using hook-provided catalogs.

- **Documentation**
  - Clarified when configuration hooks run and how hook-provided catalogs are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->