### PR TITLE
fix(napi): intern configs atomically

### DIFF
--- a/.changeset/atomic-napi-config-cache.md
+++ b/.changeset/atomic-napi-config-cache.md
@@ -2,4 +2,4 @@
 "@pnpm/napi": patch
 ---
 
-Prevented concurrent calls from retaining duplicate configuration instances.
+Fixed excess memory retention during concurrent N-API configuration resolution.

--- a/.changeset/atomic-napi-config-cache.md
+++ b/.changeset/atomic-napi-config-cache.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/napi": patch
+---
+
+Prevented concurrent calls from retaining duplicate configuration instances.

--- a/.changeset/atomic-napi-config-cache.md
+++ b/.changeset/atomic-napi-config-cache.md
@@ -2,4 +2,4 @@
 "@pnpm/napi": patch
 ---
 
-Fixed excess memory retention during concurrent N-API configuration resolution.
+Fixed a memory leak in the N-API bindings. Concurrent calls that resolved the same configuration each retained their own copy for the life of the process [pnpm/pnpm#14386](https://github.com/pnpm/pnpm/issues/14386).

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -266,10 +266,14 @@ pub fn resolve_config(
         return Ok(*config);
     }
     let config = build_config(dir, overlay)?;
-    Ok(match config_cache().entry(key) {
-        Entry::Occupied(entry) => *entry.get(),
+    Ok(intern_config(key, config))
+}
+
+fn intern_config(key: u64, config: Config) -> &'static Config {
+    match config_cache().entry(key) {
+        Entry::Occupied(entry) => entry.get(),
         Entry::Vacant(entry) => *entry.insert(config.leak()),
-    })
+    }
 }
 
 fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorkspaceYamlError> {

--- a/pnpm/crates/napi/src/config.rs
+++ b/pnpm/crates/napi/src/config.rs
@@ -31,7 +31,7 @@ use std::{
     sync::OnceLock,
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
 use indexmap::IndexMap;
 use pnpm_config::{
     Config, GetHomeDir, Host, LinkWorkspacePackages, LoadWorkspaceYamlError, NodeLinker,
@@ -266,9 +266,10 @@ pub fn resolve_config(
         return Ok(*config);
     }
     let config = build_config(dir, overlay)?;
-    let leaked: &'static Config = config.leak();
-    config_cache().insert(key, leaked);
-    Ok(leaked)
+    Ok(match config_cache().entry(key) {
+        Entry::Occupied(entry) => *entry.get(),
+        Entry::Vacant(entry) => *entry.insert(config.leak()),
+    })
 }
 
 fn build_config(dir: &Path, overlay: &ConfigOverlay) -> Result<Config, LoadWorkspaceYamlError> {

--- a/pnpm/crates/napi/src/config/tests.rs
+++ b/pnpm/crates/napi/src/config/tests.rs
@@ -1,30 +1,34 @@
 use std::{
     collections::{BTreeMap, HashSet},
-    path::{Path, PathBuf},
+    path::Path,
     sync::{Arc, Barrier},
     thread,
 };
 
 use super::{
-    ConfigOverlay, cache_key, overlay_default_registry, pin_unkeyed_header, resolve_config,
+    ConfigOverlay, build_config, cache_key, config_cache, intern_config, overlay_default_registry,
+    pin_unkeyed_header,
 };
 
 #[test]
-fn concurrent_equal_configs_share_one_interned_reference() {
+fn concurrent_publication_retains_one_interned_config() {
     const CALLER_COUNT: usize = 32;
     let temp_dir = tempfile::tempdir().expect("create temporary config directory");
-    let dir = Arc::new(PathBuf::from(temp_dir.path()));
-    let start = Arc::new(Barrier::new(CALLER_COUNT));
+    let overlay = ConfigOverlay::default();
+    let key = cache_key(temp_dir.path(), &overlay);
+    assert!(!config_cache().contains_key(&key));
+
+    let configs = (0..CALLER_COUNT)
+        .map(|_| build_config(temp_dir.path(), &overlay).expect("build config"))
+        .collect::<Vec<_>>();
+    let publish = Arc::new(Barrier::new(CALLER_COUNT));
 
     let mut handles = Vec::with_capacity(CALLER_COUNT);
-    for _ in 0..CALLER_COUNT {
-        let dir = Arc::clone(&dir);
-        let start = Arc::clone(&start);
+    for config in configs {
+        let publish = Arc::clone(&publish);
         handles.push(thread::spawn(move || {
-            start.wait();
-            resolve_config(&dir, &ConfigOverlay::default())
-                .map(|config| std::ptr::from_ref(config).addr())
-                .expect("resolve config")
+            publish.wait();
+            std::ptr::from_ref(intern_config(key, config)).addr()
         }));
     }
 
@@ -34,6 +38,11 @@ fn concurrent_equal_configs_share_one_interned_reference() {
         .collect::<HashSet<_>>();
 
     assert_eq!(config_addresses.len(), 1);
+    let cached_address = config_cache()
+        .get(&key)
+        .map(|config| std::ptr::from_ref(*config).addr())
+        .expect("config should be retained in cache");
+    assert_eq!(config_addresses.iter().next().copied(), Some(cached_address));
 }
 
 /// Two independently constructed overlays with identical map contents must

--- a/pnpm/crates/napi/src/config/tests.rs
+++ b/pnpm/crates/napi/src/config/tests.rs
@@ -1,6 +1,40 @@
-use std::{collections::BTreeMap, path::Path};
+use std::{
+    collections::{BTreeMap, HashSet},
+    path::{Path, PathBuf},
+    sync::{Arc, Barrier},
+    thread,
+};
 
-use super::{ConfigOverlay, cache_key, overlay_default_registry, pin_unkeyed_header};
+use super::{
+    ConfigOverlay, cache_key, overlay_default_registry, pin_unkeyed_header, resolve_config,
+};
+
+#[test]
+fn concurrent_equal_configs_share_one_interned_reference() {
+    const CALLER_COUNT: usize = 32;
+    let temp_dir = tempfile::tempdir().expect("create temporary config directory");
+    let dir = Arc::new(PathBuf::from(temp_dir.path()));
+    let start = Arc::new(Barrier::new(CALLER_COUNT));
+
+    let mut handles = Vec::with_capacity(CALLER_COUNT);
+    for _ in 0..CALLER_COUNT {
+        let dir = Arc::clone(&dir);
+        let start = Arc::clone(&start);
+        handles.push(thread::spawn(move || {
+            start.wait();
+            resolve_config(&dir, &ConfigOverlay::default())
+                .map(|config| std::ptr::from_ref(config).addr())
+                .expect("resolve config")
+        }));
+    }
+
+    let config_addresses = handles
+        .into_iter()
+        .map(|handle| handle.join().expect("config thread should not panic"))
+        .collect::<HashSet<_>>();
+
+    assert_eq!(config_addresses.len(), 1);
+}
 
 /// Two independently constructed overlays with identical map contents must
 /// produce the same cache key. If the map fields were `HashMap` (random


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14386.

- Publish built N-API configs through DashMap's atomic entry API.
- Drop a losing caller's owned config instead of leaking it.
- Add concurrent regression coverage that proves equal inputs share one retained reference.

This change is internal to the Rust N-API binding and does not affect the CLI surface or an on-disk contract. No TypeScript change is required.

Verification:

- `cargo nextest run -p pnpm-napi`
- `cargo fmt --check -p pnpm-napi`
- `cargo clippy --locked -p pnpm-napi --all-targets -- --deny warnings`
- `just ready`
- Repository pre-push checks

## Squash Commit Body

```text
Publish built configs through the cache entry API so concurrent callers
retain one config per key. A caller that loses the race drops its owned
config before it can be leaked.

Fixes pnpm/pnpm#14386
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790804875&installation_model_id=426870&pr_number=14387&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14387&signature=8730c866c0224b5d70b461c412ea9f982046bb61c8290a279b6fde310e5b42fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak during concurrent configuration resolution.
  * Ensured simultaneous requests for the same configuration share one retained instance.
  * Improved cache handling to prevent duplicate retained configurations.

* **Tests**
  * Expanded coverage for concurrent configuration publication.
  * Verified that simultaneous requests retain exactly one shared configuration instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->