### PR TITLE
perf(resolver): cache parsed peer ranges

### DIFF
--- a/.changeset/fresh-peers-compare.md
+++ b/.changeset/fresh-peers-compare.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Improved peer dependency resolution performance when many packages reuse the same peer ranges.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use node_semver::{Range, Version};
 use pnpm_deps_path::{DepPath, PeerId, index_of_dep_path_suffix};
-use pnpm_resolving_resolver_base::ResolveResult;
+use pnpm_resolving_resolver_base::{ResolveResult, get_peer_version_range};
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::{
     path::{Path, PathBuf},
@@ -596,7 +596,10 @@ pub(super) fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
     satisfies_with_parsed_prereleases(version, range, parsed_range.as_ref())
 }
 
-pub(super) fn satisfies_with_parsed_prereleases(
+/// [`satisfies_with_prereleases`] against a range that is already
+/// parsed. `parsed_range` must be `Range::parse(range).ok()`;
+/// [`ComparablePeerRange`] is what keeps the two in step.
+fn satisfies_with_parsed_prereleases(
     version: &str,
     range: &str,
     parsed_range: Option<&Range>,
@@ -624,6 +627,30 @@ pub(super) fn satisfies_with_parsed_prereleases(
         build: Vec::new(),
     };
     base.satisfies(parsed_range)
+}
+
+/// A peer range in the comparable form [`get_peer_version_range`]
+/// yields, paired with its parsed form so a range that many nodes
+/// declare is parsed once. Holding the two together is what keeps the
+/// parsed range in step with the text it came from.
+pub(super) struct ComparablePeerRange {
+    /// The comparable range, as peer-dependency issues quote it.
+    pub(super) text: String,
+    parsed: Option<Range>,
+}
+
+impl ComparablePeerRange {
+    pub(super) fn new(raw_range: &str) -> Self {
+        let text = get_peer_version_range(raw_range);
+        let parsed = Range::parse(&text).ok();
+        ComparablePeerRange { text, parsed }
+    }
+
+    /// Whether `version` satisfies this range, by
+    /// [`satisfies_with_prereleases`]'s rules.
+    pub(super) fn satisfies(&self, version: &str) -> bool {
+        satisfies_with_parsed_prereleases(version, &self.text, self.parsed.as_ref())
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -592,16 +592,25 @@ fn peer_segment_name(segment: &str) -> Option<&str> {
 /// the base `MAJOR.MINOR.PATCH` satisfies the range — without pulling
 /// in Yarn's full per-comparator algorithm.
 pub(super) fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
+    let parsed_range = Range::parse(range).ok();
+    satisfies_with_parsed_prereleases(version, range, parsed_range.as_ref())
+}
+
+pub(super) fn satisfies_with_parsed_prereleases(
+    version: &str,
+    range: &str,
+    parsed_range: Option<&Range>,
+) -> bool {
     if range == "*" {
         return true;
     }
     let Ok(parsed_version) = Version::parse(version) else {
         return version == range;
     };
-    let Ok(parsed_range) = Range::parse(range) else {
+    let Some(parsed_range) = parsed_range else {
         return version == range;
     };
-    if parsed_version.satisfies(&parsed_range) {
+    if parsed_version.satisfies(parsed_range) {
         return true;
     }
     if !parsed_version.is_prerelease() {
@@ -614,7 +623,7 @@ pub(super) fn satisfies_with_prereleases(version: &str, range: &str) -> bool {
         pre_release: Vec::new(),
         build: Vec::new(),
     };
-    base.satisfies(&parsed_range)
+    base.satisfies(parsed_range)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -15,9 +15,9 @@ use crate::{
             merge_realize_undo,
         },
         context::{
-            CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
-            importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
-            peer_id_pair, pkg_name_version, remap_link_node_id, satisfies_with_parsed_prereleases,
+            ComparablePeerRange, CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs,
+            SharedChain, importer_relative_link_dep_path, insert_parent_ref,
+            link_node_id_as_dep_path, peer_id_pair, pkg_name_version, remap_link_node_id,
             satisfies_with_prereleases,
         },
         discovery::PeerDiscoveryCaches,
@@ -27,7 +27,6 @@ use crate::{
         AncestorIds, ChildEdge, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
     },
 };
-use node_semver::Range;
 use pnpm_deps_path::{
     DepPath, PeerId, create_peer_dep_graph_hash, index_of_dep_path_suffix,
     link_path_to_peer_version,
@@ -160,7 +159,12 @@ pub(super) struct Walker<'tree> {
     /// and an importer-context miss there would demand an auto-install
     /// the positions do not need.
     in_canonical_drain: bool,
-    peer_ranges_by_raw: HashMap<String, Arc<ComparablePeerRange>>,
+    /// Raw `peerDependencies` range → its comparable form. Peer-heavy
+    /// workspaces declare the same few ranges across many nodes, so the
+    /// walk parses each distinct one once. Scoped to the walk: the
+    /// mapping is a pure function of the raw range, and nothing outside
+    /// it needs the entries.
+    comparable_peer_ranges: HashMap<String, Arc<ComparablePeerRange>>,
 }
 
 impl<'tree> Walker<'tree> {
@@ -248,18 +252,19 @@ impl<'tree> Walker<'tree> {
             canonical_backedge_nodes,
             pending_canonical_nodes: Vec::new(),
             in_canonical_drain: false,
-            peer_ranges_by_raw: HashMap::default(),
+            comparable_peer_ranges: HashMap::default(),
         }
     }
 
+    /// The cached [`ComparablePeerRange`] for `raw_range`, building it
+    /// on the first request. Shared out behind an [`Arc`] so the caller
+    /// can keep it while taking `&mut self` again.
     fn comparable_peer_range(&mut self, raw_range: &str) -> Arc<ComparablePeerRange> {
-        if let Some(range) = self.peer_ranges_by_raw.get(raw_range) {
+        if let Some(range) = self.comparable_peer_ranges.get(raw_range) {
             return Arc::clone(range);
         }
-        let text = get_peer_version_range(raw_range);
-        let parsed = Range::parse(&text).ok();
-        let range = Arc::new(ComparablePeerRange { text, parsed });
-        self.peer_ranges_by_raw.insert(raw_range.to_string(), Arc::clone(&range));
+        let range = Arc::new(ComparablePeerRange::new(raw_range));
+        self.comparable_peer_ranges.insert(raw_range.to_string(), Arc::clone(&range));
         range
     }
 
@@ -472,11 +477,6 @@ struct ChildParentRefs {
     /// lets the caller pass its own parent-context snapshot down
     /// instead of rebuilding an identical one.
     changed: bool,
-}
-
-struct ComparablePeerRange {
-    text: String,
-    parsed: Option<Range>,
 }
 
 /// The peers of one node, as [`Walker::resolve_node_peers`] resolves
@@ -1393,12 +1393,7 @@ impl Walker<'_> {
                 }
             }
             Some(parent) => {
-                if !satisfies_with_parsed_prereleases(
-                    &parent.version,
-                    &comparable_range.text,
-                    comparable_range.parsed.as_ref(),
-                ) && !self.in_canonical_drain
-                {
+                if !comparable_range.satisfies(&parent.version) && !self.in_canonical_drain {
                     let parents = self.issue_parents(chain);
                     self.issues.bad.entry(peer_name.to_string()).or_default().push(
                         PeerDependencyIssue {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -17,7 +17,8 @@ use crate::{
         context::{
             CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
             importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
-            peer_id_pair, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
+            peer_id_pair, pkg_name_version, remap_link_node_id, satisfies_with_parsed_prereleases,
+            satisfies_with_prereleases,
         },
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},
@@ -26,6 +27,7 @@ use crate::{
         AncestorIds, ChildEdge, DirectDep, PeerDep, ResolvedPackage, ResolvedTree, TreeChildren,
     },
 };
+use node_semver::Range;
 use pnpm_deps_path::{
     DepPath, PeerId, create_peer_dep_graph_hash, index_of_dep_path_suffix,
     link_path_to_peer_version,
@@ -158,6 +160,7 @@ pub(super) struct Walker<'tree> {
     /// and an importer-context miss there would demand an auto-install
     /// the positions do not need.
     in_canonical_drain: bool,
+    peer_ranges_by_raw: HashMap<String, Arc<ComparablePeerRange>>,
 }
 
 impl<'tree> Walker<'tree> {
@@ -245,7 +248,19 @@ impl<'tree> Walker<'tree> {
             canonical_backedge_nodes,
             pending_canonical_nodes: Vec::new(),
             in_canonical_drain: false,
+            peer_ranges_by_raw: HashMap::default(),
         }
+    }
+
+    fn comparable_peer_range(&mut self, raw_range: &str) -> Arc<ComparablePeerRange> {
+        if let Some(range) = self.peer_ranges_by_raw.get(raw_range) {
+            return Arc::clone(range);
+        }
+        let text = get_peer_version_range(raw_range);
+        let parsed = Range::parse(&text).ok();
+        let range = Arc::new(ComparablePeerRange { text, parsed });
+        self.peer_ranges_by_raw.insert(raw_range.to_string(), Arc::clone(&range));
+        range
     }
 
     pub(super) fn into_caches(self) -> PeerDiscoveryCaches {
@@ -457,6 +472,11 @@ struct ChildParentRefs {
     /// lets the caller pass its own parent-context snapshot down
     /// instead of rebuilding an identical one.
     changed: bool,
+}
+
+struct ComparablePeerRange {
+    text: String,
+    parsed: Option<Range>,
 }
 
 /// The peers of one node, as [`Walker::resolve_node_peers`] resolves
@@ -1350,7 +1370,7 @@ impl Walker<'_> {
         let range_for_match = raw_range.strip_prefix("workspace:").unwrap_or(raw_range);
         // The satisfaction check needs a comparable semver range, so
         // named-registry/`npm:` bodies are extracted and opaque specs become `*`.
-        let range_for_satisfies = get_peer_version_range(raw_range);
+        let comparable_range = self.comparable_peer_range(raw_range);
         let optional = peer_dep.optional;
 
         match parent_refs.get(peer_name) {
@@ -1363,7 +1383,7 @@ impl Walker<'_> {
                     self.record_missing_issue(
                         peer_name,
                         MissingPeer {
-                            wanted_range: range_for_satisfies,
+                            wanted_range: comparable_range.text.clone(),
                             raw_range: range_for_match.to_string(),
                             optional,
                             parents: self.issue_parents(chain),
@@ -1373,13 +1393,16 @@ impl Walker<'_> {
                 }
             }
             Some(parent) => {
-                if !satisfies_with_prereleases(&parent.version, &range_for_satisfies)
-                    && !self.in_canonical_drain
+                if !satisfies_with_parsed_prereleases(
+                    &parent.version,
+                    &comparable_range.text,
+                    comparable_range.parsed.as_ref(),
+                ) && !self.in_canonical_drain
                 {
                     let parents = self.issue_parents(chain);
                     self.issues.bad.entry(peer_name.to_string()).or_default().push(
                         PeerDependencyIssue {
-                            wanted_range: range_for_satisfies,
+                            wanted_range: comparable_range.text.clone(),
                             found_version: parent.version.clone(),
                             optional,
                             parents,


### PR DESCRIPTION
## Summary

Follow-up to the peer-heavy benchmark alert observed on pnpm/pnpm#14385. That pull request did not cause the regression: its peer-heavy result was faster than the contemporary `main`, while the alert compared it with an older historical baseline.

A Time Profiler trace attributed about 9% of peer-resolution samples to repeated `node_semver::Range` parsing. This change caches each normalized peer range and its parsed form for the lifetime of one resolver walk. The cache is bounded to that walk and preserves invalid-range fallback behavior.

The second commit encapsulates the invariant the cache introduces. The satisfaction helper had taken a range's text and its parsed form as two independent arguments that silently had to correspond, so a caller passing a parsed range built from a different string would get a wrong verdict with no error. `ComparablePeerRange` now derives both in one constructor and checks through its own `satisfies` method, which makes that pairing unbreakable and puts the type next to the matching rules it belongs to.

This is an internal Rust-only performance optimization. It does not change user-visible behavior, so no TypeScript change is needed.

### Measured effect

The win is real but small, and it is only observable in the resolution phase.

Instrumenting the cache on the in-process peer-heavy resolution fixture (120 importers, 1,230 packages) records **19,200 range lookups over 2 distinct ranges** — a 99.99% hit rate. Each hit avoids a `get_peer_version_range` plus a `Range::parse`, measured at ~338 ns for a simple range and ~688 ns for a `||` union, against ~12 ns for the cached lookup. That is about **6.3 ms removed from a 143–177 ms resolve, or 3.5–4.4% of the resolution phase**.

The focused resolver benchmark agrees: a 791 ms median improves to 755 ms over five runs, i.e. 4.5%.

Two caveats on that figure. The fixture is the most cache-favorable shape possible (2 distinct ranges), and its peers-per-package count is likely richer than a typical workspace, so treat 4% as the optimistic side for this shape.

### What the CI benchmarks do and do not show

The `isolated-linker.peer-heavy-resolve.hot-cache.offline` scenario is sub-second and cannot resolve a change of this size. Its own same-runner control shows no improvement — `pacquet@HEAD` at 552.6 ± 78.1 ms against `pacquet@main` at 533.6 ± 106.8 ms, or 1.04 ± 0.25.

The Bencher `-24.30%` on that benchmark is measured against an older historical baseline (576.82 ms), not against contemporary `main`. In the same job `main`'s own minimum (412.3 ms) was lower than HEAD's (436.7 ms), which is the value Bencher recorded. Every benchmark in that report moved down together, from -2.48% to -24.30%, including both `repeat-install` scenarios and `fresh-restore.cold-cache.cold-store.cold-pnpr`. None of those run peer resolution, so that report reflects runner drift rather than this change.

An earlier revision of this description claimed about a 10% lower mean from two 30-run integrated comparisons. That is not supported: the integrated scenario is roughly 500 ms end-to-end including process spawn, config, lockfile write and linking, so a 6.3 ms saving is about 1% there — well under that harness's noise floor.

Validation:

- `just ready` (9,737 tests passed)
- pre-push TypeScript and Rust checks, including Rustdoc and Dylint
- integrated peer-heavy benchmark in both target orders, and lockfile parity verified by the harness

## Squash Commit Body

```text
Cache normalized and parsed peer dependency ranges for the lifetime of each resolver walk. Peer-heavy workspaces reuse the same small set of ranges many times, so this avoids repeated semver parsing while keeping the cache bounded and preserving invalid-range behavior.

Hold the comparable range text and its parsed form together in ComparablePeerRange rather than passing them as two independent arguments that silently had to correspond, so the pairing cannot be broken by a caller.

Time Profiler identified range parsing as about 9% of peer-resolution samples. Instrumenting the cache on the in-process peer-heavy fixture records 19,200 range lookups over 2 distinct ranges; at roughly 327 ns saved per hit that removes about 6.3 ms from a 143-177 ms resolve, or 3.5-4.4% of the resolution phase. The focused resolver benchmark agrees at 4.5% (791 ms median to 755 ms).

The sub-second integrated peer-heavy scenario cannot resolve a change this size: its same-runner control measures HEAD at 552.6 +/- 78.1 ms against main at 533.6 +/- 106.8 ms.
```

## Checklist

- [x] This is an internal Rust-only performance optimization; no TypeScript port is needed.
- [x] Added a changeset for `pacquet`.
- [x] Existing peer-resolution tests cover behavior; no test was added for the cache implementation.
- [x] Documentation is not affected.

---
Written by an agent (Codex, gpt-5.6-sol). Reviewed, rebased, and the benchmark claims re-measured and corrected by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uz4S5MNayawmTDT9ozR9p4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14392"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790811612&installation_model_id=426870&pr_number=14392&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14392&signature=2a21c87f3795bddf57df7e2426201e1ccfeadc36ee85d27e1b0ef5d2316b3612"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved peer dependency resolution performance when many packages reuse the same peer version ranges.
  - Reduced repeated processing of peer version ranges while preserving compatibility checks, including prerelease versions.
  - Improved resolution of importer-relative linked dependencies in applicable cases.

- **Release**
  - Included in a patch release of the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
