### PR TITLE
fix(lockfile): suggest policy relaxation only for expected changes

### DIFF
--- a/.changeset/clarify-policy-relaxation-condition.md
+++ b/.changeset/clarify-policy-relaxation-condition.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Changed the lockfile policy error to suggest relaxing the policy only after expected changes fail a fresh resolution and the affected packages are trusted [#14411](https://github.com/pnpm/pnpm/issues/14411).
+The supply-chain policy error now suggests `relax the policy that flagged them` only after a fresh resolution still fails and the affected packages are trusted. Previously it followed `If the changes look expected`, so `Alternatively` read as the action for the unexpected case [#14411](https://github.com/pnpm/pnpm/issues/14411).

--- a/.changeset/clarify-policy-relaxation-condition.md
+++ b/.changeset/clarify-policy-relaxation-condition.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Changed the lockfile policy error to suggest relaxing the policy only after expected changes fail a fresh resolution and the affected packages are trusted [pnpm/pnpm#14411](https://github.com/pnpm/pnpm/issues/14411).
+Changed the lockfile policy error to suggest relaxing the policy only after expected changes fail a fresh resolution and the affected packages are trusted [#14411](https://github.com/pnpm/pnpm/issues/14411).

--- a/.changeset/clarify-policy-relaxation-condition.md
+++ b/.changeset/clarify-policy-relaxation-condition.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Changed the lockfile policy error to suggest relaxing the policy only after expected changes fail a fresh resolution and the affected packages are trusted [pnpm/pnpm#14411](https://github.com/pnpm/pnpm/issues/14411).

--- a/pnpm/crates/cli/tests/suite/tarball_url_dependency.rs
+++ b/pnpm/crates/cli/tests/suite/tarball_url_dependency.rs
@@ -308,7 +308,8 @@ fn frozen_install_refuses_a_remote_tarball_without_integrity() {
             && unwrapped.contains(
                 r#"has no "integrity" field, so its downloaded tarball cannot be verified"#
             )
-            && unwrapped.contains(r#"run "pnpm clean --lockfile""#),
+            && unwrapped.contains(r#"run "pnpm clean --lockfile""#)
+            && unwrapped.contains("If the fresh resolution still fails"),
         "the verification gate must name the error code, the entry, and the way out; got:\n{stderr}",
     );
     head_mock.assert();

--- a/pnpm/crates/lockfile-verification/src/errors.rs
+++ b/pnpm/crates/lockfile-verification/src/errors.rs
@@ -13,8 +13,8 @@ This can mean the lockfile is stale, or that someone committed a \
 lockfile that bypassed the policy locally — inspect recent changes \
 to pnpm-lock.yaml before trusting it. If the changes look expected, \
 run \"pnpm clean --lockfile\" and then \"pnpm install\" to rebuild from \
-a fresh resolution. Alternatively, relax the policy that flagged \
-them.";
+a fresh resolution. If the fresh resolution still fails and you trust \
+the affected packages, relax the policy that flagged them.";
 
 const INVALID_ALIAS_HINT: &str = "A dependency alias becomes a directory under node_modules, \
 so it must be a valid npm package name — a single `name` or `@scope/name` with no leading \

--- a/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/src/install/verifyLockfileResolutions.ts
@@ -275,8 +275,8 @@ function buildVerificationError (violations: ResolutionPolicyViolation[]): PnpmE
         'lockfile that bypassed the policy locally — inspect recent changes ' +
         'to pnpm-lock.yaml before trusting it. If the changes look expected, ' +
         'run "pnpm clean --lockfile" and then "pnpm install" to rebuild from ' +
-        'a fresh resolution. Alternatively, relax the policy that flagged ' +
-        'them.',
+        'a fresh resolution. If the fresh resolution still fails and you ' +
+        'trust the affected packages, relax the policy that flagged them.',
     }
   )
 }

--- a/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
+++ b/pnpm11/installing/deps-installer/test/install/verifyLockfileResolutions.ts
@@ -71,6 +71,7 @@ test('throws with the verifier-supplied code and reason on a single failure', as
 
   await expect(verifyLockfileResolutions(lockfile, [verifier])).rejects.toMatchObject({
     code: 'ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION',
+    hint: expect.stringMatching(/If the changes look expected[\s\S]*If the fresh resolution still fails/),
     message: expect.stringMatching(/is-odd@0\.1\.2 was published yesterday/),
   })
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

The lockfile policy error tells users to relax policy for unexpected changes:

> If the changes look expected, run "pnpm clean --lockfile" and then "pnpm install" ...
> 
> Alternatively, relax the policy that flagged them.

This can allow installation of the dependency pnpm just flagged.

In both the TypeScript and Rust verifiers, suggest changing the policy only after:

1. expected changes have been rebuilt from a fresh resolution
2. and the user trusts the affected packages

Closes pnpm/pnpm#14411.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
The lockfile policy error tells users to relax policy for unexpected changes:

> If the changes look expected, run "pnpm clean --lockfile" and then "pnpm install" ...
> 
> Alternatively, relax the policy that flagged them.

This can allow installation of the dependency pnpm just flagged.

In both the TypeScript and Rust verifiers, suggest changing the policy only after:

1. expected changes have been rebuilt from a fresh resolution
2. and the user trusts the affected packages

Closes pnpm/pnpm#14411.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856744&installation_model_id=426870&pr_number=14412&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14412&signature=176ed5ed4a6f4762af4a15f2daab2d30a4dff3a4238b271370d73397625394d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved lockfile policy error messages with clearer next steps.
* Added guidance to perform a fresh resolution before relaxing policy settings.
* Clarified that policies should only be relaxed if resolution still fails and affected packages are trusted.
* Added instructions to run `pnpm clean --lockfile` when addressing remote tarball verification issues.

## Documentation

* Updated release notes to reflect the revised lockfile policy guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->