### PR TITLE
fix(pacquet): regenerate npm Windows shims

### DIFF
--- a/.changeset/fix-npm-powershell-shim.md
+++ b/.changeset/fix-npm-powershell-shim.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed npm global installs on Windows so the PowerShell shims invoke `pnpm.exe`.

--- a/justfile
+++ b/justfile
@@ -54,13 +54,7 @@ check:
 
 # Run all the tests.
 test:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  # Tests opt into CI-sensitive pnpm defaults explicitly and must not read a
-  # contributor's global registry credentials.
-  test_config_dir="$(mktemp -d)"
-  trap 'rm -rf "$test_config_dir"' EXIT
-  env PNPM_CONFIG_CI=false XDG_CONFIG_HOME="$test_config_dir" cargo nextest run
+  node pnpm/scripts/run-rust-tests.mjs
 
 # A test process that is killed cannot run `TempDir`'s cleanup, so a
 # fail-fast or interrupted run abandons whole fixture trees — each holding a
@@ -76,8 +70,7 @@ sweep-test-temp:
 
 # Run pacquet package tests only.
 test-pacquet:
-  # GitHub Actions sets CI=true; keep lockfile-mutating tests deterministic.
-  env PNPM_CONFIG_CI=false cargo nextest run --workspace --exclude pnpr --exclude pnpr-auth --exclude pnpr-config --exclude pnpr-error --exclude pnpr-fixtures --exclude pnpr-package-name --exclude pnpr-policy --exclude pnpr-registry --exclude pnpr-route --exclude pnpr-osv --exclude pnpr-search --exclude pnpr-shared-artifacts --exclude pnpr-storage --exclude pnpr-upstream
+  node pnpm/scripts/run-rust-tests.mjs --workspace --exclude pnpr --exclude pnpr-auth --exclude pnpr-config --exclude pnpr-error --exclude pnpr-fixtures --exclude pnpr-package-name --exclude pnpr-policy --exclude pnpr-registry --exclude pnpr-route --exclude pnpr-osv --exclude pnpr-search --exclude pnpr-shared-artifacts --exclude pnpr-storage --exclude pnpr-upstream
 
 # Run pnpr package tests only.
 test-pnpr:

--- a/justfile
+++ b/justfile
@@ -54,8 +54,13 @@ check:
 
 # Run all the tests.
 test:
-  # Tests opt into CI-sensitive pnpm defaults explicitly.
-  env PNPM_CONFIG_CI=false cargo nextest run
+  #!/usr/bin/env bash
+  set -euo pipefail
+  # Tests opt into CI-sensitive pnpm defaults explicitly and must not read a
+  # contributor's global registry credentials.
+  test_config_dir="$(mktemp -d)"
+  trap 'rm -rf "$test_config_dir"' EXIT
+  env PNPM_CONFIG_CI=false XDG_CONFIG_HOME="$test_config_dir" cargo nextest run
 
 # A test process that is killed cannot run `TempDir`'s cleanup, so a
 # fail-fast or interrupted run abandons whole fixture trees — each holding a

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -2,9 +2,11 @@
 // Preinstall for the pnpm v12 wrapper (shared verbatim by `pnpm` and
 // `@pnpm/exe`): replace the shebang-less placeholder bins with the host's native
 // binary so `pnpm` runs directly, no Node startup per call. A placeholder (not a
-// Node launcher) is required because the Windows shim is generated from the bin
-// file and npm won't re-read package.json after preinstall; the tradeoff is no
-// fallback when build scripts are blocked (`--ignore-scripts`, pnpm/Bun default).
+// Node launcher) is required because npm generates the Windows shim before
+// preinstall and won't re-read package.json during that install pass. On a
+// global Windows install, postinstall asks npm to relink after the bin rewrite.
+// The tradeoff is no fallback when build scripts are blocked (`--ignore-scripts`,
+// pnpm/Bun default).
 //
 // `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts on Unix (so only `pnpm` is
 // relinked); on Windows the native binary is hardlinked onto each and
@@ -14,6 +16,7 @@
 // Corepack runs no lifecycle scripts, so it never gets here; it enters through
 // `bin/pnpm.mjs` instead.
 import console from 'node:console'
+import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -27,7 +30,11 @@ import {
 
 const BIN_NAMES = ['pnpm', 'pn', 'pnpx', 'pnx']
 
-setup()
+if (process.env.npm_lifecycle_event === 'postinstall') {
+  relinkNpmWindowsShims()
+} else {
+  setup()
+}
 
 function setup () {
   // The committed manifest has no `optionalDependencies`; generate-packages.mjs
@@ -93,9 +100,7 @@ function placeBinary (nativeBinary, destPath, mode) {
     }
     fs.renameSync(tempPath, destPath)
   } catch (err) {
-    try {
-      fs.rmSync(tempPath, { force: true })
-    } catch {}
+    removeFileIfPossible(tempPath)
     fail(`Could not install the pnpm binary at ${destPath}: ${err.message}`)
   }
 }
@@ -110,9 +115,45 @@ function rewriteBin (binMap) {
     fs.writeFileSync(tempPath, JSON.stringify(pkg, null, 2))
     fs.renameSync(tempPath, pkgJsonPath)
   } catch {
-    try {
-      fs.rmSync(tempPath, { force: true })
-    } catch {}
+    removeFileIfPossible(tempPath)
+  }
+}
+
+function relinkNpmWindowsShims () {
+  const npmExecPath = process.env.npm_execpath
+  if (
+    process.platform !== 'win32' ||
+    process.env.npm_config_global !== 'true' ||
+    npmExecPath == null ||
+    path.basename(npmExecPath).toLowerCase() !== 'npm-cli.js'
+  ) {
+    return
+  }
+
+  const packageName = readWrapperManifest().name
+  if (typeof packageName !== 'string') {
+    fail('Could not determine the pnpm wrapper package name when regenerating npm shims.')
+  }
+  const result = spawnSync(process.execPath, [
+    npmExecPath,
+    'rebuild',
+    '--global',
+    '--ignore-scripts',
+    packageName,
+  ], { stdio: 'inherit' })
+  if (result.error != null) {
+    fail(`Could not regenerate the npm shims for pnpm: ${result.error.message}`)
+  }
+  if (result.status !== 0) {
+    fail('npm could not regenerate the shims for pnpm.')
+  }
+}
+
+function removeFileIfPossible (filePath) {
+  try {
+    fs.rmSync(filePath, { force: true })
+  } catch {
+    return
   }
 }
 

--- a/pnpm/npm/pnpm/package.json
+++ b/pnpm/npm/pnpm/package.json
@@ -35,6 +35,7 @@
   "type": "module",
   "scripts": {
     "preinstall": "node install.js",
+    "postinstall": "node install.js",
     "bundle-node-gyp": "node scripts/bundle-node-gyp.mjs"
   },
   "engines": {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -58,9 +58,13 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
   ], tempDir)
 
   if (process.platform === 'win32') {
-    const shim = path.join(prefix, 'pnpm.ps1')
-    assert.match(fs.readFileSync(shim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', shim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+    const cmdShim = path.join(prefix, 'pnpm.cmd')
+    assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', `"${cmdShim}" --version`], { encoding: 'utf8' }), /^v\d+/)
+
+    const powershellShim = path.join(prefix, 'pnpm.ps1')
+    assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
   } else {
     assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
   }

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -1,0 +1,94 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
+
+const wrapperDir = path.resolve(fileURLToPath(import.meta.url), '../..')
+const wrapperManifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'package.json'), 'utf8'))
+
+test('npm installs a shim that runs the native pnpm binary', (t) => {
+  assert.equal(wrapperManifest.bin.pnpm, 'pnpm')
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm wrapper install-'))
+  t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
+
+  const candidate = getBinCandidates()[0]
+  assert.ok(candidate)
+  const { packageName, binFile } = splitBinSpecifier(candidate)
+  const nativePackageDir = path.join(tempDir, 'native-package')
+  fs.mkdirSync(nativePackageDir)
+  fs.writeFileSync(path.join(nativePackageDir, 'package.json'), JSON.stringify({
+    name: packageName,
+    version: '1.0.0',
+  }))
+  writeNativeFixture(path.join(nativePackageDir, binFile))
+
+  const fixtureDir = path.join(tempDir, 'wrapper')
+  fs.mkdirSync(fixtureDir)
+  for (const file of ['install.js', 'native-binary.mjs', wrapperManifest.bin.pnpm]) {
+    fs.copyFileSync(path.join(wrapperDir, file), path.join(fixtureDir, file))
+  }
+  fs.writeFileSync(path.join(fixtureDir, 'package.json'), JSON.stringify({
+    name: 'pnpm-install-fixture',
+    version: '1.0.0',
+    type: 'module',
+    bin: { pnpm: wrapperManifest.bin.pnpm },
+    scripts: {
+      preinstall: 'node install.js',
+      postinstall: 'node install.js',
+    },
+    optionalDependencies: { [packageName]: `file:${nativePackageDir}` },
+  }))
+
+  const prefix = path.join(tempDir, 'prefix')
+  runNpm([
+    'install',
+    '--global',
+    '--install-links=true',
+    '--dangerously-allow-all-scripts',
+    '--prefix',
+    prefix,
+    fixtureDir,
+  ], tempDir)
+
+  if (process.platform === 'win32') {
+    const shim = path.join(prefix, 'pnpm.ps1')
+    assert.match(fs.readFileSync(shim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', shim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+  } else {
+    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  }
+})
+
+function runNpm (args, cwd) {
+  if (process.platform === 'win32') {
+    const npmCli = execFileSync('where.exe', ['npm.cmd'], { encoding: 'utf8' })
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .map(launcher => path.join(path.dirname(launcher), 'node_modules', 'npm', 'bin', 'npm-cli.js'))
+      .find(candidate => fs.existsSync(candidate))
+    assert.ok(npmCli, 'Unable to find npm-cli.js next to an npm.cmd on PATH')
+    execFileSync(process.execPath, [npmCli, ...args], { cwd, stdio: 'pipe' })
+  } else {
+    execFileSync('npm', args, { cwd, stdio: 'pipe' })
+  }
+}
+
+function writeNativeFixture (destPath) {
+  if (process.platform === 'win32') {
+    try {
+      fs.linkSync(process.execPath, destPath)
+    } catch (err) {
+      if (err.code !== 'EXDEV') throw err
+      fs.copyFileSync(process.execPath, destPath)
+    }
+  } else {
+    fs.writeFileSync(destPath, '#!/bin/sh\nprintf \'fixture:%s\\n\' "$1"\n', { mode: 0o755 })
+  }
+}

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -60,7 +60,7 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
   if (process.platform === 'win32') {
     const cmdShim = path.join(prefix, 'pnpm.cmd')
     assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', `"${cmdShim}" --version`], { encoding: 'utf8' }), /^v\d+/)
+    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
 
     const powershellShim = path.join(prefix, 'pnpm.ps1')
     assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)

--- a/pnpm/scripts/run-rust-tests.mjs
+++ b/pnpm/scripts/run-rust-tests.mjs
@@ -1,0 +1,30 @@
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+
+const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-test-config-'))
+
+try {
+  const env = Object.fromEntries(Object.entries(process.env).filter(([name]) => {
+    const lowerName = name.toLowerCase()
+    return !lowerName.startsWith('npm_config_') && !lowerName.startsWith('pnpm_config_')
+  }))
+  const npmrcPath = path.join(configDir, 'npmrc')
+  fs.writeFileSync(npmrcPath, '')
+  Object.assign(env, {
+    PNPM_CONFIG_CI: 'false',
+    PNPM_CONFIG_NPMRC_AUTH_FILE: npmrcPath,
+    XDG_CONFIG_HOME: configDir,
+  })
+
+  const result = spawnSync('cargo', ['nextest', 'run', ...process.argv.slice(2)], {
+    env,
+    stdio: 'inherit',
+  })
+  if (result.error != null) throw result.error
+  process.exitCode = result.status ?? 1
+} finally {
+  fs.rmSync(configDir, { recursive: true, force: true })
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14362.

npm creates global Windows command shims before the wrapper's `preinstall` replaces the placeholder bins and rewrites the package manifest to point at `pnpm.exe`. The wrapper now runs the same installer in `postinstall`; for npm global installs on Windows only, that phase asks npm to rebuild the installed package with scripts disabled. npm then re-reads the rewritten manifest and regenerates valid `.cmd` and PowerShell shims that invoke the native executable.

The committed bin target remains extensionless, preserving compatibility with older pnpm versions and Unix installs after the regression in pnpm/pnpm#14369 was reverted by pnpm/pnpm#14393.

The wrapper fixture test exercises an npm global install. On Windows, it verifies that both npm-generated `.cmd` and PowerShell shims target `pnpm.exe` and executes each shim through its native shell. The Rust test launcher also removes inherited npm/pnpm configuration variables, supplies an empty explicit auth file, and isolates pnpm's global config directory so contributor registry credentials cannot leak into mock-registry tests.

This change is specific to the pacquet npm wrapper. The TypeScript CLI does not use this native-binary install script, so no TypeScript counterpart is needed.

## Squash Commit Body

<!--
Explain the problem before the solution. Include motivation, user-visible
effects, important implementation details, and any compatibility or migration
notes. Do not just repeat the title or list files changed.
-->

```text
fix(pacquet): regenerate npm Windows shims

npm creates global Windows shims before lifecycle scripts run, so the
pacquet wrapper's preinstall rewrite to pnpm.exe leaves npm's PowerShell
shim targeting the extensionless placeholder.

Run the wrapper installer again in postinstall and, only for npm global
Windows installs, invoke npm rebuild with lifecycle scripts disabled. npm
then re-reads the rewritten bin map and regenerates its shims against the
native executable without recursing into postinstall.

Keep the published source manifest's bin target extensionless for older
pnpm and Unix compatibility. Add a fixture test for npm global installs and
isolate the Rust test runner from contributor-level registry configuration.

Fixes pnpm/pnpm#14362.
```

## Checklist

- [x] I have checked for an existing issue or linked PR and explained above why it does not solve this case.
- [x] I have implemented this change in both the TypeScript pnpm CLI and the Rust pacquet CLI, or explained in the summary why one side does not need a counterpart.
- [x] I have added a changeset for every published package whose behavior changes.
- [x] I have added or updated tests covering the affected behavior.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed global npm installations on Windows so PowerShell shims correctly launch `pnpm.exe`.
  - Improved reliability of the pnpm wrapper across Windows and POSIX environments.

- **Tests**
  - Added coverage verifying that npm-installed wrappers invoke the native pnpm binary correctly on supported platforms.

- **Chores**
  - Improved test isolation to prevent interference from global registry credentials and local environment settings.
  - Standardized Rust test execution across development environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
