### PR TITLE
perf(install): do the workspace graph work once per run

### DIFF
--- a/.changeset/one-graph-pass.md
+++ b/.changeset/one-graph-pass.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Speed up installs in large workspaces by doing the workspace dependency-graph work once: the graph's edges now resolve in parallel, the topological sort runs over borrowed paths instead of cloned ones, and a full unfiltered install reuses the cycle report its project selection already computed instead of rebuilding the graph to search again [#14352](https://github.com/pnpm/pnpm/issues/14352).
+Sped up installs in large workspaces: the workspace dependency graph is now built and searched for cycles once per run instead of twice, and its edges resolve in parallel [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/.changeset/one-graph-pass.md
+++ b/.changeset/one-graph-pass.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Speed up installs in large workspaces by doing the workspace dependency-graph work once: the graph's edges now resolve in parallel, the topological sort runs over borrowed paths instead of cloned ones, and a full unfiltered install reuses the cycle report its project selection already computed instead of rebuilding the graph to search again [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5959,6 +5959,7 @@ dependencies = [
  "pnpm-fs",
  "pnpm-workspace-range-resolver",
  "pnpm-workspace-spec",
+ "rayon",
 ]
 
 [[package]]

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -366,6 +366,7 @@ impl AddArgs {
             .save_target();
         let InstallFamilySelection {
             workspace_root: _,
+            workspace_cycles: _,
             mut projects,
             project_dependencies,
             ordered_dirs,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -721,6 +721,14 @@ fn workspace_install_selection(
         selected_dirs: selection.selected_dirs.as_ref(),
         install_dirs: selection.install_dirs.as_ref(),
         active_manifest_is_standin: selection.active_manifest_is_standin,
+        workspace_cycles: selection.workspace_cycles.as_ref().map_or(
+            pnpm_package_manager::PrecomputedWorkspaceCycles::Unknown,
+            |cycles| {
+                pnpm_package_manager::PrecomputedWorkspaceCycles::Known(
+                    (!cycles.is_empty()).then_some(cycles.as_slice()),
+                )
+            },
+        ),
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -369,7 +369,7 @@ impl InstallPipeline {
         let lockfile = cfg
             .shares_one_lockfile()
             .then(|| State::lazy_lockfile(cfg, &manifest_path, require_lockfile));
-        let certain_full_install = {
+        let certain_full_install = cfg.shares_one_lockfile() && {
             let manifest_dir =
                 manifest_path.parent().expect("manifest path always has a parent dir");
             let lockfile_dir = cfg.lockfile_dir_for(manifest_dir);

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -46,6 +46,11 @@ pub(crate) struct InstallFamilySelection {
     pub(crate) selected_dirs: Arc<HashSet<PathBuf>>,
     pub(crate) install_dirs: Arc<HashSet<PathBuf>>,
     pub(crate) active_manifest_is_standin: bool,
+    /// `Some` when the plan already ran the install's cycle search over
+    /// the same graph the install would rebuild (the unnarrowed case);
+    /// empty means the projects are orderable. `None` — the install
+    /// searches itself.
+    pub(crate) workspace_cycles: Option<Vec<Vec<PathBuf>>>,
 }
 
 /// How a recursive / filtered install-family command should be dispatched,
@@ -174,7 +179,7 @@ pub(crate) fn select_workspace_projects(
             );
         }
     }
-    let (project_dependencies, ordered_dirs, selected_dirs) = {
+    let (project_dependencies, ordered_dirs, selected_dirs, workspace_cycles) = {
         let selection = select_recursive_projects(
             &projects,
             cfg,
@@ -185,6 +190,17 @@ pub(crate) fn select_workspace_projects(
                 AutoExcludeRoot::Disabled
             },
         )?;
+        // Computed here only when it answers exactly what the install's
+        // own cycle search over its rebuilt graph would: an unnarrowed
+        // selection (`all` unset) is the whole graph in build order, so
+        // running the same search over it here lets the install skip
+        // the rebuild. A `--filter` / `--filter-prod` selection reorders
+        // the nodes (and prod-prunes some edges), so the install keeps
+        // its own search there.
+        let workspace_cycles =
+            (selection.all.is_none() && !cfg.ignore_workspace_cycles).then(|| {
+                pnpm_package_manager::workspace_cycles(&selection.selected).unwrap_or_default()
+            });
         let project_dependencies = if recursive_sort {
             filtered_projects_dependencies(
                 &selection.selected,
@@ -197,14 +213,24 @@ pub(crate) fn select_workspace_projects(
             dirs.sort();
             dirs.into_iter().map(|dir| (dir, Vec::new())).collect()
         };
+        // Sequenced over borrowed paths: cloning a workspace-scale edge
+        // map just to sort it cost more than the sort.
         let ordered_dirs = graph_sequencer(
-            &project_dependencies.iter().map(|(key, value)| (key.clone(), value.clone())).collect(),
-            &project_dependencies.keys().cloned().collect::<Vec<_>>(),
+            &project_dependencies
+                .iter()
+                .map(|(key, value)| {
+                    (key.as_path(), value.iter().map(PathBuf::as_path).collect::<Vec<_>>())
+                })
+                .collect(),
+            &project_dependencies.keys().map(PathBuf::as_path).collect::<Vec<_>>(),
         )
-        .order;
+        .order
+        .into_iter()
+        .map(Path::to_path_buf)
+        .collect();
         let selected_dirs: Arc<HashSet<PathBuf>> =
             Arc::new(selection.selected.keys().cloned().collect());
-        (project_dependencies, ordered_dirs, selected_dirs)
+        (project_dependencies, ordered_dirs, selected_dirs, workspace_cycles)
     };
 
     let active_dir = manifest_path.parent().expect("manifest path always has a parent dir");
@@ -233,6 +259,7 @@ pub(crate) fn select_workspace_projects(
         selected_dirs,
         install_dirs: Arc::new(install_dirs),
         active_manifest_is_standin,
+        workspace_cycles,
     }))
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -133,9 +133,16 @@ fn select_install_family_plan<Reporter: self::Reporter>(
     manifest_path: &Path,
     recursive_sort: bool,
     auto_exclude_root: bool,
+    precompute_workspace_cycles: bool,
 ) -> miette::Result<InstallFamilyPlan> {
-    let Some(selection) =
-        select_workspace_projects(cfg, prefix, manifest_path, recursive_sort, auto_exclude_root)?
+    let Some(selection) = select_workspace_projects_with_cycles(
+        cfg,
+        prefix,
+        manifest_path,
+        recursive_sort,
+        auto_exclude_root,
+        precompute_workspace_cycles,
+    )?
     else {
         return Ok(InstallFamilyPlan::Single);
     };
@@ -164,6 +171,29 @@ pub(crate) fn select_workspace_projects(
     manifest_path: &Path,
     recursive_sort: bool,
     auto_exclude_root: bool,
+) -> miette::Result<Option<InstallFamilySelection>> {
+    select_workspace_projects_with_cycles(
+        cfg,
+        prefix,
+        manifest_path,
+        recursive_sort,
+        auto_exclude_root,
+        false,
+    )
+}
+
+/// [`select_workspace_projects`], optionally running the install's
+/// workspace-cycle search over the selection graph while it is still in
+/// hand. Callers pass `true` only for a run that is certain to reach
+/// the cycle check — the "Already up to date" fast path returns before
+/// it, and a search it never reads would tax exactly that path.
+fn select_workspace_projects_with_cycles(
+    cfg: &Config,
+    prefix: &Path,
+    manifest_path: &Path,
+    recursive_sort: bool,
+    auto_exclude_root: bool,
+    precompute_workspace_cycles: bool,
 ) -> miette::Result<Option<InstallFamilySelection>> {
     if !cfg.recursive {
         return Ok(None);
@@ -337,18 +367,19 @@ impl InstallPipeline {
         let lockfile = cfg
             .shares_one_lockfile()
             .then(|| State::lazy_lockfile(cfg, &manifest_path, require_lockfile));
-        if let Some(lockfile) = lockfile.as_ref()
-            && !args.fix_lockfile
-        {
+        let certain_full_install = {
             let manifest_dir =
                 manifest_path.parent().expect("manifest path always has a parent dir");
             let lockfile_dir = cfg.lockfile_dir_for(manifest_dir);
-            if frozen_lockfile
+            frozen_lockfile
                 || cfg.force
                 || !pnpm_workspace_state::get_file_path(lockfile_dir).is_file()
-            {
-                lockfile.prefetch();
-            }
+        };
+        if let Some(lockfile) = lockfile.as_ref()
+            && !args.fix_lockfile
+            && certain_full_install
+        {
+            lockfile.prefetch();
         }
         let plan = select_install_family_plan::<Reporter>(
             cfg,
@@ -356,6 +387,7 @@ impl InstallPipeline {
             &manifest_path,
             recursive_sort,
             false,
+            certain_full_install,
         )?;
         match plan {
             InstallFamilyPlan::PerProject(project_dependencies) => {
@@ -457,6 +489,7 @@ impl AddPipeline {
                 &manifest_path,
                 recursive_sort,
                 true,
+                false,
             )?
         };
         match plan {
@@ -539,6 +572,7 @@ impl UpdatePipeline {
             &prefix,
             &manifest_path,
             recursive_sort,
+            false,
             false,
         )?;
         // An empty selection has nothing to update, and — like the shared
@@ -642,6 +676,7 @@ impl RemovePipeline {
             &prefix,
             &manifest_path,
             recursive_sort,
+            false,
             false,
         )?;
         match plan {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -227,8 +227,10 @@ fn select_workspace_projects_with_cycles(
         // the rebuild. A `--filter` / `--filter-prod` selection reorders
         // the nodes (and prod-prunes some edges), so the install keeps
         // its own search there.
-        let workspace_cycles =
-            (selection.all.is_none() && !cfg.ignore_workspace_cycles).then(|| {
+        let workspace_cycles = (precompute_workspace_cycles
+            && selection.all.is_none()
+            && !cfg.ignore_workspace_cycles)
+            .then(|| {
                 pnpm_package_manager::workspace_cycles(&selection.selected).unwrap_or_default()
             });
         let project_dependencies = if recursive_sort {

--- a/pnpm/crates/cli/src/cli_args/rebuild.rs
+++ b/pnpm/crates/cli/src/cli_args/rebuild.rs
@@ -254,6 +254,7 @@ pub(crate) async fn run_rebuild<Reporter: self::Reporter + 'static>(
                         selected_dirs: selection.selected_dirs.as_ref(),
                         install_dirs: selection.selected_dirs.as_ref(),
                         active_manifest_is_standin: selection.active_manifest_is_standin,
+                        workspace_cycles: pnpm_package_manager::PrecomputedWorkspaceCycles::Unknown,
                     },
                     rebuild,
                 )

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -95,6 +95,7 @@ impl RemoveArgs {
     ) -> miette::Result<()> {
         let InstallFamilySelection {
             workspace_root: _,
+            workspace_cycles: _,
             mut projects,
             project_dependencies,
             ordered_dirs,

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -394,6 +394,7 @@ impl UpdateArgs {
         let run_package_update = !self.interactive || !package_selectors.is_empty();
         let InstallFamilySelection {
             workspace_root: _,
+            workspace_cycles: _,
             mut projects,
             project_dependencies,
             ordered_dirs,

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -486,6 +486,7 @@ where
                 selected_dirs,
                 install_dirs,
                 active_manifest_is_standin,
+                workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
             }),
         )
         .await

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -248,6 +248,25 @@ pub struct WorkspaceInstallSelection<'a> {
     /// workspace root that pnpm treats as a full-install importer.
     pub install_dirs: &'a HashSet<PathBuf>,
     pub active_manifest_is_standin: bool,
+    pub workspace_cycles: PrecomputedWorkspaceCycles<'a>,
+}
+
+/// Whether the caller of a selected install already looked for
+/// dependency cycles among the selected projects.
+///
+/// A caller may pass [`Self::Known`] only when it ran
+/// [`crate::workspace_cycles`] over the very graph the install would
+/// rebuild — the same projects, in the same order, with the same graph
+/// options — so the report (its cycle order included) stays what the
+/// install's own [`crate::install_scope_cycles`] would emit.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum PrecomputedWorkspaceCycles<'a> {
+    /// It did not; the install runs its own cycle search.
+    #[default]
+    Unknown,
+    /// The cycle report for this selection; `None` — the projects are
+    /// orderable.
+    Known(Option<&'a [Vec<PathBuf>]>),
 }
 
 /// What this run does to the manifests of the projects it installs —

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -255,11 +255,11 @@ pub struct WorkspaceInstallSelection<'a> {
 /// dependency cycles among the selected projects.
 ///
 /// A caller may pass [`Self::Known`] only when it ran
-/// [`crate::workspace_cycles`] over the very graph the install would
+/// [`fn@crate::workspace_cycles`] over the very graph the install would
 /// rebuild — the same projects, in the same order, with the same graph
 /// options — so the report (its cycle order included) stays what the
 /// install's own [`crate::install_scope_cycles`] would emit.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum PrecomputedWorkspaceCycles<'a> {
     /// It did not; the install runs its own cycle search.
     #[default]

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -449,7 +449,19 @@ where
             && let Some(workspace_dir) = workspace_dir_opt.as_deref()
         {
             let scope = match selection.as_ref() {
-                Some(selection) => Some((selection.all_projects, Some(selection.selected_dirs))),
+                // A plan that already sequenced this very graph hands
+                // its cycle report over; the install then skips
+                // rebuilding the graph just to find them again.
+                Some(selection) => match selection.workspace_cycles {
+                    crate::PrecomputedWorkspaceCycles::Known(cycles) => {
+                        crate::report_workspace_cycles::<Reporter>(config, workspace_dir, cycles)
+                            .map_err(InstallError::CyclicWorkspaceDependencies)?;
+                        None
+                    }
+                    crate::PrecomputedWorkspaceCycles::Unknown => {
+                        Some((selection.all_projects, Some(selection.selected_dirs)))
+                    }
+                },
                 // A single-project mutation (`add`, `update`, ...) has no
                 // set to cycle within; only a full install covers the
                 // whole workspace.

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -253,6 +253,7 @@ impl Remove<'_> {
             selected_dirs,
             install_dirs,
             active_manifest_is_standin,
+            workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
         })
         .await
         .pipe(defer_ignored_builds)

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -642,6 +642,7 @@ impl Update<'_> {
             selected_dirs,
             install_dirs,
             active_manifest_is_standin,
+            workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
         };
         let ignored_builds = match lockfile_specifier_project_manifests {
             Some(manifests) => {

--- a/pnpm/crates/package-manager/src/workspace_cycles.rs
+++ b/pnpm/crates/package-manager/src/workspace_cycles.rs
@@ -30,25 +30,29 @@ use std::{
 /// unorderable, so only cycles with more than one project are returned.
 #[must_use]
 pub fn workspace_cycles<Pkg>(graph: &ProjectGraph<Pkg>) -> Option<Vec<Vec<PathBuf>>> {
-    let dirs: Vec<PathBuf> = graph.keys().cloned().collect();
-    let included: HashSet<&Path> = dirs.iter().map(PathBuf::as_path).collect();
-    let edges: HashMap<PathBuf, Vec<PathBuf>> = graph
+    // The sequencer runs over borrowed paths: a workspace-scale graph
+    // holds tens of thousands of edges, and cloning every `PathBuf`
+    // into a throwaway map cost more than the sort itself.
+    let dirs: Vec<&Path> = graph.keys().map(PathBuf::as_path).collect();
+    let included: HashSet<&Path> = dirs.iter().copied().collect();
+    let edges: HashMap<&Path, Vec<&Path>> = graph
         .iter()
         .map(|(dir, node)| {
             let dependencies = node
                 .dependencies
                 .iter()
-                .filter(|dependency| included.contains(dependency.as_path()))
-                .cloned()
+                .map(PathBuf::as_path)
+                .filter(|dependency| included.contains(dependency))
                 .collect();
-            (dir.clone(), dependencies)
+            (dir.as_path(), dependencies)
         })
         .collect();
     let cycles = graph_sequencer(&edges, &dirs)
         .cycles
         .into_iter()
         .filter(|cycle| cycle.len() > 1)
-        .collect::<Vec<_>>();
+        .map(|cycle| cycle.into_iter().map(Path::to_path_buf).collect())
+        .collect::<Vec<Vec<PathBuf>>>();
     (!cycles.is_empty()).then_some(cycles)
 }
 

--- a/pnpm/crates/workspace-projects-graph/Cargo.toml
+++ b/pnpm/crates/workspace-projects-graph/Cargo.toml
@@ -17,6 +17,7 @@ pnpm-workspace-spec           = { workspace = true }
 
 indexmap    = { workspace = true }
 node-semver = { workspace = true }
+rayon       = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpm/crates/workspace-projects-graph/src/create_projects_graph.rs
+++ b/pnpm/crates/workspace-projects-graph/src/create_projects_graph.rs
@@ -7,6 +7,7 @@ use node_semver::{Range, Version};
 use pnpm_fs::lexical_normalize;
 use pnpm_workspace_range_resolver::resolve_workspace_range;
 use pnpm_workspace_spec::WorkspaceSpec;
+use rayon::prelude::*;
 use std::{collections::HashMap, path::PathBuf};
 
 /// Options for [`create_projects_graph()`].
@@ -92,18 +93,31 @@ where
         link_workspace_packages: opts.link_workspace_packages,
     };
 
+    // Each importer's edges resolve against the immutable lookup
+    // tables only, so the importers fan out across the rayon pool; the
+    // per-importer unmatched lists are flattened in importer order
+    // below, keeping the reported set and its order deterministic.
+    let per_importer: Vec<(Vec<PathBuf>, Vec<Unmatched>)> = dependency_lists
+        .par_iter()
+        .enumerate()
+        .map(|(importer, dependencies)| {
+            let mut edges = Vec::new();
+            let mut unmatched = Vec::new();
+            for (dep_name, raw_spec) in dependencies {
+                if let Some(target) =
+                    resolve_edge(importer, dep_name, raw_spec, &lookups, &mut unmatched)
+                {
+                    edges.push(target);
+                }
+            }
+            (edges, unmatched)
+        })
+        .collect();
     let mut unmatched = Vec::new();
     let mut all_edges: Vec<Vec<PathBuf>> = Vec::with_capacity(count);
-    for (importer, dependencies) in dependency_lists.iter().enumerate() {
-        let mut edges = Vec::new();
-        for (dep_name, raw_spec) in dependencies {
-            if let Some(target) =
-                resolve_edge(importer, dep_name, raw_spec, &lookups, &mut unmatched)
-            {
-                edges.push(target);
-            }
-        }
+    for (edges, importer_unmatched) in per_importer {
         all_edges.push(edges);
+        unmatched.extend(importer_unmatched);
     }
 
     let mut graph: ProjectGraph<Pkg> = IndexMap::with_capacity(count);


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352 — this one goes after a structural duplication rather than a hot loop: a workspace-scale install paid for its project dependency graph several times over. The plan built the graph (`create_projects_graph`), sorted it, and threw the sequencer's cycle report away; the install then rebuilt the same graph from the same project list just to search for the cycles again (`install_scope_cycles`). Both sequencer call sites also deep-cloned their inputs — the plan cloned the entire edge map to sort it, and `workspace_cycles` cloned every node and edge into a throwaway map. On the issue's reproduction that's ~290 ms of graph work for a graph the run needs once.

Three changes, none visible outside:

- **Parallel edge resolution.** `create_projects_graph` resolves each project's edges against immutable lookup tables only, so the projects fan out across the rayon pool; the per-project unmatched lists flatten in project order, keeping the result (and the unmatched report) deterministic. Benefits every caller — plan, cycle check, filters, `run -r`.
- **Borrowed-path sequencing.** Both `graph_sequencer` call sites now run over `&Path` maps borrowed from the graph they sort, instead of deep-cloned `PathBuf` maps.
- **One cycle search per run.** The plan's selection now carries a cycle report (`PrecomputedWorkspaceCycles`) the install consumes instead of rebuilding the graph — but only for the *unnarrowed* selection, where the plan's graph is the very graph the install would rebuild: same projects, same order, same graph options, so the emitted warning is byte-identical (verified — the reproduction's 16,956-character cyclic-dependencies warning hashes identically). A `--filter` / `--filter-prod` selection reorders nodes and prod-prunes edges, so the install keeps its own search there, as do `add` / `update` / `remove` / `rebuild` (they pass `Unknown`).

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, 87,630 `workspace:*` edges; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| scope report → resolution start (median of 8) | 310 ms | 208 ms |
| whole warm update (median of 8) | 1.50 s | 1.43 s |

The written `pnpm-lock.yaml` and the cyclic-workspace-dependencies warning are both byte-identical. The full `pnpm-cli` suite passes (the 10 failures on my machine are a pre-existing local-environment set that fails on clean main identically).

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.43 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
A workspace-scale install paid for its project dependency graph
several times over. The plan built the graph, sorted it, and threw the
sequencer's cycle report away; the install then rebuilt the same graph
from the same project list just to search for the cycles again. Both
sequencer call sites also deep-cloned their inputs - the plan cloned
the entire edge map to sort it, and workspace_cycles cloned every node
and edge into a throwaway map.

Three changes, none visible outside:

- create_projects_graph resolves each project's edges against
  immutable lookup tables, so the projects fan out across the rayon
  pool; the per-project unmatched lists flatten in project order,
  keeping the result deterministic.
- Both sequencer call sites run over borrowed paths.
- The plan's selection carries a cycle report the install consumes
  instead of rebuilding the graph - but only for the unnarrowed
  selection, where the plan's graph is the very graph the install
  would rebuild (same projects, same order, same options), so the
  emitted warning is byte-identical. A filtered or prod-pruned
  selection reorders nodes and prunes edges, so the install keeps its
  own search there, as do add/update/remove/rebuild.

On the 6,833-project reproduction from pnpm/pnpm#14352 (87,630
workspace edges, warm non-noop lockfile-only update), the span between
the scope report and resolution start drops from ~310 ms to ~208 ms
and whole-run wall time from ~1.50 s to ~1.43 s median; the written
lockfile and the cyclic-dependencies warning are byte-identical.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — determinism and the report
  format are pinned by the existing graph, sequencer, and cycle-warning tests,
  all passing unchanged; byte-identity of the lockfile and the warning was
  verified on the reproduction.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790894819&installation_model_id=426870&pr_number=14435&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14435&signature=a9e2001e58565eada29c7474ac066ce050dc88afd6b7d464dcef2967d5d33565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved workspace installation performance through parallel dependency resolution.
  * Reduced overhead when analyzing workspace dependency graphs by avoiding redundant cycle checks.
  * Reused cycle-detection results during full workspace installs.
  * Preserved deterministic dependency ordering and existing cycle-reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->