### PR TITLE
perf(lockfile): sort and render the big lockfile sections in parallel

### DIFF
--- a/.changeset/parallel-lockfile-render.md
+++ b/.changeset/parallel-lockfile-render.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up writing `pnpm-lock.yaml` in large workspaces: the entries of the big lockfile sections (`importers`, `packages`, `snapshots`) are now key-sorted and rendered to YAML in parallel [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5093,6 +5093,7 @@ dependencies = [
  "pnpm-package-manifest",
  "pnpm-resolving-parse-wanted-dependency",
  "pretty_assertions",
+ "rayon",
  "serde",
  "serde-saphyr",
  "serde_json",

--- a/pnpm/crates/lockfile/Cargo.toml
+++ b/pnpm/crates/lockfile/Cargo.toml
@@ -25,6 +25,7 @@ libc             = { workspace = true }
 miette           = { workspace = true }
 node-semver      = { workspace = true }
 pipe-trait       = { workspace = true }
+rayon            = { workspace = true }
 serde            = { workspace = true }
 serde-saphyr     = { workspace = true }
 serde_json       = { workspace = true }

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -282,46 +282,56 @@ fn write_block_mapping(
     compact: bool,
     double_line: bool,
 ) -> String {
-    if map.is_empty() {
-        return "{}".to_string();
-    }
     // Each entry's rendering depends only on its own key and value, so
-    // a large map fans its entries out across the rayon pool; the
-    // serial stitch below is the only order-dependent part (the first
-    // entry of a compact block omits its leading newline).
-    let entries: Vec<(&String, &Value)> = map.iter().collect();
-    let render_entry = |(key, value): &(&String, &Value)| -> String {
-        let mut entry = String::new();
+    // a large map fans its entries out across the rayon pool and the
+    // serial stitch below applies the only order-dependent rule — the
+    // first entry of a compact block omits its leading newline. Small
+    // maps (the nested ones inside every package entry, above all)
+    // append straight into one buffer, chunk-free.
+    let render_entry_into = |result: &mut String, key: &String, value: &Value| {
         let rendered_key = write_scalar(key, level + 1, true, true);
         let explicit_pair = rendered_key.encode_utf16().count() > EXPLICIT_KEY_THRESHOLD;
         if explicit_pair {
-            entry.push_str("? ");
-            entry.push_str(&rendered_key);
-            entry.push_str(&next_line(level, false));
+            result.push_str("? ");
+            result.push_str(&rendered_key);
+            result.push_str(&next_line(level, false));
         } else {
-            entry.push_str(&rendered_key);
+            result.push_str(&rendered_key);
         }
         let rendered = render(value, level + 1, true, explicit_pair, Some(key), false);
-        entry.push(':');
+        result.push(':');
         if !rendered.starts_with('\n') {
-            entry.push(' ');
+            result.push(' ');
         }
-        entry.push_str(&rendered);
-        entry
-    };
-    let rendered_entries: Vec<String> = if entries.len() < PARALLEL_ENTRY_THRESHOLD {
-        entries.iter().map(render_entry).collect()
-    } else {
-        entries.par_iter().map(render_entry).collect()
+        result.push_str(&rendered);
     };
     let mut result = String::new();
-    for (index, entry) in rendered_entries.iter().enumerate() {
-        if !compact || index > 0 {
-            result.push_str(&next_line(level, double_line));
+    if map.len() < PARALLEL_ENTRY_THRESHOLD {
+        for (key, value) in map {
+            if !compact || !result.is_empty() {
+                result.push_str(&next_line(level, double_line));
+            }
+            render_entry_into(&mut result, key, value);
         }
-        result.push_str(entry);
+    } else {
+        let rendered_entries: Vec<String> = map
+            .iter()
+            .collect::<Vec<_>>()
+            .par_iter()
+            .map(|(key, value)| {
+                let mut entry = String::new();
+                render_entry_into(&mut entry, key, value);
+                entry
+            })
+            .collect();
+        for (index, entry) in rendered_entries.iter().enumerate() {
+            if !compact || index > 0 {
+                result.push_str(&next_line(level, double_line));
+            }
+            result.push_str(entry);
+        }
     }
-    result
+    if result.is_empty() { "{}".to_string() } else { result }
 }
 
 fn write_block_sequence(seq: &[Value], level: usize, compact: bool) -> String {

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -28,10 +28,11 @@ use serde_json::{Map, Value};
 use std::cmp::Ordering;
 
 /// Entry count from which a map's independent per-entry work (deep key
-/// sorting, block rendering) fans out across the rayon pool. Small maps
-/// stay serial — the fan-out has fixed cost, and only the
-/// thousands-of-entries `importers:` / `packages:` / `snapshots:`
-/// sections of a large workspace repay it.
+/// sorting, block rendering) fans out across the rayon pool. In
+/// practice only a workspace's `importers:` / `packages:` /
+/// `snapshots:` sections grow past this; the small maps nested inside
+/// every package entry stay serial, where the fan-out's fixed cost
+/// would dominate.
 const PARALLEL_ENTRY_THRESHOLD: usize = 64;
 
 /// Keys whose collection value always renders on a single line (flow style).

--- a/pnpm/crates/lockfile/src/yaml_emit.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit.rs
@@ -23,8 +23,16 @@
 //!
 //! [`@zkochan/js-yaml`]: https://github.com/pnpm/js-yaml
 
+use rayon::prelude::*;
 use serde_json::{Map, Value};
 use std::cmp::Ordering;
+
+/// Entry count from which a map's independent per-entry work (deep key
+/// sorting, block rendering) fans out across the rayon pool. Small maps
+/// stay serial — the fan-out has fixed cost, and only the
+/// thousands-of-entries `importers:` / `packages:` / `snapshots:`
+/// sections of a large workspace repay it.
+const PARALLEL_ENTRY_THRESHOLD: usize = 64;
 
 /// Keys whose collection value always renders on a single line (flow style).
 /// Mirrors the fork's [`SINGLE_LINE_KEYS`][fork-single-line-keys].
@@ -136,8 +144,20 @@ fn priority_cmp(priority: &[&str], left: &str, right: &str) -> Ordering {
     }
 }
 
-fn map_values(map: Map<String, Value>, transform: impl Fn(Value) -> Value) -> Map<String, Value> {
-    map.into_iter().map(|(key, value)| (key, transform(value))).collect()
+fn map_values(
+    map: Map<String, Value>,
+    transform: impl Fn(Value) -> Value + Sync,
+) -> Map<String, Value> {
+    if map.len() < PARALLEL_ENTRY_THRESHOLD {
+        return map.into_iter().map(|(key, value)| (key, transform(value))).collect();
+    }
+    map.into_iter()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(key, value)| (key, transform(value)))
+        .collect::<Vec<_>>()
+        .into_iter()
+        .collect()
 }
 
 fn sort_direct_keys(map: Map<String, Value>) -> Map<String, Value> {
@@ -262,28 +282,46 @@ fn write_block_mapping(
     compact: bool,
     double_line: bool,
 ) -> String {
-    let mut result = String::new();
-    for (key, value) in map {
-        if !compact || !result.is_empty() {
-            result.push_str(&next_line(level, double_line));
-        }
+    if map.is_empty() {
+        return "{}".to_string();
+    }
+    // Each entry's rendering depends only on its own key and value, so
+    // a large map fans its entries out across the rayon pool; the
+    // serial stitch below is the only order-dependent part (the first
+    // entry of a compact block omits its leading newline).
+    let entries: Vec<(&String, &Value)> = map.iter().collect();
+    let render_entry = |(key, value): &(&String, &Value)| -> String {
+        let mut entry = String::new();
         let rendered_key = write_scalar(key, level + 1, true, true);
         let explicit_pair = rendered_key.encode_utf16().count() > EXPLICIT_KEY_THRESHOLD;
         if explicit_pair {
-            result.push_str("? ");
-            result.push_str(&rendered_key);
-            result.push_str(&next_line(level, false));
+            entry.push_str("? ");
+            entry.push_str(&rendered_key);
+            entry.push_str(&next_line(level, false));
         } else {
-            result.push_str(&rendered_key);
+            entry.push_str(&rendered_key);
         }
         let rendered = render(value, level + 1, true, explicit_pair, Some(key), false);
-        result.push(':');
+        entry.push(':');
         if !rendered.starts_with('\n') {
-            result.push(' ');
+            entry.push(' ');
         }
-        result.push_str(&rendered);
+        entry.push_str(&rendered);
+        entry
+    };
+    let rendered_entries: Vec<String> = if entries.len() < PARALLEL_ENTRY_THRESHOLD {
+        entries.iter().map(render_entry).collect()
+    } else {
+        entries.par_iter().map(render_entry).collect()
+    };
+    let mut result = String::new();
+    for (index, entry) in rendered_entries.iter().enumerate() {
+        if !compact || index > 0 {
+            result.push_str(&next_line(level, double_line));
+        }
+        result.push_str(entry);
     }
-    if result.is_empty() { "{}".to_string() } else { result }
+    result
 }
 
 fn write_block_sequence(seq: &[Value], level: usize, compact: bool) -> String {

--- a/pnpm/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit/tests.rs
@@ -125,10 +125,11 @@ fn a_large_section_renders_identically_through_the_parallel_path() {
         .collect(),
     ));
 
+    use std::fmt::Write;
     let mut expected = String::from("lockfileVersion: '9.0'\n\npackages:\n");
     for index in 0..count {
-        expected
-            .push_str(&format!("\n  pkg-{index:03}@1.0.0:\n    version: 1.0.0\n    dev: false\n"));
+        write!(expected, "\n  pkg-{index:03}@1.0.0:\n    version: 1.0.0\n    dev: false\n")
+            .expect("write to a String is infallible");
     }
     assert_eq!(yaml, expected);
 }

--- a/pnpm/crates/lockfile/src/yaml_emit/tests.rs
+++ b/pnpm/crates/lockfile/src/yaml_emit/tests.rs
@@ -101,3 +101,34 @@ fn key_length_is_measured_in_utf16_code_units() {
     let yaml = to_string(json!({ &key: { "b": "c" } }));
     assert_eq!(yaml, format!("? {key}\n: b: c\n"));
 }
+
+/// A section past [`super::PARALLEL_ENTRY_THRESHOLD`] takes the
+/// chunked parallel render (and the parallel deep-sort), which must
+/// stitch to the same bytes the serial path produces: entries in key
+/// order, blank-line separated, inner keys sorted.
+#[test]
+fn a_large_section_renders_identically_through_the_parallel_path() {
+    let count = super::PARALLEL_ENTRY_THRESHOLD + 9;
+    let mut packages = serde_json::Map::new();
+    // Reverse insertion order, so unsorted input is visible if either
+    // parallel stage loses the ordering.
+    for index in (0..count).rev() {
+        packages
+            .insert(format!("pkg-{index:03}@1.0.0"), json!({ "version": "1.0.0", "dev": false }));
+    }
+    let yaml = to_string(serde_json::Value::Object(
+        [
+            ("lockfileVersion".to_string(), json!("9.0")),
+            ("packages".to_string(), serde_json::Value::Object(packages)),
+        ]
+        .into_iter()
+        .collect(),
+    ));
+
+    let mut expected = String::from("lockfileVersion: '9.0'\n\npackages:\n");
+    for index in 0..count {
+        expected
+            .push_str(&format!("\n  pkg-{index:03}@1.0.0:\n    version: 1.0.0\n    dev: false\n"));
+    }
+    assert_eq!(yaml, expected);
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. Follow-up to pnpm/pnpm#14379, pnpm/pnpm#14396, and pnpm/pnpm#14402 — the next block in the warm lockfile-only update profile: writing the lockfile (~240 ms on the issue's reproduction), dominated by the YAML emitter's serial walk over the document.

On a large workspace the `importers:` / `packages:` / `snapshots:` sections carry thousands of entries each, and both expensive stages over them are independent per entry:

- the **deep key sort** (`sort_lockfile_keys`' per-entry priority sort), and
- the **block rendering** (`write_block_mapping`'s per-entry key quoting + value rendering).

The only order-dependent piece is the stitch — a compact block's first entry omits its leading newline. Both stages now fan a map's entries across the rayon pool once it has ≥64 of them, and the per-entry chunks are stitched serially in order, so the byte output is unchanged. Small maps stay serial: the fan-out has fixed cost that only the huge sections repay, and every other lockfile map is far below the threshold.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| whole warm update (`pnpm:execution-time`, median of 8) | 1.62 s | 1.53 s |

The written `pnpm-lock.yaml` (9.6 MB) is byte-identical, and all 364 lockfile-crate tests pass unchanged — the emitter is a byte-for-byte port of `@zkochan/js-yaml` and this keeps it one.

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.53 s, now below the ~1.6 s wall time the issue reports for Yarn 4.18 on the same protocol.

### Remaining headroom (not in this PR)

The `serde_json::to_value` lowering (~50 ms, single-threaded) and the resolver walk's allocator/hash traffic on its tuple cache keys (~360 ms).

## Squash Commit Body

```text
The YAML emitter walked the whole document serially, and on a large
workspace the importers/packages/snapshots sections dominate: their
deep key sort and their per-entry block rendering are each independent
per entry, with the sole order-dependent piece being the stitch (a
compact block's first entry omits its leading newline).

Both stages now fan a map's entries across the rayon pool once it has
64 or more of them; per-entry chunks are stitched in order, so the
byte output is unchanged. Small maps stay serial - the fan-out has
fixed cost only the thousands-of-entries sections repay.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), whole-run wall time drops from ~1.62 s to
~1.52 s median and the written lockfile is byte-identical.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — the byte format is pinned by
  the existing emitter test suite, all passing unchanged.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790857919&installation_model_id=426870&pr_number=14414&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14414&signature=76ca23eed7c5f2e5f816509f56e3dcc7b5d6f2820d31a7858af438227cfed5a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Accelerated `pnpm-lock.yaml` generation for large workspaces by sorting and rendering major lockfile sections in parallel.
  * Preserved deterministic entry ordering and existing behavior for smaller lockfiles.
* **Bug Fixes**
  * Ensured parallel lockfile rendering produces the same correctly ordered YAML output as serial rendering.
* **Release**
  * Prepared a patch release for the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->