### PR TITLE
fix(config): default minimumReleaseAgeStrict when age is explicit

### DIFF
--- a/.changeset/strict-release-age-follows-explicit-age.md
+++ b/.changeset/strict-release-age-follows-explicit-age.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`minimumReleaseAgeStrict` now defaults to `true` when `minimumReleaseAge` is explicitly configured — through `pnpm-workspace.yaml`, the global `config.yaml`, a `PNPM_CONFIG_*` variable, or a CLI flag — as documented. Previously an explicit cutoff was treated as non-strict, so immature versions were silently added to `minimumReleaseAgeExclude` instead of being gated with a prompt [#14409](https://github.com/pnpm/pnpm/issues/14409). The built-in 1440-minute default stays non-strict.

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -444,9 +444,14 @@ fn dedupe_check_does_not_persist_minimum_release_age_excludes() {
     .expect("write package.json");
     // 100 years: every version the mocked registry serves is immature, so
     // the fresh resolve behind `dedupe --check` records loose-mode picks.
+    // An explicit cutoff turns strict mode on by default, which would abort
+    // the resolve before the check can report its diff.
     let workspace_manifest_path = workspace.join("pnpm-workspace.yaml");
-    fs::write(&workspace_manifest_path, "minimumReleaseAge: 52560000\n")
-        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        &workspace_manifest_path,
+        "minimumReleaseAge: 52560000\nminimumReleaseAgeStrict: false\n",
+    )
+    .expect("write pnpm-workspace.yaml");
     let manifest_before =
         fs::read_to_string(&workspace_manifest_path).expect("read pnpm-workspace.yaml");
 

--- a/pnpm/crates/cli/tests/suite/lockfile_verification.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_verification.rs
@@ -90,9 +90,10 @@ fn install_fails_under_huge_minimum_release_age() {
 /// TS: `minimumReleaseAge falls back to immature version when no mature
 /// version satisfies the range (non-strict mode)` (`minimumReleaseAge.ts:68`).
 /// A 100-year cutoff makes every `@pnpm.e2e/bravo-dep` version immature.
-/// Non-strict mode (pacquet's default) must fall back to the *lowest*
-/// version matching the `1.0` range — normal resolution would pick the
-/// highest, `1.0.1` — and complete the install instead of aborting.
+/// Non-strict mode must fall back to the *lowest* version matching the `1.0`
+/// range — normal resolution would pick the highest, `1.0.1` — and complete
+/// the install instead of aborting. An explicit cutoff turns strict mode on
+/// by default, so reaching non-strict mode takes an explicit opt-out.
 #[test]
 fn non_strict_minimum_release_age_falls_back_when_no_mature_version_matches() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -100,6 +101,7 @@ fn non_strict_minimum_release_age_falls_back_when_no_mature_version_matches() {
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
     set_minimum_release_age(&workspace, 60 * 24 * 365 * 100);
+    append_workspace_yaml_key(&workspace, "minimumReleaseAgeStrict", false);
 
     let output =
         pacquet.with_args(["add", "@pnpm.e2e/bravo-dep@1.0"]).output().expect("spawn pacquet add");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2648,9 +2648,20 @@ impl Config {
         }
     }
 
-    /// Effective value of [`Self::minimum_release_age_strict`].
-    /// Returns the user-supplied value when set. Otherwise it enables strict
-    /// mode when `minimumReleaseAge` was explicitly configured, matching pnpm.
+    /// Effective value of [`Self::minimum_release_age_strict`]: the
+    /// user-supplied value when set, otherwise `true` if `minimumReleaseAge`
+    /// was explicitly configured.
+    ///
+    /// Without that default a user-set cutoff would silently fall back to an
+    /// immature version whenever no mature one satisfies the range, making the
+    /// setting look like it had no effect. The built-in 1440-minute default
+    /// stays non-strict for backward compatibility, so the two are told apart
+    /// through [`Self::explicit_settings`] rather than through the value
+    /// itself. A repository's cutoff never reaches `self-update`, which
+    /// [`WorkspaceSettings::clear_self_update_policy`] drops before the
+    /// workspace yaml is recorded there.
+    ///
+    /// [`WorkspaceSettings::clear_self_update_policy`]: crate::WorkspaceSettings::clear_self_update_policy
     pub fn resolved_minimum_release_age_strict(&self) -> bool {
         self.minimum_release_age_strict
             .unwrap_or_else(|| self.explicit_settings.contains_key("minimumReleaseAge"))

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2649,20 +2649,11 @@ impl Config {
     }
 
     /// Effective value of [`Self::minimum_release_age_strict`].
-    /// Returns the user-supplied value when set, else `false`.
-    ///
-    /// pnpm flips this to `true` when the user *explicitly* set
-    /// `minimumReleaseAge`, but the "explicitly set vs default" check
-    /// relies on an `explicitlySetKeys` tracker that pacquet's config
-    /// layer doesn't have yet. Without that, distinguishing the built-in
-    /// 1440-minute default from a user-typed `minimumReleaseAge: 1440`
-    /// isn't possible, so this resolver stays conservative: explicit
-    /// `true` / `false` from yaml wins, otherwise `false`. The verifier
-    /// itself doesn't gate on this flag — it's resolver-only — so
-    /// the conservative default is dormant until pacquet grows the
-    /// resolver and the `explicitlySetKeys` mechanism alongside it.
+    /// Returns the user-supplied value when set. Otherwise it enables strict
+    /// mode when `minimumReleaseAge` was explicitly configured, matching pnpm.
     pub fn resolved_minimum_release_age_strict(&self) -> bool {
-        self.minimum_release_age_strict.unwrap_or(false)
+        self.minimum_release_age_strict
+            .unwrap_or_else(|| self.explicit_settings.contains_key("minimumReleaseAge"))
     }
 
     /// Effective [`Self::minimum_release_age`], with `Some(0)` treated

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3835,6 +3835,24 @@ fn resolved_minimum_release_age_treats_zero_as_disabled() {
     assert_eq!(config.resolved_minimum_release_age(), None);
 }
 
+#[test]
+fn resolved_minimum_release_age_strict_defaults_to_explicit_release_age() {
+    let mut config = Config::new();
+    assert!(!config.resolved_minimum_release_age_strict(), "built-in default is non-strict");
+
+    config.explicit_settings.insert("minimumReleaseAge".to_owned(), serde_json::json!(1440));
+    assert!(
+        config.resolved_minimum_release_age_strict(),
+        "explicit release age enables strict mode"
+    );
+
+    config.minimum_release_age_strict = Some(false);
+    assert!(!config.resolved_minimum_release_age_strict(), "explicit false takes precedence");
+
+    config.minimum_release_age_strict = Some(true);
+    assert!(config.resolved_minimum_release_age_strict(), "explicit true takes precedence");
+}
+
 const NPM_DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";
 
 /// A project `.npmrc` redirecting the default registry still drives normal

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -3835,22 +3835,87 @@ fn resolved_minimum_release_age_treats_zero_as_disabled() {
     assert_eq!(config.resolved_minimum_release_age(), None);
 }
 
+/// Load a config from a workspace whose `pnpm-workspace.yaml` holds `yaml`.
+fn config_from_workspace_yaml(yaml: &str) -> Config {
+    let tmp = tempdir().expect("workspace tempdir");
+    fs::write(tmp.path().join("pnpm-workspace.yaml"), yaml).expect("write to pnpm-workspace.yaml");
+    Config::new().current::<HostNoHome>(tmp.path()).expect("config loads")
+}
+
 #[test]
-fn resolved_minimum_release_age_strict_defaults_to_explicit_release_age() {
-    let mut config = Config::new();
-    assert!(!config.resolved_minimum_release_age_strict(), "built-in default is non-strict");
+fn the_built_in_release_age_default_leaves_strict_mode_off() {
+    let config = config_from_workspace_yaml("packages:\n  - '.'\n");
 
-    config.explicit_settings.insert("minimumReleaseAge".to_owned(), serde_json::json!(1440));
-    assert!(
-        config.resolved_minimum_release_age_strict(),
-        "explicit release age enables strict mode"
-    );
+    assert_eq!(config.resolved_minimum_release_age(), Some(1440));
+    assert!(!config.resolved_minimum_release_age_strict());
+}
 
-    config.minimum_release_age_strict = Some(false);
-    assert!(!config.resolved_minimum_release_age_strict(), "explicit false takes precedence");
+/// A cutoff the user typed turns on strict mode even when it repeats the
+/// built-in default, so the setting gates the install instead of only
+/// reporting it. Regression test for
+/// <https://github.com/pnpm/pnpm/issues/14409>.
+#[test]
+fn an_explicit_release_age_turns_on_strict_mode() {
+    let config = config_from_workspace_yaml("minimumReleaseAge: 1440\n");
 
-    config.minimum_release_age_strict = Some(true);
-    assert!(config.resolved_minimum_release_age_strict(), "explicit true takes precedence");
+    assert_eq!(config.minimum_release_age, Config::new().minimum_release_age);
+    assert!(config.resolved_minimum_release_age_strict());
+}
+
+#[test]
+fn an_explicit_strict_setting_wins_over_the_release_age_default() {
+    let config =
+        config_from_workspace_yaml("minimumReleaseAge: 4320\nminimumReleaseAgeStrict: false\n");
+    assert!(!config.resolved_minimum_release_age_strict());
+
+    let config = config_from_workspace_yaml("minimumReleaseAgeStrict: true\n");
+    assert!(config.resolved_minimum_release_age_strict(), "strict mode stands on its own");
+}
+
+#[test]
+fn a_release_age_env_var_turns_on_strict_mode() {
+    struct HostWithReleaseAgeEnv;
+    impl EnvVar for HostWithReleaseAgeEnv {
+        fn var(name: &str) -> Option<String> {
+            match name {
+                "PNPM_CONFIG_MINIMUM_RELEASE_AGE" => Some("1440".to_owned()),
+                _ => safe_host_var(name),
+            }
+        }
+    }
+    impl EnvVarOs for HostWithReleaseAgeEnv {
+        fn var_os(_: &str) -> Option<OsString> {
+            None
+        }
+    }
+    impl GetHomeDir for HostWithReleaseAgeEnv {
+        fn home_dir() -> Option<PathBuf> {
+            None
+        }
+    }
+    inert_link_probe!(HostWithReleaseAgeEnv);
+    host_current_dir!(HostWithReleaseAgeEnv);
+
+    let tmp = tempdir().unwrap();
+    let config = Config::new().current::<HostWithReleaseAgeEnv>(tmp.path()).expect("config loads");
+
+    assert!(config.resolved_minimum_release_age_strict());
+}
+
+/// A repository must not reach strict mode for `self-update`: turning it on
+/// would let the repo refuse an immature pnpm release and pin the machine to
+/// the installed version, which is what
+/// [`WorkspaceSettings::clear_self_update_policy`] exists to prevent.
+#[test]
+fn self_update_ignores_a_workspace_release_age_for_strict_mode() {
+    let tmp = tempdir().unwrap();
+    fs::write(tmp.path().join("pnpm-workspace.yaml"), "minimumReleaseAge: 4320\n")
+        .expect("write to pnpm-workspace.yaml");
+
+    let config =
+        Config::new().current_for_self_update::<HostNoHome>(tmp.path()).expect("config loads");
+
+    assert!(!config.resolved_minimum_release_age_strict());
 }
 
 const NPM_DEFAULT_REGISTRY: &str = "https://registry.npmjs.org/";

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/settings.rs
@@ -298,7 +298,7 @@ pub(crate) fn current_settings(
         // `WorkspaceStateSettings::minimum_release_age_strict`.
         minimum_release_age_strict: config
             .minimum_release_age_strict
-            .or_else(|| config.explicit_settings.contains_key("minimumReleaseAge").then_some(true)),
+            .or_else(|| config.resolved_minimum_release_age_strict().then_some(true)),
         node_linker: Some(map_node_linker(node_linker)),
         optional: Some(included.optional_dependencies),
         overrides: config


### PR DESCRIPTION
## Summary

- Fix pacquet's `minimumReleaseAgeStrict` default when `minimumReleaseAge` is explicitly configured.
- Preserve explicit `minimumReleaseAgeStrict` true/false overrides.
- Add regression coverage for implicit and explicit precedence.

Fixes #14409.

## Testing

- `cargo test -p pnpm-config`
- `cargo clippy -p pnpm-config --tests -- -D warnings`
- `cargo fmt -p pnpm-config`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790855865&installation_model_id=426870&pr_number=14410&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14410&signature=7ca7ecd847ff82ea0a82ee8b660d636b0131f177d46b48cea3728f877c1fa513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicitly configured minimum release ages now enable strict enforcement by default.
  * Immature package versions are gated appropriately instead of being silently excluded.
  * Explicit strictness settings continue to override the default behavior.
* **Documentation**
  * Added release notes describing the updated minimum release age behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->