### PR TITLE
fix(cli): parse config flags before subcommand

### DIFF
--- a/.changeset/config-flags-before-subcommand.md
+++ b/.changeset/config-flags-before-subcommand.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm config` now accepts `-g`/`--global`, `--location`, and `--json` before its subcommand [pnpm/pnpm#14421](https://github.com/pnpm/pnpm/issues/14421).

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -12,7 +12,7 @@ use super::{
     ci::CiArgs,
     clean::CleanArgs,
     completion::{CompletionArgs, CompletionServerArgs},
-    config::{ConfigArgs, ConfigGetArgs, ConfigSetArgs},
+    config::{ConfigArgs, ConfigGetAliasArgs, ConfigSetAliasArgs},
     create::CreateArgs,
     dedupe::DedupeArgs,
     deploy::DeployArgs,
@@ -696,10 +696,10 @@ pub enum CliCommand {
     Config(ConfigArgs),
     /// Print the config value for the provided key. Shorthand for
     /// `pnpm config get`.
-    Get(ConfigGetArgs),
+    Get(ConfigGetAliasArgs),
     /// Set the config key to the value provided. Shorthand for
     /// `pnpm config set`.
-    Set(ConfigSetArgs),
+    Set(ConfigSetAliasArgs),
     /// Manages your package.json.
     Pkg(PkgArgs),
     /// Pack a `CommonJS` entry file into a standalone executable for one or more target platforms.

--- a/pnpm/crates/cli/src/cli_args/config.rs
+++ b/pnpm/crates/cli/src/cli_args/config.rs
@@ -31,6 +31,9 @@ use std::path::{Path, PathBuf};
 /// Manage the pnpm configuration files.
 #[derive(Debug, Args)]
 pub struct ConfigArgs {
+    #[clap(flatten)]
+    pub flags: ConfigFlags,
+
     #[clap(subcommand)]
     pub command: ConfigSubcommand,
 }
@@ -39,12 +42,7 @@ impl ConfigArgs {
     /// Whether `--global` / `-g` was passed, ignoring the default
     /// [`resolve_global`] applies when no location flag is given.
     pub(super) fn is_global(&self) -> bool {
-        match &self.command {
-            ConfigSubcommand::Set(args) => args.flags.global,
-            ConfigSubcommand::Get(args) => args.flags.global,
-            ConfigSubcommand::Delete(args) => args.flags.global,
-            ConfigSubcommand::List(args) => args.flags.global,
-        }
+        self.flags.global
     }
 }
 
@@ -87,26 +85,35 @@ pub enum ConfigLocation {
 pub struct ConfigSetArgs {
     pub key: Option<String>,
     pub value: Option<String>,
-    #[clap(flatten)]
-    pub flags: ConfigFlags,
 }
 
 #[derive(Debug, Args)]
 pub struct ConfigGetArgs {
     pub key: Option<String>,
-    #[clap(flatten)]
-    pub flags: ConfigFlags,
 }
 
 #[derive(Debug, Args)]
 pub struct ConfigDeleteArgs {
     pub key: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct ConfigListArgs {}
+
+#[derive(Debug, Args)]
+pub struct ConfigSetAliasArgs {
+    #[clap(flatten)]
+    pub args: ConfigSetArgs,
+
     #[clap(flatten)]
     pub flags: ConfigFlags,
 }
 
 #[derive(Debug, Args)]
-pub struct ConfigListArgs {
+pub struct ConfigGetAliasArgs {
+    #[clap(flatten)]
+    pub args: ConfigGetArgs,
+
     #[clap(flatten)]
     pub flags: ConfigFlags,
 }
@@ -172,9 +179,9 @@ pub enum ConfigError {
 
 impl ConfigArgs {
     pub fn run(self, config: &Config, dir: &Path) -> miette::Result<()> {
-        match self.command {
+        let Self { flags, command } = self;
+        match command {
             ConfigSubcommand::Set(args) => {
-                let flags = args.flags;
                 let (key, value) = split_set_params(args.key, args.value, "set")?;
                 config_set(config, dir, flags, &key, Some(value))?;
             }
@@ -183,17 +190,16 @@ impl ConfigArgs {
                     .key
                     .filter(|key| !key.is_empty())
                     .ok_or_else(|| ConfigError::NoParams { subcommand: "delete".to_string() })?;
-                config_set(config, dir, args.flags, &key, None)?;
+                config_set(config, dir, flags, &key, None)?;
             }
             ConfigSubcommand::Get(args) => {
                 let output = match args.key.as_deref().filter(|key| !key.is_empty()) {
-                    Some(key) => config_get(config, args.flags, key)?,
+                    Some(key) => config_get(config, flags, key)?,
                     None => config_list(config),
                 };
                 println!("{output}");
             }
-            ConfigSubcommand::List(args) => {
-                let _ = args.flags;
+            ConfigSubcommand::List(_) => {
                 println!("{}", config_list(config));
             }
         }

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -8,7 +8,7 @@ use super::{
     cat_index::CatIndexArgs,
     change::ChangeArgs,
     clean::CleanArgs,
-    config::{ConfigArgs, ConfigGetArgs, ConfigSetArgs, ConfigSubcommand},
+    config::{ConfigArgs, ConfigGetAliasArgs, ConfigSetAliasArgs, ConfigSubcommand},
     deprecate::DeprecateArgs,
     dispatch::{CommandFuture, RunCtx},
     dist_tag::DistTagArgs,
@@ -571,16 +571,16 @@ pub(super) fn config<'a>(ctx: &RunCtx<'a>, args: ConfigArgs) -> miette::Result<C
 // cannot drift.
 pub(super) fn config_get<'a>(
     ctx: &RunCtx<'a>,
-    args: ConfigGetArgs,
+    args: ConfigGetAliasArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    config(ctx, ConfigArgs { command: ConfigSubcommand::Get(args) })
+    config(ctx, ConfigArgs { flags: args.flags, command: ConfigSubcommand::Get(args.args) })
 }
 
 pub(super) fn config_set<'a>(
     ctx: &RunCtx<'a>,
-    args: ConfigSetArgs,
+    args: ConfigSetAliasArgs,
 ) -> miette::Result<CommandFuture<'a>> {
-    config(ctx, ConfigArgs { command: ConfigSubcommand::Set(args) })
+    config(ctx, ConfigArgs { flags: args.flags, command: ConfigSubcommand::Set(args.args) })
 }
 
 pub(super) fn not_implemented<'a>(command: &'static str) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -595,7 +595,7 @@ enum KeyIssueReporting {
 
 fn key_issue_reporting(command: &CliCommand) -> KeyIssueReporting {
     match command {
-        CliCommand::Get(get) if get.key.is_some() => KeyIssueReporting::Skip,
+        CliCommand::Get(get) if get.args.key.is_some() => KeyIssueReporting::Skip,
         CliCommand::Config(args) => match &args.command {
             ConfigSubcommand::Get(get) if get.key.is_some() => KeyIssueReporting::Skip,
             _ => KeyIssueReporting::WarnOnly,
@@ -645,12 +645,7 @@ fn is_global(command: &CliCommand) -> bool {
         CliCommand::Add(args) => args.global,
         CliCommand::ApproveBuilds(args) => args.global,
         CliCommand::Bin(args) => args.global,
-        CliCommand::Config(args) => match &args.command {
-            ConfigSubcommand::Set(args) => args.flags.global,
-            ConfigSubcommand::Get(args) => args.flags.global,
-            ConfigSubcommand::Delete(args) => args.flags.global,
-            ConfigSubcommand::List(args) => args.flags.global,
-        },
+        CliCommand::Config(args) => args.flags.global,
         CliCommand::Get(args) => args.flags.global,
         CliCommand::Set(args) => args.flags.global,
         CliCommand::Env(args) => args.global,

--- a/pnpm/crates/cli/src/cli_args/sudo_guard.rs
+++ b/pnpm/crates/cli/src/cli_args/sudo_guard.rs
@@ -82,11 +82,11 @@ fn sudo_blocked_operation(command: &CliCommand) -> Option<String> {
         // Config writes default to the global config file when no
         // `--location` is given, so gate on the effective scope, not the
         // `--global` flag alone.
-        CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Set(args), .. }) => {
-            global_write(super::config::resolve_global(args.flags), "config set")
+        CliCommand::Config(ConfigArgs { flags, command: ConfigSubcommand::Set(_), .. }) => {
+            global_write(super::config::resolve_global(*flags), "config set")
         }
-        CliCommand::Config(ConfigArgs { command: ConfigSubcommand::Delete(args), .. }) => {
-            global_write(super::config::resolve_global(args.flags), "config delete")
+        CliCommand::Config(ConfigArgs { flags, command: ConfigSubcommand::Delete(_), .. }) => {
+            global_write(super::config::resolve_global(*flags), "config delete")
         }
         CliCommand::Set(args) => global_write(super::config::resolve_global(args.flags), "set"),
         // `env use --global` installs a runtime into the global packages

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -2,7 +2,7 @@ use super::{
     CliArgs,
     add::AddArgs,
     cli_command::{CliCommand, WorkspaceRootError},
-    config::ConfigLocation,
+    config::{ConfigLocation, ConfigSubcommand},
     dedupe::DedupeArgs,
     install::{InstallArgs, resolve_bool_override},
     list::RecursionLimit,
@@ -1079,54 +1079,98 @@ fn unlink_args(argv: &[&str]) -> UnlinkArgs {
 
 #[test]
 fn get_and_set_are_top_level_spellings_of_the_config_subcommands() {
-    let CliCommand::Get(get) = command(&["pacquet", "get", "store-dir"]) else {
-        panic!("expected get");
-    };
-    assert_eq!(get.args.key.as_deref(), Some("store-dir"));
+    for (alias, params) in
+        [("get", ["store-dir"].as_slice()), ("set", ["store-dir", "/tmp/store"].as_slice())]
+    {
+        for (flag, expected_global, expected_location, expected_json) in config_flag_cases() {
+            for flag_before_params in [true, false] {
+                let mut argv = vec!["pacquet", alias];
+                if flag_before_params {
+                    argv.extend(flag);
+                }
+                argv.extend(params);
+                if !flag_before_params {
+                    argv.extend(flag);
+                }
 
-    let CliCommand::Set(set) = command(&["pacquet", "set", "store-dir", "/tmp/store", "--global"])
-    else {
-        panic!("expected set");
-    };
-    assert_eq!(set.args.key.as_deref(), Some("store-dir"));
-    assert_eq!(set.args.value.as_deref(), Some("/tmp/store"));
-    assert!(set.flags.global);
+                match (alias, command(&argv)) {
+                    ("get", CliCommand::Get(get)) => {
+                        assert_eq!(get.args.key.as_deref(), Some("store-dir"), "{argv:?}");
+                        assert_eq!(get.flags.global, expected_global, "{argv:?}");
+                        assert_eq!(get.flags.location, expected_location, "{argv:?}");
+                        assert_eq!(get.flags.json, expected_json, "{argv:?}");
+                    }
+                    ("set", CliCommand::Set(set)) => {
+                        assert_eq!(set.args.key.as_deref(), Some("store-dir"), "{argv:?}");
+                        assert_eq!(set.args.value.as_deref(), Some("/tmp/store"), "{argv:?}");
+                        assert_eq!(set.flags.global, expected_global, "{argv:?}");
+                        assert_eq!(set.flags.location, expected_location, "{argv:?}");
+                        assert_eq!(set.flags.json, expected_json, "{argv:?}");
+                    }
+                    (_, command) => panic!("expected {alias}, got {command:?}"),
+                }
+            }
+        }
+    }
 }
 
 #[test]
 fn config_flags_parse_on_either_side_of_the_subcommand() {
-    for (argv, expected_global, expected_location, expected_json) in [
-        (
-            ["pacquet", "config", "--global", "set", "registry", "https://registry.test"]
-                .as_slice(),
-            true,
-            None,
-            false,
-        ),
-        (["pacquet", "config", "-g", "get", "registry"].as_slice(), true, None, false),
-        (["pacquet", "config", "get", "registry", "--global"].as_slice(), true, None, false),
-        (
-            ["pacquet", "config", "--location", "project", "delete", "registry"].as_slice(),
-            false,
-            Some(ConfigLocation::Project),
-            false,
-        ),
-        (
-            ["pacquet", "config", "delete", "registry", "--location", "global"].as_slice(),
-            false,
-            Some(ConfigLocation::Global),
-            false,
-        ),
-        (["pacquet", "config", "--json", "list"].as_slice(), false, None, true),
-        (["pacquet", "config", "list", "--json"].as_slice(), false, None, true),
+    for subcommand in [
+        ["set", "registry", "https://registry.test"].as_slice(),
+        ["get", "registry"].as_slice(),
+        ["delete", "registry"].as_slice(),
+        ["list"].as_slice(),
     ] {
-        let CliCommand::Config(args) = command(argv) else {
-            panic!("expected config");
-        };
-        assert_eq!(args.flags.global, expected_global, "{argv:?}");
-        assert_eq!(args.flags.location, expected_location, "{argv:?}");
-        assert_eq!(args.flags.json, expected_json, "{argv:?}");
+        for (flag, expected_global, expected_location, expected_json) in config_flag_cases() {
+            for flag_before_subcommand in [true, false] {
+                let mut argv = vec!["pacquet", "config"];
+                if flag_before_subcommand {
+                    argv.extend(flag);
+                }
+                argv.extend(subcommand);
+                if !flag_before_subcommand {
+                    argv.extend(flag);
+                }
+
+                let CliCommand::Config(args) = command(&argv) else {
+                    panic!("expected config");
+                };
+                assert_eq!(args.flags.global, expected_global, "{argv:?}");
+                assert_eq!(args.flags.location, expected_location, "{argv:?}");
+                assert_eq!(args.flags.json, expected_json, "{argv:?}");
+                match (subcommand[0], args.command) {
+                    ("set", ConfigSubcommand::Set(set)) => {
+                        assert_eq!(set.key.as_deref(), Some("registry"), "{argv:?}");
+                        assert_eq!(set.value.as_deref(), Some("https://registry.test"), "{argv:?}");
+                    }
+                    ("get", ConfigSubcommand::Get(get)) => {
+                        assert_eq!(get.key.as_deref(), Some("registry"), "{argv:?}");
+                    }
+                    ("delete", ConfigSubcommand::Delete(delete)) => {
+                        assert_eq!(delete.key.as_deref(), Some("registry"), "{argv:?}");
+                    }
+                    ("list", ConfigSubcommand::List(_)) => {}
+                    (subcommand, command) => {
+                        panic!("expected config {subcommand}, got {command:?}")
+                    }
+                }
+            }
+        }
     }
+}
+
+type ConfigFlagCase = (&'static [&'static str], bool, Option<ConfigLocation>, bool);
+
+fn config_flag_cases() -> impl Iterator<Item = ConfigFlagCase> {
+    [
+        (["--global"].as_slice(), true, None, false),
+        (["-g"].as_slice(), true, None, false),
+        (["--location", "project"].as_slice(), false, Some(ConfigLocation::Project), false),
+        (["--location", "global"].as_slice(), false, Some(ConfigLocation::Global), false),
+        (["--json"].as_slice(), false, None, true),
+    ]
+    .into_iter()
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -2,6 +2,7 @@ use super::{
     CliArgs,
     add::AddArgs,
     cli_command::{CliCommand, WorkspaceRootError},
+    config::ConfigLocation,
     dedupe::DedupeArgs,
     install::{InstallArgs, resolve_bool_override},
     list::RecursionLimit,
@@ -1081,15 +1082,51 @@ fn get_and_set_are_top_level_spellings_of_the_config_subcommands() {
     let CliCommand::Get(get) = command(&["pacquet", "get", "store-dir"]) else {
         panic!("expected get");
     };
-    assert_eq!(get.key.as_deref(), Some("store-dir"));
+    assert_eq!(get.args.key.as_deref(), Some("store-dir"));
 
     let CliCommand::Set(set) = command(&["pacquet", "set", "store-dir", "/tmp/store", "--global"])
     else {
         panic!("expected set");
     };
-    assert_eq!(set.key.as_deref(), Some("store-dir"));
-    assert_eq!(set.value.as_deref(), Some("/tmp/store"));
+    assert_eq!(set.args.key.as_deref(), Some("store-dir"));
+    assert_eq!(set.args.value.as_deref(), Some("/tmp/store"));
     assert!(set.flags.global);
+}
+
+#[test]
+fn config_flags_parse_on_either_side_of_the_subcommand() {
+    for (argv, expected_global, expected_location, expected_json) in [
+        (
+            ["pacquet", "config", "--global", "set", "registry", "https://registry.test"]
+                .as_slice(),
+            true,
+            None,
+            false,
+        ),
+        (["pacquet", "config", "-g", "get", "registry"].as_slice(), true, None, false),
+        (["pacquet", "config", "get", "registry", "--global"].as_slice(), true, None, false),
+        (
+            ["pacquet", "config", "--location", "project", "delete", "registry"].as_slice(),
+            false,
+            Some(ConfigLocation::Project),
+            false,
+        ),
+        (
+            ["pacquet", "config", "delete", "registry", "--location", "global"].as_slice(),
+            false,
+            Some(ConfigLocation::Global),
+            false,
+        ),
+        (["pacquet", "config", "--json", "list"].as_slice(), false, None, true),
+        (["pacquet", "config", "list", "--json"].as_slice(), false, None, true),
+    ] {
+        let CliCommand::Config(args) = command(argv) else {
+            panic!("expected config");
+        };
+        assert_eq!(args.flags.global, expected_global, "{argv:?}");
+        assert_eq!(args.flags.location, expected_location, "{argv:?}");
+        assert_eq!(args.flags.json, expected_json, "{argv:?}");
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14421.

Hoists the shared `config` flags onto the parent command so `-g`/`--global`, `--location`, and `--json` parse both before and after `set`, `get`, `delete`, and `list`. Dedicated wrappers preserve the existing flag behavior of the top-level `pnpm get` and `pnpm set` aliases.

This is a Rust pacquet parity fix only. The TypeScript CLI already accepts both argument orderings, so no TypeScript-side change is needed.

## Squash Commit Body

```text
Hoist the shared config flags onto the config command so clap accepts them before and after each leaf subcommand.

Keep dedicated wrappers for the top-level get and set aliases so their existing flags continue to parse.

Closes pnpm/pnpm#14421.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14457"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790943935&installation_model_id=426870&pr_number=14457&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14457&signature=37817d1909cdf5c592513806e4df50229bee8b2f073244706194f10d02114e1e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm config` now accepts `--global`/`-g`, `--location`, and `--json` before or after the subcommand.
  * Top-level `pnpm get` and `pnpm set` aliases support these shared options in either position.
* **Bug Fixes**
  * Improved consistency when using configuration commands with shared options.
* **Documentation**
  * Added a patch release note for this CLI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->