### PR TITLE
perf(install): trim the fixed overhead around a workspace-scale resolve

### DIFF
--- a/.changeset/lean-install-overhead.md
+++ b/.changeset/lean-install-overhead.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces: the fast lockfile-update check no longer compares every project against every lockfile entry (or copies the whole lockfile before discovering a change needs the resolver), project ordering uses faster hashing, and the version-preference table builds in parallel [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4473,6 +4473,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmp-serde",
+ "rustc-hash 2.1.2",
  "same-file",
  "serde",
  "serde-saphyr",
@@ -5113,6 +5114,7 @@ dependencies = [
  "pnpm-package-manifest",
  "pnpm-resolving-resolver-base",
  "pretty_assertions",
+ "rayon",
  "serde_json",
  "tempfile",
 ]
@@ -5998,6 +6000,7 @@ dependencies = [
  "pnpm-fs",
  "pnpm-reporter",
  "pretty_assertions",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "tokio",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -91,6 +91,7 @@ p256                 = { workspace = true }
 pathdiff             = { workspace = true }
 pipe-trait           = { workspace = true }
 rayon                = { workspace = true }
+rustc-hash           = { workspace = true }
 reflink-copy         = { workspace = true }
 regex                = { workspace = true }
 reqwest              = { workspace = true }

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -131,17 +131,22 @@ fn sorted_dependencies<Pkg>(
     sorted: &HashSet<&Path>,
 ) -> Vec<PathBuf> {
     let mut dependencies: Vec<PathBuf> = Vec::new();
-    let mut visited: HashSet<PathBuf> = HashSet::new();
-    let mut stack: Vec<PathBuf> =
-        projects_graph.get(project_dir).map(|node| node.dependencies.clone()).unwrap_or_default();
+    // Borrowed paths and an FxHash set: this walk runs once per
+    // selected project, and cloning every visited `PathBuf` into a
+    // SipHash set dominated it on a workspace-scale graph.
+    let mut visited: rustc_hash::FxHashSet<&Path> = rustc_hash::FxHashSet::default();
+    let mut stack: Vec<&Path> = projects_graph
+        .get(project_dir)
+        .map(|node| node.dependencies.iter().map(PathBuf::as_path).collect())
+        .unwrap_or_default();
     while let Some(dependency_dir) = stack.pop() {
-        if dependency_dir.as_path() == project_dir || !visited.insert(dependency_dir.clone()) {
+        if dependency_dir == project_dir || !visited.insert(dependency_dir) {
             continue;
         }
-        if sorted.contains(dependency_dir.as_path()) {
-            dependencies.push(dependency_dir);
-        } else if let Some(node) = full_projects_graph.get(&dependency_dir) {
-            stack.extend(node.dependencies.iter().cloned());
+        if sorted.contains(dependency_dir) {
+            dependencies.push(dependency_dir.to_path_buf());
+        } else if let Some(node) = full_projects_graph.get(dependency_dir) {
+            stack.extend(node.dependencies.iter().map(PathBuf::as_path));
         }
     }
     dependencies

--- a/pnpm/crates/lockfile-preferred-versions/Cargo.toml
+++ b/pnpm/crates/lockfile-preferred-versions/Cargo.toml
@@ -16,6 +16,7 @@ pnpm-package-manifest        = { workspace = true }
 pnpm-resolving-resolver-base = { workspace = true }
 
 node-semver = { workspace = true }
+rayon       = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/lockfile-preferred-versions/src/lib.rs
+++ b/pnpm/crates/lockfile-preferred-versions/src/lib.rs
@@ -13,6 +13,7 @@ use pnpm_resolving_resolver_base::{
     DIRECT_DEP_SELECTOR_WEIGHT, EXISTING_VERSION_SELECTOR_WEIGHT, PreferredVersions,
     VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
 };
+use rayon::prelude::*;
 
 mod version_selector_type;
 
@@ -40,23 +41,38 @@ pub fn get_preferred_versions_from_lockfile_and_manifests_excluding(
     manifests: &[&PackageManifest],
     withheld: &dyn Fn(&PackageKey) -> bool,
 ) -> PreferredVersions {
-    let mut preferred: PreferredVersions = PreferredVersions::new();
-    for manifest in manifests {
-        for (name, spec) in manifest.dependencies([
-            DependencyGroup::Dev,
-            DependencyGroup::Prod,
-            DependencyGroup::Optional,
-        ]) {
-            let Some(selector_type) = get_version_selector_type(spec) else { continue };
-            preferred.entry(name.to_string()).or_default().insert(
-                spec.to_string(),
-                VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
-                    selector_type,
-                    weight: DIRECT_DEP_SELECTOR_WEIGHT,
-                }),
-            );
-        }
-    }
+    // Each manifest's selector classification (semver parses, mostly)
+    // is independent, so a workspace-scale manifest list fans out
+    // across the rayon pool. Every entry is a pure function of its
+    // `(name, spec)` pair — same selector type, same weight — so the
+    // reduce's merge order is immaterial: colliding inserts write the
+    // same value the serial loop would.
+    let mut preferred: PreferredVersions = manifests
+        .par_iter()
+        .map(|manifest| {
+            let mut preferred = PreferredVersions::new();
+            for (name, spec) in manifest.dependencies([
+                DependencyGroup::Dev,
+                DependencyGroup::Prod,
+                DependencyGroup::Optional,
+            ]) {
+                let Some(selector_type) = get_version_selector_type(spec) else { continue };
+                preferred.entry(name.to_string()).or_default().insert(
+                    spec.to_string(),
+                    VersionSelectorEntry::Weighted(VersionSelectorWithWeight {
+                        selector_type,
+                        weight: DIRECT_DEP_SELECTOR_WEIGHT,
+                    }),
+                );
+            }
+            preferred
+        })
+        .reduce(PreferredVersions::new, |mut merged, next| {
+            for (name, selectors) in next {
+                merged.entry(name).or_default().extend(selectors);
+            }
+            merged
+        });
     if let Some(snapshots) = snapshots {
         add_preferred_versions_from_lockfile(snapshots, withheld, &mut preferred);
     }

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -38,8 +38,11 @@ pub(crate) struct ImportersPlan<'a, 'manifest> {
 }
 
 /// Whether the importers' records diverge from the manifests, without
-/// cloning anything. [`Drift::Resolve`] when an alias cannot be parsed,
-/// which the resolver reports.
+/// cloning anything. [`Drift::Resolve`] when an alias cannot be parsed
+/// (which the resolver reports) or when a changed specifier is one
+/// [`apply_importers_update`] is certain to refuse — bailing here keeps
+/// the compose from cloning a workspace-scale lockfile it would then
+/// throw away.
 pub(crate) fn detect_importers_drift<'a, 'manifest>(
     lockfile: &Lockfile,
     manifests: &'a [(String, &'manifest PackageManifest)],
@@ -65,20 +68,28 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
         manifest_dependencies.push((importer_id, *manifest, dependencies));
     }
     let stale: Vec<String> = if prune_stale_importers {
+        let manifest_ids: HashSet<&str> =
+            manifests.iter().map(|(importer_id, _)| importer_id.as_str()).collect();
         lockfile
             .importers
             .keys()
-            .filter(|importer_id| !manifests.iter().any(|(id, _)| id == *importer_id))
+            .filter(|importer_id| !manifest_ids.contains(importer_id.as_str()))
             .cloned()
             .collect()
     } else {
         Vec::new()
     };
-    if !stale.is_empty()
-        || manifest_dependencies.iter().any(|(importer_id, _, dependencies)| {
-            importer_diverges(lockfile, importer_id, dependencies)
-        })
-    {
+    let mut any_diverged = false;
+    for (importer_id, _, dependencies) in &manifest_dependencies {
+        match importer_divergence(lockfile, importer_id, dependencies) {
+            ImporterDivergence::Clean => {}
+            ImporterDivergence::Absorbable => any_diverged = true,
+            // Bail before the compose clones the whole lockfile: the
+            // apply would fail on this importer regardless.
+            ImporterDivergence::NeedsResolve => return Drift::Resolve,
+        }
+    }
+    if !stale.is_empty() || any_diverged {
         Drift::Absorb(ImportersPlan {
             manifest_dependencies,
             stale,
@@ -425,13 +436,25 @@ pub(crate) fn locked_version_resolution_would_pick(
 /// under another group, a dependency the manifest no longer declares, or
 /// a manifest entry the importer does not record (which the loop turns
 /// into a fallback).
-fn importer_diverges(
+enum ImporterDivergence {
+    Clean,
+    Absorbable,
+    /// A change [`apply_importers_update`] is certain to refuse, so the
+    /// compose can go to the resolver without cloning the lockfile.
+    NeedsResolve,
+}
+
+fn importer_divergence(
     lockfile: &Lockfile,
     importer_id: &str,
     manifest_dependencies: &ManifestDependencies<'_>,
-) -> bool {
+) -> ImporterDivergence {
     let Some(importer) = lockfile.importers.get(importer_id) else {
-        return !manifest_dependencies.is_empty();
+        return if manifest_dependencies.is_empty() {
+            ImporterDivergence::Clean
+        } else {
+            ImporterDivergence::Absorbable
+        };
     };
     let recorded_but_undeclared = [
         importer.dependencies.as_ref(),
@@ -442,13 +465,33 @@ fn importer_diverges(
     .flatten()
     .flat_map(HashMap::keys)
     .any(|alias| !manifest_dependencies.contains_key(alias));
-    recorded_but_undeclared
-        || manifest_dependencies.iter().any(|(alias, (specifier, target))| {
-            let Some((recorded_in, dependency)) = importer_dependency(importer, alias) else {
-                return true;
-            };
-            dependency.specifier != *specifier || recorded_in != *target
-        })
+    let mut diverged = recorded_but_undeclared;
+    for (alias, (specifier, target)) in manifest_dependencies {
+        let Some((recorded_in, dependency)) = importer_dependency(importer, alias) else {
+            diverged = true;
+            continue;
+        };
+        if dependency.specifier != *specifier {
+            // The same conditions [`apply_importers_update`] holds a
+            // changed specifier to before it consults the locked
+            // versions; a specifier they reject (a `workspace:` range
+            // above all) can only resolve.
+            if Range::parse(specifier).is_err()
+                || dependency
+                    .version
+                    .ver_peer()
+                    .and_then(|ver_peer| ver_peer.version_semver())
+                    .is_none()
+            {
+                return ImporterDivergence::NeedsResolve;
+            }
+            diverged = true;
+        }
+        if recorded_in != *target {
+            diverged = true;
+        }
+    }
+    if diverged { ImporterDivergence::Absorbable } else { ImporterDivergence::Clean }
 }
 
 fn importer_dependency<'a>(

--- a/pnpm/crates/workspace-task-scheduler/Cargo.toml
+++ b/pnpm/crates/workspace-task-scheduler/Cargo.toml
@@ -19,6 +19,7 @@ derive_more  = { workspace = true }
 futures-util = { workspace = true }
 indexmap     = { workspace = true }
 miette       = { workspace = true }
+rustc-hash   = { workspace = true }
 serde        = { workspace = true }
 
 [dev-dependencies]

--- a/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
@@ -1,3 +1,4 @@
+use rustc_hash::FxHashMap;
 use std::{
     collections::{HashMap, VecDeque},
     hash::Hash,
@@ -142,13 +143,16 @@ where
 /// Node ↔ index mapping: every hash lookup the sort needs happens once
 /// here, and the algorithm itself runs on plain indices.
 struct Interner<'graph, Node> {
-    index_of: HashMap<&'graph Node, usize>,
+    index_of: FxHashMap<&'graph Node, usize>,
     nodes: Vec<&'graph Node>,
 }
 
 impl<'graph, Node: Eq + Hash + Clone> Interner<'graph, Node> {
     fn with_capacity(capacity: usize) -> Self {
-        Interner { index_of: HashMap::with_capacity(capacity), nodes: Vec::with_capacity(capacity) }
+        Interner {
+            index_of: FxHashMap::with_capacity_and_hasher(capacity, rustc_hash::FxBuildHasher),
+            nodes: Vec::with_capacity(capacity),
+        }
     }
 
     fn intern(&mut self, node: &'graph Node) -> usize {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. A fresh profile after pnpm/pnpm#14435 shows the next block is fixed overhead that every non-noop install of a large workspace pays regardless of what changed. Four fixes, none visible outside:

- **O(n²) stale-importer scan.** `try_compose_fast_updates`' importer-drift detector compared every lockfile importer against every manifest by linear search — ~46 million string comparisons on the reproduction. It now probes a `HashSet` of manifest ids.
- **A thrown-away lockfile clone.** The composer cloned the entire parsed lockfile *before* its apply phase discovered a changed specifier it cannot absorb (a `workspace:` range, precisely the reproduction's change) and discarded the clone. The divergence scan now applies the apply phase's own refusal preconditions up front (`Range::parse` + a semver'd locked version) and returns `Drift::Resolve` clone-free. Same outcome on every input — only the wasted copy is gone.
- **SipHash in the graph paths.** The sequencer's node interner and the per-project dependency walk's visited set both hashed `Path`s through `RandomState`; they now use FxHash, and the walk borrows `&Path` instead of cloning every visited `PathBuf`.
- **Serial preferred-versions classification.** The version-preference table parsed every manifest's specifiers one manifest at a time. Each manifest's classification is independent, and every entry is a pure function of its `(name, spec)` pair — same selector type, same weight — so the manifests fan out across the rayon pool and the merge order is immaterial.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| whole warm update (median of 8) | 1.46 s | 1.36 s |

The written `pnpm-lock.yaml` is byte-identical, and all 124 fast-update tests pass unchanged, as do the package-manager and CLI suites (only the pre-existing local-environment failures that also fail on clean main).

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.36 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
Four fixed costs sat on every non-noop install of a large workspace,
none proportional to what changed:

- The fast-update composer's stale-importer scan compared every
  lockfile importer against every manifest by linear search - O(n^2)
  string comparisons on a workspace where n is in the thousands. It
  now probes a set of manifest ids.
- The composer cloned the entire parsed lockfile before its apply
  phase discovered a changed specifier it cannot absorb (a workspace:
  range above all) and threw the clone away. The divergence scan now
  applies the same refusal rules up front and routes straight to the
  resolver, clone-free. The rules are the apply's own preconditions,
  so the outcome is unchanged - only the wasted copy is gone.
- The graph sequencer interned nodes through a SipHash map, and the
  per-project dependency walk collected its visited set by cloning
  every PathBuf into one; both now use FxHash, and the walk borrows.
- The preferred-versions table classified every manifest's specifiers
  serially; each manifest's classification is independent and every
  entry is a pure function of its (name, spec) pair, so the manifests
  now fan out across the rayon pool and merge order is immaterial.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), whole-run wall time drops from ~1.46 s to
~1.36 s median and the written lockfile is byte-identical.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — the fast-update refusal rules,
  sequencer determinism, and preferred-versions contents are pinned by the
  existing suites, all passing unchanged.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790939074&installation_model_id=426870&pr_number=14453&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14453&signature=110a9ef5bf527e1ef5d145c93fc7abf09e2e100d89a8c33c6ff767223f1138a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved install performance in large workspaces.
  - Faster lockfile update checks reduce unnecessary processing during installations.
  - Improved dependency ordering performance for quicker workspace operations.
  - Parallel processing improves the generation of package version preferences.
  - Install workflows now identify changes requiring dependency resolution earlier, helping avoid unnecessary work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->