### PR TITLE
fix(release): sign Rust Windows executables

### DIFF
--- a/.changeset/sign-windows-binaries.md
+++ b/.changeset/sign-windows-binaries.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Digitally sign the Windows pnpm executables.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,7 +619,21 @@ jobs:
       - name: Build with cross
         run: cross build --locked -p pnpm-cli --bin pnpm --release --target=${{ matrix.target }}
 
+      - name: Prepare unsigned Windows binary
+        if: runner.os == 'Windows'
+        shell: bash
+        run: mv target/${{ matrix.target }}/release/pnpm.exe pnpm.exe
+
+      - name: Upload unsigned Windows binary
+        if: runner.os == 'Windows'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          name: unsigned-binary-rust-${{ matrix.code-target }}
+          path: pnpm.exe
+
       - name: Download node-gyp payload
+        if: runner.os != 'Windows'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: node-gyp-payload
@@ -627,7 +641,9 @@ jobs:
           # `*.tar.gz` glob the Upload Binary step publishes.
           path: node-gyp-payload
 
-      # The binary is archived to fix permission loss
+      # Non-Windows binaries are archived here. Windows binaries are handed to
+      # sign-rust-windows as raw build outputs and archived only after signing.
+      # The archives fix permission loss
       # (https://github.com/actions/upload-artifact#permission-loss) and ships
       # under its final name: `pnpm-<target>` archives with a plain `pnpm`
       # binary at the root beside a `dist/` holding node-gyp — the layout the
@@ -635,14 +651,6 @@ jobs:
       # the binary resolves node-gyp from at `<exe dir>/dist/node-gyp-bin` — so
       # the github-release-rust job can upload them to the GitHub release
       # byte-for-byte as attested here.
-      - name: Archive Binary
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          mv target/${{ matrix.target }}/release/pnpm.exe pnpm.exe
-          tar xzf node-gyp-payload/node-gyp-payload.tar.gz
-          7z a pnpm-${{ matrix.code-target }}.zip pnpm.exe dist
-
       - name: Archive Binary
         if: runner.os != 'Windows'
         # Everything is staged in a scratch directory because the repo root
@@ -656,11 +664,13 @@ jobs:
           tar czf pnpm-${{ matrix.code-target }}.tar.gz -C stage pnpm dist
 
       - name: Attest build provenance
+        if: runner.os != 'Windows'
         uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: pnpm-${{ matrix.code-target }}.*
 
       - name: Upload Binary
+        if: runner.os != 'Windows'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           if-no-files-found: error
@@ -668,6 +678,86 @@ jobs:
           path: |
             *.zip
             *.tar.gz
+
+  # Keep the signing identity in the protected release environment instead of
+  # exposing it to every target build. Only this job can turn the raw Windows
+  # build outputs into the binaries-rust-* artifacts consumed downstream.
+  sign-rust-windows:
+    name: Sign pnpm (Rust) ${{ matrix.code-target }}
+    needs:
+      - plan
+      - build-node-gyp-payload
+      - build-rust
+    if: needs.plan.outputs.rust == 'true' && !inputs.verify_ts_release
+    runs-on: blacksmith-8vcpu-windows-2025
+    environment: release
+    permissions:
+      contents: read
+      id-token: write # authenticate to Azure Artifact Signing and attest the signed archive
+      attestations: write
+    strategy:
+      matrix:
+        include:
+          - code-target: win32-x64
+          - code-target: win32-arm64
+    steps:
+      - name: Download unsigned binary
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: unsigned-binary-rust-${{ matrix.code-target }}
+
+      - name: Log in to Azure
+        uses: azure/login@7ddb5af1ef8758cf1353cf3b42f940aee27ba21c # v3.0.2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign pnpm.exe
+        uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
+        with:
+          endpoint: ${{ secrets.AZURE_ARTIFACT_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME }}
+          files: ${{ github.workspace }}\pnpm.exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: pnpm
+          description-url: https://pnpm.io
+
+      - name: Verify Authenticode signature
+        shell: pwsh
+        run: |
+          $signature = Get-AuthenticodeSignature pnpm.exe
+          if ($signature.Status -ne 'Valid') {
+            throw "Invalid Authenticode signature: $($signature.StatusMessage)"
+          }
+          $signature.SignerCertificate | Format-List Subject, Issuer, NotBefore, NotAfter, Thumbprint
+
+      - name: Download node-gyp payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: node-gyp-payload
+          path: node-gyp-payload
+
+      - name: Archive signed binary
+        shell: bash
+        run: |
+          tar xzf node-gyp-payload/node-gyp-payload.tar.gz
+          7z a pnpm-${{ matrix.code-target }}.zip pnpm.exe dist
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: pnpm-${{ matrix.code-target }}.zip
+
+      - name: Upload signed binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          if-no-files-found: error
+          name: binaries-rust-${{ matrix.code-target }}
+          path: pnpm-${{ matrix.code-target }}.zip
 
   build-rust-napi:
     # Deliberately not waiting on build-node-gyp-payload: the addon ships no
@@ -785,6 +875,7 @@ jobs:
       - plan
       - build-rust
       - build-rust-napi
+      - sign-rust-windows
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -930,6 +1021,7 @@ jobs:
       - plan
       - build-rust
       - build-rust-napi
+      - sign-rust-windows
       - verify-rust-artifacts
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -179,6 +179,38 @@ The key's user ID must carry the same email as `user.email`, and that address
 must be verified on the GitHub account — otherwise the signature is valid but
 GitHub still renders it Unverified.
 
+<!-- cspell:ignore Authenticode -->
+
+### Windows executable signing
+
+The Rust pnpm release signs `pnpm.exe` through Azure Artifact Signing before
+creating the Windows release archives. The signing job runs in the protected
+`release` environment and authenticates through GitHub OIDC. Its Microsoft
+Entra application must have a federated credential with these claims:
+
+- Issuer: `https://token.actions.githubusercontent.com`
+- Subject: `repo:pnpm/pnpm:environment:release`
+- Audience: `api://AzureADTokenExchange`
+
+Assign that application the `Artifact Signing Certificate Profile Signer` role
+at the certificate-profile scope. The profile must use Public Trust so Windows
+can validate the Authenticode chain without installing a private root.
+
+Configure these secrets on the GitHub `release` environment:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+- `AZURE_ARTIFACT_SIGNING_ENDPOINT`
+- `AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME`
+- `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME`
+
+The release fails before packaging if signing fails or Windows does not report
+the resulting Authenticode signature as valid. Unsigned intermediate binaries
+are uploaded under `unsigned-binary-rust-*`; only the signed
+`binaries-rust-*` artifacts are downloaded by the verification, npm publish,
+and GitHub release jobs.
+
 ## Known gap
 
 The release commit itself is created by `create-release-pr.yml` and merged


### PR DESCRIPTION
## Summary

- sign both Rust pnpm Windows release binaries with Azure Artifact Signing
- keep signing credentials in the protected `release` environment and authenticate with GitHub OIDC
- verify Authenticode before packaging, then preserve the existing npm and GitHub artifact names and archive layout
- document the required Azure and Entra setup

This is a release-pipeline change only. It preserves pnpm's current atomic, versioned global package layout while giving Windows releases a consistent verified publisher identity. The TypeScript CLI runs through Node.js and has no corresponding native executable to sign.

Fixes pnpm/pnpm#14405.

## Squash Commit Body

```text
Route the two Rust Windows build outputs through a protected signing job before packaging or publication. Authenticate to Azure Artifact Signing with GitHub OIDC, verify each Authenticode signature, and attest only the signed release archive.

The unsigned build artifacts remain internal to the release run; downstream verification, npm publication, and GitHub release jobs continue consuming the existing signed artifact names and layouts.

Document the Entra federated credential, certificate-profile role, Public Trust requirement, and release-environment secrets.

Fixes pnpm/pnpm#14405.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790868046&installation_model_id=426870&pr_number=14425&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14425&signature=48716b5d2cc6a5a928b0975c49c998e9ae3b065eb0e2ebe858bc3d043cda196e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows pnpm executables are now digitally signed before release.
  * Releases verify the executable’s Authenticode signature before publication.

* **Documentation**
  * Added release guidance covering Windows executable signing and verification.
  * Documented that only signed Windows artifacts are included in published releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->