### PR TITLE
fix(release): verify declared Rust pnpm binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -910,7 +910,8 @@ jobs:
           tar -xzf "$wrapper_tarball" \
             -C "$smoke_dir/node_modules/pnpm" --strip-components=1
           node "$smoke_dir/node_modules/pnpm/install.js"
-          "$smoke_dir/node_modules/pnpm/pnpm" --version
+          wrapper_bin=$(node -p 'require(process.argv[1]).bin.pnpm' "$smoke_dir/node_modules/pnpm/package.json")
+          "$smoke_dir/node_modules/pnpm/$wrapper_bin" --version
           # Corepack's entry point into the same tarball; it never runs
           # install.js, so its only job here is to prove it was published and
           # can reach the binary.


### PR DESCRIPTION
## Summary

Fix the Rust npm artifact smoke test after the pnpm wrapper's executable target changed from `pnpm` to `pnpm.exe`.

The verifier now reads `bin.pnpm` from the generated package manifest and executes that declared target instead of hard-coding a filename. This fixes the failure in https://github.com/pnpm/pnpm/actions/runs/33448408962/job/99678304536 and prevents the verifier from drifting if the wrapper target changes again.

## Squash Commit Body

```text
The pnpm v12 wrapper now declares pnpm.exe as its cross-platform executable target, but the Rust release verifier still invoked the old extensionless path directly.

Read the executable target from the generated package manifest before running the smoke test so verification follows the package's declared bin contract.
```

## Checklist

- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790810828&installation_model_id=426870&pr_number=14390&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14390&signature=3eed5a9f423f9f3e012b3d1b34837b8e539bb8dd85884046716fe0379dfb1e18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release verification to reliably locate and run the installed pnpm executable, preventing smoke-test failures caused by path differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->