### PR TITLE
docs: remove NODE_ENV mention from pnpm install

### DIFF
--- a/.changeset/install-help-no-node-env.md
+++ b/.changeset/install-help-no-node-env.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The `pnpm install --help` descriptions of `--prod` and `--dev` no longer claim that the flags take precedence over `NODE_ENV`. pnpm does not read `NODE_ENV` when selecting which dependency groups to install [#14445](https://github.com/pnpm/pnpm/issues/14445).

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -63,11 +63,11 @@ impl NodeLinkerArg {
 #[derive(Debug, Clone, Args)]
 pub struct InstallDependencyOptions {
     /// Install only production dependencies. devDependencies are skipped,
-    /// and removed if already installed. Takes precedence over `NODE_ENV`.
+    /// and removed if already installed.
     #[arg(short = 'P', long, visible_alias = "production")]
     prod: bool,
     /// Install only devDependencies. Regular dependencies are skipped, and
-    /// removed if already installed, regardless of `NODE_ENV`.
+    /// removed if already installed.
     #[arg(short = 'D', long)]
     dev: bool,
     /// Include optionalDependencies even when the configured default excludes them.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

After https://github.com/pnpm/pnpm/issues/8827, pnpm install should not mention NODE_ENV.

## Squash Commit Body

```text
Remove NODE_ENV mention from pnpm install (Closes pnpm/pnpm#14445).
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790908320&installation_model_id=426870&pr_number=14446&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14446&signature=5dfe2b807a25f956733c69dfddfdc95e9ef44b35409db9bcbc896a5608cd6169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI option documentation for production and development-only dependency installation.
  * Removed references to `NODE_ENV` precedence and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->