### PR TITLE
fix(cli): honor unused-patch overrides

### DIFF
--- a/.changeset/allow-unused-patches-overrides.md
+++ b/.changeset/allow-unused-patches-overrides.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm deploy --legacy` ignoring `allowUnusedPatches` supplied through `--config.allow-unused-patches` or the `PNPM_CONFIG_ALLOW_UNUSED_PATCHES` environment variable [pnpm/pnpm#14450](https://github.com/pnpm/pnpm/issues/14450).

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -767,7 +767,8 @@ enum SettingArity {
 /// setting the invoked command declares as its own option is left for
 /// clap; a setting that collides with a *global* option would be claimed
 /// on every command line and so must not appear here at all.
-const BARE_SETTING_FLAGS: [(&str, SettingArity); 19] = [
+const BARE_SETTING_FLAGS: [(&str, SettingArity); 20] = [
+    ("allow-unused-patches", SettingArity::Boolean),
     ("child-concurrency", SettingArity::Parsed(is_i32)),
     ("global-dir", SettingArity::Text),
     ("hoist", SettingArity::Boolean),

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -98,6 +98,7 @@ fn home_relative_store_dir(store_dir: &Path) -> Option<&Path> {
 /// installed has to be ported here.
 #[derive(Debug, Default)]
 pub struct ConfigOverrides {
+    allow_unused_patches: Option<bool>,
     bail: Option<bool>,
     ci: Option<bool>,
     color: Option<ColorMode>,
@@ -221,6 +222,7 @@ impl ConfigOverrides {
 
     fn set(&mut self, key: &str, value: &str) {
         match key {
+            "allow-unused-patches" => self.allow_unused_patches = parse_bool(value),
             "bail" => self.bail = parse_bool(value),
             "ci" => self.ci = parse_bool(value),
             "color" => {
@@ -393,6 +395,10 @@ impl ConfigOverrides {
             self.http_proxy.as_deref(),
             self.no_proxy.as_deref(),
         );
+        if let Some(value) = self.allow_unused_patches {
+            config.allow_unused_patches = value;
+            config.explicit_settings.insert("allowUnusedPatches".to_string(), value.into());
+        }
         if let Some(value) = self.bail {
             config.bail = value;
         }

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -403,6 +403,34 @@ fn extract_applies_ignore_scripts_override() {
 }
 
 #[test]
+fn extract_applies_allow_unused_patches_override() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "--config.allow-unused-patches=true", "deploy"]));
+    assert_eq!(remaining, argv(["pacquet", "deploy"]));
+    let mut config = Config::default();
+    assert!(!config.allow_unused_patches);
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.allow_unused_patches);
+    assert_eq!(
+        config.explicit_settings.get("allowUnusedPatches"),
+        Some(&serde_json::Value::Bool(true)),
+    );
+
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "--config.allow-unused-patches=false",
+        "deploy",
+    ]));
+    let mut config = Config { allow_unused_patches: true, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(!config.allow_unused_patches);
+    assert_eq!(
+        config.explicit_settings.get("allowUnusedPatches"),
+        Some(&serde_json::Value::Bool(false)),
+    );
+}
+
+#[test]
 fn extract_applies_default_parity_overrides() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
         "pacquet",

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -404,30 +404,46 @@ fn extract_applies_ignore_scripts_override() {
 
 #[test]
 fn extract_applies_allow_unused_patches_override() {
-    let (overrides, remaining) =
-        ConfigOverrides::extract(argv(["pacquet", "--config.allow-unused-patches=true", "deploy"]));
-    assert_eq!(remaining, argv(["pacquet", "deploy"]));
-    let mut config = Config::default();
-    assert!(!config.allow_unused_patches);
-    overrides.apply(&mut config, Path::new("/workspace"));
-    assert!(config.allow_unused_patches);
-    assert_eq!(
-        config.explicit_settings.get("allowUnusedPatches"),
-        Some(&serde_json::Value::Bool(true)),
-    );
+    for (flag, expected) in [
+        ("--allow-unused-patches", true),
+        ("--allow-unused-patches=true", true),
+        ("--allow-unused-patches=false", false),
+        ("--allow-unused-patches=1", true),
+        ("--allow-unused-patches=0", false),
+        ("--config.allow-unused-patches=true", true),
+        ("--config.allow-unused-patches=false", false),
+        ("--config.allow-unused-patches=1", true),
+        ("--config.allow-unused-patches=0", false),
+        ("--no-allow-unused-patches", false),
+    ] {
+        let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "deploy"]));
+        assert_eq!(remaining, argv(["pacquet", "deploy"]));
 
-    let (overrides, _) = ConfigOverrides::extract(argv([
-        "pacquet",
-        "--config.allow-unused-patches=false",
-        "deploy",
-    ]));
-    let mut config = Config { allow_unused_patches: true, ..Config::default() };
-    overrides.apply(&mut config, Path::new("/workspace"));
-    assert!(!config.allow_unused_patches);
-    assert_eq!(
-        config.explicit_settings.get("allowUnusedPatches"),
-        Some(&serde_json::Value::Bool(false)),
-    );
+        let mut config = Config { allow_unused_patches: !expected, ..Config::default() };
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert_eq!(config.allow_unused_patches, expected);
+        assert_eq!(
+            config.explicit_settings.get("allowUnusedPatches"),
+            Some(&serde_json::Value::Bool(expected)),
+        );
+    }
+}
+
+#[test]
+fn extract_leaves_invalid_allow_unused_patches_values_for_clap() {
+    for flag in [
+        "--allow-unused-patches=yes",
+        "--allow-unused-patches=",
+        "--config.allow-unused-patches=yes",
+        "--config.allow-unused-patches=",
+    ] {
+        let (overrides, remaining) = ConfigOverrides::extract(argv(["pacquet", flag, "deploy"]));
+        assert_eq!(remaining, argv(["pacquet", flag, "deploy"]));
+
+        let mut config = Config::default();
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert!(!config.explicit_settings.contains_key("allowUnusedPatches"));
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -1657,6 +1657,43 @@ fn unused_patch_warns_when_allow_unused_patches_is_set() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn legacy_deploy_honors_allow_unused_patches_overrides() {
+    let (root, workspace, npmrc_info) = setup_configured_patch_with_yaml(
+        "is-positive@1.0.0",
+        "is-positive@1.0.0.patch",
+        "packages:\n  - 'packages/*'\n",
+    );
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let app = workspace.join("packages/app");
+    fs::create_dir_all(&app).expect("create app directory");
+    fs::write(
+        app.join("package.json"),
+        serde_json::json!({ "name": "app", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write app manifest");
+
+    pacquet(&workspace, ["install"]).assert().success();
+    pacquet(
+        &workspace,
+        [
+            "--config.allow-unused-patches=true",
+            "--filter=app",
+            "deploy",
+            "--legacy",
+            "config-deploy",
+        ],
+    )
+    .assert()
+    .success();
+    pacquet(&workspace, ["--filter=app", "deploy", "--legacy", "env-deploy"])
+        .env("PNPM_CONFIG_ALLOW_UNUSED_PATCHES", "true")
+        .assert()
+        .success();
+
+    drop((root, mock_instance));
+}
+
 /// pnpm skips patch usage validation when a first filtered install's
 /// previous wanted lockfile does not cover every resolved importer.
 #[test]

--- a/pnpm/crates/config/src/env_overlay.rs
+++ b/pnpm/crates/config/src/env_overlay.rs
@@ -248,6 +248,7 @@ impl WorkspaceSettings {
         json_field!(fetch_min_speed_ki_bps, "FETCH_MIN_SPEED_KI_BPS");
         string_field!(user_agent, "USER_AGENT");
         json_field!(patched_dependencies, "PATCHED_DEPENDENCIES");
+        json_field!(allow_unused_patches, "ALLOW_UNUSED_PATCHES");
         string_field!(patches_dir, "PATCHES_DIR");
         string_field!(global_pnpmfile, "GLOBAL_PNPMFILE");
         enum_field!(pnpmfile, "PNPMFILE", crate::PnpmfileSetting);

--- a/pnpm/crates/config/src/env_overlay/tests.rs
+++ b/pnpm/crates/config/src/env_overlay/tests.rs
@@ -36,6 +36,18 @@ fn materialization_settings_read_from_the_environment() {
 }
 
 #[test]
+fn allow_unused_patches_reads_from_the_environment() {
+    struct EnvAllowUnusedPatches;
+    impl EnvVar for EnvAllowUnusedPatches {
+        fn var(name: &str) -> Option<String> {
+            (name == "PNPM_CONFIG_ALLOW_UNUSED_PATCHES").then(|| "true".to_owned())
+        }
+    }
+    let settings = WorkspaceSettings::from_pnpm_config_env::<EnvAllowUnusedPatches>();
+    assert_eq!(settings.allow_unused_patches, Some(true));
+}
+
+#[test]
 fn parity_settings_read_from_the_environment() {
     struct EnvParity;
     impl EnvVar for EnvParity {


### PR DESCRIPTION
## Summary

- Honor `allowUnusedPatches` in the Rust pnpm CLI when it is supplied through
  `--config.allow-unused-patches` or the pnpm-specific
  `PNPM_CONFIG_ALLOW_UNUSED_PATCHES`/`pnpm_config_allow_unused_patches`
  environment variable.
- Record the command-line override as an explicit setting and cover both
  configuration paths with unit and `deploy --legacy` regression tests.
- This is Rust-only: the frozen TypeScript v11 CLI already honors the relevant
  override path. General `npm_config_*` settings remain intentionally unsupported
  by the Rust CLI; the issue's v11 no-setting case also succeeds, so it does not
  establish that namespace as the cause of the version difference.

Fixes pnpm/pnpm#14450.

## Squash Commit Body

```text
Apply allowUnusedPatches from dotted command-line overrides and the
pnpm-specific configuration environment before dispatching commands. This
keeps legacy deploys from rejecting patches that belong only to projects
outside the selected deployment subset.

Add parser and environment unit coverage together with a legacy deploy
regression test for both supported override paths.

Fixes pnpm/pnpm#14450.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790944792&installation_model_id=426870&pr_number=14459&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14459&signature=c3c893127f9ceda6c6d1519b07f12c8ff098e9574ba8d941daf66c21c708b711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed legacy `pnpm deploy` so it honors the `allow-unused-patches` setting provided through CLI configuration or the `PNPM_CONFIG_ALLOW_UNUSED_PATCHES` environment variable.
  - Added support for common boolean forms, including `true`, `false`, `1`, `0`, and the `--no-allow-unused-patches` flag.

- **Tests**
  - Added coverage confirming the setting is correctly read, applied, and preserved across supported configuration sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->