### PR TITLE
fix(cli): load pnpmfile for link, outdated, and import

### DIFF
--- a/.changeset/tidy-dodos-load-hooks.md
+++ b/.changeset/tidy-dodos-load-hooks.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm link`, `pnpm outdated`, and `pnpm import` now apply pnpmfile `updateConfig` hooks before resolving dependencies.

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -31,6 +31,7 @@ use super::{
     update::UpdateArgs,
     update_notifier,
 };
+use crate::State;
 use miette::Context;
 use pnpm_config::Config;
 use pnpm_default_reporter::DefaultReporter;
@@ -444,29 +445,39 @@ pub(super) fn fetch<'a>(ctx: &RunCtx<'a>, args: FetchArgs) -> miette::Result<Com
 }
 
 pub(super) fn import<'a>(ctx: &RunCtx<'a>, args: ImportArgs) -> miette::Result<CommandFuture<'a>> {
-    let command_state = (ctx.state)(false)?;
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>(command_state))
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path.to_path_buf();
+    let reporter = ctx.reporter;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        let command_state =
+            State::init(manifest_path, config, false).wrap_err("initialize the state")?;
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                args.run::<DefaultReporter>(command_state).await
+            }
+            ReporterType::Ndjson => args.run::<NdjsonReporter>(command_state).await,
+            ReporterType::Silent => args.run::<SilentReporter>(command_state).await,
         }
-        ReporterType::Ndjson => Box::pin(args.run::<NdjsonReporter>(command_state)),
-        ReporterType::Silent => Box::pin(args.run::<SilentReporter>(command_state)),
-    })
+    }))
 }
 
 pub(super) fn link<'a>(ctx: &RunCtx<'a>, args: LinkArgs) -> miette::Result<CommandFuture<'a>> {
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
     let manifest_path = ctx.manifest_path.to_path_buf();
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(args.run::<DefaultReporter>((ctx.config)()?, manifest_path))
+    let reporter = ctx.reporter;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                args.run::<DefaultReporter>(config, manifest_path).await
+            }
+            ReporterType::Ndjson => args.run::<NdjsonReporter>(config, manifest_path).await,
+            ReporterType::Silent => args.run::<SilentReporter>(config, manifest_path).await,
         }
-        ReporterType::Ndjson => {
-            Box::pin(args.run::<NdjsonReporter>((ctx.config)()?, manifest_path))
-        }
-        ReporterType::Silent => {
-            Box::pin(args.run::<SilentReporter>((ctx.config)()?, manifest_path))
-        }
-    })
+    }))
 }
 
 pub(super) fn unlink<'a>(ctx: &RunCtx<'a>, args: UnlinkArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -10,7 +10,7 @@ use super::{
     clean::CleanArgs,
     config::{ConfigArgs, ConfigGetArgs, ConfigSetArgs, ConfigSubcommand},
     deprecate::DeprecateArgs,
-    dispatch::{CommandFuture, RunCtx},
+    dispatch::{CommandFuture, RunCtx, apply_update_config},
     dist_tag::DistTagArgs,
     docs::DocsArgs,
     doctor::{DoctorArgs, DoctorOutcome},
@@ -51,8 +51,9 @@ use super::{
     why::WhyArgs,
     with::WithArgs,
 };
-use crate::config_deps::prepare_config;
+use crate::{State, config_deps::prepare_config};
 use clap::CommandFactory;
+use miette::Context;
 use pnpm_config::Config;
 use pnpm_default_reporter::DefaultReporter;
 use pnpm_reporter::{NdjsonReporter, SilentReporter};
@@ -88,26 +89,30 @@ pub(super) fn outdated<'a>(
             Ok(())
         }));
     }
-    let command_state = (ctx.state)(false)?;
-    macro_rules! run_outdated {
-        ($reporter:ty) => {
-            Box::pin(async move {
-                if args.run::<$reporter>(command_state).await? == OutdatedOutcome::Outdated {
-                    #[expect(
-                        clippy::exit,
-                        reason = "`outdated` exits non-zero when a dependency is outdated, mirroring pnpm"
-                    )]
-                    std::process::exit(1);
-                }
-                Ok(())
-            })
+    let config = (ctx.config)()?;
+    let dir = ctx.dir;
+    let manifest_path = ctx.manifest_path.to_path_buf();
+    let reporter = ctx.reporter;
+    Ok(Box::pin(async move {
+        apply_update_config(config, dir, reporter).await?;
+        let command_state =
+            State::init(manifest_path, config, false).wrap_err("initialize the state")?;
+        let outcome = match reporter {
+            ReporterType::Default | ReporterType::AppendOnly => {
+                args.run::<DefaultReporter>(command_state).await?
+            }
+            ReporterType::Ndjson => args.run::<NdjsonReporter>(command_state).await?,
+            ReporterType::Silent => args.run::<SilentReporter>(command_state).await?,
         };
-    }
-    Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => run_outdated!(DefaultReporter),
-        ReporterType::Ndjson => run_outdated!(NdjsonReporter),
-        ReporterType::Silent => run_outdated!(SilentReporter),
-    })
+        if outcome == OutdatedOutcome::Outdated {
+            #[expect(
+                clippy::exit,
+                reason = "`outdated` exits non-zero when a dependency is outdated, mirroring pnpm"
+            )]
+            std::process::exit(1);
+        }
+        Ok(())
+    }))
 }
 
 pub(super) fn audit<'a>(ctx: &RunCtx<'a>, args: AuditArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -1,6 +1,7 @@
 use crate::State;
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
+use pnpm_lockfile::EnvLockfile;
 use pnpm_package_manager::{Install, ProjectMutation};
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_reporter::Reporter;
@@ -18,6 +19,9 @@ impl ImportArgs {
             &state;
         let dir = manifest.path().parent().expect("manifest path always has a parent dir");
         let lockfile_path = dir.join("pnpm-lock.yaml");
+        let env_lockfile = EnvLockfile::read(dir)
+            .into_diagnostic()
+            .wrap_err("reading the env lockfile before import")?;
 
         let lockfile_backup = lockfile_path.with_extension("yaml.import.bak");
         let lockfile_existed = lockfile_path.exists();
@@ -102,19 +106,47 @@ impl ImportArgs {
             .wrap_err("importing dependencies")
         };
 
-        match install_result {
+        let import_result = install_result.and_then(|()| {
+            if let Some(env_lockfile) = env_lockfile {
+                env_lockfile
+                    .write(dir)
+                    .into_diagnostic()
+                    .wrap_err("preserving the env lockfile after import")?;
+            }
+            Ok(())
+        });
+
+        match import_result {
             Ok(()) => {
                 if lockfile_existed {
-                    let _ = std::fs::remove_file(&lockfile_backup);
+                    std::fs::remove_file(&lockfile_backup)
+                        .into_diagnostic()
+                        .wrap_err("removing the import lockfile backup")?;
                 }
                 Ok(())
             }
             Err(error) => {
                 if lockfile_existed {
-                    let _ = std::fs::rename(&lockfile_backup, &lockfile_path);
+                    restore_lockfile(&lockfile_path, &lockfile_backup).wrap_err_with(|| {
+                        format!("restoring pnpm-lock.yaml after import failed: {error}")
+                    })?;
                 }
                 Err(error)
             }
         }
     }
+}
+
+fn restore_lockfile(
+    lockfile_path: &std::path::Path,
+    backup_path: &std::path::Path,
+) -> miette::Result<()> {
+    if let Err(error) = std::fs::remove_file(lockfile_path)
+        && error.kind() != std::io::ErrorKind::NotFound
+    {
+        return Err(error).into_diagnostic().wrap_err("removing the failed imported lockfile");
+    }
+    std::fs::rename(backup_path, lockfile_path)
+        .into_diagnostic()
+        .wrap_err("restoring the original pnpm-lock.yaml")
 }

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -1,8 +1,8 @@
 use crate::_utils::pacquet_in;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::CommandTempCwd;
-use std::fs;
+use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use std::{fs, path::Path};
 
 #[test]
 fn filter_log_is_ignored_with_a_warning() {
@@ -29,6 +29,81 @@ const EXTRA_ENV_PNPMFILE: &str = "module.exports = { hooks: { updateConfig (conf
 /// [`EXTRA_ENV_PNPMFILE`] exports — in `marker.txt` next to the manifest.
 const WRITE_MARKER_SCRIPT: &str =
     r#"node -e "require('fs').writeFileSync('marker.txt', process.env.PNPM_HOOK_MARKER || '')""#;
+
+const CATALOG_DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
+
+fn write_catalog_hook_project(workspace: &Path) {
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "catalog-hook-project",
+            "version": "1.0.0",
+            "dependencies": { (CATALOG_DEP): "catalog:" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        format!(
+            "module.exports = {{ hooks: {{ updateConfig (config) {{ config.catalogs = {{ default: {{ '{CATALOG_DEP}': '^100.0.0' }} }}; return config }} }} }}",
+        ),
+    )
+    .expect("write pnpmfile");
+}
+
+#[test]
+fn update_config_catalog_applies_to_link() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_catalog_hook_project(&workspace);
+    let target = root.path().join("other-pkg");
+    fs::create_dir_all(&target).expect("create link target");
+    fs::write(target.join("package.json"), r#"{ "name": "other-pkg", "version": "1.0.0" }"#)
+        .expect("write link target manifest");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+    pacquet_in(&workspace).with_args(["link", "../other-pkg"]).assert().success();
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn update_config_catalog_applies_to_outdated() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_catalog_hook_project(&workspace);
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+    let output = pacquet_in(&workspace).with_arg("outdated").output().expect("run outdated");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert!(stdout.contains(CATALOG_DEP), "outdated should report the catalog dependency");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn update_config_catalog_applies_to_import() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_catalog_hook_project(&workspace);
+
+    pacquet_in(&workspace).with_arg("import").assert().success();
+
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+        "the imported lockfile should resolve the hook-provided catalog entry:\n{lockfile}",
+    );
+
+    drop((root, mock_instance));
+}
 
 /// `updateConfig` applies to `pnpm run`, not just to the install family:
 /// the settings a hook returns — `extraEnv` here — reach the environment of

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -1,6 +1,7 @@
 use crate::_utils::pacquet_in;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pnpm_lockfile::EnvLockfile;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path};
 
@@ -63,7 +64,6 @@ fn update_config_catalog_applies_to_link() {
     fs::write(target.join("package.json"), r#"{ "name": "other-pkg", "version": "1.0.0" }"#)
         .expect("write link target manifest");
 
-    pacquet_in(&workspace).with_arg("install").assert().success();
     pacquet_in(&workspace).with_args(["link", "../other-pkg"]).assert().success();
 
     drop((root, mock_instance));
@@ -93,14 +93,37 @@ fn update_config_catalog_applies_to_import() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_catalog_hook_project(&workspace);
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut settings = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    settings.push_str("\nconfigDependencies:\n  '@pnpm/plugin-pnpmfile': 1.0.0\n");
+    fs::write(workspace_yaml, settings).expect("write configDependencies");
 
     pacquet_in(&workspace).with_arg("import").assert().success();
 
     let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(lockfile.starts_with("---\n"), "env document must lead pnpm-lock.yaml");
+    assert!(lockfile.contains("configDependencies:"), "env document must retain config deps");
+    let env_lockfile = EnvLockfile::read(&workspace)
+        .expect("read env lockfile")
+        .expect("env lockfile should be present");
+    assert!(
+        env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+            .config_dependencies
+            .contains_key("@pnpm/plugin-pnpmfile"),
+        "env document must retain the config dependency pin",
+    );
+    assert!(
+        env_lockfile
+            .packages
+            .values()
+            .any(|package| package.resolution.checkable_integrity().is_some()),
+        "env document must retain the config dependency integrity",
+    );
     assert!(
         lockfile.contains("@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
         "the imported lockfile should resolve the hook-provided catalog entry:\n{lockfile}",
     );
+    pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -1,7 +1,7 @@
 use crate::_utils::pacquet_in;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_lockfile::EnvLockfile;
+use pnpm_lockfile::{EnvLockfile, PackageKey};
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path};
 
@@ -106,17 +106,20 @@ fn update_config_catalog_applies_to_import() {
     let env_lockfile = EnvLockfile::read(&workspace)
         .expect("read env lockfile")
         .expect("env lockfile should be present");
-    assert!(
-        env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
-            .config_dependencies
-            .contains_key("@pnpm/plugin-pnpmfile"),
-        "env document must retain the config dependency pin",
-    );
+    let config_dependency = &env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .config_dependencies["@pnpm/plugin-pnpmfile"];
+    let config_dependency_key: PackageKey =
+        format!("@pnpm/plugin-pnpmfile@{}", config_dependency.version)
+            .parse()
+            .expect("parse config dependency package key");
     assert!(
         env_lockfile
             .packages
-            .values()
-            .any(|package| package.resolution.checkable_integrity().is_some()),
+            .get(&config_dependency_key)
+            .expect("config dependency package must be retained")
+            .resolution
+            .checkable_integrity()
+            .is_some(),
         "env document must retain the config dependency integrity",
     );
     assert!(


### PR DESCRIPTION
## Summary

- Load pnpmfile configuration dependencies and apply `updateConfig` before `pnpm link`, local `pnpm outdated`, and `pnpm import` initialize resolver state in the Rust CLI.
- Preserve the config-dependency env lockfile document, including integrity pins, when import replaces the main dependency lockfile.
- Reuse the shared configuration preparation path used by the other hook-aware commands.
- Add end-to-end coverage for fresh link resolution, outdated reporting, import resolution, and frozen reuse of imported config-dependency pins.
- The TypeScript CLI already loads the pnpmfile for these commands, so this restores parity without a TypeScript change.

Fixes pnpm/pnpm#14444.

## Squash Commit Body

```text
Load pnpmfile configuration dependencies and apply updateConfig before link,
local outdated, and import initialize resolver state. This lets those commands
consume settings such as catalogs supplied by hooks and brings the Rust CLI
into parity with the TypeScript implementation.

Preserve the config-dependency env document when import replaces the main
lockfile so executable dependencies retain their integrity pins.

Fixes pnpm/pnpm#14444.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5.6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm link`, `pnpm outdated`, and `pnpm import` now apply pnpmfile configuration hooks before resolving dependencies.
  * `pnpm import` preserves environment lockfile data during successful imports.

* **Bug Fixes**
  * Improved lockfile recovery and diagnostics when imports fail.
  * Preserved hook-provided dependency and integrity information during imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->