### PR TITLE
fix(lockfile): order env document writes like main document writes

### DIFF
--- a/.changeset/env-lockfile-write-matches-main-document.md
+++ b/.changeset/env-lockfile-write-matches-main-document.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/lockfile.fs": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink — as build sandboxes such as Bazel and Nix stage it — and the project has config dependencies. Writing the leading env document that records them now follows the same rules as the rest of the lockfile: an unchanged document is not rewritten at all, so such an install no longer needs to write, and only a *changed* write through a symlink is refused. A lockfile that carries a byte order mark also keeps its main document intact when the env document is replaced.

--- a/.changeset/env-lockfile-write-matches-main-document.md
+++ b/.changeset/env-lockfile-write-matches-main-document.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink — as build sandboxes such as Bazel and Nix stage it — and the project has config dependencies. Writing the leading env document that records them now follows the same rules as the rest of the lockfile: an unchanged document is not rewritten at all, so such an install no longer needs to write, and only a *changed* write through a symlink is refused. A lockfile that carries a byte order mark also keeps its main document intact when the env document is replaced.
+Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink — as build sandboxes such as Bazel and Nix stage it — and the project has config dependencies. An install that leaves the env document unchanged no longer rewrites it, and writing a *changed* env document through a symlink is still refused. A lockfile that carries a byte order mark now keeps its main document when the env document is replaced.

--- a/.changeset/env-lockfile-write-matches-main-document.md
+++ b/.changeset/env-lockfile-write-matches-main-document.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` when `pnpm-lock.yaml` is a symlink — as build sandboxes such as Bazel and Nix stage it — and the project has config dependencies. An install that leaves the env document unchanged no longer rewrites it, and writing a *changed* env document through a symlink is still refused. A lockfile that carries a byte order mark now keeps its main document when the env document is replaced.
+Fixed `pnpm install` failing with `ERR_PNPM_LOCKFILE_IS_SYMLINK` in a project with config dependencies when `pnpm-lock.yaml` is a symlink, as build sandboxes such as Bazel and Nix stage it. pnpm no longer rewrites the lockfile when the recorded config dependencies are unchanged. Writing changed config dependencies through a symlinked lockfile is still refused. A lockfile that starts with a byte order mark now keeps its main document when its config dependencies are updated [#14372](https://github.com/pnpm/pnpm/issues/14372).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5136,7 +5136,6 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "indexmap 2.14.0",
- "libc",
  "miette 7.6.0",
  "node-semver",
  "pipe-trait",

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -21,7 +21,6 @@ pnpm-resolving-parse-wanted-dependency = { workspace = true }
 
 derive_more      = { workspace = true }
 indexmap         = { workspace = true }
-libc             = { workspace = true }
 miette           = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -17,21 +17,19 @@ use crate::{
     extract_main_document,
     save_lockfile::ensure_lockfile_is_not_symlink,
     serialize_yaml,
-    yaml_documents::{YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START, read_first_yaml_document},
+    yaml_documents::{
+        YAML_DOCUMENT_SEPARATOR, YAML_DOCUMENT_START, normalize_lockfile_content,
+        read_first_yaml_document,
+    },
 };
 use pnpm_fs::write_atomic;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, HashMap},
     fs::{self, File},
-    io::{self, ErrorKind, Read as _},
+    io::{self, ErrorKind},
     path::Path,
 };
-
-#[cfg(unix)]
-use crate::save_lockfile::symlinked_lockfile_error;
-#[cfg(unix)]
-use std::os::unix::fs::OpenOptionsExt as _;
 
 /// The resolved `{ specifier, version }` pair recorded for each config
 /// (or package-manager) dependency under an importer.
@@ -126,15 +124,27 @@ impl EnvLockfile {
     /// Write this env document as the first YAML document of
     /// `<root_dir>/pnpm-lock.yaml`, preserving any existing main
     /// document. Emits `---\n${envYaml}\n---\n${mainDoc}`.
+    ///
+    /// Ordered like [`crate::save_value_to_path`], and for the same reasons:
+    /// the read follows a symlink, an unchanged document is not rewritten, and
+    /// only a changed write refuses a symlinked lockfile.
     pub fn write(&self, root_dir: &Path) -> Result<(), SaveLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
-        ensure_lockfile_is_not_symlink(&path).map_err(SaveLockfileError::WriteFile)?;
         let env_yaml = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
-        let main_doc = read_lockfile_to_string_no_follow(&path)
-            .map_err(SaveLockfileError::WriteFile)?
-            .map_or_else(String::new, |existing| extract_main_document(&existing).to_string());
+        let existing = match fs::read_to_string(&path) {
+            Ok(existing) => Some(normalize_lockfile_content(&existing).into_owned()),
+            Err(error) if error.kind() == ErrorKind::NotFound => None,
+            Err(error) => return Err(SaveLockfileError::WriteFile(error)),
+        };
+        let main_doc = existing
+            .as_deref()
+            .map_or_else(String::new, |existing| extract_main_document(existing).to_string());
         let combined =
             format!("{YAML_DOCUMENT_START}{env_yaml}{YAML_DOCUMENT_SEPARATOR}{main_doc}");
+        if existing.as_deref() == Some(combined.as_str()) {
+            return Ok(());
+        }
+        ensure_lockfile_is_not_symlink(&path).map_err(SaveLockfileError::WriteFile)?;
         write_atomic(&path, combined.as_bytes()).map_err(SaveLockfileError::WriteFile)
     }
 }
@@ -147,41 +157,6 @@ fn read_env_document(path: &Path) -> io::Result<Option<String>> {
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
-}
-
-fn read_lockfile_to_string_no_follow(path: &Path) -> io::Result<Option<String>> {
-    let mut file = match open_lockfile_no_follow(path) {
-        Ok(file) => file,
-        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error),
-    };
-    let mut content = String::new();
-    #[expect(
-        clippy::verbose_file_reads,
-        reason = "Reading from the caller's file handle avoids reopening the lockfile by path."
-    )]
-    file.read_to_string(&mut content)?;
-    Ok(Some(content))
-}
-
-#[cfg(unix)]
-fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
-    fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-        .map_err(|error| normalize_no_follow_error(path, error))
-}
-
-#[cfg(not(unix))]
-fn open_lockfile_no_follow(path: &Path) -> io::Result<File> {
-    ensure_lockfile_is_not_symlink(path)?;
-    File::open(path)
-}
-
-#[cfg(unix)]
-fn normalize_no_follow_error(path: &Path, error: io::Error) -> io::Error {
-    if error.raw_os_error() == Some(libc::ELOOP) { symlinked_lockfile_error(path) } else { error }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -123,11 +123,8 @@ impl EnvLockfile {
 
     /// Write this env document as the first YAML document of
     /// `<root_dir>/pnpm-lock.yaml`, preserving any existing main
-    /// document. Emits `---\n${envYaml}\n---\n${mainDoc}`.
-    ///
-    /// Ordered like [`crate::save_value_to_path`], and for the same reasons:
-    /// the read follows a symlink, an unchanged document is not rewritten, and
-    /// only a changed write refuses a symlinked lockfile.
+    /// document. Emits `---\n${envYaml}\n---\n${mainDoc}`. An unchanged
+    /// document is not rewritten.
     pub fn write(&self, root_dir: &Path) -> Result<(), SaveLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
         let env_yaml = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -133,9 +133,7 @@ impl EnvLockfile {
             Err(error) if error.kind() == ErrorKind::NotFound => None,
             Err(error) => return Err(SaveLockfileError::WriteFile(error)),
         };
-        let main_doc = existing
-            .as_deref()
-            .map_or_else(String::new, |existing| extract_main_document(existing).to_string());
+        let main_doc = existing.as_deref().map(extract_main_document).unwrap_or_default();
         let combined =
             format!("{YAML_DOCUMENT_START}{env_yaml}{YAML_DOCUMENT_SEPARATOR}{main_doc}");
         if existing.as_deref() == Some(combined.as_str()) {

--- a/pnpm/crates/lockfile/src/env_lockfile.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile.rs
@@ -128,11 +128,12 @@ impl EnvLockfile {
     pub fn write(&self, root_dir: &Path) -> Result<(), SaveLockfileError> {
         let path = root_dir.join(Lockfile::FILE_NAME);
         let env_yaml = serialize_yaml::to_string(self).map_err(SaveLockfileError::SerializeYaml)?;
-        let existing = match fs::read_to_string(&path) {
-            Ok(existing) => Some(normalize_lockfile_content(&existing).into_owned()),
+        let raw = match fs::read_to_string(&path) {
+            Ok(raw) => Some(raw),
             Err(error) if error.kind() == ErrorKind::NotFound => None,
             Err(error) => return Err(SaveLockfileError::WriteFile(error)),
         };
+        let existing = raw.as_deref().map(normalize_lockfile_content);
         let main_doc = existing.as_deref().map(extract_main_document).unwrap_or_default();
         let combined =
             format!("{YAML_DOCUMENT_START}{env_yaml}{YAML_DOCUMENT_SEPARATOR}{main_doc}");

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -1,9 +1,7 @@
-#[cfg(unix)]
-use super::read_lockfile_to_string_no_follow;
 use super::{EnvLockfile, SpecifierAndResolution};
 use crate::{
     Lockfile, LockfileResolution, PackageKey, PackageMetadata, RegistryResolution, SnapshotEntry,
-    extract_env_document,
+    extract_env_document, extract_main_document,
 };
 use tempfile::TempDir;
 
@@ -119,18 +117,41 @@ fn read_symlinked_lockfile() {
 
 #[cfg(unix)]
 #[test]
-fn no_follow_read_rejects_symlinked_lockfile() {
+fn write_accepts_symlinked_lockfile_when_unchanged() {
+    let source = TempDir::new().unwrap();
+    let env = sample_env_lockfile();
+    env.write(source.path()).unwrap();
+    let content = std::fs::read_to_string(source.path().join(Lockfile::FILE_NAME)).unwrap();
+
     let dir = TempDir::new().unwrap();
     let real_lockfile = dir.path().join("real-lockfile.yaml");
-    std::fs::write(&real_lockfile, "target content").unwrap();
+    std::fs::write(&real_lockfile, &content).unwrap();
     let lockfile_path = dir.path().join(Lockfile::FILE_NAME);
     std::os::unix::fs::symlink(&real_lockfile, &lockfile_path).unwrap();
 
-    let error = read_lockfile_to_string_no_follow(&lockfile_path)
-        .expect_err("symlinked lockfile must fail");
+    env.write(dir.path()).expect("an unchanged env document must not need a write");
 
-    assert!(error.to_string().contains("symlinked lockfile"), "unexpected error: {error:?}");
-    assert_eq!(std::fs::read_to_string(real_lockfile).unwrap(), "target content");
+    assert!(std::fs::symlink_metadata(&lockfile_path).unwrap().file_type().is_symlink());
+    assert_eq!(std::fs::read_to_string(real_lockfile).unwrap(), content);
+}
+
+#[test]
+fn write_replaces_the_env_document_of_a_lockfile_carrying_a_bom() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let main_doc = "lockfileVersion: '9.0'\n\nimporters:\n\n  .:\n    dependencies:\n      is-odd:\n        specifier: 1.0.0\n        version: 1.0.0\n";
+    let old_env_doc = "lockfileVersion: '9.0'\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n";
+    std::fs::write(&path, format!("\u{feff}---\n{old_env_doc}\n---\n{main_doc}")).unwrap();
+
+    sample_env_lockfile().write(dir.path()).unwrap();
+
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(raw.starts_with("---\n"), "the BOM must not survive into the written lockfile");
+    assert_eq!(extract_main_document(&raw), main_doc);
+    assert!(
+        !extract_main_document(&raw).contains("configDependencies: {}"),
+        "the replaced env document must not end up inside the main document"
+    );
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -150,7 +150,7 @@ fn write_replaces_the_env_document_of_a_lockfile_carrying_a_bom() {
     assert_eq!(extract_main_document(&raw), main_doc);
     assert!(
         !extract_main_document(&raw).contains("configDependencies: {}"),
-        "the replaced env document must not end up inside the main document"
+        "the replaced env document must not end up inside the main document",
     );
 }
 

--- a/pnpm/crates/lockfile/src/env_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/env_lockfile/tests.rs
@@ -136,6 +136,22 @@ fn write_accepts_symlinked_lockfile_when_unchanged() {
 }
 
 #[test]
+fn write_leaves_an_unchanged_crlf_lockfile_untouched() {
+    let dir = TempDir::new().unwrap();
+    let path = dir.path().join(Lockfile::FILE_NAME);
+    let env = sample_env_lockfile();
+    env.write(dir.path()).unwrap();
+    let crlf_content = std::fs::read_to_string(&path).unwrap().replace('\n', "\r\n");
+    std::fs::write(&path, &crlf_content).unwrap();
+    let mtime_before = std::fs::metadata(&path).unwrap().modified().unwrap();
+
+    env.write(dir.path()).unwrap();
+
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), crlf_content);
+    assert_eq!(std::fs::metadata(&path).unwrap().modified().unwrap(), mtime_before);
+}
+
+#[test]
 fn write_replaces_the_env_document_of_a_lockfile_carrying_a_bom() {
     let dir = TempDir::new().unwrap();
     let path = dir.path().join(Lockfile::FILE_NAME);
@@ -148,9 +164,10 @@ fn write_replaces_the_env_document_of_a_lockfile_carrying_a_bom() {
     let raw = std::fs::read_to_string(&path).unwrap();
     assert!(raw.starts_with("---\n"), "the BOM must not survive into the written lockfile");
     assert_eq!(extract_main_document(&raw), main_doc);
-    assert!(
-        !extract_main_document(&raw).contains("configDependencies: {}"),
-        "the replaced env document must not end up inside the main document",
+    assert_eq!(
+        EnvLockfile::read(dir.path()).unwrap(),
+        Some(sample_env_lockfile()),
+        "the new env document must have replaced the old one",
     );
 }
 

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -8,7 +8,7 @@ import { sortLockfileKeys } from './sortLockfileKeys.js'
 import { lockfileYamlDump, writeWantedLockfileAtomic } from './write.js'
 import {
   extractMainDocument,
-  readLockfileToStringNoFollow,
+  readLockfileToString,
   streamReadFirstYamlDocument,
   YAML_DOCUMENT_SEPARATOR,
   YAML_DOCUMENT_START,
@@ -60,17 +60,20 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
 }
 
 /**
- * Replaces the env document that leads `pnpm-lock.yaml` while preserving its
- * main document. Refuses to replace a symlinked lockfile.
+ * Replaces the env document that leads `pnpm-lock.yaml`, preserving the main
+ * document after it. Follows {@link writeLockfileDoc}'s order, for the same
+ * reasons: reads may follow a symlink, an unchanged document is not rewritten,
+ * and only the publication step refuses to write through a symlink.
  */
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)
   const sorted = sortLockfileKeys(lockfile)
   const envYaml = lockfileYamlDump(sorted)
 
-  const existing = await readLockfileToStringNoFollow(lockfilePath)
+  const existing = await readLockfileToString(lockfilePath)
   const mainDoc = existing == null ? '' : extractMainDocument(existing)
 
   const combined = `${YAML_DOCUMENT_START}${envYaml}${YAML_DOCUMENT_SEPARATOR}${mainDoc}`
+  if (existing === combined) return
   await writeWantedLockfileAtomic(lockfilePath, combined)
 }

--- a/pnpm11/lockfile/fs/src/envLockfile.ts
+++ b/pnpm11/lockfile/fs/src/envLockfile.ts
@@ -61,9 +61,7 @@ export async function readEnvLockfile (rootDir: string): Promise<EnvLockfile | n
 
 /**
  * Replaces the env document that leads `pnpm-lock.yaml`, preserving the main
- * document after it. Follows {@link writeLockfileDoc}'s order, for the same
- * reasons: reads may follow a symlink, an unchanged document is not rewritten,
- * and only the publication step refuses to write through a symlink.
+ * document after it. An unchanged document is not rewritten.
  */
 export async function writeEnvLockfile (rootDir: string, lockfile: EnvLockfile): Promise<void> {
   const lockfilePath = path.join(rootDir, WANTED_LOCKFILE)

--- a/pnpm11/lockfile/fs/src/yamlDocuments.ts
+++ b/pnpm11/lockfile/fs/src/yamlDocuments.ts
@@ -10,7 +10,6 @@ export const YAML_DOCUMENT_SEPARATOR = '\n---\n'
 export const YAML_DOCUMENT_START = '---\n'
 
 const READ_BUFFER_SIZE = 64 * 1024
-const LOCKFILE_READ_FLAGS = constants.O_RDONLY | (process.platform === 'win32' ? 0 : constants.O_NOFOLLOW)
 
 /**
  * Reads the first YAML document from a multi-document YAML file using streaming.
@@ -71,33 +70,6 @@ export async function readLockfileToString (filePath: string): Promise<string | 
   } catch (err: unknown) {
     if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
       return null
-    }
-    throw err
-  }
-}
-
-export async function readLockfileToStringNoFollow (filePath: string): Promise<string | null> {
-  let fileHandle: FileHandle | undefined
-  try {
-    fileHandle = await openLockfileNoFollow(filePath)
-    return await fileHandle.readFile('utf8')
-  } catch (err: unknown) {
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOENT') {
-      return null
-    }
-    throw err
-  } finally {
-    await fileHandle?.close().catch(() => {})
-  }
-}
-
-async function openLockfileNoFollow (filePath: string): Promise<FileHandle> {
-  await ensureLockfileIsNotSymlink(filePath)
-  try {
-    return await open(filePath, LOCKFILE_READ_FLAGS)
-  } catch (err: unknown) {
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ELOOP') {
-      throw symlinkedLockfileError(filePath)
     }
     throw err
   }

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -129,6 +129,9 @@ test('writeEnvLockfile replaces the env document of a lockfile that carries a BO
   const written = fs.readFileSync(lockfilePath, 'utf8')
   expect(extractMainDocument(written)).toBe(mainDoc)
   expect(written.startsWith('---\n')).toBe(true)
+  await expect(readEnvLockfile(dir)).resolves.toMatchObject({
+    importers: { '.': { configDependencies: { 'my-config': { specifier: '^1.0.0', version: '1.0.0' } } } },
+  })
 })
 
 testOnNonWindows('writeEnvLockfile preserves the lockfile mode against the umask', async () => {

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
 import { WANTED_LOCKFILE } from '@pnpm/constants'
-import { createEnvLockfile, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
+import { createEnvLockfile, extractMainDocument, readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { temporaryDirectory } from 'tempy'
 
 const testOnNonWindows = process.platform === 'win32' ? test.skip : test
@@ -97,6 +97,38 @@ test('writeEnvLockfile leaves no temporary file behind', async () => {
   await writeEnvLockfile(dir, envLockfileWithConfigDep())
 
   expect(fs.readdirSync(dir)).toStrictEqual([WANTED_LOCKFILE])
+})
+
+testOnNonWindows('writeEnvLockfile accepts a symlinked lockfile when the env document is unchanged', async () => {
+  const source = temporaryDirectory()
+  const lockfile = envLockfileWithConfigDep()
+  await writeEnvLockfile(source, lockfile)
+  const content = fs.readFileSync(path.join(source, WANTED_LOCKFILE), 'utf8')
+
+  const dir = temporaryDirectory()
+  const realLockfile = path.join(dir, 'real-lockfile.yaml')
+  fs.writeFileSync(realLockfile, content)
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  fs.symlinkSync(realLockfile, lockfilePath, 'file')
+
+  await expect(writeEnvLockfile(dir, lockfile)).resolves.toBeUndefined()
+
+  expect(fs.lstatSync(lockfilePath).isSymbolicLink()).toBe(true)
+  expect(fs.readFileSync(realLockfile, 'utf8')).toBe(content)
+})
+
+test('writeEnvLockfile replaces the env document of a lockfile that carries a BOM', async () => {
+  const dir = temporaryDirectory()
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  const mainDoc = "lockfileVersion: '9.0'\nsettings:\n  autoInstallPeers: true\n"
+  const oldEnvDoc = "lockfileVersion: '9.0'\nimporters:\n  .:\n    configDependencies: {}\npackages: {}\nsnapshots: {}\n"
+  fs.writeFileSync(lockfilePath, `\uFEFF---\n${oldEnvDoc}\n---\n${mainDoc}`)
+
+  await writeEnvLockfile(dir, envLockfileWithConfigDep())
+
+  const written = fs.readFileSync(lockfilePath, 'utf8')
+  expect(extractMainDocument(written)).toBe(mainDoc)
+  expect(written.startsWith('---\n')).toBe(true)
 })
 
 testOnNonWindows('writeEnvLockfile preserves the lockfile mode against the umask', async () => {

--- a/pnpm11/lockfile/fs/test/envLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/envLockfile.test.ts
@@ -117,6 +117,21 @@ testOnNonWindows('writeEnvLockfile accepts a symlinked lockfile when the env doc
   expect(fs.readFileSync(realLockfile, 'utf8')).toBe(content)
 })
 
+test('writeEnvLockfile leaves an unchanged CRLF lockfile untouched', async () => {
+  const dir = temporaryDirectory()
+  const lockfilePath = path.join(dir, WANTED_LOCKFILE)
+  const lockfile = envLockfileWithConfigDep()
+  await writeEnvLockfile(dir, lockfile)
+  const crlfContent = fs.readFileSync(lockfilePath, 'utf8').replace(/\n/g, '\r\n')
+  fs.writeFileSync(lockfilePath, crlfContent)
+  const mtimeBefore = fs.statSync(lockfilePath).mtimeMs
+
+  await writeEnvLockfile(dir, lockfile)
+
+  expect(fs.readFileSync(lockfilePath, 'utf8')).toBe(crlfContent)
+  expect(fs.statSync(lockfilePath).mtimeMs).toBe(mtimeBefore)
+})
+
 test('writeEnvLockfile replaces the env document of a lockfile that carries a BOM', async () => {
   const dir = temporaryDirectory()
   const lockfilePath = path.join(dir, WANTED_LOCKFILE)


### PR DESCRIPTION
## Summary

`writeEnvLockfile` refuses a symlinked `pnpm-lock.yaml` before anything has decided whether the write would change a byte, so an install that records config dependencies still fails with `ERR_PNPM_LOCKFILE_IS_SYMLINK` in the Bazel/Nix sandboxes that pnpm/pnpm#13073 was about — even when the env document it would write is identical to the one on disk. `readEnvLockfile` directly above it already follows symlinks, so the reader and the writer of the same document disagreed with each other.

This gives the env-document writer the ordering the main-document writer already has, on both stacks:

| | before | after |
| --- | --- | --- |
| read | `readLockfileToStringNoFollow` / `read_lockfile_to_string_no_follow` — refuses a symlink outright | follows it, like `writeLockfileDoc` / `save_value_to_path` |
| unchanged document | rewritten | returns without writing |
| symlink refusal | at the read | at the publication step, and only for a changed write |

The no-follow read had no other callers on either side, so it goes; `libc` was in `pnpm-lockfile`'s dependencies only for its `O_NOFOLLOW` / `ELOOP` handling, so that goes too.

Closes pnpm/pnpm#14372

## The BOM half is TypeScript-only

The issue also reports that a byte order mark makes the writer treat the whole file as the main document and embed the old env document inside it. That is real on the TypeScript side, where `extractMainDocument` only rewrites CRLF — but not on pacquet, where `extract_main_document` calls `normalize_lockfile_content` itself. Verified by running the new regression tests against the unchanged writers:

| test | TypeScript, before | pacquet, before |
| --- | --- | --- |
| symlinked lockfile, env document unchanged | fails | fails |
| BOM-prefixed lockfile, env document replaced | fails | **passes** |

So the BOM fix is TypeScript-only; the Rust test is added as a guard, not as a change. (This corrects a line in pnpm/pnpm#14373's description and a note in the triage on the issue, both of which read the Rust no-follow read as carrying the same BOM problem.)

## Squash Commit Body

```text
writeEnvLockfile refused a symlinked pnpm-lock.yaml at the read, before
anything had decided whether the write would change a byte. An install
recording config dependencies therefore failed in the build sandboxes
that stage the lockfile as a symlink, even when the env document it
would write matched the one on disk.

Both stacks now order the env write the way the main-document write is
already ordered: follow the symlink on read, build the combined
document, return early when it equals what is on disk, and refuse the
symlink at the publication step. EnvLockfile::write mirrors
save_value_to_path; writeEnvLockfile mirrors writeLockfileDoc.

Dropping the no-follow read left it with no callers on either side, and
libc was in pnpm-lockfile's dependencies only for its O_NOFOLLOW and
ELOOP handling.

The BOM half of the issue is TypeScript-only: extractMainDocument
rewrites CRLF but does not strip a BOM, so a BOM-prefixed lockfile was
taken for a main document and the old env document ended up inside it.
extract_main_document normalizes through normalize_lockfile_content, so
the Rust test added alongside is a regression guard rather than a fix.

Closes pnpm/pnpm#14372
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

## Testing

- `pnpm --filter @pnpm/lockfile.fs test` — 9 suites, 83 tests.
- `cargo test -p pnpm-lockfile` — 371 tests.
- Each added test was checked against a writer with the fix removed:
  `write_accepts_symlinked_lockfile_when_unchanged` and its TypeScript
  counterpart fail when the symlink guard runs before the unchanged-document
  return, and `write_leaves_an_unchanged_crlf_lockfile_untouched` and its
  counterpart fail when the read stops normalizing.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --workspace -- -D
  warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --workspace
  --all-features --document-private-items`, `cargo dylint`, `typos` and `taplo
  format --check` all clean.
- `@pnpm/installing.env-installer` and `pnpm` use the `with-registry` jest
  preset, whose `globalSetup` needs `pnpr-prepare`; those suites are down to CI.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790807577&installation_model_id=426870&pr_number=14388&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14388&signature=5780dffc4f43a14ccd63331e270de3c0424692487d51bbcaa4e66d657cc55073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installations failing when `pnpm-lock.yaml` is a symlink and configuration dependencies are present.
  * Unchanged environment lockfile data is no longer rewritten unnecessarily.
  * Hardened lockfile updates to prevent writes from being redirected through symlinks.
  * Preserved the main lockfile document when updating environment data.
  * Improved handling of lockfiles containing a byte order mark (BOM).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
