### PR TITLE
perf(install): parse the wanted lockfile while discovering projects

### DIFF
--- a/.changeset/eager-lockfile-prefetch.md
+++ b/.changeset/eager-lockfile-prefetch.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up installs in large workspaces by reading and parsing `pnpm-lock.yaml` on a background thread while workspace projects are being discovered, whenever the run is certain to need it (`--frozen-lockfile`, `--force`, or no state from a previous install on disk) [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -303,12 +303,16 @@ impl InstallPipeline {
         // `--frozen-lockfile` / `--force`, and it requires a workspace
         // state from a previous install — a workspace with none on
         // disk (a lockfile-only workflow never writes one) always
-        // reaches the full pipeline. Only the shared-lockfile arms
-        // consume this lockfile; the per-project arms load their own.
+        // reaches the full pipeline. A `--fix-lockfile` run reads
+        // through the separate repair loader, which this prefetch does
+        // not feed. Only the shared-lockfile arms consume this
+        // lockfile; the per-project arms load their own.
         let lockfile = cfg
             .shares_one_lockfile()
             .then(|| State::lazy_lockfile(cfg, &manifest_path, require_lockfile));
-        if let Some(lockfile) = lockfile.as_ref() {
+        if let Some(lockfile) = lockfile.as_ref()
+            && !args.fix_lockfile
+        {
             let manifest_dir =
                 manifest_path.parent().expect("manifest path always has a parent dir");
             let lockfile_dir = cfg.lockfile_dir_for(manifest_dir);

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -296,6 +296,29 @@ impl InstallPipeline {
         }
         config_deps::install_config_deps::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
         config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        // Built ahead of project discovery so a run that is certain to
+        // read the wanted lockfile parses it on a background thread
+        // while discovery walks the workspace. Certain means the fast
+        // "Already up to date" return cannot fire: it is off under
+        // `--frozen-lockfile` / `--force`, and it requires a workspace
+        // state from a previous install — a workspace with none on
+        // disk (a lockfile-only workflow never writes one) always
+        // reaches the full pipeline. Only the shared-lockfile arms
+        // consume this lockfile; the per-project arms load their own.
+        let lockfile = cfg
+            .shares_one_lockfile()
+            .then(|| State::lazy_lockfile(cfg, &manifest_path, require_lockfile));
+        if let Some(lockfile) = lockfile.as_ref() {
+            let manifest_dir =
+                manifest_path.parent().expect("manifest path always has a parent dir");
+            let lockfile_dir = cfg.lockfile_dir_for(manifest_dir);
+            if frozen_lockfile
+                || cfg.force
+                || !pnpm_workspace_state::get_file_path(lockfile_dir).is_file()
+            {
+                lockfile.prefetch();
+            }
+        }
         let plan = select_install_family_plan::<Reporter>(
             cfg,
             &prefix,
@@ -314,8 +337,7 @@ impl InstallPipeline {
                     return Ok(());
                 }
                 let cfg: &'static Config = cfg;
-                let state = State::init(manifest_path, cfg, require_lockfile)
-                    .wrap_err("initialize the state")?;
+                let state = init_shared_state(manifest_path, cfg, require_lockfile, lockfile)?;
                 Box::pin(args.run_selected::<Reporter>(state, *selection)).await
             }
             InstallFamilyPlan::Single => {
@@ -332,12 +354,27 @@ impl InstallPipeline {
                     .await;
                 }
                 let cfg: &'static Config = cfg;
-                let state = State::init(manifest_path, cfg, require_lockfile)
-                    .wrap_err("initialize the state")?;
+                let state = init_shared_state(manifest_path, cfg, require_lockfile, lockfile)?;
                 Box::pin(args.run::<Reporter>(state)).await
             }
         }
     }
+}
+
+/// [`State::init`], consuming the pipeline's pre-built lockfile when
+/// there is one so an already-running prefetch isn't thrown away.
+fn init_shared_state(
+    manifest_path: PathBuf,
+    config: &'static Config,
+    require_lockfile: bool,
+    lockfile: Option<pnpm_lockfile::LazyLockfile>,
+) -> miette::Result<State> {
+    match lockfile {
+        Some(lockfile) => State::init_with_lockfile(manifest_path, config, lockfile),
+        None => State::init(manifest_path, config, require_lockfile),
+    }
+    .wrap_err("initialize the state")
+    .map_err(Into::into)
 }
 
 pub(crate) struct AddPipeline {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -374,7 +374,6 @@ fn init_shared_state(
         None => State::init(manifest_path, config, require_lockfile),
     }
     .wrap_err("initialize the state")
-    .map_err(Into::into)
 }
 
 pub(crate) struct AddPipeline {

--- a/pnpm/crates/cli/src/state.rs
+++ b/pnpm/crates/cli/src/state.rs
@@ -67,8 +67,23 @@ impl State {
         config: &'static Config,
         require_lockfile: bool,
     ) -> Result<Self, InitStateError> {
+        let lockfile = Self::lazy_lockfile(config, &manifest_path, require_lockfile);
+        Self::init_with_lockfile(manifest_path, config, lockfile)
+    }
+
+    /// The lazy wanted lockfile [`Self::init`] would build. Split out
+    /// so a caller with work between here and the install — project
+    /// discovery above all — can build it first and start its
+    /// [`LazyLockfile::prefetch`] over that work, handing the result to
+    /// [`Self::init_with_lockfile`].
+    #[must_use]
+    pub fn lazy_lockfile(
+        config: &Config,
+        manifest_path: &Path,
+        require_lockfile: bool,
+    ) -> LazyLockfile {
         let should_load = config.lockfile || require_lockfile;
-        let lockfile = if should_load {
+        if should_load {
             manifest_path
                 .parent()
                 .expect("manifest path always has a parent dir")
@@ -77,7 +92,15 @@ impl State {
                 .pipe(|dir| LazyLockfile::deferred(dir, config.wanted_lockfile_selection()))
         } else {
             LazyLockfile::disabled()
-        };
+        }
+    }
+
+    /// [`Self::init`] with a caller-built [`Self::lazy_lockfile`].
+    pub fn init_with_lockfile(
+        manifest_path: PathBuf,
+        config: &'static Config,
+        lockfile: LazyLockfile,
+    ) -> Result<Self, InitStateError> {
         Ok(State {
             config,
             manifest: load_or_create_manifest(manifest_path, config)?,

--- a/pnpm/crates/lockfile/src/lazy_lockfile.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile.rs
@@ -2,7 +2,11 @@ use crate::{
     LoadLockfileError, LoadedRepairLockfile, LoadedWantedLockfile, Lockfile, ProjectSnapshot,
     WantedLockfileSelection,
 };
-use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::{Mutex, OnceLock},
+};
 
 /// Wanted lockfile (`pnpm-lock.yaml`) whose read + parse are deferred
 /// until a consumer actually needs the contents.
@@ -18,7 +22,10 @@ pub struct LazyLockfile {
     source: Option<(PathBuf, WantedLockfileSelection)>,
     cell: OnceLock<LoadedWantedLockfile>,
     fix_cell: OnceLock<LoadedRepairLockfile>,
+    prefetch: Mutex<Option<PrefetchHandle>>,
 }
+
+type PrefetchHandle = std::thread::JoinHandle<Result<LoadedWantedLockfile, LoadLockfileError>>;
 
 impl LazyLockfile {
     /// A lockfile that will be loaded from `dir` (the same source as
@@ -29,6 +36,7 @@ impl LazyLockfile {
             source: Some((dir, selection)),
             cell: OnceLock::new(),
             fix_cell: OnceLock::new(),
+            prefetch: Mutex::new(None),
         }
     }
 
@@ -37,7 +45,12 @@ impl LazyLockfile {
     /// config.
     #[must_use]
     pub fn disabled() -> Self {
-        LazyLockfile { source: None, cell: OnceLock::new(), fix_cell: OnceLock::new() }
+        LazyLockfile {
+            source: None,
+            cell: OnceLock::new(),
+            fix_cell: OnceLock::new(),
+            prefetch: Mutex::new(None),
+        }
     }
 
     /// A lockfile that is already in memory; [`Self::get`] returns it
@@ -47,7 +60,31 @@ impl LazyLockfile {
         let cell = OnceLock::new();
         cell.set(LoadedWantedLockfile { lockfile, pre_merge_importers: None })
             .expect("a fresh OnceLock accepts the first set");
-        LazyLockfile { source: None, cell, fix_cell: OnceLock::new() }
+        LazyLockfile { source: None, cell, fix_cell: OnceLock::new(), prefetch: Mutex::new(None) }
+    }
+
+    /// Start the read + parse on a background thread, so a later
+    /// [`Self::get`] finds the work done (or joins it) instead of
+    /// paying for a multi-megabyte YAML parse inline. Idempotent, and
+    /// a no-op when the lockfile is disabled or already loaded.
+    ///
+    /// Call this only on a path that is certain to need the contents:
+    /// the deferred design exists so the repeat-install fast path never
+    /// pays for the parse, and a prefetch spends that work even when
+    /// its result goes unused.
+    pub fn prefetch(&self) {
+        if self.cell.get().is_some() {
+            return;
+        }
+        let Some((dir, selection)) = self.source.clone() else { return };
+        let mut slot = match self.prefetch.lock() {
+            Ok(slot) => slot,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if slot.is_some() {
+            return;
+        }
+        *slot = Some(std::thread::spawn(move || Lockfile::load_wanted_detailed(&dir, &selection)));
     }
 
     /// The parsed wanted lockfile, loading it on first call. `None`
@@ -85,6 +122,19 @@ impl LazyLockfile {
     fn load(&self) -> Result<&LoadedWantedLockfile, LoadLockfileError> {
         if let Some(loaded) = self.cell.get() {
             return Ok(loaded);
+        }
+        let prefetched = match self.prefetch.lock() {
+            Ok(mut slot) => slot.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        // A panicked prefetch thread falls through to the inline load,
+        // which reproduces the panic's cause as a plain error or
+        // succeeds where a transient condition has passed.
+        if let Some(handle) = prefetched
+            && let Ok(result) = handle.join()
+        {
+            let loaded = result?;
+            return Ok(self.cell.get_or_init(|| loaded));
         }
         let loaded = match self.source.as_ref() {
             Some((dir, selection)) => Lockfile::load_wanted_detailed(dir, selection)?,
@@ -153,6 +203,15 @@ impl<'a> MaybeLazyLockfile<'a> {
             MaybeLazyLockfile::Loaded(lockfile) => Ok(lockfile),
             MaybeLazyLockfile::Lazy(lazy) => lazy.get(),
             MaybeLazyLockfile::Repair(lazy) => lazy.get_for_fix_merge(),
+        }
+    }
+
+    /// See [`LazyLockfile::prefetch`], including its "only on a path
+    /// certain to need the contents" caveat. A repair load takes a
+    /// different loader, so only the plain lazy case prefetches.
+    pub fn prefetch(self) {
+        if let MaybeLazyLockfile::Lazy(lazy) = self {
+            lazy.prefetch();
         }
     }
 

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -366,3 +366,44 @@ fn loaded_variant_passes_through() {
     assert!(maybe.get().expect("loaded variant is infallible").is_none());
     assert!(!maybe.is_loaded_or_on_disk());
 }
+
+#[test]
+fn prefetch_hands_get_the_background_parse() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join(Lockfile::FILE_NAME), "lockfileVersion: '9.0'\n")
+        .expect("write pnpm-lock.yaml");
+
+    let lazy = LazyLockfile::deferred(dir.path().to_path_buf(), WantedLockfileSelection::default());
+    lazy.prefetch();
+    // A second prefetch must not race or double-load.
+    lazy.prefetch();
+    assert!(lazy.get().expect("prefetched load succeeds").is_some());
+
+    // The parse happened on the background thread: deleting the file
+    // after the prefetch has been consumed doesn't lose the contents.
+    fs::remove_file(dir.path().join(Lockfile::FILE_NAME)).expect("remove pnpm-lock.yaml");
+    assert!(lazy.get().expect("cached load succeeds").is_some());
+}
+
+#[test]
+fn prefetch_on_a_disabled_lockfile_is_a_noop() {
+    let lazy = LazyLockfile::disabled();
+    lazy.prefetch();
+    assert!(lazy.get().expect("disabled lockfile loads as None").is_none());
+}
+
+#[test]
+fn a_failed_prefetch_is_surfaced_and_then_retried() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    fs::write(dir.path().join(Lockfile::FILE_NAME), "lockfileVersion: [broken\n")
+        .expect("write broken pnpm-lock.yaml");
+
+    let lazy = LazyLockfile::deferred(dir.path().to_path_buf(), WantedLockfileSelection::default());
+    lazy.prefetch();
+    lazy.get().expect_err("the background parse failure must surface");
+
+    // The error is not cached: a repaired file loads on the next call.
+    fs::write(dir.path().join(Lockfile::FILE_NAME), "lockfileVersion: '9.0'\n")
+        .expect("repair pnpm-lock.yaml");
+    assert!(lazy.get().expect("retried load succeeds").is_some());
+}

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -377,11 +377,27 @@ fn prefetch_hands_get_the_background_parse() {
     lazy.prefetch();
     // A second prefetch must not race or double-load.
     lazy.prefetch();
-    assert!(lazy.get().expect("prefetched load succeeds").is_some());
 
-    // The parse happened on the background thread: deleting the file
-    // after the prefetch has been consumed doesn't lose the contents.
+    // Wait for the background thread, then delete the file *before*
+    // the first read: the contents can only come from that thread's
+    // parse, never from an inline load.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    loop {
+        let finished = lazy
+            .prefetch
+            .lock()
+            .expect("prefetch slot lock")
+            .as_ref()
+            .expect("prefetch spawned a load")
+            .is_finished();
+        if finished {
+            break;
+        }
+        assert!(std::time::Instant::now() < deadline, "background load never finished");
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
     fs::remove_file(dir.path().join(Lockfile::FILE_NAME)).expect("remove pnpm-lock.yaml");
+    assert!(lazy.get().expect("prefetched load succeeds").is_some());
     assert!(lazy.get().expect("cached load succeeds").is_some());
 }
 

--- a/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile/tests.rs
@@ -381,7 +381,7 @@ fn prefetch_hands_get_the_background_parse() {
     // Wait for the background thread, then delete the file *before*
     // the first read: the contents can only come from that thread's
     // parse, never from an inline load.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
     loop {
         let finished = lazy
             .prefetch

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -432,6 +432,14 @@ where
             }
         }
 
+        // Past the fast path every install flavor reads the wanted
+        // lockfile; start its read + parse on a background thread so it
+        // overlaps the cycle check below. The forced load further down
+        // joins it. (A run the pipeline knew would get here — frozen /
+        // forced — started this prefetch before project discovery, and
+        // this call is then a no-op.)
+        lockfile.prefetch();
+
         // Report the projects this install covers depending on each
         // other in a cycle — after the short-circuit above, because pnpm
         // returns from "Already up to date" before reaching its own


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. Follow-up to pnpm/pnpm#14379 and pnpm/pnpm#14396 — the next block in the warm lockfile-only update profile: the wanted `pnpm-lock.yaml` (9.6 MB on the issue's reproduction) was read and parsed inline at the point the install dispatch needs it, serializing a ~250 ms YAML parse behind workspace discovery, project selection, and the workspace-cycle check.

`LazyLockfile` gains a `prefetch()` that runs the load on a background thread and hands the result to the next `get()` (which joins it). The deferred inline load stays the fallback: a panicked background thread falls through to the inline load, and a background load *error* surfaces once without being cached and is retried on the next call — the same contract the inline load has.

Two call sites start it:

- **The install pipeline, before project discovery** — but only when the run is *certain* to read the lockfile, because the deferred design exists so the "Already up to date" fast path never pays for the parse. Certain means the fast path cannot fire: `--frozen-lockfile` or `--force`, or no workspace state from a previous install on disk (the fast path requires one, and a lockfile-only workflow never writes one — precisely the reproduction's shape). The pre-built lockfile is handed to `State` via a new `State::init_with_lockfile`, so the running prefetch isn't thrown away; only the shared-lockfile plan arms consume it, and the per-project arms behave as before.
- **The install dispatch, right after the fast-path check misses** — every install flavor past that point reads the lockfile, so the parse at least overlaps the workspace-cycle check (covers plain `pnpm install` with a change, `add`, `update`, …).

A no-op `pnpm install` that takes the fast path still never parses the lockfile.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| `load_wanted_lockfile` phase | ~250 ms | ~0 ms (fully overlapped by discovery) |
| whole warm update (`pnpm:execution-time`, median of 8) | 1.84 s* | 1.60 s |

\* fast-run cluster; a jamf endpoint-protection burst inflates a tail run in both columns.

The written `pnpm-lock.yaml` is byte-identical. With pnpm/pnpm#14379 and pnpm/pnpm#14396 this brings the whole warm update from ~2.43 s (pre-#14379) to ~1.6 s — level with the ~1.6 s wall time the issue reports for Yarn 4.18 on the same protocol.

New tests cover the prefetch: the background parse is handed to `get()` (asserted by deleting the file between prefetch and read), a disabled lockfile is a no-op, and a failed background parse surfaces once and is retried.

### Remaining headroom (not in this PR)

From the same profile: the lockfile serialize (~240 ms, goes through a `serde_json::Value` intermediate) and the resolver walk's allocator/hash traffic on its tuple cache keys (~360 ms).

## Squash Commit Body

```text
The wanted pnpm-lock.yaml was read and parsed inline at the point the
install dispatch needs it, serializing a multi-megabyte YAML parse
behind workspace discovery, project selection, and the cycle check.

LazyLockfile gains a prefetch that runs the load on a background
thread and hands the result to the next get(); the deferred inline
load stays the fallback, and a background failure surfaces once and
then retries, like an inline one. The install pipeline starts the
prefetch before project discovery whenever the run is certain to read
the lockfile - the "Already up to date" fast path is off under
--frozen-lockfile / --force, and it requires a workspace state from a
previous install, so a workspace with none on disk (a lockfile-only
workflow never writes one) always reaches the full pipeline. Runs the
fast path may still short-circuit keep the deferred behavior; when the
check misses, the install dispatch starts the prefetch so the parse at
least overlaps the workspace-cycle check.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), the load_wanted_lockfile phase drops from
~250 ms to 0 (fully overlapped by discovery) and whole-run wall time
from ~1.84 s to ~1.59 s median, with a byte-identical lockfile.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790841197&installation_model_id=426870&pr_number=14402&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14402&signature=4b5a57a2acd26a19a1e013f832819aa465d9c91e4d7d008d7c73fc400c49ea9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved install performance by reading and parsing the lockfile in the background while workspace projects are discovered.
  * Applies optimized lockfile handling during frozen, forced, and initial installs.
  * Preserves existing fast paths and surfaces lockfile errors reliably.
  * Avoids unnecessary background processing during lockfile repair operations, maintaining the expected repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->