### PR TITLE
feat(pnpr): allow configuration through environment variables

### DIFF
--- a/.changeset/pnpr-config-in-env.md
+++ b/.changeset/pnpr-config-in-env.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr now reads its command-line options from environment variables when the corresponding flag is omitted: `PNPR_CONFIG`, `PNPR_LISTEN`, `PNPR_STORAGE`, `PNPR_CACHE`, `PNPR_PUBLIC_URL`, `PNPR_PACKUMENT_TTL_SECS`, `PNPR_OSV`, `PNPR_OSV_DB`, `PNPR_DISABLE_REGISTRY`, `PNPR_DISABLE_RESOLVER`, and `PNPR_DISABLE_ARTIFACTS`. Boolean flags accept common truthy and falsy strings such as `true`, `1`, and `yes`.
+pnpr now reads its command-line options from environment variables when the corresponding flag is omitted: `PNPR_CONFIG`, `PNPR_LISTEN`, `PNPR_STORAGE`, `PNPR_CACHE`, `PNPR_PUBLIC_URL`, `PNPR_PACKUMENT_TTL_SECS`, `PNPR_OSV`, `PNPR_OSV_DB`, `PNPR_DISABLE_REGISTRY`, `PNPR_DISABLE_RESOLVER`, and `PNPR_DISABLE_ARTIFACTS`. Boolean flags accept common truthy and falsy strings such as `true`, `1`, `yes`, `false`, `0`, and `no`.

--- a/.changeset/pnpr-config-in-env.md
+++ b/.changeset/pnpr-config-in-env.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+pnpr now reads its command-line options from environment variables when the corresponding flag is omitted: `PNPR_CONFIG`, `PNPR_LISTEN`, `PNPR_STORAGE`, `PNPR_CACHE`, `PNPR_PUBLIC_URL`, `PNPR_PACKUMENT_TTL_SECS`, `PNPR_OSV`, `PNPR_OSV_DB`, `PNPR_DISABLE_REGISTRY`, `PNPR_DISABLE_RESOLVER`, and `PNPR_DISABLE_ARTIFACTS`. Boolean flags accept common truthy and falsy strings such as `true`, `1`, and `yes`.

--- a/.changeset/pnpr-config-in-env.md
+++ b/.changeset/pnpr-config-in-env.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr now reads its command-line options from environment variables when the corresponding flag is omitted: `PNPR_CONFIG`, `PNPR_LISTEN`, `PNPR_STORAGE`, `PNPR_CACHE`, `PNPR_PUBLIC_URL`, `PNPR_PACKUMENT_TTL_SECS`, `PNPR_OSV`, `PNPR_OSV_DB`, `PNPR_DISABLE_REGISTRY`, `PNPR_DISABLE_RESOLVER`, and `PNPR_DISABLE_ARTIFACTS`. Boolean flags accept common truthy and falsy strings such as `true`, `1`, `yes`, `false`, `0`, and `no`.
+pnpr now reads every command-line option from an environment variable when the flag is omitted. The variable is named after the flag with a `PNPR_` prefix, so `--public-url` becomes `PNPR_PUBLIC_URL` and `--disable-resolver` becomes `PNPR_DISABLE_RESOLVER`. A flag given on the command line wins over its environment variable. Boolean flags accept `true`, `1`, `yes`, `on`, `false`, `0`, `no`, and `off`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5985,6 +5985,7 @@ dependencies = [
  "pnpm-shared-artifact-protocol",
  "pnpm-store-dir",
  "pnpm-tarball",
+ "pnpm-testing-utils",
  "pnpr-auth",
  "pnpr-config",
  "pnpr-error",

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -58,7 +58,7 @@ axum                          = { workspace = true }
 base64                        = { workspace = true }
 bcrypt                        = { workspace = true }
 chrono                        = { workspace = true }
-clap                          = { workspace = true }
+clap                          = { workspace = true, features = ["env"] }
 dashmap                       = { workspace = true }
 derive_more                   = { workspace = true }
 flate2                        = { workspace = true }

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -89,11 +89,12 @@ wax                           = { workspace = true }
 zip                           = { workspace = true }
 
 [dev-dependencies]
-mockito    = { workspace = true }
-pipe-trait = { workspace = true }
-tempfile   = { workspace = true }
-tokio      = { workspace = true }
-tower      = { workspace = true }
+mockito            = { workspace = true }
+pipe-trait         = { workspace = true }
+pnpm-testing-utils = { workspace = true }
+tempfile           = { workspace = true }
+tokio              = { workspace = true }
+tower              = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -1,4 +1,4 @@
-use clap::Parser;
+use clap::{Parser, builder::BoolishValueParser};
 use pnpr::{Config, ConfigSource, LogConfig, LogFormat, RegistryError, default_cache_dir, serve};
 use std::{io::IsTerminal, net::SocketAddr, path::PathBuf, time::Duration};
 use tracing_subscriber::EnvFilter;
@@ -45,7 +45,7 @@ struct Args {
 
     /// Enable local OSV npm vulnerability checks. Requires a local OSV
     /// npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`.
-    #[arg(long, env = "PNPR_OSV")]
+    #[arg(long, env = "PNPR_OSV", value_parser = BoolishValueParser::new())]
     osv: bool,
 
     /// Path to the local OSV npm database zip or extracted JSON directory.
@@ -56,18 +56,18 @@ struct Args {
     /// unpublish, dist-tag, search) on this tier. Without the flag the
     /// surface is served whenever the loaded config declares at least one
     /// registry under `registries:`.
-    #[arg(long, env = "PNPR_DISABLE_REGISTRY")]
+    #[arg(long, env = "PNPR_DISABLE_REGISTRY", value_parser = BoolishValueParser::new())]
     disable_registry: bool,
 
     /// Disable the install-accelerator surface (`/-/pnpr`, `/-/pnpr/v0/resolve`,
     /// `/-/pnpr/v0/verify-lockfile`). Overrides `resolver.enabled` from the
     /// loaded config.
-    #[arg(long, env = "PNPR_DISABLE_RESOLVER")]
+    #[arg(long, env = "PNPR_DISABLE_RESOLVER", value_parser = BoolishValueParser::new())]
     disable_resolver: bool,
 
     /// Disable the signed shared-artifact surface. Overrides
     /// `artifacts.enabled` from the loaded config.
-    #[arg(long, env = "PNPR_DISABLE_ARTIFACTS")]
+    #[arg(long, env = "PNPR_DISABLE_ARTIFACTS", value_parser = BoolishValueParser::new())]
     disable_artifacts: bool,
 }
 

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -10,11 +10,11 @@ struct Args {
     /// packages, log). When omitted, the global `config.yaml` in
     /// pnpr's config dir (pnpm's config-dir rules, under `pnpr`) is
     /// used if it exists, otherwise the bundled default config.
-    #[arg(short = 'c', long)]
+    #[arg(short = 'c', long, env = "PNPR_CONFIG")]
     config: Option<PathBuf>,
 
     /// Address to bind to.
-    #[arg(long, default_value = Config::DEFAULT_LISTEN)]
+    #[arg(long, default_value = Config::DEFAULT_LISTEN, env = "PNPR_LISTEN")]
     listen: SocketAddr,
 
     /// Override the storage path from the loaded config (bundled or
@@ -22,52 +22,52 @@ struct Args {
     /// storage directory without writing a custom YAML. Unless
     /// `--cache` is also given, the disposable proxy cache is
     /// re-derived as a subdirectory of this path.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_STORAGE")]
     storage: Option<PathBuf>,
 
     /// Override the proxy-cache path — the disposable mirror of
     /// upstream registries plus the resolver's cache. Point
     /// it at separate, ephemeral disk to keep published packages and
     /// cached upstream content on different volumes.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_CACHE")]
     cache: Option<PathBuf>,
 
     /// URL clients should use to reach this server. Used when
     /// rewriting `dist.tarball` URLs in served packuments. Defaults
     /// to `http://<listen>`.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_PUBLIC_URL")]
     public_url: Option<String>,
 
     /// Seconds before a cached packument is considered stale and
     /// refetched. When omitted, the loaded config's value wins.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_PACKUMENT_TTL_SECS")]
     packument_ttl_secs: Option<u64>,
 
     /// Enable local OSV npm vulnerability checks. Requires a local OSV
     /// npm database zip at `--osv-db` or `<cache>/osv/npm/all.zip`.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_OSV")]
     osv: bool,
 
     /// Path to the local OSV npm database zip or extracted JSON directory.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_OSV_DB")]
     osv_db: Option<PathBuf>,
 
     /// Disable the npm-registry surface (packument/tarball reads, publish,
     /// unpublish, dist-tag, search) on this tier. Without the flag the
     /// surface is served whenever the loaded config declares at least one
     /// registry under `registries:`.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_DISABLE_REGISTRY")]
     disable_registry: bool,
 
     /// Disable the install-accelerator surface (`/-/pnpr`, `/-/pnpr/v0/resolve`,
     /// `/-/pnpr/v0/verify-lockfile`). Overrides `resolver.enabled` from the
     /// loaded config.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_DISABLE_RESOLVER")]
     disable_resolver: bool,
 
     /// Disable the signed shared-artifact surface. Overrides
     /// `artifacts.enabled` from the loaded config.
-    #[arg(long)]
+    #[arg(long, env = "PNPR_DISABLE_ARTIFACTS")]
     disable_artifacts: bool,
 }
 

--- a/pnpr/crates/pnpr/src/tests.rs
+++ b/pnpr/crates/pnpr/src/tests.rs
@@ -1,8 +1,49 @@
 use super::{Args, RegistryError, redacted_report};
-use clap::Parser as _;
+use clap::{CommandFactory as _, Parser as _};
+use pnpm_testing_utils::env_guard::EnvGuard;
+use std::{ffi::OsStr, net::SocketAddr};
+
+const ENV_VARS: [&str; 11] = [
+    "PNPR_CONFIG",
+    "PNPR_LISTEN",
+    "PNPR_STORAGE",
+    "PNPR_CACHE",
+    "PNPR_PUBLIC_URL",
+    "PNPR_PACKUMENT_TTL_SECS",
+    "PNPR_OSV",
+    "PNPR_OSV_DB",
+    "PNPR_DISABLE_REGISTRY",
+    "PNPR_DISABLE_RESOLVER",
+    "PNPR_DISABLE_ARTIFACTS",
+];
+
+/// Hold the env lock with every `PNPR_*` variable cleared, so a parse sees
+/// only what the test sets and never what the developer's shell exports.
+fn scrubbed_env() -> EnvGuard {
+    let env = EnvGuard::snapshot(ENV_VARS);
+    for var in ENV_VARS {
+        // SAFETY: `env` holds the process-wide env-mutation lock and restores
+        // every variable in `ENV_VARS` on drop.
+        unsafe { std::env::remove_var(var) };
+    }
+    env
+}
+
+#[test]
+fn every_flag_is_bound_to_the_env_var_named_after_it() {
+    let mut bound = Vec::new();
+    for arg in Args::command().get_arguments() {
+        let long = arg.get_long().expect("every pnpr option has a long flag");
+        let expected = format!("PNPR_{}", long.to_uppercase().replace('-', "_"));
+        assert_eq!(arg.get_env(), Some(OsStr::new(&expected)), "--{long}");
+        bound.push(expected);
+    }
+    assert_eq!(bound, ENV_VARS);
+}
 
 #[test]
 fn disable_artifacts_sets_the_config_override() {
+    let _env = scrubbed_env();
     let args = Args::try_parse_from(["pnpr", "--disable-artifacts"]).unwrap();
 
     let overrides = args.feature_overrides();
@@ -10,6 +51,108 @@ fn disable_artifacts_sets_the_config_override() {
     assert!(overrides.disable_artifacts);
     assert!(!overrides.disable_registry);
     assert!(!overrides.disable_resolver);
+}
+
+#[test]
+fn env_vars_stand_in_for_omitted_flags() {
+    let env = scrubbed_env();
+    env.set("PNPR_CONFIG", "/etc/pnpr/config.yaml");
+    env.set("PNPR_LISTEN", "0.0.0.0:4873");
+    env.set("PNPR_STORAGE", "/var/lib/pnpr");
+    env.set("PNPR_CACHE", "/var/cache/pnpr");
+    env.set("PNPR_PUBLIC_URL", "https://registry.example.com");
+    env.set("PNPR_PACKUMENT_TTL_SECS", "90");
+    env.set("PNPR_OSV", "1");
+    env.set("PNPR_OSV_DB", "/var/cache/osv/all.zip");
+    env.set("PNPR_DISABLE_REGISTRY", "yes");
+    env.set("PNPR_DISABLE_RESOLVER", "true");
+    env.set("PNPR_DISABLE_ARTIFACTS", "on");
+
+    let args = Args::try_parse_from(["pnpr"]).unwrap();
+
+    assert_eq!(args.config.as_deref(), Some("/etc/pnpr/config.yaml".as_ref()));
+    assert_eq!(args.listen, "0.0.0.0:4873".parse::<SocketAddr>().unwrap());
+    assert_eq!(args.storage.as_deref(), Some("/var/lib/pnpr".as_ref()));
+    assert_eq!(args.cache.as_deref(), Some("/var/cache/pnpr".as_ref()));
+    assert_eq!(args.public_url.as_deref(), Some("https://registry.example.com"));
+    assert_eq!(args.packument_ttl_secs, Some(90));
+    assert!(args.osv);
+    assert_eq!(args.osv_db.as_deref(), Some("/var/cache/osv/all.zip".as_ref()));
+    assert!(args.disable_registry);
+    assert!(args.disable_resolver);
+    assert!(args.disable_artifacts);
+}
+
+#[test]
+fn omitted_flags_without_env_vars_keep_their_defaults() {
+    let _env = scrubbed_env();
+
+    let args = Args::try_parse_from(["pnpr"]).unwrap();
+
+    assert_eq!(args.listen, super::Config::DEFAULT_LISTEN.parse::<SocketAddr>().unwrap());
+    assert_eq!(args.config, None);
+    assert_eq!(args.packument_ttl_secs, None);
+    assert!(!args.osv);
+    assert!(!args.disable_registry);
+    assert!(!args.disable_resolver);
+    assert!(!args.disable_artifacts);
+}
+
+#[test]
+fn flags_on_the_command_line_win_over_env_vars() {
+    let env = scrubbed_env();
+    env.set("PNPR_LISTEN", "0.0.0.0:4873");
+    env.set("PNPR_PACKUMENT_TTL_SECS", "90");
+    env.set("PNPR_DISABLE_ARTIFACTS", "false");
+
+    let args = Args::try_parse_from([
+        "pnpr",
+        "--listen",
+        "127.0.0.1:7677",
+        "--packument-ttl-secs",
+        "5",
+        "--disable-artifacts",
+    ])
+    .unwrap();
+
+    assert_eq!(args.listen, "127.0.0.1:7677".parse::<SocketAddr>().unwrap());
+    assert_eq!(args.packument_ttl_secs, Some(5));
+    assert!(args.disable_artifacts);
+}
+
+#[test]
+fn falsy_boolean_env_values_leave_the_flag_off() {
+    let env = scrubbed_env();
+    env.set("PNPR_OSV", "false");
+    env.set("PNPR_DISABLE_REGISTRY", "0");
+    env.set("PNPR_DISABLE_RESOLVER", "no");
+    env.set("PNPR_DISABLE_ARTIFACTS", "off");
+
+    let args = Args::try_parse_from(["pnpr"]).unwrap();
+
+    assert!(!args.osv);
+    assert!(!args.disable_registry);
+    assert!(!args.disable_resolver);
+    assert!(!args.disable_artifacts);
+}
+
+#[test]
+fn invalid_env_values_are_rejected() {
+    let env = scrubbed_env();
+
+    env.set("PNPR_OSV", "maybe");
+    let err = Args::try_parse_from(["pnpr"]).unwrap_err().to_string();
+    assert!(err.contains("'maybe' for '--osv'"), "{err}");
+    env.set("PNPR_OSV", "true");
+
+    env.set("PNPR_LISTEN", "not-an-address");
+    let err = Args::try_parse_from(["pnpr"]).unwrap_err().to_string();
+    assert!(err.contains("'not-an-address' for '--listen"), "{err}");
+    env.set("PNPR_LISTEN", "127.0.0.1:7677");
+
+    env.set("PNPR_PACKUMENT_TTL_SECS", "soon");
+    let err = Args::try_parse_from(["pnpr"]).unwrap_err().to_string();
+    assert!(err.contains("'soon' for '--packument-ttl-secs"), "{err}");
 }
 
 #[test]

--- a/pnpr/npm/pnpr/README.md
+++ b/pnpr/npm/pnpr/README.md
@@ -45,6 +45,19 @@ pnpm config set registry http://127.0.0.1:7677/
 | `--cache <path>` | Override the disposable proxy-cache directory (the mirror of upstream registries plus the resolver cache). Defaults to a `.pnpr-cache` subdirectory of `--storage`. |
 | `--public-url <url>` | URL clients should use to reach the server, used when rewriting `dist.tarball` in served packuments. Defaults to `http://<listen>`. |
 | `--packument-ttl-secs <n>` | Seconds before a cached packument is considered stale and refetched. |
+| `--osv` | Enable local OSV npm vulnerability checks. Requires a local OSV npm database at `--osv-db` or `<cache>/osv/npm/all.zip`. |
+| `--osv-db <path>` | Path to the local OSV npm database zip or extracted JSON directory. |
+| `--disable-registry` | Disable the npm-registry surface (packument and tarball reads, publish, unpublish, dist-tag, search). |
+| `--disable-resolver` | Disable the install-accelerator surface (`/-/pnpr/v0/resolve`, `/-/pnpr/v0/verify-lockfile`). |
+| `--disable-artifacts` | Disable the signed shared-artifact surface. |
+
+Every flag can also be set through an environment variable named after
+it: `PNPR_` followed by the flag name in upper case with dashes replaced
+by underscores. `--public-url` becomes `PNPR_PUBLIC_URL` and
+`--packument-ttl-secs` becomes `PNPR_PACKUMENT_TTL_SECS`. A flag given on
+the command line wins over its environment variable. Boolean flags such
+as `--disable-registry` accept `true`, `1`, `yes`, `on`, `false`, `0`,
+`no`, and `off`.
 
 Log level is controlled via the standard `RUST_LOG` environment
 variable (e.g. `RUST_LOG=debug pnpr`).


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

This PR adds the ability to configure the pnpr server through environment variables. It uses the `env` feature of the `clap` crate to bind existing CLI arguments to an environment variable.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
In somes cases it's easier to configure the pnpr server through environment variables (e.g. containers). This commit binds all CLI arguments to an environment variable (e.g. `--config` -> `PNPR_CONFIG`, `--public-url` -> `PNPR_PUBLIC_URL`)
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790893878&installation_model_id=426870&pr_number=14434&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14434&signature=5d99c7b524521493b76801581426c85cc19df86a58f04382405f9201f688852d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command-line configuration options can now be set through environment variables when corresponding flags are omitted.
  * Environment-variable configuration covers server settings, storage and cache paths, public URL, package metadata caching, security scanning, and feature-disable options.
  * Boolean settings now correctly recognize common truthy and falsy values, including `true`, `1`, `yes`, `false`, `0`, and `no`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->