### PR TITLE
fix(peers): reuse cached owner during finalization

### DIFF
--- a/.changeset/closed-cyclic-peer-cache.md
+++ b/.changeset/closed-cyclic-peer-cache.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed pnpm generating a broken lockfile when an npm-aliased dependency in a cyclic peer graph reuses a cached resolution [#14449](https://github.com/pnpm/pnpm/issues/14449). Frozen installs now reference the cached occurrence's emitted snapshot.

--- a/.changeset/closed-cyclic-peer-cache.md
+++ b/.changeset/closed-cyclic-peer-cache.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed pnpm generating a broken lockfile when an npm-aliased dependency in a cyclic peer graph reuses a cached resolution [#14449](https://github.com/pnpm/pnpm/issues/14449). Frozen installs now reference the cached occurrence's emitted snapshot.
+Fixed `pnpm install --lockfile-only` writing a lockfile that referenced a missing peer-suffixed snapshot when an npm-aliased dependency took part in a cyclic peer dependency graph. The following `pnpm install --frozen-lockfile` failed with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` [#14449](https://github.com/pnpm/pnpm/issues/14449).

--- a/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
+++ b/pnpm/crates/cli/tests/suite/hoisted_node_linker.rs
@@ -351,6 +351,59 @@ fn peer_dependencies_installed_with_auto_install_peers() {
     drop((root, mock_instance));
 }
 
+/// A cached occurrence of an npm-aliased package in a peer cycle must
+/// reuse the fully walked occurrence's final depPath. Otherwise the
+/// lockfile points at a peer-suffixed snapshot that was never emitted,
+/// and the following frozen install cannot replay it.
+#[test]
+fn frozen_install_replays_a_cached_cyclic_alias_peer_snapshot() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "cached-cyclic-alias-peer",
+            "version": "1.0.0",
+            "devDependencies": {
+                "devtools": "npm:@pnpm.e2e/peer-a@1.0.0",
+                "vite": "npm:@pnpm.e2e/foo@1.0.0",
+                "vite-plus": "npm:@pnpm.e2e/pkg-with-1-dep@100.0.0"
+            }
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    write_workspace_yaml(
+        &workspace,
+        concat!(
+            "nodeLinker: hoisted\n",
+            "packageExtensions:\n",
+            "  '@pnpm.e2e/foo@1.0.0':\n",
+            "    peerDependencies:\n",
+            "      devtools: '*'\n",
+            "    peerDependenciesMeta:\n",
+            "      devtools:\n",
+            "        optional: true\n",
+            "  '@pnpm.e2e/peer-a@1.0.0':\n",
+            "    peerDependencies:\n",
+            "      vite: '*'\n",
+            "  '@pnpm.e2e/pkg-with-1-dep@100.0.0':\n",
+            "    dependencies:\n",
+            "      '@pnpm.e2e/foo': 1.0.0\n",
+        ),
+    );
+
+    pacquet.with_args(["install", "--lockfile-only", "--ignore-scripts"]).assert().success();
+    pacquet_at(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--ignore-scripts"])
+        .assert()
+        .success();
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn package_map_resolves_declared_hoisted_dependencies_at_runtime() {
     if node_major() < 27 {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -38,6 +38,10 @@ use std::{collections::BTreeMap, sync::Arc};
 /// subtree promotes its providers to importer level.
 #[derive(Debug)]
 pub(super) struct PeersCacheItem {
+    /// The fully walked occurrence that produced this verdict. Cache
+    /// hits are semantically equivalent to this node and must reuse its
+    /// final depPath instead of being finalized as independent nodes.
+    pub(super) owner_node_id: NodeId,
     pub(super) dep_path: DepPath,
     pub(super) resolved_peers: Arc<HashMap<String, NodeId>>,
     pub(super) missing_peers: Arc<HashMap<String, MissingPeerInfo>>,
@@ -64,6 +68,7 @@ impl PeersCacheItem {
 
     pub(super) fn to_cached_node_output(&self) -> CachedNodeOutput {
         CachedNodeOutput {
+            owner_node_id: self.owner_node_id.clone(),
             output: self.to_node_output(),
             missing_peers_of_children: Arc::clone(&self.missing_peers_of_children),
         }
@@ -71,6 +76,7 @@ impl PeersCacheItem {
 }
 
 pub(super) struct CachedNodeOutput {
+    owner_node_id: NodeId,
     output: NodeOutput,
     missing_peers_of_children: Arc<HashMap<String, MissingPeerInfo>>,
 }
@@ -369,7 +375,7 @@ impl Walker<'_> {
             parent_pkg_ids_chain,
             preview_undo,
         } = context;
-        let output = cached.output;
+        let CachedNodeOutput { owner_node_id, output, missing_peers_of_children } = cached;
         self.undo_realize(node_id, preview_undo, None);
 
         if !output.missing_peers.is_empty() {
@@ -395,11 +401,13 @@ impl Walker<'_> {
         }
         self.remember_resolved_node(node_id, &output.dep_path);
         if !self.discovery {
+            if &owner_node_id != node_id {
+                self.cache_owner_by_node_id.insert(node_id.clone(), owner_node_id);
+            }
             self.node_external_peers
                 .insert(node_id.clone(), Arc::clone(&output.external_resolved_peers));
             self.node_missing_peers.insert(node_id.clone(), Arc::clone(&output.missing_peers));
-            self.node_missing_peers_of_children
-                .insert(node_id.clone(), cached.missing_peers_of_children);
+            self.node_missing_peers_of_children.insert(node_id.clone(), missing_peers_of_children);
         }
         if let Some(node) = self.graph.get_mut(&output.dep_path)
             && node.depth > tree_node_depth

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/cache.rs
@@ -402,6 +402,12 @@ impl Walker<'_> {
         self.remember_resolved_node(node_id, &output.dep_path);
         if !self.discovery {
             if &owner_node_id != node_id {
+                let owner_is_fully_walked =
+                    !self.cache_owner_by_node_id.contains_key(&owner_node_id);
+                debug_assert!(
+                    owner_is_fully_walked,
+                    "cache owner {owner_node_id:?} of {node_id:?} is itself a cache hit",
+                );
                 self.cache_owner_by_node_id.insert(node_id.clone(), owner_node_id);
             }
             self.node_external_peers

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -88,6 +88,14 @@ struct FinalPeerContext<'a> {
 }
 
 impl Walker<'_> {
+    /// Return the fully walked occurrence whose peer-resolution verdict
+    /// `node_id` reused. The cache hit is the same semantic node for
+    /// final depPath construction even though it remains a distinct tree
+    /// occurrence for traversal and edge labels.
+    fn cache_owner_node_id<'a>(&'a self, node_id: &'a NodeId) -> &'a NodeId {
+        self.cache_owner_by_node_id.get(node_id).unwrap_or(node_id)
+    }
+
     /// Record one walked node: its entry in the provisional
     /// depPath-keyed graph, and the [`NodeRecord`] the post-walk rebuild
     /// consumes. A discovery pass runs neither of the passes that read
@@ -295,6 +303,7 @@ impl Walker<'_> {
         final_dep_paths: &mut HashMap<NodeId, DepPath>,
         visiting: &mut HashSet<NodeId>,
     ) -> DepPath {
+        let node_id = self.cache_owner_node_id(node_id);
         if let Some(dep_path) = final_dep_paths.get(node_id) {
             return dep_path.clone();
         }
@@ -336,6 +345,7 @@ impl Walker<'_> {
         node_id: &NodeId,
         final_dep_paths: &HashMap<NodeId, DepPath>,
     ) -> DepPath {
+        let node_id = self.cache_owner_node_id(node_id);
         if let Some(dep_path) = final_dep_paths.get(node_id) {
             return dep_path.clone();
         }
@@ -357,6 +367,8 @@ impl Walker<'_> {
         final_dep_paths: &mut HashMap<NodeId, DepPath>,
         visiting: &mut HashSet<NodeId>,
     ) -> PeerId {
+        let node_id = self.cache_owner_node_id(node_id);
+        let peer_node_id = self.cache_owner_node_id(peer_node_id);
         if let NodeId::Leaf(id) = peer_node_id
             && let Some(rel) = id.strip_prefix("link:")
         {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/finalize.rs
@@ -367,7 +367,6 @@ impl Walker<'_> {
         final_dep_paths: &mut HashMap<NodeId, DepPath>,
         visiting: &mut HashSet<NodeId>,
     ) -> PeerId {
-        let node_id = self.cache_owner_node_id(node_id);
         let peer_node_id = self.cache_owner_node_id(peer_node_id);
         if let NodeId::Leaf(id) = peer_node_id
             && let Some(rel) = id.strip_prefix("link:")
@@ -527,12 +526,17 @@ impl Walker<'_> {
     /// peers, restricted to peers that themselves carry peers — peerless
     /// peers can't close a cycle). Iterative Tarjan, returning the SCCs
     /// in reverse-topological order plus a `NodeId → SCC index` map.
+    ///
+    /// Vertices and edge targets are canonicalized through
+    /// [`Self::cache_owner_node_id`] to match the owner-keyed lookups
+    /// in [`Self::final_peer_id`]: a cycle through a cache-hit
+    /// occurrence is a cycle through its owner.
     fn peer_sccs(&self) -> (Vec<Vec<NodeId>>, HashMap<NodeId, usize>) {
         let mut participants: Vec<NodeId> = self
             .node_external_peers
             .iter()
             .filter(|(_, peers)| !peers.is_empty())
-            .map(|(node_id, _)| node_id.clone())
+            .map(|(node_id, _)| self.cache_owner_node_id(node_id).clone())
             .collect();
         participants.sort();
         participants.dedup();
@@ -543,10 +547,12 @@ impl Walker<'_> {
                 .get(node_id)
                 .into_iter()
                 .flat_map(|peers| peers.values())
+                .map(|peer| self.cache_owner_node_id(peer))
                 .filter(|peer| participant_set.contains(*peer))
                 .cloned()
                 .collect();
             out.sort();
+            out.dedup();
             out
         };
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    ImporterPeerInput, ResolvePeersOptions,
+    ImporterPeerInput, ResolvePeersOptions, ResolvePeersResult,
     context::peer_id_pair,
     resolve_peers, resolve_peers_workspace,
     test_support::{
@@ -439,8 +439,12 @@ fn peer_name_cycle_collapses_provider_suffixes() {
     );
 }
 
-#[test]
-fn cached_cyclic_alias_peer_occurrences_share_a_closed_dep_path() {
+/// The cyclic aliased peer graph of pnpm/pnpm#14449: `vite` and the
+/// `core` nested under `vite-plus` are two occurrences of one package,
+/// so whichever is walked second reuses the first one's peer-cache
+/// verdict, and `@vitejs/devtools` closes the peer cycle. The direct
+/// dependency order decides which occurrence becomes the cache owner.
+fn cyclic_alias_peer_tree(direct_aliases: [&str; 3]) -> ResolvedTree {
     let core_direct = NodeId::next();
     let core_nested = NodeId::next();
     let devtools = NodeId::next();
@@ -449,24 +453,21 @@ fn cached_cyclic_alias_peer_occurrences_share_a_closed_dep_path() {
     let mut vite_plus_children = BTreeMap::new();
     vite_plus_children.insert("core".to_string(), core_nested.clone());
 
-    let mut tree = ResolvedTree {
-        direct: vec![
-            DirectDep {
-                alias: "@vitejs/devtools".to_string(),
-                node_id: devtools.clone(),
-                id: "@vitejs/devtools@1.0.0".to_string(),
-            },
-            DirectDep {
-                alias: "vite".to_string(),
-                node_id: core_direct.clone(),
-                id: "core@1.0.0".to_string(),
-            },
-            DirectDep {
-                alias: "vite-plus".to_string(),
-                node_id: vite_plus.clone(),
-                id: "vite-plus@1.0.0".to_string(),
-            },
-        ],
+    let direct = direct_aliases
+        .into_iter()
+        .map(|alias| {
+            let (node_id, id) = match alias {
+                "@vitejs/devtools" => (&devtools, "@vitejs/devtools@1.0.0"),
+                "vite" => (&core_direct, "core@1.0.0"),
+                "vite-plus" => (&vite_plus, "vite-plus@1.0.0"),
+                _ => unreachable!("unknown direct dependency alias {alias}"),
+            };
+            DirectDep { alias: alias.to_string(), node_id: node_id.clone(), id: id.to_string() }
+        })
+        .collect();
+
+    ResolvedTree {
+        direct,
         packages: HashMap::from_iter([
             (
                 Arc::from("core@1.0.0".to_string()),
@@ -496,19 +497,54 @@ fn cached_cyclic_alias_peer_occurrences_share_a_closed_dep_path() {
         policy_violations: Vec::new(),
         applied_patches: HashSet::default(),
         children_by_id: HashMap::default(),
-    };
+    }
+}
 
-    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
-    let vite_core = result.direct_dependencies_by_alias["vite"].clone();
+/// Both `core` occurrences must share the cycle-collapsed depPath, and
+/// every edge of the result must point at an emitted graph node.
+fn assert_cyclic_alias_peer_graph_is_closed(result: &ResolvePeersResult) {
+    let vite_core = &result.direct_dependencies_by_alias["vite"];
     let vite_plus_path = &result.direct_dependencies_by_alias["vite-plus"];
-    let nested_core = result.graph[vite_plus_path].children["core"].clone();
+    let nested_core = &result.graph[vite_plus_path].children["core"];
 
     assert_eq!(nested_core, vite_core);
-    assert!(
-        result.graph.contains_key(&nested_core),
-        "every final dependency edge must resolve to a graph node: {:#?}",
-        result.graph,
+    assert_eq!(vite_core, &DepPath::from("core@1.0.0(@vitejs/devtools@1.0.0)"));
+    assert_eq!(
+        result.direct_dependencies_by_alias["@vitejs/devtools"],
+        DepPath::from("@vitejs/devtools@1.0.0(core@1.0.0)"),
     );
+    for node in result.graph.values() {
+        for (alias, child) in &node.children {
+            assert!(
+                result.graph.contains_key(child),
+                "edge {alias} of {} points at a missing graph node {child}: {:#?}",
+                node.dep_path,
+                result.graph,
+            );
+        }
+    }
+}
+
+#[test]
+fn cached_cyclic_alias_peer_occurrences_share_a_closed_dep_path() {
+    let mut tree = cyclic_alias_peer_tree(["@vitejs/devtools", "vite", "vite-plus"]);
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert_cyclic_alias_peer_graph_is_closed(&result);
+}
+
+/// Walking `vite-plus` first makes the nested `core` the cache owner
+/// and the direct `vite` the cache hit, so the peer edge of
+/// `@vitejs/devtools` targets the hit occurrence. The cycle must still
+/// be detected through the owner.
+#[test]
+fn cached_cyclic_alias_peer_occurrence_targeted_by_a_peer_collapses_the_cycle() {
+    let mut tree = cyclic_alias_peer_tree(["vite-plus", "vite", "@vitejs/devtools"]);
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+
+    assert_cyclic_alias_peer_graph_is_closed(&result);
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -440,6 +440,78 @@ fn peer_name_cycle_collapses_provider_suffixes() {
 }
 
 #[test]
+fn cached_cyclic_alias_peer_occurrences_share_a_closed_dep_path() {
+    let core_direct = NodeId::next();
+    let core_nested = NodeId::next();
+    let devtools = NodeId::next();
+    let vite_plus = NodeId::next();
+
+    let mut vite_plus_children = BTreeMap::new();
+    vite_plus_children.insert("core".to_string(), core_nested.clone());
+
+    let mut tree = ResolvedTree {
+        direct: vec![
+            DirectDep {
+                alias: "@vitejs/devtools".to_string(),
+                node_id: devtools.clone(),
+                id: "@vitejs/devtools@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "vite".to_string(),
+                node_id: core_direct.clone(),
+                id: "core@1.0.0".to_string(),
+            },
+            DirectDep {
+                alias: "vite-plus".to_string(),
+                node_id: vite_plus.clone(),
+                id: "vite-plus@1.0.0".to_string(),
+            },
+        ],
+        packages: HashMap::from_iter([
+            (
+                Arc::from("core@1.0.0".to_string()),
+                package_with_peer_dependencies(
+                    "core",
+                    "1.0.0",
+                    &[("@vitejs/devtools", "*", true)],
+                    false,
+                ),
+            ),
+            (
+                Arc::from("@vitejs/devtools@1.0.0".to_string()),
+                package("@vitejs/devtools", "1.0.0", &[("vite", "*")], false),
+            ),
+            ("vite-plus@1.0.0".into(), package("vite-plus", "1.0.0", &[], false)),
+        ]),
+        dependencies_tree: HashMap::from_iter([
+            (core_direct, tree_node("core@1.0.0", BTreeMap::new(), 0)),
+            (core_nested, tree_node("core@1.0.0", BTreeMap::new(), 1)),
+            (devtools, tree_node("@vitejs/devtools@1.0.0", BTreeMap::new(), 0)),
+            (vite_plus, tree_node("vite-plus@1.0.0", vite_plus_children, 0)),
+        ]),
+        all_peer_dep_names: HashSet::from_iter([
+            "@vitejs/devtools".to_string(),
+            "vite".to_string(),
+        ]),
+        policy_violations: Vec::new(),
+        applied_patches: HashSet::default(),
+        children_by_id: HashMap::default(),
+    };
+
+    let result = resolve_peers(&mut tree, ResolvePeersOptions::default());
+    let vite_core = result.direct_dependencies_by_alias["vite"].clone();
+    let vite_plus_path = &result.direct_dependencies_by_alias["vite-plus"];
+    let nested_core = result.graph[vite_plus_path].children["core"].clone();
+
+    assert_eq!(nested_core, vite_core);
+    assert!(
+        result.graph.contains_key(&nested_core),
+        "every final dependency edge must resolve to a graph node: {:#?}",
+        result.graph,
+    );
+}
+
+#[test]
 fn missing_names_by_pkg_records_only_children_context_missing_peers() {
     let parent = NodeId::next();
     let child = NodeId::next();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -50,6 +50,9 @@ pub(super) struct Walker<'tree> {
     /// its descendants' peer dependencies into its own peer suffix.
     /// Indexed by `NodeId`; value's keys are peer aliases.
     pub(super) node_external_peers: HashMap<NodeId, Arc<HashMap<String, NodeId>>>,
+    /// Cache-hit occurrence → fully walked occurrence that produced the
+    /// reused peer-resolution verdict.
+    pub(super) cache_owner_by_node_id: HashMap<NodeId, NodeId>,
     /// Peers each node and its subtree declared but couldn't find.
     /// Indexed by `NodeId`; value's keys are peer aliases.
     pub(super) node_missing_peers: HashMap<NodeId, Arc<HashMap<String, MissingPeerInfo>>>,
@@ -217,6 +220,7 @@ impl<'tree> Walker<'tree> {
             missing_ancestor_pkg_ids: HashMap::default(),
             node_dep_paths,
             node_external_peers: HashMap::default(),
+            cache_owner_by_node_id: HashMap::default(),
             node_missing_peers: HashMap::default(),
             node_missing_peers_of_children: HashMap::default(),
             resolved_peer_providers_by_alias: BTreeMap::new(),
@@ -973,6 +977,7 @@ impl Walker<'_> {
                 .entry(std::sync::Arc::<str>::clone(&pkg.id).to_string())
                 .or_default()
                 .push(PeersCacheItem {
+                    owner_node_id: node_id.clone(),
                     dep_path: dep_path.clone(),
                     resolved_peers: Arc::clone(&all_resolved_peers),
                     missing_peers: Arc::clone(&all_missing_peers),


### PR DESCRIPTION
## Summary

- Fixes a pnpm 12 lockfile corruption where a cached occurrence in a cyclic aliased peer graph was finalized to a snapshot key that the graph never emitted.
- Records the fully walked owner of each peer-cache entry and canonicalizes cached occurrences through that owner during final depPath and SCC lookup.
- Keeps dependency aliases as edge labels and leaves cache matching, cache short-circuiting, and lockfile serializer fallbacks unchanged.
- Adds resolver-level graph-closure coverage and an end-to-end lockfile-only to frozen-install regression test.
- Rust-only because the TypeScript resolver already behaves this way: `resolvePeers.ts` records `peersCacheOwnerByNodeId` and a cache hit awaits the owner's `depPath` promise, so the hit inherits the owner's final depPath. pacquet's post-walk finalizer lacked that step.
- Builds the peer-graph SCC table over cache owners as well, so a cycle that runs through a cache-hit occurrence still collapses whichever occurrence the walk visited first.

Fixes pnpm/pnpm#14449.

Reproduction: [zhsama/pnpm12-hoisted-cyclic-alias-peer-repro](https://github.com/zhsama/pnpm12-hoisted-cyclic-alias-peer-repro)

## Design

A peer-cache hit is a claim that the reused occurrence has the same peer-resolution semantics as the occurrence that produced the cache entry. The finalizer must therefore use the same semantic node identity. If an occurrence requires a distinct long-form peer key, the cache match is invalid and it must be fully walked instead.

`PeersCacheItem` now carries its producer NodeId. A cache hit records `occurrence -> owner`, and final depPath construction, graph edge rendering, and SCC comparisons resolve through that owner. The occurrence remains distinct in the dependency tree, and aliases remain on dependency edges; only final peer-graph identity is shared.

This fixes the producer/consumer mismatch directly rather than removing the existing lockfile fallback or adding another production validation pass. The end-to-end frozen replay test guards the observable closure invariant.

## Validation

- `node pnpm/scripts/run-rust-tests.mjs --no-fail-fast -j 8`: 9793 passed, 5 skipped, 0 failed.
- Official pre-push hook: TypeScript compile/lint/spellcheck/meta checks, Rust fmt, Clippy with warnings denied, and private-item rustdoc all passed.
- The public reproduction passes both lockfile-only generation and frozen installation with the patched binary.
- Ablation: recording the owner without consuming it in the finalizer still fails; bypassing owner canonicalization reproduces the missing-snapshot CLI error; the complete producer and consumer change passes.
- Twelve interleaved release benchmark runs showed no peerless regression (+0.11%), while peer-heavy and hoist-heavy workspace resolution improved by 13.93% and 8.18%. Peak RSS showed no regression.

## Squash Commit Body

```text
The peer walker can reuse one occurrence from another compatible occurrence and return before creating a second node record. The post-walk finalizer previously discarded that equivalence and recomputed the cached occurrence by its own NodeId, which could produce a longer peer-qualified key with no corresponding graph entry.

Track the fully walked occurrence that produces each peer-cache entry. Canonicalize cache hits through that owner while finalizing depPaths, rendering graph edges, and building and comparing peer SCCs. Keep aliases on dependency edges and preserve the existing cache fast path.

Fixes pnpm/pnpm#14449.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The description explains why this pacquet-only fix requires no TypeScript CLI port.
- [x] Added a `pacquet` patch changeset.
- [x] Added resolver and CLI regression tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790935645&installation_model_id=426870&pr_number=14451&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14451&signature=6f588cf87ea7be7fe1e3e305185aba80fb2046d3a7b13c86e90b6b952a131dbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lockfile generation for npm-aliased dependencies involved in cyclic peer-dependency graphs.
  * Frozen installs now correctly reuse cached dependency resolutions and reference valid snapshots.
  * Prevented broken lockfiles caused by unresolved peer-suffixed snapshots in these scenarios.

* **Tests**
  * Added coverage for lockfile-only and frozen installations involving cyclic aliased peer dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
