### PR TITLE
fix(cli): load the pnpmfile for run, exec and rebuild

### DIFF
--- a/.changeset/run-loads-the-pnpmfile.md
+++ b/.changeset/run-loads-the-pnpmfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm run`, `pnpm exec`, `pnpm rebuild`, and the script shortcuts (`pnpm test`, `pnpm start`, `pnpm stop`, `pnpm restart`, `pnpm <script>`) not loading the pnpmfile, so an `updateConfig` hook never applied to them [#14433](https://github.com/pnpm/pnpm/issues/14433). A hook's settings — `extraEnv` and `extraBinPaths` among them — now reach the scripts and commands these spawn, as they do on pnpm 11.

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::{
     State,
+    config_deps::prepare_config,
     config_overrides::{
         ConfigOverrides, apply_registry_override, apply_state_dir_override,
         apply_store_dir_override,
@@ -16,8 +17,9 @@ use crate::{
 };
 use miette::{Context, IntoDiagnostic};
 use pnpm_config::{ColorMode, Config, Host, default_pnpm_home_dir};
+use pnpm_default_reporter::DefaultReporter;
 use pnpm_network_web_auth::OtpNonInteractiveError;
-use pnpm_reporter::{ExecutionTimeLog, LogEvent, LogLevel};
+use pnpm_reporter::{ExecutionTimeLog, LogEvent, LogLevel, NdjsonReporter, SilentReporter};
 use std::{future::Future, path::Path, pin::Pin};
 
 pub(crate) type CommandFuture<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
@@ -485,6 +487,31 @@ impl CliArgs {
 
         Ok(())
     }
+}
+
+/// Install the project's config dependencies and apply their `updateConfig`
+/// pnpmfile hooks to `config` before a command spawns anything, so a hook's
+/// settings — `extraEnv` and `extraBinPaths` among them — reach the child
+/// processes the command starts. pnpm applies them once per invocation,
+/// whatever the command.
+///
+/// Every [`RunCtx::config`] call yields a fresh `Config`, so the pass has to
+/// run on the instance the handler goes on to use — it cannot be hoisted ahead
+/// of [`route`]. The install family and pack/publish apply the same pass at
+/// their own entry points, where they already hold that instance.
+pub(super) async fn apply_update_config(
+    config: &mut Config,
+    dir: &Path,
+    reporter: ReporterType,
+) -> miette::Result<()> {
+    match reporter {
+        ReporterType::Default | ReporterType::AppendOnly => {
+            prepare_config::<DefaultReporter>(config, dir).await?
+        }
+        ReporterType::Ndjson => prepare_config::<NdjsonReporter>(config, dir).await?,
+        ReporterType::Silent => prepare_config::<SilentReporter>(config, dir).await?,
+    };
+    Ok(())
 }
 
 /// Route a parsed [`CliCommand`] to its handler. The per-command logic lives

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -5,7 +5,7 @@ use super::{
     create::CreateArgs,
     dedupe::DedupeArgs,
     deploy::DeployArgs,
-    dispatch::{CommandFuture, RunCtx},
+    dispatch::{CommandFuture, RunCtx, apply_update_config},
     dlx::DlxArgs,
     env::{EnvArgs, EnvSubcommand},
     fetch::FetchArgs,
@@ -523,6 +523,7 @@ pub(super) fn rebuild<'a>(
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        apply_update_config(cfg, dir, reporter).await?;
         let recursive_sort = cfg.sort;
         let recursive_no_bail = !cfg.bail;
         args.pending = resolve_bool_override(args.pending, args.no_pending, cfg.pending);

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -51,6 +51,7 @@ use super::{
     why::WhyArgs,
     with::WithArgs,
 };
+use crate::config_deps::prepare_config;
 use clap::CommandFactory;
 use pnpm_config::Config;
 use pnpm_default_reporter::DefaultReporter;
@@ -425,15 +426,15 @@ pub(super) fn pack<'a>(ctx: &RunCtx<'a>, args: PackArgs) -> miette::Result<Comma
     Ok(Box::pin(async move {
         let output = match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
-                let hooks = run_update_config_for_packing::<DefaultReporter>(config, dir).await?;
+                let hooks = prepare_config::<DefaultReporter>(config, dir).await?;
                 args.run::<DefaultReporter>(dir, config, recursive, hooks).await?
             }
             ReporterType::Ndjson => {
-                let hooks = run_update_config_for_packing::<NdjsonReporter>(config, dir).await?;
+                let hooks = prepare_config::<NdjsonReporter>(config, dir).await?;
                 args.run::<NdjsonReporter>(dir, config, recursive, hooks).await?
             }
             ReporterType::Silent => {
-                let hooks = run_update_config_for_packing::<SilentReporter>(config, dir).await?;
+                let hooks = prepare_config::<SilentReporter>(config, dir).await?;
                 args.run::<SilentReporter>(dir, config, recursive, hooks).await?
             }
         };
@@ -466,7 +467,7 @@ pub(super) fn publish<'a>(
         config: &mut Config,
         recursive: bool,
     ) -> miette::Result<()> {
-        let hooks = run_update_config_for_packing::<Reporter>(config, dir).await?;
+        let hooks = prepare_config::<Reporter>(config, dir).await?;
         args.run::<Reporter>(dir, config, recursive, hooks).await
     }
     if args.flags.json {
@@ -500,7 +501,7 @@ pub(super) fn stage<'a>(
         recursive: bool,
     ) -> miette::Result<()> {
         let hooks = if args.params.first().is_some_and(|subcommand| subcommand == "publish") {
-            run_update_config_for_packing::<Reporter>(config, dir).await?
+            prepare_config::<Reporter>(config, dir).await?
         } else {
             Vec::new()
         };
@@ -523,20 +524,6 @@ pub(super) fn stage<'a>(
             Box::pin(print_output::<SilentReporter>(args, dir, config, recursive))
         }
     })
-}
-
-async fn run_update_config_for_packing<Reporter: pnpm_reporter::Reporter>(
-    config: &mut Config,
-    dir: &std::path::Path,
-) -> miette::Result<Vec<std::sync::Arc<dyn pnpm_hooks::PnpmfileHooks>>> {
-    let config_root = config.root_project_manifest_dir(dir).to_path_buf();
-    crate::config_deps::install_config_deps::<Reporter>(
-        config,
-        &config_root,
-        config.frozen_lockfile.unwrap_or(false),
-    )
-    .await?;
-    crate::config_deps::run_update_config_hooks::<Reporter>(config, &config_root).await
 }
 
 pub(super) fn bin<'a>(ctx: &RunCtx<'a>, args: BinArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -1,5 +1,5 @@
 use super::{
-    dispatch::{CommandFuture, RunCtx},
+    dispatch::{CommandFuture, RunCtx, apply_update_config},
     exec::ExecArgs,
     init::InitArgs,
     pkg::PkgArgs,
@@ -81,12 +81,18 @@ pub(super) fn test<'a>(
 pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<CommandFuture<'a>> {
     let config = (ctx.config)()?;
     let args = with_recursive_run_options(ctx, args, config);
-    if ctx.recursive {
-        args.run_recursive(config, ctx.dir, ctx.reporter)?;
-    } else {
-        args.run(ctx.dir, config, ctx.reporter)?;
-    }
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    let dir = ctx.dir;
+    let reporter = ctx.reporter;
+    let recursive = ctx.recursive;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        let config: &'static Config = config;
+        if recursive {
+            args.run_recursive(config, dir, reporter)
+        } else {
+            args.run(dir, config, reporter)
+        }
+    }))
 }
 
 pub(super) fn fallback<'a>(
@@ -108,25 +114,35 @@ pub(super) fn fallback<'a>(
     };
     let config = (ctx.config)()?;
     let args = with_recursive_run_options(ctx, args, config);
-    if ctx.recursive {
-        args.run_recursive(config, ctx.dir, ctx.reporter)?;
-    } else {
-        args.run_fallback(ctx.dir, config, ctx.reporter)?;
-    }
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    let dir = ctx.dir;
+    let reporter = ctx.reporter;
+    let recursive = ctx.recursive;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        let config: &'static Config = config;
+        if recursive {
+            args.run_recursive(config, dir, reporter)
+        } else {
+            args.run_fallback(dir, config, reporter)
+        }
+    }))
 }
 
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
-    let config: &'static Config = (ctx.config)()?;
+    let config = (ctx.config)()?;
     let args = with_recursive_exec_options(ctx, args, config);
-    if ctx.recursive {
-        let dir = ctx.dir;
-        let reporter = ctx.reporter;
-        Ok(Box::pin(async move { args.run_recursive(config, dir, reporter).await }))
-    } else {
-        args.run(ctx.dir, config, ctx.reporter)?;
-        Ok(Box::pin(std::future::ready(Ok(()))))
-    }
+    let dir = ctx.dir;
+    let reporter = ctx.reporter;
+    let recursive = ctx.recursive;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        let config: &'static Config = config;
+        if recursive {
+            args.run_recursive(config, dir, reporter).await
+        } else {
+            args.run(dir, config, reporter)
+        }
+    }))
 }
 
 fn with_recursive_run_options(ctx: &RunCtx<'_>, mut args: RunArgs, config: &Config) -> RunArgs {
@@ -164,8 +180,14 @@ pub(super) fn stop<'a>(
     if ctx.recursive {
         run(ctx, args.into_run_args("stop", ctx.if_present))
     } else {
-        args.run("stop", ctx.if_present, ctx.dir, (ctx.config)()?, ctx.reporter)?;
-        Ok(Box::pin(std::future::ready(Ok(()))))
+        let config = (ctx.config)()?;
+        let dir = ctx.dir;
+        let reporter = ctx.reporter;
+        let if_present = ctx.if_present;
+        Ok(Box::pin(async move {
+            apply_update_config(config, dir, reporter).await?;
+            args.run("stop", if_present, dir, config, reporter)
+        }))
     }
 }
 
@@ -174,6 +196,11 @@ pub(super) fn restart<'a>(
     mut args: RestartArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     args.if_present |= ctx.if_present;
-    args.run(ctx.dir, (ctx.config)()?, ctx.reporter)?;
-    Ok(Box::pin(std::future::ready(Ok(()))))
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let reporter = ctx.reporter;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        args.run(dir, config, reporter)
+    }))
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -80,13 +80,14 @@ pub(super) fn test<'a>(
 
 pub(super) fn run<'a>(ctx: &RunCtx<'a>, args: RunArgs) -> miette::Result<CommandFuture<'a>> {
     let config = (ctx.config)()?;
-    let args = with_recursive_run_options(ctx, args, config);
+    let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
     Ok(Box::pin(async move {
         apply_update_config(config, dir, reporter).await?;
         let config: &'static Config = config;
+        let args = with_recursive_run_options(cli_options, args, config);
         if recursive {
             args.run_recursive(config, dir, reporter)
         } else {
@@ -113,13 +114,14 @@ pub(super) fn fallback<'a>(
         json: false,
     };
     let config = (ctx.config)()?;
-    let args = with_recursive_run_options(ctx, args, config);
+    let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
     Ok(Box::pin(async move {
         apply_update_config(config, dir, reporter).await?;
         let config: &'static Config = config;
+        let args = with_recursive_run_options(cli_options, args, config);
         if recursive {
             args.run_recursive(config, dir, reporter)
         } else {
@@ -130,13 +132,14 @@ pub(super) fn fallback<'a>(
 
 pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<CommandFuture<'a>> {
     let config = (ctx.config)()?;
-    let args = with_recursive_exec_options(ctx, args, config);
+    let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
     Ok(Box::pin(async move {
         apply_update_config(config, dir, reporter).await?;
         let config: &'static Config = config;
+        let args = with_recursive_exec_options(cli_options, args, config);
         if recursive {
             args.run_recursive(config, dir, reporter).await
         } else {
@@ -145,24 +148,54 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
     }))
 }
 
-fn with_recursive_run_options(ctx: &RunCtx<'_>, mut args: RunArgs, config: &Config) -> RunArgs {
-    args.resume_from = ctx.recursive_resume_from.map(str::to_string);
-    args.report_summary = ctx.recursive_report_summary;
+/// The top-level recursive flags of a `run` / `exec` invocation, copied out
+/// of [`RunCtx`] so the handler's future can merge them with `bail`, `sort`
+/// and `reverse` only after `updateConfig` has had its say on those settings.
+#[derive(Clone, Copy)]
+struct RecursiveCliOptions<'a> {
+    resume_from: Option<&'a str>,
+    report_summary: bool,
+    parallel: bool,
+    if_present: bool,
+}
+
+impl<'a> RecursiveCliOptions<'a> {
+    fn from_ctx(ctx: &RunCtx<'a>) -> Self {
+        Self {
+            resume_from: ctx.recursive_resume_from,
+            report_summary: ctx.recursive_report_summary,
+            parallel: ctx.recursive_parallel,
+            if_present: ctx.if_present,
+        }
+    }
+}
+
+fn with_recursive_run_options(
+    cli_options: RecursiveCliOptions<'_>,
+    mut args: RunArgs,
+    config: &Config,
+) -> RunArgs {
+    args.resume_from = cli_options.resume_from.map(str::to_string);
+    args.report_summary = cli_options.report_summary;
     args.no_bail = !config.bail;
     args.sort = config.sort;
     args.reverse = config.reverse;
-    args.parallel = ctx.recursive_parallel;
-    args.if_present |= ctx.if_present;
+    args.parallel = cli_options.parallel;
+    args.if_present |= cli_options.if_present;
     args
 }
 
-fn with_recursive_exec_options(ctx: &RunCtx<'_>, mut args: ExecArgs, config: &Config) -> ExecArgs {
-    args.resume_from = ctx.recursive_resume_from.map(str::to_string);
-    args.report_summary = ctx.recursive_report_summary;
+fn with_recursive_exec_options(
+    cli_options: RecursiveCliOptions<'_>,
+    mut args: ExecArgs,
+    config: &Config,
+) -> ExecArgs {
+    args.resume_from = cli_options.resume_from.map(str::to_string);
+    args.report_summary = cli_options.report_summary;
     args.no_bail = !config.bail;
     args.sort = config.sort;
     args.reverse = config.reverse;
-    args.parallel = ctx.recursive_parallel;
+    args.parallel = cli_options.parallel;
     args
 }
 

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -455,6 +455,25 @@ pub fn load_before_packing_hooks(
         .collect())
 }
 
+/// Install the project's `configDependencies` and apply the `updateConfig`
+/// pnpmfile hooks to `config`, returning the loaded hook objects. `dir` is
+/// the command's working directory; the config root is derived from it the
+/// same way the install family derives it.
+///
+/// The entry point for commands outside the install family, each of which
+/// resolves its own [`Config`]: pnpm applies `updateConfig` once per
+/// invocation, before the command runs, so a hook's settings — including
+/// `extraEnv` and `extraBinPaths` — reach every command's child processes.
+pub async fn prepare_config<Reporter: self::Reporter>(
+    config: &mut Config,
+    dir: &Path,
+) -> Result<Vec<Arc<dyn PnpmfileHooks>>> {
+    let config_root = config.root_project_manifest_dir(dir).to_path_buf();
+    install_config_deps::<Reporter>(config, &config_root, config.frozen_lockfile.unwrap_or(false))
+        .await?;
+    run_update_config_hooks::<Reporter>(config, &config_root).await
+}
+
 /// Run the `updateConfig` pnpmfile hooks contributed by config-dependency
 /// plugins and the project's own pnpmfile, applying their result to `config`.
 /// The returned handles are the same loaded hook objects that ran

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -110,3 +110,36 @@ fn update_config_applies_to_recursive_run() {
 
     drop(root);
 }
+
+/// A hook that changes an install-affecting setting must be applied before
+/// the verify-deps-before-run check compares the live settings with the ones
+/// the last install recorded. Without the hook, `pnpm run` sees the
+/// pre-hook value, reports the setting as changed, and — under
+/// `verifyDepsBeforeRun: error` — refuses to run any script at all.
+#[cfg(unix)]
+#[test]
+fn update_config_applies_before_the_verify_deps_check() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let manifest = serde_json::json!({
+        "name": "run-under-verify-deps",
+        "private": true,
+        "scripts": { "foo": "printf ran" },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages: []\nverifyDepsBeforeRun: error\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.dedupePeers = true; return config } } }",
+    )
+    .expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+    let output = pacquet_in(&workspace).with_arg("run").with_arg("foo").assert().success();
+
+    let stdout = String::from_utf8_lossy(&output.get_output().stdout);
+    assert!(stdout.contains("ran"), "the script should have run\nSTDOUT:\n{stdout}");
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -25,20 +25,21 @@ fn filter_log_is_ignored_with_a_warning() {
 
 const EXTRA_ENV_PNPMFILE: &str = "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, PNPM_HOOK_MARKER: 'from-hook' }; return config } } }";
 
+/// A script that records `PNPM_HOOK_MARKER` — the variable
+/// [`EXTRA_ENV_PNPMFILE`] exports — in `marker.txt` next to the manifest.
+const WRITE_MARKER_SCRIPT: &str =
+    r#"node -e "require('fs').writeFileSync('marker.txt', process.env.PNPM_HOOK_MARKER || '')""#;
+
 /// `updateConfig` applies to `pnpm run`, not just to the install family:
 /// the settings a hook returns — `extraEnv` here — reach the environment of
 /// the script it spawns.
-#[cfg(unix)]
 #[test]
 fn update_config_applies_to_run() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let marker = workspace.join("marker.txt");
     let manifest = serde_json::json!({
         "name": "run-reads-extra-env",
         "version": "0.0.0",
-        "scripts": {
-            "write-marker": format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()),
-        },
+        "scripts": { "write-marker": WRITE_MARKER_SCRIPT },
     })
     .to_string();
     fs::write(workspace.join("package.json"), manifest).expect("write package.json");
@@ -46,38 +47,35 @@ fn update_config_applies_to_run() {
 
     pacquet_in(&workspace).with_arg("run").with_arg("write-marker").assert().success();
 
-    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
+    assert_eq!(fs::read_to_string(workspace.join("marker.txt")).expect("read marker"), "from-hook");
 
     drop(root);
 }
 
 /// The same for `pnpm exec`, which spawns its command through the same
 /// environment.
-#[cfg(unix)]
 #[test]
 fn update_config_applies_to_exec() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let marker = workspace.join("marker.txt");
     fs::write(workspace.join("package.json"), r#"{"name":"exec-reads-extra-env"}"#)
         .expect("write package.json");
     fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
 
     pacquet_in(&workspace)
         .with_arg("exec")
-        .with_arg("sh")
-        .with_arg("-c")
-        .with_arg(format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()))
+        .with_arg("node")
+        .with_arg("-e")
+        .with_arg("require('fs').writeFileSync('marker.txt', process.env.PNPM_HOOK_MARKER || '')")
         .assert()
         .success();
 
-    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
+    assert_eq!(fs::read_to_string(workspace.join("marker.txt")).expect("read marker"), "from-hook");
 
     drop(root);
 }
 
 /// A recursive `pnpm run` applies the workspace-root hook to every
 /// project's script environment.
-#[cfg(unix)]
 #[test]
 fn update_config_applies_to_recursive_run() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
@@ -88,13 +86,10 @@ fn update_config_applies_to_recursive_run() {
     fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
     let project = workspace.join("packages").join("a");
     fs::create_dir_all(&project).expect("create project dir");
-    let marker = project.join("marker.txt");
     let manifest = serde_json::json!({
         "name": "a",
         "version": "0.0.0",
-        "scripts": {
-            "write-marker": format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()),
-        },
+        "scripts": { "write-marker": WRITE_MARKER_SCRIPT },
     })
     .to_string();
     fs::write(project.join("package.json"), manifest).expect("write project package.json");
@@ -106,6 +101,85 @@ fn update_config_applies_to_recursive_run() {
         .assert()
         .success();
 
+    assert_eq!(fs::read_to_string(project.join("marker.txt")).expect("read marker"), "from-hook");
+
+    drop(root);
+}
+
+/// The recursive-run defaults `bail`, `sort` and `reverse` are read after
+/// the hook ran: a hook that turns `bail` off keeps a recursive run
+/// dispatching past a failing project.
+#[test]
+fn update_config_applies_to_recursive_run_defaults() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{"name":"root","private":true}"#)
+        .expect("write root package.json");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages:\n  - packages/*\nworkspaceConcurrency: 1\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.bail = false; return config } } }",
+    )
+    .expect("write pnpmfile");
+    // One project at a time, in name order: the failure comes first, so
+    // the default `bail` would never dispatch the second project.
+    let failing = workspace.join("packages").join("a-fails");
+    fs::create_dir_all(&failing).expect("create failing project dir");
+    fs::write(
+        failing.join("package.json"),
+        serde_json::json!({
+            "name": "a-fails",
+            "version": "0.0.0",
+            "scripts": { "check": r#"node -e "process.exit(1)""# },
+        })
+        .to_string(),
+    )
+    .expect("write failing project package.json");
+    let next = workspace.join("packages").join("b-writes-marker");
+    fs::create_dir_all(&next).expect("create next project dir");
+    fs::write(
+        next.join("package.json"),
+        serde_json::json!({
+            "name": "b-writes-marker",
+            "version": "0.0.0",
+            "scripts": { "check": WRITE_MARKER_SCRIPT },
+        })
+        .to_string(),
+    )
+    .expect("write next project package.json");
+
+    pacquet_in(&workspace).with_args(["--recursive", "run", "check"]).assert().failure();
+
+    assert!(
+        next.join("marker.txt").exists(),
+        "with the hook's `bail: false`, the run must go on to the project after the failure",
+    );
+
+    drop(root);
+}
+
+/// `pnpm rebuild` re-runs install scripts with the hook's settings too.
+#[test]
+fn update_config_applies_to_rebuild() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let manifest = serde_json::json!({
+        "name": "rebuild-reads-extra-env",
+        "version": "0.0.0",
+        "scripts": { "install": WRITE_MARKER_SCRIPT },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+    fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
+    let marker = workspace.join("marker.txt");
+
+    pacquet_in(&workspace).with_args(["install", "--ignore-scripts"]).assert().success();
+    assert!(!marker.exists(), "--ignore-scripts must leave the install script for rebuild");
+
+    pacquet_in(&workspace).with_args(["rebuild", "--pending"]).assert().success();
+
     assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
 
     drop(root);
@@ -116,14 +190,13 @@ fn update_config_applies_to_recursive_run() {
 /// the last install recorded. Without the hook, `pnpm run` sees the
 /// pre-hook value, reports the setting as changed, and — under
 /// `verifyDepsBeforeRun: error` — refuses to run any script at all.
-#[cfg(unix)]
 #[test]
 fn update_config_applies_before_the_verify_deps_check() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
     let manifest = serde_json::json!({
         "name": "run-under-verify-deps",
         "private": true,
-        "scripts": { "foo": "printf ran" },
+        "scripts": { "foo": r#"node -e "console.log('ran')""# },
     })
     .to_string();
     fs::write(workspace.join("package.json"), manifest).expect("write package.json");

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -22,3 +22,91 @@ fn filter_log_is_ignored_with_a_warning() {
 
     drop(root);
 }
+
+const EXTRA_ENV_PNPMFILE: &str = "module.exports = { hooks: { updateConfig (config) { config.extraEnv = { ...config.extraEnv, PNPM_HOOK_MARKER: 'from-hook' }; return config } } }";
+
+/// `updateConfig` applies to `pnpm run`, not just to the install family:
+/// the settings a hook returns — `extraEnv` here — reach the environment of
+/// the script it spawns.
+#[cfg(unix)]
+#[test]
+fn update_config_applies_to_run() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("marker.txt");
+    let manifest = serde_json::json!({
+        "name": "run-reads-extra-env",
+        "version": "0.0.0",
+        "scripts": {
+            "write-marker": format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()),
+        },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+    fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_arg("run").with_arg("write-marker").assert().success();
+
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
+
+    drop(root);
+}
+
+/// The same for `pnpm exec`, which spawns its command through the same
+/// environment.
+#[cfg(unix)]
+#[test]
+fn update_config_applies_to_exec() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let marker = workspace.join("marker.txt");
+    fs::write(workspace.join("package.json"), r#"{"name":"exec-reads-extra-env"}"#)
+        .expect("write package.json");
+    fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace)
+        .with_arg("exec")
+        .with_arg("sh")
+        .with_arg("-c")
+        .with_arg(format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()))
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
+
+    drop(root);
+}
+
+/// A recursive `pnpm run` applies the workspace-root hook to every
+/// project's script environment.
+#[cfg(unix)]
+#[test]
+fn update_config_applies_to_recursive_run() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{"name":"root","private":true}"#)
+        .expect("write root package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(workspace.join(".pnpmfile.cjs"), EXTRA_ENV_PNPMFILE).expect("write pnpmfile");
+    let project = workspace.join("packages").join("a");
+    fs::create_dir_all(&project).expect("create project dir");
+    let marker = project.join("marker.txt");
+    let manifest = serde_json::json!({
+        "name": "a",
+        "version": "0.0.0",
+        "scripts": {
+            "write-marker": format!(r#"printf %s "$PNPM_HOOK_MARKER" > "{}""#, marker.display()),
+        },
+    })
+    .to_string();
+    fs::write(project.join("package.json"), manifest).expect("write project package.json");
+
+    pacquet_in(&workspace)
+        .with_arg("--recursive")
+        .with_arg("run")
+        .with_arg("write-marker")
+        .assert()
+        .success();
+
+    assert_eq!(fs::read_to_string(&marker).expect("read marker"), "from-hook");
+
+    drop(root);
+}


### PR DESCRIPTION
## Summary

`pnpm run`, `pnpm exec`, `pnpm rebuild` and the script shortcuts (`pnpm test`, `start`, `stop`, `restart`, `pnpm <script>`) never loaded the pnpmfile, so an `updateConfig` hook did not apply to them: `config.extra_env` / `config.extra_bin_paths` stayed empty at the spawn sites that forward them, and any other setting a hook changed was lost. The TypeScript CLI applies the hooks once per invocation for every command (`installConfigDepsAndLoadHooks` in `pnpm11/pnpm/src/main.ts`); the Rust CLI only did so in the install-family pipelines and, since pnpm/pnpm#14381, pack/publish.

Fixes pnpm/pnpm#14433.

The hook's absence is not only a silently missing setting. Under `verifyDepsBeforeRun: error`, a hook that changes an install-affecting setting (`dedupePeers: true`, say) makes `pnpm run` refuse to run any script: the check compares the pre-hook value with what the install recorded and reports the setting as changed (`ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`). Reported on the issue, reproduced against 12.2.1, and covered by a test here.

This is the sibling of pnpm/pnpm#14377 for the script commands. `pnpm dlx` / `pnpm create` still don't apply the hooks — they resolve config against the dlx cache dir rather than a project root, so they need their own treatment; left out deliberately.

## Squash Commit Body

```text
`pnpm run`, `pnpm exec`, `pnpm rebuild` and the script shortcuts never
loaded the pnpmfile, so an `updateConfig` hook did not apply to them:
`config.extra_env` / `config.extra_bin_paths` stayed empty at the spawn
sites that forward them, and any setting a hook changed was lost. The
TypeScript CLI applies the hooks once per invocation for every command,
in `installConfigDepsAndLoadHooks`; the Rust CLI only did so in the
install-family pipelines and, since pnpm/pnpm#14381, pack/publish.

Extract the pack/publish pass as `config_deps::prepare_config` and apply
it in the script commands and `rebuild` as well. Each `RunCtx::config`
call yields a fresh `Config`, so the pass runs inside each handler on the
instance that handler goes on to use rather than once ahead of `route`.
Commands without a pnpmfile are unaffected: the hook pass returns before
loading anything when no pnpmfile is found, and config-dependency install
returns early when none are declared.

Closes pnpm/pnpm#14433
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Rust-only: the TypeScript CLI already behaves correctly — verified against
  pnpm 11.25.0, where the same fixture exports the hook's `extraEnv` to
  `pnpm run`.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. Four e2e tests in `hooks.rs` cover `run`, `exec`,
  recursive `run`, and the verify-deps interaction; each was confirmed to fail
  without the fix.
- [ ] Updated the documentation if needed.

### Validation

- `cargo test -p pnpm-cli` — 1837 e2e + 1252 unit tests pass.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo doc` with `-D warnings`, `taplo format --check` — clean.
- Manually against a built binary: a `.pnpmfile.cjs` whose `updateConfig` sets `extraEnv` and `nodeOptions` now reaches `pnpm run`, `pnpm exec` and the bare-script fallback, matching pnpm 11; `ignorePnpmfile: true` still skips it.

### Performance

A project with no pnpmfile pays only the pnpmfile path lookups: `run_update_config_hooks` returns before loading any hook when none is found, and `install_config_deps` returns early with no `configDependencies`. A project that has a pnpmfile now spawns its Node worker for these commands, which is the cost pnpm 11 pays for the same behavior.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm run`, `pnpm exec`, `pnpm rebuild`, and script shortcuts now apply `updateConfig` settings before execution.
  * Environment variables, binary paths, and other configuration changes from pnpmfile hooks now reach spawned commands.
  * Recursive scripts correctly receive workspace-level configuration.
  * Configuration changes are applied before dependency verification checks, preventing valid scripts from being blocked.
  * `pnpm pack`, `pnpm publish`, and staged publishing now consistently apply configuration hooks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->