### PR TITLE
ci: cancel stale workflow approval requests

### DIFF
--- a/.github/workflows/cancel-unapproved-workflows.yml
+++ b/.github/workflows/cancel-unapproved-workflows.yml
@@ -4,7 +4,7 @@ name: Cancel Unapproved Workflows
 # not apply to them. Sweep from the trusted default branch instead.
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/30 * * * *'
   workflow_dispatch: {}
 
 permissions:
@@ -33,7 +33,7 @@ jobs:
             -f status=action_required \
             -f "created=<=$cutoff" \
             -f per_page=100 \
-            --jq '.workflow_runs[].id' |
+            --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id' |
           while IFS= read -r run_id; do
             conclusion=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.conclusion')
             if [ "$conclusion" != action_required ]; then

--- a/.github/workflows/cancel-unapproved-workflows.yml
+++ b/.github/workflows/cancel-unapproved-workflows.yml
@@ -1,0 +1,60 @@
+name: Cancel Unapproved Workflows
+
+# Approval-held workflows never start a job, so job-level timeout-minutes does
+# not apply to them. Sweep from the trusted default branch instead.
+on:
+  schedule:
+    - cron: '*/5 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  actions: write
+
+concurrency:
+  group: cancel-unapproved-workflows
+  cancel-in-progress: false
+
+jobs:
+  cancel:
+    name: Cancel workflows awaiting approval for over 30 minutes
+    if: github.repository == 'pnpm/pnpm'
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 5
+    steps:
+      - name: Cancel expired approval requests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          cutoff=$(date -u -d '30 minutes ago' '+%Y-%m-%dT%H:%M:%SZ')
+          gh api --method GET --paginate "repos/$REPO/actions/runs" \
+            -f status=action_required \
+            -f "created=<=$cutoff" \
+            -f per_page=100 \
+            --jq '.workflow_runs[].id' |
+          while IFS= read -r run_id; do
+            conclusion=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.conclusion')
+            if [ "$conclusion" != action_required ]; then
+              echo "Workflow run $run_id no longer needs approval; skipping"
+              continue
+            fi
+
+            echo "Canceling workflow run $run_id after its 30-minute approval window expired"
+            if cancel_error=$(gh api --silent --method POST \
+              "repos/$REPO/actions/runs/$run_id/cancel" 2>&1); then
+              continue
+            fi
+
+            # Approval can arrive between the re-check and the cancellation.
+            # That expected race returns a conflict and must not fail the sweep.
+            conclusion=$(gh api "repos/$REPO/actions/runs/$run_id" --jq '.conclusion')
+            if [ "$conclusion" != action_required ]; then
+              echo "Workflow run $run_id was approved before cancellation; skipping"
+              continue
+            fi
+
+            printf '%s\n' "$cancel_error" >&2
+            exit 1
+          done


### PR DESCRIPTION
## Summary

Adds a trusted scheduled workflow that cancels GitHub Actions runs left awaiting approval for more than 30 minutes. The workflow checks every 30 minutes, queries only `action_required` runs older than the cutoff, and re-checks each conclusion before cancellation so a late approval is not raced. This deliberately favors a lower sweep frequency, so cancellation occurs on the first sweep after the 30-minute cutoff and the observed wait can be between 30 and 60 minutes.

A separate scheduled workflow is necessary because an approval-held run never starts its jobs, so its own `timeout-minutes` cannot enforce the approval window. The token is limited to `actions: write`, and the workflow neither checks out nor executes code from the held run.

## Squash Commit Body

```text
Add a trusted scheduled workflow that cancels action-required workflow runs once their 30-minute approval window expires.

Use the workflow-runs API because approval-held jobs never start and therefore cannot enforce their own job timeout. Re-check each run immediately before cancellation to tolerate approvals racing the scheduled sweep.
```

## Checklist

No published package, CLI parity, changeset, test-suite, or documentation updates are required for this workflow-only change. The workflow passes actionlint, and its cutoff query was verified read-only against live repository workflow-run data.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790859899&installation_model_id=426870&pr_number=14415&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14415&signature=b9e6cdc26d96bb516fc277673321ce16eb4bd446c9df7596b4d33aff337c65e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated cleanup for workflow runs that have been awaiting approval for more than 30 minutes.
  * Added support for manually starting the cleanup when needed.
  * Improved reliability by preventing overlapping cleanup tasks and rechecking run status before cancellation.
  * Failed cleanup attempts are now reported clearly for follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->