### PR TITLE
fix(cli): select requested docs version

### DIFF
--- a/.changeset/docs-selects-requested-version.md
+++ b/.changeset/docs-selects-requested-version.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm docs <package>@<version>` ignoring the requested version. It now opens the selected version's homepage and reports a missing version instead of opening the package-level homepage [pnpm/pnpm#14428](https://github.com/pnpm/pnpm/issues/14428).

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -1,13 +1,6 @@
 use clap::Args;
-use miette::{Context, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_network::{RetryOpts, ThrottledClient};
-use pnpm_package_manifest::PackageManifest;
-use pnpm_resolving_npm_resolver::{
-    FetchFullMetadataOptions, FetchFullMetadataOutcome, fetch_full_metadata,
-    pick_registry_for_package,
-};
-use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use serde_json::Value;
 
 /// Open the documentation page of a package in a browser.
 #[derive(Debug, Args)]
@@ -18,57 +11,31 @@ pub struct DocsArgs {
 
 impl DocsArgs {
     pub async fn run(self, config: &Config) -> miette::Result<()> {
-        let raw_spec = &self.package;
-
-        let parsed = parse_wanted_dependency(raw_spec);
-        let name = parsed.alias.as_deref().unwrap_or(raw_spec);
-        let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
-        let (resolved_name, _range) = PackageManifest::resolve_registry_dependency(name, bare);
-
-        let http_client = ThrottledClient::for_installs(
-            &config.proxy,
-            &config.tls,
-            &config.tls_by_uri,
-            &config.network_settings(),
-        )
-        .into_diagnostic()
-        .wrap_err("create the network client for docs")?;
-        let registries: std::collections::HashMap<String, String> =
-            config.resolved_registries().into_iter().collect();
-        let registry = pick_registry_for_package(&registries, resolved_name, Some(bare));
-
-        let outcome = fetch_full_metadata(
-            resolved_name,
-            &FetchFullMetadataOptions {
-                registry: &registry,
-                http_client: &http_client,
-                auth_headers: &config.auth_headers,
-                full_metadata: true,
-                etag: None,
-                modified: None,
-                retry_opts: RetryOpts::default(),
-            },
-        )
-        .await
-        .into_diagnostic()
-        .wrap_err_with(|| format!("fetch package info for {raw_spec}"))?;
-
-        let package = match outcome {
-            FetchFullMetadataOutcome::Modified(pkg) => *pkg,
-            FetchFullMetadataOutcome::NotModified => {
-                miette::bail!("registry returned 304 Not Modified unexpectedly")
-            }
-        };
-
-        let fallback = || format!("https://npmx.dev/package/{}", package.name);
-        let url = package
-            .homepage
-            .as_deref()
-            .filter(|s| is_http_url(s))
-            .map_or_else(fallback, ToString::to_string);
-
+        let url = self.documentation_url(config).await?;
         open_url(&url)
     }
+
+    async fn documentation_url(&self, config: &Config) -> miette::Result<String> {
+        let info = super::view::fetch_package_info(config, None, &self.package, "docs").await?;
+        Ok(documentation_url_from_info(&info))
+    }
+}
+
+fn documentation_url_from_info(info: &Value) -> String {
+    info.get("homepage")
+        .and_then(Value::as_str)
+        .filter(|homepage| is_http_url(homepage))
+        .map_or_else(
+            || {
+                format!(
+                    "https://npmx.dev/package/{}",
+                    info.get("name")
+                        .and_then(Value::as_str)
+                        .expect("selected registry manifests always have a package name"),
+                )
+            },
+            ToString::to_string,
+        )
 }
 
 fn is_http_url(value: &str) -> bool {

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use pnpm_config::Config;
-use serde_json::Value;
+use pnpm_registry::PackageVersion;
 
 /// Open the documentation page of a package in a browser.
 #[derive(Debug, Args)]
@@ -16,26 +16,19 @@ impl DocsArgs {
     }
 
     async fn documentation_url(&self, config: &Config) -> miette::Result<String> {
-        let info = super::view::fetch_package_info(config, None, &self.package, "docs").await?;
-        Ok(documentation_url_from_info(&info))
+        let (_, manifest) =
+            super::view::fetch_package_metadata(config, None, &self.package, "docs").await?;
+        Ok(documentation_url_from_manifest(&manifest))
     }
 }
 
-fn documentation_url_from_info(info: &Value) -> String {
-    info.get("homepage")
-        .and_then(Value::as_str)
+fn documentation_url_from_manifest(manifest: &PackageVersion) -> String {
+    manifest
+        .other
+        .get("homepage")
+        .and_then(serde_json::Value::as_str)
         .filter(|homepage| is_http_url(homepage))
-        .map_or_else(
-            || {
-                format!(
-                    "https://npmx.dev/package/{}",
-                    info.get("name")
-                        .and_then(Value::as_str)
-                        .expect("selected registry manifests always have a package name"),
-                )
-            },
-            ToString::to_string,
-        )
+        .map_or_else(|| format!("https://npmx.dev/package/{}", manifest.name), ToString::to_string)
 }
 
 fn is_http_url(value: &str) -> bool {

--- a/pnpm/crates/cli/src/cli_args/docs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/docs/tests.rs
@@ -1,4 +1,35 @@
-use super::is_http_url;
+use pnpm_config::Config;
+use serde_json::json;
+
+use super::{DocsArgs, is_http_url};
+use crate::cli_args::view::ViewError;
+
+fn packument() -> String {
+    json!({
+        "name": "is-negative",
+        "homepage": "https://latest.example/docs",
+        "dist-tags": { "latest": "2.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "is-negative",
+                "version": "1.0.0",
+                "homepage": "https://v1.example/docs",
+                "dist": { "tarball": "https://registry.example/is-negative-1.0.0.tgz" }
+            },
+            "2.0.0": {
+                "name": "is-negative",
+                "version": "2.0.0",
+                "homepage": "https://v2.example/docs",
+                "dist": { "tarball": "https://registry.example/is-negative-2.0.0.tgz" }
+            }
+        }
+    })
+    .to_string()
+}
+
+fn config_for(registry: &str) -> Config {
+    Config { registry: format!("{registry}/"), ..Config::default() }
+}
 
 #[test]
 fn test_is_http_url_valid_https() {
@@ -28,4 +59,45 @@ fn test_is_http_url_ftp() {
 #[test]
 fn test_is_http_url_spaces() {
     assert!(!is_http_url("https://exa mple.com"));
+}
+
+#[tokio::test]
+async fn requested_version_uses_its_homepage() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/is-negative")
+        .with_status(200)
+        .with_body(packument())
+        .create_async()
+        .await;
+    let args = DocsArgs { package: "is-negative@1.0.0".to_string() };
+
+    let url =
+        args.documentation_url(&config_for(&server.url())).await.expect("docs URL must resolve");
+
+    mock.assert_async().await;
+    assert_eq!(url, "https://v1.example/docs");
+}
+
+#[tokio::test]
+async fn missing_requested_version_fails() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/is-negative")
+        .with_status(200)
+        .with_body(packument())
+        .create_async()
+        .await;
+    let args = DocsArgs { package: "is-negative@9999.0.0".to_string() };
+
+    let error = args
+        .documentation_url(&config_for(&server.url()))
+        .await
+        .expect_err("a missing version must fail");
+
+    mock.assert_async().await;
+    assert!(
+        matches!(error.downcast_ref::<ViewError>(), Some(ViewError::PackageNotFound { .. })),
+        "unexpected error: {error:?}",
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/docs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/docs/tests.rs
@@ -1,7 +1,8 @@
 use pnpm_config::Config;
+use pnpm_registry::PackageVersion;
 use serde_json::json;
 
-use super::{DocsArgs, is_http_url};
+use super::{DocsArgs, documentation_url_from_manifest, is_http_url};
 use crate::cli_args::view::ViewError;
 
 fn packument() -> String {
@@ -77,6 +78,40 @@ async fn requested_version_uses_its_homepage() {
 
     mock.assert_async().await;
     assert_eq!(url, "https://v1.example/docs");
+}
+
+#[tokio::test]
+async fn unversioned_spec_uses_the_latest_tag_homepage() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/is-negative")
+        .with_status(200)
+        .with_body(packument())
+        .create_async()
+        .await;
+    let args = DocsArgs { package: "is-negative".to_string() };
+
+    let url =
+        args.documentation_url(&config_for(&server.url())).await.expect("docs URL must resolve");
+
+    mock.assert_async().await;
+    assert_eq!(url, "https://v2.example/docs");
+}
+
+#[test]
+fn manifest_without_http_homepage_falls_back_to_npmx() {
+    let manifest: PackageVersion = serde_json::from_value(json!({
+        "name": "@scope/is-negative",
+        "version": "1.0.0",
+        "homepage": "git+ssh://git@example.com/docs.git",
+        "dist": { "tarball": "https://registry.example/is-negative-1.0.0.tgz" }
+    }))
+    .expect("manifest must deserialize");
+
+    assert_eq!(
+        documentation_url_from_manifest(&manifest),
+        "https://npmx.dev/package/@scope/is-negative",
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cli_args/docs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/docs/tests.rs
@@ -9,7 +9,7 @@ fn packument() -> String {
     json!({
         "name": "is-negative",
         "homepage": "https://latest.example/docs",
-        "dist-tags": { "latest": "2.0.0" },
+        "dist-tags": { "latest": "2.0.0", "legacy": "1.0.0" },
         "versions": {
             "1.0.0": {
                 "name": "is-negative",
@@ -96,6 +96,42 @@ async fn unversioned_spec_uses_the_latest_tag_homepage() {
 
     mock.assert_async().await;
     assert_eq!(url, "https://v2.example/docs");
+}
+
+#[tokio::test]
+async fn named_tag_uses_the_tagged_version_homepage() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/is-negative")
+        .with_status(200)
+        .with_body(packument())
+        .create_async()
+        .await;
+    let args = DocsArgs { package: "is-negative@legacy".to_string() };
+
+    let url =
+        args.documentation_url(&config_for(&server.url())).await.expect("docs URL must resolve");
+
+    mock.assert_async().await;
+    assert_eq!(url, "https://v1.example/docs");
+}
+
+#[tokio::test]
+async fn semver_range_uses_the_highest_matching_version_homepage() {
+    let mut server = mockito::Server::new_async().await;
+    let mock = server
+        .mock("GET", "/is-negative")
+        .with_status(200)
+        .with_body(packument())
+        .create_async()
+        .await;
+    let args = DocsArgs { package: "is-negative@^1.0.0".to_string() };
+
+    let url =
+        args.documentation_url(&config_for(&server.url())).await.expect("docs URL must resolve");
+
+    mock.assert_async().await;
+    assert_eq!(url, "https://v1.example/docs");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -6,7 +6,7 @@
 //! field arguments, only those fields are printed; otherwise a formatted
 //! summary (or, with `--json`, the whole assembled info object) is shown.
 
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 use chrono::{DateTime, Utc};
 use clap::Args;
@@ -93,8 +93,9 @@ impl ViewArgs {
         };
         let fields = self.params.get(1..).unwrap_or(&[]);
 
-        let info =
-            fetch_package_info(config, self.registry.as_deref(), &package_spec, "view").await?;
+        let (meta, picked) =
+            fetch_package_metadata(config, self.registry.as_deref(), &package_spec, "view").await?;
+        let info = assemble_info(&meta, &picked);
 
         if !fields.is_empty() {
             return Ok(render_fields(&info, fields, self.json));
@@ -149,17 +150,14 @@ fn invalid_manifest(dir: &Path) -> ViewError {
     }
 }
 
-/// Fetch and assemble the registry info object for `package_spec`: parse the
-/// spec (rejecting non-registry protocols), fetch full metadata, pick the
-/// version satisfying the spec, then extend that version's manifest with the
-/// packument-level `versions`, `dist-tags`, and `time` fields the renderers
-/// read.
-pub(super) async fn fetch_package_info(
+/// Fetch the registry packument for `package_spec` and select the version that
+/// satisfies the spec. The caller decides how much of the result to assemble.
+pub(super) async fn fetch_package_metadata(
     config: &Config,
     registry_override: Option<&str>,
     package_spec: &str,
     command_name: &str,
-) -> miette::Result<Value> {
+) -> miette::Result<(pnpm_registry::Package, Arc<pnpm_registry::PackageVersion>)> {
     let parsed = parse_wanted_dependency(package_spec);
     let alias = parsed.alias.as_deref();
     let bare = parsed.bare_specifier.as_deref().unwrap_or("latest");
@@ -216,7 +214,7 @@ pub(super) async fn fetch_package_info(
         spec: spec.fetch_spec.clone(),
     })?;
 
-    Ok(assemble_info(&meta, &picked))
+    Ok((meta, picked))
 }
 
 /// Build the info object the renderers consume from the picked version's

--- a/pnpm/crates/cli/src/cli_args/view.rs
+++ b/pnpm/crates/cli/src/cli_args/view.rs
@@ -93,7 +93,8 @@ impl ViewArgs {
         };
         let fields = self.params.get(1..).unwrap_or(&[]);
 
-        let info = fetch_package_info(config, self.registry.as_deref(), &package_spec).await?;
+        let info =
+            fetch_package_info(config, self.registry.as_deref(), &package_spec, "view").await?;
 
         if !fields.is_empty() {
             return Ok(render_fields(&info, fields, self.json));
@@ -153,10 +154,11 @@ fn invalid_manifest(dir: &Path) -> ViewError {
 /// version satisfying the spec, then extend that version's manifest with the
 /// packument-level `versions`, `dist-tags`, and `time` fields the renderers
 /// read.
-async fn fetch_package_info(
+pub(super) async fn fetch_package_info(
     config: &Config,
     registry_override: Option<&str>,
     package_spec: &str,
+    command_name: &str,
 ) -> miette::Result<Value> {
     let parsed = parse_wanted_dependency(package_spec);
     let alias = parsed.alias.as_deref();
@@ -180,7 +182,7 @@ async fn fetch_package_info(
         &config.network_settings(),
     )
     .into_diagnostic()
-    .wrap_err("create the network client for view")?;
+    .wrap_err_with(|| format!("create the network client for {command_name}"))?;
     let outcome = fetch_full_metadata(
         &spec.name,
         &FetchFullMetadataOptions {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

- Make the Rust `pnpm docs` command select the requested package version before it reads `homepage`.
- Report `ERR_PNPM_PACKAGE_NOT_FOUND` when no version matches, instead of opening the package-level homepage.
- Keep the existing browser launch behavior unchanged. The TypeScript CLI already selects the requested version, so no TypeScript change is needed.

Fixes pnpm/pnpm#14428.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
The Rust docs command fetched full package metadata but discarded the requested
version and read the packument-level homepage. Reuse the package selection path
from the Rust view command, then read the homepage from the selected manifest.
This also gives missing versions the same package-not-found error as view and
the TypeScript CLI. Keep the platform browser launch code unchanged.

Fixes pnpm/pnpm#14428.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that do not apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790877424&installation_model_id=426870&pr_number=14429&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14429&signature=88c09a4572713a37b7a8da59aed4ef57bb3f63149b78a34209293ff55b53ad70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm docs <package>@<version>` now opens the homepage for the selected package version.
  - Unversioned requests use the package’s latest version homepage.
  - Documentation links fall back to the package page when no valid HTTP homepage is available.

- **Bug Fixes**
  - Requests for unavailable versions now report that the version could not be found.
  - Improved error reporting for documentation and package metadata requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->