### PR TITLE
perf(resolver): lighten the per-edge wanted-dependency cache keys

### DIFF
--- a/.changeset/nimble-keys-resolve.md
+++ b/.changeset/nimble-keys-resolve.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up dependency resolution in large workspaces: the resolver's per-dependency cache keys now compare paths by their raw bytes instead of walking them component by component, and the importer-wide part of the shared workspace-resolution key is built once per project instead of once per dependency edge [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -132,7 +132,7 @@ pub struct TreeCtx {
     pub(super) importer_order: usize,
     /// The importer-wide slice of the shared workspace-resolution cache
     /// key, built once here so the per-edge key construction shares it.
-    /// See [`workspace_ctx::WorkspaceResolutionOptionsKey`].
+    /// See [`super::workspace_ctx::WorkspaceResolutionOptionsKey`].
     pub(super) workspace_resolution_options_key:
         Arc<super::workspace_ctx::WorkspaceResolutionOptionsKey>,
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -29,11 +29,11 @@ use super::{ManifestHook, UpdateReuseScope, reuse::UpdateScope, workspace_ctx::W
 pub(super) fn project_relative_cache_scope(
     wanted: &WantedDependency,
     opts: &ResolveOptions,
-) -> Option<PathBuf> {
+) -> Option<super::workspace_ctx::PathKey> {
     (wanted.bare_specifier.as_deref().is_some_and(|spec| {
         spec.starts_with("link:") || spec.starts_with("file:") || spec.starts_with("workspace:")
     }) || (opts.always_try_workspace_packages && opts.workspace_packages.is_some()))
-    .then(|| opts.project_dir.clone())
+    .then(|| opts.project_dir.clone().into())
 }
 
 /// The directory the `file:` dependencies declared by a resolved
@@ -130,6 +130,11 @@ pub struct TreeCtx {
     /// occurrences owns a package's shared children context.
     pub(super) importer_id: String,
     pub(super) importer_order: usize,
+    /// The importer-wide slice of the shared workspace-resolution cache
+    /// key, built once here so the per-edge key construction shares it.
+    /// See [`workspace_ctx::WorkspaceResolutionOptionsKey`].
+    pub(super) workspace_resolution_options_key:
+        Arc<super::workspace_ctx::WorkspaceResolutionOptionsKey>,
 }
 
 impl TreeCtx {
@@ -147,6 +152,9 @@ impl TreeCtx {
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
+            workspace_resolution_options_key: Arc::new(
+                super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
+            ),
             base_opts,
             lockfile_dir: pnpm_fs::lexical_normalize(&lockfile_dir),
             catalogs: Catalogs::new(),
@@ -170,6 +178,9 @@ impl TreeCtx {
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
+            workspace_resolution_options_key: Arc::new(
+                super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
+            ),
             base_opts,
             lockfile_dir: pnpm_fs::lexical_normalize(&lockfile_dir),
             catalogs: Catalogs::new(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1222,6 +1222,7 @@ fn render_workspace_resolution(
 /// Remove the consumer directory from a named `workspace:` request while
 /// retaining every other input the explicit workspace resolver reads.
 fn shared_workspace_key(
+    ctx: &TreeCtx,
     cache_key: &WantedKey,
     wanted: &WantedDependency,
     opts: &ResolveOptions,
@@ -1230,12 +1231,21 @@ fn shared_workspace_key(
     if !bare_specifier.starts_with("workspace:") || bare_specifier.starts_with("workspace:.") {
         return None;
     }
+    #[cfg(debug_assertions)]
+    debug_assert!(
+        ctx.workspace_resolution_options_key.matches_options(opts),
+        "the importer-wide workspace-resolution key must describe every edge's options",
+    );
     // The consumer scope is exactly what the shared key drops. Every
     // `workspace:` selector carries one, so its absence means this edge is not
     // the shape assumed here.
     let mut wanted_key = cache_key.clone();
     wanted_key.6.take()?;
-    Some(SharedWorkspaceWantedKey::new(wanted_key, wanted.prev_specifier.clone(), opts))
+    Some(SharedWorkspaceWantedKey::new(
+        wanted_key,
+        wanted.prev_specifier.clone(),
+        &ctx.workspace_resolution_options_key,
+    ))
 }
 
 /// Look the wanted edge up in the per-wanted dedup cache or run the resolver
@@ -1290,7 +1300,7 @@ where
     let shared_workspace_key = ctx
         .workspace
         .share_workspace_resolutions
-        .then(|| shared_workspace_key(&cache_key, wanted, opts))
+        .then(|| shared_workspace_key(ctx, &cache_key, wanted, opts))
         .flatten();
     let cached_workspace = shared_workspace_key.as_ref().and_then(|key| {
         lock_recoverable(&ctx.workspace.resolved_workspace_by_wanted).get(key).map(Arc::clone)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1232,10 +1232,13 @@ fn shared_workspace_key(
         return None;
     }
     #[cfg(debug_assertions)]
-    debug_assert!(
-        ctx.workspace_resolution_options_key.matches_options(opts),
-        "the importer-wide workspace-resolution key must describe every edge's options",
-    );
+    {
+        let importer_key_covers_edge = ctx.workspace_resolution_options_key.matches_options(opts);
+        debug_assert!(
+            importer_key_covers_edge,
+            "the importer-wide workspace-resolution key must describe every edge's options",
+        );
+    }
     // The consumer scope is exactly what the shared key drops. Every
     // `workspace:` selector carries one, so its absence means this edge is not
     // the shape assumed here.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use super::super::{canonical_workspace_resolution, render_workspace_resolution};
-use crate::resolve_dependency_tree::workspace_ctx::WantedKey;
+use crate::resolve_dependency_tree::{TreeCtx, workspace_ctx::WantedKey};
 
 fn wanted(specifier: &str) -> WantedDependency {
     WantedDependency {
@@ -27,7 +27,7 @@ fn key(wanted: &WantedDependency, project_dir: &str) -> WantedKey {
         wanted.injected,
         false,
         None,
-        Some(PathBuf::from(project_dir)),
+        Some(PathBuf::from(project_dir).into()),
         None,
         Vec::new(),
         None,
@@ -74,18 +74,24 @@ fn rendered_link(canonical: &ResolveResult, project_dir: &str) -> String {
 fn shares_only_named_workspace_selectors_and_ignores_project_dir() {
     let base_wanted = wanted("workspace:^");
     let options = opts("/repo/packages/a");
+    let ctx = TreeCtx::new(options.clone());
     let shared = super::super::shared_workspace_key(
+        &ctx,
         &key(&base_wanted, "/repo/packages/a"),
         &base_wanted,
         &options,
     )
     .expect("named workspace selector is shareable");
+    let other_options =
+        ResolveOptions { project_dir: PathBuf::from("/repo/apps/b"), ..options.clone() };
+    let other_ctx = TreeCtx::new(other_options.clone());
     assert_eq!(
         shared,
         super::super::shared_workspace_key(
+            &other_ctx,
             &key(&base_wanted, "/repo/apps/b"),
             &base_wanted,
-            &ResolveOptions { project_dir: PathBuf::from("/repo/apps/b"), ..options.clone() },
+            &other_options,
         )
         .expect("consumer-independent key"),
     );
@@ -94,6 +100,7 @@ fn shares_only_named_workspace_selectors_and_ignores_project_dir() {
         let wanted = wanted(specifier);
         assert_eq!(
             super::super::shared_workspace_key(
+                &ctx,
                 &key(&wanted, "/repo/packages/a"),
                 &wanted,
                 &options
@@ -109,9 +116,21 @@ fn separates_distinct_workspace_maps() {
     let wanted = wanted("workspace:^");
     let first = opts("/repo/packages/a");
     let second = opts("/repo/apps/b");
+    let first_ctx = TreeCtx::new(first.clone());
+    let second_ctx = TreeCtx::new(second.clone());
     assert_ne!(
-        super::super::shared_workspace_key(&key(&wanted, "/repo/packages/a"), &wanted, &first),
-        super::super::shared_workspace_key(&key(&wanted, "/repo/apps/b"), &wanted, &second),
+        super::super::shared_workspace_key(
+            &first_ctx,
+            &key(&wanted, "/repo/packages/a"),
+            &wanted,
+            &first
+        ),
+        super::super::shared_workspace_key(
+            &second_ctx,
+            &key(&wanted, "/repo/apps/b"),
+            &wanted,
+            &second
+        ),
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -94,12 +94,45 @@ pub(super) type WantedKey = (
     Option<bool>,
     bool,
     Option<DateTime<Utc>>,
-    Option<PathBuf>,
+    Option<PathKey>,
     Option<PkgNameVerPeer>,
     Vec<(String, Vec<String>)>,
     Option<String>,
     bool,
 );
+
+/// A path slot of a resolver cache key.
+///
+/// `Path`'s own `Hash` and `Eq` walk the path component by component,
+/// and the per-edge key lookups made that walk one of the hottest
+/// spots of a large workspace's resolution. The paths that reach these
+/// keys come from one canonical config-derived source per importer, so
+/// this wrapper compares and hashes the underlying `OsStr` — a plain
+/// byte comparison. That is *stricter* than component equality
+/// (`a//b` ≠ `a/b` here), which for a dedup cache can only cost an
+/// extra identical resolution, never conflate two different paths.
+#[derive(Debug, Clone)]
+pub(super) struct PathKey(pub(super) PathBuf);
+
+impl From<PathBuf> for PathKey {
+    fn from(path: PathBuf) -> Self {
+        PathKey(path)
+    }
+}
+
+impl PartialEq for PathKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_os_str() == other.0.as_os_str()
+    }
+}
+
+impl Eq for PathKey {}
+
+impl Hash for PathKey {
+    fn hash<State: Hasher>(&self, state: &mut State) {
+        self.0.as_os_str().hash(state);
+    }
+}
 
 /// A wanted dependency key without its consumer directory, plus the resolver
 /// inputs that may vary between importers.
@@ -107,29 +140,37 @@ pub(super) type WantedKey = (
 pub(super) struct SharedWorkspaceWantedKey {
     wanted: WantedKey,
     previous_specifier: Option<String>,
-    resolve_options: WorkspaceResolutionOptionsKey,
+    // Behind an `Arc` because the fields are invariant per importer
+    // (see [`WorkspaceResolutionOptionsKey`]) while a key is built per
+    // dependency edge; the derived `Hash`/`Eq` see through the `Arc`,
+    // so keys built by different importers still match by value.
+    resolve_options: Arc<WorkspaceResolutionOptionsKey>,
 }
 
 impl SharedWorkspaceWantedKey {
     pub(super) fn new(
         wanted: WantedKey,
         previous_specifier: Option<String>,
-        resolve_options: &ResolveOptions,
+        resolve_options: &Arc<WorkspaceResolutionOptionsKey>,
     ) -> Self {
-        Self {
-            wanted,
-            previous_specifier,
-            resolve_options: WorkspaceResolutionOptionsKey::new(resolve_options),
-        }
+        Self { wanted, previous_specifier, resolve_options: Arc::clone(resolve_options) }
     }
 }
 
 /// Resolver inputs that can change a named workspace resolution independently
 /// of the consuming project directory.
+///
+/// Every field is invariant across the [`ResolveOptions`] variants one
+/// importer's walk hands the resolver — the depth split changes only
+/// the version pick, and the per-edge overrides change only
+/// `project_dir` / `current_pkg` / the overlay — so [`TreeCtx`] builds
+/// this once per importer and every edge shares it.
+/// [`Self::matches_options`] backs the debug assertion pinning that
+/// invariance.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct WorkspaceResolutionOptionsKey {
+pub(super) struct WorkspaceResolutionOptionsKey {
     workspace_packages: Option<WorkspacePackagesKey>,
-    lockfile_dir: PathBuf,
+    lockfile_dir: PathKey,
     default_tag: Option<String>,
     inject_workspace_packages: bool,
     calc_specifier: bool,
@@ -138,16 +179,24 @@ struct WorkspaceResolutionOptionsKey {
 }
 
 impl WorkspaceResolutionOptionsKey {
-    fn new(options: &ResolveOptions) -> Self {
+    pub(super) fn new(options: &ResolveOptions) -> Self {
         Self {
             workspace_packages: options.workspace_packages.as_ref().map(WorkspacePackagesKey::new),
-            lockfile_dir: options.lockfile_dir.clone(),
+            lockfile_dir: PathKey(options.lockfile_dir.clone()),
             default_tag: options.default_tag.clone(),
             inject_workspace_packages: options.inject_workspace_packages,
             calc_specifier: options.calc_specifier,
             range_spec_style_discriminant: options.range_spec_style.map(|style| style as u8),
             save_workspace_protocol_discriminant: options.save_workspace_protocol as u8,
         }
+    }
+
+    /// Whether the importer-wide key still describes `options` — the
+    /// per-importer invariance the shared cache relies on, asserted at
+    /// the key's use site in debug builds.
+    #[cfg(debug_assertions)]
+    pub(super) fn matches_options(&self, options: &ResolveOptions) -> bool {
+        *self == Self::new(options)
     }
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -111,14 +111,8 @@ pub(super) type WantedKey = (
 /// byte comparison. That is *stricter* than component equality
 /// (`a//b` ≠ `a/b` here), which for a dedup cache can only cost an
 /// extra identical resolution, never conflate two different paths.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, derive_more::From)]
 pub(super) struct PathKey(pub(super) PathBuf);
-
-impl From<PathBuf> for PathKey {
-    fn from(path: PathBuf) -> Self {
-        PathKey(path)
-    }
-}
 
 impl PartialEq for PathKey {
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. Follow-up to pnpm/pnpm#14379, pnpm/pnpm#14396, pnpm/pnpm#14402, and pnpm/pnpm#14414 — a fresh profile on current main puts the hottest remaining block of the warm update inside the resolver walk's dedup-cache keys: ~130 samples of component-wise `Path` hashing/equality plus the per-edge rebuild of the shared workspace-resolution key.

Two changes, both invisible outside the cache:

- **`PathKey`** — the project-scope slot every workspace-protocol edge's `WantedKey` carries, and the shared key's `lockfile_dir`, were hashed with `Path`'s component-by-component `Hash`/`Eq` on every lookup. The new wrapper delegates both to the underlying `OsStr`, a plain byte comparison (so `Hash` and `Eq` stay mutually consistent). Byte equality is *stricter* than component equality: for a dedup cache that can only cost an extra identical resolution, never conflate two different paths — and the paths reaching these keys come from one config-derived source per importer anyway.
- **Importer-wide `WorkspaceResolutionOptionsKey`** — it was rebuilt per edge, cloning `lockfile_dir` and `default_tag` each time, although its fields are invariant across every `ResolveOptions` variant one importer's walk hands the resolver (the depth split changes only the version pick; the per-edge overrides change only `project_dir` / `current_pkg` / the overlay). `TreeCtx` now builds it once per importer behind an `Arc`; the derived `Hash`/`Eq` see through the `Arc`, so keys built by different importers still match by value, and a debug assertion at the use site pins the invariance (exercised by the whole test suite, which runs in debug).

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, 87,630 `workspace:*` edges; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| `resolution` stage (median of 8) | 570 ms | 538 ms |
| whole warm update (median of 8) | 1.51 s | 1.48 s |

The written `pnpm-lock.yaml` is byte-identical, and all 366 resolver tests pass (the shared-workspace-key tests now build their keys through a real `TreeCtx`).

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.48 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
Two per-edge costs in the walk's dedup-cache keys showed up as the
hottest remaining block of a large workspace's resolution profile:

- Path's component-wise Hash and Eq. The project-scope slot of every
  workspace-protocol edge's key and the shared key's lockfile_dir were
  hashed component by component on every lookup. The new PathKey
  wrapper delegates both to the underlying OsStr - a plain byte
  comparison. Byte equality is stricter than component equality, which
  for a dedup cache can only cost an extra identical resolution, never
  conflate two paths; the paths reaching these keys come from one
  config-derived source per importer anyway.

- Rebuilding WorkspaceResolutionOptionsKey per edge, cloning
  lockfile_dir and default_tag each time. Its fields are invariant
  across every ResolveOptions variant one importer's walk hands the
  resolver (the depth split changes only the version pick; the
  per-edge overrides change only project_dir / current_pkg / the
  overlay), so TreeCtx now builds it once per importer behind an Arc,
  with a debug assertion at the use site pinning that invariance. The
  derived Hash/Eq see through the Arc, so keys from different
  importers still match by value.

On the 6,833-project reproduction from pnpm/pnpm#14352 (87,630
workspace edges, warm non-noop lockfile-only update), the resolution
stage drops from ~570 ms to ~538 ms (median of 8) and the written
lockfile is byte-identical. Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790868441&installation_model_id=426870&pr_number=14426&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14426&signature=ba802081995b98f54a9c20d7bde61c0ed2188b8464c5f3eafb53872723ad9c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved dependency resolution speed in large workspaces through more efficient resolver caching.
  * Reduced repeated processing when resolving dependencies across workspace projects.

* **Bug Fixes**
  * Improved consistency and reliability of workspace resolution cache results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->