### PR TITLE
fix(cli): parse global flags before `with current`

### DIFF
--- a/.changeset/fix-with-current-global-flags.md
+++ b/.changeset/fix-with-current-global-flags.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm with current` when a Boolean global option precedes it [pnpm/pnpm#14413](https://github.com/pnpm/pnpm/issues/14413).

--- a/.changeset/fix-with-current-global-flags.md
+++ b/.changeset/fix-with-current-global-flags.md
@@ -5,3 +5,5 @@
 Fixed `pnpm with current <command>` when global options precede it, such as `pnpm --workspace-root with current --version` [pnpm/pnpm#14413](https://github.com/pnpm/pnpm/issues/14413).
 
 A short-option cluster that mixes a global flag with an option owned by the command, such as `pnpm -ro dist pack-app`, is now parsed like the same options written after the command.
+
+An option that no command defines, written before the command name, is now reported as an unknown option instead of being taken for the command to run — `pnpm -z exec echo` fails the way `pnpm --zzz exec echo` does.

--- a/.changeset/fix-with-current-global-flags.md
+++ b/.changeset/fix-with-current-global-flags.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm with current` when a Boolean global option precedes it [pnpm/pnpm#14413](https://github.com/pnpm/pnpm/issues/14413).
+Fixed `pnpm with current <command>` when global options precede it, such as `pnpm --workspace-root with current --version` [pnpm/pnpm#14413](https://github.com/pnpm/pnpm/issues/14413).

--- a/.changeset/fix-with-current-global-flags.md
+++ b/.changeset/fix-with-current-global-flags.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed `pnpm with current <command>` when global options precede it, such as `pnpm --workspace-root with current --version` [pnpm/pnpm#14413](https://github.com/pnpm/pnpm/issues/14413).
+
+A short-option cluster that mixes a global flag with an option owned by the command, such as `pnpm -ro dist pack-app`, is now parsed like the same options written after the command.

--- a/.changeset/fix-with-current-global-flags.md
+++ b/.changeset/fix-with-current-global-flags.md
@@ -6,4 +6,4 @@ Fixed `pnpm with current <command>` when global options precede it, such as `pnp
 
 A short-option cluster that mixes a global flag with an option owned by the command, such as `pnpm -ro dist pack-app`, is now parsed like the same options written after the command.
 
-An option that no command defines, written before the command name, is now reported as an unknown option instead of being taken for the command to run — `pnpm -z exec echo` fails the way `pnpm --zzz exec echo` does.
+An option written before the command name is now reported as an unknown option unless that command accepts it, instead of being taken for the command to run — `pnpm -P exec echo` and `pnpm -z exec echo` fail the way `pnpm --tag next exec echo` does.

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -148,18 +148,28 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
             // A cluster is judged by every short it stacks, not by its
             // first one: `-ro dist` mixes the global `-r` with
             // `pack-app`'s `-o`, and the whole token has to travel for
-            // clap to see the option its subcommand owns.
-            let mut belongs_to_subcommand = false;
+            // clap to see the option its subcommand owns. One short no
+            // grammar defines pins the whole cluster, since moving it
+            // would hand the unknown short to the subcommand too.
+            let mut has_subcommand_short = false;
+            let mut has_unknown_short = false;
             let consumes_value = short_cluster_consumes_value(rest, |short| {
                 if let Some(consumes_value) = top_level.short_consumes_value(short) {
                     return Some(consumes_value);
                 }
-                let consumes_value = subcommand_union.short_consumes_value(short);
-                belongs_to_subcommand |= consumes_value.is_some();
-                consumes_value
+                match subcommand_union.short_consumes_value(short) {
+                    Some(consumes_value) => {
+                        has_subcommand_short = true;
+                        Some(consumes_value)
+                    }
+                    None => {
+                        has_unknown_short = true;
+                        None
+                    }
+                }
             });
             let width = token_width(consumes_value, false);
-            if belongs_to_subcommand {
+            if has_subcommand_short && !has_unknown_short {
                 for offset in 0..width.min(argv.len() - index) {
                     moved_indexes.insert(index + offset);
                 }

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -157,15 +157,12 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
                 if let Some(consumes_value) = top_level.short_consumes_value(short) {
                     return Some(consumes_value);
                 }
-                match subcommand_union.short_consumes_value(short) {
-                    Some(consumes_value) => {
-                        has_subcommand_short = true;
-                        Some(consumes_value)
-                    }
-                    None => {
-                        has_unknown_short = true;
-                        None
-                    }
+                if let Some(consumes_value) = subcommand_union.short_consumes_value(short) {
+                    has_subcommand_short = true;
+                    Some(consumes_value)
+                } else {
+                    has_unknown_short = true;
+                    None
                 }
             });
             let width = token_width(consumes_value, false);

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -140,22 +140,23 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
                 index += width;
             }
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
-            let short = rest.chars().next().expect("checked non-empty");
-            if top_level.short_consumes_value(short).is_some() {
-                let consumes_value = short_cluster_consumes_value(rest, |short| {
-                    top_level.short_consumes_value(short)
-                });
-                index += token_width(consumes_value, false);
-            } else {
-                let consumes_value = short_cluster_consumes_value(rest, |short| {
-                    subcommand_union.short_consumes_value(short)
-                });
-                let width = token_width(consumes_value, false);
+            // A cluster is judged by every short it stacks, not by its
+            // first one: `-ro dist` mixes the global `-r` with
+            // `pack-app`'s `-o`, and the whole token has to travel for
+            // clap to see the option its subcommand owns.
+            let mut belongs_to_subcommand = false;
+            let consumes_value = short_cluster_consumes_value(rest, |short| {
+                let top_level_arity = top_level.short_consumes_value(short);
+                belongs_to_subcommand |= top_level_arity.is_none();
+                top_level_arity.or_else(|| subcommand_union.short_consumes_value(short))
+            });
+            let width = token_width(consumes_value, false);
+            if belongs_to_subcommand {
                 for offset in 0..width.min(argv.len() - index) {
                     moved_indexes.insert(index + offset);
                 }
-                index += width;
             }
+            index += width;
         } else {
             break;
         }
@@ -192,10 +193,11 @@ pub(crate) fn token_width(consumes_value: bool, has_inline_value: bool) -> usize
 /// (`-rC dir` is `-r -C dir`), and a value written against its option
 /// (`-rCdir`) leaves nothing for the next token. `arity` reports whether
 /// one short takes a value, or `None` for a short the grammar does not
-/// define, which consumes nothing.
+/// define, which consumes nothing; it is called for exactly the shorts
+/// clap parses as options, so a caller can classify them as it scans.
 pub(crate) fn short_cluster_consumes_value(
     rest: &str,
-    arity: impl Fn(char) -> Option<bool>,
+    mut arity: impl FnMut(char) -> Option<bool>,
 ) -> bool {
     let mut shorts = rest.chars();
     while let Some(short) = shorts.next() {

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -11,10 +11,14 @@
 //! subcommand.
 //!
 //! [`relocate_pre_subcommand_flags`] closes the gap in argv space:
-//! option tokens that appear before the subcommand and are not part of
-//! the top-level grammar move to directly after the subcommand token
-//! (relative order preserved), so clap parses them with the subcommand's
-//! grammar exactly as if they had been written there. Whether a moved
+//! option tokens that appear before the subcommand and belong to a
+//! subcommand's grammar rather than the top-level one move to directly
+//! after the subcommand token (relative order preserved), so clap parses
+//! them with the subcommand's grammar exactly as if they had been
+//! written there. An option no grammar defines stays where it is, so
+//! clap reports it against the top-level command the way nopt does,
+//! instead of a `trailing_var_arg` command such as `exec` taking it for
+//! the command to run. Whether a moved
 //! option consumes the following token as its value is decided from the
 //! union of every subcommand's arg table; on an arity conflict between
 //! subcommands the option is treated as boolean so a subcommand name is
@@ -131,13 +135,14 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
                 rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
             if let Some(consumes_value) = top_level.long_consumes_value(name) {
                 index += token_width(consumes_value, has_inline_value);
-            } else {
-                let consumes_value = subcommand_union.long_consumes_value(name).unwrap_or(false);
+            } else if let Some(consumes_value) = subcommand_union.long_consumes_value(name) {
                 let width = token_width(consumes_value, has_inline_value);
                 for offset in 0..width.min(argv.len() - index) {
                     moved_indexes.insert(index + offset);
                 }
                 index += width;
+            } else {
+                index += token_width(false, has_inline_value);
             }
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
             // A cluster is judged by every short it stacks, not by its
@@ -146,9 +151,12 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
             // clap to see the option its subcommand owns.
             let mut belongs_to_subcommand = false;
             let consumes_value = short_cluster_consumes_value(rest, |short| {
-                let top_level_arity = top_level.short_consumes_value(short);
-                belongs_to_subcommand |= top_level_arity.is_none();
-                top_level_arity.or_else(|| subcommand_union.short_consumes_value(short))
+                if let Some(consumes_value) = top_level.short_consumes_value(short) {
+                    return Some(consumes_value);
+                }
+                let consumes_value = subcommand_union.short_consumes_value(short);
+                belongs_to_subcommand |= consumes_value.is_some();
+                consumes_value
             });
             let width = token_width(consumes_value, false);
             if belongs_to_subcommand {

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -23,7 +23,7 @@
 //! (`pnpm <script>`) keep their argv untouched, as does everything after
 //! a `--` terminator.
 
-use clap::{Arg, ArgAction, Command};
+use clap::{Arg, Command};
 use std::{
     collections::{HashMap, HashSet},
     ffi::OsString,
@@ -223,7 +223,9 @@ impl ArgTable {
 
     fn absorb<'a, Args: IntoIterator<Item = &'a Arg>>(&mut self, args: Args) {
         for arg in args {
-            let consumes_value = matches!(arg.get_action(), ArgAction::Set | ArgAction::Append);
+            let consumes_value = arg.get_action().takes_values()
+                && arg.get_num_args().is_none_or(|range| range.takes_values())
+                && !arg.is_require_equals_set();
             for long in
                 arg.get_long().into_iter().chain(arg.get_all_aliases().into_iter().flatten())
             {

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -76,14 +76,12 @@ pub(crate) fn scan_for_positional(
                 index += token_width(consumes_value, has_inline_value);
             }
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
-            let short = rest.chars().next().expect("checked non-empty");
-            let is_bare_short = rest.chars().count() == 1;
-            if let Some(consumes_value) = top_level.short_consumes_value(short) {
-                index += token_width(consumes_value && is_bare_short, false);
-            } else {
-                let consumes_value = subcommand_union.short_consumes_value(short).unwrap_or(false);
-                index += token_width(consumes_value && is_bare_short, false);
-            }
+            let consumes_value = short_cluster_consumes_value(rest, |short| {
+                top_level
+                    .short_consumes_value(short)
+                    .or_else(|| subcommand_union.short_consumes_value(short))
+            });
+            index += token_width(consumes_value, false);
         } else {
             return Some(PositionalScan::Positional(index));
         }
@@ -143,12 +141,16 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
             }
         } else if let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) {
             let short = rest.chars().next().expect("checked non-empty");
-            let is_bare_short = rest.chars().count() == 1;
-            if let Some(consumes_value) = top_level.short_consumes_value(short) {
-                index += token_width(consumes_value && is_bare_short, false);
+            if top_level.short_consumes_value(short).is_some() {
+                let consumes_value = short_cluster_consumes_value(rest, |short| {
+                    top_level.short_consumes_value(short)
+                });
+                index += token_width(consumes_value, false);
             } else {
-                let consumes_value = subcommand_union.short_consumes_value(short).unwrap_or(false);
-                let width = token_width(consumes_value && is_bare_short, false);
+                let consumes_value = short_cluster_consumes_value(rest, |short| {
+                    subcommand_union.short_consumes_value(short)
+                });
+                let width = token_width(consumes_value, false);
                 for offset in 0..width.min(argv.len() - index) {
                     moved_indexes.insert(index + offset);
                 }
@@ -182,6 +184,26 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
 /// when the value is a separate token rather than `--flag=value` inline.
 pub(crate) fn token_width(consumes_value: bool, has_inline_value: bool) -> usize {
     if consumes_value && !has_inline_value { 2 } else { 1 }
+}
+
+/// Whether a short-option token consumes the next argv token as its
+/// value. `rest` is the token with its leading `-` stripped, and may be a
+/// cluster: clap lets boolean shorts stack ahead of a value-taking one
+/// (`-rC dir` is `-r -C dir`), and a value written against its option
+/// (`-rCdir`) leaves nothing for the next token. `arity` reports whether
+/// one short takes a value, or `None` for a short the grammar does not
+/// define, which consumes nothing.
+pub(crate) fn short_cluster_consumes_value(
+    rest: &str,
+    arity: impl Fn(char) -> Option<bool>,
+) -> bool {
+    let mut shorts = rest.chars();
+    while let Some(short) = shorts.next() {
+        if arity(short).unwrap_or(false) {
+            return shorts.as_str().is_empty();
+        }
+    }
+    false
 }
 
 /// Option-name lookup table: long / short spelling → whether the option

--- a/pnpm/crates/cli/src/flag_relocation.rs
+++ b/pnpm/crates/cli/src/flag_relocation.rs
@@ -11,18 +11,19 @@
 //! subcommand.
 //!
 //! [`relocate_pre_subcommand_flags`] closes the gap in argv space:
-//! option tokens that appear before the subcommand and belong to a
-//! subcommand's grammar rather than the top-level one move to directly
-//! after the subcommand token (relative order preserved), so clap parses
-//! them with the subcommand's grammar exactly as if they had been
-//! written there. An option no grammar defines stays where it is, so
-//! clap reports it against the top-level command the way nopt does,
-//! instead of a `trailing_var_arg` command such as `exec` taking it for
-//! the command to run. Whether a moved
-//! option consumes the following token as its value is decided from the
-//! union of every subcommand's arg table; on an arity conflict between
-//! subcommands the option is treated as boolean so a subcommand name is
-//! never swallowed as a value. Tokens move only when the first
+//! option tokens that appear before the subcommand and belong to the
+//! invoked command's grammar rather than the top-level one move to
+//! directly after the subcommand token (relative order preserved), so
+//! clap parses them with that command's grammar exactly as if they had
+//! been written there. Ownership is decided against the invoked command
+//! alone: an option only some other command declares stays where it is,
+//! as does one no grammar defines at all, so clap reports it the way
+//! nopt does instead of a `trailing_var_arg` command such as `exec`
+//! taking it for the command to run. The scan that has yet to find the
+//! subcommand has no command to consult, so it steps over options using
+//! the union of every subcommand's arg table; on an arity conflict
+//! between subcommands the option is treated as boolean so a subcommand
+//! name is never swallowed as a value. Tokens move only when the first
 //! positional token names a real subcommand — external commands
 //! (`pnpm <script>`) keep their argv untouched, as does everything after
 //! a `--` terminator.
@@ -120,6 +121,10 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
     let Some(subcommand_index) = subcommand_index else {
         return argv;
     };
+    let Some(subcommand) = cmd.find_subcommand(&argv[subcommand_index]) else {
+        return argv;
+    };
+    let subcommand_table = ArgTable::subcommand(subcommand);
 
     // Now we must re-calculate moved_indexes, because find_positional just skipped.
     let mut index = 1;
@@ -135,7 +140,7 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
                 rest.split_once('=').map_or((rest, false), |(name, _)| (name, true));
             if let Some(consumes_value) = top_level.long_consumes_value(name) {
                 index += token_width(consumes_value, has_inline_value);
-            } else if let Some(consumes_value) = subcommand_union.long_consumes_value(name) {
+            } else if let Some(consumes_value) = subcommand_table.long_consumes_value(name) {
                 let width = token_width(consumes_value, has_inline_value);
                 for offset in 0..width.min(argv.len() - index) {
                     moved_indexes.insert(index + offset);
@@ -148,16 +153,16 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
             // A cluster is judged by every short it stacks, not by its
             // first one: `-ro dist` mixes the global `-r` with
             // `pack-app`'s `-o`, and the whole token has to travel for
-            // clap to see the option its subcommand owns. One short no
-            // grammar defines pins the whole cluster, since moving it
-            // would hand the unknown short to the subcommand too.
+            // clap to see the option `pack-app` owns. One short the
+            // command does not declare pins the whole cluster, since
+            // moving it would hand that short to the command too.
             let mut has_subcommand_short = false;
             let mut has_unknown_short = false;
             let consumes_value = short_cluster_consumes_value(rest, |short| {
                 if let Some(consumes_value) = top_level.short_consumes_value(short) {
                     return Some(consumes_value);
                 }
-                if let Some(consumes_value) = subcommand_union.short_consumes_value(short) {
+                if let Some(consumes_value) = subcommand_table.short_consumes_value(short) {
                     has_subcommand_short = true;
                     Some(consumes_value)
                 } else {
@@ -177,7 +182,7 @@ pub fn relocate_pre_subcommand_flags(cmd: &Command, mut argv: Vec<OsString>) -> 
         }
     }
 
-    if moved_indexes.is_empty() || cmd.find_subcommand(&argv[subcommand_index]).is_none() {
+    if moved_indexes.is_empty() {
         return argv;
     }
 
@@ -244,11 +249,20 @@ impl ArgTable {
         table
     }
 
-    /// The union of every subcommand's args, used only to decide how
-    /// many tokens a to-be-moved option occupies.
+    /// The union of every subcommand's args. It cannot say which command
+    /// owns an option, so it serves only the scan that has yet to find the
+    /// subcommand and needs a token's width to step over it.
     pub(crate) fn subcommand_union(cmd: &Command) -> Self {
         let mut table = Self::default();
         table.absorb(cmd.get_subcommands().flat_map(Command::get_arguments));
+        table
+    }
+
+    /// One subcommand's own args, which decide whether a token written
+    /// before it belongs to the command being invoked.
+    pub(crate) fn subcommand(cmd: &Command) -> Self {
+        let mut table = Self::default();
+        table.absorb(cmd.get_arguments());
         table
     }
 

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -13,11 +13,13 @@ fn relocate(tokens: &[&str]) -> Vec<String> {
 }
 
 fn parse(tokens: &[&str]) -> CliArgs {
+    try_parse(tokens).expect("parses after relocation")
+}
+
+fn try_parse(tokens: &[&str]) -> Result<CliArgs, clap::Error> {
     let cmd = with_boolean_negations(CliArgs::command());
     let argv = relocate_pre_subcommand_flags(&cmd, tokens.iter().map(OsString::from).collect());
-    cmd.try_get_matches_from(argv)
-        .and_then(|matches| CliArgs::from_arg_matches(&matches))
-        .expect("parses after relocation")
+    cmd.try_get_matches_from(argv).and_then(|matches| CliArgs::from_arg_matches(&matches))
 }
 
 #[test]
@@ -135,11 +137,16 @@ fn unknown_options_before_a_subcommand_stay_in_place() {
         ["pnpm", "-z", "exec", "echo"],
         ["pnpm", "--zzz", "exec", "echo"],
         ["pnpm", "-rz", "exec", "echo"],
+        ["pnpm", "-zP", "exec", "echo"],
     ] {
         assert_eq!(
             relocate(&argv),
             argv,
             "an option no grammar defines must reach clap as a top-level error, not as exec's command",
+        );
+        assert!(
+            try_parse(&argv).is_err(),
+            "clap must reject the unknown option instead of exec running it: {argv:?}",
         );
     }
 }

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -95,6 +95,36 @@ fn short_subcommand_flag_moves() {
 }
 
 #[test]
+fn mixed_short_cluster_moves_with_its_value() {
+    assert_eq!(
+        relocate(&["pnpm", "-ro", "dist", "pack-app"]),
+        ["pnpm", "pack-app", "-ro", "dist"],
+        "the global -r rides along so clap sees pack-app's -o after the subcommand",
+    );
+    assert_eq!(
+        relocate(&["pnpm", "-rodist", "pack-app"]),
+        ["pnpm", "pack-app", "-rodist"],
+        "an attached value keeps the cluster a single token",
+    );
+}
+
+#[test]
+fn relocated_mixed_short_cluster_parses_with_both_options_applied() {
+    let args = parse(&["pnpm", "-ro", "dist", "pack-app"]);
+    assert!(args.recursive);
+    let crate::cli_args::cli_command::CliCommand::PackApp(pack_app) = args.command else {
+        panic!("expected pack-app");
+    };
+    assert_eq!(pack_app.output_dir.as_deref(), Some("dist"));
+}
+
+#[test]
+fn global_short_cluster_stays_in_place() {
+    let argv = ["pnpm", "-rC", "project", "install"];
+    assert_eq!(relocate(&argv), argv, "every short in the cluster is top-level grammar already");
+}
+
+#[test]
 fn subcommand_alias_is_recognized() {
     assert_eq!(relocate(&["pnpm", "--prod", "i"]), ["pnpm", "i", "--prod"]);
 }

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -130,6 +130,21 @@ fn subcommand_alias_is_recognized() {
 }
 
 #[test]
+fn unknown_options_before_a_subcommand_stay_in_place() {
+    for argv in [
+        ["pnpm", "-z", "exec", "echo"],
+        ["pnpm", "--zzz", "exec", "echo"],
+        ["pnpm", "-rz", "exec", "echo"],
+    ] {
+        assert_eq!(
+            relocate(&argv),
+            argv,
+            "an option no grammar defines must reach clap as a top-level error, not as exec's command",
+        );
+    }
+}
+
+#[test]
 fn external_command_argv_is_untouched() {
     let argv = ["pnpm", "--ignore-scripts", "some-script"];
     assert_eq!(relocate(&argv), argv, "not a subcommand → script argv must not be reshaped");

--- a/pnpm/crates/cli/src/flag_relocation/tests.rs
+++ b/pnpm/crates/cli/src/flag_relocation/tests.rs
@@ -152,6 +152,28 @@ fn unknown_options_before_a_subcommand_stay_in_place() {
 }
 
 #[test]
+fn options_another_command_owns_stay_in_place() {
+    for argv in [
+        ["pnpm", "-P", "exec", "echo"],
+        ["pnpm", "-rP", "exec", "echo"],
+        ["pnpm", "--node-linker=hoisted", "exec", "echo"],
+    ] {
+        assert_eq!(
+            relocate(&argv),
+            argv,
+            "`exec` does not declare the option, so it must not travel into its command vector",
+        );
+        assert!(
+            try_parse(&argv).is_err(),
+            "clap must reject the option `exec` does not declare: {argv:?}",
+        );
+    }
+    let argv = ["pnpm", "--tag", "next-11", "exec", "echo"];
+    assert_eq!(relocate(&argv), argv, "a value-taking option of another command stays whole");
+    assert!(try_parse(&argv).is_err(), "clap must reject --tag against exec");
+}
+
+#[test]
 fn external_command_argv_is_untouched() {
     let argv = ["pnpm", "--ignore-scripts", "some-script"];
     assert_eq!(relocate(&argv), argv, "not a subcommand → script argv must not be reshaped");

--- a/pnpm/crates/cli/src/with_current.rs
+++ b/pnpm/crates/cli/src/with_current.rs
@@ -9,7 +9,10 @@
 //! survives clap's `-v` / `--version` short-circuit and reaches both the
 //! in-process config load and any child process the command spawns.
 
-use crate::{cli_args::grammar, flag_relocation::ArgTable};
+use crate::{
+    cli_args::grammar,
+    flag_relocation::{ArgTable, short_cluster_consumes_value},
+};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::ffi::OsString;
@@ -98,17 +101,10 @@ fn option_consumes_value(token: &str) -> bool {
     if token.starts_with("--") {
         long_option_consumes_value(token)
     } else {
-        let Some(rest) = token.strip_prefix('-') else {
+        let Some(rest) = token.strip_prefix('-').filter(|rest| !rest.is_empty()) else {
             return false;
         };
-        let mut chars = rest.chars();
-        let Some(short) = chars.next() else {
-            return false;
-        };
-        if chars.next().is_some() {
-            return false;
-        }
-        top_level_arity().short_consumes_value(short).unwrap_or(false)
+        short_cluster_consumes_value(rest, |short| top_level_arity().short_consumes_value(short))
     }
 }
 

--- a/pnpm/crates/cli/src/with_current.rs
+++ b/pnpm/crates/cli/src/with_current.rs
@@ -9,21 +9,10 @@
 //! survives clap's `-v` / `--version` short-circuit and reaches both the
 //! in-process config load and any child process the command spawns.
 
+use crate::{cli_args::grammar, flag_relocation::ArgTable};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::ffi::OsString;
-
-/// Global long options that do **not** take a value, so the next token is
-/// the subcommand rather than the option's argument. Every other long
-/// option (known value-takers like `--dir` / `--reporter`, and any unknown
-/// flag) is assumed to consume its successor: a non-boolean (including
-/// unknown) option is treated as value-consuming.
-const BOOLEAN_LONG_OPTIONS: &[&str] = &["color", "recursive", "yes"];
-
-/// Global short options that take a value (`-C` = `--dir`, `-F` =
-/// `--filter`), so the next token is the value, not the subcommand. Other
-/// short flags (`-r`) are boolean and consume nothing.
-const VALUE_TAKING_SHORT_OPTIONS: &[&str] = &["-C", "-F"];
 
 /// Raised when `with current` has no command after it.
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -109,12 +98,23 @@ fn option_consumes_value(token: &str) -> bool {
     if token.starts_with("--") {
         long_option_consumes_value(token)
     } else {
-        VALUE_TAKING_SHORT_OPTIONS.contains(&token)
+        let Some(rest) = token.strip_prefix('-') else {
+            return false;
+        };
+        let mut chars = rest.chars();
+        let Some(short) = chars.next() else {
+            return false;
+        };
+        if chars.next().is_some() {
+            return false;
+        }
+        top_level_arity().short_consumes_value(short).unwrap_or(false)
     }
 }
 
 /// Whether a long option consumes the next argv token as its value.
-/// Booleans and `--no-` negations don't; an inline `--opt=val` carries its
+/// Known option arity comes from clap's top-level grammar. `--no-`
+/// negations don't consume a value, and an inline `--opt=val` carries its
 /// own value. Unknown long options are assumed to consume a value.
 fn long_option_consumes_value(token: &str) -> bool {
     if token.contains('=') {
@@ -124,7 +124,12 @@ fn long_option_consumes_value(token: &str) -> bool {
     if name.starts_with("no-") {
         return false;
     }
-    !BOOLEAN_LONG_OPTIONS.contains(&name)
+    top_level_arity().long_consumes_value(name).unwrap_or(true)
+}
+
+fn top_level_arity() -> &'static ArgTable {
+    static ARITY: std::sync::OnceLock<ArgTable> = std::sync::OnceLock::new();
+    ARITY.get_or_init(|| ArgTable::top_level(grammar()))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/with_current/tests.rs
+++ b/pnpm/crates/cli/src/with_current/tests.rs
@@ -32,7 +32,7 @@ fn preserves_global_flags_before_with() {
     assert!(force);
     assert_eq!(strings(&rewritten), vec!["pnpm", "--recursive", "install"]);
 
-    for flag in ["--color", "--yes"] {
+    for flag in ["--color", "--yes", "--workspace-root", "-rw"] {
         let (rewritten, force) = plan(argv(&[flag, "with", "current", "--version"])).expect("plan");
         assert!(force);
         assert_eq!(strings(&rewritten), vec!["pnpm", flag, "--version"]);
@@ -92,17 +92,33 @@ fn rewrites_with_current_after_a_value_taking_global_flag() {
 }
 
 #[test]
+fn rewrites_with_current_after_a_clustered_value_taking_short() {
+    // `-rC` is `-r -C`, so the directory is the value and `with` the command.
+    let (rewritten, force) =
+        plan(argv(&["-rC", "packages/foo", "with", "current", "install"])).expect("plan");
+    assert!(force);
+    assert_eq!(strings(&rewritten), vec!["pnpm", "-rC", "packages/foo", "install"]);
+}
+
+#[test]
 fn option_value_consumption_matches_pnpm() {
-    // Value-takers and unknown long options consume their successor.
+    // Value-takers and unknown long options consume their successor, as
+    // does a cluster ending in a value-taking short.
     assert!(option_consumes_value("--reporter"));
     assert!(option_consumes_value("--unknown-flag"));
     assert!(option_consumes_value("-C"));
     assert!(option_consumes_value("-F"));
-    // Booleans, `--no-` negations, inline `=` values, and boolean shorts do not.
+    assert!(option_consumes_value("-rC"));
+    assert!(option_consumes_value("-rwF"));
+    // Booleans, `--no-` negations, inline `=` values, boolean shorts and
+    // their clusters, and a short carrying its value inline do not.
     assert!(!option_consumes_value("--color"));
     assert!(!option_consumes_value("--recursive"));
     assert!(!option_consumes_value("--yes"));
     assert!(!option_consumes_value("--no-something"));
     assert!(!option_consumes_value("--reporter=ndjson"));
     assert!(!option_consumes_value("-r"));
+    assert!(!option_consumes_value("-rw"));
+    assert!(!option_consumes_value("-Cpackages/foo"));
+    assert!(!option_consumes_value("-rCpackages/foo"));
 }

--- a/pnpm/crates/cli/tests/suite/exec.rs
+++ b/pnpm/crates/cli/tests/suite/exec.rs
@@ -44,6 +44,11 @@ fn make_connected_detached_node_script(ready_path: &Path, port: u16) -> String {
 fn assert_connection_closes(mut connection: std::net::TcpStream) {
     use std::io::{ErrorKind, Read, Write};
 
+    // A socket accepted from a non-blocking listener inherits that mode on
+    // Windows, which makes the read below return `WouldBlock` at once and
+    // the timeout moot — the assertion would race the job object's cleanup
+    // rather than wait for it.
+    connection.set_nonblocking(false).expect("set detached child connection blocking");
     connection
         .set_read_timeout(Some(Duration::from_secs(10)))
         .expect("set detached child connection timeout");

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -93,7 +93,7 @@ fn with_forwards_subsequent_args_to_the_child_pnpm() {
 
 #[test]
 fn with_current_dispatches_the_inner_command_after_a_global_boolean_flag() {
-    for flag in ["--color", "--workspace-root", "--yes"] {
+    for flag in ["--color", "--yes"] {
         let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
         write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
 
@@ -107,6 +107,22 @@ fn with_current_dispatches_the_inner_command_after_a_global_boolean_flag() {
 
         drop(root);
     }
+}
+
+#[test]
+fn with_current_dispatches_after_workspace_root() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
+
+    let output = test_command(pacquet, root.path())
+        .with_args(["--workspace-root", "with", "current", "--version"])
+        .output()
+        .expect("run pacquet with current --version after --workspace-root");
+    dbg!(&output);
+    assert_success(&output);
+    assert_semver_like(stdout(&output).trim());
+
+    drop(root);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -118,7 +118,6 @@ fn with_current_dispatches_after_workspace_root() {
         .with_args(["--workspace-root", "with", "current", "--version"])
         .output()
         .expect("run pacquet with current --version after --workspace-root");
-    dbg!(&output);
     assert_success(&output);
     assert_semver_like(stdout(&output).trim());
 

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -93,7 +93,7 @@ fn with_forwards_subsequent_args_to_the_child_pnpm() {
 
 #[test]
 fn with_current_dispatches_the_inner_command_after_a_global_boolean_flag() {
-    for flag in ["--color", "--yes"] {
+    for flag in ["--color", "--workspace-root", "--yes"] {
         let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
         write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
 

--- a/pnpm/crates/cli/tests/suite/with.rs
+++ b/pnpm/crates/cli/tests/suite/with.rs
@@ -92,36 +92,23 @@ fn with_forwards_subsequent_args_to_the_child_pnpm() {
 }
 
 #[test]
-fn with_current_dispatches_the_inner_command_after_a_global_boolean_flag() {
-    for flag in ["--color", "--yes"] {
+fn with_current_dispatches_the_inner_command_after_global_options() {
+    for global in [vec!["--color"], vec!["--yes"], vec!["--workspace-root"], vec!["-yC", "."]] {
         let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
         write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
 
+        let args: Vec<&str> =
+            global.iter().copied().chain(["with", "current", "--version"]).collect();
         let output = test_command(pacquet, root.path())
-            .with_args([flag, "with", "current", "--version"])
+            .with_args(args)
             .output()
-            .expect("run pacquet with current --version after a global boolean flag");
-        dbg!(&output);
+            .expect("run pacquet with current --version after a global option");
+        dbg!(&global, &output);
         assert_success(&output);
         assert_semver_like(stdout(&output).trim());
 
         drop(root);
     }
-}
-
-#[test]
-fn with_current_dispatches_after_workspace_root() {
-    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_manifest(&workspace, &serde_json::json!({ "name": "project", "version": "1.0.0" }));
-
-    let output = test_command(pacquet, root.path())
-        .with_args(["--workspace-root", "with", "current", "--version"])
-        .output()
-        .expect("run pacquet with current --version after --workspace-root");
-    assert_success(&output);
-    assert_semver_like(stdout(&output).trim());
-
-    drop(root);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14413.

The Rust `with current` pre-parser now gets global option arity from the clap grammar instead of a hand-maintained Boolean-option list. This prevents flags such as `--workspace-root` from consuming `with` as their value and bypassing the rewrite.

Follow-up commits fix two neighbouring defects in `relocate_pre_subcommand_flags`, both found in review:

- It classified a whole short cluster from its first member, so a cluster such as `-ro dist` (global `-r` stacked ahead of `pack-app`'s `-o`) stayed before the subcommand and clap rejected the option its subcommand owns. Every short in the cluster is now scanned, and the relocation scan agrees with the positional scan on the token's width.
- It relocated options that *no* grammar defines, which a `trailing_var_arg` command then took for its own argument: `pnpm -z exec echo hi` ran `-z` as the command rather than reporting an unknown option. A token now moves only when a subcommand actually declares it — for long options and for the shorts inside a cluster alike — so an unknown option reaches clap as a top-level error, matching `nopt` and therefore the TypeScript CLI.
- A cluster mixing an undefined short with a subcommand-owned one (`-zP`) still travelled on the strength of the known member, handing `exec` the unknown short as its command. A cluster now relocates only when clap can parse every short in it.
- Ownership was decided from the union of every subcommand's args, so an option only *some other* command declares travelled anyway — `pnpm -P exec echo hi` and `pnpm --tag next exec echo hi` reached `exec` and became its command vector. The subcommand is now resolved before the ownership pass and only its own args count; the union is kept for the first scan, which has no command to consult and needs each token's width to step over it. `nopt` rejects all of these, so this matches the TypeScript CLI (`Unknown option: 'save-prod'` / `'tag'`).

The relocation tests assert the parse as well as the argv, so a token that reaches the wrong grammar fails them rather than passing a string comparison.

A third commit fixes an unrelated Windows flake this PR's CI hit in `exec_cleans_up_a_detached_process_after_failure`: the socket it reads is accepted from a non-blocking listener, whose mode Windows inherits, so the read returned `WouldBlock` at once and the ten-second timeout never applied — the assertion raced the job object's cleanup instead of waiting for it.

This change is Rust-only. The special in-process `with current` rewrite exists only in the Rust CLI; the TypeScript CLI already accepts the reported command through its own `with` path. The relocation shim likewise has no TypeScript counterpart — `nopt` is position-independent by construction.

## Squash Commit Body

```text
The `with current` pre-parser used a small list of Boolean global options. Any unlisted Boolean option could be treated as value-taking, which moved the detected command position past the real `with current` pair.

Use the existing option-arity table built from the clap grammar. Also treat optional values that require `=` as not consuming the following token. Keep the conservative behavior for unknown long options.

Add a process-level regression for `--workspace-root with current --version`.

Fixes pnpm/pnpm#14413
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790860151&installation_model_id=426870&pr_number=14416&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14416&signature=b0c0c7a97fc8be25b3000869b67a4a988f0a6f452b44db24ad723d8b3df2b298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm with current` command dispatch when preceded by global Boolean options, including clustered short options.
  - Improved handling of option values, inline values, and negated flags for more reliable command execution.
  - Ensured mixed short-option clusters preserve both global and command-specific settings.

- **Tests**
  - Expanded coverage for global options, clustered short options, and value consumption.

- **Documentation**
  - Added a patch release note describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



