### PR TITLE
fix(cli): run regexp scripts concurrently

### DIFF
--- a/.changeset/parallel-regexp-scripts.md
+++ b/.changeset/parallel-regexp-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm run "/pattern/"` running matching scripts one at a time in a single project. Matching scripts now run concurrently up to `workspaceConcurrency`, and their output is prefixed so concurrent lines remain distinguishable [pnpm discussion 14357](https://github.com/orgs/pnpm/discussions/14357).

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -4,7 +4,8 @@ use super::{
 };
 use clap::Args;
 use derive_more::{Display, Error};
-use miette::Diagnostic;
+use indexmap::IndexMap;
+use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_executor::{
     ProcessTracker, RunScript, ScriptExit, ScriptOutput, ScriptsPrependNodePath, run_script,
@@ -16,6 +17,7 @@ use pnpm_package_manager::{
 };
 use pnpm_package_manifest::PackageManifest;
 use pnpm_workspace::{ReadProjectManifestOnlyError, read_project_manifest_only};
+use pnpm_workspace_task_scheduler::{ScheduleGraphOptions, TaskCompletion, schedule_graph};
 use regex::Regex;
 use serde_json::Value;
 use std::{
@@ -23,6 +25,7 @@ use std::{
     env,
     fmt::Write as _,
     path::{Path, PathBuf},
+    sync::Mutex,
 };
 
 mod recursive;
@@ -198,6 +201,8 @@ impl RunArgs {
         // spawning a doomed install (see check_deps_status_before_run_at).
         super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
         let silent = matches!(reporter, ReporterType::Silent);
+        let parallel = self.parallel;
+        let sequential = self.sequential;
         let RunArgs { script, if_present, .. } = self;
         let Some((script_name, args)) = script.split_first() else {
             let manifest = read_project_manifest_only(dir).map_err(RunError::Manifest)?;
@@ -254,6 +259,15 @@ impl RunArgs {
         }
 
         let init_cwd: PathBuf = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
+        let concurrency = if parallel {
+            specified.len()
+        } else if sequential {
+            1
+        } else {
+            usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
+        };
+        let process_tracker = (concurrency > 1).then(ProcessTracker::default);
+        let dep_path = dir.to_string_lossy().into_owned();
         let ctx = RunContext {
             manifest: &manifest,
             dir,
@@ -261,25 +275,84 @@ impl RunArgs {
             config,
             extra_env: &extra_env,
             silent,
-            output: ScriptOutput::Inherit,
-            process_tracker: None,
+            output: if specified.len() > 1 && concurrency > 1 {
+                ScriptOutput::Streamed { dep_path: &dep_path, emit: reporter_emit(reporter) }
+            } else {
+                ScriptOutput::Inherit
+            },
+            process_tracker: process_tracker.as_ref(),
         };
-        for name in &specified {
+        let tasks: IndexMap<String, Vec<String>> =
+            specified.into_iter().map(|name| (name, Vec::new())).collect();
+        let failure = Mutex::new(None);
+        let abort = Mutex::new(None);
+        let on_script_skipped = |_: &String| {};
+        let run_script = |name: String| {
             // Resolve the main body (with `start` → `node server.js`
             // fallback) and apply the args-aware `npx only-allow pnpm`
             // no-op skip. After both pass, [`run_stages`] is
             // guaranteed to actually run the main stage, so its return
             // is a plain [`ScriptExit`].
-            let Some(main) = resolve_main_script(&ctx, name)? else { continue };
+            let main = match resolve_main_script(&ctx, &name) {
+                Ok(Some(main)) => main,
+                Ok(None) => return TaskCompletion::Passed,
+                Err(error) => {
+                    let mut abort = abort.lock().expect("run abort lock is not poisoned");
+                    if abort.is_none() {
+                        *abort = Some(miette::Report::new(error));
+                    }
+                    if let Some(process_tracker) = &process_tracker {
+                        process_tracker.cancel();
+                    }
+                    return TaskCompletion::Aborted;
+                }
+            };
             if args.is_empty() && main == "npx only-allow pnpm" {
-                continue;
+                return TaskCompletion::Passed;
             }
-            let status = run_stages(&ctx, name, &main, args)?;
-            if !status.success() {
-                // A failing script sets the process exit code.
-                // `run_stage` already emitted the `[ELIFECYCLE]` line.
-                std::process::exit(status.code().unwrap_or(1));
+            match run_stages(&ctx, &name, &main, args) {
+                Ok(status) if status.success() => TaskCompletion::Passed,
+                Ok(status) => {
+                    let mut failure = failure.lock().expect("run failure lock is not poisoned");
+                    if failure.is_none() {
+                        *failure = Some(status.code().unwrap_or(1));
+                    }
+                    if let Some(process_tracker) = &process_tracker {
+                        process_tracker.cancel();
+                    }
+                    TaskCompletion::Failed
+                }
+                Err(error) => {
+                    let mut abort = abort.lock().expect("run abort lock is not poisoned");
+                    if abort.is_none() {
+                        *abort = Some(error);
+                    }
+                    if let Some(process_tracker) = &process_tracker {
+                        process_tracker.cancel();
+                    }
+                    TaskCompletion::Aborted
+                }
             }
+        };
+        if concurrency == 1 {
+            for name in tasks.keys() {
+                if !matches!(run_script(name.clone()), TaskCompletion::Passed) {
+                    break;
+                }
+            }
+        } else {
+            schedule_graph(
+                &tasks,
+                &ScheduleGraphOptions::new(concurrency, true, &run_script, &on_script_skipped),
+            )
+            .into_diagnostic()?;
+        }
+        if let Some(error) = abort.into_inner().expect("run abort lock is not poisoned") {
+            return Err(error);
+        }
+        if let Some(code) = failure.into_inner().expect("run failure lock is not poisoned") {
+            // `run_stage` already emitted the `[ELIFECYCLE]` line.
+            std::process::exit(code);
         }
         Ok(())
     }

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -266,7 +266,8 @@ impl RunArgs {
         } else {
             usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
         };
-        let process_tracker = (concurrency > 1).then(ProcessTracker::default);
+        let process_tracker =
+            (specified.len() > 1 && concurrency > 1).then(ProcessTracker::foreground);
         let dep_path = dir.to_string_lossy().into_owned();
         let ctx = RunContext {
             manifest: &manifest,
@@ -334,7 +335,7 @@ impl RunArgs {
                 }
             }
         };
-        if concurrency == 1 {
+        if concurrency == 1 || tasks.len() == 1 {
             for name in tasks.keys() {
                 if !matches!(run_script(name.clone()), TaskCompletion::Passed) {
                     break;

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -889,6 +889,57 @@ fn run_executes_every_script_matching_a_regexp_selector() {
     }
 }
 
+#[test]
+fn regexp_selected_scripts_run_concurrently_by_default() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("track-concurrency.js"),
+        r"const fs = require('fs')
+const [self, other] = process.argv.slice(2)
+const marker = `active-${self}`
+fs.writeFileSync(marker, '')
+const started = Date.now()
+const check = setInterval(() => {
+  if (fs.existsSync(`active-${other}`)) {
+    fs.writeFileSync('saw-parallel', '')
+    finish()
+  } else if (Date.now() - started > 1000) {
+    finish()
+  }
+}, 10)
+function finish () {
+  clearInterval(check)
+  fs.rmSync(marker, { force: true })
+  console.log(self)
+}
+",
+    )
+    .expect("write concurrency probe");
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {
+                "dev:one": "node track-concurrency.js one two",
+                "dev:two": "node track-concurrency.js two one",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = pacquet.with_args(["run", "/^dev:/"]).assert().success().get_output().clone();
+
+    assert!(workspace.join("saw-parallel").exists(), "the selected scripts should overlap");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert!(stdout.contains("dev:one: one"));
+    assert!(stdout.contains("dev:two: two"));
+
+    drop(root);
+}
+
 /// Flags on a selector say nothing about which scripts to pick, so pnpm
 /// rejects them instead of honouring a subset.
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -2,7 +2,10 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::CommandTempCwd;
 use serde_json::json;
-use std::fs;
+use std::{
+    fs,
+    time::{Duration, Instant},
+};
 
 #[cfg(unix)]
 fn write_executable(path: &std::path::Path, body: &str) {
@@ -929,13 +932,45 @@ function finish () {
     )
     .expect("write package.json");
 
-    let output = pacquet.with_args(["run", "/^dev:/"]).assert().success().get_output().clone();
+    let output = pacquet
+        .with_args(["--workspace-concurrency=2", "run", "/^dev:/"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
 
     assert!(workspace.join("saw-parallel").exists(), "the selected scripts should overlap");
     let stdout = String::from_utf8_lossy(&output.stdout);
     eprintln!("STDOUT:\n{stdout}\n");
     assert!(stdout.contains("dev:one: one"));
     assert!(stdout.contains("dev:two: two"));
+
+    drop(root);
+}
+
+#[test]
+fn regexp_selected_scripts_cancel_siblings_after_failure() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {
+                "dev:slow": r#"node -e "require('fs').writeFileSync('slow-started', ''); setTimeout(() => {}, 5000)""#,
+                "dev:fail": r#"node -e "const fs = require('fs'); const wait = () => fs.existsSync('slow-started') ? process.exit(1) : setTimeout(wait, 10); wait()""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let start = Instant::now();
+    pacquet.with_args(["--workspace-concurrency=2", "run", "/^dev:/"]).assert().failure();
+    assert!(
+        start.elapsed() < Duration::from_secs(4),
+        "a failed script should cancel its in-flight sibling",
+    );
 
     drop(root);
 }

--- a/pnpm/crates/executor/src/lifecycle.rs
+++ b/pnpm/crates/executor/src/lifecycle.rs
@@ -22,6 +22,8 @@ use std::{
 };
 use tokio::io::{AsyncBufReadExt, AsyncRead, BufReader as AsyncBufReader};
 
+const STREAMED_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+
 /// Error from running lifecycle scripts.
 #[derive(Debug, Display, Error, Diagnostic)]
 #[non_exhaustive]
@@ -561,8 +563,8 @@ impl StreamedScript<'_> {
         status
     }
 
-    /// Spawn a thread that reads `reader` line-by-line and republishes
-    /// each line.
+    /// Spawn a thread that reads `reader` and republishes newline-delimited
+    /// output in bounded chunks.
     ///
     /// Read as bytes and decoded lossily rather than through
     /// [`BufRead::lines`], whose `Err` on non-UTF-8 would stop the drain
@@ -581,19 +583,24 @@ impl StreamedScript<'_> {
             let target = StreamedScript { dep_path: &dep_path, stage: &stage, wd: &wd, emit };
             let mut reader = BufReader::new(reader);
             let mut line = Vec::new();
-            loop {
-                line.clear();
-                match reader.read_until(b'\n', &mut line) {
-                    // EOF. A final line with no newline was already
-                    // emitted by the read that returned it.
-                    Ok(0) => break,
-                    Ok(_) => {}
-                    // An EBADF or EPIPE means the child closed the
-                    // stream. Not fatal — the caller's `wait` surfaces a
-                    // non-zero exit code if the child failed over it.
-                    Err(_) => break,
+            // An EBADF or EPIPE means the child closed the stream. Not
+            // fatal — the caller's `wait` surfaces a non-zero exit code
+            // if the child failed over it.
+            while let Ok(buffered) = reader.fill_buf() {
+                if buffered.is_empty() {
+                    if !line.is_empty() {
+                        target.emit_bytes_line(stdio, &mut line);
+                    }
+                    break;
                 }
-                target.emit_bytes_line(stdio, &mut line);
+                let consumed = streamed_chunk_len(buffered, line.len());
+                line.extend_from_slice(&buffered[..consumed]);
+                let line_finished = line.last() == Some(&b'\n');
+                reader.consume(consumed);
+                if line_finished || line.len() == STREAMED_OUTPUT_CHUNK_BYTES {
+                    target.emit_bytes_line(stdio, &mut line);
+                    line.clear();
+                }
             }
         })
     }
@@ -601,12 +608,20 @@ impl StreamedScript<'_> {
     async fn pump_async_stream(&self, reader: impl AsyncRead + Unpin, stdio: LifecycleStdio) {
         let mut reader = AsyncBufReader::new(reader);
         let mut line = Vec::new();
-        loop {
-            line.clear();
-            match reader.read_until(b'\n', &mut line).await {
-                Ok(0) => break,
-                Ok(_) => self.emit_bytes_line(stdio, &mut line),
-                Err(_) => break,
+        while let Ok(buffered) = reader.fill_buf().await {
+            if buffered.is_empty() {
+                if !line.is_empty() {
+                    self.emit_bytes_line(stdio, &mut line);
+                }
+                break;
+            }
+            let consumed = streamed_chunk_len(buffered, line.len());
+            line.extend_from_slice(&buffered[..consumed]);
+            let line_finished = line.last() == Some(&b'\n');
+            reader.consume(consumed);
+            if line_finished || line.len() == STREAMED_OUTPUT_CHUNK_BYTES {
+                self.emit_bytes_line(stdio, &mut line);
+                line.clear();
             }
         }
     }
@@ -634,6 +649,12 @@ impl StreamedScript<'_> {
             },
         }));
     }
+}
+
+fn streamed_chunk_len(buffered: &[u8], accumulated: usize) -> usize {
+    let through_newline =
+        buffered.iter().position(|byte| *byte == b'\n').map_or(buffered.len(), |i| i + 1);
+    through_newline.min(STREAMED_OUTPUT_CHUNK_BYTES - accumulated)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/executor/src/lifecycle/tests.rs
+++ b/pnpm/crates/executor/src/lifecycle/tests.rs
@@ -1,12 +1,57 @@
-use super::{LifecycleScriptError, RunPostinstallHooks, run_postinstall_hooks};
+use super::{
+    LifecycleScriptError, RunPostinstallHooks, STREAMED_OUTPUT_CHUNK_BYTES, StreamedScript,
+    run_postinstall_hooks,
+};
 use crate::extend_path::ScriptsPrependNodePath;
 use pnpm_package_manifest::PackageManifestError;
 use pnpm_reporter::{
     LifecycleMessage, LifecycleStdio, LogEvent, LogLevel, Reporter, SilentReporter,
 };
 use pretty_assertions::assert_eq;
-use std::{collections::HashMap, fs, sync::Mutex};
+use std::{collections::HashMap, fs, io::Cursor, sync::Mutex};
 use tempfile::tempdir;
+
+#[test]
+fn streamed_output_splits_newline_free_data_into_bounded_chunks() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    EVENTS.lock().expect("lock").clear();
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().expect("lock").push(event.clone());
+        }
+    }
+
+    let streamed = StreamedScript {
+        dep_path: "test",
+        stage: "build",
+        wd: "test",
+        emit: RecordingReporter::emit,
+    };
+    let trailing_bytes = 17;
+    streamed
+        .pump_stream(
+            Cursor::new(vec![b'a'; STREAMED_OUTPUT_CHUNK_BYTES + trailing_bytes]),
+            LifecycleStdio::Stdout,
+        )
+        .join()
+        .expect("output pump");
+
+    let line_lengths: Vec<_> = EVENTS
+        .lock()
+        .expect("lock")
+        .iter()
+        .filter_map(|event| match event {
+            LogEvent::Lifecycle(log) => match &log.message {
+                LifecycleMessage::Stdio { line, .. } => Some(line.len()),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(line_lengths, [STREAMED_OUTPUT_CHUNK_BYTES, trailing_bytes]);
+}
 
 /// Recording-fake reporter that pushes every emitted [`LogEvent`] into
 /// `EVENTS`. The static lives in this test function's own scope, so

--- a/pnpm/crates/executor/src/process_tracker.rs
+++ b/pnpm/crates/executor/src/process_tracker.rs
@@ -9,11 +9,17 @@ use tokio::sync::watch;
 #[cfg(unix)]
 use std::{io::Read, os::unix::process::CommandExt, process::Stdio, time::Duration};
 
-/// Tracks the processes started by one recursive command so a bailing task
-/// can stop the other work that is still in flight.
-#[derive(Default)]
+/// Tracks the processes started by one command so a bailing task can stop
+/// other work that is still in flight.
 pub struct ProcessTracker {
     state: Mutex<TrackerState>,
+    separate_process_groups: bool,
+}
+
+impl Default for ProcessTracker {
+    fn default() -> Self {
+        Self { state: Mutex::new(TrackerState::default()), separate_process_groups: true }
+    }
 }
 
 #[derive(Default)]
@@ -25,14 +31,16 @@ struct TrackerState {
 
 #[derive(Clone)]
 enum RunningExecution {
-    Process(u32),
+    Process { pid: u32, separate_process_group: bool },
     Emulated(watch::Sender<bool>),
 }
 
 impl RunningExecution {
     fn cancel(&self) {
         match self {
-            Self::Process(pid) => terminate_process_tree(*pid),
+            Self::Process { pid, separate_process_group } => {
+                terminate_process(*pid, *separate_process_group);
+            }
             Self::Emulated(sender) => {
                 let _ = sender.send(true);
             }
@@ -41,6 +49,13 @@ impl RunningExecution {
 }
 
 impl ProcessTracker {
+    /// Track foreground children without moving them out of the terminal's
+    /// process group, so terminal signals continue to reach them directly.
+    #[must_use]
+    pub fn foreground() -> Self {
+        Self { state: Mutex::new(TrackerState::default()), separate_process_groups: false }
+    }
+
     /// Cancel every registered execution. Returns `true` only to the caller
     /// that initiated cancellation.
     pub fn cancel(&self) -> bool {
@@ -59,7 +74,7 @@ impl ProcessTracker {
         }
         #[cfg(unix)]
         for pid in descendants {
-            terminate_process(pid);
+            terminate_descendant(pid);
         }
         true
     }
@@ -89,19 +104,23 @@ impl ProcessTracker {
     }
 }
 
-/// Spawn a child and optionally register it for recursive-command
-/// cancellation. On Unix a tracked child starts a process group so
-/// cancellation also reaches descendants.
+/// Spawn a child and optionally register it for cancellation. The default
+/// tracker gives each Unix child its own process group; a foreground tracker
+/// preserves the caller's process group and discovers descendants at cancel.
 pub fn spawn_child<'tracker>(
     command: &mut Command,
     process_tracker: Option<&'tracker ProcessTracker>,
 ) -> io::Result<SpawnedChild<'tracker>> {
-    if process_tracker.is_some() {
+    if process_tracker.is_some_and(|tracker| tracker.separate_process_groups) {
         prepare_command(command);
     }
     let child = command.spawn()?;
-    let registration =
-        process_tracker.map(|tracker| tracker.register(RunningExecution::Process(child.id())));
+    let registration = process_tracker.map(|tracker| {
+        tracker.register(RunningExecution::Process {
+            pid: child.id(),
+            separate_process_group: tracker.separate_process_groups,
+        })
+    });
     Ok(SpawnedChild { child, _registration: registration })
 }
 
@@ -157,18 +176,19 @@ fn prepare_command(command: &mut Command) {
 fn prepare_command(_: &mut Command) {}
 
 #[cfg(unix)]
-fn terminate_process_tree(pid: u32) {
+fn terminate_process(pid: u32, separate_process_group: bool) {
     let Ok(pid) = i32::try_from(pid) else { return };
-    // SAFETY: a negative PID asks `kill` to signal the process group whose
-    // ID is the tracked child's PID. The child was placed in that group by
-    // `prepare_command`; ESRCH is harmless when it exited concurrently.
+    let target = if separate_process_group { -pid } else { pid };
+    // SAFETY: a negative target signals the process group created by
+    // `prepare_command`; a positive target signals the foreground child.
+    // ESRCH is harmless when the process exited concurrently.
     unsafe {
-        libc::kill(-pid, libc::SIGKILL);
+        libc::kill(target, libc::SIGKILL);
     }
 }
 
 #[cfg(unix)]
-fn terminate_process(pid: i32) {
+fn terminate_descendant(pid: i32) {
     // SAFETY: every PID comes from the OS process list as a descendant of
     // this process. ESRCH is harmless when it exited concurrently.
     unsafe {
@@ -237,7 +257,7 @@ fn descendant_processes(root: u32) -> Vec<i32> {
 }
 
 #[cfg(windows)]
-fn terminate_process_tree(pid: u32) {
+fn terminate_process(pid: u32, _separate_process_group: bool) {
     use std::{os::windows::process::CommandExt, process::Stdio};
 
     let Some(taskkill) = taskkill_path() else { return };
@@ -274,3 +294,6 @@ fn taskkill_path() -> Option<std::path::PathBuf> {
         )
     }
 }
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/pnpm/crates/executor/src/process_tracker/tests.rs
+++ b/pnpm/crates/executor/src/process_tracker/tests.rs
@@ -1,0 +1,19 @@
+use super::{ProcessTracker, spawn_child};
+use std::process::Command;
+
+#[test]
+fn foreground_children_stay_in_the_terminal_process_group() {
+    let tracker = ProcessTracker::foreground();
+    let mut command = Command::new("sleep");
+    command.arg("30");
+    let mut child = spawn_child(&mut command, Some(&tracker)).expect("spawn child");
+    let child_pid = i32::try_from(child.child_mut().id()).expect("child PID fits i32");
+
+    // SAFETY: both calls only query process-group IDs for this process
+    // and the live child spawned immediately above.
+    let (parent_group, child_group) = unsafe { (libc::getpgrp(), libc::getpgid(child_pid)) };
+    assert_eq!(child_group, parent_group);
+
+    tracker.cancel();
+    assert!(!child.wait().expect("wait for cancelled child").success());
+}


### PR DESCRIPTION
## Summary

- Restores the TypeScript CLI behavior for Rust pnpm: scripts selected by a regular-expression command in one project run concurrently up to `workspaceConcurrency`.
- Streams concurrent script output through the lifecycle reporter so each line remains distinguishable, while bounding newline-free output chunks and retaining inherited output for sequential and single-script runs.
- Keeps tracked concurrent children in the terminal's foreground process group so Ctrl-C reaches them, while still cancelling siblings after a script failure.
- Adds regression coverage for overlap, output prefixes, deterministic concurrency, sibling cancellation, foreground process groups, and bounded output.

Related to [pnpm discussion 14357](https://github.com/orgs/pnpm/discussions/14357).

## Squash Commit Body

```text
Rust pnpm 12 handled regular-expression-selected scripts with a sequential loop, unlike the TypeScript CLI and the documented behavior. Schedule matched scripts under workspaceConcurrency, stream concurrent output through the lifecycle reporter in bounded chunks, and cancel remaining processes when a script fails. Keep tracked concurrent scripts in the foreground process group so terminal interrupts reach them, and preserve the existing fast path for single-script and sequential invocations.

Related to https://github.com/orgs/pnpm/discussions/14357
```

## Checklist

- [x] I checked the referenced discussion and verified that no linked or open PR already solves it.
- [x] The TypeScript CLI already implements this behavior; this change restores parity in the Rust `pnpm/` port.
- [x] Added a changeset for `pacquet`.
- [x] Added an end-to-end regression test.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790796811&installation_model_id=426870&pr_number=14382&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14382&signature=8104769c94658864d0dcfeb99287f611c444a4a883f92b9713c70d7394147ad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Matching scripts selected with `pnpm run "/pattern/"` now run concurrently by default, up to the configured workspace concurrency.
  * Added clearer prefixed output when multiple scripts run at the same time.
  * Sequential execution remains available through existing options.

* **Bug Fixes**
  * Improved handling of failures and interruptions when running multiple matched scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->