### PR TITLE
fix(cli): keep filtered scripts in foreground group

### DIFF
--- a/.changeset/filter-tty-foreground.md
+++ b/.changeset/filter-tty-foreground.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Keep non-concurrent filtered `run` and recursive `exec` children in the foreground process group, so interactive scripts can read from the terminal instead of being stopped by `SIGTTIN` [#14397](https://github.com/pnpm/pnpm/issues/14397).

--- a/.changeset/filter-tty-foreground.md
+++ b/.changeset/filter-tty-foreground.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Keep non-concurrent filtered `run` and recursive `exec` children in the foreground process group, so interactive scripts can read from the terminal instead of being stopped by `SIGTTIN` [#14397](https://github.com/pnpm/pnpm/issues/14397).
+Fixed `pnpm --filter <package> <script>` hanging when the script reads from the terminal. Scripts that cannot run alongside another script now stay in the terminal's foreground process group, so interactive prompts work again [#14397](https://github.com/pnpm/pnpm/issues/14397).

--- a/.changeset/filter-tty-foreground.md
+++ b/.changeset/filter-tty-foreground.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm --filter <package> <script>` hanging when the script reads from the terminal. Scripts that cannot run alongside another script now stay in the terminal's foreground process group, so interactive prompts work again [#14397](https://github.com/pnpm/pnpm/issues/14397).
+Fixed filtered and recursive `pnpm run` and `pnpm exec` hanging when a script reads from the terminal. A script the workspace never runs alongside another one — a single `--filter`ed project, `--workspace-concurrency=1`, a dependency chain, or a task declaring `concurrency: 1` — now stays in the terminal's foreground process group, so interactive prompts work again [#14397](https://github.com/pnpm/pnpm/issues/14397).

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -28,7 +28,8 @@ use pnpm_executor::{ProcessTracker, ScriptOutput};
 use pnpm_reporter::LogEvent;
 use pnpm_workspace_task_scheduler::{
     ScheduleTasksOptions, SequenceTasksOptions, TaskCompletion, TaskGraph, TaskKey, TaskNode,
-    resume_task_graph_from, reverse_task_graph, schedule_tasks, sequence_tasks,
+    is_serial_task_graph, resume_task_graph_from, reverse_task_graph, schedule_tasks,
+    sequence_tasks,
 };
 use std::{
     collections::HashSet,
@@ -181,7 +182,7 @@ pub async fn exec_recursive(
     };
     // Also the cycle check: a cyclic graph cannot be scheduled, and
     // sequenced into an arbitrary order it would succeed or fail by luck.
-    sequence_tasks(
+    let sequenced_tasks = sequence_tasks(
         &mut task_graph,
         &SequenceTasksOptions {
             workspace_dir: workspace_root,
@@ -208,7 +209,10 @@ pub async fn exec_recursive(
     );
     let first_failure: Mutex<Option<String>> = Mutex::new(None);
     let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
-    let process_tracker = bail.then(ProcessTracker::default);
+    let runs_concurrently = concurrency > 1 && !is_serial_task_graph(&task_graph, &sequenced_tasks);
+    let process_tracker = bail.then(|| {
+        if runs_concurrently { ProcessTracker::default() } else { ProcessTracker::foreground() }
+    });
 
     let run_task = |node: &TaskNode| -> TaskCompletion {
         let root = node.project.as_path();

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -276,8 +276,8 @@ pub fn run_recursive(
     // pnpm pipes unless the output cannot interleave: `--stream` off, and
     // either one task at a time or a graph that forces the scripts to run
     // one after another.
-    let inherit_output =
-        !config.stream && (concurrency == 1 || is_serial_task_graph(&task_graph, &sequenced_tasks));
+    let runs_concurrently = concurrency > 1 && !is_serial_task_graph(&task_graph, &sequenced_tasks);
+    let inherit_output = !config.stream && !runs_concurrently;
 
     let result: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(
         task_graph
@@ -288,7 +288,9 @@ pub fn run_recursive(
     let has_command = AtomicUsize::new(0);
     let first_failure: Mutex<Option<String>> = Mutex::new(None);
     let abort: Mutex<Option<miette::Report>> = Mutex::new(None);
-    let process_tracker = bail.then(ProcessTracker::default);
+    let process_tracker = bail.then(|| {
+        if runs_concurrently { ProcessTracker::default() } else { ProcessTracker::foreground() }
+    });
 
     let init_cwd = env::current_dir().unwrap_or_else(|_| dir.to_path_buf());
 

--- a/pnpm/crates/cli/src/cli_args/run/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/run/recursive.rs
@@ -273,10 +273,9 @@ pub fn run_recursive(
     } else {
         usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
     };
-    // pnpm pipes unless the output cannot interleave: `--stream` off, and
-    // either one task at a time or a graph that forces the scripts to run
-    // one after another.
     let runs_concurrently = concurrency > 1 && !is_serial_task_graph(&task_graph, &sequenced_tasks);
+    // pnpm pipes unless the output cannot interleave: `--stream` off, and
+    // the graph cannot put two scripts in flight at once.
     let inherit_output = !config.stream && !runs_concurrently;
 
     let result: Mutex<IndexMap<String, ExecutionStatus>> = Mutex::new(

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -69,6 +69,12 @@ rmdir "$marker"
     .expect("write concurrency probe");
 }
 
+fn process_group_probe() -> &'static str {
+    r#"child_group=$(ps -o pgid= -p $$ | tr -d ' ')
+parent_group=$(ps -o pgid= -p $PPID | tr -d ' ')
+printf "%s %s\n" "$child_group" "$parent_group" > ../process-groups.txt"#
+}
+
 /// `pacquet -r exec <command>` runs the command once in every workspace
 /// project, each with cwd == its own package root — a relative `touch`
 /// lands a marker inside each package directory.
@@ -91,6 +97,26 @@ fn recursive_exec_runs_command_in_every_project() {
             "{name} should have run the command in its own directory",
         );
     }
+
+    drop(root);
+}
+
+#[test]
+fn filtered_exec_keeps_single_command_in_foreground_process_group() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &["project-1", "project-2"]);
+
+    pacquet
+        .with_args(["--filter", "project-1", "exec", "sh", "-c", process_group_probe()])
+        .assert()
+        .success();
+
+    let groups =
+        fs::read_to_string(workspace.join("process-groups.txt")).expect("read process groups");
+    let mut fields = groups.split_whitespace();
+    let child_group = fields.next().expect("child process group");
+    let parent_group = fields.next().expect("parent process group");
+    assert_eq!(child_group, parent_group);
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -101,6 +101,9 @@ fn recursive_exec_runs_command_in_every_project() {
     drop(root);
 }
 
+/// A single filtered command cannot run alongside a sibling, so it must
+/// stay in pacquet's own process group: a child moved into its own group
+/// is stopped the moment it reads from the terminal.
 #[test]
 fn filtered_exec_keeps_single_command_in_foreground_process_group() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -116,7 +119,10 @@ fn filtered_exec_keeps_single_command_in_foreground_process_group() {
     let mut fields = groups.split_whitespace();
     let child_group = fields.next().expect("child process group");
     let parent_group = fields.next().expect("parent process group");
-    assert_eq!(child_group, parent_group);
+    assert_eq!(
+        child_group, parent_group,
+        "the child must share pacquet's process group to keep reading the terminal",
+    );
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -100,6 +100,12 @@ rmdir "$marker"
     .expect("write concurrency probe");
 }
 
+fn process_group_probe() -> &'static str {
+    r#"child_group=$(ps -o pgid= -p $$ | tr -d ' ')
+parent_group=$(ps -o pgid= -p $PPID | tr -d ' ')
+printf "%s %s\n" "$child_group" "$parent_group" > ../process-groups.txt"#
+}
+
 /// `pacquet -r run <script>` runs the script in every workspace project,
 /// in topological order derived from the workspace dependency graph.
 #[test]
@@ -126,6 +132,36 @@ fn recursive_run_executes_script_in_every_project() {
         !workspace.join("ran.txt").exists(),
         "scripts must run from each package root, not the workspace root",
     );
+
+    drop(root);
+}
+
+#[test]
+fn filtered_run_keeps_single_script_in_foreground_process_group() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(
+        &workspace,
+        &[
+            (
+                "project-1",
+                json!({
+                    "name": "project-1",
+                    "version": "1.0.0",
+                    "scripts": { "prompt": process_group_probe() },
+                }),
+            ),
+            ("project-2", build_writes_marker("project-2")),
+        ],
+    );
+
+    pacquet.with_args(["--filter", "project-1", "run", "prompt"]).assert().success();
+
+    let groups =
+        fs::read_to_string(workspace.join("process-groups.txt")).expect("read process groups");
+    let mut fields = groups.split_whitespace();
+    let child_group = fields.next().expect("child process group");
+    let parent_group = fields.next().expect("parent process group");
+    assert_eq!(child_group, parent_group);
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -136,6 +136,9 @@ fn recursive_run_executes_script_in_every_project() {
     drop(root);
 }
 
+/// A single filtered script cannot run alongside a sibling, so it must
+/// stay in pacquet's own process group: a child moved into its own group
+/// is stopped the moment it reads from the terminal.
 #[test]
 fn filtered_run_keeps_single_script_in_foreground_process_group() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
@@ -161,7 +164,10 @@ fn filtered_run_keeps_single_script_in_foreground_process_group() {
     let mut fields = groups.split_whitespace();
     let child_group = fields.next().expect("child process group");
     let parent_group = fields.next().expect("parent process group");
-    assert_eq!(child_group, parent_group);
+    assert_eq!(
+        child_group, parent_group,
+        "the child must share pacquet's process group to keep reading the terminal",
+    );
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/run_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/run_recursive.rs
@@ -103,7 +103,7 @@ rmdir "$marker"
 fn process_group_probe() -> &'static str {
     r#"child_group=$(ps -o pgid= -p $$ | tr -d ' ')
 parent_group=$(ps -o pgid= -p $PPID | tr -d ' ')
-printf "%s %s\n" "$child_group" "$parent_group" > ../process-groups.txt"#
+printf "%s %s\n" "$child_group" "$parent_group" >> ../process-groups.txt"#
 }
 
 /// `pacquet -r run <script>` runs the script in every workspace project,
@@ -168,6 +168,63 @@ fn filtered_run_keeps_single_script_in_foreground_process_group() {
         child_group, parent_group,
         "the child must share pacquet's process group to keep reading the terminal",
     );
+
+    drop(root);
+}
+
+/// A per-task `concurrency: 1` serializes the scripts just as firmly as a
+/// dependency chain does, so they must stay in pacquet's process group
+/// too — the scheduler never has two of them in flight to keep apart.
+#[test]
+fn task_concurrency_of_one_keeps_scripts_in_the_foreground_process_group() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = |name: &str| {
+        json!({
+            "name": name,
+            "version": "1.0.0",
+            "scripts": { "build": process_group_probe() },
+        })
+    };
+    write_workspace(
+        &workspace,
+        &[
+            ("project-1", manifest("project-1")),
+            ("project-2", manifest("project-2")),
+            ("project-3", manifest("project-3")),
+        ],
+    );
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        concat!(
+            "packages:\n",
+            "  - project-1\n",
+            "  - project-2\n",
+            "  - project-3\n",
+            "tasks:\n",
+            "  build:\n",
+            "    concurrency: 1\n",
+        ),
+    )
+    .expect("write task settings");
+
+    pacquet.with_args(["-r", "run", "build"]).assert().success();
+
+    let groups =
+        fs::read_to_string(workspace.join("process-groups.txt")).expect("read process groups");
+    let mut lines = groups.lines();
+    let parent_group = lines
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .expect("parent process group")
+        .to_string();
+    for line in groups.lines() {
+        let child_group = line.split_whitespace().next().expect("child process group");
+        assert_eq!(
+            child_group, parent_group,
+            "every serialized script must share pacquet's process group",
+        );
+    }
+    assert_eq!(groups.lines().count(), 3, "every project should have run");
 
     drop(root);
 }

--- a/pnpm/crates/executor/src/process_tracker.rs
+++ b/pnpm/crates/executor/src/process_tracker.rs
@@ -49,11 +49,13 @@ impl RunningExecution {
 }
 
 impl ProcessTracker {
-    /// Track foreground children without moving them out of the terminal's
-    /// process group, so terminal signals continue to reach them directly
-    /// and a child reading the terminal is not stopped as a background job.
-    /// In exchange, cancellation reaches each child and the descendants
-    /// found by scanning the process list, not a process group at once.
+    /// Track children without giving them a process group of their own.
+    /// On Unix they stay in the terminal's foreground group, so terminal
+    /// signals reach them directly and a child reading the terminal is
+    /// not stopped as a background job; cancellation in exchange reaches
+    /// each child and its scanned descendants, not a group at once. Only
+    /// Unix spawns into a separate group, so on other platforms this
+    /// matches [`ProcessTracker::default`].
     #[must_use]
     pub fn foreground() -> Self {
         Self { state: Mutex::new(TrackerState::default()), separate_process_groups: false }

--- a/pnpm/crates/executor/src/process_tracker.rs
+++ b/pnpm/crates/executor/src/process_tracker.rs
@@ -50,7 +50,10 @@ impl RunningExecution {
 
 impl ProcessTracker {
     /// Track foreground children without moving them out of the terminal's
-    /// process group, so terminal signals continue to reach them directly.
+    /// process group, so terminal signals continue to reach them directly
+    /// and a child reading the terminal is not stopped as a background job.
+    /// In exchange, cancellation reaches each child and the descendants
+    /// found by scanning the process list, not a process group at once.
     #[must_use]
     pub fn foreground() -> Self {
         Self { state: Mutex::new(TrackerState::default()), separate_process_groups: false }

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -320,8 +320,9 @@ fn transitive_dependencies(graph: &TaskGraph, anchor: &TaskNode) -> HashSet<Task
 
 /// Whether at most one script can ever be in flight, which is when output
 /// may stay inherited rather than piped: no task runs several scripts, and
-/// every script-running task lies on one dependency chain, so the graph
-/// forces them to run one after another.
+/// the scripts are held apart either by the dependency edges — every
+/// script-running task on one chain — or by the per-task concurrency
+/// limits [`schedule_tasks`] enforces.
 ///
 /// `sequenced_tasks` is [`sequence_tasks`]'s result — the proof the graph
 /// is acyclic, and the evaluation order for the longest-chain scan.
@@ -334,7 +335,7 @@ pub fn is_serial_task_graph(graph: &TaskGraph, sequenced_tasks: &[TaskKey]) -> b
         }
         script_task_count += node.scripts.len();
     }
-    if script_task_count <= 1 {
+    if script_task_count <= 1 || serialized_by_one_task_limit(graph) {
         return true;
     }
     let mut chain_length: HashMap<&TaskKey, usize> = HashMap::new();
@@ -352,6 +353,24 @@ pub fn is_serial_task_graph(graph: &TaskGraph, sequenced_tasks: &[TaskKey]) -> b
         longest_chain = longest_chain.max(length);
     }
     longest_chain == script_task_count
+}
+
+/// Whether [`schedule_tasks`]'s concurrency limits alone leave at most one
+/// script in flight: every script-running task shares a single limit group
+/// — the group is the task name — and that group admits one task at a time.
+fn serialized_by_one_task_limit(graph: &TaskGraph) -> bool {
+    let mut limited_group: Option<&str> = None;
+    for node in graph.values().filter(|node| !node.scripts.is_empty()) {
+        // `schedule_tasks` floors the declared limit at 1.
+        if node.concurrency.map(|limit| limit.max(1)) != Some(1) {
+            return false;
+        }
+        let group = limited_group.get_or_insert(node.task_name.as_str());
+        if *group != node.task_name.as_str() {
+            return false;
+        }
+    }
+    true
 }
 
 /// The task's key in the recursive summary. The task of the script the

--- a/pnpm/crates/workspace-task-scheduler/src/tests.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/tests.rs
@@ -62,6 +62,17 @@ fn tasks(entries: &[(&str, Option<&[&str]>)]) -> IndexMap<String, TaskSettings> 
         .collect()
 }
 
+fn tasks_with_concurrency(entries: &[(&str, i64)]) -> IndexMap<String, TaskSettings> {
+    entries
+        .iter()
+        .map(|(name, concurrency)| {
+            let mut settings = TaskSettings::default();
+            settings.concurrency = Some(*concurrency);
+            (name.to_string(), settings)
+        })
+        .collect()
+}
+
 fn build_graph(
     projects: &[(&'static str, FakeProject)],
     task_name: &str,
@@ -268,6 +279,34 @@ fn is_serial_tells_a_chain_from_a_graph_with_independent_tasks() {
     );
     let sequenced = sequence(&mut diamond).unwrap();
     assert!(!is_serial_task_graph(&diamond, &sequenced));
+}
+
+#[test]
+fn is_serial_counts_a_task_concurrency_limit_of_one_as_serial() {
+    let settings = tasks_with_concurrency(&[("build", 1)]);
+    let mut graph = build_graph(
+        &[
+            ("a", project(&[], &["build"])),
+            ("b", project(&[], &["build"])),
+            ("c", project(&[], &["build"])),
+        ],
+        "build",
+        Some(&settings),
+    );
+    let sequenced = sequence(&mut graph).unwrap();
+    assert!(is_serial_task_graph(&graph, &sequenced));
+}
+
+#[test]
+fn is_serial_rejects_a_task_concurrency_limit_above_one() {
+    let settings = tasks_with_concurrency(&[("build", 2)]);
+    let mut graph = build_graph(
+        &[("a", project(&[], &["build"])), ("b", project(&[], &["build"]))],
+        "build",
+        Some(&settings),
+    );
+    let sequenced = sequence(&mut graph).unwrap();
+    assert!(!is_serial_task_graph(&graph, &sequenced));
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14397.

Filtered `run` and recursive `exec` can dispatch a single script through the bail process tracker. That tracker moved the child into its own Unix process group, so interactive scripts trying to read from the terminal could be stopped by `SIGTTIN`.

This keeps non-concurrent recursive `run`/`exec` children in the foreground process group while preserving separate process groups for truly concurrent runs, so bail cancellation can still stop sibling work.

## Squash Commit Body

```text
Keep serial recursive run and exec tasks in the terminal foreground process group when bail tracking is active.

The previous recursive run path used ProcessTracker::default for every bail-enabled invocation. That puts each Unix child in a separate process group, which is required for cancelling concurrent sibling tasks but breaks interactive single-script filtered runs because the child reads from a background process group and can receive SIGTTIN.

Reuse the same concurrency predicate used for stdout inheritance: serial task graphs use a foreground tracker, while concurrent task graphs keep the existing separate process group behavior. Add regression coverage for filtered run and exec.

Closes pnpm/pnpm#14397.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] No TypeScript CLI port is needed; pnpm/pnpm#14397 is Rust pacquet v12 only per accepted triage.
- [x] Added a changeset for `pacquet`.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).
Reviewed and revised by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790824968&installation_model_id=426870&pr_number=14398&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14398&signature=e9193e52153037b8b30081034a0aa4b86c8662881f45ec134a6befb1d8f1d58f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed filtered and recursive `run` and `exec` commands hanging when scripts read input from the terminal.
  - Interactive prompts and terminal signals now work correctly for single-project runs, dependency chains, and tasks serialized with concurrency set to 1.
  - Serialized scripts now remain in the terminal’s foreground process group.

- **Tests**
  - Added coverage for filtered commands and serialized task execution, including terminal input and foreground process handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->