### PR TITLE
fix(peers): recognize auto-installed linked peers

### DIFF
--- a/.changeset/fix-linked-auto-peers.md
+++ b/.changeset/fix-linked-auto-peers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed false unmet peer errors for auto-installed peers in linked workspace packages.

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -393,6 +393,61 @@ fn auto_installed_peer_of_linked_workspace_package_is_not_reported_missing() {
 }
 
 #[test]
+fn auto_installed_workspace_peer_is_resolved_from_the_linked_importer() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/**\nstrictPeerDependencies: true\nautoInstallPeers: true\nlinkWorkspacePackages: true\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "private": true }"#)
+        .expect("write root manifest");
+
+    let peer = workspace.join("packages/peers/foo");
+    fs::create_dir_all(&peer).expect("create the peer project");
+    fs::write(peer.join("package.json"), r#"{ "name": "@pnpm.e2e/foo", "version": "1.0.0" }"#)
+        .expect("write the peer manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the linked project");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the linked manifest");
+
+    let app = workspace.join("packages/apps/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write the consuming manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile = _utils::read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(
+        _utils::importer_version(&lockfile, "packages/lib", "@pnpm.e2e/foo"),
+        "link:../peers/foo",
+    );
+    let _ = run_peers(&workspace, &["peers", "check", "--lockfile-only", "--json"]);
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn catalog_peer_of_a_linked_workspace_package_is_resolved() {
     assert_catalog_peer_of_workspace_package_is_resolved(false);
 }

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -448,6 +448,81 @@ fn auto_installed_workspace_peer_is_resolved_from_the_linked_importer() {
 }
 
 #[test]
+fn incompatible_injected_auto_installed_peer_is_reported() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/**\nautoInstallPeers: true\ninjectWorkspacePackages: true\ndedupeInjectedDeps: false\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "private": true }"#)
+        .expect("write root manifest");
+
+    let peer = workspace.join("packages/peers/foo");
+    fs::create_dir_all(&peer).expect("create the peer project");
+    fs::write(peer.join("package.json"), r#"{ "name": "@pnpm.e2e/foo", "version": "1.0.0" }"#)
+        .expect("write the peer manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the linked project");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write the linked manifest");
+
+    let app = workspace.join("packages/apps/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "link:../../lib" },
+        })
+        .to_string(),
+    )
+    .expect("write the consuming manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile = _utils::read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    let peer_version = _utils::importer_version(&lockfile, "packages/lib", "@pnpm.e2e/foo");
+    assert!(
+        peer_version.starts_with("file:"),
+        "the auto-installed peer should be injected, got {peer_version}",
+    );
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "2.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("make the injected peer incompatible");
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&workspace)
+        .with_args(["peers", "check", "--lockfile-only", "--json"])
+        .output()
+        .expect("inspect injected peers");
+    assert_eq!(output.status.code(), Some(1), "the injected peer is incompatible: {output:?}");
+    let issues: Value = serde_json::from_slice(&output.stdout).expect("parse peers JSON");
+    assert_eq!(issues["packages/apps/app"]["bad"]["@pnpm.e2e/foo"][0]["foundVersion"], "1.0.0");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn catalog_peer_of_a_linked_workspace_package_is_resolved() {
     assert_catalog_peer_of_workspace_package_is_resolved(false);
 }

--- a/pnpm/crates/cli/tests/suite/peers.rs
+++ b/pnpm/crates/cli/tests/suite/peers.rs
@@ -1,3 +1,5 @@
+use crate::_utils;
+
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{
@@ -339,6 +341,53 @@ fn strict_peer_dependencies_fails_on_a_linked_workspace_packages_unmet_peer() {
         "stdout:\n{stdout}",
     );
     assert!(stdout.contains("unmet peer @pnpm.e2e/foo"), "stdout:\n{stdout}");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn auto_installed_peer_of_linked_workspace_package_is_not_reported_missing() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nstrictPeerDependencies: true\nautoInstallPeers: true\n",
+    )
+    .expect("write workspace manifest");
+    fs::write(workspace.join("package.json"), r#"{ "name": "root", "private": true }"#)
+        .expect("write root manifest");
+
+    let lib = workspace.join("packages/lib");
+    fs::create_dir_all(&lib).expect("create the linked project");
+    fs::write(
+        lib.join("package.json"),
+        serde_json::json!({
+            "name": "lib",
+            "version": "1.0.0",
+            "peerDependencies": { "@pnpm.e2e/foo": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the linked manifest");
+
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create the consuming project");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({
+            "name": "app",
+            "version": "1.0.0",
+            "dependencies": { "lib": "workspace:*" },
+        })
+        .to_string(),
+    )
+    .expect("write the consuming manifest");
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile = _utils::read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    assert_eq!(_utils::importer_version(&lockfile, "packages/lib", "@pnpm.e2e/foo"), "1.0.0");
+    let _ = run_peers(&workspace, &["peers", "check", "--lockfile-only", "--json"]);
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -31,8 +31,8 @@ use pnpm_catalogs_resolver::{
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::PeerDependencyRules;
 use pnpm_lockfile::{
-    Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencySpec,
-    SnapshotEntry,
+    Lockfile, LockfileResolution, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot,
+    ResolvedDependencySpec, SnapshotEntry,
 };
 use pnpm_package_manifest::PackageManifest;
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -249,6 +249,21 @@ fn resolve_link_version(base_dir: &Path, lockfile_dir: &Path, link_target: &str)
     package_manifest_version(&manifest)
 }
 
+fn resolve_file_version(
+    lockfile: &Lockfile,
+    lockfile_dir: &Path,
+    alias: &PkgName,
+    spec: &ResolvedDependencySpec,
+) -> Option<String> {
+    let key = spec.version.resolved_key(alias)?.without_peer();
+    let metadata = lockfile.packages.as_ref()?.get(&key)?;
+    if let Some(version) = &metadata.version {
+        return Some(version.clone());
+    }
+    let LockfileResolution::Directory(directory) = &metadata.resolution else { return None };
+    resolve_link_version(lockfile_dir, lockfile_dir, &directory.directory)
+}
+
 fn package_manifest_version(manifest: &PackageManifest) -> Option<String> {
     manifest.value().get("version").and_then(|version| version.as_str()).map(String::from)
 }
@@ -256,6 +271,7 @@ fn package_manifest_version(manifest: &PackageManifest) -> Option<String> {
 /// A workspace package an importer reaches through `link:`, whose own
 /// `peerDependencies` the importer has to satisfy.
 struct LinkedPackagePeers<'a> {
+    lockfile: &'a Lockfile,
     importer: &'a ProjectSnapshot,
     linked_importer: Option<&'a ProjectSnapshot>,
     importer_dir: &'a Path,
@@ -272,6 +288,7 @@ fn check_linked_package_peers(
     inputs: LinkedPackagePeers<'_>,
 ) -> Result<(), CatalogResolutionError> {
     let LinkedPackagePeers {
+        lockfile,
         importer,
         linked_importer,
         importer_dir,
@@ -315,30 +332,29 @@ fn check_linked_package_peers(
 
         match resolved_ref {
             Some((spec, dependency_dir)) => {
-                if let Some(ver_peer) = spec.version.ver_peer() {
-                    let version_str = ver_peer.version().to_string();
-                    if !satisfies(&version_str, &peer_range) {
-                        issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
-                            parents: current_parents.clone(),
-                            optional: is_optional,
-                            wanted_range: peer_range.clone(),
-                            found_version: version_str,
-                            resolved_from: Vec::new(),
-                        });
-                    }
+                let found_version = if let Some(ver_peer) = spec.version.ver_peer() {
+                    Some(ver_peer.version().to_string())
                 } else if let Some(link_target) = spec.version.as_link_target() {
-                    let found_version =
+                    Some(
                         resolve_link_version(dependency_dir, lockfile_dir, link_target)
-                            .unwrap_or_else(|| format!("link:{link_target}"));
-                    if !satisfies(&found_version, &peer_range) {
-                        issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
-                            parents: current_parents.clone(),
-                            optional: is_optional,
-                            wanted_range: peer_range.clone(),
-                            found_version,
-                            resolved_from: Vec::new(),
-                        });
-                    }
+                            .unwrap_or_else(|| format!("link:{link_target}")),
+                    )
+                } else {
+                    spec.version.as_file_target().map(|file_target| {
+                        resolve_file_version(lockfile, lockfile_dir, &peer_pkg_name, spec)
+                            .unwrap_or_else(|| format!("file:{file_target}"))
+                    })
+                };
+                if let Some(found_version) = found_version
+                    && !satisfies(&found_version, &peer_range)
+                {
+                    issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
+                        parents: current_parents.clone(),
+                        optional: is_optional,
+                        wanted_range: peer_range.clone(),
+                        found_version,
+                        resolved_from: Vec::new(),
+                    });
                 }
             }
             None => {
@@ -436,6 +452,7 @@ fn collect_initial_keys(
 
                 if let Some(linked_manifest) = &linked_manifest {
                     check_linked_package_peers(LinkedPackagePeers {
+                        lockfile: context.lockfile,
                         importer,
                         linked_importer,
                         importer_dir: &importer_dir,

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -252,6 +252,7 @@ struct LinkedPackagePeers<'a> {
     importer: &'a ProjectSnapshot,
     linked_importer: Option<&'a ProjectSnapshot>,
     importer_dir: &'a Path,
+    linked_importer_dir: &'a Path,
     lockfile_dir: &'a Path,
     manifest: &'a PackageManifest,
     alias: &'a str,
@@ -267,6 +268,7 @@ fn check_linked_package_peers(
         importer,
         linked_importer,
         importer_dir,
+        linked_importer_dir,
         lockfile_dir,
         manifest,
         alias,
@@ -296,12 +298,16 @@ fn check_linked_package_peers(
             .unwrap_or(false);
 
         let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-        let resolved_ref = project_dependency(importer, &peer_pkg_name).or_else(|| {
-            linked_importer.and_then(|importer| project_dependency(importer, &peer_pkg_name))
-        });
+        let resolved_ref = project_dependency(importer, &peer_pkg_name)
+            .map(|spec| (spec, importer_dir))
+            .or_else(|| {
+                linked_importer
+                    .and_then(|importer| project_dependency(importer, &peer_pkg_name))
+                    .map(|spec| (spec, linked_importer_dir))
+            });
 
         match resolved_ref {
-            Some(spec) => {
+            Some((spec, dependency_dir)) => {
                 if let Some(ver_peer) = spec.version.ver_peer() {
                     let version_str = ver_peer.version().to_string();
                     if !satisfies(&version_str, &peer_range) {
@@ -315,7 +321,7 @@ fn check_linked_package_peers(
                     }
                 } else if let Some(link_target) = spec.version.as_link_target() {
                     let found_version =
-                        resolve_link_version(importer_dir, lockfile_dir, link_target)
+                        resolve_link_version(dependency_dir, lockfile_dir, link_target)
                             .unwrap_or_else(|| format!("link:{link_target}"));
                     if !satisfies(&found_version, &peer_range) {
                         issues.bad.entry(peer_name.clone()).or_default().push(BadPeerIssue {
@@ -426,6 +432,7 @@ fn collect_initial_keys(
                         importer,
                         linked_importer,
                         importer_dir: &importer_dir,
+                        linked_importer_dir: &linked_dir,
                         lockfile_dir: context.lockfile_dir,
                         manifest: linked_manifest,
                         alias: &alias.to_string(),

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -224,20 +224,27 @@ pub fn check_peer_dependencies_of_importers(
     Ok(result)
 }
 
-fn canonical_path_within(path: &Path, base: &Path) -> Option<PathBuf> {
+struct CanonicalPathWithin {
+    path: PathBuf,
+    base: PathBuf,
+}
+
+fn canonical_path_within(path: &Path, base: &Path) -> Option<CanonicalPathWithin> {
     let (Ok(canonical_path), Ok(canonical_base)) =
         (dunce::canonicalize(path), dunce::canonicalize(base))
     else {
         return None;
     };
-    canonical_path.starts_with(&canonical_base).then_some(canonical_path)
+    canonical_path
+        .starts_with(&canonical_base)
+        .then_some(CanonicalPathWithin { path: canonical_path, base: canonical_base })
 }
 
 /// `base_dir` is the directory the `link:` target is relative to — the
 /// importer's directory for importer dependencies, the lockfile directory for
 /// snapshot dependencies. Targets escaping `lockfile_dir` are rejected.
 fn resolve_link_version(base_dir: &Path, lockfile_dir: &Path, link_target: &str) -> Option<String> {
-    let target_dir = canonical_path_within(&base_dir.join(link_target), lockfile_dir)?;
+    let target_dir = canonical_path_within(&base_dir.join(link_target), lockfile_dir)?.path;
     let manifest = PackageManifest::from_path(target_dir.join("package.json")).ok()?;
     package_manifest_version(&manifest)
 }
@@ -408,7 +415,7 @@ fn collect_initial_keys(
                 // dependency: the version, the peer check, and the
                 // recursion all need the same two answers, and this walk
                 // now runs on the install path.
-                let Some(linked_dir) =
+                let Some(CanonicalPathWithin { path: linked_dir, base: canonical_lockfile_dir }) =
                     canonical_path_within(&importer_dir.join(link_target), context.lockfile_dir)
                 else {
                     continue;
@@ -424,7 +431,7 @@ fn collect_initial_keys(
                     .push(ParentPkg { name: alias.to_string(), version: linked_version.clone() });
 
                 let linked_importer_id =
-                    pnpm_workspace::importer_id_from_root_dir(context.lockfile_dir, &linked_dir);
+                    pnpm_workspace::importer_id_from_root_dir(&canonical_lockfile_dir, &linked_dir);
                 let linked_importer = context.lockfile.importers.get(&linked_importer_id);
 
                 if let Some(linked_manifest) = &linked_manifest {

--- a/pnpm/crates/deps-inspection-peers/src/lib.rs
+++ b/pnpm/crates/deps-inspection-peers/src/lib.rs
@@ -30,7 +30,10 @@ use pnpm_catalogs_resolver::{
 };
 use pnpm_catalogs_types::Catalogs;
 use pnpm_config::PeerDependencyRules;
-use pnpm_lockfile::{Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, SnapshotEntry};
+use pnpm_lockfile::{
+    Lockfile, PackageMetadata, PkgName, PkgNameVerPeer, ProjectSnapshot, ResolvedDependencySpec,
+    SnapshotEntry,
+};
 use pnpm_package_manifest::PackageManifest;
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pnpm_resolving_resolver_base::get_peer_version_range;
@@ -221,23 +224,20 @@ pub fn check_peer_dependencies_of_importers(
     Ok(result)
 }
 
-fn path_is_within(path: &Path, base: &Path) -> bool {
+fn canonical_path_within(path: &Path, base: &Path) -> Option<PathBuf> {
     let (Ok(canonical_path), Ok(canonical_base)) =
         (dunce::canonicalize(path), dunce::canonicalize(base))
     else {
-        return false;
+        return None;
     };
-    canonical_path.starts_with(&canonical_base)
+    canonical_path.starts_with(&canonical_base).then_some(canonical_path)
 }
 
 /// `base_dir` is the directory the `link:` target is relative to — the
 /// importer's directory for importer dependencies, the lockfile directory for
 /// snapshot dependencies. Targets escaping `lockfile_dir` are rejected.
 fn resolve_link_version(base_dir: &Path, lockfile_dir: &Path, link_target: &str) -> Option<String> {
-    let target_dir = base_dir.join(link_target);
-    if !path_is_within(&target_dir, lockfile_dir) {
-        return None;
-    }
+    let target_dir = canonical_path_within(&base_dir.join(link_target), lockfile_dir)?;
     let manifest = PackageManifest::from_path(target_dir.join("package.json")).ok()?;
     package_manifest_version(&manifest)
 }
@@ -249,7 +249,8 @@ fn package_manifest_version(manifest: &PackageManifest) -> Option<String> {
 /// A workspace package an importer reaches through `link:`, whose own
 /// `peerDependencies` the importer has to satisfy.
 struct LinkedPackagePeers<'a> {
-    importer: &'a pnpm_lockfile::ProjectSnapshot,
+    importer: &'a ProjectSnapshot,
+    linked_importer: Option<&'a ProjectSnapshot>,
     importer_dir: &'a Path,
     lockfile_dir: &'a Path,
     manifest: &'a PackageManifest,
@@ -264,6 +265,7 @@ fn check_linked_package_peers(
 ) -> Result<(), CatalogResolutionError> {
     let LinkedPackagePeers {
         importer,
+        linked_importer,
         importer_dir,
         lockfile_dir,
         manifest,
@@ -294,16 +296,9 @@ fn check_linked_package_peers(
             .unwrap_or(false);
 
         let Ok(peer_pkg_name) = peer_name.parse::<PkgName>() else { continue };
-        let resolved_ref = importer
-            .dependencies
-            .as_ref()
-            .and_then(|deps| deps.get(&peer_pkg_name))
-            .or_else(|| {
-                importer.dev_dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name))
-            })
-            .or_else(|| {
-                importer.optional_dependencies.as_ref().and_then(|deps| deps.get(&peer_pkg_name))
-            });
+        let resolved_ref = project_dependency(importer, &peer_pkg_name).or_else(|| {
+            linked_importer.and_then(|importer| project_dependency(importer, &peer_pkg_name))
+        });
 
         match resolved_ref {
             Some(spec) => {
@@ -345,6 +340,18 @@ fn check_linked_package_peers(
         }
     }
     Ok(())
+}
+
+fn project_dependency<'a>(
+    importer: &'a ProjectSnapshot,
+    name: &PkgName,
+) -> Option<&'a ResolvedDependencySpec> {
+    importer
+        .dependencies
+        .as_ref()
+        .and_then(|deps| deps.get(name))
+        .or_else(|| importer.dev_dependencies.as_ref().and_then(|deps| deps.get(name)))
+        .or_else(|| importer.optional_dependencies.as_ref().and_then(|deps| deps.get(name)))
 }
 
 fn resolve_peer_range(
@@ -395,10 +402,11 @@ fn collect_initial_keys(
                 // dependency: the version, the peer check, and the
                 // recursion all need the same two answers, and this walk
                 // now runs on the install path.
-                let linked_dir = importer_dir.join(link_target);
-                if !path_is_within(&linked_dir, context.lockfile_dir) {
+                let Some(linked_dir) =
+                    canonical_path_within(&importer_dir.join(link_target), context.lockfile_dir)
+                else {
                     continue;
-                }
+                };
                 let linked_manifest =
                     PackageManifest::from_path(linked_dir.join("package.json")).ok();
                 let linked_version = linked_manifest
@@ -409,9 +417,14 @@ fn collect_initial_keys(
                 next_parents
                     .push(ParentPkg { name: alias.to_string(), version: linked_version.clone() });
 
+                let linked_importer_id =
+                    pnpm_workspace::importer_id_from_root_dir(context.lockfile_dir, &linked_dir);
+                let linked_importer = context.lockfile.importers.get(&linked_importer_id);
+
                 if let Some(linked_manifest) = &linked_manifest {
                     check_linked_package_peers(LinkedPackagePeers {
                         importer,
+                        linked_importer,
                         importer_dir: &importer_dir,
                         lockfile_dir: context.lockfile_dir,
                         manifest: linked_manifest,
@@ -422,8 +435,6 @@ fn collect_initial_keys(
                     })?;
                 }
 
-                let linked_importer_id =
-                    pnpm_workspace::importer_id_from_root_dir(context.lockfile_dir, &linked_dir);
                 collect_initial_keys(
                     &linked_importer_id,
                     context,

--- a/pnpm/crates/deps-inspection-peers/src/tests.rs
+++ b/pnpm/crates/deps-inspection-peers/src/tests.rs
@@ -544,3 +544,21 @@ fn test_path_is_within() {
     let absolute_outside = std::path::Path::new("/etc");
     assert!(canonical_path_within(absolute_outside, base).is_none());
 }
+
+#[cfg(unix)]
+#[test]
+fn canonical_containment_keeps_the_root_used_for_importer_ids() {
+    let temp = tempfile::tempdir().unwrap();
+    let real_root = temp.path().join("real");
+    let project = real_root.join("packages/lib");
+    std::fs::create_dir_all(&project).unwrap();
+    let linked_root = temp.path().join("linked");
+    std::os::unix::fs::symlink(&real_root, &linked_root).unwrap();
+
+    let canonical = canonical_path_within(&linked_root.join("packages/lib"), &linked_root).unwrap();
+
+    assert_eq!(
+        pnpm_workspace::importer_id_from_root_dir(&canonical.base, &canonical.path),
+        "packages/lib",
+    );
+}

--- a/pnpm/crates/deps-inspection-peers/src/tests.rs
+++ b/pnpm/crates/deps-inspection-peers/src/tests.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 use pnpm_config::PeerDependencyRules;
 
 use super::{
-    BadPeerIssue, IssuesByProjects, MissingPeerIssue, ParentPkg, PeerIssues, filter_peer_issues,
-    format_range, intersect_multiple_ranges, merge_missing_peers, normalize_version_str,
-    parse_allowed_versions, path_is_within, satisfies,
+    BadPeerIssue, IssuesByProjects, MissingPeerIssue, ParentPkg, PeerIssues, canonical_path_within,
+    filter_peer_issues, format_range, intersect_multiple_ranges, merge_missing_peers,
+    normalize_version_str, parse_allowed_versions, satisfies,
 };
 
 fn have_common_version(version_ranges: &[String]) -> bool {
@@ -535,12 +535,12 @@ fn test_path_is_within() {
     let sub = base.join("foo");
     std::fs::create_dir(&sub).unwrap();
 
-    assert!(path_is_within(&sub, base));
-    assert!(path_is_within(base, base));
+    assert!(canonical_path_within(&sub, base).is_some());
+    assert!(canonical_path_within(base, base).is_some());
 
     let outside = base.join("../bar");
-    assert!(!path_is_within(&outside, base));
+    assert!(canonical_path_within(&outside, base).is_none());
 
     let absolute_outside = std::path::Path::new("/etc");
-    assert!(!path_is_within(absolute_outside, base));
+    assert!(canonical_path_within(absolute_outside, base).is_none());
 }


### PR DESCRIPTION
## Summary

- canonicalize both workspace roots and linked targets before deriving importer IDs during peer inspection
- fall back to the linked importer’s resolved dependencies for auto-installed peers
- retain the supplying importer directory so nested `link:` peers resolve from the correct workspace package
- validate injected `file:` peers through lockfile metadata and workspace manifests
- cover strict install and `pnpm peers check` for registry, linked, and injected auto-installed peers
- cover symlinked workspace roots when deriving linked importer IDs

Closes pnpm/pnpm#14418.

This is a pacquet-only parity fix: the TypeScript pnpm 11 CLI already has the expected behavior, so no TypeScript implementation change is needed.

## Squash Commit Body

```text
Canonicalize workspace roots and linked targets before deriving importer IDs so
peer inspection can find their lockfile snapshots. Fall back to each linked
importer when the consumer does not provide the peer.

Keep the importer directory that supplied a dependency so relative link
targets are resolved from their owning workspace package. Resolve injected
file-backed peer versions before applying their peer ranges.

Closes pnpm/pnpm#14418
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false unmet peer dependency errors for linked workspace packages when peers are automatically installed.
  * Improved peer checks for workspace dependencies resolved through linked or injected packages.
  * Correctly handles peer dependencies resolved from local package paths.

* **Tests**
  * Added regression coverage for automatically installed peers in linked workspaces.
  * Verified incompatible peer ranges are accurately reported during peer checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->