### PR TITLE
fix(config): preserve UTF-8 during env substitution

### DIFF
--- a/.changeset/utf8-env-literals.md
+++ b/.changeset/utf8-env-literals.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Preserved non-ASCII text in configuration values during environment-variable substitution.
+Fixed non-ASCII characters in configuration values being mangled during environment-variable substitution. Paths such as `storeDir: ./café-store` are now preserved [#14383](https://github.com/pnpm/pnpm/issues/14383).

--- a/.changeset/utf8-env-literals.md
+++ b/.changeset/utf8-env-literals.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Preserved non-ASCII text in configuration values during environment-variable substitution.

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -592,8 +592,8 @@ fn expands_env_vars_inside_non_registry_workspace_values() {
     }
 
     let yaml = r"
-storeDir: ${STORE_DIR}/café
-cacheDir: ${CACHE_DIR}/日本語
+storeDir: ${STORE_DIR}
+cacheDir: ${CACHE_DIR}
 scriptShell: ${SHELL}
 nodeOptions: --require=${HOOK}
 userAgent: ${USER_AGENT}
@@ -605,11 +605,41 @@ userAgent: ${USER_AGENT}
     let mut config = Config::new();
     settings.apply_to(&mut config, base);
 
-    assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir/café")));
-    assert_eq!(config.cache_dir, base.join("cache-dir/日本語"));
+    assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir")));
+    assert_eq!(config.cache_dir, base.join("cache-dir"));
     assert_eq!(config.script_shell.as_deref(), Some("custom-shell"));
     assert_eq!(config.node_options.as_deref(), Some("--require=hook.js"));
     assert_eq!(config.user_agent, "pacquet-test/1.0");
+}
+
+#[test]
+fn keeps_non_ascii_text_in_workspace_values() {
+    struct EnvWithPaths;
+    impl EnvVar for EnvWithPaths {
+        fn var(name: &str) -> Option<String> {
+            match name {
+                "CACHE_DIR" => Some("cache-dir".to_owned()),
+                "STORE_DIR" => Some("store-dir".to_owned()),
+                _ => None,
+            }
+        }
+    }
+
+    let yaml = r"
+storeDir: ${STORE_DIR}/café
+cacheDir: 日本語/${CACHE_DIR}
+scriptShell: ./ünicode-shell
+";
+    let mut settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
+    settings.substitute_env_untrusted::<EnvWithPaths>();
+
+    let base = Path::new("/workspace/root");
+    let mut config = Config::new();
+    settings.apply_to(&mut config, base);
+
+    assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir/café")));
+    assert_eq!(config.cache_dir, base.join("日本語/cache-dir"));
+    assert_eq!(config.script_shell.as_deref(), Some("./ünicode-shell"));
 }
 
 #[test]

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -592,8 +592,8 @@ fn expands_env_vars_inside_non_registry_workspace_values() {
     }
 
     let yaml = r"
-storeDir: ${STORE_DIR}
-cacheDir: ${CACHE_DIR}
+storeDir: ${STORE_DIR}/café
+cacheDir: ${CACHE_DIR}/日本語
 scriptShell: ${SHELL}
 nodeOptions: --require=${HOOK}
 userAgent: ${USER_AGENT}
@@ -605,8 +605,8 @@ userAgent: ${USER_AGENT}
     let mut config = Config::new();
     settings.apply_to(&mut config, base);
 
-    assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir")));
-    assert_eq!(config.cache_dir, base.join("cache-dir"));
+    assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir/café")));
+    assert_eq!(config.cache_dir, base.join("cache-dir/日本語"));
     assert_eq!(config.script_shell.as_deref(), Some("custom-shell"));
     assert_eq!(config.node_options.as_deref(), Some("--require=hook.js"));
     assert_eq!(config.user_agent, "pacquet-test/1.0");

--- a/pnpm/crates/env-replace/src/lib.rs
+++ b/pnpm/crates/env-replace/src/lib.rs
@@ -103,6 +103,7 @@ pub fn env_replace_lossy<Sys: EnvVar>(text: &str) -> (String, Vec<String>) {
         };
 
         output.push_str(&text[literal_start..index - backslashes]);
+        // Each pair of backslashes collapses to one literal backslash.
         for _ in 0..(backslashes / 2) {
             output.push('\\');
         }

--- a/pnpm/crates/env-replace/src/lib.rs
+++ b/pnpm/crates/env-replace/src/lib.rs
@@ -81,10 +81,9 @@ pub fn env_replace_lossy<Sys: EnvVar>(text: &str) -> (String, Vec<String>) {
     let mut output = String::with_capacity(text.len());
     let mut unresolved = Vec::new();
     let mut index = 0;
+    let mut literal_start = 0;
     while index < bytes.len() {
-        let char = bytes[index];
-        if char != b'$' {
-            output.push(char as char);
+        if bytes[index] != b'$' {
             index += 1;
             continue;
         }
@@ -99,16 +98,11 @@ pub fn env_replace_lossy<Sys: EnvVar>(text: &str) -> (String, Vec<String>) {
         }
 
         let Some(end) = find_placeholder_end(bytes, index) else {
-            output.push('$');
             index += 1;
             continue;
         };
 
-        // Each pair of backslashes collapses to one literal backslash.
-        // The source backslashes are already in `output` from the
-        // literal-passthrough loop, so we truncate them off and re-emit
-        // half.
-        output.truncate(output.len() - backslashes);
+        output.push_str(&text[literal_start..index - backslashes]);
         for _ in 0..(backslashes / 2) {
             output.push('\\');
         }
@@ -131,7 +125,9 @@ pub fn env_replace_lossy<Sys: EnvVar>(text: &str) -> (String, Vec<String>) {
             }
         }
         index = end + 1;
+        literal_start = index;
     }
+    output.push_str(&text[literal_start..]);
     (output, unresolved)
 }
 

--- a/pnpm/crates/env-replace/src/lib.rs
+++ b/pnpm/crates/env-replace/src/lib.rs
@@ -102,8 +102,9 @@ pub fn env_replace_lossy<Sys: EnvVar>(text: &str) -> (String, Vec<String>) {
             continue;
         };
 
+        // The escape backslashes are held back from the literal span and
+        // re-emitted halved: each pair collapses to one literal backslash.
         output.push_str(&text[literal_start..index - backslashes]);
-        // Each pair of backslashes collapses to one literal backslash.
         for _ in 0..(backslashes / 2) {
             output.push('\\');
         }

--- a/pnpm/crates/env-replace/src/tests.rs
+++ b/pnpm/crates/env-replace/src/tests.rs
@@ -69,6 +69,25 @@ fn passthrough_when_no_placeholder() {
 }
 
 #[test]
+fn preserves_utf8_literal_text() {
+    struct EnvWithValue;
+    impl EnvVar for EnvWithValue {
+        fn var(name: &str) -> Option<String> {
+            (name == "VALUE").then(|| "resolved".to_owned())
+        }
+    }
+
+    for (input, expected) in [
+        ("café/日本語", "café/日本語"),
+        ("café/${VALUE}/日本語", "café/resolved/日本語"),
+        ("café/${MISSING:-défaut}/日本語", "café/défaut/日本語"),
+        (r"café/\${VALUE}/日本語", "café/${VALUE}/日本語"),
+    ] {
+        assert_eq!(replace_clean::<EnvWithValue>(input), expected);
+    }
+}
+
+#[test]
 fn lone_dollar_is_left_alone() {
     assert_eq!(replace_clean::<NoEnv>("$ price"), "$ price");
 }

--- a/pnpm/crates/env-replace/src/tests.rs
+++ b/pnpm/crates/env-replace/src/tests.rs
@@ -68,23 +68,25 @@ fn passthrough_when_no_placeholder() {
     assert_eq!(replace_clean::<NoEnv>("plain string"), "plain string");
 }
 
+/// The scan walks `text` byte by byte, so every span it leaves
+/// untouched has to be copied back as a string slice; decoding a
+/// multi-byte character one byte at a time would mangle it.
 #[test]
-fn preserves_utf8_literal_text() {
+fn preserves_non_ascii_literal_text() {
     struct EnvWithValue;
     impl EnvVar for EnvWithValue {
         fn var(name: &str) -> Option<String> {
             (name == "VALUE").then(|| "resolved".to_owned())
         }
     }
-
-    for (input, expected) in [
-        ("café/日本語", "café/日本語"),
-        ("café/${VALUE}/日本語", "café/resolved/日本語"),
-        ("café/${MISSING:-défaut}/日本語", "café/défaut/日本語"),
-        (r"café/\${VALUE}/日本語", "café/${VALUE}/日本語"),
-    ] {
-        assert_eq!(replace_clean::<EnvWithValue>(input), expected);
-    }
+    assert_eq!(replace_clean::<EnvWithValue>("café/日本語"), "café/日本語");
+    assert_eq!(replace_clean::<EnvWithValue>("café/${VALUE}/日本語"), "café/resolved/日本語");
+    assert_eq!(
+        replace_clean::<EnvWithValue>("café/${MISSING:-défaut}/日本語"),
+        "café/défaut/日本語",
+    );
+    assert_eq!(replace_clean::<EnvWithValue>(r"café/\${VALUE}/日本語"), "café/${VALUE}/日本語");
+    assert_eq!(replace_clean::<EnvWithValue>("café/${OPEN/日本語"), "café/${OPEN/日本語");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14383.

- Copy literal input spans as UTF-8 strings while scanning environment
  placeholders instead of converting each byte into a character.
- Preserve non-ASCII workspace paths with and without substitutions.
- Add unit and workspace-config regression coverage.

This restores parity with the TypeScript CLI, which already preserves Unicode.
No TypeScript code change is required.

Verification:

- `cargo nextest run -p pnpm-env-replace`
- `cargo nextest run -p pnpm-config expands_env_vars_inside_non_registry_workspace_values`
- `cargo fmt --check -p pnpm-env-replace -p pnpm-config`
- `cargo clippy --locked -p pnpm-env-replace -p pnpm-config --all-targets -- --deny warnings`
- `cargo nextest run -p pnpm-env-replace -p pnpm-config`
- Repository pre-push checks

## Squash Commit Body

```text
Copy unchanged source spans as UTF-8 strings while scanning environment
placeholders. This preserves non-ASCII configuration paths and values without
changing placeholder, fallback, or escape behavior.

Fixes pnpm/pnpm#14383
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790802478&installation_model_id=426870&pr_number=14385&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14385&signature=979227befe957039926dd120bfa82280c8e621442ea1b2d7e2f10d052c42321b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved non-ASCII characters, including accented and Japanese text, in configuration values during environment-variable substitution.
  - Fixed path values so literal segments following environment-variable placeholders are retained.
  - Maintained expected handling of escaped placeholders and backslashes in configuration strings.

- **Tests**
  - Added coverage for UTF-8 text, default values, literal content, and escaped environment-variable placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->