### PR TITLE
fix(network): use the system DNS resolver on Windows

### DIFF
--- a/.changeset/windows-native-dns-firewall.md
+++ b/.changeset/windows-native-dns-firewall.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+On Windows, pnpm now resolves hostnames through the system resolver instead of its own DNS client. The built-in client bound a UDP socket for every lookup, which made Windows Defender Firewall ask to allow `pnpm.exe` again after every `pnpm self-update` [#14405](https://github.com/pnpm/pnpm/issues/14405).

--- a/.changeset/windows-native-dns-firewall.md
+++ b/.changeset/windows-native-dns-firewall.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-On Windows, pnpm now resolves hostnames through the system resolver instead of its own DNS client. The built-in client bound a UDP socket for every lookup, which made Windows Defender Firewall ask to allow `pnpm.exe` again after every `pnpm self-update` [#14405](https://github.com/pnpm/pnpm/issues/14405).
+On Windows, pnpm now resolves host names through the system resolver instead of its own DNS client. The built-in client bound a UDP socket for every lookup, which made Windows Defender Firewall ask to allow `pnpm.exe` again after every `pnpm self-update` [#14405](https://github.com/pnpm/pnpm/issues/14405).

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -366,11 +366,13 @@ impl ThrottledClient {
     /// [`DEFAULT_FETCH_TIMEOUT_MS`] (60s), the `fetchTimeout` setting's
     /// default.
     ///
-    /// DNS resolution is platform-specific. macOS uses its native
-    /// `getaddrinfo` resolver because Hickory misses scoped resolver
-    /// routing used by VPNs. A four-request cap matches Node's libuv DNS
-    /// pool and prevents concurrent calls from overwhelming
-    /// `mDNSResponder`. Other platforms keep Hickory's async resolver.
+    /// DNS resolution is platform-specific. macOS and Windows use the
+    /// native `getaddrinfo` resolver: Hickory misses the scoped resolver
+    /// routing VPNs use on macOS, and its wildcard UDP binds trip Windows
+    /// Defender Firewall prompts. A process-wide four-lookup cap, shared
+    /// by every client, matches Node's libuv DNS pool and keeps
+    /// concurrent calls from overwhelming `mDNSResponder`. Other
+    /// platforms keep Hickory's async resolver.
     #[must_use]
     pub fn new_for_installs() -> Self {
         Self::for_installs(

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -27,9 +27,9 @@ pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use priority_semaphore::{Permit, PrioritySemaphore};
 use proxy::{NoProxyMatcher, parse_proxy_url, strip_userinfo};
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 use reqwest::dns::Addrs;
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", windows, test))]
 use reqwest::dns::{Name, Resolve, Resolving};
 use reqwest::{
     Certificate, Client, Identity, Proxy,
@@ -760,16 +760,16 @@ fn is_redirect_status(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 301 | 302 | 303 | 307 | 308)
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", windows, test))]
 struct CappedDnsResolver<Inner> {
     inner: Arc<Inner>,
     permits: Arc<Semaphore>,
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 struct NativeDnsResolver;
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", windows))]
 impl Resolve for NativeDnsResolver {
     fn resolve(&self, name: Name) -> Resolving {
         let host = name.as_str().to_owned();
@@ -782,14 +782,14 @@ impl Resolve for NativeDnsResolver {
     }
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", windows, test))]
 impl<Inner> CappedDnsResolver<Inner> {
     fn new(inner: Inner, concurrency: NonZeroUsize) -> Self {
         Self { inner: Arc::new(inner), permits: Arc::new(Semaphore::new(concurrency.get())) }
     }
 }
 
-#[cfg(any(target_os = "macos", test))]
+#[cfg(any(target_os = "macos", windows, test))]
 impl<Inner> Resolve for CappedDnsResolver<Inner>
 where
     Inner: Resolve + 'static,
@@ -805,14 +805,26 @@ where
     }
 }
 
-#[cfg(target_os = "macos")]
+/// Resolve through the platform's `getaddrinfo`, capped at Node's libuv
+/// thread-pool width so `mDNSResponder` is not overloaded.
+///
+/// macOS needs the system resolver for its scoped/supplemental resolver
+/// graph (VPN split DNS), which Hickory does not read. Windows needs it
+/// because Hickory sends every query from a freshly bound wildcard UDP
+/// socket, and Windows Defender Firewall treats that bind as a listener:
+/// it prompts the user to allow `pnpm.exe`, keyed on the executable's
+/// path, so every newly installed engine prompts again
+/// (pnpm/pnpm#14405). `getaddrinfo` hands the query to the Dnscache
+/// service and binds nothing in this process, and it also honors NRPT and
+/// per-adapter DNS settings.
+#[cfg(any(target_os = "macos", windows))]
 fn configure_dns(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     const DNS_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(4).expect("four is non-zero");
 
     builder.dns_resolver(CappedDnsResolver::new(NativeDnsResolver, DNS_CONCURRENCY))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", windows)))]
 fn configure_dns(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
     builder.hickory_dns(true)
 }

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -760,13 +760,16 @@ fn is_redirect_status(status: reqwest::StatusCode) -> bool {
     matches!(status.as_u16(), 301 | 302 | 303 | 307 | 308)
 }
 
+/// Caps concurrent lookups through `Inner`. Clones share the cap.
 #[cfg(any(target_os = "macos", windows, test))]
+#[derive(Clone)]
 struct CappedDnsResolver<Inner> {
     inner: Arc<Inner>,
     permits: Arc<Semaphore>,
 }
 
 #[cfg(any(target_os = "macos", windows))]
+#[derive(Clone)]
 struct NativeDnsResolver;
 
 #[cfg(any(target_os = "macos", windows))]
@@ -819,9 +822,15 @@ where
 /// per-adapter DNS settings.
 #[cfg(any(target_os = "macos", windows))]
 fn configure_dns(builder: reqwest::ClientBuilder) -> reqwest::ClientBuilder {
-    const DNS_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(4).expect("four is non-zero");
+    // One cap per process, like the libuv thread pool it mirrors: the
+    // redirect pair, every per-registry override, and the bundled-roots
+    // retry all draw on the same four permits.
+    static RESOLVER: LazyLock<CappedDnsResolver<NativeDnsResolver>> = LazyLock::new(|| {
+        const DNS_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(4).expect("four is non-zero");
+        CappedDnsResolver::new(NativeDnsResolver, DNS_CONCURRENCY)
+    });
 
-    builder.dns_resolver(CappedDnsResolver::new(NativeDnsResolver, DNS_CONCURRENCY))
+    builder.dns_resolver(RESOLVER.clone())
 }
 
 #[cfg(not(any(target_os = "macos", windows)))]

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -13,8 +13,8 @@
 
 use super::{
     CappedDnsResolver, ForInstallsError, NetworkSettings, NoProxyMatcher, NoProxySetting,
-    PerRegistryTls, ProxyConfig, ProxyError, ThrottledClient, TlsConfig, origin_of,
-    parse_proxy_url,
+    PerRegistryTls, ProxyConfig, ProxyError, ThrottledClient, TlsConfig, bundled_root_certs,
+    origin_of, parse_proxy_url,
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
 use pnpm_testing_utils::env_guard::EnvGuard;
@@ -531,11 +531,15 @@ async fn from_clients_uses_the_supplied_no_redirect_configuration() {
         .create_async()
         .await;
     let final_mock = registry.mock("GET", "/final").expect(0).create_async().await;
+    // Bundled roots only: a sibling test may have pointed `SSL_CERT_FILE` at
+    // an empty bundle, which makes a platform-verifier client unbuildable.
     let client = reqwest::Client::builder()
+        .tls_certs_only(bundled_root_certs().iter().cloned())
         .user_agent("ordinary-client")
         .build()
         .expect("build ordinary client");
     let client_without_redirects = reqwest::Client::builder()
+        .tls_certs_only(bundled_root_certs().iter().cloned())
         .user_agent("strict-client")
         .redirect(reqwest::redirect::Policy::none())
         .build()


### PR DESCRIPTION
## Summary

On Windows, the Rust CLI resolved host names with Hickory DNS, which sends every query from a freshly bound wildcard UDP socket. Windows Defender Firewall treats that bind as a listener and shows the "Allow pnpm.exe to communicate" prompt, keyed on the executable's path. Since every `pnpm self-update` installs the engine into a new uniquely named directory (and project pins run version-specific engines from the global virtual store), every new version prompts again.

This PR routes Windows through the same `getaddrinfo` resolver macOS already uses (`tokio::net::lookup_host`, capped at four concurrent lookups for Node parity). The lookup is handed to the Dnscache service, nothing is bound inside the pnpm process, and NRPT / per-adapter DNS settings are honored. Hickory stays on Linux only. Hickory was originally enabled to dodge macOS `mDNSResponder` failures under concurrent `getaddrinfo`, and macOS itself moved back to the native resolver in pnpm/pnpm#12934.

It also fixes a pre-existing race in the network test suite: `from_clients_uses_the_supplied_no_redirect_configuration` built platform-verifier clients while a sibling test points `SSL_CERT_FILE` at an empty bundle, so the suite failed as a whole on Linux with "No CA certificates were loaded from the system" while the test passed alone. The test now builds its clients on the bundled roots.

Related to pnpm/pnpm#14425: code signing gives the binaries a publisher identity, but Win32 firewall rules are keyed on the program path, not the signer, so signing alone does not stop the re-prompt. Removing the bind does, regardless of path.

The TypeScript CLI resolves through Node's `dns.lookup` (`getaddrinfo`) already, so this brings the Rust CLI to parity; no TS change is needed.

Closes pnpm/pnpm#14405

## Squash Commit Body

```text
Hickory sends every DNS query from a freshly bound wildcard UDP socket.
Windows Defender Firewall treats that bind as a listener and prompts the
user to allow pnpm.exe, keyed on the executable's path. Every
self-update installs the engine into a new uniquely named directory, so
every new version prompts again.

Windows now takes the getaddrinfo path macOS already uses: the lookup is
handed to the Dnscache service, nothing is bound in this process, and
NRPT / per-adapter DNS settings are honored. The Node-parity concurrency
cap of four is kept. Hickory was only ever needed to dodge macOS
mDNSResponder failures, and macOS itself no longer uses it.

Also stop `from_clients_uses_the_supplied_no_redirect_configuration`
from consulting the system trust store: a sibling test points
SSL_CERT_FILE at an empty bundle, which made the platform-verifier
clients unbuildable when the suite ran as a whole.

Closes https://github.com/pnpm/pnpm/issues/14405
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoGrKWfG1GwDT6F2BXhr3d

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790895013&installation_model_id=426870&pr_number=14436&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14436&signature=0924166261b03677bd83ce339b98288be9166e4a0c0aa7cdb7ab22137f8e709e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows host-name resolution by using the system’s native DNS resolver.
  * Reduced repeated firewall prompts that could appear after application self-updates.
* **Reliability**
  * Coordinated DNS requests across network connections with a shared lookup limit.
  * Improved certificate handling by using bundled trusted certificate authorities when needed.
  * Increased consistency for network connections across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->