### PR TITLE
fix(fs): retry Windows file locks in the isolated linker

### DIFF
--- a/.changeset/retry-windows-isolated-links.md
+++ b/.changeset/retry-windows-isolated-links.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Retry transient Windows file-lock errors while linking dependencies with the default (isolated) `nodeLinker`, and treat sharing violations as transient locks in every retried filesystem operation. This fixes [pnpm/pnpm#14407](https://github.com/pnpm/pnpm/issues/14407).
+Retry transient Windows file-lock errors, including sharing violations, while linking dependencies with the default (isolated) `nodeLinker`. This fixes [pnpm/pnpm#14407](https://github.com/pnpm/pnpm/issues/14407).

--- a/.changeset/retry-windows-isolated-links.md
+++ b/.changeset/retry-windows-isolated-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Retry transient Windows file-lock errors while linking dependencies with the default (isolated) `nodeLinker`, and treat sharing violations as transient locks in every retried filesystem operation. This fixes [pnpm/pnpm#14407](https://github.com/pnpm/pnpm/issues/14407).

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -8,19 +8,29 @@ const RETRY_BUDGET: Duration = Duration::from_mins(1);
 #[cfg(any(windows, test))]
 const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(100);
 
+pub(crate) const ERROR_SHARING_VIOLATION: i32 = 32;
+pub(crate) const ERROR_LOCK_VIOLATION: i32 = 33;
+
 /// Rename a filesystem entry, retrying transient Windows file-lock errors.
+///
+/// Antivirus and indexer scans briefly hold Windows paths open, failing an
+/// unlucky rename or removal with an access-denied, sharing-violation, or
+/// busy error that clears moments later. Such errors are retried with a
+/// bounded backoff for up to one minute before the last one is returned.
+/// On Unix the operation runs exactly once: the equivalent error kinds
+/// there usually mean a permanent permissions or mount-point problem, so
+/// retrying would only delay the failure.
 pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
     retry_transient_file_locks(|| fs::rename(src, dst))
 }
 
-/// Remove a directory tree, retrying transient Windows file-lock errors.
+/// Remove a directory tree with the retry policy of [`rename_with_retry`].
 pub fn remove_dir_all_with_retry(path: &Path) -> io::Result<()> {
     retry_transient_file_locks(|| fs::remove_dir_all(path))
 }
 
-/// Run a filesystem operation, retrying it with a bounded backoff while
-/// it fails with a [transient Windows file lock](is_transient_file_lock_error).
-/// On Unix the operation runs exactly once.
+/// Run a filesystem operation with the retry policy of [`rename_with_retry`];
+/// [`is_transient_file_lock_error`] decides which failures are retried.
 pub(crate) fn retry_transient_file_locks<Value>(
     operation: impl FnMut() -> io::Result<Value>,
 ) -> io::Result<Value> {
@@ -98,32 +108,17 @@ where
     }
 }
 
-/// Whether `error` is the kind of failure an antivirus or indexer scan
-/// causes by briefly holding a Windows path open: `ERROR_ACCESS_DENIED`
-/// (a directory rename blocked by an open handle below it),
-/// `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` (an open or delete
-/// refused by another handle's share mode), or `ERROR_BUSY`. The sharing
-/// and lock violations have no [`io::ErrorKind`] of their own, so they
-/// are matched by raw OS error.
-///
-/// Never `true` on Unix: the equivalent error kinds there usually mean a
-/// permanent permissions or mount-point problem, so retrying them would
-/// only delay the failure.
-pub(crate) fn is_transient_file_lock_error(
-    #[cfg_attr(not(windows), allow(unused, reason = "only inspected on Windows"))]
-    error: &io::Error,
-) -> bool {
-    #[cfg(windows)]
-    {
-        const ERROR_SHARING_VIOLATION: i32 = 32;
-        const ERROR_LOCK_VIOLATION: i32 = 33;
-        matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
-            || matches!(error.raw_os_error(), Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION))
-    }
-    #[cfg(not(windows))]
-    {
-        false
-    }
+/// Whether `error` is a transient Windows file lock in the sense of
+/// [`rename_with_retry`]: `ERROR_ACCESS_DENIED` (a directory rename blocked
+/// by an open handle below it), [`ERROR_SHARING_VIOLATION`] or
+/// [`ERROR_LOCK_VIOLATION`] (an open or delete refused by another handle's
+/// share mode), or `ERROR_BUSY`. The sharing and lock violations have no
+/// [`io::ErrorKind`] of their own, so they are matched by raw OS error.
+/// Always `false` on Unix.
+pub(crate) fn is_transient_file_lock_error(error: &io::Error) -> bool {
+    cfg!(windows)
+        && (matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
+            || matches!(error.raw_os_error(), Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION)))
 }
 
 #[cfg(test)]

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -10,25 +10,28 @@ const RETRY_BACKOFF_CAP: Duration = Duration::from_millis(100);
 
 /// Rename a filesystem entry, retrying transient Windows file-lock errors.
 pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
-    #[cfg(windows)]
-    {
-        retry_fs_operation(|| fs::rename(src, dst), is_transient_file_lock_error)
-    }
-    #[cfg(not(windows))]
-    {
-        fs::rename(src, dst)
-    }
+    retry_transient_file_locks(|| fs::rename(src, dst))
 }
 
 /// Remove a directory tree, retrying transient Windows file-lock errors.
 pub fn remove_dir_all_with_retry(path: &Path) -> io::Result<()> {
+    retry_transient_file_locks(|| fs::remove_dir_all(path))
+}
+
+/// Run a filesystem operation, retrying it with a bounded backoff while
+/// it fails with a [transient Windows file lock](is_transient_file_lock_error).
+/// On Unix the operation runs exactly once.
+pub(crate) fn retry_transient_file_locks<Value>(
+    operation: impl FnMut() -> io::Result<Value>,
+) -> io::Result<Value> {
     #[cfg(windows)]
     {
-        retry_fs_operation(|| fs::remove_dir_all(path), is_transient_file_lock_error)
+        retry_fs_operation(operation, is_transient_file_lock_error)
     }
     #[cfg(not(windows))]
     {
-        fs::remove_dir_all(path)
+        let mut operation = operation;
+        operation()
     }
 }
 
@@ -95,17 +98,27 @@ where
     }
 }
 
-#[cfg(any(windows, test))]
-fn is_transient_file_lock_error(
+/// Whether `error` is the kind of failure an antivirus or indexer scan
+/// causes by briefly holding a Windows path open: `ERROR_ACCESS_DENIED`
+/// (a directory rename blocked by an open handle below it),
+/// `ERROR_SHARING_VIOLATION` / `ERROR_LOCK_VIOLATION` (an open or delete
+/// refused by another handle's share mode), or `ERROR_BUSY`. The sharing
+/// and lock violations have no [`io::ErrorKind`] of their own, so they
+/// are matched by raw OS error.
+///
+/// Never `true` on Unix: the equivalent error kinds there usually mean a
+/// permanent permissions or mount-point problem, so retrying them would
+/// only delay the failure.
+pub(crate) fn is_transient_file_lock_error(
     #[cfg_attr(not(windows), allow(unused, reason = "only inspected on Windows"))]
     error: &io::Error,
 ) -> bool {
-    // Antivirus and indexer scans can briefly hold a Windows path open. The equivalent error
-    // kinds on Unix usually mean a permanent permissions or mount-point problem, so retrying
-    // them there would only delay the failure.
     #[cfg(windows)]
     {
+        const ERROR_SHARING_VIOLATION: i32 = 32;
+        const ERROR_LOCK_VIOLATION: i32 = 33;
         matches!(error.kind(), io::ErrorKind::PermissionDenied | io::ErrorKind::ResourceBusy)
+            || matches!(error.raw_os_error(), Some(ERROR_SHARING_VIOLATION | ERROR_LOCK_VIOLATION))
     }
     #[cfg(not(windows))]
     {

--- a/pnpm/crates/fs/src/retry/tests.rs
+++ b/pnpm/crates/fs/src/retry/tests.rs
@@ -74,6 +74,13 @@ fn transient_file_lock_error_classifier_is_windows_specific() {
         assert_eq!(is_transient_file_lock_error(&error), cfg!(windows), "{kind:?}");
     }
 
+    // `ERROR_SHARING_VIOLATION` and `ERROR_LOCK_VIOLATION` reach callers as
+    // `Uncategorized`, so they are only recognizable by raw OS error.
+    for code in [32, 33] {
+        let error = io::Error::from_raw_os_error(code);
+        assert_eq!(is_transient_file_lock_error(&error), cfg!(windows), "os error {code}");
+    }
+
     for kind in [
         io::ErrorKind::NotFound,
         io::ErrorKind::AlreadyExists,

--- a/pnpm/crates/fs/src/retry/tests.rs
+++ b/pnpm/crates/fs/src/retry/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    RetryTiming, is_transient_file_lock_error, remove_dir_all_with_retry, rename_with_retry,
-    retry_fs_operation, retry_fs_operation_with_timing,
+    ERROR_LOCK_VIOLATION, ERROR_SHARING_VIOLATION, RetryTiming, is_transient_file_lock_error,
+    remove_dir_all_with_retry, rename_with_retry, retry_fs_operation,
+    retry_fs_operation_with_timing,
 };
 use std::{cell::Cell, fs, io, time::Duration};
 use tempfile::tempdir;
@@ -74,9 +75,7 @@ fn transient_file_lock_error_classifier_is_windows_specific() {
         assert_eq!(is_transient_file_lock_error(&error), cfg!(windows), "{kind:?}");
     }
 
-    // `ERROR_SHARING_VIOLATION` and `ERROR_LOCK_VIOLATION` reach callers as
-    // `Uncategorized`, so they are only recognizable by raw OS error.
-    for code in [32, 33] {
+    for code in [ERROR_SHARING_VIOLATION, ERROR_LOCK_VIOLATION] {
         let error = io::Error::from_raw_os_error(code);
         assert_eq!(is_transient_file_lock_error(&error), cfg!(windows), "os error {code}");
     }

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -5,6 +5,11 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use crate::retry::{
+    is_transient_file_lock_error, remove_dir_all_with_retry, rename_with_retry,
+    retry_transient_file_locks,
+};
+
 /// Create a symlink to a directory, matching the on-disk shape pnpm
 /// produces.
 ///
@@ -114,11 +119,15 @@ pub fn is_symlink_or_junction(link: &Path) -> io::Result<bool> {
 /// need `fs::remove_dir` to be unlinked — `remove_file` returns
 /// `ERROR_ACCESS_DENIED`. Wrapping the platform split here keeps
 /// callers free of `#[cfg]`.
+///
+/// On Windows the unlink retries transient file-lock errors: an
+/// antivirus or indexer holding the reparse point open blocks
+/// `RemoveDirectoryW` for a moment.
 pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     return std::fs::remove_file(link);
     #[cfg(windows)]
-    return std::fs::remove_dir(link);
+    return retry_transient_file_locks(|| std::fs::remove_dir(link));
 }
 
 /// Read the target of a directory symlink (or junction on Windows).
@@ -339,12 +348,13 @@ fn existing_symlink_up_to_date(wanted: &Path, link: &Path, existing_link_string:
 
 /// Remove a regular file or directory that's occupying a symlink
 /// slot. Tries `remove_dir_all` first; if the target isn't a
-/// directory, falls back to `remove_file`.
+/// directory, falls back to `remove_file`. Both retry transient
+/// Windows file-lock errors.
 fn remove_occupant(path: &Path) -> io::Result<()> {
-    match fs::remove_dir_all(path) {
+    match remove_dir_all_with_retry(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(_) => fs::remove_file(path),
+        Err(_) => retry_transient_file_locks(|| fs::remove_file(path)),
     }
 }
 
@@ -354,24 +364,29 @@ fn remove_occupant(path: &Path) -> io::Result<()> {
 /// package's approach: if the rename fails because the destination
 /// is occupied (`AlreadyExists` for files, `DirectoryNotEmpty` for
 /// dirs, `PermissionDenied` on Windows when something holds a handle
-/// to the dest), remove the destination and retry once.
+/// to the dest), remove the destination and retry. A transient Windows
+/// file lock on either side is treated the same way: the destination
+/// is cleared once, then the rename itself is retried.
 fn rename_overwrite(src: &Path, dst: &Path) -> io::Result<()> {
     match fs::rename(src, dst) {
         Ok(()) => Ok(()),
         Err(error) => {
-            let occupied = matches!(
-                error.kind(),
-                io::ErrorKind::AlreadyExists
-                    | io::ErrorKind::DirectoryNotEmpty
-                    | io::ErrorKind::PermissionDenied,
-            );
-            if !occupied {
+            if !rename_error_allows_destination_removal(&error) {
                 return Err(error);
             }
             remove_occupant(dst)?;
-            fs::rename(src, dst)
+            rename_with_retry(src, dst)
         }
     }
+}
+
+fn rename_error_allows_destination_removal(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::AlreadyExists
+            | io::ErrorKind::DirectoryNotEmpty
+            | io::ErrorKind::PermissionDenied,
+    ) || is_transient_file_lock_error(error)
 }
 
 #[cfg(windows)]
@@ -491,7 +506,7 @@ mod windows {
             }
         }
 
-        let rename_error = match fs::rename(staging, link) {
+        let rename_error = match super::rename_with_retry(staging, link) {
             Ok(()) => return Ok(()),
             Err(error) => error,
         };

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -347,14 +347,19 @@ fn existing_symlink_up_to_date(wanted: &Path, link: &Path, existing_link_string:
 }
 
 /// Remove a regular file or directory that's occupying a symlink
-/// slot. Tries `remove_dir_all` first; if the target isn't a
-/// directory, falls back to `remove_file`. Both retry transient
-/// Windows file-lock errors.
+/// slot. Tries `remove_dir_all` first and unlinks a non-directory
+/// instead. Both retry transient Windows file-lock errors; the
+/// fallback is taken only when the path is not a directory, so a
+/// directory that stays locked through its retry budget fails without
+/// starting a second one.
 fn remove_occupant(path: &Path) -> io::Result<()> {
     match remove_dir_all_with_retry(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(_) => retry_transient_file_locks(|| fs::remove_file(path)),
+        Err(error) if error.kind() == io::ErrorKind::NotADirectory => {
+            retry_transient_file_locks(|| fs::remove_file(path))
+        }
+        Err(error) => Err(error),
     }
 }
 
@@ -475,9 +480,6 @@ mod windows {
 
     pub(super) fn create_junction(original: &Path, link: &Path) -> io::Result<()> {
         let staging = stage_junction(original, link)?;
-        // Serialize only the commit. The slow part — the reparse-point
-        // conversion inside `stage_junction` — already ran in parallel.
-        let _commit_guard = JUNCTION_COMMIT_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         commit_staged_junction(link, &staging)
     }
 
@@ -495,19 +497,24 @@ mod windows {
     }
 
     /// Publish `staging` at `link` with an atomic rename, folding a lost race
-    /// into the `AlreadyExists` reuse signal. Runs under [`JUNCTION_COMMIT_LOCK`].
+    /// into the `AlreadyExists` reuse signal.
+    ///
+    /// A transient Windows file lock on the rename is retried, with each
+    /// attempt serialized on its own by [`attempt_commit`]: the lock is not
+    /// held while waiting, so one blocked path never stalls the other
+    /// junction commits in the process, and every attempt re-inspects the
+    /// destination first, so a race lost while waiting is reused right away
+    /// rather than retried through the budget.
     fn commit_staged_junction(link: &Path, staging: &Path) -> io::Result<()> {
-        // A worker that took the lock before us may already have committed.
-        match inspect_destination(link) {
-            Destination::Missing => {}
-            Destination::Exists => return Err(reuse_completed_destination(link, staging, "")),
-            Destination::InspectFailed(error) => {
+        let rename_error = match super::retry_transient_file_locks(|| attempt_commit(link, staging))
+        {
+            Ok(CommitAttempt::Committed) => return Ok(()),
+            Ok(CommitAttempt::DestinationTaken) => {
+                return Err(reuse_completed_destination(link, staging, ""));
+            }
+            Ok(CommitAttempt::InspectFailed(error)) => {
                 return Err(inspect_failed(link, staging, &error, ""));
             }
-        }
-
-        let rename_error = match super::rename_with_retry(staging, link) {
-            Ok(()) => return Ok(()),
             Err(error) => error,
         };
 
@@ -521,6 +528,30 @@ mod windows {
             }
             Destination::Missing => Err(discard_staging_after_rename(staging, link, rename_error)),
         }
+    }
+
+    /// Outcome of one serialized attempt to publish a staged junction.
+    enum CommitAttempt {
+        Committed,
+        /// Another worker already committed the link.
+        DestinationTaken,
+        InspectFailed(io::Error),
+    }
+
+    /// One attempt under [`JUNCTION_COMMIT_LOCK`]: inspect the destination,
+    /// then rename. Only the rename failure is returned as `Err`, so the
+    /// retry loop in [`commit_staged_junction`] never repeats a final
+    /// verdict about the destination. Serializing only the commit keeps the
+    /// slow part — the reparse-point conversion inside [`stage_junction`] —
+    /// running in parallel.
+    fn attempt_commit(link: &Path, staging: &Path) -> io::Result<CommitAttempt> {
+        let _commit_guard = JUNCTION_COMMIT_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
+        match inspect_destination(link) {
+            Destination::Missing => {}
+            Destination::Exists => return Ok(CommitAttempt::DestinationTaken),
+            Destination::InspectFailed(error) => return Ok(CommitAttempt::InspectFailed(error)),
+        }
+        fs::rename(staging, link).map(|()| CommitAttempt::Committed)
     }
 
     /// What `symlink_metadata` reports about a would-be junction destination.

--- a/pnpm/crates/fs/src/symlink_dir.rs
+++ b/pnpm/crates/fs/src/symlink_dir.rs
@@ -120,9 +120,8 @@ pub fn is_symlink_or_junction(link: &Path) -> io::Result<bool> {
 /// `ERROR_ACCESS_DENIED`. Wrapping the platform split here keeps
 /// callers free of `#[cfg]`.
 ///
-/// On Windows the unlink retries transient file-lock errors: an
-/// antivirus or indexer holding the reparse point open blocks
-/// `RemoveDirectoryW` for a moment.
+/// On Windows the unlink follows the retry policy of
+/// [`crate::rename_with_retry`].
 pub fn remove_symlink_dir(link: &Path) -> io::Result<()> {
     #[cfg(unix)]
     return std::fs::remove_file(link);
@@ -347,11 +346,9 @@ fn existing_symlink_up_to_date(wanted: &Path, link: &Path, existing_link_string:
 }
 
 /// Remove a regular file or directory that's occupying a symlink
-/// slot. Tries `remove_dir_all` first and unlinks a non-directory
-/// instead. Both retry transient Windows file-lock errors; the
-/// fallback is taken only when the path is not a directory, so a
-/// directory that stays locked through its retry budget fails without
-/// starting a second one.
+/// slot, retrying transient Windows file locks. The `remove_file`
+/// fallback is taken only on `NotADirectory`, so a directory that stays
+/// locked through its retry budget fails without starting a second one.
 fn remove_occupant(path: &Path) -> io::Result<()> {
     match remove_dir_all_with_retry(path) {
         Ok(()) => Ok(()),
@@ -497,14 +494,8 @@ mod windows {
     }
 
     /// Publish `staging` at `link` with an atomic rename, folding a lost race
-    /// into the `AlreadyExists` reuse signal.
-    ///
-    /// A transient Windows file lock on the rename is retried, with each
-    /// attempt serialized on its own by [`attempt_commit`]: the lock is not
-    /// held while waiting, so one blocked path never stalls the other
-    /// junction commits in the process, and every attempt re-inspects the
-    /// destination first, so a race lost while waiting is reused right away
-    /// rather than retried through the budget.
+    /// into the `AlreadyExists` reuse signal. A transient Windows file lock
+    /// on the rename is retried, one [`attempt_commit`] per try.
     fn commit_staged_junction(link: &Path, staging: &Path) -> io::Result<()> {
         let rename_error = match super::retry_transient_file_locks(|| attempt_commit(link, staging))
         {
@@ -533,17 +524,20 @@ mod windows {
     /// Outcome of one serialized attempt to publish a staged junction.
     enum CommitAttempt {
         Committed,
-        /// Another worker already committed the link.
         DestinationTaken,
         InspectFailed(io::Error),
     }
 
-    /// One attempt under [`JUNCTION_COMMIT_LOCK`]: inspect the destination,
-    /// then rename. Only the rename failure is returned as `Err`, so the
-    /// retry loop in [`commit_staged_junction`] never repeats a final
-    /// verdict about the destination. Serializing only the commit keeps the
+    /// One try at publishing a staged junction under [`JUNCTION_COMMIT_LOCK`].
+    ///
+    /// Holding the lock for a single inspect-and-rename, rather than across
+    /// the retries in [`commit_staged_junction`], keeps one locked path from
+    /// stalling every other junction commit in the process and leaves the
     /// slow part — the reparse-point conversion inside [`stage_junction`] —
-    /// running in parallel.
+    /// running in parallel. Re-inspecting the destination on every try means
+    /// a race lost while waiting is reused rather than retried through the
+    /// budget. Only the rename failure is returned as `Err`, so the retry
+    /// never repeats a final verdict about the destination.
     fn attempt_commit(link: &Path, staging: &Path) -> io::Result<CommitAttempt> {
         let _commit_guard = JUNCTION_COMMIT_LOCK.lock().unwrap_or_else(PoisonError::into_inner);
         match inspect_destination(link) {

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -160,8 +160,10 @@ fn remove_occupant_clears_files_directories_and_missing_paths() {
     super::remove_occupant(&dir).expect("remove dir occupant");
     super::remove_occupant(&root.path().join("missing")).expect("missing path is not an error");
 
-    assert!(!file.exists());
-    assert!(!dir.exists());
+    for path in [&file, &dir] {
+        let error = fs::symlink_metadata(path).expect_err("occupant should be gone");
+        assert_eq!(error.kind(), std::io::ErrorKind::NotFound, "{path:?}");
+    }
 }
 
 #[test]

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -148,6 +148,23 @@ fn force_symlink_dir_replaces_a_stale_ignored_occupant() {
 }
 
 #[test]
+fn remove_occupant_clears_files_directories_and_missing_paths() {
+    let root = tempdir().expect("create temp dir");
+    let file = root.path().join("file");
+    let dir = root.path().join("dir");
+    fs::write(&file, b"occupant").expect("seed file");
+    fs::create_dir_all(dir.join("nested")).expect("seed dir");
+    fs::write(dir.join("nested/file"), b"occupant").expect("seed nested file");
+
+    super::remove_occupant(&file).expect("remove file occupant");
+    super::remove_occupant(&dir).expect("remove dir occupant");
+    super::remove_occupant(&root.path().join("missing")).expect("missing path is not an error");
+
+    assert!(!file.exists());
+    assert!(!dir.exists());
+}
+
+#[test]
 fn rename_error_allows_destination_removal_covers_occupied_and_locked_destinations() {
     use std::io::{Error, ErrorKind};
 

--- a/pnpm/crates/fs/src/symlink_dir/tests.rs
+++ b/pnpm/crates/fs/src/symlink_dir/tests.rs
@@ -123,6 +123,47 @@ fn force_symlink_dir_moves_non_symlink_occupant_to_ignored_name() {
 }
 
 #[test]
+fn force_symlink_dir_replaces_a_stale_ignored_occupant() {
+    let root = tempdir().expect("create temp dir");
+    let target = root.path().join("target");
+    let link = root.path().join("link");
+    let ignored_path = root.path().join(".ignored_link");
+    fs::create_dir_all(&target).expect("create target");
+    fs::create_dir_all(link.join("nested")).expect("seed occupant dir");
+    fs::write(link.join("nested/file"), b"fresh occupant").expect("seed occupant file");
+    fs::create_dir_all(ignored_path.join("nested")).expect("seed stale ignored dir");
+    fs::write(ignored_path.join("nested/file"), b"stale occupant").expect("seed stale file");
+
+    let outcome = force_symlink_dir(&target, &link).expect("force_symlink_dir succeeds");
+    assert!(!outcome.reused);
+
+    let resolved_link = fs::canonicalize(&link).expect("canonicalize the new symlink");
+    let resolved_target = fs::canonicalize(&target).expect("canonicalize target");
+    assert_eq!(resolved_link, resolved_target);
+    assert_eq!(
+        fs::read(ignored_path.join("nested/file")).expect("read displaced occupant"),
+        b"fresh occupant",
+        "the displaced occupant must replace the stale `.ignored_` tree",
+    );
+}
+
+#[test]
+fn rename_error_allows_destination_removal_covers_occupied_and_locked_destinations() {
+    use std::io::{Error, ErrorKind};
+
+    for kind in
+        [ErrorKind::AlreadyExists, ErrorKind::DirectoryNotEmpty, ErrorKind::PermissionDenied]
+    {
+        assert!(super::rename_error_allows_destination_removal(&Error::from(kind)), "{kind:?}");
+    }
+    assert_eq!(
+        super::rename_error_allows_destination_removal(&Error::from(ErrorKind::ResourceBusy)),
+        cfg!(windows),
+    );
+    assert!(!super::rename_error_allows_destination_removal(&Error::from(ErrorKind::NotFound)));
+}
+
+#[test]
 fn force_symlink_dir_creates_missing_parent_directories() {
     let root = tempdir().expect("create temp dir");
     let target = root.path().join("target");


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14407 by retrying transient Windows file-lock failures on the default (isolated) linker's write paths in the Rust pnpm CLI.

pnpm/pnpm#14366 added the bounded retry only to the hoisted linker's staging swap. The isolated linker never reached it:

- `commit_staged_junction` published a staged junction with a plain `fs::rename`.
- `remove_symlink_dir` unlinked a stale junction with a plain `fs::remove_dir`.
- `rename_overwrite` / `remove_occupant` moved a link-slot occupant aside with plain renames and removals.

All of those now go through the shared `pnpm-fs` retry (same one-minute budget and backoff as the hoisted path).

The classifier from pnpm/pnpm#14366 also had a gap that affected both linkers: it matched `PermissionDenied` and `ResourceBusy`, but Rust's std maps only `ERROR_BUSY` to `ResourceBusy`. `ERROR_SHARING_VIOLATION` (32) and `ERROR_LOCK_VIOLATION` (33), the codes a delete or open refused by another handle's share mode actually produces, surface as `Uncategorized` and were never retried. They are now matched by raw OS error, which mirrors the `EBUSY` that libuv hands the TypeScript CLI's `rimraf`/`rename-overwrite` retries.

No TypeScript changes: that stack already retries these operations via `rimrafSync` and `renameOverwriteSync`.

Validation: `cargo nextest run -p pnpm-fs` (71 passed), `cargo clippy --all-targets -D warnings` for `pnpm-fs` on both the Linux and the `x86_64-pc-windows-msvc` target, `cargo doc` with `-D warnings` on both targets, and the full pre-push Rust gate.

## Squash Commit Body

```text
Isolated installs publish staged Windows junctions with a rename, unlink
stale junctions with `RemoveDirectoryW`, and move link-slot occupants
aside with a rename. Antivirus and indexer scans can briefly hold any of
those paths open, failing the whole install with `Access is denied`, and
until now only the hoisted staging swap retried such errors.

Route the junction commit, the stale-link unlink, and the occupant
rename/removal through the shared bounded retry. Widen the transient
classifier to `ERROR_SHARING_VIOLATION` and `ERROR_LOCK_VIOLATION`: std
maps neither to an `io::ErrorKind`, so a delete or open refused by
another handle's share mode surfaced as `Uncategorized` and was never
retried, on either linker.

Fixes pnpm/pnpm#14407.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E2Cgw8yV3Hn28k4q9mFzaS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14456"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943821&installation_model_id=426870&pr_number=14456&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14456&signature=7df38f171be94621314d953955481ed763811e9a17299642937c1964a904025c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency linking on Windows by retrying transient file-lock, sharing-violation, and lock-violation errors.
  - Increased reliability when replacing, removing, or renaming symlink and junction targets during isolated dependency installation.
  - Ensured stale ignored link contents are correctly replaced when a new occupant is moved into place.
  - Improved handling of locked, missing, occupied, and file-based link targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->