### PR TITLE
fix(cli): render the interactive update prompt like pnpm 11

### DIFF
--- a/.changeset/quiet-prompt-headings.md
+++ b/.changeset/quiet-prompt-headings.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update --interactive` renders its checklist the way pnpm 11 does: group headings and column headers are separators the cursor skips instead of checkboxes that select nothing, the columns of one group line up with the next, `a` toggles all and `i` inverts the selection, and the confirmed selection is echoed as a list of package names [#14423](https://github.com/pnpm/pnpm/issues/14423).

--- a/pnpm/crates/cli/src/checkbox_prompt.rs
+++ b/pnpm/crates/cli/src/checkbox_prompt.rs
@@ -1,0 +1,378 @@
+//! A checkbox prompt shaped like `@inquirer/checkbox`, the prompt behind
+//! pnpm's interactive commands.
+//!
+//! The list can hold separators — a group heading, a table's column
+//! header — that are drawn but never selected: the cursor skips them and
+//! they take no part in the answer. `dialoguer::MultiSelect` has no such
+//! notion, so a heading shown through it is a checkbox that toggles
+//! nothing.
+//!
+//! The keys are `@inquirer/checkbox`'s with its vim bindings: the arrows
+//! or `j`/`k` move, space toggles, `a` toggles all, `i` inverts, a digit
+//! toggles that choice, Enter confirms, and Ctrl-C cancels.
+
+use console::{Key, Term, measure_text_width};
+use owo_colors::{OwoColorize, Stream};
+use std::io;
+
+/// One line of a [`CheckboxPrompt`].
+pub(crate) enum CheckboxItem<Value> {
+    /// Drawn as is, skipped by the cursor.
+    Separator(String),
+    Choice(CheckboxChoice<Value>),
+}
+
+pub(crate) struct CheckboxChoice<Value> {
+    /// The line shown while choosing.
+    pub name: String,
+    /// How the confirmed answer names the choice.
+    pub short: String,
+    pub value: Value,
+}
+
+/// The glyphs and highlighting of a [`CheckboxPrompt`].
+///
+/// The default is `@inquirer/checkbox`'s own theme: a filled circle for a
+/// checked choice, a hollow one otherwise, and the active row in cyan.
+pub(crate) struct CheckboxTheme {
+    pub checked: String,
+    pub unchecked: String,
+    pub highlight_active: bool,
+}
+
+impl Default for CheckboxTheme {
+    fn default() -> Self {
+        Self {
+            checked: stdout_styled("◉", |text| text.green().to_string()),
+            unchecked: "◯".to_string(),
+            highlight_active: true,
+        }
+    }
+}
+
+/// What the answer to a [`CheckboxPrompt`] was.
+#[derive(Debug)]
+pub(crate) enum CheckboxAnswer<Value> {
+    /// Enter confirmed these choices, in list order.
+    Selected(Vec<Value>),
+    /// Ctrl-C.
+    Cancelled,
+}
+
+pub(crate) struct CheckboxPrompt<Value> {
+    message: String,
+    items: Vec<CheckboxItem<Value>>,
+    checked: Vec<bool>,
+    active: usize,
+    /// The first item on screen.
+    top: usize,
+    /// Lines of the list shown at once; `0` until the terminal is measured,
+    /// which shows the whole list.
+    page_size: usize,
+    required: bool,
+    theme: CheckboxTheme,
+    error: Option<&'static str>,
+}
+
+/// What a key did, beyond changing the screen.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum KeyOutcome {
+    Redraw,
+    Submit,
+    Cancel,
+}
+
+/// The [`CheckboxPrompt::page_size`] `@inquirer/checkbox` is given when the
+/// terminal height is unknown, and the least it is given otherwise.
+const MIN_PAGE_SIZE: usize = 7;
+/// The lines of a frame that are not the list: the message and the
+/// help line, with room for a wrapped message and the error line.
+const FRAME_OVERHEAD: usize = 6;
+
+impl<Value> CheckboxPrompt<Value> {
+    pub(crate) fn new(message: impl Into<String>, items: Vec<CheckboxItem<Value>>) -> Self {
+        let checked = vec![false; items.len()];
+        let active = items.iter().position(is_choice).unwrap_or_default();
+        Self {
+            message: message.into(),
+            items,
+            checked,
+            active,
+            top: 0,
+            page_size: 0,
+            required: false,
+            theme: CheckboxTheme::default(),
+            error: None,
+        }
+    }
+
+    /// Refuse to confirm an empty selection.
+    pub(crate) fn required(mut self, required: bool) -> Self {
+        self.required = required;
+        self
+    }
+
+    pub(crate) fn theme(mut self, theme: CheckboxTheme) -> Self {
+        self.theme = theme;
+        self
+    }
+
+    /// Run the prompt on the terminal behind stdout.
+    ///
+    /// Fails when stdout is not a terminal or the list has no choice to
+    /// make.
+    pub(crate) fn interact(mut self) -> io::Result<CheckboxAnswer<Value>> {
+        if !self.items.iter().any(is_choice) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "the checkbox prompt was given no choice to make",
+            ));
+        }
+        let term = Term::stdout();
+        if !term.is_term() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "the checkbox prompt needs a terminal on stdout",
+            ));
+        }
+        if self.page_size == 0 {
+            self.page_size = page_size_for(&term);
+        }
+        term.hide_cursor()?;
+        let answer = self.interact_on(&term);
+        term.show_cursor()?;
+        term.flush()?;
+        answer
+    }
+
+    fn interact_on(&mut self, term: &Term) -> io::Result<CheckboxAnswer<Value>> {
+        let columns = usize::from(term.size().1);
+        let mut drawn_rows = 0;
+        loop {
+            let frame = self.render_frame();
+            term.clear_last_lines(drawn_rows)?;
+            term.write_line(&frame)?;
+            term.flush()?;
+            drawn_rows = terminal_rows(&frame, columns);
+            match self.handle_key(&term.read_key_raw()?) {
+                KeyOutcome::Redraw => {}
+                KeyOutcome::Submit => {
+                    term.clear_last_lines(drawn_rows)?;
+                    term.write_line(&self.render_answer())?;
+                    return Ok(CheckboxAnswer::Selected(self.take_selected()));
+                }
+                KeyOutcome::Cancel => return Ok(CheckboxAnswer::Cancelled),
+            }
+        }
+    }
+
+    pub(crate) fn handle_key(&mut self, key: &Key) -> KeyOutcome {
+        match key {
+            Key::Enter => {
+                if self.required && !self.checked.iter().any(|&checked| checked) {
+                    self.error = Some("At least one choice must be selected");
+                    return KeyOutcome::Redraw;
+                }
+                return KeyOutcome::Submit;
+            }
+            Key::CtrlC => return KeyOutcome::Cancel,
+            Key::ArrowUp | Key::Char('k') => self.move_active(-1),
+            Key::ArrowDown | Key::Char('j') => self.move_active(1),
+            Key::Char(' ') => {
+                self.error = None;
+                self.checked[self.active] = !self.checked[self.active];
+            }
+            Key::Char('a') => {
+                let select_all = self
+                    .items
+                    .iter()
+                    .zip(&self.checked)
+                    .any(|(item, &checked)| is_choice(item) && !checked);
+                self.check_every_choice(|_| select_all);
+            }
+            Key::Char('i') => self.check_every_choice(|checked| !checked),
+            Key::Char(digit @ '1'..='9') => {
+                let nth = usize::from(*digit as u8 - b'1');
+                if let Some(index) = self
+                    .items
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, item)| is_choice(item))
+                    .nth(nth)
+                    .map(|(index, _)| index)
+                {
+                    self.active = index;
+                    self.checked[index] = !self.checked[index];
+                }
+            }
+            _ => {}
+        }
+        self.scroll_into_view();
+        KeyOutcome::Redraw
+    }
+
+    /// Move the cursor `offset` choices, wrapping around the list and
+    /// stepping over separators.
+    fn move_active(&mut self, offset: isize) {
+        self.error = None;
+        let len = self.items.len();
+        let mut next = self.active;
+        loop {
+            next = (next as isize + offset).rem_euclid(len as isize) as usize;
+            if is_choice(&self.items[next]) {
+                break;
+            }
+        }
+        self.active = next;
+    }
+
+    fn check_every_choice(&mut self, checked: impl Fn(bool) -> bool) {
+        for (item, slot) in self.items.iter().zip(&mut self.checked) {
+            if is_choice(item) {
+                *slot = checked(*slot);
+            }
+        }
+    }
+
+    /// Keep the active row on the page, and with it the separators
+    /// directly above it — a group's heading and column header — when
+    /// they fit.
+    fn scroll_into_view(&mut self) {
+        if self.page_size == 0 {
+            return;
+        }
+        if self.active < self.top {
+            self.top = self.active;
+        } else if self.active >= self.top + self.page_size {
+            self.top = self.active + 1 - self.page_size;
+        }
+        while self.top > 0
+            && !is_choice(&self.items[self.top - 1])
+            && self.active + 1 - (self.top - 1) <= self.page_size
+        {
+            self.top -= 1;
+        }
+    }
+
+    /// The screen while choosing: the message, the visible page of the
+    /// list, an error if the last Enter was refused, and the key help.
+    pub(crate) fn render_frame(&self) -> String {
+        let prefix = stdout_styled("?", |text| text.blue().to_string());
+        let message = stdout_styled(&self.message, |text| text.bold().to_string());
+        let mut lines = vec![format!("{prefix} {message}")];
+        lines.extend(self.render_page());
+        lines.push(" ".to_string());
+        if let Some(error) = self.error {
+            let error = format!("> {error}");
+            lines.push(stdout_styled(&error, |text| text.red().to_string()));
+        }
+        lines.push(render_help_line());
+        lines.join("\n").trim_end().to_string()
+    }
+
+    fn render_page(&self) -> Vec<String> {
+        let end = if self.page_size == 0 {
+            self.items.len()
+        } else {
+            (self.top + self.page_size).min(self.items.len())
+        };
+        (self.top..end).map(|index| self.render_item(index)).collect()
+    }
+
+    fn render_item(&self, index: usize) -> String {
+        match &self.items[index] {
+            CheckboxItem::Separator(text) => format!(" {text}"),
+            CheckboxItem::Choice(choice) => {
+                let active = index == self.active;
+                let cursor = if active { "❯" } else { " " };
+                let checkbox =
+                    if self.checked[index] { &self.theme.checked } else { &self.theme.unchecked };
+                let line = format!("{cursor}{checkbox} {}", choice.name);
+                if active && self.theme.highlight_active {
+                    stdout_styled(&line, |text| text.cyan().to_string())
+                } else {
+                    line
+                }
+            }
+        }
+    }
+
+    /// The line left behind once Enter confirmed the selection.
+    pub(crate) fn render_answer(&self) -> String {
+        let prefix = stdout_styled("✔", |text| text.green().to_string());
+        let message = stdout_styled(&self.message, |text| text.bold().to_string());
+        let shorts = self
+            .selected_choices()
+            .map(|choice| choice.short.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let answer = stdout_styled(&shorts, |text| text.cyan().to_string());
+        format!("{prefix} {message} {answer}")
+    }
+
+    pub(crate) fn selected_choices(&self) -> impl Iterator<Item = &CheckboxChoice<Value>> {
+        self.items.iter().zip(&self.checked).filter_map(|(item, &checked)| match item {
+            CheckboxItem::Choice(choice) if checked => Some(choice),
+            _ => None,
+        })
+    }
+
+    fn take_selected(&mut self) -> Vec<Value> {
+        let checked = std::mem::take(&mut self.checked);
+        std::mem::take(&mut self.items)
+            .into_iter()
+            .zip(checked)
+            .filter_map(|(item, checked)| match item {
+                CheckboxItem::Choice(choice) if checked => Some(choice.value),
+                _ => None,
+            })
+            .collect()
+    }
+}
+
+fn is_choice<Value>(item: &CheckboxItem<Value>) -> bool {
+    matches!(item, CheckboxItem::Choice(_))
+}
+
+/// `↑↓ navigate • space select • a all • i invert • ⏎ submit`, with the
+/// keys in bold and the rest dimmed.
+fn render_help_line() -> String {
+    [("↑↓", "navigate"), ("space", "select"), ("a", "all"), ("i", "invert"), ("⏎", "submit")]
+        .into_iter()
+        .map(|(key, action)| {
+            let key = stdout_styled(key, |text| text.bold().to_string());
+            let action = stdout_styled(action, |text| text.dimmed().to_string());
+            format!("{key} {action}")
+        })
+        .collect::<Vec<_>>()
+        .join(&stdout_styled(" • ", |text| text.dimmed().to_string()))
+}
+
+/// pnpm's `interactivePromptPageSize()`: the terminal height less the
+/// frame around the list, and never fewer than seven lines.
+fn page_size_for(term: &Term) -> usize {
+    term.size_checked().map_or(MIN_PAGE_SIZE, |(rows, _)| {
+        usize::from(rows).saturating_sub(FRAME_OVERHEAD).max(MIN_PAGE_SIZE)
+    })
+}
+
+/// The terminal rows `frame` occupies once lines wider than the terminal
+/// wrap, which is how many rows clearing it has to reach back over.
+fn terminal_rows(frame: &str, columns: usize) -> usize {
+    frame
+        .split('\n')
+        .map(|line| {
+            if columns == 0 {
+                return 1;
+            }
+            measure_text_width(line).div_ceil(columns).max(1)
+        })
+        .sum()
+}
+
+fn stdout_styled(text: &str, style: impl Fn(&str) -> String) -> String {
+    text.if_supports_color(Stream::Stdout, |text| style(text)).to_string()
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/checkbox_prompt.rs
+++ b/pnpm/crates/cli/src/checkbox_prompt.rs
@@ -1,15 +1,9 @@
 //! A checkbox prompt shaped like `@inquirer/checkbox`, the prompt behind
-//! pnpm's interactive commands.
+//! pnpm's interactive commands, with its keys and vim bindings.
 //!
 //! The list can hold separators — a group heading, a table's column
 //! header — that are drawn but never selected: the cursor skips them and
-//! they take no part in the answer. `dialoguer::MultiSelect` has no such
-//! notion, so a heading shown through it is a checkbox that toggles
-//! nothing.
-//!
-//! The keys are `@inquirer/checkbox`'s with its vim bindings: the arrows
-//! or `j`/`k` move, space toggles, `a` toggles all, `i` inverts, a digit
-//! toggles that choice, Enter confirms, and Ctrl-C cancels.
+//! they take no part in the answer.
 
 use console::{Key, Term, measure_text_width};
 use owo_colors::{OwoColorize, Stream};
@@ -117,10 +111,10 @@ impl<Value> CheckboxPrompt<Value> {
         self
     }
 
-    /// Run the prompt on the terminal behind stdout.
+    /// Run the prompt on the terminal behind stdout, where pnpm draws it,
+    /// or behind stderr when stdout is redirected.
     ///
-    /// Fails when stdout is not a terminal or the list has no choice to
-    /// make.
+    /// Fails when neither is a terminal or the list has no choice to make.
     pub(crate) fn interact(mut self) -> io::Result<CheckboxAnswer<Value>> {
         if !self.items.iter().any(is_choice) {
             return Err(io::Error::new(
@@ -128,13 +122,13 @@ impl<Value> CheckboxPrompt<Value> {
                 "the checkbox prompt was given no choice to make",
             ));
         }
-        let term = Term::stdout();
-        if !term.is_term() {
-            return Err(io::Error::new(
-                io::ErrorKind::NotConnected,
-                "the checkbox prompt needs a terminal on stdout",
-            ));
-        }
+        let term =
+            [Term::stdout(), Term::stderr()].into_iter().find(Term::is_term).ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "the checkbox prompt needs a terminal on stdout or stderr",
+                )
+            })?;
         if self.page_size == 0 {
             self.page_size = page_size_for(&term);
         }

--- a/pnpm/crates/cli/src/checkbox_prompt.rs
+++ b/pnpm/crates/cli/src/checkbox_prompt.rs
@@ -161,6 +161,10 @@ impl<Value> CheckboxPrompt<Value> {
     }
 
     pub(crate) fn handle_key(&mut self, key: &Key) -> KeyOutcome {
+        // A refused Enter is answered by whatever the user does next.
+        if *key != Key::Enter {
+            self.error = None;
+        }
         match key {
             Key::Enter => {
                 if self.required && !self.checked.iter().any(|&checked| checked) {
@@ -172,10 +176,7 @@ impl<Value> CheckboxPrompt<Value> {
             Key::CtrlC => return KeyOutcome::Cancel,
             Key::ArrowUp | Key::Char('k') => self.move_active(-1),
             Key::ArrowDown | Key::Char('j') => self.move_active(1),
-            Key::Char(' ') => {
-                self.error = None;
-                self.checked[self.active] = !self.checked[self.active];
-            }
+            Key::Char(' ') => self.checked[self.active] = !self.checked[self.active],
             Key::Char('a') => {
                 let select_all = self
                     .items
@@ -208,7 +209,6 @@ impl<Value> CheckboxPrompt<Value> {
     /// Move the cursor `offset` choices, wrapping around the list and
     /// stepping over separators.
     fn move_active(&mut self, offset: isize) {
-        self.error = None;
         let len = self.items.len();
         let mut next = self.active;
         loop {

--- a/pnpm/crates/cli/src/checkbox_prompt/tests.rs
+++ b/pnpm/crates/cli/src/checkbox_prompt/tests.rs
@@ -130,6 +130,10 @@ fn a_required_prompt_refuses_an_empty_selection() {
     press(&mut prompt, &[Key::ArrowDown]);
     assert!(!prompt.render_frame().contains("At least one"), "moving clears the error");
 
+    press(&mut prompt, &[Key::Enter, Key::Char('a')]);
+    assert!(!prompt.render_frame().contains("At least one"), "toggling all clears the error");
+    press(&mut prompt, &[Key::Char('a')]);
+
     assert_eq!(press(&mut prompt, &[Key::Char(' '), Key::Enter]), KeyOutcome::Submit);
 }
 

--- a/pnpm/crates/cli/src/checkbox_prompt/tests.rs
+++ b/pnpm/crates/cli/src/checkbox_prompt/tests.rs
@@ -1,0 +1,209 @@
+use super::{CheckboxChoice, CheckboxItem, CheckboxPrompt, CheckboxTheme, KeyOutcome};
+use console::{Key, strip_ansi_codes};
+
+fn separator(text: &str) -> CheckboxItem<&'static str> {
+    CheckboxItem::Separator(text.to_string())
+}
+
+fn choice(value: &'static str) -> CheckboxItem<&'static str> {
+    CheckboxItem::Choice(CheckboxChoice {
+        name: format!("{value} 1.0.0 ❯ 2.0.0"),
+        short: value.to_string(),
+        value,
+    })
+}
+
+/// Two groups the way `update --interactive` lays them out: a heading and
+/// a column header above each group's rows.
+fn grouped_prompt() -> CheckboxPrompt<&'static str> {
+    CheckboxPrompt::new(
+        "Choose",
+        vec![
+            separator("── dependencies ──"),
+            separator("  Package"),
+            choice("foo"),
+            choice("bar"),
+            separator("── devDependencies ──"),
+            separator("  Package"),
+            choice("baz"),
+        ],
+    )
+}
+
+fn press(prompt: &mut CheckboxPrompt<&'static str>, keys: &[Key]) -> KeyOutcome {
+    let mut outcome = KeyOutcome::Redraw;
+    for key in keys {
+        outcome = prompt.handle_key(key);
+    }
+    outcome
+}
+
+fn selected(prompt: &CheckboxPrompt<&'static str>) -> Vec<&'static str> {
+    prompt.selected_choices().map(|choice| choice.value).collect()
+}
+
+fn frame_lines(prompt: &CheckboxPrompt<&'static str>) -> Vec<String> {
+    strip_ansi_codes(&prompt.render_frame()).lines().map(str::to_string).collect()
+}
+
+#[test]
+fn the_cursor_starts_on_the_first_choice_below_the_headings() {
+    let prompt = grouped_prompt();
+
+    let lines = frame_lines(&prompt);
+    assert_eq!(
+        &lines[1..5],
+        [" ── dependencies ──", "   Package", "❯◯ foo 1.0.0 ❯ 2.0.0", " ◯ bar 1.0.0 ❯ 2.0.0"],
+    );
+}
+
+#[test]
+fn moving_skips_separators_and_wraps_around() {
+    let mut prompt = grouped_prompt();
+
+    press(&mut prompt, &[Key::ArrowDown, Key::ArrowDown]);
+    assert_eq!(prompt.active, 6, "the second move steps over the devDependencies headings");
+
+    press(&mut prompt, &[Key::ArrowDown]);
+    assert_eq!(prompt.active, 2, "moving past the end wraps to the first choice");
+
+    press(&mut prompt, &[Key::Char('k')]);
+    assert_eq!(prompt.active, 6, "moving before the start wraps to the last choice");
+}
+
+#[test]
+fn space_toggles_the_active_choice_only() {
+    let mut prompt = grouped_prompt();
+
+    press(&mut prompt, &[Key::Char(' '), Key::Char('j'), Key::Char(' '), Key::Char(' ')]);
+
+    assert_eq!(selected(&prompt), ["foo"]);
+}
+
+#[test]
+fn a_toggles_every_choice_and_i_inverts() {
+    let mut prompt = grouped_prompt();
+
+    press(&mut prompt, &[Key::Char('a')]);
+    assert_eq!(selected(&prompt), ["foo", "bar", "baz"]);
+
+    press(&mut prompt, &[Key::Char('a')]);
+    assert_eq!(selected(&prompt), Vec::<&str>::new(), "all checked, so `a` clears them");
+
+    press(&mut prompt, &[Key::Char(' '), Key::Char('i')]);
+    assert_eq!(selected(&prompt), ["bar", "baz"]);
+
+    press(&mut prompt, &[Key::Char('a')]);
+    assert_eq!(selected(&prompt), ["foo", "bar", "baz"], "one unchecked, so `a` checks the rest");
+}
+
+#[test]
+fn a_digit_toggles_that_choice_counting_choices_only() {
+    let mut prompt = grouped_prompt();
+
+    press(&mut prompt, &[Key::Char('3')]);
+
+    assert_eq!(selected(&prompt), ["baz"]);
+    assert_eq!(prompt.active, 6);
+}
+
+#[test]
+fn enter_submits_and_ctrl_c_cancels() {
+    let mut prompt = grouped_prompt();
+
+    assert_eq!(press(&mut prompt, &[Key::Char(' '), Key::Enter]), KeyOutcome::Submit);
+    assert_eq!(press(&mut prompt, &[Key::CtrlC]), KeyOutcome::Cancel);
+}
+
+#[test]
+fn a_required_prompt_refuses_an_empty_selection() {
+    let mut prompt = grouped_prompt().required(true);
+
+    assert_eq!(press(&mut prompt, &[Key::Enter]), KeyOutcome::Redraw);
+    let lines = frame_lines(&prompt);
+    assert!(
+        lines.contains(&"> At least one choice must be selected".to_string()),
+        "no error shown:\n{}",
+        lines.join("\n"),
+    );
+
+    press(&mut prompt, &[Key::ArrowDown]);
+    assert!(!prompt.render_frame().contains("At least one"), "moving clears the error");
+
+    assert_eq!(press(&mut prompt, &[Key::Char(' '), Key::Enter]), KeyOutcome::Submit);
+}
+
+#[test]
+fn the_frame_ends_with_the_key_help() {
+    let prompt = grouped_prompt();
+
+    let lines = frame_lines(&prompt);
+    assert_eq!(lines[0], "? Choose");
+    assert_eq!(
+        lines.last().map(String::as_str),
+        Some("↑↓ navigate • space select • a all • i invert • ⏎ submit"),
+    );
+    assert_eq!(lines[lines.len() - 2].trim(), "", "a blank line separates the list from the help");
+}
+
+#[test]
+fn the_answer_names_the_selection_by_its_short_form() {
+    let mut prompt = grouped_prompt();
+
+    press(&mut prompt, &[Key::Char(' '), Key::Char('3')]);
+
+    assert_eq!(strip_ansi_codes(&prompt.render_answer()), "✔ Choose foo, baz");
+}
+
+#[test]
+fn the_theme_picks_the_icons() {
+    let mut prompt = grouped_prompt().theme(CheckboxTheme {
+        checked: "●".to_string(),
+        unchecked: "○".to_string(),
+        highlight_active: false,
+    });
+
+    press(&mut prompt, &[Key::Char(' ')]);
+
+    let lines = frame_lines(&prompt);
+    assert_eq!(lines[3], "❯● foo 1.0.0 ❯ 2.0.0");
+    assert_eq!(lines[4], " ○ bar 1.0.0 ❯ 2.0.0");
+}
+
+/// The page scrolls to keep the cursor on it. When the rows directly
+/// above the cursor are separators — a group's heading and column
+/// header — they scroll on with it, so a group is never shown without
+/// its title.
+#[test]
+fn the_page_follows_the_cursor_and_keeps_the_headings_above_it() {
+    let mut prompt = grouped_prompt();
+    prompt.page_size = 3;
+
+    let page = |prompt: &CheckboxPrompt<&'static str>| frame_lines(prompt)[1..4].to_vec();
+    assert_eq!(page(&prompt), [" ── dependencies ──", "   Package", "❯◯ foo 1.0.0 ❯ 2.0.0"]);
+
+    press(&mut prompt, &[Key::ArrowDown, Key::ArrowDown]);
+    assert_eq!(page(&prompt), [" ── devDependencies ──", "   Package", "❯◯ baz 1.0.0 ❯ 2.0.0"]);
+
+    press(&mut prompt, &[Key::ArrowDown]);
+    assert_eq!(
+        page(&prompt),
+        [" ── dependencies ──", "   Package", "❯◯ foo 1.0.0 ❯ 2.0.0"],
+        "wrapping to the first row brings its headings back",
+    );
+
+    press(&mut prompt, &[Key::ArrowUp, Key::ArrowUp]);
+    assert_eq!(
+        page(&prompt),
+        ["❯◯ bar 1.0.0 ❯ 2.0.0", " ── devDependencies ──", "   Package"],
+        "a row under another row scrolls in on its own",
+    );
+}
+
+#[test]
+fn a_prompt_without_choices_cannot_run() {
+    let prompt: CheckboxPrompt<&str> = CheckboxPrompt::new("Choose", vec![separator("── none ──")]);
+
+    let error = prompt.interact().expect_err("no choice to make");
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+}

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -460,7 +460,7 @@ impl UpdateArgs {
             return Err(crate::cli_args::global::GlobalError::GlobalPnpmInstall.into());
         }
         let selected_hashes: Option<HashSet<String>> = if self.interactive {
-            match crate::cli_args::update_interactive::select_global_package_groups(
+            match crate::cli_args::update_interactive::select_global_package_groups::<Reporter>(
                 config,
                 &self.packages,
                 self.latest,

--- a/pnpm/crates/cli/src/cli_args/update_interactive.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive.rs
@@ -16,6 +16,9 @@
 //! renders. Which prompt that is comes in as an [`UpdatePrompt`].
 
 use crate::{
+    checkbox_prompt::{
+        CheckboxAnswer, CheckboxChoice, CheckboxItem, CheckboxPrompt, CheckboxTheme,
+    },
     cli_args::{
         global::has_pnpm_cli_dependency,
         outdated::{
@@ -28,14 +31,13 @@ use crate::{
     },
     github_actions,
 };
-use dialoguer::MultiSelect;
 use miette::{IntoDiagnostic, miette};
 use owo_colors::{OwoColorize, Stream};
 use pnpm_config::Config;
 use pnpm_lockfile::Lockfile;
 use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
-use pnpm_reporter::Reporter;
+use pnpm_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
 use std::{collections::HashSet, path::Path, sync::Arc};
 
 struct InteractiveUpdateProject<'a> {
@@ -50,42 +52,79 @@ pub(crate) struct InteractiveUpdateOptions<'a> {
     pub prompt: UpdatePrompt,
 }
 
-/// One row of the checkbox prompt: the line the user reads, and the
-/// package checking it updates. A group heading and a group's header row
-/// update nothing — `dialoguer` cannot mark an item unselectable the way
-/// pnpm's prompt does, so [`selected_packages`] drops them from the
-/// answer instead.
-struct PromptRow {
-    label: String,
-    value: Option<String>,
+/// One row of the checkbox prompt.
+enum PromptRow {
+    /// A group heading or a group's column header: shown, never selected.
+    Separator(String),
+    /// Checking it selects `value`, which the confirmed answer names by
+    /// `short`.
+    Choice { label: String, short: String, value: String },
+}
+
+/// The look of the prompt: pnpm's own theme for the dependency list, the
+/// prompt library's default for the global package groups.
+#[derive(Clone, Copy)]
+enum PromptStyle {
+    Dependencies,
+    GlobalGroups,
 }
 
 /// How `update --interactive` asks which dependencies to update.
 ///
 /// `clap` never sets it. It exists so a test can answer the prompt the
 /// way the upstream suite answers its own — by mocking
-/// `@inquirer/prompts` — which `dialoguer` cannot offer, since it reads a
-/// terminal.
+/// `@inquirer/prompts` — which a prompt reading the terminal cannot offer.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) enum UpdatePrompt {
     #[default]
-    Dialoguer,
+    Terminal,
     #[cfg(test)]
     Scripted,
 }
 
 impl UpdatePrompt {
-    /// The rows the user checked, by index.
-    fn select(self, message: &str, rows: &[PromptRow]) -> miette::Result<Vec<usize>> {
+    /// The rows the user checked, by index, or [`None`] when the prompt
+    /// was cancelled with Ctrl-C.
+    fn select(
+        self,
+        message: &str,
+        rows: &[PromptRow],
+        style: PromptStyle,
+    ) -> miette::Result<Option<Vec<usize>>> {
         match self {
-            Self::Dialoguer => {
-                let labels = rows.iter().map(|row| row.label.as_str()).collect::<Vec<_>>();
-                MultiSelect::new()
-                    .with_prompt(message)
-                    .items(&labels)
+            Self::Terminal => {
+                let items = rows
+                    .iter()
+                    .enumerate()
+                    .map(|(index, row)| match row {
+                        PromptRow::Separator(text) => CheckboxItem::Separator(text.clone()),
+                        PromptRow::Choice { label, short, .. } => {
+                            CheckboxItem::Choice(CheckboxChoice {
+                                name: label.clone(),
+                                short: short.clone(),
+                                value: index,
+                            })
+                        }
+                    })
+                    .collect();
+                let prompt = match style {
+                    PromptStyle::Dependencies => {
+                        CheckboxPrompt::new(message, items).required(true).theme(CheckboxTheme {
+                            checked: "●".to_string(),
+                            unchecked: "○".to_string(),
+                            highlight_active: false,
+                        })
+                    }
+                    PromptStyle::GlobalGroups => CheckboxPrompt::new(message, items),
+                };
+                match prompt
                     .interact()
                     .into_diagnostic()
-                    .map_err(|err| miette!("interactive update selection failed: {err}"))
+                    .map_err(|err| miette!("interactive update selection failed: {err}"))?
+                {
+                    CheckboxAnswer::Selected(indices) => Ok(Some(indices)),
+                    CheckboxAnswer::Cancelled => Ok(None),
+                }
             }
             #[cfg(test)]
             Self::Scripted => Ok(tests::answer_prompt(message, rows)),
@@ -93,7 +132,16 @@ impl UpdatePrompt {
     }
 }
 
-pub(crate) async fn select_global_package_groups(
+/// pnpm's `globalInfo('Update canceled')`: leaving the prompt with Ctrl-C
+/// is how the user declines to update, not an error.
+fn report_cancelled<Reporter: self::Reporter>() {
+    Reporter::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Info,
+        message: "Update canceled".to_string(),
+    }));
+}
+
+pub(crate) async fn select_global_package_groups<Reporter: self::Reporter>(
     base_config: &'static Config,
     packages: &[String],
     latest: bool,
@@ -166,21 +214,19 @@ pub(crate) async fn select_global_package_groups(
         if outdated.is_empty() {
             continue;
         }
-        rows.push(PromptRow {
-            label: outdated
-                .iter()
-                .map(|package| {
-                    format!(
-                        "{} {} → {}",
-                        sanitize_inline(&package.alias),
-                        package.current,
-                        package.target,
-                    )
-                })
-                .collect::<Vec<_>>()
-                .join(", "),
-            value: Some(pkg.hash),
-        });
+        let label = outdated
+            .iter()
+            .map(|package| {
+                format!(
+                    "{} {} → {}",
+                    sanitize_inline(&package.alias),
+                    package.current,
+                    package.target,
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        rows.push(PromptRow::Choice { short: label.clone(), label, value: pkg.hash });
     }
     if rows.is_empty() {
         let message = if latest {
@@ -191,14 +237,16 @@ pub(crate) async fn select_global_package_groups(
         println!("{message}");
         return Ok(None);
     }
-    let selected_indices = prompt.select(
+    let Some(selected_indices) = prompt.select(
         "Choose which global package groups to update (space to select, enter to confirm)",
         &rows,
-    )?;
-    let selected = selected_indices
-        .into_iter()
-        .filter_map(|index| rows.get(index).and_then(|row| row.value.clone()))
-        .collect::<HashSet<_>>();
+        PromptStyle::GlobalGroups,
+    )?
+    else {
+        report_cancelled::<Reporter>();
+        return Ok(None);
+    };
+    let selected = selected_packages(&rows, &selected_indices).into_iter().collect::<HashSet<_>>();
     if selected.is_empty() {
         return Ok(None);
     }
@@ -237,7 +285,12 @@ pub(crate) async fn select_packages<Reporter: self::Reporter>(
         )
         .await?;
     }
-    prompt_for_packages(&choices, options.latest, config.workspace_dir.is_some(), options.prompt)
+    prompt_for_packages::<Reporter>(
+        &choices,
+        options.latest,
+        config.workspace_dir.is_some(),
+        options.prompt,
+    )
 }
 
 pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
@@ -278,7 +331,7 @@ pub(crate) async fn select_packages_for_projects<Reporter: self::Reporter>(
         )
         .await?;
     }
-    prompt_for_packages(&choices, options.latest, true, options.prompt)
+    prompt_for_packages::<Reporter>(&choices, options.latest, true, options.prompt)
 }
 
 async fn append_github_actions<Reporter: self::Reporter>(
@@ -346,7 +399,7 @@ async fn collect_choices(
     Ok(collected)
 }
 
-fn prompt_for_packages(
+fn prompt_for_packages<Reporter: self::Reporter>(
     choices: &[OutdatedPackage],
     latest: bool,
     workspaces_enabled: bool,
@@ -365,8 +418,12 @@ fn prompt_for_packages(
     let groups = choices::update_choices(&choices.iter().collect::<Vec<_>>(), workspaces_enabled);
     let rows = flatten_groups(&groups);
 
-    let selected_indices = prompt
-        .select("Choose which dependencies to update (space to select, enter to confirm)", &rows)?;
+    let Some(selected_indices) =
+        prompt.select(&dependencies_prompt_message(), &rows, PromptStyle::Dependencies)?
+    else {
+        report_cancelled::<Reporter>();
+        return Ok(None);
+    };
 
     let selected = selected_packages(&rows, &selected_indices);
     if selected.is_empty() {
@@ -375,28 +432,41 @@ fn prompt_for_packages(
     Ok(Some(selected))
 }
 
-/// Flatten the groups into the one item list the prompt takes.
+fn dependencies_prompt_message() -> String {
+    let space = cyan("<space>");
+    let all = cyan("<a>");
+    let invert = cyan("<i>");
+    format!(
+        "Choose which dependencies to update (Press {space} to select, {all} to toggle all, {invert} to invert selection)\n\nEnter to start updating. Ctrl-c to cancel.",
+    )
+}
+
+/// Flatten the groups into the one item list the prompt takes: each
+/// group's heading, its column header, then its rows.
 fn flatten_groups(groups: &[choices::ChoiceGroup]) -> Vec<PromptRow> {
     let mut rows = Vec::new();
     for group in groups {
-        rows.push(PromptRow { label: bold(&group.message), value: None });
-        rows.extend(
-            group
-                .rows
-                .iter()
-                .map(|row| PromptRow { label: row.label.clone(), value: row.value.clone() }),
-        );
+        let heading = format!("── {} ──", group.message);
+        rows.push(PromptRow::Separator(bold(&heading)));
+        rows.extend(group.rows.iter().map(|row| match &row.value {
+            None => PromptRow::Separator(format!("  {}", row.label)),
+            Some(value) => PromptRow::Choice {
+                label: row.label.clone(),
+                short: sanitize_inline(value).into_owned(),
+                value: value.clone(),
+            },
+        }));
     }
     rows
 }
 
-/// The packages behind `indices`, in the order the user checked them and
+/// The values behind `indices`, in the order the user checked them and
 /// without repeats — the same package can be offered by two importers.
 fn selected_packages(rows: &[PromptRow], indices: &[usize]) -> Vec<String> {
     let mut selected = Vec::new();
     let mut seen = HashSet::new();
     for &index in indices {
-        let Some(value) = rows.get(index).and_then(|row| row.value.as_ref()) else { continue };
+        let Some(PromptRow::Choice { value, .. }) = rows.get(index) else { continue };
         if seen.insert(value.as_str()) {
             selected.push(value.clone());
         }
@@ -405,7 +475,11 @@ fn selected_packages(rows: &[PromptRow], indices: &[usize]) -> Vec<String> {
 }
 
 fn bold(text: &str) -> String {
-    text.if_supports_color(Stream::Stdout, |t| t.bold()).to_string()
+    text.if_supports_color(Stream::Stdout, |text| text.bold()).to_string()
+}
+
+fn cyan(text: &str) -> String {
+    text.if_supports_color(Stream::Stdout, |text| text.cyan()).to_string()
 }
 
 mod choices;

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices.rs
@@ -19,9 +19,7 @@ pub(crate) struct ChoiceRow {
     /// The rendered, column-aligned line shown in the prompt.
     pub label: String,
     /// The package name selecting this row updates. `None` marks the
-    /// group's header row, which carries no selection — pnpm renders it
-    /// as a disabled entry, and `dialoguer` has no such notion, so
-    /// [`super::prompt_for_packages`] drops it from the result instead.
+    /// group's header row, which carries no selection.
     pub value: Option<String>,
 }
 
@@ -212,14 +210,31 @@ fn column_widths(cells: &[Vec<String>]) -> Vec<usize> {
 /// of a group end at the same offset, as pnpm aligns it.
 const CURRENT_COLUMN: usize = 1;
 
+/// The least width of the `Package`, `Current`, arrow, and `Target`
+/// columns — the widths pnpm fixes them at. Every group is laid out on
+/// its own, so these are what line one group's columns up with the
+/// next's. A cell wider than the minimum widens its column rather than
+/// wrapping.
+const MIN_COLUMN_WIDTHS: [usize; 4] = [50, 15, 0, 15];
+
+/// The columns after `Target` — `Workspace` and `URL` — are set off by
+/// two more spaces than the rest, as pnpm pads them.
+const FIRST_WIDE_GAP_COLUMN: usize = 4;
+
 fn pad_row(row: &[String], widths: &[usize]) -> String {
     let mut line = String::new();
     for (index, cell) in row.iter().enumerate() {
-        if index > 0 {
+        if index >= FIRST_WIDE_GAP_COLUMN {
+            line.push_str("   ");
+        } else if index > 0 {
             line.push(' ');
         }
-        let padding =
-            widths.get(index).copied().unwrap_or_default().saturating_sub(measure_text_width(cell));
+        let width = widths
+            .get(index)
+            .copied()
+            .unwrap_or_default()
+            .max(MIN_COLUMN_WIDTHS.get(index).copied().unwrap_or_default());
+        let padding = width.saturating_sub(measure_text_width(cell));
         if index == CURRENT_COLUMN {
             line.extend(std::iter::repeat_n(' ', padding));
             line.push_str(cell);

--- a/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/choices/tests.rs
@@ -1,10 +1,9 @@
 //! Ports `getUpdateChoices()` from
 //! `pnpm11/installing/commands/test/update/getUpdateChoices.test.ts`.
 //!
-//! The rendered padding is pacquet's own — pnpm lays its table out with
-//! `@zkochan/table` and fixed column widths — so these assert the shape
-//! the user sees: which groups appear, in what order, which packages sit
-//! in each, and that every column lines up.
+//! The layout follows the column widths pnpm gives `@zkochan/table`, so
+//! these assert the shape the user sees: which groups appear, in what
+//! order, which packages sit in each, and that every column lines up.
 
 use super::{ChoiceGroup, column_widths, pad_row, update_choices};
 use crate::cli_args::outdated::OutdatedPackage;
@@ -183,6 +182,64 @@ fn columns_line_up_within_a_group() {
 
     let offsets = arrow_offsets(&groups[0]);
     assert_eq!(offsets[0], offsets[1]);
+}
+
+/// Each group is laid out on its own, so it is the minimum column widths
+/// that keep the `❯` of one group under the `❯` of the next when their
+/// names and versions differ in length — the misalignment the user sees
+/// otherwise, since the groups sit one above the other in the prompt.
+#[test]
+fn columns_line_up_across_groups() {
+    let packages = [
+        pkg(
+            "a-very-long-package-name",
+            "a-very-long-package-name",
+            "0.10.3",
+            "0.10.5",
+            DependencyGroup::Prod,
+        ),
+        pkg("b", "b", "1.0.0", "2.0.0", DependencyGroup::Dev),
+    ];
+
+    let groups = update_choices(&packages.iter().collect::<Vec<_>>(), false);
+
+    assert_eq!(groups.len(), 2);
+    assert_eq!(arrow_offsets(&groups[0]), arrow_offsets(&groups[1]));
+}
+
+/// The header row is padded like the rows under it, so each column's
+/// title starts where the column does — `Current` being right-aligned,
+/// its title ends where its cells do.
+#[test]
+fn the_header_row_lines_up_with_its_rows() {
+    let mut package = pkg("a", "a", "1.0.0", "2.0.0", DependencyGroup::Prod);
+    package.homepage = Some("https://example.test/".to_string());
+    package.workspace = Some("web".to_string());
+
+    let groups = update_choices(&[&package], true);
+
+    let header = &groups[0].rows[0].label;
+    let row = &groups[0].rows[1].label;
+    assert_eq!(
+        column_of(header, "Current") + "Current".len(),
+        column_of(row, "1.0.0") + "1.0.0".len(),
+        "Current is out of line:\n{header}\n{row}",
+    );
+    for (title, cell) in
+        [("Target", "2.0.0"), ("Workspace", "web"), ("URL", "https://example.test/")]
+    {
+        assert_eq!(
+            column_of(header, title),
+            column_of(row, cell),
+            "{title} is out of line:\n{header}\n{row}",
+        );
+    }
+}
+
+/// The terminal column `text` starts at in `line`.
+fn column_of(line: &str, text: &str) -> usize {
+    let start = line.find(text).unwrap_or_else(|| panic!("{text:?} is missing from {line:?}"));
+    measure_text_width(&line[..start])
 }
 
 /// Padding is counted in terminal columns rather than in `char`s, so a

--- a/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update_interactive/tests.rs
@@ -1,10 +1,13 @@
-use super::{InteractiveUpdateProject, PromptRow, UpdatePrompt, collect_choices};
+use super::{
+    InteractiveUpdateProject, PromptRow, UpdatePrompt, collect_choices, dependencies_prompt_message,
+};
 use crate::cli_args::update::UpdateArgs;
 use clap::Parser;
 use pnpm_config::Config;
 use pnpm_lockfile::Lockfile;
 use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
+use pnpm_reporter::{GlobalLog, LogEvent, LogLevel, Reporter, SilentReporter};
 use pnpm_testing_utils::registry::TestRegistry;
 use serde_json::{Value, json};
 use std::{
@@ -492,9 +495,15 @@ struct SeenPrompt {
     rows: Vec<(String, Option<String>)>,
 }
 
+/// How a test answers one prompt: the packages to check, or Ctrl-C.
+enum ScriptedAnswer {
+    Check(Vec<String>),
+    Cancel,
+}
+
 struct PromptScript {
-    /// The packages to check, one entry per prompt, in call order.
-    answers: VecDeque<Vec<String>>,
+    /// One entry per prompt, in call order.
+    answers: VecDeque<ScriptedAnswer>,
     seen: Vec<SeenPrompt>,
 }
 
@@ -533,7 +542,12 @@ impl ScriptedPrompts {
     /// the way the upstream suite resolves its `@inquirer/prompts` mock.
     fn answer_next(&self, packages: &[&str]) {
         let answer = packages.iter().map(|package| (*package).to_string()).collect();
-        self.claimed().answers.push_back(answer);
+        self.claimed().answers.push_back(ScriptedAnswer::Check(answer));
+    }
+
+    /// Leave the next prompt with Ctrl-C.
+    fn cancel_next(&self) {
+        self.claimed().answers.push_back(ScriptedAnswer::Cancel);
     }
 
     /// Take the prompts shown since the last call.
@@ -546,7 +560,7 @@ impl ScriptedPrompts {
     }
 }
 
-pub(super) fn answer_prompt(message: &str, rows: &[PromptRow]) -> Vec<usize> {
+pub(super) fn answer_prompt(message: &str, rows: &[PromptRow]) -> Option<Vec<usize>> {
     let mut script = script();
     let answer = script
         .answers
@@ -554,15 +568,24 @@ pub(super) fn answer_prompt(message: &str, rows: &[PromptRow]) -> Vec<usize> {
         .unwrap_or_else(|| panic!("the test scripted no answer for the prompt {message:?}"));
     script.seen.push(SeenPrompt {
         message: message.to_string(),
-        rows: rows.iter().map(|row| (row.label.clone(), row.value.clone())).collect(),
+        rows: rows
+            .iter()
+            .map(|row| match row {
+                PromptRow::Separator(text) => (text.clone(), None),
+                PromptRow::Choice { label, value, .. } => (label.clone(), Some(value.clone())),
+            })
+            .collect(),
     });
-    rows.iter()
-        .enumerate()
-        .filter(|(_, row)| {
-            row.value.as_ref().is_some_and(|value| answer.iter().any(|name| name == value))
-        })
-        .map(|(index, _)| index)
-        .collect()
+    let ScriptedAnswer::Check(answer) = answer else { return None };
+    Some(
+        rows.iter()
+            .enumerate()
+            .filter(|(_, row)| {
+                matches!(row, PromptRow::Choice { value, .. } if answer.iter().any(|name| name == value))
+            })
+            .map(|(index, _)| index)
+            .collect(),
+    )
 }
 
 /// `(package, current, target)` for every row the user could check. The
@@ -581,15 +604,19 @@ fn offered(prompt: &SeenPrompt) -> Vec<(String, String, String)> {
         .collect()
 }
 
-/// The group headings a prompt showed, in order. A heading is the row
-/// that opens a group: the one unselectable row followed by another
-/// unselectable one, the group's column header.
+/// The group headings a prompt showed, in order: the separators drawn
+/// as `── heading ──`.
 fn headings(prompt: &SeenPrompt) -> Vec<String> {
     prompt
         .rows
-        .windows(2)
-        .filter(|pair| pair[0].1.is_none() && pair[1].1.is_none())
-        .map(|pair| pair[0].0.trim().to_string())
+        .iter()
+        .filter(|(_, value)| value.is_none())
+        .filter_map(|(label, _)| {
+            console::strip_ansi_codes(label)
+                .strip_prefix("── ")?
+                .strip_suffix(" ──")
+                .map(str::to_string)
+        })
         .collect()
 }
 
@@ -651,6 +678,10 @@ impl UpdateFixture {
     }
 
     async fn update(&self, args: &[&str]) {
+        self.update_reporting::<SilentReporter>(args).await;
+    }
+
+    async fn update_reporting<Reporter: self::Reporter>(&self, args: &[&str]) {
         #[derive(Parser)]
         struct Harness {
             #[clap(flatten)]
@@ -663,7 +694,7 @@ impl UpdateFixture {
         parsed.prompt = UpdatePrompt::Scripted;
         let state = crate::State::init(self.project.join("package.json"), self.config, false)
             .expect("initialize the state");
-        parsed.run::<pnpm_reporter::SilentReporter>(state).await.expect("run pacquet update");
+        parsed.run::<Reporter>(state).await.expect("run pacquet update");
     }
 
     /// The `packages:` keys of the lockfile the last run wrote.
@@ -699,10 +730,7 @@ async fn interactively_update() {
 
     let prompts = scripted.seen();
     assert_eq!(prompts.len(), 1);
-    assert_eq!(
-        prompts[0].message,
-        "Choose which dependencies to update (space to select, enter to confirm)",
-    );
+    assert_eq!(prompts[0].message, dependencies_prompt_message());
     assert_eq!(headings(&prompts[0]), ["dependencies"]);
     assert_eq!(
         offered(&prompts[0]),
@@ -763,6 +791,41 @@ async fn interactively_update_skips_ignored_dependencies() {
     );
 }
 
+/// Ports `global interactive update leaves without an error when the
+/// prompt is canceled`, for the dependency prompt: Ctrl-C is how the
+/// user declines, so the command reports it and leaves with nothing
+/// updated and no error.
+#[tokio::test]
+async fn interactive_update_leaves_without_an_error_when_the_prompt_is_canceled() {
+    static EVENTS: Mutex<Vec<LogEvent>> = Mutex::new(Vec::new());
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            EVENTS.lock().unwrap().push(event.clone());
+        }
+    }
+
+    let fixture = UpdateFixture::new();
+    fixture.write_manifest(&json!({ MULTI_A: "1.0.0" }));
+    fixture.update(&["update"]).await;
+    fixture.write_manifest(&json!({ MULTI_A: "^1.0.0" }));
+
+    let scripted = scripted_prompts();
+    scripted.cancel_next();
+    fixture.update_reporting::<RecordingReporter>(&["update", "--interactive"]).await;
+
+    assert_eq!(scripted.seen().len(), 1);
+    assert_eq!(fixture.lockfile_packages(), [format!("{MULTI_A}@1.0.0")]);
+    let events = EVENTS.lock().unwrap();
+    let canceled = events.iter().any(|event| {
+        matches!(
+            event,
+            LogEvent::Global(GlobalLog { level: LogLevel::Info, message }) if message == "Update canceled",
+        )
+    });
+    assert!(canceled, "no `Update canceled` was reported: {events:?}");
+}
+
 /// Ports `global interactive update handles an empty global directory`.
 #[tokio::test]
 async fn global_interactive_update_handles_an_empty_global_directory() {
@@ -772,9 +835,14 @@ async fn global_interactive_update_handles_an_empty_global_directory() {
     let config = Config::leak(config);
     let scripted = scripted_prompts();
 
-    let selected = super::select_global_package_groups(config, &[], true, UpdatePrompt::Scripted)
-        .await
-        .expect("select global package groups");
+    let selected = super::select_global_package_groups::<pnpm_reporter::SilentReporter>(
+        config,
+        &[],
+        true,
+        UpdatePrompt::Scripted,
+    )
+    .await
+    .expect("select global package groups");
 
     assert!(selected.is_none());
     assert!(scripted.seen().is_empty(), "an empty global directory must not prompt");

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod boolean_negations;
+mod checkbox_prompt;
 mod cli_args;
 mod config_deps;
 mod config_overrides;


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14423.

`pnpm update --interactive` in pnpm 12 rendered its checklist through `dialoguer::MultiSelect`, which has no notion of an unselectable row. That produced the three symptoms in the issue:

- the group headings (`dependencies`, `devDependencies`) and the column headers were `[ ]` checkboxes the user could select, which selected nothing;
- each group was column-aligned only with itself, so the groups' columns did not line up with each other;
- after Enter, the whole selected table rows were echoed glued onto one line.

This PR gives pacquet a checkbox prompt shaped like `@inquirer/checkbox`, the prompt the TypeScript CLI uses, and moves `update --interactive` onto it:

- Group headings and column headers are separators: drawn, skipped by the cursor, never part of the answer.
- Same theme as pnpm 11: `●`/`○` icons, `❯` cursor, no highlight on the active row, `↑↓ navigate • space select • a all • i invert • ⏎ submit` footer, and pnpm's prompt message (`Press <space> to select, <a> to toggle all, <i> to invert selection … Enter to start updating. Ctrl-c to cancel.`).
- Same keys: arrows or `j`/`k`, space, `a`, `i`, digits, Enter; an empty selection is refused with `At least one choice must be selected`.
- The confirmed answer is echoed as `✔ <message> foo, bar` — the package names, comma-joined, as pnpm 11 prints them.
- Ctrl-C reports `Update canceled` and exits successfully, matching pnpm's `runUpdatePrompt`.
- The choice table adopts pnpm's minimum column widths (50 for `Package`, 15 for `Current` and `Target`) and the two-space gap before `Workspace`/`URL`, so the groups line up with each other. A cell wider than the minimum widens its column instead of wrapping.
- The global `update -i -g` prompt goes through the same prompt with the library's default theme, as its TypeScript counterpart does.

Verified end to end by driving the built binary through a pty against the npm registry (`update -i --latest` on a project with outdated `is-odd`, `kind-of`, `is-even`): headings render as separators, the columns of both groups align, the answer line reads `is-odd, kind-of`, and the update proceeds with those two packages.

TypeScript side: no change needed — pnpm 11 already behaves this way, which is what the issue compares against.

Not in scope: `pnpm approve-builds` and `pnpm audit --fix` still use `dialoguer::MultiSelect` in pacquet. They have the same visual divergence from their `@inquirer/checkbox` counterparts and could move onto this prompt in a follow-up.

## Squash Commit Body

```text
`pnpm update --interactive` went through `dialoguer::MultiSelect`, which
has no unselectable rows: the group headings and column headers were
checkboxes that selected nothing, each group was aligned only with
itself, and the confirmed selection was echoed as the whole table rows
glued onto one line.

Replace the prompt with a checkbox prompt shaped like `@inquirer/checkbox`,
the one the TypeScript CLI uses: separators the cursor skips, the
`●`/`○` icons and `❯` cursor pnpm themes it with, `a` to toggle all, `i`
to invert, digits to toggle a choice, a required selection, the key-help
footer, and an answer line that names the chosen packages. Ctrl-C now
reports `Update canceled` and exits successfully, as pnpm does. The
choice table adopts pnpm's minimum column widths and gaps so the groups
line up with each other, and the prompt message matches pnpm's.

The prompt is a state machine (`handle_key` / `render_frame`) with a thin
terminal loop on `console::Term`, so its behaviour is unit-tested without
a terminal; `update --interactive` keeps its scripted test seam and gains
a cancel test.

Fixes https://github.com/pnpm/pnpm/issues/14423
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3ih4C8bNNGuyfCZpxjnVX

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790898699&installation_model_id=426870&pr_number=14439&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14439&signature=df33052ef2378ede0213cab58fa0f8fbc1616717b87b3a62ff1d026023453a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved interactive updates with pnpm-style grouped headings, column headers, and aligned columns.
  * Added keyboard shortcuts to select all, invert selections, toggle individual choices, and navigate efficiently.
  * Selected packages are now clearly displayed after confirmation.
  * Ctrl-C cancellation is handled gracefully without reporting an error.

* **Bug Fixes**
  * Improved checklist rendering, scrolling, pagination, and selection behavior across terminal sizes.
  * Corrected validation and selection handling for required prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->