### PR TITLE
fix(add): resolve alias-less local, tarball and URL selectors

### DIFF
--- a/.changeset/aliasless-add-specifiers.md
+++ b/.changeset/aliasless-add-specifiers.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm add <local directory>`, `pnpm add <local tarball>`, `pnpm add file:<path>` and `pnpm add <tarball URL>` work again: a specifier given without a `<name>@` prefix is no longer read as a registry package name and rejected with `ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST` [#14437](https://github.com/pnpm/pnpm/issues/14437).

--- a/.changeset/no-cataloging-of-local-paths.md
+++ b/.changeset/no-cataloging-of-local-paths.md
@@ -1,8 +1,9 @@
 ---
 "@pnpm/resolving.local-resolver": minor
+"@pnpm/installing.deps-resolver": minor
 "@pnpm/installing.deps-installer": patch
 "pacquet": patch
 "pnpm": patch
 ---
 
-`catalogMode` and `--save-catalog` no longer move a local path or tarball specifier into a catalog. A catalog entry is shared by every project that references it, so it cannot hold a path that resolves against the project declaring it — cataloging one wrote an entry the next install rejected with `ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC` [#14437](https://github.com/pnpm/pnpm/issues/14437).
+`catalogMode` and `--save-catalog` no longer move a local path, tarball, or `workspace:<path>` specifier into a catalog — such a path is resolved against the project that declares it, so a shared catalog entry cannot mean the same directory for every project referencing it [#14437](https://github.com/pnpm/pnpm/issues/14437).

--- a/.changeset/no-cataloging-of-local-paths.md
+++ b/.changeset/no-cataloging-of-local-paths.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/resolving.local-resolver": minor
+"@pnpm/installing.deps-installer": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`catalogMode` and `--save-catalog` no longer move a local path or tarball specifier into a catalog. A catalog entry is shared by every project that references it, so it cannot hold a path that resolves against the project declaring it — cataloging one wrote an entry the next install rejected with `ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC` [#14437](https://github.com/pnpm/pnpm/issues/14437).

--- a/.changeset/redact-tarball-error-urls.md
+++ b/.changeset/redact-tarball-error-urls.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Tarball download errors no longer print the inline `user:pass@` credentials of the URL they name, so a failed install or `pnpm add <url>` cannot leak them into terminal scrollback or CI logs.

--- a/.changeset/redact-tarball-error-urls.md
+++ b/.changeset/redact-tarball-error-urls.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Tarball download errors no longer print the inline `user:pass@` credentials of the URL they name, so a failed install or `pnpm add <url>` cannot leak them into terminal scrollback or CI logs.
+Tarball download and resolution errors no longer print the secrets of the URL they name — inline `user:pass@` credentials, and the query string or fragment of a signed URL — so a failed install or `pnpm add <url>` cannot leak them into terminal scrollback or CI logs.

--- a/.changeset/redact-tarball-error-urls.md
+++ b/.changeset/redact-tarball-error-urls.md
@@ -1,5 +1,7 @@
 ---
+"@pnpm/error": patch
 "pacquet": patch
+"pnpm": patch
 ---
 
-Tarball download and resolution errors no longer print the secrets of the URL they name — inline `user:pass@` credentials, and the query string or fragment of a signed URL — so a failed install or `pnpm add <url>` cannot leak them into terminal scrollback or CI logs.
+Fetch and tarball errors no longer print the secrets of the URL they name — inline `user:pass@` credentials, and the query string or fragment of a signed URL — so a failed install or `pnpm add <url>` cannot leak them into terminal scrollback or CI logs.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5833,6 +5833,9 @@ importers:
       '@pnpm/pnpr.client':
         specifier: workspace:*
         version: link:../../../pnpr/client
+      '@pnpm/resolving.local-resolver':
+        specifier: workspace:*
+        version: link:../../resolving/local-resolver
       '@pnpm/resolving.parse-wanted-dependency':
         specifier: workspace:*
         version: link:../../resolving/parse-wanted-dependency

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1379,3 +1379,176 @@ const HERMETIC_STORE_YAML: &str =
 fn write_json(path: &Path, value: &serde_json::Value) {
     std::fs::write(path, value.to_string()).expect("write manifest");
 }
+
+/// An alias-less selector — the whole argument is the specifier, with no
+/// `<name>@` in front — names a package whose name lives only in its own
+/// manifest. Covers <https://github.com/pnpm/pnpm/issues/14437>: every such
+/// selector but a git URL used to be read as a registry package name and
+/// failed with `ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST`.
+mod aliasless_selectors {
+    use super::{Path, prod_spec, write_json};
+    use crate::_utils::append_workspace_yaml_key;
+    use assert_cmd::prelude::*;
+    use command_extra::CommandExtra;
+    use pnpm_testing_utils::{
+        bin::{AddMockedRegistry, CommandTempCwd},
+        fixtures::tarball_with_manifest,
+    };
+    use pretty_assertions::assert_eq;
+    use std::fs;
+
+    /// Write `<workspace>/localpkg/package.json`, the package the
+    /// directory-shaped selectors below point at.
+    fn write_local_package(workspace: &Path) {
+        let package_dir = workspace.join("localpkg");
+        fs::create_dir_all(&package_dir).expect("create local package dir");
+        write_json(
+            &package_dir.join("package.json"),
+            &serde_json::json!({ "name": "localpkg", "version": "1.0.0" }),
+        );
+    }
+
+    /// A bare relative path is a directory dependency, so it saves as
+    /// `link:` — the protocol the local resolver normalizes an
+    /// un-injected directory to.
+    #[test]
+    fn a_relative_directory_path_saves_as_a_link() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        write_local_package(&workspace);
+
+        pacquet.with_args(["add", "./localpkg"]).assert().success();
+
+        assert_eq!(prod_spec(&workspace, "localpkg"), "link:localpkg");
+        assert!(
+            workspace.join("node_modules/localpkg/package.json").exists(),
+            "the local package must be installed",
+        );
+
+        drop((root, npmrc_info));
+    }
+
+    /// The `file:` protocol asks for copy semantics, so it is kept.
+    #[test]
+    fn the_file_protocol_on_a_directory_is_kept() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        write_local_package(&workspace);
+
+        pacquet.with_args(["add", "file:./localpkg"]).assert().success();
+
+        assert_eq!(prod_spec(&workspace, "localpkg"), "file:localpkg");
+
+        drop((root, npmrc_info));
+    }
+
+    /// A local tarball's name lives in the `package.json` it bundles, so
+    /// the archive has to be read before the manifest entry can be
+    /// written.
+    #[test]
+    fn a_local_tarball_path_saves_as_a_file_spec() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        fs::write(
+            workspace.join("pkg-from-tarball-1.0.0.tgz"),
+            tarball_with_manifest(
+                &serde_json::json!({ "name": "pkg-from-tarball", "version": "1.0.0" }),
+            ),
+        )
+        .expect("write tarball");
+
+        pacquet.with_args(["add", "./pkg-from-tarball-1.0.0.tgz"]).assert().success();
+
+        assert_eq!(prod_spec(&workspace, "pkg-from-tarball"), "file:pkg-from-tarball-1.0.0.tgz",);
+        assert!(
+            workspace.join("node_modules/pkg-from-tarball/package.json").exists(),
+            "the tarball package must be installed",
+        );
+
+        drop((root, npmrc_info));
+    }
+
+    /// A remote tarball is the same shape one step further out: the name
+    /// is inside the archive, so the resolver downloads it.
+    ///
+    /// The URL points at the mocked registry through `localhost` while it
+    /// is configured as `127.0.0.1`, so the prefix doesn't match and the
+    /// tarball resolver — not the npm resolver — claims it (see
+    /// `tarball_url_dependency.rs`).
+    #[test]
+    fn a_remote_tarball_url_is_saved_verbatim() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+        let tarball = format!(
+            "{}is-positive/-/is-positive-1.0.0.tgz",
+            mock_instance.url().replace("127.0.0.1", "localhost"),
+        );
+
+        pacquet.with_args(["add", &tarball]).assert().success();
+
+        assert_eq!(prod_spec(&workspace, "is-positive"), tarball);
+        assert!(
+            workspace.join("node_modules/is-positive/package.json").exists(),
+            "the remote tarball package must be installed",
+        );
+
+        drop((root, mock_instance));
+    }
+
+    /// A catalog entry is read by every project referencing it, so it
+    /// cannot hold a path that resolves against the project declaring it.
+    /// `catalogMode` has to leave such a specifier direct — cataloging it
+    /// writes an entry the next install refuses with
+    /// `ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`.
+    #[test]
+    fn a_local_directory_is_not_auto_cataloged() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        write_local_package(&workspace);
+        append_workspace_yaml_key(&workspace, "catalogMode", "prefer");
+
+        pacquet.with_args(["add", "./localpkg"]).assert().success();
+
+        assert_eq!(prod_spec(&workspace, "localpkg"), "link:localpkg");
+        let workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml"))
+            .expect("read pnpm-workspace.yaml");
+        assert!(
+            !workspace_yaml.contains("localpkg"),
+            "the local dependency must not reach the catalog:\n{workspace_yaml}",
+        );
+
+        drop((root, npmrc_info));
+    }
+
+    /// The name keys the manifest entry and names the `node_modules`
+    /// directory the package is linked into, so a directory that declares
+    /// none is refused instead of guessed at — and the project is left
+    /// untouched.
+    #[test]
+    fn a_directory_declaring_no_name_is_refused() {
+        let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let package_dir = workspace.join("nameless");
+        fs::create_dir_all(&package_dir).expect("create local package dir");
+        write_json(&package_dir.join("package.json"), &serde_json::json!({ "version": "1.0.0" }));
+        write_json(
+            &workspace.join("package.json"),
+            &serde_json::json!({ "name": "project", "version": "1.0.0" }),
+        );
+        let manifest_before =
+            fs::read_to_string(workspace.join("package.json")).expect("read manifest");
+
+        let output = pacquet.with_args(["add", "./nameless"]).output().expect("run pnpm add");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("STDERR:\n{stderr}\n");
+        assert!(!output.status.success());
+        assert!(stderr.contains("ERR_PNPM_MISSING_PACKAGE_NAME"), "stderr:\n{stderr}");
+        assert_eq!(
+            fs::read_to_string(workspace.join("package.json")).expect("reread manifest"),
+            manifest_before,
+        );
+
+        drop((root, npmrc_info));
+    }
+}

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1382,9 +1382,10 @@ fn write_json(path: &Path, value: &serde_json::Value) {
 
 /// An alias-less selector — the whole argument is the specifier, with no
 /// `<name>@` in front — names a package whose name lives only in its own
-/// manifest. Covers <https://github.com/pnpm/pnpm/issues/14437>: every such
-/// selector but a git URL used to be read as a registry package name and
-/// failed with `ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST`.
+/// manifest, so `add` reads it from the directory, the archive, or the
+/// checkout rather than from the selector.
+///
+/// Covers <https://github.com/pnpm/pnpm/issues/14437>.
 mod aliasless_selectors {
     use super::{Path, prod_spec, write_json};
     use crate::_utils::append_workspace_yaml_key;

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1459,7 +1459,7 @@ mod aliasless_selectors {
 
         pacquet.with_args(["add", "./pkg-from-tarball-1.0.0.tgz"]).assert().success();
 
-        assert_eq!(prod_spec(&workspace, "pkg-from-tarball"), "file:pkg-from-tarball-1.0.0.tgz",);
+        assert_eq!(prod_spec(&workspace, "pkg-from-tarball"), "file:pkg-from-tarball-1.0.0.tgz");
         assert!(
             workspace.join("node_modules/pkg-from-tarball/package.json").exists(),
             "the tarball package must be installed",

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1166,32 +1166,66 @@ fn redacted_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
     strip_url_query_and_fragment(&redact_and_sanitize(&frames.join(": ")))
 }
 
-/// Cut every URL in `text` at its query or fragment. A URL in error prose
-/// ends at whitespace or at one of the marks a message wraps it in, and a
-/// `://` not preceded by a scheme character is not an authority boundary.
+/// Cut every URL in `text` back to its display-safe form. A URL in error
+/// prose ends at whitespace or at one of the marks a message wraps it in,
+/// and a `://` not preceded by a scheme is not an authority boundary.
 fn strip_url_query_and_fragment(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
     while let Some(pos) = rest.find("://") {
-        let has_scheme = pos > 0 && rest.as_bytes()[pos - 1].is_ascii_alphanumeric();
-        let authority_start = pos + "://".len();
-        out.push_str(&rest[..authority_start]);
-        let after = &rest[authority_start..];
-        if !has_scheme {
-            rest = after;
+        // Walk back over the scheme so the whole URL token can be replaced,
+        // not just its authority onwards.
+        let scheme_start = rest[..pos]
+            .rfind(|character: char| {
+                !(character.is_ascii_alphanumeric() || matches!(character, '+' | '-' | '.'))
+            })
+            .map_or(0, |index| index + 1);
+        if scheme_start == pos {
+            out.push_str(&rest[..pos + "://".len()]);
+            rest = &rest[pos + "://".len()..];
             continue;
         }
-        let end = after
-            .find(|character: char| {
-                character.is_whitespace() || matches!(character, ')' | ']' | '"' | '\'')
-            })
-            .unwrap_or(after.len());
-        let (token, tail) = after.split_at(end);
-        out.push_str(&token[..token.find(['?', '#']).unwrap_or(token.len())]);
+        out.push_str(&rest[..scheme_start]);
+        let token_and_tail = &rest[scheme_start..];
+        let end = url_token_len(token_and_tail);
+        let (token, tail) = token_and_tail.split_at(end);
+        out.push_str(&redact_url_token(token));
         rest = tail;
     }
     out.push_str(rest);
     out
+}
+
+/// Where the URL at the start of `text` ends: at whitespace, at one of the
+/// marks a message wraps a URL in, or at a `": "` — which cannot occur
+/// inside a URL, and is how a message punctuates the URL from what follows
+/// it (`GET <url>: 404`). Without that last case, cutting the query would
+/// swallow the message's own separator.
+fn url_token_len(text: &str) -> usize {
+    let wrapped = text
+        .find(|character: char| {
+            character.is_whitespace() || matches!(character, ')' | ']' | '"' | '\'')
+        })
+        .unwrap_or(text.len());
+    text.find(": ").map_or(wrapped, |punctuated| wrapped.min(punctuated))
+}
+
+/// One URL token cut at its query or fragment, or `[hidden]` when the cut
+/// would leave credential material behind.
+///
+/// A password containing `?` or `#` defeats the userinfo scan that runs
+/// before this — the scan reads the `?` as the end of the authority and
+/// leaves the whole `user:pa?ss@host` in place — so cutting there would
+/// publish the password's prefix. The authority is therefore checked on the
+/// *uncut* token: any `@` still in front of the path means the userinfo
+/// survived, and the token fails closed instead.
+fn redact_url_token(token: &str) -> String {
+    let after_scheme = token.find("://").map_or(token, |pos| &token[pos + "://".len()..]);
+    let authority = &after_scheme[..after_scheme.find('/').unwrap_or(after_scheme.len())];
+    if authority.contains('@') {
+        return "[hidden]".to_string();
+    }
+    token[..token.find(['?', '#']).unwrap_or(token.len())].to_string()
 }
 
 /// The display-safe form of an alias-less selector, which may be a local

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -32,6 +32,11 @@ use pnpm_resolving_deps_resolver::{UpdateDepth, UpdateTargets, is_valid_dependen
 use pnpm_resolving_git_resolver::{
     GitFetchContext, GitResolver, HostedGit, HostedOpts, RealGitProbe, RealGitRunner,
 };
+use pnpm_resolving_local_resolver::{
+    LocalResolverContext, LocalResolverOptions, LocalResolverUpdate, ResolveLocalError,
+    WantedLocalDependency, is_local_filesystem_specifier, resolve_from_local_path,
+    resolve_from_local_scheme,
+};
 use pnpm_resolving_npm_resolver::{
     DeclaredSpecifiers, InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError,
     PickPackageOptions, calc_specifier_for_workspace_dep, calc_version_range,
@@ -39,11 +44,13 @@ use pnpm_resolving_npm_resolver::{
     pick_package, pick_registry_for_package, shared_packument_fetch_locker,
 };
 use pnpm_resolving_resolver_base::{GitResolveError, PreferredVersions, WorkspacePackages};
+use pnpm_resolving_tarball_resolver::{TarballFetchContext, TarballResolver};
+use pnpm_store_dir::SharedVerifiedFilesCache;
 use pnpm_tarball::MemCache;
 use pnpm_workspace_range_resolver::resolve_workspace_range;
 use pnpm_workspace_spec::WorkspaceSpec;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     path::PathBuf,
     sync::Arc,
 };
@@ -160,6 +167,28 @@ pub enum AddError {
     #[display("Invalid package name {name:?} in git dependency {specifier:?}")]
     #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_NAME))]
     InvalidGitPackageName { specifier: String, name: String },
+
+    /// Reading the directory or tarball an alias-less local selector names
+    /// failed. Kept as the diagnostic the local resolver raised, which
+    /// already names the offending path and carries its own code.
+    #[diagnostic(transparent)]
+    ResolveLocal(#[error(source)] ResolveLocalError),
+
+    #[display("Failed to resolve tarball dependency {specifier:?}: {source}")]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_TARBALL))]
+    ResolveTarball {
+        specifier: String,
+        #[error(source)]
+        source: pnpm_resolving_resolver_base::ResolveError,
+    },
+
+    #[display("Could not determine the package name of dependency {specifier:?}")]
+    #[diagnostic(code(ERR_PNPM_MISSING_PACKAGE_NAME))]
+    MissingPackageName { specifier: String },
+
+    #[display("Invalid package name {name:?} in dependency {specifier:?}")]
+    #[diagnostic(code(ERR_PNPM_INVALID_PACKAGE_NAME))]
+    InvalidPackageName { specifier: String, name: String },
 
     /// Resolving a `node@runtime:<spec>` selector against the Node.js
     /// release index (to pin the manifest to the picked version) failed.
@@ -836,16 +865,14 @@ async fn resolve_added_dependency<'a>(
     workspace_packages: Option<&WorkspacePackages>,
 ) -> Result<ResolvedAddedDependency, AddError> {
     let parsed = pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency(package_selector);
-    let aliasless_git = match (parsed.alias.as_deref(), parsed.bare_specifier.as_deref()) {
-        (None, Some(specifier))
-            if pnpm_resolving_git_resolver::parse_bare_specifier(specifier).is_some() =>
-        {
-            Some(resolve_aliasless_git(specifier, config, http_client_arc).await?)
+    let aliasless = match (parsed.alias.as_deref(), parsed.bare_specifier.as_deref()) {
+        (None, Some(specifier)) => {
+            resolve_aliasless_specifier(specifier, config, http_client_arc, manifest).await?
         }
         _ => None,
     };
-    let (package_name, explicit_spec) = match aliasless_git.as_ref() {
-        Some(git) => (git.package_name.as_str(), Some(git.manifest_specifier.as_str())),
+    let (package_name, explicit_spec) = match aliasless.as_ref() {
+        Some(dep) => (dep.package_name.as_str(), Some(dep.manifest_specifier.as_str())),
         None => split_name_spec(package_selector),
     };
 
@@ -979,16 +1006,163 @@ async fn resolve_added_dependency<'a>(
     })
 }
 
-struct AliaslessGitDependency {
+/// The package name and manifest specifier for an add selector that names
+/// no alias: a git URL, a remote tarball URL, or a local directory /
+/// tarball. Such a selector is the whole specifier, and the package's name
+/// lives only in its own manifest — inside the archive, the checkout, or
+/// the directory — so it has to be read from there before the manifest
+/// entry can be written.
+struct AliaslessDependency {
     package_name: String,
     manifest_specifier: String,
+}
+
+/// Resolve an alias-less add selector, or `None` to leave it to
+/// [`split_name_spec`], which reads it as a registry `<name>[@<spec>]`.
+///
+/// Dispatch order mirrors the install's resolver chain: git and the tarball
+/// URL are matched first, because the local-path detector would otherwise
+/// claim those shapes on the strength of an embedded `/` or `:`.
+async fn resolve_aliasless_specifier(
+    specifier: &str,
+    config: &'static Config,
+    http_client: &Arc<ThrottledClient>,
+    manifest: &PackageManifest,
+) -> Result<Option<AliaslessDependency>, AddError> {
+    if pnpm_resolving_git_resolver::parse_bare_specifier(specifier).is_some() {
+        return resolve_aliasless_git(specifier, config, http_client).await.map(Some);
+    }
+    if specifier.starts_with("http:") || specifier.starts_with("https:") {
+        return resolve_aliasless_tarball(specifier, config, http_client).await.map(Some);
+    }
+    resolve_aliasless_local(specifier, manifest).await
+}
+
+/// Resolve a local directory or tarball selector by reading the package's
+/// own manifest — off disk for a directory, out of the archive for a
+/// tarball.
+///
+/// `link:` / `file:` are claimed by their scheme, everything else by path
+/// shape ([`is_local_filesystem_specifier`]).
+async fn resolve_aliasless_local(
+    specifier: &str,
+    manifest: &PackageManifest,
+) -> Result<Option<AliaslessDependency>, AddError> {
+    if !is_local_filesystem_specifier(specifier) {
+        return Ok(None);
+    }
+    let wanted = WantedLocalDependency { bare_specifier: specifier.to_string(), injected: false };
+    let ctx = LocalResolverContext { preserve_absolute_paths: false };
+    let opts = LocalResolverOptions {
+        project_dir: manifest
+            .path()
+            .parent()
+            .expect("manifest path always has a parent dir")
+            .to_path_buf(),
+        // The name and the normalized specifier are all this resolve is
+        // after, and neither is measured from the lockfile root.
+        lockfile_dir: None,
+        current_pkg: None,
+        update: LocalResolverUpdate::On,
+    };
+    let scheme_resolved =
+        resolve_from_local_scheme(&ctx, &wanted, &opts).await.map_err(AddError::ResolveLocal)?;
+    let resolved = match scheme_resolved {
+        Some(resolved) => resolved,
+        None => {
+            let path_resolved = resolve_from_local_path(&ctx, &wanted, &opts)
+                .await
+                .map_err(AddError::ResolveLocal)?;
+            match path_resolved {
+                Some(resolved) => resolved,
+                None => return Ok(None),
+            }
+        }
+    };
+    let manifest_specifier =
+        resolved.normalized_bare_specifier.unwrap_or_else(|| normalized_save_specifier(specifier));
+    let package_name = aliasless_package_name(resolved.manifest.as_deref(), specifier)?;
+    Ok(Some(AliaslessDependency { package_name, manifest_specifier }))
+}
+
+/// Resolve a remote (non-registry) tarball URL by downloading and
+/// extracting it: a tarball's name lives in the `package.json` it bundles,
+/// and nothing in the URL is required to spell it.
+///
+/// No store-index row is written here. The install that follows re-resolves
+/// the dependency with the writer it owns, keyed by the same `pkg_id`, so a
+/// row from this pass would only duplicate that one.
+async fn resolve_aliasless_tarball(
+    specifier: &str,
+    config: &'static Config,
+    http_client: &Arc<ThrottledClient>,
+) -> Result<AliaslessDependency, AddError> {
+    let resolver = TarballResolver {
+        http_client: Arc::clone(http_client),
+        fetch_context: Some(TarballFetchContext {
+            store_dir: &config.store_dir,
+            store_index_writer: None,
+            mem_cache: None,
+            auth_headers: Arc::clone(&config.auth_headers),
+            retry_opts: crate::retry_config::retry_opts_from_config(config),
+            store_index: None,
+            verify_store_integrity: config.verify_store_integrity,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
+            prior_tarball_entries: Arc::new(HashMap::new()),
+        }),
+    };
+    let wanted = pnpm_resolving_resolver_base::WantedDependency {
+        bare_specifier: Some(specifier.to_string()),
+        ..pnpm_resolving_resolver_base::WantedDependency::default()
+    };
+    let result = pnpm_resolving_resolver_base::Resolver::resolve(
+        &resolver,
+        &wanted,
+        &pnpm_resolving_resolver_base::ResolveOptions::default(),
+    )
+    .await
+    // A tarball URL can carry `user:pass@` credentials, and every error
+    // here echoes it back.
+    .map_err(|source| AddError::ResolveTarball {
+        specifier: redact_and_sanitize(specifier),
+        source,
+    })?
+    .ok_or_else(|| AddError::MissingPackageName { specifier: redact_and_sanitize(specifier) })?;
+    let manifest_specifier =
+        result.normalized_bare_specifier.unwrap_or_else(|| normalized_save_specifier(specifier));
+    let package_name = aliasless_package_name(result.manifest.as_deref(), specifier)?;
+    Ok(AliaslessDependency { package_name, manifest_specifier })
+}
+
+/// The `name` an alias-less selector's own manifest declares. The name keys
+/// the project's manifest entry and names the `node_modules` directory the
+/// package is linked into, so a missing or invalid one is refused rather
+/// than guessed at.
+fn aliasless_package_name(
+    manifest: Option<&serde_json::Value>,
+    specifier: &str,
+) -> Result<String, AddError> {
+    let name = manifest
+        .and_then(|manifest| manifest.get("name"))
+        .and_then(serde_json::Value::as_str)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| AddError::MissingPackageName {
+            specifier: redact_and_sanitize(specifier),
+        })?;
+    if !is_valid_dependency_alias(name) {
+        return Err(AddError::InvalidPackageName {
+            specifier: redact_and_sanitize(specifier),
+            name: name.to_string(),
+        });
+    }
+    Ok(name.to_string())
 }
 
 async fn resolve_aliasless_git(
     specifier: &str,
     config: &'static Config,
     http_client: &Arc<ThrottledClient>,
-) -> Result<AliaslessGitDependency, AddError> {
+) -> Result<AliaslessDependency, AddError> {
     let resolver = GitResolver::new(
         Arc::new(RealGitProbe::new(Arc::clone(http_client))),
         Arc::new(RealGitRunner::new()),
@@ -1034,7 +1208,7 @@ async fn resolve_aliasless_git(
     }
     let manifest_specifier =
         result.normalized_bare_specifier.unwrap_or_else(|| normalized_save_specifier(specifier));
-    Ok(AliaslessGitDependency { package_name, manifest_specifier })
+    Ok(AliaslessDependency { package_name, manifest_specifier })
 }
 
 /// Resolve an explicit `add <name>@<spec>` registry specifier to the

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -24,7 +24,7 @@ use pnpm_config::{Config, SaveWorkspaceProtocol};
 use pnpm_engine_runtime_node_resolver::{NodeResolver, NodeResolverError};
 use pnpm_lockfile::{Lockfile, MaybeLazyLockfile};
 use pnpm_lockfile_preferred_versions::get_preferred_versions_from_lockfile_and_manifests;
-use pnpm_network::{ThrottledClient, redact_and_sanitize};
+use pnpm_network::{ThrottledClient, redact_and_sanitize, redact_url_for_display};
 use pnpm_package_manifest::{DependencyGroup, PackageManifest, PackageManifestError};
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::{LogEvent, LogLevel, PackageManifestLog, PackageManifestMessage, Reporter};
@@ -183,12 +183,17 @@ pub enum AddError {
 
     /// Anything else the tarball resolver raised — a malformed URL, a
     /// transport failure the fetcher doesn't classify.
-    #[display("Failed to resolve tarball dependency {specifier:?}: {source}")]
+    ///
+    /// The cause is carried as already-redacted text rather than as an
+    /// `#[error(source)]`: `reqwest` echoes the request URL back in its own
+    /// message, and miette renders every frame of a source chain, so an
+    /// attached cause would print the URL this variant took care to redact.
+    #[display("Failed to resolve tarball dependency {specifier:?}: {reason}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_TARBALL))]
     ResolveTarball {
+        #[error(not(source))]
         specifier: String,
-        #[error(source)]
-        source: pnpm_resolving_resolver_base::ResolveError,
+        reason: String,
     },
 
     #[display("Could not determine the package name of dependency {specifier:?}")]
@@ -1127,17 +1132,76 @@ async fn resolve_aliasless_tarball(
     .await
     .map_err(|source| match source.downcast::<pnpm_tarball::TarballError>() {
         Ok(tarball) => AddError::TarballResolve(tarball),
-        // A tarball URL can carry `user:pass@` credentials, and an
-        // unclassified error here echoes it back.
-        Err(source) => {
-            AddError::ResolveTarball { specifier: redact_and_sanitize(specifier), source }
-        }
+        Err(source) => AddError::ResolveTarball {
+            specifier: redact_url_for_display(specifier),
+            reason: redacted_error_chain(source.as_ref(), specifier),
+        },
     })?
-    .ok_or_else(|| AddError::MissingPackageName { specifier: redact_and_sanitize(specifier) })?;
+    .ok_or_else(|| AddError::MissingPackageName { specifier: redact_url_for_display(specifier) })?;
     let manifest_specifier =
         result.normalized_bare_specifier.unwrap_or_else(|| normalized_save_specifier(specifier));
     let package_name = aliasless_package_name(result.manifest.as_deref(), specifier)?;
     Ok(AliaslessDependency { package_name, manifest_specifier })
+}
+
+/// Flatten an error chain into one line, with every rendering of `url` cut
+/// back to its display-safe form.
+///
+/// `reqwest` echoes the request URL back in its own message, and it redacts
+/// only the userinfo — a signed tarball URL carries its token in the query
+/// string, which [`redact_and_sanitize`] keeps too. Once the credentials are
+/// stripped, the safe form is a prefix of every spelling of the same URL
+/// (raw, or normalized by the resolver), so each occurrence is truncated at
+/// the token boundary that follows it.
+fn redacted_error_chain(error: &(dyn std::error::Error + 'static), url: &str) -> String {
+    let mut frames = Vec::new();
+    let mut current = Some(error);
+    while let Some(frame) = current {
+        frames.push(frame.to_string());
+        current = frame.source();
+    }
+    // Order is load-bearing: `redact_and_sanitize` runs first so a rendering
+    // that carries `user:pass@` loses it here, leaving a URL that starts with
+    // the safe prefix the truncation below matches on.
+    let sanitized = redact_and_sanitize(&frames.join(": "));
+    truncate_url_tokens(&sanitized, &redact_url_for_display(url))
+}
+
+/// Replace every token in `text` that starts with `safe_url` by `safe_url`
+/// alone, dropping whatever query, fragment, or trailing path the rendering
+/// carried. A URL in error prose ends at whitespace or one of the
+/// punctuation marks a message wraps it in.
+fn truncate_url_tokens(text: &str, safe_url: &str) -> String {
+    if safe_url.is_empty() {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find(safe_url) {
+        out.push_str(&rest[..start]);
+        out.push_str(safe_url);
+        let after = &rest[start + safe_url.len()..];
+        let end = after
+            .find(|character: char| {
+                character.is_whitespace() || matches!(character, ')' | ']' | '"' | '\'')
+            })
+            .unwrap_or(after.len());
+        rest = &after[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
+/// The display-safe form of an alias-less selector, which may be a local
+/// path or a URL. A URL loses its credentials, query, and fragment; a path
+/// is only stripped of control characters, since it carries no secret and
+/// naming it is the whole point of the message.
+fn redact_specifier_for_display(specifier: &str) -> String {
+    if specifier.starts_with("http:") || specifier.starts_with("https:") {
+        redact_url_for_display(specifier)
+    } else {
+        redact_and_sanitize(specifier)
+    }
 }
 
 /// The `name` an alias-less selector's own manifest declares. The name keys
@@ -1153,11 +1217,11 @@ fn aliasless_package_name(
         .and_then(serde_json::Value::as_str)
         .filter(|name| !name.is_empty())
         .ok_or_else(|| AddError::MissingPackageName {
-            specifier: redact_and_sanitize(specifier),
+            specifier: redact_specifier_for_display(specifier),
         })?;
     if !is_valid_dependency_alias(name) {
         return Err(AddError::InvalidPackageName {
-            specifier: redact_and_sanitize(specifier),
+            specifier: redact_specifier_for_display(specifier),
             name: name.to_string(),
         });
     }

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -174,6 +174,15 @@ pub enum AddError {
     #[diagnostic(transparent)]
     ResolveLocal(#[error(source)] ResolveLocalError),
 
+    /// The tarball fetch itself failed. Kept as the diagnostic the fetcher
+    /// raised, so `pnpm add <url>` reports the same code an install of the
+    /// same URL does (`ERR_PNPM_TARBALL_HTTP_STATUS`, ...) rather than one
+    /// only this command can produce.
+    #[diagnostic(transparent)]
+    TarballResolve(#[error(source)] Box<pnpm_tarball::TarballError>),
+
+    /// Anything else the tarball resolver raised — a malformed URL, a
+    /// transport failure the fetcher doesn't classify.
     #[display("Failed to resolve tarball dependency {specifier:?}: {source}")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_TARBALL))]
     ResolveTarball {
@@ -1116,11 +1125,13 @@ async fn resolve_aliasless_tarball(
         &pnpm_resolving_resolver_base::ResolveOptions::default(),
     )
     .await
-    // A tarball URL can carry `user:pass@` credentials, and every error
-    // here echoes it back.
-    .map_err(|source| AddError::ResolveTarball {
-        specifier: redact_and_sanitize(specifier),
-        source,
+    .map_err(|source| match source.downcast::<pnpm_tarball::TarballError>() {
+        Ok(tarball) => AddError::TarballResolve(tarball),
+        // A tarball URL can carry `user:pass@` credentials, and an
+        // unclassified error here echoes it back.
+        Err(source) => {
+            AddError::ResolveTarball { specifier: redact_and_sanitize(specifier), source }
+        }
     })?
     .ok_or_else(|| AddError::MissingPackageName { specifier: redact_and_sanitize(specifier) })?;
     let manifest_specifier =

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1134,7 +1134,7 @@ async fn resolve_aliasless_tarball(
         Ok(tarball) => AddError::TarballResolve(tarball),
         Err(source) => AddError::ResolveTarball {
             specifier: redact_url_for_display(specifier),
-            reason: redacted_error_chain(source.as_ref(), specifier),
+            reason: redacted_error_chain(source.as_ref()),
         },
     })?
     .ok_or_else(|| AddError::MissingPackageName { specifier: redact_url_for_display(specifier) })?;
@@ -1144,49 +1144,51 @@ async fn resolve_aliasless_tarball(
     Ok(AliaslessDependency { package_name, manifest_specifier })
 }
 
-/// Flatten an error chain into one line, with every rendering of `url` cut
-/// back to its display-safe form.
+/// Flatten an error chain into one line, with every URL in it cut back to
+/// its display-safe form.
 ///
-/// `reqwest` echoes the request URL back in its own message, and it redacts
-/// only the userinfo — a signed tarball URL carries its token in the query
-/// string, which [`redact_and_sanitize`] keeps too. Once the credentials are
-/// stripped, the safe form is a prefix of every spelling of the same URL
-/// (raw, or normalized by the resolver), so each occurrence is truncated at
-/// the token boundary that follows it.
-fn redacted_error_chain(error: &(dyn std::error::Error + 'static), url: &str) -> String {
+/// `reqwest` echoes the request URL back in its own message and redacts
+/// only the userinfo, while a signed tarball URL carries its token in the
+/// query string — which [`redact_and_sanitize`] keeps too. The scrub is
+/// URL-agnostic rather than keyed to the specifier: the HEAD request
+/// follows redirects, so the URL a failure names may be a signed storage
+/// URL the caller never saw.
+fn redacted_error_chain(error: &(dyn std::error::Error + 'static)) -> String {
     let mut frames = Vec::new();
     let mut current = Some(error);
     while let Some(frame) = current {
         frames.push(frame.to_string());
         current = frame.source();
     }
-    // Order is load-bearing: `redact_and_sanitize` runs first so a rendering
-    // that carries `user:pass@` loses it here, leaving a URL that starts with
-    // the safe prefix the truncation below matches on.
-    let sanitized = redact_and_sanitize(&frames.join(": "));
-    truncate_url_tokens(&sanitized, &redact_url_for_display(url))
+    // Order is load-bearing: `redact_and_sanitize` strips the `user:pass@`
+    // and the control characters, leaving each URL as a plain token for the
+    // query/fragment cut below.
+    strip_url_query_and_fragment(&redact_and_sanitize(&frames.join(": ")))
 }
 
-/// Replace every token in `text` that starts with `safe_url` by `safe_url`
-/// alone, dropping whatever query, fragment, or trailing path the rendering
-/// carried. A URL in error prose ends at whitespace or one of the
-/// punctuation marks a message wraps it in.
-fn truncate_url_tokens(text: &str, safe_url: &str) -> String {
-    if safe_url.is_empty() {
-        return text.to_string();
-    }
+/// Cut every URL in `text` at its query or fragment. A URL in error prose
+/// ends at whitespace or at one of the marks a message wraps it in, and a
+/// `://` not preceded by a scheme character is not an authority boundary.
+fn strip_url_query_and_fragment(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     let mut rest = text;
-    while let Some(start) = rest.find(safe_url) {
-        out.push_str(&rest[..start]);
-        out.push_str(safe_url);
-        let after = &rest[start + safe_url.len()..];
+    while let Some(pos) = rest.find("://") {
+        let has_scheme = pos > 0 && rest.as_bytes()[pos - 1].is_ascii_alphanumeric();
+        let authority_start = pos + "://".len();
+        out.push_str(&rest[..authority_start]);
+        let after = &rest[authority_start..];
+        if !has_scheme {
+            rest = after;
+            continue;
+        }
         let end = after
             .find(|character: char| {
                 character.is_whitespace() || matches!(character, ')' | ']' | '"' | '\'')
             })
             .unwrap_or(after.len());
-        rest = &after[end..];
+        let (token, tail) = after.split_at(end);
+        out.push_str(&token[..token.find(['?', '#']).unwrap_or(token.len())]);
+        rest = tail;
     }
     out.push_str(rest);
     out

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1065,19 +1065,14 @@ async fn resolve_aliasless_local(
         current_pkg: None,
         update: LocalResolverUpdate::On,
     };
-    let scheme_resolved =
+    let mut claimed =
         resolve_from_local_scheme(&ctx, &wanted, &opts).await.map_err(AddError::ResolveLocal)?;
-    let resolved = match scheme_resolved {
-        Some(resolved) => resolved,
-        None => {
-            let path_resolved = resolve_from_local_path(&ctx, &wanted, &opts)
-                .await
-                .map_err(AddError::ResolveLocal)?;
-            match path_resolved {
-                Some(resolved) => resolved,
-                None => return Ok(None),
-            }
-        }
+    if claimed.is_none() {
+        claimed =
+            resolve_from_local_path(&ctx, &wanted, &opts).await.map_err(AddError::ResolveLocal)?;
+    }
+    let Some(resolved) = claimed else {
+        return Ok(None);
     };
     let manifest_specifier =
         resolved.normalized_bare_specifier.unwrap_or_else(|| normalized_save_specifier(specifier));

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -792,6 +792,26 @@ fn a_tarball_error_chain_drops_url_secrets() {
     }
 }
 
+/// A password containing `?` or `#` defeats the userinfo scan — it reads the
+/// `?` as the end of the authority and leaves `user:pa?ss@host` in place —
+/// so cutting the URL there would publish the password's prefix. Such a
+/// token fails closed rather than being shortened.
+#[test]
+fn a_url_whose_userinfo_survives_the_scan_is_hidden_entirely() {
+    for url in [
+        "https://alice:hunter2?x@example.com/pkg.tgz",
+        "https://alice:hunter2#x@example.com/pkg.tgz",
+    ] {
+        let rendered = super::redacted_error_chain(&std::io::Error::other(format!(
+            "error sending request for url ({url}): tcp connect error",
+        )));
+        eprintln!("RENDERED: {rendered}");
+        assert!(!rendered.contains("hunter"), "no part of the password may survive: {rendered}");
+        assert!(rendered.contains("[hidden]"), "the URL must fail closed: {rendered}");
+        assert!(rendered.contains("tcp connect error"), "the reason must survive: {rendered}");
+    }
+}
+
 /// A `://` that no scheme precedes is not a URL authority, and a message
 /// carrying no URL at all is passed through untouched.
 #[test]
@@ -799,4 +819,14 @@ fn url_scrubbing_leaves_non_urls_alone() {
     for text in ["no url here at all", "why? because", "see :// for the syntax"] {
         assert_eq!(super::strip_url_query_and_fragment(text), text);
     }
+}
+
+/// An `@` past the authority belongs to the path or query, and must not
+/// make an otherwise safe URL fail closed.
+#[test]
+fn url_scrubbing_keeps_a_path_that_contains_an_at_sign() {
+    assert_eq!(
+        super::strip_url_query_and_fragment("GET https://host/@scope%2fpkg?to=a@b: 403"),
+        "GET https://host/@scope%2fpkg: 403",
+    );
 }

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -773,21 +773,30 @@ fn a_tarball_error_chain_drops_url_secrets() {
         "https://example.com/pkg.tgz?token=SIGNEDSECRET",
         "https://alice:hunter2@example.com/pkg.tgz",
         "https://alice:hunter2@example.com/pkg.tgz?token=SIGNEDSECRET#frag",
+        // The HEAD request follows redirects, so the URL a failure names
+        // need not be the one the command was given.
+        "https://storage.example.net/blob?X-Amz-Signature=SIGNEDSECRET",
     ] {
         // The shape `reqwest` renders for a transport failure, whose leaf
         // frames carry the reason and whose first frame carries the URL.
-        let rendered = super::redacted_error_chain(
-            &std::io::Error::other(format!(
-                "error sending request for url ({url}): tcp connect error",
-            )),
-            url,
-        );
+        let rendered = super::redacted_error_chain(&std::io::Error::other(format!(
+            "error sending request for url ({url}): tcp connect error",
+        )));
         eprintln!("RENDERED: {rendered}");
         assert!(!rendered.contains("SIGNEDSECRET"), "query token must not survive: {rendered}");
         assert!(!rendered.contains("hunter2"), "password must not survive: {rendered}");
         assert!(
-            rendered.contains("example.com/pkg.tgz") && rendered.contains("tcp connect error"),
+            rendered.contains("example") && rendered.contains("tcp connect error"),
             "the host and the reason must survive: {rendered}",
         );
+    }
+}
+
+/// A `://` that no scheme precedes is not a URL authority, and a message
+/// carrying no URL at all is passed through untouched.
+#[test]
+fn url_scrubbing_leaves_non_urls_alone() {
+    for text in ["no url here at all", "why? because", "see :// for the syntax"] {
+        assert_eq!(super::strip_url_query_and_fragment(text), text);
     }
 }

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -762,3 +762,32 @@ fn saved_dependency_specifier(manifest: &PackageManifest, name: &str) -> Option<
         PackageManifest::from_path(manifest.path().to_path_buf()).expect("reread package.json");
     dependency_specifier(&saved, name).map(str::to_string)
 }
+
+/// A signed tarball URL carries its token in the query string, which
+/// `redact_and_sanitize` keeps — and `reqwest` echoes the request URL back
+/// in its own message, so the cause has to be scrubbed as well as the
+/// specifier.
+#[test]
+fn a_tarball_error_chain_drops_url_secrets() {
+    for url in [
+        "https://example.com/pkg.tgz?token=SIGNEDSECRET",
+        "https://alice:hunter2@example.com/pkg.tgz",
+        "https://alice:hunter2@example.com/pkg.tgz?token=SIGNEDSECRET#frag",
+    ] {
+        // The shape `reqwest` renders for a transport failure, whose leaf
+        // frames carry the reason and whose first frame carries the URL.
+        let rendered = super::redacted_error_chain(
+            &std::io::Error::other(format!(
+                "error sending request for url ({url}): tcp connect error",
+            )),
+            url,
+        );
+        eprintln!("RENDERED: {rendered}");
+        assert!(!rendered.contains("SIGNEDSECRET"), "query token must not survive: {rendered}");
+        assert!(!rendered.contains("hunter2"), "password must not survive: {rendered}");
+        assert!(
+            rendered.contains("example.com/pkg.tgz") && rendered.contains("tcp connect error"),
+            "the host and the reason must survive: {rendered}",
+        );
+    }
+}

--- a/pnpm/crates/package-manager/src/catalog_mode.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode.rs
@@ -10,6 +10,7 @@
 //!   rewritten to `catalog:` / `catalog:<name>` and, when no entry
 //!   exists yet, recorded for write-back to `pnpm-workspace.yaml`.
 
+use crate::is_workspace_local_path_specifier;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
@@ -115,12 +116,7 @@ pub(crate) fn decide_catalog_outcome(
         return Ok(CatalogDecisionOutcome { decision: CatalogDecision::KeepDirect, warning: None });
     }
 
-    // A local path resolves against the project that declares it, while a
-    // catalog entry is read by every project referencing it, so the two
-    // cannot name the same directory. `resolve_from_catalog` refuses such an
-    // entry (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`), so cataloging one writes
-    // an entry the next install rejects. Skip it, matching pnpm.
-    if is_local_filesystem_specifier(dep.bare_specifier) {
+    if is_project_relative_path(dep.bare_specifier) {
         return Ok(CatalogDecisionOutcome { decision: CatalogDecision::KeepDirect, warning: None });
     }
 
@@ -195,6 +191,20 @@ pub(crate) fn decide_catalog_outcome(
             Ok(CatalogDecisionOutcome { decision: CatalogDecision::KeepDirect, warning: None })
         }
     }
+}
+
+/// Whether `specifier` names a path resolved against the project that
+/// declares it — a `file:` / `link:` protocol, a bare path or tarball
+/// filename, or a `workspace:` pointing at a directory rather than a range.
+///
+/// A catalog entry is read by every project that references it, so it
+/// cannot mean the same directory for all of them. The catalog resolver
+/// already refuses a `link:` / `file:` entry outright
+/// (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`); it accepts a `workspace:` one,
+/// which is worse — every consumer silently resolves the relative path from
+/// its own directory. Auto-cataloging leaves all of them alone.
+fn is_project_relative_path(specifier: &str) -> bool {
+    is_local_filesystem_specifier(specifier) || is_workspace_local_path_specifier(specifier)
 }
 
 /// Whether the catalog entry already covers the wanted specifier, so the

--- a/pnpm/crates/package-manager/src/catalog_mode.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode.rs
@@ -18,6 +18,7 @@ use pnpm_catalogs_resolver::{CatalogResolutionResult, WantedDependency, resolve_
 use pnpm_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
 use pnpm_config::CatalogMode;
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
+use pnpm_resolving_local_resolver::is_local_filesystem_specifier;
 
 /// Wanted dependency outside the version range defined in catalog.
 ///
@@ -111,6 +112,15 @@ pub(crate) fn decide_catalog_outcome(
     // the manifest writer; promoting it into a catalog would strand it in
     // `devDependencies`. Skip it, matching pnpm.
     if dep.bare_specifier.starts_with("runtime:") {
+        return Ok(CatalogDecisionOutcome { decision: CatalogDecision::KeepDirect, warning: None });
+    }
+
+    // A local path resolves against the project that declares it, while a
+    // catalog entry is read by every project referencing it, so the two
+    // cannot name the same directory. `resolve_from_catalog` refuses such an
+    // entry (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`), so cataloging one writes
+    // an entry the next install rejects. Skip it, matching pnpm.
+    if is_local_filesystem_specifier(dep.bare_specifier) {
         return Ok(CatalogDecisionOutcome { decision: CatalogDecision::KeepDirect, warning: None });
     }
 

--- a/pnpm/crates/package-manager/src/catalog_mode/tests.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode/tests.rs
@@ -146,17 +146,42 @@ fn strict_skips_runtime_specifiers() {
 }
 
 #[test]
-fn local_filesystem_specifiers_are_never_cataloged() {
+fn project_relative_paths_are_never_cataloged() {
     let catalogs = Catalogs::new();
-    for specifier in ["./localpkg", "file:./localpkg", "link:../lib", "../deps/pkg-1.0.0.tgz"] {
+    for specifier in [
+        "./localpkg",
+        "file:./localpkg",
+        "link:../lib",
+        "../deps/pkg-1.0.0.tgz",
+        "workspace:../lib",
+        "workspace:./lib",
+    ] {
         let decision = decide(CatalogMode::Prefer, &catalogs, &dep("localpkg", specifier)).unwrap();
         assert_eq!(
             decision,
             CatalogDecision::KeepDirect,
-            "{specifier:?} must stay direct — a catalog entry holding it is refused with \
-             ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC",
+            "{specifier:?} resolves against the declaring project, so a catalog entry cannot \
+             mean the same directory for every consumer",
         );
     }
+}
+
+/// A `workspace:` range names a package, not a directory, so it stays
+/// catalogable — only the path forms are held back.
+#[test]
+fn a_workspace_range_is_still_cataloged() {
+    let catalogs = Catalogs::new();
+    let decision = decide(CatalogMode::Prefer, &catalogs, &dep("lib", "workspace:^")).unwrap();
+    assert_eq!(
+        decision,
+        CatalogDecision::Catalog {
+            manifest_specifier: "catalog:".to_string(),
+            updated_entry: Some(CatalogEntry {
+                catalog_name: "default".to_string(),
+                specifier: "workspace:^".to_string(),
+            }),
+        },
+    );
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/catalog_mode/tests.rs
+++ b/pnpm/crates/package-manager/src/catalog_mode/tests.rs
@@ -146,6 +146,20 @@ fn strict_skips_runtime_specifiers() {
 }
 
 #[test]
+fn local_filesystem_specifiers_are_never_cataloged() {
+    let catalogs = Catalogs::new();
+    for specifier in ["./localpkg", "file:./localpkg", "link:../lib", "../deps/pkg-1.0.0.tgz"] {
+        let decision = decide(CatalogMode::Prefer, &catalogs, &dep("localpkg", specifier)).unwrap();
+        assert_eq!(
+            decision,
+            CatalogDecision::KeepDirect,
+            "{specifier:?} must stay direct — a catalog entry holding it is refused with \
+             ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC",
+        );
+    }
+}
+
+#[test]
 fn reinstalling_a_catalog_dependency_reuses_the_existing_entry() {
     let catalogs = catalogs(&[("default", &[("is-positive", "^1.0.0")])]);
     let dep = CatalogModeDep {

--- a/pnpm/crates/resolving-local-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-local-resolver/src/lib.rs
@@ -33,5 +33,6 @@ pub use local_resolver::{
     resolve_from_local_scheme, resolve_latest_from_local,
 };
 pub use parse_bare_specifier::{
-    PathProtocolNotSupportedError, WantedLocalDependency, is_tarball_filename,
+    PathProtocolNotSupportedError, WantedLocalDependency, is_local_filesystem_specifier,
+    is_tarball_filename,
 };

--- a/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
@@ -64,6 +64,42 @@ pub struct PathProtocolNotSupportedError {
     pub protocol: String,
 }
 
+/// Whether a bare specifier's shape can only mean a local file or
+/// directory: the `link:` / `file:` protocols, a path-prefixed spec
+/// (`./`, `../`, `~/`, absolute POSIX paths, and Windows drive paths —
+/// including drive-relative ones like `C:dir`), or a bare tarball file
+/// name.
+///
+/// Narrower than what `parse_local_path` claims, which also takes any
+/// spec containing a path separator. That shape is statically
+/// indistinguishable from a hosted-git shorthand (`user/repo`) or a
+/// named-registry alias (`gh:@scope/pkg`), and the resolver chain only
+/// gets away with claiming it by running the local resolver last.
+/// Callers that dispatch on specifier shape without that ordering ask
+/// this instead.
+#[must_use]
+pub fn is_local_filesystem_specifier(bare: &str) -> bool {
+    if bare.starts_with("link:") || bare.starts_with("file:") {
+        return true;
+    }
+    if is_filespec(bare) {
+        return true;
+    }
+    // Any other protocol — a `git+ssh:` / `https:` URL, an `npm:` alias, a
+    // named-registry prefix — belongs to its own resolver, tarball-shaped
+    // path or not.
+    if bare.contains(':') {
+        return false;
+    }
+    // A `#` here marks a hosted-git shorthand's committish
+    // (`user/repo#release.tgz`), not a local tarball: the protocol and
+    // path-prefixed forms already returned above.
+    if bare.contains('#') {
+        return false;
+    }
+    is_tarball_filename(bare)
+}
+
 /// Parse a wanted dep with an explicit local-scheme prefix
 /// (`link:` / `workspace:` / `file:`). Returns `Ok(None)` when the
 /// specifier doesn't carry one of those prefixes; returns

--- a/pnpm/crates/resolving-local-resolver/tests/resolve.rs
+++ b/pnpm/crates/resolving-local-resolver/tests/resolve.rs
@@ -4,7 +4,8 @@
 use pnpm_lockfile::{LockfileResolution, TarballResolution};
 use pnpm_resolving_local_resolver::{
     LocalResolverContext, LocalResolverOptions, LocalResolverUpdate, ResolveLocalError,
-    WantedLocalDependency, resolve_from_local_path, resolve_from_local_scheme,
+    WantedLocalDependency, is_local_filesystem_specifier, resolve_from_local_path,
+    resolve_from_local_scheme,
 };
 use pnpm_resolving_resolver_base::PkgResolutionId;
 use std::{
@@ -602,4 +603,38 @@ impl LexicalNormalize for PathBuf {
 
 fn forward_slashes(input: String) -> String {
     if input.contains('\\') { input.replace('\\', "/") } else { input }
+}
+
+/// The narrowed shape test [`is_local_filesystem_specifier`] answers,
+/// versus what [`resolve_from_local_path`] itself claims: a bare
+/// `<a>/<b>` is a hosted-git shorthand and a `<alias>:<pkg>` a
+/// named-registry reference, and neither is this predicate's to take.
+#[test]
+fn recognizes_only_unambiguous_local_specifiers() {
+    for specifier in [
+        "file:./pkg",
+        "link:../pkg",
+        "./pkg",
+        "../pkg",
+        "/abs/pkg",
+        "~/pkg",
+        "C:/pkg",
+        "C:pkg",
+        "pkg-1.0.0.tgz",
+        "deps/pkg-1.0.0.tar.gz",
+    ] {
+        assert!(is_local_filesystem_specifier(specifier), "{specifier:?} names a local path");
+    }
+    for specifier in [
+        "is-positive",
+        "^1.0.0",
+        "latest",
+        "npm:is-positive@1",
+        "user/repo",
+        "gh:@scope/pkg",
+        "https://example.com/pkg.tgz",
+        "workspace:*",
+    ] {
+        assert!(!is_local_filesystem_specifier(specifier), "{specifier:?} is not a local path");
+    }
 }

--- a/pnpm/crates/tarball/src/error.rs
+++ b/pnpm/crates/tarball/src/error.rs
@@ -2,6 +2,7 @@
 
 use derive_more::{Display, Error, From};
 use miette::Diagnostic;
+use pnpm_network::redact_url_for_display;
 use pnpm_store_dir::{StoreIndexError, WriteCasFileError};
 use std::{error::Error as StdError, io, path::PathBuf};
 use zune_inflate::errors::InflateDecodeErrors;
@@ -36,8 +37,14 @@ fn walk_reqwest_chain(error: &reqwest::Error) -> String {
     out
 }
 
+/// Every URL below is rendered through [`redact_url_for_display`]: a
+/// tarball URL can carry inline `user:pass@` credentials — typed on the
+/// command line for `pnpm add <url>`, or declared in a manifest — and an
+/// error message ends up in terminal scrollback and CI logs. The field
+/// keeps the URL the request actually used; only the rendering is
+/// redacted.
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Failed to fetch {url}: {}", walk_reqwest_chain(error))]
+#[display("Failed to fetch {}: {}", redact_url_for_display(url), walk_reqwest_chain(error))]
 pub struct NetworkError {
     pub url: String,
     /// Marked `#[error(source)]` so miette can also walk the chain on
@@ -49,14 +56,14 @@ pub struct NetworkError {
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Tarball server returned HTTP {status} for {url}")]
+#[display("Tarball server returned HTTP {status} for {}", redact_url_for_display(url))]
 pub struct HttpStatusError {
     pub url: String,
     pub status: u16,
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Failed to verify the integrity of {url}: {error}")]
+#[display("Failed to verify the integrity of {}: {error}", redact_url_for_display(url))]
 pub struct VerifyChecksumError {
     pub url: String,
     #[error(source)]
@@ -85,7 +92,8 @@ pub enum TarballError {
     /// configured.
     #[from(ignore)]
     #[display(
-        "{url} is not allowed by this pnpr server; the operator must declare its registry as a public route or an upstream"
+        "{} is not allowed by this pnpr server; the operator must declare its registry as a public route or an upstream",
+        redact_url_for_display(url)
     )]
     #[diagnostic(code(ERR_PNPM_REGISTRY_OFF_ALLOWLIST))]
     OffAllowlist {
@@ -153,7 +161,8 @@ pub enum TarballError {
 
     #[from(ignore)]
     #[display(
-        "Archive at {url} advertised a Content-Length of {advertised_size} bytes, which exceeds what pnpm can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)"
+        "Archive at {} advertised a Content-Length of {advertised_size} bytes, which exceeds what pnpm can allocate (either larger than `usize::MAX` on this target or memory pressure prevented a one-shot reservation)",
+        redact_url_for_display(url)
     )]
     #[diagnostic(code(ERR_PNPM_TARBALL_TOO_LARGE))]
     TarballTooLarge { url: String, advertised_size: u64 },
@@ -166,7 +175,8 @@ pub enum TarballError {
     /// owner (it can't be cloned past `reqwest::Error`).
     #[from(ignore)]
     #[display(
-        "A concurrent fetch for {url} failed; this request waited on the shared mem cache and inherits the failure"
+        "A concurrent fetch for {} failed; this request waited on the shared mem cache and inherits the failure",
+        redact_url_for_display(url)
     )]
     #[diagnostic(code(ERR_PNPM_TARBALL_SIBLING_FETCH_FAILED))]
     SiblingFetchFailed { url: String },
@@ -176,7 +186,10 @@ pub enum TarballError {
     /// or whose normalized form would land outside the target
     /// directory is rejected before any bytes are written to the CAS.
     #[from(ignore)]
-    #[display("Refusing to extract zip entry {entry_path:?} from {url} — {reason}")]
+    #[display(
+        "Refusing to extract zip entry {entry_path:?} from {} — {reason}",
+        redact_url_for_display(url)
+    )]
     #[diagnostic(code(ERR_PNPM_PATH_TRAVERSAL))]
     PathTraversal { url: String, entry_path: String, reason: &'static str },
 
@@ -184,7 +197,7 @@ pub enum TarballError {
     /// crate error verbatim; pacquet does not interpret the failure
     /// mode beyond surfacing the entry path that triggered it.
     #[from(ignore)]
-    #[display("Failed to read zip archive {url}: {source}")]
+    #[display("Failed to read zip archive {}: {source}", redact_url_for_display(url))]
     #[diagnostic(code(ERR_PNPM_TARBALL_READ_ZIP))]
     ReadZipArchive {
         url: String,
@@ -203,7 +216,10 @@ pub enum TarballError {
     /// the retry-classification path emits `ERR_PNPM_ZIP`
     /// rather than the tar-specific `ERR_PNPM_TARBALL_TAR`.
     #[from(ignore)]
-    #[display("Failed to read zip entry {entry_path:?} from {url}: {source}")]
+    #[display(
+        "Failed to read zip entry {entry_path:?} from {}: {source}",
+        redact_url_for_display(url)
+    )]
     #[diagnostic(code(ERR_PNPM_TARBALL_READ_ZIP_ENTRY))]
     ReadZipEntries {
         url: String,

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5404,3 +5404,22 @@ fn extract_reads_a_windows_separator_entry_as_a_nested_path() {
 
     drop(tempdir);
 }
+
+/// A tarball URL can carry inline `user:pass@` credentials — typed on the
+/// command line for `pnpm add <url>`, or declared in a manifest — and every
+/// error rendering the URL lands in terminal scrollback and CI logs.
+#[test]
+fn url_bearing_errors_redact_inline_credentials() {
+    let url = "https://alice:hunter2@example.com/pkg.tgz".to_string();
+    let rendered = [
+        TarballError::HttpStatus(HttpStatusError { url: url.clone(), status: 404 }).to_string(),
+        TarballError::TarballTooLarge { url: url.clone(), advertised_size: u64::MAX }.to_string(),
+        TarballError::SiblingFetchFailed { url: url.clone() }.to_string(),
+        TarballError::OffAllowlist { url }.to_string(),
+    ];
+    for message in rendered {
+        eprintln!("MESSAGE: {message}");
+        assert!(!message.contains("hunter2"), "the password must not be rendered: {message}");
+        assert!(message.contains("example.com/pkg.tgz"), "the host must survive: {message}");
+    }
+}

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -81,13 +81,24 @@ export class FetchError extends PnpmError {
  * query or fragment onwards dropped — a signed tarball or registry URL
  * carries a reusable token there, which credential redaction alone keeps.
  *
+ * `[hidden]` when the cut would leave credential material behind. A password
+ * containing `?` or `#` defeats the userinfo scan — it reads the `?` as the
+ * end of the authority and leaves the whole `user:pa?ss@host` in place — so
+ * cutting there would publish the password's prefix. The authority is
+ * therefore checked before the cut, not after: any `@` still in front of the
+ * path means the userinfo survived.
+ *
  * Cuts rather than re-rendering through `URL`, unlike
  * {@link redactUrlForDisplay}: that round-trip normalizes the spelling
- * (`https://host` gains a trailing slash), and an error message should echo
- * the URL the request was given.
+ * (`https://host` gains a trailing slash, percent-escapes change case), and
+ * an error message should echo the URL the request was given.
  */
 function redactUrlSecrets (url: string): string {
-  return redactAndSanitize(url).split(/[?#]/)[0]
+  const sanitized = redactAndSanitize(url)
+  const schemeEnd = sanitized.indexOf('://')
+  const afterScheme = schemeEnd === -1 ? sanitized : sanitized.slice(schemeEnd + '://'.length)
+  if (afterScheme.split('/')[0].includes('@')) return '[hidden]'
+  return sanitized.split(/[?#]/)[0]
 }
 
 export function redactUrlCredentials (text: string): string {

--- a/pnpm11/core/error/src/index.ts
+++ b/pnpm11/core/error/src/index.ts
@@ -45,7 +45,7 @@ export class FetchError extends PnpmError {
     if (request.authHeaderValue) {
       _request.authHeaderValue = hideAuthInformation(request.authHeaderValue)
     }
-    const message = `GET ${redactUrlCredentials(request.url)}: ${response.statusText} - ${response.status}`
+    const message = `GET ${redactUrlSecrets(request.url)}: ${response.statusText} - ${response.status}`
     // NOTE: For security reasons, some registries respond with 404 on authentication errors as well.
     // So we print authorization info on 404 errors as well.
     if (response.status === 401 || response.status === 403 || response.status === 404) {
@@ -75,6 +75,21 @@ export class FetchError extends PnpmError {
  * a ReDoS vector, and the scan strips up to the **last** `@` in the authority
  * so a raw `@` inside the password (`user:p@ss@host`) doesn't leak its tail.
  */
+/**
+ * A request URL made safe to print: its `user:pass@` userinfo and control
+ * characters redacted ({@link redactAndSanitize}), then everything from the
+ * query or fragment onwards dropped — a signed tarball or registry URL
+ * carries a reusable token there, which credential redaction alone keeps.
+ *
+ * Cuts rather than re-rendering through `URL`, unlike
+ * {@link redactUrlForDisplay}: that round-trip normalizes the spelling
+ * (`https://host` gains a trailing slash), and an error message should echo
+ * the URL the request was given.
+ */
+function redactUrlSecrets (url: string): string {
+  return redactAndSanitize(url).split(/[?#]/)[0]
+}
+
 export function redactUrlCredentials (text: string): string {
   let result = ''
   let cursor = 0

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -75,6 +75,25 @@ test('FetchError drops the query string of a signed URL', () => {
   expect(error.request.url).toBe('https://storage.example.net/pkg.tgz?X-Amz-Signature=SIGNEDSECRET#frag')
 })
 
+test('FetchError hides a URL whose userinfo survives the credential scan', () => {
+  // A password containing `?` or `#` defeats the userinfo scan, so cutting
+  // the URL there would publish the password's prefix.
+  for (const url of ['https://alice:hunter2?x@example.com/pkg.tgz', 'https://alice:hunter2#x@example.com/pkg.tgz']) {
+    const error = new FetchError({ url }, { status: 404, statusText: 'Not Found' })
+    expect(error.message).toBe('GET [hidden]: Not Found - 404')
+  }
+})
+
+test('FetchError keeps a path that contains an at sign', () => {
+  const error = new FetchError(
+    { url: 'https://registry.example/@scope%2fpkg?write=true' },
+    { status: 403, statusText: 'Forbidden' }
+  )
+  // The `@` is past the authority, so it is the scope of a package name, not
+  // credential material — and the spelling is echoed, not normalized.
+  expect(error.message).toBe('GET https://registry.example/@scope%2fpkg: Forbidden - 403')
+})
+
 test('redactUrlCredentials', () => {
   // user:pass@ and user@ userinfo are stripped, regardless of scheme.
   expect(redactUrlCredentials('GET https://user:pass@host/pkg: timed out'))

--- a/pnpm11/core/error/test/index.ts
+++ b/pnpm11/core/error/test/index.ts
@@ -64,6 +64,17 @@ test('FetchError strips basic-auth credentials embedded in the request URL', () 
   expect(error.message).toBe('GET https://registry.example/@scope%2fpkg: Forbidden - 403')
 })
 
+test('FetchError drops the query string of a signed URL', () => {
+  const error = new FetchError(
+    { url: 'https://storage.example.net/pkg.tgz?X-Amz-Signature=SIGNEDSECRET#frag' },
+    { status: 404, statusText: 'Not Found' }
+  )
+  // A signed URL's token is reusable, so it must not reach terminal
+  // scrollback or CI logs — credential redaction alone would keep it.
+  expect(error.message).toBe('GET https://storage.example.net/pkg.tgz: Not Found - 404')
+  expect(error.request.url).toBe('https://storage.example.net/pkg.tgz?X-Amz-Signature=SIGNEDSECRET#frag')
+})
+
 test('redactUrlCredentials', () => {
   // user:pass@ and user@ userinfo are stripped, regardless of scheme.
   expect(redactUrlCredentials('GET https://user:pass@host/pkg: timed out'))

--- a/pnpm11/installing/deps-installer/package.json
+++ b/pnpm11/installing/deps-installer/package.json
@@ -107,6 +107,7 @@
     "@pnpm/patching.config": "workspace:*",
     "@pnpm/pkg-manifest.utils": "workspace:*",
     "@pnpm/pnpr.client": "workspace:*",
+    "@pnpm/resolving.local-resolver": "workspace:*",
     "@pnpm/resolving.parse-wanted-dependency": "workspace:*",
     "@pnpm/resolving.resolver-base": "workspace:*",
     "@pnpm/store.controller-types": "workspace:*",

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -76,6 +76,7 @@ import { allProjectsAreUpToDate, catalogResolutionIsStale, catalogResolutionsAre
 import { logger, streamParser } from '@pnpm/logger'
 import { groupPatchedDependencies, type PatchGroupRecord } from '@pnpm/patching.config'
 import { createVersionSpecFromResolvedVersion, getAllDependenciesFromManifest, getAllUniqueSpecs } from '@pnpm/pkg-manifest.utils'
+import { isLocalFilesystemSpecifier } from '@pnpm/resolving.local-resolver'
 import { parseWantedDependency } from '@pnpm/resolving.parse-wanted-dependency'
 import {
   EXISTING_VERSION_SELECTOR_WEIGHT,
@@ -1185,6 +1186,11 @@ export async function mutateModules (
           // Promoting it into a catalog rewrites the entry to `catalog:`, which
           // breaks that round-trip and strands it in `devDependencies`.
           if (wantedDep.bareSpecifier?.startsWith('runtime:')) continue
+          // A local path resolves against the project that declares it, so a
+          // catalog entry — shared by every project referencing it — cannot
+          // hold one. Cataloging it writes an entry the next install rejects
+          // with ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC.
+          if (wantedDep.bareSpecifier != null && isLocalFilesystemSpecifier(wantedDep.bareSpecifier)) continue
           const perDepCatalogName = getPerDepCatalogName(wantedDep, opts.saveCatalogName)
           const catalogBareSpecifier = `catalog:${perDepCatalogName === 'default' ? '' : perDepCatalogName}`
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -39,6 +39,7 @@ import {
   type DependenciesGraph,
   type DependenciesGraphNode,
   getWantedDependencies,
+  isWorkspaceLocalPathSpecifier,
   type RangeSpecStyle,
   resolveDependencies,
   type UpdateMatchingFunction,
@@ -342,6 +343,22 @@ const pickCatalogSpecifier: CatalogResultMatcher<string | undefined> = {
     found.resolution.specifier,
   misconfiguration: () => undefined,
   unused: () => undefined,
+}
+
+/**
+ * Whether `specifier` names a path resolved against the project that declares
+ * it — a `file:` / `link:` protocol, a bare path or tarball filename, or a
+ * `workspace:` pointing at a directory rather than a range.
+ *
+ * A catalog entry is read by every project that references it, so it cannot
+ * mean the same directory for all of them. `resolveFromCatalog` already
+ * refuses a `link:` / `file:` entry outright
+ * (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`); it accepts a `workspace:` one,
+ * which is worse — every consumer silently resolves the relative path from its
+ * own directory. Auto-cataloging leaves all of them alone.
+ */
+function isProjectRelativePath (specifier: string): boolean {
+  return isLocalFilesystemSpecifier(specifier) || isWorkspaceLocalPathSpecifier(specifier)
 }
 
 export async function mutateModules (
@@ -1186,11 +1203,7 @@ export async function mutateModules (
           // Promoting it into a catalog rewrites the entry to `catalog:`, which
           // breaks that round-trip and strands it in `devDependencies`.
           if (wantedDep.bareSpecifier?.startsWith('runtime:')) continue
-          // A local path resolves against the project that declares it, so a
-          // catalog entry — shared by every project referencing it — cannot
-          // hold one. Cataloging it writes an entry the next install rejects
-          // with ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC.
-          if (wantedDep.bareSpecifier != null && isLocalFilesystemSpecifier(wantedDep.bareSpecifier)) continue
+          if (wantedDep.bareSpecifier != null && isProjectRelativePath(wantedDep.bareSpecifier)) continue
           const perDepCatalogName = getPerDepCatalogName(wantedDep, opts.saveCatalogName)
           const catalogBareSpecifier = `catalog:${perDepCatalogName === 'default' ? '' : perDepCatalogName}`
           const catalog = resolveFromCatalog(opts.catalogs, { ...wantedDep, bareSpecifier: catalogBareSpecifier })

--- a/pnpm11/installing/deps-installer/src/install/index.ts
+++ b/pnpm11/installing/deps-installer/src/install/index.ts
@@ -345,22 +345,6 @@ const pickCatalogSpecifier: CatalogResultMatcher<string | undefined> = {
   unused: () => undefined,
 }
 
-/**
- * Whether `specifier` names a path resolved against the project that declares
- * it — a `file:` / `link:` protocol, a bare path or tarball filename, or a
- * `workspace:` pointing at a directory rather than a range.
- *
- * A catalog entry is read by every project that references it, so it cannot
- * mean the same directory for all of them. `resolveFromCatalog` already
- * refuses a `link:` / `file:` entry outright
- * (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`); it accepts a `workspace:` one,
- * which is worse — every consumer silently resolves the relative path from its
- * own directory. Auto-cataloging leaves all of them alone.
- */
-function isProjectRelativePath (specifier: string): boolean {
-  return isLocalFilesystemSpecifier(specifier) || isWorkspaceLocalPathSpecifier(specifier)
-}
-
 export async function mutateModules (
   projects: MutatedProject[],
   maybeOpts: MutateModulesOptions
@@ -1596,6 +1580,22 @@ async function runUnignoredDependencyBuilds (
     })).ignoredBuilds ?? previousIgnoredBuilds
   }
   return previousIgnoredBuilds
+}
+
+/**
+ * Whether `specifier` names a path resolved against the project that declares
+ * it — a `file:` / `link:` protocol, a bare path or tarball filename, or a
+ * `workspace:` pointing at a directory rather than a range.
+ *
+ * A catalog entry is read by every project that references it, so it cannot
+ * mean the same directory for all of them. `resolveFromCatalog` already
+ * refuses a `link:` / `file:` entry outright
+ * (`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`); it accepts a `workspace:` one,
+ * which is worse — every consumer silently resolves the relative path from its
+ * own directory. Auto-cataloging leaves all of them alone.
+ */
+function isProjectRelativePath (specifier: string): boolean {
+  return isLocalFilesystemSpecifier(specifier) || isWorkspaceLocalPathSpecifier(specifier)
 }
 
 function cacheExpired (prunedAt: string, maxAgeInMinutes: number): boolean {

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1492,15 +1492,19 @@ describe('add', () => {
       dependencies: {},
     }])
     const projectDir = path.join(options.lockfileDir, 'project1')
-    fs.mkdirSync(path.join(projectDir, 'local-pkg'), { recursive: true })
-    fs.writeFileSync(
-      path.join(projectDir, 'local-pkg/package.json'),
-      JSON.stringify({ name: 'local-pkg', version: '1.0.0' })
-    )
+    for (const name of ['bare-pkg', 'file-pkg']) {
+      fs.mkdirSync(path.join(projectDir, name), { recursive: true })
+      fs.writeFileSync(
+        path.join(projectDir, name, 'package.json'),
+        JSON.stringify({ name, version: '1.0.0' })
+      )
+    }
 
+    // The bare path and the explicit `file:` protocol take different branches
+    // of the shape test, so both are pinned here.
     const { updatedManifest } = await addDependenciesToPackage(
       projects['project1' as ProjectId],
-      ['./local-pkg'],
+      ['./bare-pkg', 'file:./file-pkg'],
       {
         ...options,
         dir: projectDir,
@@ -1518,7 +1522,8 @@ describe('add', () => {
     expect(updatedManifest).toEqual({
       name: 'project1',
       dependencies: {
-        'local-pkg': 'link:local-pkg',
+        'bare-pkg': 'link:bare-pkg',
+        'file-pkg': 'file:file-pkg',
       },
     })
     expect(readLockfile().catalogs).toBeUndefined()

--- a/pnpm11/installing/deps-installer/test/catalogs.ts
+++ b/pnpm11/installing/deps-installer/test/catalogs.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { describe, expect, jest, test } from '@jest/globals'
@@ -5,11 +6,14 @@ import { createPeerDepGraphHash } from '@pnpm/deps.path'
 import type { MutatedProject, MutateModulesOptions, ProjectOptions } from '@pnpm/installing.deps-installer'
 import type { CatalogSnapshots } from '@pnpm/lockfile.types'
 import { prepareEmpty } from '@pnpm/prepare'
+import { fixtures } from '@pnpm/test-fixtures'
 import { addDistTag } from '@pnpm/testing.registry-mock'
 import type { ProjectId, ProjectManifest, ProjectRootDir } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
 
 import { testDefaults } from './utils/index.js'
+
+const f = fixtures(import.meta.dirname)
 
 const originalModule = await import('@pnpm/logger')
 jest.unstable_mockModule('@pnpm/logger', () => {
@@ -1480,6 +1484,75 @@ describe('add', () => {
       importers: { project1: { dependencies: { 'is-positive': { specifier: 'catalog:', version: '1.0.0' } } } },
       packages: { 'is-positive@1.0.0': expect.any(Object) },
     })
+  })
+
+  test('adding a local directory with catalogMode: prefer keeps it out of the catalog', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {},
+    }])
+    const projectDir = path.join(options.lockfileDir, 'project1')
+    fs.mkdirSync(path.join(projectDir, 'local-pkg'), { recursive: true })
+    fs.writeFileSync(
+      path.join(projectDir, 'local-pkg/package.json'),
+      JSON.stringify({ name: 'local-pkg', version: '1.0.0' })
+    )
+
+    const { updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['./local-pkg'],
+      {
+        ...options,
+        dir: projectDir,
+        lockfileOnly: true,
+        allowNew: true,
+        catalogs: {
+          default: {},
+        },
+        catalogMode: 'prefer',
+      })
+
+    // A catalog entry is read by every project referencing it, so it cannot
+    // hold a path that resolves against the project declaring it — the catalog
+    // resolver refuses a `link:` / `file:` entry outright.
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        'local-pkg': 'link:local-pkg',
+      },
+    })
+    expect(readLockfile().catalogs).toBeUndefined()
+  })
+
+  test('adding a local tarball with catalogMode: prefer keeps it out of the catalog', async () => {
+    const { options, projects, readLockfile } = preparePackagesAndReturnObjects([{
+      name: 'project1',
+      dependencies: {},
+    }])
+    const projectDir = path.join(options.lockfileDir, 'project1')
+    f.copy('pkg-with-bundled-dependencies-1.0.0.tgz', path.join(projectDir, 'local-pkg-1.0.0.tgz'))
+
+    const { updatedManifest } = await addDependenciesToPackage(
+      projects['project1' as ProjectId],
+      ['./local-pkg-1.0.0.tgz'],
+      {
+        ...options,
+        dir: projectDir,
+        lockfileOnly: true,
+        allowNew: true,
+        catalogs: {
+          default: {},
+        },
+        catalogMode: 'prefer',
+      })
+
+    expect(updatedManifest).toEqual({
+      name: 'project1',
+      dependencies: {
+        '@pnpm.e2e/pkg-with-bundled-dependencies': 'file:local-pkg-1.0.0.tgz',
+      },
+    })
+    expect(readLockfile().catalogs).toBeUndefined()
   })
 
   test('adding mismatched version with catalogMode: strict will error', async () => {

--- a/pnpm11/installing/deps-installer/tsconfig.json
+++ b/pnpm11/installing/deps-installer/tsconfig.json
@@ -160,6 +160,9 @@
       "path": "../../pkg-manifest/utils"
     },
     {
+      "path": "../../resolving/local-resolver"
+    },
+    {
       "path": "../../resolving/parse-wanted-dependency"
     },
     {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -73,6 +73,7 @@ export {
   type UpdateMatchingFunction,
   type WantedDependency,
 }
+export { isWorkspaceLocalPathSpecifier } from './updateProjectManifest.js'
 export { assertValidDependencyAliases, isValidDependencyAlias } from './validateDependencyAlias.js'
 
 interface ProjectToLink {

--- a/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
+++ b/pnpm11/installing/deps-resolver/src/updateProjectManifest.ts
@@ -119,7 +119,12 @@ function getBareSpecifierToSave (
   return resolvedDep.normalizedBareSpecifier ?? wantedDep.bareSpecifier
 }
 
-function isWorkspaceLocalPathSpecifier (bareSpecifier: string): boolean {
+/**
+ * Whether a `workspace:` specifier points at a directory rather than a range
+ * (`workspace:../pkg`, not `workspace:^`). Such a path is resolved against the
+ * project that declares it.
+ */
+export function isWorkspaceLocalPathSpecifier (bareSpecifier: string): boolean {
   if (!bareSpecifier.startsWith('workspace:')) return false
   const pref = bareSpecifier.slice('workspace:'.length)
   return pref.startsWith('.') || pref.startsWith('/') || pref.startsWith('~/') || /^[A-Z]:/i.test(pref)

--- a/pnpm11/resolving/local-resolver/src/index.ts
+++ b/pnpm11/resolving/local-resolver/src/index.ts
@@ -8,9 +8,9 @@ import type { DirectoryResolution, LatestInfo, LatestQuery, Resolution, ResolveR
 import type { DependencyManifest, PkgResolutionId } from '@pnpm/types'
 import { readProjectManifestOnly } from '@pnpm/workspace.project-manifest-reader'
 
-import { type LocalPackageSpec, parseLocalPath, parseLocalScheme, type WantedLocalDependency } from './parseBareSpecifier.js'
+import { isLocalFilesystemSpecifier, type LocalPackageSpec, parseLocalPath, parseLocalScheme, type WantedLocalDependency } from './parseBareSpecifier.js'
 
-export { type WantedLocalDependency }
+export { isLocalFilesystemSpecifier, type WantedLocalDependency }
 
 export interface LocalResolveResult extends ResolveResult {
   manifest?: DependencyManifest

--- a/pnpm11/resolving/local-resolver/src/parseBareSpecifier.ts
+++ b/pnpm11/resolving/local-resolver/src/parseBareSpecifier.ts
@@ -35,6 +35,33 @@ class PathIsUnsupportedProtocolError extends PnpmError {
   }
 }
 
+/**
+ * Whether a bare specifier's shape can only mean a local file or directory:
+ * the `link:` / `file:` protocols, a path-prefixed spec (`./`, `../`, `~/`,
+ * absolute POSIX paths, and Windows drive paths — including drive-relative
+ * ones like `C:dir`), or a bare tarball file name.
+ *
+ * Narrower than what {@link parseLocalPath} claims, which also takes any spec
+ * containing a path separator. That shape is statically indistinguishable from
+ * a hosted-git shorthand (`user/repo`) or a named-registry alias
+ * (`gh:@scope/pkg`), and the resolver chain only gets away with claiming it by
+ * running the local resolver last. Callers that dispatch on specifier shape
+ * without that ordering ask this instead.
+ */
+export function isLocalFilesystemSpecifier (bareSpecifier: string): boolean {
+  if (bareSpecifier.startsWith('link:') || bareSpecifier.startsWith('file:')) return true
+  if (isFilespec.test(bareSpecifier)) return true
+  // Any other protocol — a `git+ssh:` / `https:` URL, an `npm:` alias, a
+  // named-registry prefix — belongs to its own resolver, tarball-shaped path
+  // or not.
+  if (bareSpecifier.includes(':')) return false
+  // A `#` here marks a hosted-git shorthand's committish
+  // (`user/repo#release.tgz`), not a local tarball: the protocol and
+  // path-prefixed forms already returned above.
+  if (bareSpecifier.includes('#')) return false
+  return isFilename.test(bareSpecifier)
+}
+
 export function parseLocalScheme (
   wd: WantedLocalDependency,
   projectDir: string,

--- a/pnpm11/resolving/local-resolver/test/index.ts
+++ b/pnpm11/resolving/local-resolver/test/index.ts
@@ -4,7 +4,7 @@ import path from 'node:path'
 
 import { expect, jest, test } from '@jest/globals'
 import { logger } from '@pnpm/logger'
-import { resolveFromLocalPath, resolveFromLocalScheme } from '@pnpm/resolving.local-resolver'
+import { isLocalFilesystemSpecifier, resolveFromLocalPath, resolveFromLocalScheme } from '@pnpm/resolving.local-resolver'
 import type { DirectoryResolution } from '@pnpm/resolving.resolver-base'
 import normalize from 'normalize-path'
 
@@ -211,4 +211,17 @@ test('resolveFromLocalPath ignores explicit local schemes', async () => {
   await expect(resolveFromLocalPath({}, { bareSpecifier: 'workspace:..' }, { projectDir: import.meta.dirname })).resolves.toBeNull()
   await expect(resolveFromLocalPath({}, { bareSpecifier: 'file:..' }, { projectDir: import.meta.dirname })).resolves.toBeNull()
   await expect(resolveFromLocalPath({}, { bareSpecifier: 'path:..' }, { projectDir: import.meta.dirname })).resolves.toBeNull()
+})
+
+// The narrowed shape test `isLocalFilesystemSpecifier` answers, versus what
+// `resolveFromLocalPath` itself claims: a bare `<a>/<b>` is a hosted-git
+// shorthand and a `<alias>:<pkg>` a named-registry reference, and neither is
+// this predicate's to take.
+test('isLocalFilesystemSpecifier recognizes only unambiguous local specifiers', () => {
+  for (const specifier of ['file:./pkg', 'link:../pkg', './pkg', '../pkg', '/abs/pkg', '~/pkg', 'C:/pkg', 'C:pkg', 'pkg-1.0.0.tgz', 'deps/pkg-1.0.0.tar.gz']) {
+    expect([specifier, isLocalFilesystemSpecifier(specifier)]).toEqual([specifier, true])
+  }
+  for (const specifier of ['is-positive', '^1.0.0', 'latest', 'npm:is-positive@1', 'user/repo', 'user/repo#release.tgz', 'gh:@scope/pkg', 'https://example.com/pkg.tgz', 'workspace:*']) {
+    expect([specifier, isLocalFilesystemSpecifier(specifier)]).toEqual([specifier, false])
+  }
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm add ./pkg`, `pnpm add file:./pkg`, `pnpm add ./pkg-1.0.0.tgz` and `pnpm add https://host/pkg.tgz` all failed on the Rust CLI with `ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST` — the specifier was sent to the npm resolver as a package name. Closes pnpm/pnpm#14437.

`add` decides the manifest specifier *before* the install runs, so an alias-less selector has to learn the package's name from the package itself. `resolve_added_dependency` only did that for a git URL; every other bare specifier fell through to `split_name_spec`. It now dispatches the way the install's resolver chain does — git, then a remote tarball URL, then the local filesystem — and reads the name out of the checkout, the downloaded archive, or the directory / local tarball.

The second half of the issue is the catalog one, and it affects **both** stacks: under `catalogMode` other than `manual` (or `--save-catalog`), a local path or tarball specifier was promoted into the catalog, and the very next resolve failed with `ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`. A catalog entry is read by every project that references it, so it cannot hold a path that resolves against the project declaring it — which is exactly why the catalog resolver refuses a `link:` / `file:` entry. Both stacks now skip auto-cataloging any project-relative path, next to the existing `runtime:` skip.

### Two fixes that came out of review

- **Tarball errors leaked URL secrets.** Every `TarballError` that names a URL rendered it verbatim, so `pnpm add https://user:pass@host/pkg.tgz` — or an install of a manifest declaring one — printed the password into terminal scrollback and CI logs on a 404, a checksum mismatch, or an archive error. Each such `Display` now goes through `redact_url_for_display`, with the field keeping the URL the request actually used. (`reqwest`'s own errors already redact userinfo, which is why only the pnpm-side messages leaked.)

  A signed URL leaked its token the same way, one layer up: `redact_and_sanitize` strips credentials and control characters but keeps the query and fragment, so the unclassified-failure path printed `?token=…` twice — in the specifier, and inside `reqwest`'s message, which echoes the request URL back. That specifier now renders through `redact_url_for_display`, and the cause is flattened into already-redacted text rather than attached as a source, since miette renders every frame of a source chain. Both are reproduced-and-verified, and pinned by `a_tarball_error_chain_drops_url_secrets` and `url_bearing_errors_redact_inline_credentials`.

  The same leak existed on the TypeScript side — `FetchError` rendered its URL through `redactUrlCredentials`, which keeps the query — so it is fixed there too, keeping the two stacks in agreement on what a failed fetch may print. It cuts the URL at its query rather than re-rendering through `redactUrlForDisplay`, because that round-trip normalizes the spelling (`https://foo.com` gains a trailing slash) and would have changed every fetch error message in the CLI.

  One gap is deliberately left: Rust's `NetworkError` still flattens `reqwest`'s chain raw, so the install path can print a query token for the same URL. Closing that everywhere wants a text-level URL scrubber applied at every fetch site — a wider blast radius than this PR should carry.
- **`workspace:<path>` was still catalogable.** It is worse than the shapes the catalog resolver refuses outright: `resolveFromCatalog` rejects only `link:` and `file:`, so a `workspace:../pkg` entry is *accepted* and every consumer silently resolves the relative path from its own directory. The guard now covers it in both stacks, while a `workspace:` range stays catalogable.

### Verifying the TypeScript half

The TypeScript CLI's `pnpm add ./pkg` already worked (it rewrites the manifest after resolution), so only the catalog guard is mirrored there. That guard is not a no-op: with it disabled, `adding a local tarball with catalogMode: prefer` writes `"catalog:"` into the manifest.

Two of its branches are currently unreachable in TypeScript and are kept for parity of the predicate rather than for behavior: a `link:` directory and a `workspace:` path both escape auto-cataloging on their own, because `resolveDependencyTree` only attaches `catalogLookup` when the direct dependency has a resolved `version`, and neither shape has one. Those two are pinned in the Rust suite, where the guard is load-bearing; the TypeScript tests cover the shapes that actually reach it there.

### Notes for reviewers

- `is_local_filesystem_specifier` / `isLocalFilesystemSpecifier` (new, exported from the local resolver in both stacks) is deliberately **narrower** than what `parse_local_path` / `parseLocalPath` claims. The resolver chain also takes any specifier containing a path separator, but it only gets away with that by running the local resolver *last* — a bare `<a>/<b>` is a hosted-git shorthand and `gh:@scope/pkg` a named-registry reference. Callers that dispatch on shape without that ordering need the narrow test.
- A remote tarball URL is resolved through the existing `TarballResolver` with a fetch context, since a tarball's name lives only in the `package.json` it bundles. This costs one extra download of that tarball on `pnpm add <url>`: `FetchTarballForResolution::run` never reads the mem cache, and the warm-store reuse is keyed off the *prior* lockfile, which cannot contain a URL being added for the first time. Closing it means handing resolution state from `Add` to `Install`, which is a larger change than this fix.
- A failed tarball fetch reports the fetcher's own code (`ERR_PNPM_TARBALL_HTTP_STATUS`, …) rather than one only `add` can produce, so `add` and `install` agree on the same URL. This mirrors how `GitResolve` already preserves `ERR_PNPM_GIT_RESOLVE_FAILED`.
- The `path:` protocol is left alone: it still reports the registry-name error rather than `ERR_PNPM_PATH_IS_UNSUPPORTED_PROTOCOL`. Likewise `pnpm add workspace:./pkg`, which needs `preserveWorkspaceProtocol` wired into the alias-less path before it can save the right specifier. Both are pre-existing parity gaps, unrelated to this issue, and out of scope here.

Verified end to end against the reproduction in the issue (all four commands), plus the workspace `catalogMode: prefer` case and the credential-leak repro. `cargo nextest run -p pnpm-tarball -p pnpm-package-manager -p pnpm-resolving-local-resolver -p pnpm-cli`: 3893 passed.

## Squash Commit Body

```text
`pnpm add ./pkg`, `pnpm add file:./pkg`, `pnpm add ./pkg-1.0.0.tgz` and
`pnpm add https://host/pkg.tgz` all failed with
`ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST`: the Rust CLI's `add` only
special-cased an alias-less *git* selector before falling through to
`split_name_spec`, which read every other bare specifier as a registry
package name.

`add` decides the manifest specifier before the install runs, so an
alias-less selector has to learn the package's name from the package
itself. `resolve_aliasless_specifier` now dispatches the way the install's
resolver chain does — git, then a remote tarball URL, then the local
filesystem — and reads the name out of the checkout, the downloaded
archive, or the directory / local tarball. A classified tarball failure is
forwarded transparently, so `add` reports the same code an install of the
same URL does. Resolving a remote tarball downloads it once more than
before: the fetcher never reads the mem cache, and the warm-store reuse is
keyed off the prior lockfile, which cannot hold a URL being added for the
first time.

The local branch dispatches on `is_local_filesystem_specifier`, a new
predicate deliberately narrower than what the local resolver itself claims:
a bare `<a>/<b>` is a hosted-git shorthand and a `<alias>:<pkg>` a
named-registry reference, and the resolver chain only gets away with
claiming those by running the local resolver last.

Auto-cataloging now holds back every project-relative path in both stacks.
A catalog entry is read by every project that references it, so it cannot
hold a path that resolves against the project declaring it: the catalog
resolver refuses a `link:` / `file:` entry with
`ERR_PNPM_CATALOG_ENTRY_INVALID_SPEC`, and — worse — accepts a
`workspace:../pkg` one, leaving every consumer to resolve the relative path
from its own directory. The TypeScript CLI is affected for a local tarball,
which resolves to a version; the `link:` and `workspace:` directory shapes
escaped only because they resolve to none.

Separately, every `TarballError` that names a URL rendered it verbatim, so a
failed fetch of `https://user:pass@host/pkg.tgz` printed the password into
terminal scrollback and CI logs, and the unclassified-failure path printed the
query token of a signed URL — `redact_and_sanitize` keeps the query and
fragment. Each such message now goes through `redact_url_for_display`, and the
unclassified cause is flattened into redacted text rather than attached as a
source, since miette renders every frame of a source chain.

Closes pnpm/pnpm#14437
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvR3L7fw75KNFKcTfr1Fyu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm add` now accepts local directories, local tarballs, `file:` paths, and tarball URLs without requiring a package name prefix.
  - Local and project-relative workspace paths are no longer incorrectly added to shared catalogs.
  - Failed tarball operations now hide credentials, signed URL tokens, query strings, and fragments in error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->