### PR TITLE
fix: ignore non-pnpm releases in Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build:
     name: Build
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     runs-on: blacksmith-8vcpu-ubuntu-2404
     environment: release
     permissions:


### PR DESCRIPTION
## Summary

Limit the pnpm Docker build job to manual dispatches and published releases whose tags start with `v`.

The workflow currently receives every published release event. Publishing `pnpr@0.1.0-alpha.10` therefore started the pnpm image workflow, which rejected the pnpr tag as an invalid pnpm version in [this failed job](https://github.com/pnpm/pnpm/actions/runs/33451045413/job/99680783981). The pnpr image is already published by its dedicated job in the unified Release workflow.

## Squash Commit Body

```text
The pnpm Docker workflow receives release events for every product in the repository but only accepts pnpm version tags. As a result, publishing a pnpr release starts the workflow and fails during version validation.

Run the job for manual dispatches and v-prefixed release tags only, leaving pnpr image publication to the unified Release workflow.
```

## Checklist

- [x] No changeset is needed because no published package changes.
- [x] No pnpm/pacquet parity work is needed because this is CI-only.
- [x] Validated the workflow with `actionlint`.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790811403&installation_model_id=426870&pr_number=14391&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14391&signature=136ccc21505196dd84cdce8de48043e19a9e2229be3746388ec8e10ef77b832e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted Docker builds to manual triggers and releases using version-style tags.
  * Releases with other tag formats no longer start Docker builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->