### PR TITLE
fix(registry): decode version manifests by what pnpm depends on

### DIFF
--- a/.changeset/report-undecodable-latest-manifest.md
+++ b/.changeset/report-undecodable-latest-manifest.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+When `dist-tags.latest` names a version whose manifest pnpm cannot read, the error now names that version and the field it could not decode, instead of reporting the tag as empty.

--- a/.changeset/tolerate-registry-trust-marker-shapes.md
+++ b/.changeset/tolerate-registry-trust-marker-shapes.md
@@ -2,8 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed resolution against registries whose packuments differ from npm's in ways pnpm did not model. A version manifest pnpm cannot read is skipped as though the registry never published that version, so a single unexpected field shape could remove a package's newest releases — including whichever one `latest` pointed at — from resolution, surfacing as a misleading "no version found for the latest tag".
-
-Manifest fields pnpm reads but never installs from — the publisher and attestation records, `dist.unpackedSize`, `dist.fileCount`, and `peerDependenciesMeta.<name>.optional` — now degrade on their own instead of taking the version with them. `dist.integrity` still fails the version, since a tarball hash pnpm cannot read is one it cannot verify.
-
-When `latest` names a version whose manifest cannot be read, the error now says so and names the field pnpm choked on, instead of reporting the tag as empty.
+Fixed resolution against registries whose version manifests carry `_npmUser`, `dist.attestations`, `dist.unpackedSize`, `dist.fileCount`, or `peerDependenciesMeta` in a shape npm does not use. Such a version was skipped as though it had never been published, so `pnpm add` could fail with "no version found for the latest tag" even though the registry served it.

--- a/.changeset/tolerate-registry-trust-marker-shapes.md
+++ b/.changeset/tolerate-registry-trust-marker-shapes.md
@@ -4,13 +4,6 @@
 
 Fixed resolution against registries whose packuments differ from npm's in ways pnpm did not model. A version manifest pnpm cannot read is skipped as though the registry never published that version, so a single unexpected field shape could remove a package's newest releases — including whichever one `latest` pointed at — from resolution, surfacing as a misleading "no version found for the latest tag".
 
-Fields pnpm reads but does not depend on now degrade on their own instead of taking the version with them:
+Manifest fields pnpm reads but never installs from — the publisher and attestation records, `dist.unpackedSize`, `dist.fileCount`, and `peerDependenciesMeta.<name>.optional` — now degrade on their own instead of taking the version with them. `dist.integrity` still fails the version, since a tarball hash pnpm cannot read is one it cannot verify.
 
-- `dist.attestations.provenance`, `_npmUser.trustedPublisher`, and `_npmUser.approver` are treated as the presence signals they are, keeping the published details when the registry sends an object and accepting any other shape.
-- `dist.unpackedSize` and `dist.fileCount` accept any integral encoding, including the floats and numeric strings a registry's serializer may produce.
-- `_npmUser` accepts a non-object in place of the publisher record.
-- `peerDependenciesMeta.<name>.optional` accepts a non-boolean, which counts as unset — matching how the flag is compared.
-
-`dist.integrity` stays strict: a version whose tarball hash pnpm cannot read is one it cannot verify, and that has to fail rather than resolve.
-
-When `latest` does resolve to a version whose manifest cannot be read, the error now names that version and the field pnpm choked on instead of reporting the tag as empty.
+When `latest` names a version whose manifest cannot be read, the error now says so and names the field pnpm choked on, instead of reporting the tag as empty.

--- a/.changeset/tolerate-registry-trust-marker-shapes.md
+++ b/.changeset/tolerate-registry-trust-marker-shapes.md
@@ -1,0 +1,16 @@
+---
+"pacquet": patch
+---
+
+Fixed resolution against registries whose packuments differ from npm's in ways pnpm did not model. A version manifest pnpm cannot read is skipped as though the registry never published that version, so a single unexpected field shape could remove a package's newest releases — including whichever one `latest` pointed at — from resolution, surfacing as a misleading "no version found for the latest tag".
+
+Fields pnpm reads but does not depend on now degrade on their own instead of taking the version with them:
+
+- `dist.attestations.provenance`, `_npmUser.trustedPublisher`, and `_npmUser.approver` are treated as the presence signals they are, keeping the published details when the registry sends an object and accepting any other shape.
+- `dist.unpackedSize` and `dist.fileCount` accept any integral encoding, including the floats and numeric strings a registry's serializer may produce.
+- `_npmUser` accepts a non-object in place of the publisher record.
+- `peerDependenciesMeta.<name>.optional` accepts a non-boolean, which counts as unset — matching how the flag is compared.
+
+`dist.integrity` stays strict: a version whose tarball hash pnpm cannot read is one it cannot verify, and that has to fail rather than resolve.
+
+When `latest` does resolve to a version whose manifest cannot be read, the error now names that version and the field pnpm choked on instead of reporting the tag as empty.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,6 +5543,7 @@ dependencies = [
  "pipe-trait",
  "pnpm-diagnostics",
  "pnpm-network",
+ "pnpm-package-manifest",
  "pretty_assertions",
  "reqwest",
  "serde",

--- a/pnpm/crates/exportable-manifest/src/transform.rs
+++ b/pnpm/crates/exportable-manifest/src/transform.rs
@@ -7,6 +7,7 @@
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pnpm_package_manifest::is_truthy;
 use serde_json::{Map, Value};
 
 /// Failures raised while transforming a publish manifest. Both carry
@@ -46,20 +47,6 @@ fn transform_required_fields(manifest: &Map<String, Value>) -> Result<(), Transf
         }
     }
     Ok(())
-}
-
-/// Whether a JSON value is truthy under JavaScript's coercion rules, so
-/// the publish-manifest transforms gate on the same falsy set a JS
-/// `if (!value)` check would. Arrays and objects are always truthy,
-/// even when empty.
-fn is_truthy(value: &Value) -> bool {
-    match value {
-        Value::Null => false,
-        Value::Bool(boolean) => *boolean,
-        Value::Number(number) => number.as_f64().is_some_and(|number| number != 0.0),
-        Value::String(string) => !string.is_empty(),
-        Value::Array(_) | Value::Object(_) => true,
-    }
 }
 
 /// Normalize a string `bin` into the object form `{ <command>: <path> }`.

--- a/pnpm/crates/pack/src/lib.rs
+++ b/pnpm/crates/pack/src/lib.rs
@@ -39,7 +39,7 @@ use pnpm_exportable_manifest::{
 use pnpm_fs::lexical_normalize;
 use pnpm_fs_packlist::{PacklistError, PacklistOptions, packlist_with_options};
 use pnpm_hooks::{HookContext, LogFn, PnpmfileHooks};
-use pnpm_package_manifest::{PackageManifestError, safe_read_package_json_from_dir};
+use pnpm_package_manifest::{PackageManifestError, is_truthy, safe_read_package_json_from_dir};
 use pnpm_reporter::{HookLog, LogEvent, LogLevel, Reporter};
 use pnpm_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 use serde_json::Value;
@@ -586,20 +586,6 @@ fn prevent_bundled_dependencies_without_hoisted(
         }
     }
     Ok(())
-}
-
-/// Whether a JSON value is truthy under JavaScript's coercion rules, so
-/// the guard fires for exactly the values pnpm's `if (bundledDependencies)`
-/// check rejects — `false`, `0`, `""`, and `null`/absent are skipped,
-/// while a non-empty array, object, number, string, or `true` all fire.
-fn is_truthy(value: &Value) -> bool {
-    match value {
-        Value::Null => false,
-        Value::Bool(boolean) => *boolean,
-        Value::Number(number) => number.as_f64().is_some_and(|number| number != 0.0),
-        Value::String(string) => !string.is_empty(),
-        Value::Array(_) | Value::Object(_) => true,
-    }
 }
 
 fn node_linker_str(node_linker: NodeLinker) -> &'static str {

--- a/pnpm/crates/package-manager/src/resolve_latest.rs
+++ b/pnpm/crates/package-manager/src/resolve_latest.rs
@@ -12,7 +12,7 @@ use crate::resolution_policy::{PickPolicy, pick_package_context};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::Config;
-use pnpm_network::ThrottledClient;
+use pnpm_network::{ThrottledClient, redact_and_sanitize};
 use pnpm_registry::{PackageTag, PackageVersion};
 use pnpm_resolving_npm_resolver::{
     InMemoryPackageMetaCache, PackumentFetchLocker, PickPackageError, PickPackageOptions,
@@ -44,6 +44,9 @@ pub enum ResolveLatestError {
     /// The guidance lives in the message rather than a `help(..)`
     /// because every caller wraps this behind its own diagnostic code,
     /// which drops the inner help before it reaches the terminal.
+    ///
+    /// `version` and `error` reproduce registry-controlled text, so both
+    /// are sanitized on the way in.
     #[display(
         "the registry served a manifest for {name}@{version} that pnpm could not read, so the version was skipped: {error}"
     )]
@@ -147,10 +150,17 @@ impl<'a> LatestPicker<'a> {
         let Some((version, error)) = pick.meta.latest_decode_error() else {
             return Err(ResolveLatestError::NoLatestVersion);
         };
+        // Both halves are the registry's text: `version` is whatever
+        // string `dist-tags.latest` held, and the decoder quotes the
+        // value it choked on. Neither reaches the terminal able to carry
+        // its own line breaks or escape sequences.
         Err(ResolveLatestError::UndecodableLatestManifest {
             name: package_name.to_string(),
-            version: version.to_string(),
-            error,
+            version: redact_and_sanitize(version),
+            error: redact_and_sanitize(&error),
         })
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/resolve_latest.rs
+++ b/pnpm/crates/package-manager/src/resolve_latest.rs
@@ -34,6 +34,21 @@ pub enum ResolveLatestError {
     #[display("no version found for the latest tag")]
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_NO_LATEST_VERSION))]
     NoLatestVersion,
+
+    /// The `latest` tag names a version the packument lists but whose
+    /// manifest pnpm could not decode. A version that fails to decode is
+    /// skipped as if the registry never served it, so without this the
+    /// failure surfaces as an empty `latest` tag and points the user at
+    /// the wrong thing entirely.
+    ///
+    /// The guidance lives in the message rather than a `help(..)`
+    /// because every caller wraps this behind its own diagnostic code,
+    /// which drops the inner help before it reaches the terminal.
+    #[display(
+        "the registry served a manifest for {name}@{version} that pnpm could not read, so the version was skipped: {error}"
+    )]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_UNDECODABLE_LATEST_MANIFEST))]
+    UndecodableLatestManifest { name: String, version: String, error: String },
 }
 
 /// Maturity-aware picker for `latest` dist-tags (see the module docs for
@@ -122,6 +137,20 @@ impl<'a> LatestPicker<'a> {
         let pick = pick_package(&ctx, &spec, &opts)
             .await
             .map_err(|error| ResolveLatestError::Pick(Box::new(error)))?;
-        pick.picked_package.ok_or(ResolveLatestError::NoLatestVersion)
+        if let Some(picked) = pick.picked_package {
+            return Ok(picked);
+        }
+        // A `latest` the packument lists but can't decode is a registry
+        // compatibility problem, not an empty dist-tag; reporting it as
+        // `NoLatestVersion` sends the user looking for an unpublished
+        // package instead of at the manifest field pnpm choked on.
+        let Some((version, error)) = pick.meta.latest_decode_error() else {
+            return Err(ResolveLatestError::NoLatestVersion);
+        };
+        Err(ResolveLatestError::UndecodableLatestManifest {
+            name: package_name.to_string(),
+            version: version.to_string(),
+            error,
+        })
     }
 }

--- a/pnpm/crates/package-manager/src/resolve_latest.rs
+++ b/pnpm/crates/package-manager/src/resolve_latest.rs
@@ -143,17 +143,9 @@ impl<'a> LatestPicker<'a> {
         if let Some(picked) = pick.picked_package {
             return Ok(picked);
         }
-        // A `latest` the packument lists but can't decode is a registry
-        // compatibility problem, not an empty dist-tag; reporting it as
-        // `NoLatestVersion` sends the user looking for an unpublished
-        // package instead of at the manifest field pnpm choked on.
         let Some((version, error)) = pick.meta.latest_decode_error() else {
             return Err(ResolveLatestError::NoLatestVersion);
         };
-        // Both halves are the registry's text: `version` is whatever
-        // string `dist-tags.latest` held, and the decoder quotes the
-        // value it choked on. Neither reaches the terminal able to carry
-        // its own line breaks or escape sequences.
         Err(ResolveLatestError::UndecodableLatestManifest {
             name: package_name.to_string(),
             version: redact_and_sanitize(version),

--- a/pnpm/crates/package-manager/src/resolve_latest/tests.rs
+++ b/pnpm/crates/package-manager/src/resolve_latest/tests.rs
@@ -26,7 +26,7 @@ fn undecodable_latest_packument(latest: &str) -> String {
                     }}
                 }}
             }}
-        }}"#
+        }}"#,
     )
 }
 

--- a/pnpm/crates/package-manager/src/resolve_latest/tests.rs
+++ b/pnpm/crates/package-manager/src/resolve_latest/tests.rs
@@ -1,0 +1,98 @@
+use super::{LatestPicker, ResolveLatestError};
+use crate::resolution_policy::PickPolicy;
+use pnpm_config::Config;
+use pnpm_network::ThrottledClient;
+use pnpm_resolving_npm_resolver::shared_packument_fetch_locker;
+use std::sync::Arc;
+use tempfile::tempdir;
+
+/// A packument that lists `latest` and serves it an unreadable manifest.
+/// `dist.integrity` decodes strictly — a tarball hash pnpm cannot read
+/// is one it cannot verify — so the version is listed yet unhydratable,
+/// which is exactly the state a dangling tag is indistinguishable from.
+fn undecodable_latest_packument(latest: &str) -> String {
+    format!(
+        r#"{{
+            "name": "acme",
+            "dist-tags": {{ "latest": "{latest}" }},
+            "time": {{ "{latest}": "2020-01-10T08:30:00.000Z" }},
+            "versions": {{
+                "{latest}": {{
+                    "name": "acme",
+                    "version": "{latest}",
+                    "dist": {{
+                        "tarball": "https://registry/acme.tgz",
+                        "integrity": "not-an-integrity"
+                    }}
+                }}
+            }}
+        }}"#
+    )
+}
+
+async fn resolve_latest_error(latest: &str) -> ResolveLatestError {
+    let dir = tempdir().expect("tempdir");
+    let mut server = mockito::Server::new_async().await;
+    let _packument = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(undecodable_latest_packument(latest))
+        .create_async()
+        .await;
+
+    let mut config = Config::new();
+    config.cache_dir = dir.path().join("cache");
+    config.registry = format!("{}/", server.url());
+    // A maturity cutoff routes the resolve through the package picker
+    // rather than the dist-tag endpoint, which is the only path that can
+    // tell an undecodable manifest from an empty tag.
+    config.minimum_release_age = Some(24 * 60);
+
+    let http_client = ThrottledClient::default();
+    let policy = PickPolicy::from_config(&config).expect("derive pick policy");
+    let picker = LatestPicker::new(
+        &config,
+        &http_client,
+        policy,
+        Arc::default(),
+        shared_packument_fetch_locker(),
+    );
+
+    picker.resolve("acme", true).await.expect_err("latest cannot resolve")
+}
+
+#[tokio::test]
+async fn an_undecodable_latest_manifest_is_reported_instead_of_an_empty_tag() {
+    let error = resolve_latest_error("1.0.0").await;
+
+    let ResolveLatestError::UndecodableLatestManifest { name, version, error } = error else {
+        panic!("expected an undecodable-manifest error, got: {error}");
+    };
+    assert_eq!(name, "acme");
+    assert_eq!(version, "1.0.0");
+    assert!(error.contains("integrity"), "the error names the field pnpm choked on: {error}");
+}
+
+/// `dist-tags.latest` and the decoder's quoting of the value it rejected
+/// are both the registry's text. Rendering either verbatim would let a
+/// packument redraw the diagnostic with escape sequences or split it
+/// across lines.
+#[tokio::test]
+async fn registry_text_reaches_the_diagnostic_stripped_of_control_characters() {
+    let error = resolve_latest_error(r"1.0.0\u001b[31m\nnot the error").await;
+
+    let ResolveLatestError::UndecodableLatestManifest { version, .. } = &error else {
+        panic!("expected an undecodable-manifest error, got: {error}");
+    };
+    assert_eq!(
+        version, "1.0.0[31mnot the error",
+        "the version keeps its text and loses the control characters",
+    );
+
+    let rendered = error.to_string();
+    assert!(
+        !rendered.chars().any(char::is_control),
+        "no control character survives into the diagnostic: {rendered:?}",
+    );
+}

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -13,6 +13,9 @@ use strum::IntoStaticStr;
 use tempfile::NamedTempFile;
 
 pub mod package_manager_spec;
+mod truthiness;
+
+pub use truthiness::is_truthy;
 
 #[derive(Debug, Display, Error, Diagnostic, From)]
 #[non_exhaustive]

--- a/pnpm/crates/package-manifest/src/truthiness.rs
+++ b/pnpm/crates/package-manifest/src/truthiness.rs
@@ -1,0 +1,16 @@
+use serde_json::Value;
+
+/// Whether a JSON value is truthy under JavaScript's coercion rules, so
+/// a Rust guard fires for exactly the values a JS `if (value)` check
+/// accepts: `null`, `false`, `0`, and `""` are falsy; every array and
+/// object, even an empty one, is truthy.
+#[must_use]
+pub fn is_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null => false,
+        Value::Bool(boolean) => *boolean,
+        Value::Number(number) => number.as_f64().is_some_and(|number| number != 0.0),
+        Value::String(string) => !string.is_empty(),
+        Value::Array(_) | Value::Object(_) => true,
+    }
+}

--- a/pnpm/crates/registry/Cargo.toml
+++ b/pnpm/crates/registry/Cargo.toml
@@ -11,8 +11,9 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-pnpm-diagnostics = { workspace = true }
-pnpm-network     = { workspace = true }
+pnpm-diagnostics      = { workspace = true }
+pnpm-network          = { workspace = true }
+pnpm-package-manifest = { workspace = true }
 
 derive_more = { workspace = true }
 reqwest     = { workspace = true }

--- a/pnpm/crates/registry/src/lib.rs
+++ b/pnpm/crates/registry/src/lib.rs
@@ -4,6 +4,7 @@ mod package_tag;
 mod package_version;
 mod package_versions;
 mod range_spec_style;
+mod wire_tolerance;
 
 pub use package::{DerivedPackuments, Package};
 pub use package_distribution::{AttestationsDist, PackageDistribution, ProvenanceMeta};

--- a/pnpm/crates/registry/src/package.rs
+++ b/pnpm/crates/registry/src/package.rs
@@ -257,6 +257,20 @@ impl Package {
     pub fn latest(&self) -> Option<Arc<PackageVersion>> {
         self.versions.get(self.dist_tags.get("latest")?)
     }
+
+    /// The version behind `dist-tags.latest` and why its manifest
+    /// failed to decode, when the packument lists that version but
+    /// pnpm can't parse it.
+    ///
+    /// `None` covers every healthy case as well as a genuinely dangling
+    /// tag, so a caller that has already failed to resolve `latest` can
+    /// use this to tell "the registry serves a manifest pnpm can't read"
+    /// apart from "the tag points at nothing".
+    #[must_use]
+    pub fn latest_decode_error(&self) -> Option<(&str, String)> {
+        let version = self.dist_tag("latest")?;
+        Some((version, self.versions.decode_error(version)?))
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/registry/src/package/tests.rs
+++ b/pnpm/crates/registry/src/package/tests.rs
@@ -209,8 +209,9 @@ fn package_deserializes_full_provenance_packument() {
     let version = pkg.versions.get("1.0.0").expect("1.0.0 deserialized");
     let user = version.npm_user.as_ref().expect("_npmUser present");
     let publisher = user.trusted_publisher.as_ref().expect("trustedPublisher present");
-    assert_eq!(publisher.id, "github");
-    assert_eq!(publisher.oidc_config_id, "release-pipeline");
+    assert_eq!(publisher.id.as_deref(), Some("github"));
+    assert_eq!(publisher.oidc_config_id.as_deref(), Some("release-pipeline"));
+    assert_eq!(pkg.latest_decode_error(), None, "a healthy latest reports no decode error");
 
     let attestations = version.dist.attestations.as_ref().expect("attestations present");
     let provenance = attestations.provenance.as_ref().expect("provenance present");
@@ -500,4 +501,56 @@ fn drop_incomplete_publish_times_discards_an_empty_timestamp() {
     pkg.drop_incomplete_publish_times();
 
     assert_eq!(pkg.time, None);
+}
+
+/// A `latest` whose manifest can't be decoded must be distinguishable
+/// from a `latest` pointing at nothing: the version is listed, so the
+/// caller reports the parse failure instead of an empty dist-tag.
+#[test]
+fn latest_decode_error_names_the_version_and_the_parse_failure() {
+    let body = r#"{
+        "name": "acme",
+        "dist-tags": { "latest": "2.0.0" },
+        "versions": {
+            "1.0.0": {
+                "name": "acme",
+                "version": "1.0.0",
+                "dist": { "tarball": "https://registry/acme-1.0.0.tgz" }
+            },
+            "2.0.0": {
+                "name": "acme",
+                "version": "2.0.0",
+                "dist": {
+                    "tarball": "https://registry/acme-2.0.0.tgz",
+                    "integrity": "not-an-integrity"
+                }
+            }
+        }
+    }"#;
+    let pkg: Package = serde_json::from_str(body).expect("deserialize packument");
+
+    assert!(pkg.versions.contains_key("2.0.0"), "the packument lists the version");
+    assert!(pkg.latest().is_none(), "but it cannot be hydrated");
+
+    let (version, error) = pkg.latest_decode_error().expect("latest reports a decode error");
+    assert_eq!(version, "2.0.0");
+    assert!(error.contains("integrity"), "error names the offending field: {error}");
+
+    assert_eq!(pkg.versions.decode_error("1.0.0"), None, "a decodable version reports nothing");
+    assert_eq!(pkg.versions.decode_error("9.9.9"), None, "an absent version reports nothing");
+}
+
+/// A dangling tag is not a decode failure, so the caller keeps reporting
+/// it as an empty `latest`.
+#[test]
+fn latest_decode_error_stays_silent_for_a_dangling_tag() {
+    let body = r#"{
+        "name": "acme",
+        "dist-tags": { "latest": "9.9.9" },
+        "versions": {}
+    }"#;
+    let pkg: Package = serde_json::from_str(body).expect("deserialize packument");
+
+    assert!(pkg.latest().is_none());
+    assert_eq!(pkg.latest_decode_error(), None);
 }

--- a/pnpm/crates/registry/src/package_distribution.rs
+++ b/pnpm/crates/registry/src/package_distribution.rs
@@ -4,6 +4,14 @@ use ssri::Integrity;
 #[derive(Debug, Default, Clone, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PackageDistribution {
+    /// Subresource integrity for the version's tarball.
+    ///
+    /// Decoded strictly, unlike the advisory fields below: a registry
+    /// package with no usable integrity cannot be locked at all — the
+    /// snapshot builder rejects it — so softening the parse would only
+    /// move "pnpm cannot verify this tarball" to a later, quieter
+    /// failure. An unparsable value fails the manifest, and so the
+    /// version, on purpose.
     pub integrity: Option<Integrity>,
     pub shasum: Option<String>,
     pub tarball: String,
@@ -11,7 +19,18 @@ pub struct PackageDistribution {
     pub revision: Option<serde_json::Value>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub revisions: Option<serde_json::Value>,
+    /// Number of files in the tarball, as the registry reports it.
+    ///
+    /// Advisory: any integral, non-negative encoding decodes — `12`,
+    /// `12.0`, `"12"` — and anything else reads as "not reported".
+    #[serde(default, deserialize_with = "crate::wire_tolerance::deserialize_advisory_count")]
     pub file_count: Option<usize>,
+    /// Unpacked byte size of the tarball, as the registry reports it.
+    /// Read only as an allocation hint by the tarball extractor, which
+    /// caps it — never trusted as fact.
+    ///
+    /// Decoded as leniently as [`Self::file_count`].
+    #[serde(default, deserialize_with = "crate::wire_tolerance::deserialize_advisory_count")]
     pub unpacked_size: Option<usize>,
 
     /// Sigstore-based supply-chain evidence the npm registry attaches
@@ -35,7 +54,11 @@ pub struct PackageDistribution {
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttestationsDist {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_presence_marker",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub provenance: Option<ProvenanceMeta>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
@@ -45,7 +68,10 @@ pub struct AttestationsDist {
 /// `dist.attestations.provenance` is what counts as the "provenance"
 /// rank when ranking a version's trust evidence; the inner
 /// `predicateType` field is kept for round-trip parity but the
-/// verifier itself does not inspect it.
+/// verifier itself does not inspect it. Because only the presence of
+/// the field is read, a registry that marks provenance with something
+/// other than an object still counts as carrying it, and decodes here
+/// with no `predicateType`.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProvenanceMeta {

--- a/pnpm/crates/registry/src/package_distribution.rs
+++ b/pnpm/crates/registry/src/package_distribution.rs
@@ -43,14 +43,19 @@ pub struct PackageDistribution {
     /// Read by the `trustPolicy='no-downgrade'` verifier when it
     /// decides whether a version's trust evidence is weaker than
     /// an earlier-published one's.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_record_or_absent",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub attestations: Option<AttestationsDist>,
 }
 
 /// Container for the attestation evidence a version exposes on its
 /// `dist.attestations` field. Right now the only value the verifier
 /// reads is `provenance`; the `url` field is the registry's link to
-/// the raw Sigstore bundle and is kept for round-trip parity.
+/// the raw Sigstore bundle and is kept for round-trip parity, decoded
+/// leniently so it cannot cost the version its provenance rank.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AttestationsDist {
@@ -60,7 +65,11 @@ pub struct AttestationsDist {
         skip_serializing_if = "Option::is_none"
     )]
     pub provenance: Option<ProvenanceMeta>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_text_or_absent",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub url: Option<String>,
 }
 

--- a/pnpm/crates/registry/src/package_version.rs
+++ b/pnpm/crates/registry/src/package_version.rs
@@ -198,13 +198,22 @@ pub struct PeerDependencyMeta {
 /// `_npmUser` field on a per-version manifest. The verifier reads
 /// `approver` and `trusted_publisher` to assign the trust rank
 /// (`stagedPublish` > `trustedPublisher` > `provenance` > none).
-/// `name` / `email` are kept for round-trip parity.
+/// `name` / `email` are kept for round-trip parity, and are decoded
+/// leniently so neither can cost the version its trust rank.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NpmUser {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_text_or_absent",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub name: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_text_or_absent",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub email: Option<String>,
     #[serde(
         default,

--- a/pnpm/crates/registry/src/package_version.rs
+++ b/pnpm/crates/registry/src/package_version.rs
@@ -53,6 +53,7 @@ pub struct PackageVersion {
     #[serde(
         default,
         rename = "_npmUser",
+        deserialize_with = "crate::wire_tolerance::deserialize_record_or_absent",
         skip_serializing_if = "Option::is_none",
         alias = "_npm_user"
     )]
@@ -186,7 +187,11 @@ where
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PeerDependencyMeta {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_strict_flag",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub optional: Option<bool>,
 }
 
@@ -201,9 +206,17 @@ pub struct NpmUser {
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_presence_marker",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub approver: Option<Approver>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_presence_marker",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub trusted_publisher: Option<TrustedPublisher>,
 }
 
@@ -211,7 +224,7 @@ pub struct NpmUser {
 /// marks a staged publish — one that required a 2FA publish approval,
 /// the strongest trust signal. The verifier only checks for the
 /// field's presence; `name` / `email` are kept for round-trip parity.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Approver {
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -222,12 +235,15 @@ pub struct Approver {
 
 /// OIDC trusted-publisher record on `_npmUser.trustedPublisher`.
 /// The verifier only checks for the field's presence; the inner
-/// values are kept for round-trip parity.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// values are kept for round-trip parity, and stay `None` for a
+/// registry that marks the publisher without describing it.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TrustedPublisher {
-    pub id: String,
-    pub oidc_config_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oidc_config_id: Option<String>,
 }
 
 impl PartialEq for PackageVersion {

--- a/pnpm/crates/registry/src/package_version.rs
+++ b/pnpm/crates/registry/src/package_version.rs
@@ -36,7 +36,11 @@ pub struct PackageVersion {
         skip_serializing_if = "Option::is_none"
     )]
     pub optional_dependencies: Option<HashMap<String, String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "crate::wire_tolerance::deserialize_record_map",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub peer_dependencies_meta: Option<HashMap<String, PeerDependencyMeta>>,
 
     /// npm registry's per-version publisher metadata. When
@@ -184,7 +188,7 @@ where
 /// `peerDependenciesMeta[name]` shape from the npm registry. Only the
 /// `optional` flag is consumed by the resolver; other fields the
 /// registry may serve are ignored.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PeerDependencyMeta {
     #[serde(

--- a/pnpm/crates/registry/src/package_version/tests.rs
+++ b/pnpm/crates/registry/src/package_version/tests.rs
@@ -100,7 +100,7 @@ fn manifest_with(dist_extra: &str, npm_user: &str, top_extra: &str) -> String {
                 "integrity": "sha512-AAAA"
                 {dist_extra}
             }}
-        }}"#
+        }}"#,
     )
 }
 

--- a/pnpm/crates/registry/src/package_version/tests.rs
+++ b/pnpm/crates/registry/src/package_version/tests.rs
@@ -85,3 +85,147 @@ fn deserializes_optional_dependencies_and_peer_dependencies_meta() {
     assert!(value.get("optionalDependencies").is_some_and(serde_json::Value::is_object));
     assert!(value.get("peerDependenciesMeta").is_some_and(serde_json::Value::is_object));
 }
+
+/// A minimal decodable manifest with fragments spliced into `dist`,
+/// `_npmUser`, and the top level, for the wire-shape tolerance tests.
+fn manifest_with(dist_extra: &str, npm_user: &str, top_extra: &str) -> String {
+    format!(
+        r#"{{
+            "name": "acme",
+            "version": "1.0.0"
+            {top_extra},
+            "_npmUser": {npm_user},
+            "dist": {{
+                "tarball": "https://registry/acme-1.0.0.tgz",
+                "integrity": "sha512-AAAA"
+                {dist_extra}
+            }}
+        }}"#
+    )
+}
+
+fn decodes(json: &str) -> bool {
+    serde_json::from_str::<PackageVersion>(json).is_ok()
+}
+
+/// The registry wire format grows fields and reshapes the trust markers
+/// without warning, and a manifest that fails to decode is skipped as if
+/// the version were never published — so a shape pnpm doesn't model can
+/// silently erase `dist-tags.latest` from a packument. Every shape here
+/// must keep costing nothing.
+#[test]
+fn net_new_fields_and_marker_reshapes_never_cost_the_version() {
+    let cases = [
+        (
+            "provenance gains net-new fields",
+            manifest_with(
+                r#", "attestations": { "provenance": { "predicateType": "https://slsa.dev/provenance/v1", "sigstoreBundle": { "x": 1 } } }"#,
+                "{}",
+                "",
+            ),
+        ),
+        (
+            "predicateType reshapes from string to object",
+            manifest_with(
+                r#", "attestations": { "provenance": { "predicateType": { "uri": "https://slsa.dev/provenance/v2" } } }"#,
+                "{}",
+                "",
+            ),
+        ),
+        (
+            "provenance reshapes from object to a list of attestations",
+            manifest_with(
+                r#", "attestations": { "provenance": [ { "predicateType": "a" } ] }"#,
+                "{}",
+                "",
+            ),
+        ),
+        (
+            "provenance abbreviates to a presence marker",
+            manifest_with(r#", "attestations": { "provenance": 1 }"#, "{}", ""),
+        ),
+        (
+            "attestations gains a sibling of provenance",
+            manifest_with(
+                r#", "attestations": { "provenance": {}, "publishAttestation": { "kind": "x" } }"#,
+                "{}",
+                "",
+            ),
+        ),
+        (
+            "trustedPublisher gains net-new fields",
+            manifest_with(
+                "",
+                r#"{ "trustedPublisher": { "id": "github", "oidcConfigId": "r", "workflowRef": "w" } }"#,
+                "",
+            ),
+        ),
+        (
+            "trustedPublisher abbreviates to a presence marker",
+            manifest_with("", r#"{ "trustedPublisher": 1 }"#, ""),
+        ),
+        (
+            "dist gains a net-new field",
+            manifest_with(r#", "signatures": [ { "sig": "s" } ]"#, "{}", ""),
+        ),
+        (
+            "the manifest gains a net-new top-level field",
+            manifest_with("", "{}", r#", "hasShrinkwrap": false"#),
+        ),
+        ("unpackedSize as a float", manifest_with(r#", "unpackedSize": 12345.0"#, "{}", "")),
+        ("unpackedSize as a string", manifest_with(r#", "unpackedSize": "12345""#, "{}", "")),
+        ("fileCount as a float", manifest_with(r#", "fileCount": 12.0"#, "{}", "")),
+        (
+            "peerDependenciesMeta.optional as a string",
+            manifest_with(
+                "",
+                "{}",
+                r#", "peerDependenciesMeta": { "react": { "optional": "true" } }"#,
+            ),
+        ),
+        ("_npmUser abbreviated to a presence marker", manifest_with("", "1", "")),
+        ("_npmUser as a maintainer string", manifest_with("", r#""alice""#, "")),
+    ];
+
+    for (label, json) in cases {
+        assert!(decodes(&json), "{label} must not make the version undecodable");
+    }
+}
+
+/// Counterpart to
+/// [`net_new_fields_and_marker_reshapes_never_cost_the_version`]: what a
+/// version manifest still has to get right. Each of these fails the
+/// manifest, and so the version, by design — pnpm cannot install a
+/// version it can't name, locate, or verify, and a quieter failure would
+/// only defer the problem. Everything else about a manifest degrades to
+/// `None` instead.
+///
+/// A case that starts decoding here is a behavior change, not a fix:
+/// weigh what pnpm would do with the version afterwards before removing
+/// it from this list.
+#[test]
+fn a_version_pnpm_could_not_install_still_fails_the_manifest() {
+    let cases = [
+        // Without a verifiable tarball hash the version cannot be locked;
+        // the snapshot builder rejects it either way, and failing here
+        // keeps pnpm from silently resolving an older version instead.
+        (
+            "integrity with an algorithm ssri doesn't know",
+            manifest_with("", "{}", "").replace("sha512-AAAA", "blake3-AAAA"),
+        ),
+        (
+            "integrity that isn't a subresource integrity string",
+            manifest_with("", "{}", "").replace("sha512-AAAA", "not-an-integrity"),
+        ),
+        // No tarball to fetch, and no version to order against its peers.
+        ("dist omitted entirely", r#"{ "name": "acme", "version": "1.0.0" }"#.to_string()),
+        (
+            "a version that isn't semver",
+            manifest_with("", "{}", "").replace(r#""version": "1.0.0""#, r#""version": "1.0.0.0""#),
+        ),
+    ];
+
+    for (label, json) in cases {
+        assert!(!decodes(&json), "{label} must still fail the manifest");
+    }
+}

--- a/pnpm/crates/registry/src/package_versions.rs
+++ b/pnpm/crates/registry/src/package_versions.rs
@@ -232,6 +232,22 @@ impl PackageVersions {
         self.slot(version).is_some()
     }
 
+    /// Why `version`'s fragment failed to decode, or `None` when the
+    /// version is absent or decodes fine.
+    ///
+    /// [`Self::get`] answers "absent" for both a version the packument
+    /// never listed and one whose manifest pnpm couldn't parse. The two
+    /// need different reporting — the second is a registry serving a
+    /// field in a shape pnpm doesn't model, and the caller can only say
+    /// so if it can recover the parse error. Re-parses the fragment, so
+    /// this belongs on error paths only.
+    #[must_use]
+    pub fn decode_error(&self, version: &str) -> Option<String> {
+        let slot = self.slot(version)?;
+        let json = slot.source.json()?;
+        serde_json::from_str::<PackageVersion>(&json).err().map(|error| error.to_string())
+    }
+
     /// Whether `version` is marked deprecated, equivalent to
     /// `get(version).is_some_and(|manifest| manifest.deprecated.is_some())`
     /// but without hydrating the full manifest: an unhydrated fragment

--- a/pnpm/crates/registry/src/wire_tolerance.rs
+++ b/pnpm/crates/registry/src/wire_tolerance.rs
@@ -18,14 +18,19 @@ use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use serde_json::Value;
 
 /// Deserialize a field pnpm reads for presence alone, keeping the typed
-/// body when the registry sends one and decoding any other shape as
-/// present-with-no-detail.
+/// body when the registry sends one and decoding any other truthy shape
+/// as present-with-no-detail.
 ///
 /// npm serves these markers as objects, but their body is not part of
 /// the wire contract that registries mirroring npm honor — some
 /// abbreviate a marker to a bare flag such as `1`. Nothing downstream
 /// reads the body, only whether the marker is there, so an unrecognized
 /// one must not cost the version.
+///
+/// Presence is decided by [`is_truthy`], not by the field merely being
+/// set: these markers rank supply-chain trust evidence, and a value the
+/// TypeScript resolver reads as no evidence must not read as evidence
+/// here.
 pub(crate) fn deserialize_presence_marker<'de, Marker, Deser>(
     deserializer: Deser,
 ) -> Result<Option<Marker>, Deser::Error>
@@ -36,7 +41,27 @@ where
     let Some(value) = Option::<Value>::deserialize(deserializer)? else {
         return Ok(None);
     };
+    if !is_truthy(&value) {
+        return Ok(None);
+    }
     Ok(Some(serde_json::from_value(value).unwrap_or_default()))
+}
+
+/// Whether a marker counts as set, under the truthiness test the
+/// TypeScript resolver's `getTrustEvidence` applies to the same fields.
+///
+/// `false`, `0`, and `""` are values a registry uses to say a marker is
+/// *not* set. Reading them as set would rank a version above what the
+/// TypeScript resolver ranks it, and `trustPolicy=no-downgrade` would
+/// stop rejecting a downgrade it is meant to catch. An object or array —
+/// empty or not — is truthy in JavaScript and stays present here.
+fn is_truthy(value: &Value) -> bool {
+    match value {
+        Value::Null | Value::Bool(false) => false,
+        Value::Number(number) => number.as_f64().is_none_or(|float| float != 0.0),
+        Value::String(text) => !text.is_empty(),
+        _ => true,
+    }
 }
 
 /// Deserialize a record whose fields pnpm reads, tolerating a registry
@@ -59,6 +84,27 @@ where
         return Ok(None);
     }
     Ok(serde_json::from_value(value).ok())
+}
+
+/// Deserialize a descriptive string pnpm carries but never acts on,
+/// tolerating a registry that sends another scalar in its place.
+///
+/// These fields sit in the same record as the trust markers, and
+/// [`deserialize_record_or_absent`] decodes that record as a unit: a
+/// strict decode here would take a valid `approver` or
+/// `trustedPublisher` down with a mistyped display name, ranking the
+/// version *below* what the TypeScript resolver ranks it — which reads
+/// the markers without regard to the shape of their siblings.
+pub(crate) fn deserialize_text_or_absent<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<String>, Deser::Error>
+where
+    Deser: Deserializer<'de>,
+{
+    Ok(Option::<Value>::deserialize(deserializer)?.and_then(|value| match value {
+        Value::String(text) => Some(text),
+        _ => None,
+    }))
 }
 
 /// Deserialize a byte/entry count the resolver treats as advisory,
@@ -86,12 +132,19 @@ where
     })
 }
 
+/// A count is only a count if it survives the trip to `usize` intact.
+/// Casting a float straight across would saturate, turning a bogus
+/// `1e100` into `usize::MAX` — a number the extractor would read as a
+/// real, enormous size instead of as nothing reported. `u128` holds
+/// every in-range value, so the range check is the conversion out of it.
 fn integral_count(number: &serde_json::Number) -> Option<usize> {
     if let Some(exact) = number.as_u64() {
         return usize::try_from(exact).ok();
     }
     let float = number.as_f64()?;
-    (float.is_finite() && float >= 0.0 && float.fract() == 0.0).then_some(float as usize)
+    (float.is_finite() && float >= 0.0 && float.fract() == 0.0)
+        .then_some(float as u128)
+        .and_then(|count| usize::try_from(count).ok())
 }
 
 /// Deserialize a flag that only counts when the registry sends a real

--- a/pnpm/crates/registry/src/wire_tolerance.rs
+++ b/pnpm/crates/registry/src/wire_tolerance.rs
@@ -1,0 +1,114 @@
+//! Tolerant decoding for registry wire-format variance.
+//!
+//! The npm wire format is a de-facto contract rather than a specified
+//! one, and registries mirroring npm diverge on the shape of individual
+//! fields. That divergence is unusually expensive here: a version
+//! manifest that fails to decode is skipped as though the registry never
+//! published the version, so a single unmodeled field can erase
+//! `dist-tags.latest` from a packument and strand resolution.
+//!
+//! Fields whose value pnpm does not depend on are therefore decoded
+//! leniently — the field degrades to `None`, never the version. Fields
+//! pnpm *does* depend on stay strict, because a version that cannot be
+//! installed safely must fail loudly rather than quietly: see
+//! [`PackageDistribution::integrity`](crate::PackageDistribution), where
+//! an unusable value has to reach the install as an error.
+
+use serde::{Deserialize, Deserializer, de::DeserializeOwned};
+use serde_json::Value;
+
+/// Deserialize a field pnpm reads for presence alone, keeping the typed
+/// body when the registry sends one and decoding any other shape as
+/// present-with-no-detail.
+///
+/// npm serves these markers as objects, but their body is not part of
+/// the wire contract that registries mirroring npm honor — some
+/// abbreviate a marker to a bare flag such as `1`. Nothing downstream
+/// reads the body, only whether the marker is there, so an unrecognized
+/// one must not cost the version.
+pub(crate) fn deserialize_presence_marker<'de, Marker, Deser>(
+    deserializer: Deser,
+) -> Result<Option<Marker>, Deser::Error>
+where
+    Marker: DeserializeOwned + Default,
+    Deser: Deserializer<'de>,
+{
+    let Some(value) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::from_value(value).unwrap_or_default()))
+}
+
+/// Deserialize a record whose fields pnpm reads, tolerating a registry
+/// that sends something other than an object in its place.
+///
+/// Unlike [`deserialize_presence_marker`], the container's *presence*
+/// carries no signal of its own — everything pnpm wants is inside it —
+/// so a non-object decodes as absent rather than as an empty record.
+pub(crate) fn deserialize_record_or_absent<'de, Record, Deser>(
+    deserializer: Deser,
+) -> Result<Option<Record>, Deser::Error>
+where
+    Record: DeserializeOwned,
+    Deser: Deserializer<'de>,
+{
+    let Some(value) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    if !value.is_object() {
+        return Ok(None);
+    }
+    Ok(serde_json::from_value(value).ok())
+}
+
+/// Deserialize a byte/entry count the resolver treats as advisory,
+/// accepting the numeric shapes a registry's serializer may emit.
+///
+/// A JSON number that is integral and non-negative decodes whatever its
+/// encoding — `12345` and `12345.0` are the same count, and a registry
+/// whose backend round-trips through a float (Go's `float64`, Python's
+/// `json`, Ruby's `JSON`) emits the latter. A numeric string is accepted
+/// on the same reasoning. Anything else decodes as absent, which is
+/// already a shape every reader handles.
+pub(crate) fn deserialize_advisory_count<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<usize>, Deser::Error>
+where
+    Deser: Deserializer<'de>,
+{
+    let Some(value) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    Ok(match value {
+        Value::Number(number) => integral_count(&number),
+        Value::String(text) => text.trim().parse().ok(),
+        _ => None,
+    })
+}
+
+fn integral_count(number: &serde_json::Number) -> Option<usize> {
+    if let Some(exact) = number.as_u64() {
+        return usize::try_from(exact).ok();
+    }
+    let float = number.as_f64()?;
+    (float.is_finite() && float >= 0.0 && float.fract() == 0.0).then_some(float as usize)
+}
+
+/// Deserialize a flag that only counts when the registry sends a real
+/// boolean.
+///
+/// The TypeScript resolver compares these with `=== true`, so a string
+/// `"true"` is not a `true` there and must not become one here. Decoding
+/// every non-boolean as absent reproduces that comparison exactly while
+/// keeping an off-shape value from costing the whole version.
+pub(crate) fn deserialize_strict_flag<'de, Deser>(
+    deserializer: Deser,
+) -> Result<Option<bool>, Deser::Error>
+where
+    Deser: Deserializer<'de>,
+{
+    Ok(Option::<Value>::deserialize(deserializer)?.and_then(|value| value.as_bool()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/registry/src/wire_tolerance.rs
+++ b/pnpm/crates/registry/src/wire_tolerance.rs
@@ -14,6 +14,9 @@
 //! [`PackageDistribution::integrity`](crate::PackageDistribution), where
 //! an unusable value has to reach the install as an error.
 
+use std::collections::HashMap;
+
+use pnpm_package_manifest::is_truthy;
 use serde::{Deserialize, Deserializer, de::DeserializeOwned};
 use serde_json::Value;
 
@@ -47,23 +50,6 @@ where
     Ok(Some(serde_json::from_value(value).unwrap_or_default()))
 }
 
-/// Whether a marker counts as set, under the truthiness test the
-/// TypeScript resolver's `getTrustEvidence` applies to the same fields.
-///
-/// `false`, `0`, and `""` are values a registry uses to say a marker is
-/// *not* set. Reading them as set would rank a version above what the
-/// TypeScript resolver ranks it, and `trustPolicy=no-downgrade` would
-/// stop rejecting a downgrade it is meant to catch. An object or array —
-/// empty or not — is truthy in JavaScript and stays present here.
-fn is_truthy(value: &Value) -> bool {
-    match value {
-        Value::Null | Value::Bool(false) => false,
-        Value::Number(number) => number.as_f64().is_none_or(|float| float != 0.0),
-        Value::String(text) => !text.is_empty(),
-        _ => true,
-    }
-}
-
 /// Deserialize a record whose fields pnpm reads, tolerating a registry
 /// that sends something other than an object in its place.
 ///
@@ -84,6 +70,32 @@ where
         return Ok(None);
     }
     Ok(serde_json::from_value(value).ok())
+}
+
+/// Deserialize a map of records, tolerating an entry whose value is not
+/// an object as well as a container that is not a map.
+///
+/// The keys carry the signal — the TypeScript resolver reads
+/// `peerDependenciesMeta` by name to learn which peers a manifest
+/// declares — so a non-object entry keeps its key with a default record
+/// rather than costing the version. A non-object container decodes as
+/// absent, like [`deserialize_record_or_absent`].
+pub(crate) fn deserialize_record_map<'de, Record, Deser>(
+    deserializer: Deser,
+) -> Result<Option<HashMap<String, Record>>, Deser::Error>
+where
+    Record: DeserializeOwned + Default,
+    Deser: Deserializer<'de>,
+{
+    let Some(Value::Object(entries)) = Option::<Value>::deserialize(deserializer)? else {
+        return Ok(None);
+    };
+    Ok(Some(
+        entries
+            .into_iter()
+            .map(|(name, value)| (name, serde_json::from_value(value).unwrap_or_default()))
+            .collect(),
+    ))
 }
 
 /// Deserialize a descriptive string pnpm carries but never acts on,

--- a/pnpm/crates/registry/src/wire_tolerance.rs
+++ b/pnpm/crates/registry/src/wire_tolerance.rs
@@ -27,9 +27,9 @@ use serde_json::Value;
 /// reads the body, only whether the marker is there, so an unrecognized
 /// one must not cost the version.
 ///
-/// Presence is decided by [`is_truthy`], not by the field merely being
-/// set: these markers rank supply-chain trust evidence, and a value the
-/// TypeScript resolver reads as no evidence must not read as evidence
+/// Presence is decided by JavaScript truthiness, not by the field merely
+/// being set: these markers rank supply-chain trust evidence, and a value
+/// the TypeScript resolver reads as no evidence must not read as evidence
 /// here.
 pub(crate) fn deserialize_presence_marker<'de, Marker, Deser>(
     deserializer: Deser,
@@ -132,18 +132,19 @@ where
     })
 }
 
-/// A count is only a count if it survives the trip to `usize` intact.
-/// Casting a float straight across would saturate, turning a bogus
-/// `1e100` into `usize::MAX` — a number the extractor would read as a
-/// real, enormous size instead of as nothing reported. `u128` holds
-/// every in-range value, so the range check is the conversion out of it.
+/// A float only counts when it is a whole number below 2^53, the range
+/// in which `f64` holds every integer. Past that the JSON parser has
+/// already rounded the digits it was given, and casting straight across
+/// would saturate, turning a bogus `1e100` into `usize::MAX` — a size
+/// the extractor would then try to honor.
 fn integral_count(number: &serde_json::Number) -> Option<usize> {
     if let Some(exact) = number.as_u64() {
         return usize::try_from(exact).ok();
     }
+    const EXACT_FLOAT_LIMIT: f64 = (1u64 << 53) as f64;
     let float = number.as_f64()?;
-    (float.is_finite() && float >= 0.0 && float.fract() == 0.0)
-        .then_some(float as u128)
+    ((0.0..EXACT_FLOAT_LIMIT).contains(&float) && float.fract() == 0.0)
+        .then_some(float as u64)
         .and_then(|count| usize::try_from(count).ok())
 }
 

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -1,0 +1,196 @@
+use crate::PackageVersion;
+
+/// A per-version manifest with `attestations` / `_npmUser` bodies spliced in.
+fn manifest_json(npm_user: &str, attestations: &str) -> String {
+    format!(
+        r#"{{
+            "name": "acme",
+            "version": "1.0.0",
+            "_npmUser": {npm_user},
+            "dist": {{
+                "tarball": "https://registry/acme-1.0.0.tgz",
+                "attestations": {attestations}
+            }}
+        }}"#
+    )
+}
+
+fn parse(npm_user: &str, attestations: &str) -> PackageVersion {
+    serde_json::from_str(&manifest_json(npm_user, attestations)).expect("deserialize manifest")
+}
+
+#[test]
+fn an_object_marker_keeps_its_body() {
+    let version = parse(
+        r#"{ "trustedPublisher": { "id": "github", "oidcConfigId": "release" } }"#,
+        r#"{ "provenance": { "predicateType": "https://slsa.dev/provenance/v1" } }"#,
+    );
+
+    let publisher = version
+        .npm_user
+        .as_ref()
+        .and_then(|user| user.trusted_publisher.as_ref())
+        .expect("trustedPublisher present");
+    assert_eq!(publisher.id.as_deref(), Some("github"));
+    assert_eq!(publisher.oidc_config_id.as_deref(), Some("release"));
+
+    let provenance = version
+        .dist
+        .attestations
+        .as_ref()
+        .and_then(|att| att.provenance.as_ref())
+        .expect("provenance present");
+    assert_eq!(provenance.predicate_type.as_deref(), Some("https://slsa.dev/provenance/v1"));
+}
+
+/// A registry may abbreviate either marker to a bare `1`. Decoding that
+/// strictly failed the whole manifest, which then read as a version the
+/// packument never listed, leaving resolution with "no version found for
+/// the latest tag"
+/// ([pnpm/pnpm#14432](https://github.com/pnpm/pnpm/issues/14432)).
+#[test]
+fn a_numeric_marker_still_counts_as_present() {
+    let version = parse(r#"{ "trustedPublisher": 1 }"#, r#"{ "provenance": 1 }"#);
+
+    let publisher = version
+        .npm_user
+        .as_ref()
+        .and_then(|user| user.trusted_publisher.as_ref())
+        .expect("trustedPublisher present");
+    assert_eq!(publisher.id, None);
+    assert_eq!(publisher.oidc_config_id, None);
+
+    let provenance = version
+        .dist
+        .attestations
+        .as_ref()
+        .and_then(|att| att.provenance.as_ref())
+        .expect("provenance present");
+    assert_eq!(provenance.predicate_type, None);
+}
+
+#[test]
+fn a_marker_body_of_any_other_shape_still_counts_as_present() {
+    for marker in [r#""yes""#, "true", "[]", "{}", r#"{ "predicateType": 7 }"#] {
+        let version = parse(
+            &format!(r#"{{ "trustedPublisher": {marker} }}"#),
+            &format!(r#"{{ "provenance": {marker} }}"#),
+        );
+        assert!(
+            version.npm_user.as_ref().is_some_and(|user| user.trusted_publisher.is_some()),
+            "trustedPublisher marked with {marker} should count as present",
+        );
+        assert!(
+            version.dist.attestations.as_ref().is_some_and(|att| att.provenance.is_some()),
+            "provenance marked with {marker} should count as present",
+        );
+    }
+}
+
+#[test]
+fn an_absent_or_null_marker_stays_absent() {
+    for marker in ["null", "{}"] {
+        let version = parse(marker, marker);
+        assert!(
+            version.npm_user.as_ref().is_none_or(|user| user.trusted_publisher.is_none()),
+            "trustedPublisher should be absent for _npmUser {marker}",
+        );
+        assert!(
+            version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()),
+            "provenance should be absent for attestations {marker}",
+        );
+    }
+}
+
+/// The `approver` marker takes the same tolerance: it is the sibling
+/// presence-only field on `_npmUser`, and a strict decode of it would
+/// erase the version exactly the same way.
+#[test]
+fn the_approver_marker_is_equally_tolerant() {
+    let version = parse(r#"{ "approver": 1 }"#, "{}");
+    assert!(version.npm_user.as_ref().is_some_and(|user| user.approver.is_some()));
+}
+
+/// A manifest with arbitrary fragments spliced into `dist` and the top level.
+fn parse_with(dist_extra: &str, top_extra: &str) -> PackageVersion {
+    let json = format!(
+        r#"{{
+            "name": "acme",
+            "version": "1.0.0"
+            {top_extra},
+            "dist": {{
+                "tarball": "https://registry/acme-1.0.0.tgz"
+                {dist_extra}
+            }}
+        }}"#
+    );
+    serde_json::from_str(&json).expect("deserialize manifest")
+}
+
+#[test]
+fn an_advisory_count_accepts_every_numeric_encoding() {
+    for (encoded, expected) in [
+        ("12345", Some(12345)),
+        ("12345.0", Some(12345)),
+        (r#""12345""#, Some(12345)),
+        (r#"" 12345 ""#, Some(12345)),
+        ("0", Some(0)),
+    ] {
+        let version = parse_with(&format!(r#", "unpackedSize": {encoded}"#), "");
+        assert_eq!(version.dist.unpacked_size, expected, "unpackedSize {encoded}");
+        let version = parse_with(&format!(r#", "fileCount": {encoded}"#), "");
+        assert_eq!(version.dist.file_count, expected, "fileCount {encoded}");
+    }
+}
+
+/// A count pnpm can't make sense of degrades to "not reported" — the
+/// same state an abbreviated packument leaves it in — rather than
+/// costing the version. Only the extractor's allocation hint reads it.
+#[test]
+fn an_unusable_advisory_count_degrades_to_absent() {
+    for encoded in ["-1", "12.5", r#""not a number""#, "true", "null", "{}", "[]"] {
+        let version = parse_with(&format!(r#", "unpackedSize": {encoded}"#), "");
+        assert_eq!(version.dist.unpacked_size, None, "unpackedSize {encoded}");
+    }
+    let version = parse_with("", "");
+    assert_eq!(version.dist.unpacked_size, None, "an omitted unpackedSize is absent");
+}
+
+/// The TypeScript resolver tests this flag with `=== true`, so only a
+/// real boolean may produce `Some(true)` here.
+#[test]
+fn a_peer_optional_flag_counts_only_when_it_is_a_real_boolean() {
+    let peer_meta = |encoded: &str| {
+        parse_with(
+            "",
+            &format!(r#", "peerDependenciesMeta": {{ "react": {{ "optional": {encoded} }} }}"#),
+        )
+        .peer_dependencies_meta
+        .as_ref()
+        .and_then(|map| map.get("react"))
+        .expect("react entry present")
+        .optional
+    };
+
+    assert_eq!(peer_meta("true"), Some(true));
+    assert_eq!(peer_meta("false"), Some(false));
+    for encoded in [r#""true""#, "1", "null", "{}"] {
+        assert_eq!(peer_meta(encoded), None, "optional {encoded} is not a boolean `true`");
+    }
+}
+
+/// `_npmUser` is a container, not a marker: everything pnpm reads lives
+/// inside it, so a registry sending a scalar in its place has supplied
+/// no publisher metadata — and must not thereby erase the version.
+#[test]
+fn a_non_object_npm_user_decodes_as_absent() {
+    for encoded in ["1", r#""alice <alice@example.com>""#, "[]", "true"] {
+        let version = parse_with("", &format!(r#", "_npmUser": {encoded}"#));
+        assert!(version.npm_user.is_none(), "_npmUser {encoded} carries no metadata");
+    }
+
+    let version = parse_with("", r#", "_npmUser": { "name": "alice", "approver": {} }"#);
+    let user = version.npm_user.as_ref().expect("an object _npmUser still decodes");
+    assert_eq!(user.name.as_deref(), Some("alice"));
+    assert!(user.approver.is_some());
+}

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -87,17 +87,59 @@ fn a_marker_body_of_any_other_shape_still_counts_as_present() {
     }
 }
 
+/// Tolerating unrecognized marker shapes must not promote the shapes a
+/// registry uses to say the marker is *unset* into trust evidence. The
+/// TypeScript resolver reads these fields for truthiness, so a version
+/// carrying `false`, `0`, or `""` has no evidence in either stack and
+/// stays subject to the `no-downgrade` rejection.
 #[test]
-fn an_absent_or_null_marker_stays_absent() {
-    for marker in ["null", "{}"] {
-        let version = parse(marker, marker);
+fn a_falsy_marker_grants_no_evidence() {
+    for marker in ["false", "0", "0.0", "-0", r#""""#] {
+        let version = parse(
+            &format!(r#"{{ "trustedPublisher": {marker}, "approver": {marker} }}"#),
+            &format!(r#"{{ "provenance": {marker} }}"#),
+        );
+        let npm_user = version.npm_user.as_ref();
         assert!(
-            version.npm_user.as_ref().is_none_or(|user| user.trusted_publisher.is_none()),
-            "trustedPublisher should be absent for _npmUser {marker}",
+            npm_user.is_none_or(|user| user.trusted_publisher.is_none()),
+            "trustedPublisher of {marker} is not a trusted publisher",
+        );
+        assert!(
+            npm_user.is_none_or(|user| user.approver.is_none()),
+            "approver of {marker} is not an approver",
         );
         assert!(
             version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()),
-            "provenance should be absent for attestations {marker}",
+            "provenance of {marker} is not a provenance attestation",
+        );
+    }
+}
+
+/// The marker's own `null` — as opposed to a missing or null container
+/// around it — is the shape that reaches the decoder, and it means the
+/// registry named the field to say it holds nothing.
+#[test]
+fn a_null_marker_stays_absent() {
+    let version =
+        parse(r#"{ "trustedPublisher": null, "approver": null }"#, r#"{ "provenance": null }"#);
+
+    let npm_user = version.npm_user.as_ref();
+    assert!(npm_user.is_none_or(|user| user.trusted_publisher.is_none()));
+    assert!(npm_user.is_none_or(|user| user.approver.is_none()));
+    assert!(version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()));
+}
+
+#[test]
+fn an_absent_or_null_container_leaves_every_marker_absent() {
+    for container in ["null", "{}"] {
+        let version = parse(container, container);
+        assert!(
+            version.npm_user.as_ref().is_none_or(|user| user.trusted_publisher.is_none()),
+            "trustedPublisher should be absent for _npmUser {container}",
+        );
+        assert!(
+            version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()),
+            "provenance should be absent for attestations {container}",
         );
     }
 }
@@ -156,6 +198,26 @@ fn an_unusable_advisory_count_degrades_to_absent() {
     assert_eq!(version.dist.unpacked_size, None, "an omitted unpackedSize is absent");
 }
 
+/// A count too large for a `usize` is not a count. It has to read as
+/// absent rather than clamp, since a saturating cast would hand the
+/// extractor `usize::MAX` as though the registry had reported it.
+#[test]
+fn an_out_of_range_advisory_count_does_not_clamp() {
+    for encoded in ["1e100", "1e30", "18446744073709551616", "1.8446744073709552e19"] {
+        let version = parse_with(&format!(r#", "unpackedSize": {encoded}"#), "");
+        assert_eq!(version.dist.unpacked_size, None, "unpackedSize {encoded} is out of range");
+        let version = parse_with(&format!(r#", "fileCount": {encoded}"#), "");
+        assert_eq!(version.dist.file_count, None, "fileCount {encoded} is out of range");
+    }
+
+    let version = parse_with(&format!(r#", "unpackedSize": {}"#, usize::MAX), "");
+    assert_eq!(
+        version.dist.unpacked_size,
+        Some(usize::MAX),
+        "an exactly encoded usize::MAX is still in range",
+    );
+}
+
 /// The TypeScript resolver tests this flag with `=== true`, so only a
 /// real boolean may produce `Some(true)` here.
 #[test]
@@ -193,4 +255,27 @@ fn a_non_object_npm_user_decodes_as_absent() {
     let user = version.npm_user.as_ref().expect("an object _npmUser still decodes");
     assert_eq!(user.name.as_deref(), Some("alice"));
     assert!(user.approver.is_some());
+}
+
+/// The publisher's display fields are decoration; the markers beside
+/// them decide the version's trust rank. Decoding the record as a unit
+/// means a mistyped `name` would otherwise discard a real `approver`,
+/// weakening the rank and letting `no-downgrade` reject a version the
+/// TypeScript resolver accepts.
+#[test]
+fn a_mistyped_publisher_name_keeps_the_trust_markers() {
+    let version = parse_with(
+        "",
+        r#", "_npmUser": { "name": 1, "email": [], "approver": {}, "trustedPublisher": { "id": "github" } }"#,
+    );
+
+    let user = version.npm_user.as_ref().expect("_npmUser survives a mistyped name");
+    assert_eq!(user.name, None, "a non-string name reads as absent");
+    assert_eq!(user.email, None, "a non-string email reads as absent");
+    assert!(user.approver.is_some(), "the approver marker survives");
+    assert_eq!(
+        user.trusted_publisher.as_ref().and_then(|publisher| publisher.id.as_deref()),
+        Some("github"),
+        "the trusted publisher survives with its body intact",
+    );
 }

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -43,11 +43,9 @@ fn an_object_marker_keeps_its_body() {
     assert_eq!(provenance.predicate_type.as_deref(), Some("https://slsa.dev/provenance/v1"));
 }
 
-/// A registry may abbreviate either marker to a bare `1`. Decoding that
-/// strictly failed the whole manifest, which then read as a version the
-/// packument never listed, leaving resolution with "no version found for
-/// the latest tag"
-/// ([pnpm/pnpm#14432](https://github.com/pnpm/pnpm/issues/14432)).
+/// A registry may abbreviate either marker to a bare `1`
+/// ([pnpm/pnpm#14432](https://github.com/pnpm/pnpm/issues/14432)); the
+/// marker still counts, and the manifest still decodes.
 #[test]
 fn a_numeric_marker_still_counts_as_present() {
     let version = parse(r#"{ "trustedPublisher": 1 }"#, r#"{ "provenance": 1 }"#);

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -301,3 +301,49 @@ fn a_mistyped_publisher_name_keeps_the_trust_markers() {
         "the trusted publisher survives with its body intact",
     );
 }
+
+/// `dist.attestations` is a container like `_npmUser`: only the
+/// `provenance` marker inside it is read, so neither the container's own
+/// shape nor its `url` sibling may cost the version.
+#[test]
+fn an_off_shape_attestations_container_or_url_keeps_the_version() {
+    for encoded in ["1", r#""signed""#, "[]", "true"] {
+        let version = parse_with(&format!(r#", "attestations": {encoded}"#), "");
+        assert!(version.dist.attestations.is_none(), "attestations {encoded} carries no metadata");
+    }
+
+    let version = parse_with(r#", "attestations": { "provenance": {}, "url": 7 }"#, "");
+    let attestations = version.dist.attestations.as_ref().expect("an object attestations decodes");
+    assert_eq!(attestations.url, None, "a non-string url reads as absent");
+    assert!(attestations.provenance.is_some(), "the provenance marker survives a mistyped url");
+}
+
+/// A `peerDependenciesMeta` entry names a peer even when its value is not
+/// an object: the TypeScript resolver keeps the name and finds no
+/// `optional === true` inside it.
+#[test]
+fn an_off_shape_peer_meta_entry_keeps_its_name_with_optional_unset() {
+    for encoded in ["true", "1", r#""optional""#, "[]", "null"] {
+        let version = parse_with(
+            "",
+            &format!(
+                r#", "peerDependenciesMeta": {{ "react": {encoded}, "vue": {{ "optional": true }} }}"#,
+            ),
+        );
+        let meta = version.peer_dependencies_meta.as_ref().expect("the map decodes");
+        assert_eq!(meta.get("react").map(|entry| entry.optional), Some(None), "react: {encoded}");
+        assert_eq!(
+            meta.get("vue").map(|entry| entry.optional),
+            Some(Some(true)),
+            "vue keeps its flag beside react: {encoded}",
+        );
+    }
+
+    for encoded in ["1", "[]", r#""react""#] {
+        let version = parse_with("", &format!(r#", "peerDependenciesMeta": {encoded}"#));
+        assert!(
+            version.peer_dependencies_meta.is_none(),
+            "peerDependenciesMeta {encoded} has no entries",
+        );
+    }
+}

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -124,9 +124,18 @@ fn a_null_marker_stays_absent() {
         parse(r#"{ "trustedPublisher": null, "approver": null }"#, r#"{ "provenance": null }"#);
 
     let npm_user = version.npm_user.as_ref();
-    assert!(npm_user.is_none_or(|user| user.trusted_publisher.is_none()));
-    assert!(npm_user.is_none_or(|user| user.approver.is_none()));
-    assert!(version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()));
+    assert!(
+        npm_user.is_none_or(|user| user.trusted_publisher.is_none()),
+        "a null trustedPublisher is not a trusted publisher",
+    );
+    assert!(
+        npm_user.is_none_or(|user| user.approver.is_none()),
+        "a null approver is not an approver",
+    );
+    assert!(
+        version.dist.attestations.as_ref().is_none_or(|att| att.provenance.is_none()),
+        "a null provenance is not a provenance attestation",
+    );
 }
 
 #[test]
@@ -198,17 +207,32 @@ fn an_unusable_advisory_count_degrades_to_absent() {
     assert_eq!(version.dist.unpacked_size, None, "an omitted unpackedSize is absent");
 }
 
-/// A count too large for a `usize` is not a count. It has to read as
-/// absent rather than clamp, since a saturating cast would hand the
-/// extractor `usize::MAX` as though the registry had reported it.
+/// A count too large for a `usize`, or a float the parser has already
+/// rounded, is not a count. It has to read as absent rather than clamp
+/// or round, since a saturating cast would hand the extractor
+/// `usize::MAX` as though the registry had reported it.
 #[test]
 fn an_out_of_range_advisory_count_does_not_clamp() {
-    for encoded in ["1e100", "1e30", "18446744073709551616", "1.8446744073709552e19"] {
+    for encoded in [
+        "1e100",
+        "1e30",
+        "18446744073709551616",
+        "1.8446744073709552e19",
+        "9007199254740993.0",
+        "9007199254740992.0",
+    ] {
         let version = parse_with(&format!(r#", "unpackedSize": {encoded}"#), "");
         assert_eq!(version.dist.unpacked_size, None, "unpackedSize {encoded} is out of range");
         let version = parse_with(&format!(r#", "fileCount": {encoded}"#), "");
         assert_eq!(version.dist.file_count, None, "fileCount {encoded} is out of range");
     }
+
+    let version = parse_with(r#", "unpackedSize": 1099511627776.0"#, "");
+    assert_eq!(
+        version.dist.unpacked_size,
+        usize::try_from(1_099_511_627_776_u64).ok(),
+        "a terabyte-scale float is still in range",
+    );
 
     let version = parse_with(&format!(r#", "unpackedSize": {}"#, usize::MAX), "");
     assert_eq!(

--- a/pnpm/crates/registry/src/wire_tolerance/tests.rs
+++ b/pnpm/crates/registry/src/wire_tolerance/tests.rs
@@ -11,7 +11,7 @@ fn manifest_json(npm_user: &str, attestations: &str) -> String {
                 "tarball": "https://registry/acme-1.0.0.tgz",
                 "attestations": {attestations}
             }}
-        }}"#
+        }}"#,
     )
 }
 
@@ -173,7 +173,7 @@ fn parse_with(dist_extra: &str, top_extra: &str) -> PackageVersion {
                 "tarball": "https://registry/acme-1.0.0.tgz"
                 {dist_extra}
             }}
-        }}"#
+        }}"#,
     );
     serde_json::from_str(&json).expect("deserialize manifest")
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Today - in `pnpm@12` - a package version manifest that fails to decode is skipped as though the registry never published that version, so an unmodeled/unrecognized field can result in the removal of that entire version - potentially stranding resolution & throwing an `ERR_PNPM_PACKAGE_MANAGER_ADD_RESOLVE_LATEST` error. This was notable to us since npm-compatible package registries can serve packument/manifest metadata differently (as there has been/continues to be poor documentation for much of this data). `pnpm@11` gracefully handled ambiguous fields without dropping versions from the available set. This PR patches `pnpm@12` to be similarly tolerant.

Ultimately, the changes here allow for more leniency with the shape of package metadata without invalidating the version or the intent behind any fields; ex. trust markers like `_npmUser.trustedPublisher` & `dist.attestations.provenance` keep their body when the registry sends an object but accept most any other truthy value; `dist.unpackedSize` and `dist.fileCount` take any integral encoding, including floats and numeric strings a serializer may emit; and `peerDependenciesMeta.<name>.optional` tolerates a non-boolean, which counts as unset exactly as the TypeScript resolver's `=== true` comparison would have previously treat it.

Notably, I've left the `dist.integrity` checks strict. It should be noted though that `ssri` rejects an entire SRI string when any hash uses an algorithm it doesn't know (ie. only sha1/sha256/sha384/sha512/xxh3 today), so if a newer algo gets introduced the affected versions would silently drop out of resolution instead of erroring; worth fixing separately/considering how to handle to future-proof.

Lastly, when `latest` does ultimately happen to match a version whose manifest cannot be parsed for some reason, we'd now report that version and the parse failure rather than an empty tag (improving debuggability).

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
- Decode version manifests by what pnpm depends on: a field pnpm reads but
  does not rely on now degrades to `None` instead of failing the manifest,
  which previously dropped the whole version from resolution.
- Treat `dist.attestations.provenance`, `_npmUser.trustedPublisher`, and
  `_npmUser.approver` as presence markers — the typed body is kept when the
  registry sends an object, and any other shape still counts as present (maintaining trust policy ordering).
- Accept any integral encoding for `dist.unpackedSize` and `dist.fileCount`
  (`12`, `12.0`, `"12"`); both are advisory, and `unpackedSize` only feeds a
  capped allocation hint.
- Accept a non-object `_npmUser`, and a non-boolean
  `peerDependenciesMeta.<name>.optional` which counts as unset, matching the
  `=== true` comparison the TypeScript resolver applies.
- Keep `dist.integrity` strict: a tarball hash pnpm cannot read is one it
  cannot verify, and the snapshot builder rejects it regardless.
- Report the offending version and parse failure when `latest` names an
  undecodable manifest, rather than reporting the tag as empty.
- These changes only affect the Rust-version: the TypeScript CLI parses these manifests without validating them, so it was never affected.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790915593&installation_model_id=426870&pr_number=14448&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14448&signature=a1adea5f2f021fe39c4e8512fbeb6f3d997461a8ed535e8bbb23a866746657be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with registry metadata containing unexpected or malformed optional field shapes.
  * Preserved strict validation for package integrity and other install-critical metadata.
  * Handled malformed advisory fields, trust markers, and optional records more gracefully.
  * Prevented valid package versions from being discarded because of unsupported registry metadata formats.
  * Improved `latest` tag errors by identifying the affected version and the specific decoding issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->