### PR TITLE
fix(pnpm): make the placeholder bin runnable when the install script is skipped

### DIFF
--- a/.changeset/runnable-pnpm-placeholder-bin.md
+++ b/.changeset/runnable-pnpm-placeholder-bin.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The `pnpm` bin of the npm package now works even when the install script that replaces it with the native binary was skipped, as happens under `--ignore-scripts` and under pnpm and Bun, which block build scripts by default [#14346](https://github.com/pnpm/pnpm/issues/14346). Such an install used to fail every command with a shell syntax error. The bin now runs the native binary through Node.js and puts it in its own place, so only the first call takes the detour; with no Node.js on `PATH` it explains what is missing instead. On Windows the install script is still required.

--- a/.changeset/runnable-pnpm-placeholder-bin.md
+++ b/.changeset/runnable-pnpm-placeholder-bin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The `pnpm` bin of the npm package now works even when the install script that replaces it with the native binary was skipped, as happens under `--ignore-scripts` and under pnpm and Bun, which block build scripts by default [#14346](https://github.com/pnpm/pnpm/issues/14346). Such an install used to fail every command with a shell syntax error. The bin now runs the native binary through Node.js and, in a terminal, says so: reinstalling pnpm with its build scripts allowed makes it start faster.
+The `pnpm` executable of the npm package now works when the package was installed without running its install scripts, as under `--ignore-scripts` or the default build-script block of pnpm and Bun [#14346](https://github.com/pnpm/pnpm/issues/14346). In that case it runs through Node.js and, in a terminal, says how to switch to the native binary.

--- a/.changeset/runnable-pnpm-placeholder-bin.md
+++ b/.changeset/runnable-pnpm-placeholder-bin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The `pnpm` bin of the npm package now works even when the install script that replaces it with the native binary was skipped, as happens under `--ignore-scripts` and under pnpm and Bun, which block build scripts by default [#14346](https://github.com/pnpm/pnpm/issues/14346). Such an install used to fail every command with a shell syntax error. The bin now runs the native binary through Node.js and puts it in its own place, so only the first call takes the detour; with no Node.js on `PATH` it explains what is missing instead. On Windows the install script is still required.
+The `pnpm` bin of the npm package now works even when the install script that replaces it with the native binary was skipped, as happens under `--ignore-scripts` and under pnpm and Bun, which block build scripts by default [#14346](https://github.com/pnpm/pnpm/issues/14346). Such an install used to fail every command with a shell syntax error. The bin now runs the native binary through Node.js and, in a terminal, says so: reinstalling pnpm with its build scripts allowed makes it start faster.

--- a/pnpm/npm/pnpm/bin/pnpm.mjs
+++ b/pnpm/npm/pnpm/bin/pnpm.mjs
@@ -3,14 +3,18 @@
 // `./bin/pnpx.mjs` for every pnpm >=11 (see its `config.json`) and loads them
 // into its own Node.js process, which a native executable cannot be loaded into.
 //
-// Nothing else runs this file: `package.json#bin` still points at the native
-// binary, so an ordinary `npm install -g pnpm` never pays for a Node.js startup.
+// The only other way in is the `pnpm` placeholder bin, when the install script
+// that replaces it with the native binary did not run (build scripts blocked).
+// An ordinary `npm install -g pnpm` never pays for a Node.js startup:
+// `package.json#bin` points at the native binary.
 //
 // Corepack installs no dependencies and runs no lifecycle scripts, so the
 // `@pnpm/exe.<target>` package that carries the binary is absent and
 // `install.js` never ran. The binary is therefore downloaded on first use and
 // kept next to this wrapper — where the native binary also finds the `dist/`
-// payload it ships node-gyp in.
+// payload it ships node-gyp in. The placeholder's installs usually do carry
+// that package; either way, the binary this run ends up with is put in the
+// placeholder's place, as `install.js` would have, so the next call is native.
 //
 // The download itself is `get-pnpm`, the package behind https://get.pnpm.io,
 // which already knows how to verify one; it travels in that same `dist/`
@@ -24,7 +28,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { URL } from 'node:url'
-import { readWrapperManifest, resolveInstalledBinary, wrapperDir } from '../native-binary.mjs'
+import { placeBinary, readWrapperManifest, resolveInstalledBinary, wrapperDir } from '../native-binary.mjs'
 
 // Deliberately not the `pnpm` placeholder that `install.js` overwrites: a name
 // of its own is what tells a downloaded binary apart from the placeholder.
@@ -34,8 +38,16 @@ const DOWNLOADED_BINARY = path.join(
 )
 const GET_PNPM = new URL('../dist/node_modules/get-pnpm/lib/index.js', import.meta.url)
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org'
+// Set by the placeholder for this process alone; the binary's environment is
+// the caller's.
+const RUN_BY_PLACEHOLDER = process.env.PNPM_WRAPPER_PLACEHOLDER === '1'
+delete process.env.PNPM_WRAPPER_PLACEHOLDER
 
-run(await nativeBinary())
+const binary = await nativeBinary()
+if (RUN_BY_PLACEHOLDER) {
+  replacePlaceholder(binary)
+}
+run(binary)
 
 function run (binary) {
   // Ctrl-C reaches the whole foreground process group, so the binary gets its
@@ -84,6 +96,17 @@ async function nativeBinary () {
     fail(`Could not download the pnpm ${version} binary: ${err.message}`)
   }
   return DOWNLOADED_BINARY
+}
+
+/**
+ * Finish what the skipped install script would have done, so the placeholder
+ * runs only once. Best effort: a wrapper that cannot be written to (a read-only
+ * install, another user's) just keeps running through here.
+ */
+function replacePlaceholder (binary) {
+  try {
+    placeBinary(binary, path.join(wrapperDir, 'pnpm'), 0o755)
+  } catch {}
 }
 
 /**

--- a/pnpm/npm/pnpm/bin/pnpm.mjs
+++ b/pnpm/npm/pnpm/bin/pnpm.mjs
@@ -3,9 +3,9 @@
 // `./bin/pnpx.mjs` for every pnpm >=11 (see its `config.json`) and loads them
 // into its own Node.js process, which a native executable cannot be loaded into.
 //
-// The only other way in is the `pnpm` placeholder bin, when the install script
-// that replaces it with the native binary did not run (build scripts blocked).
-// An ordinary `npm install -g pnpm` never pays for a Node.js startup:
+// The `pnpm` placeholder bin runs it too, when the install script that
+// replaces it with the native binary did not run (build scripts blocked). An
+// ordinary `npm install -g pnpm` never pays for a Node.js startup:
 // `package.json#bin` points at the native binary.
 //
 // Corepack installs no dependencies and runs no lifecycle scripts, so the
@@ -13,8 +13,7 @@
 // `install.js` never ran. The binary is therefore downloaded on first use and
 // kept next to this wrapper — where the native binary also finds the `dist/`
 // payload it ships node-gyp in. The placeholder's installs usually do carry
-// that package; either way, the binary this run ends up with is put in the
-// placeholder's place, as `install.js` would have, so the next call is native.
+// that package, and the binary is taken from there.
 //
 // The download itself is `get-pnpm`, the package behind https://get.pnpm.io,
 // which already knows how to verify one; it travels in that same `dist/`
@@ -28,7 +27,7 @@ import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { URL } from 'node:url'
-import { placeBinary, readWrapperManifest, resolveInstalledBinary, wrapperDir } from '../native-binary.mjs'
+import { readWrapperManifest, resolveInstalledBinary, wrapperDir } from '../native-binary.mjs'
 
 // Deliberately not the `pnpm` placeholder that `install.js` overwrites: a name
 // of its own is what tells a downloaded binary apart from the placeholder.
@@ -38,16 +37,8 @@ const DOWNLOADED_BINARY = path.join(
 )
 const GET_PNPM = new URL('../dist/node_modules/get-pnpm/lib/index.js', import.meta.url)
 const DEFAULT_REGISTRY = 'https://registry.npmjs.org'
-// Set by the placeholder for this process alone; the binary's environment is
-// the caller's.
-const RUN_BY_PLACEHOLDER = process.env.PNPM_WRAPPER_PLACEHOLDER === '1'
-delete process.env.PNPM_WRAPPER_PLACEHOLDER
 
-const binary = await nativeBinary()
-if (RUN_BY_PLACEHOLDER) {
-  replacePlaceholder(binary)
-}
-run(binary)
+run(await nativeBinary())
 
 function run (binary) {
   // Ctrl-C reaches the whole foreground process group, so the binary gets its
@@ -96,17 +87,6 @@ async function nativeBinary () {
     fail(`Could not download the pnpm ${version} binary: ${err.message}`)
   }
   return DOWNLOADED_BINARY
-}
-
-/**
- * Finish what the skipped install script would have done, so the placeholder
- * runs only once. Best effort: a wrapper that cannot be written to (a read-only
- * install, another user's) just keeps running through here.
- */
-function replacePlaceholder (binary) {
-  try {
-    placeBinary(binary, path.join(wrapperDir, 'pnpm'), 0o755)
-  } catch {}
 }
 
 /**

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 // Preinstall for the pnpm v12 wrapper (shared verbatim by `pnpm` and
-// `@pnpm/exe`): replace the shebang-less placeholder bins with the host's native
-// binary so `pnpm` runs directly, no Node startup per call. A placeholder (not a
-// Node launcher) is required because npm generates the Windows shim before
-// preinstall and won't re-read package.json during that install pass. On a
-// global Windows install, postinstall asks npm to relink after the bin rewrite.
-// The tradeoff is no fallback when build scripts are blocked (`--ignore-scripts`,
-// pnpm/Bun default).
+// `@pnpm/exe`): replace the placeholder bins with the host's native binary so
+// `pnpm` runs directly, no Node startup per call. npm generates the Windows
+// shim before preinstall and won't re-read package.json during that install
+// pass, which is what shapes the placeholder (see the `pnpm` file); on a global
+// Windows install, postinstall asks npm to relink after the bin rewrite. When
+// build scripts are blocked (`--ignore-scripts`, the pnpm/Bun default) the
+// placeholder stays: on Unix it runs as a `sh` script that hands over to
+// `bin/pnpm.mjs`, on Windows it does not run.
 //
 // `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts on Unix (so only `pnpm` is
 // relinked); on Windows the native binary is hardlinked onto each and
@@ -14,7 +15,7 @@
 // in the cli crate).
 //
 // Corepack runs no lifecycle scripts, so it never gets here; it enters through
-// `bin/pnpm.mjs` instead.
+// `bin/pnpm.mjs` too.
 import console from 'node:console'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -22,6 +23,7 @@ import path from 'node:path'
 import process from 'node:process'
 import {
   getBinCandidates,
+  placeBinary,
   readWrapperManifest,
   resolveInstalledBinary,
   splitBinSpecifier,
@@ -64,43 +66,24 @@ function setup () {
     for (const name of BIN_NAMES) {
       // The existing shim points at the no-ext file, so it must become the
       // binary; the `.exe` twin + bin rewrite are for shims generated later.
-      placeBinary(nativeBinary, path.join(wrapperDir, `${name}.exe`))
-      placeBinary(nativeBinary, path.join(wrapperDir, name))
+      placeBinaryOrExit(nativeBinary, path.join(wrapperDir, `${name}.exe`))
+      placeBinaryOrExit(nativeBinary, path.join(wrapperDir, name))
       newBin[name] = `${name}.exe`
     }
     rewriteBin(newBin)
   } else {
-    placeBinary(nativeBinary, path.join(wrapperDir, 'pnpm'), 0o755)
+    placeBinaryOrExit(nativeBinary, path.join(wrapperDir, 'pnpm'), 0o755)
   }
 }
 
 /**
- * Atomically place `nativeBinary` at `destPath` (hard link, falling back to a
- * copy across filesystems, via a temp file + rename). Exits the process on
- * failure — without the binary there is no working `pnpm`.
- *
- * @param {string} nativeBinary Absolute path to the resolved native binary.
- * @param {string} destPath Absolute path to create.
- * @param {number} [mode] chmod for the copy path only; a hard link shares the
- *   source inode (the shared store blob under pnpm), so its mode must not change.
+ * {@link placeBinary}, exiting the process on failure — without the binary
+ * there is no working `pnpm`.
  */
-function placeBinary (nativeBinary, destPath, mode) {
-  const tempPath = `${destPath}.pnpm-tmp`
+function placeBinaryOrExit (nativeBinary, destPath, mode) {
   try {
-    fs.rmSync(tempPath, { force: true })
-    let linked = false
-    try {
-      fs.linkSync(nativeBinary, tempPath)
-      linked = true
-    } catch {
-      fs.copyFileSync(nativeBinary, tempPath)
-    }
-    if (!linked && mode != null) {
-      fs.chmodSync(tempPath, mode)
-    }
-    fs.renameSync(tempPath, destPath)
+    placeBinary(nativeBinary, destPath, mode)
   } catch (err) {
-    removeFileIfPossible(tempPath)
     fail(`Could not install the pnpm binary at ${destPath}: ${err.message}`)
   }
 }

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -1,13 +1,12 @@
 #!/usr/bin/env node
 // Preinstall for the pnpm v12 wrapper (shared verbatim by `pnpm` and
 // `@pnpm/exe`): replace the placeholder bins with the host's native binary so
-// `pnpm` runs directly, no Node startup per call. npm generates the Windows
-// shim before preinstall and won't re-read package.json during that install
-// pass, which is what shapes the placeholder (see the `pnpm` file); on a global
-// Windows install, postinstall asks npm to relink after the bin rewrite. When
-// build scripts are blocked (`--ignore-scripts`, the pnpm/Bun default) the
-// placeholder stays: on Unix it runs as a `sh` script that hands over to
-// `bin/pnpm.mjs`, on Windows it does not run.
+// `pnpm` runs directly, no Node startup per call. Package managers write bin
+// shims after preinstall, so the shims are made from the binary; where build
+// scripts are blocked (`--ignore-scripts`, the pnpm/Bun default) the
+// placeholder stays and runs pnpm through Node.js (see the `pnpm` file). npm
+// does not re-read the rewritten `bin` during the same install pass, so on a
+// global Windows install, postinstall asks it to relink.
 //
 // `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts on Unix (so only `pnpm` is
 // relinked); on Windows the native binary is hardlinked onto each and
@@ -15,7 +14,7 @@
 // in the cli crate).
 //
 // Corepack runs no lifecycle scripts, so it never gets here; it enters through
-// `bin/pnpm.mjs` too.
+// `bin/pnpm.mjs` instead.
 import console from 'node:console'
 import { spawnSync } from 'node:child_process'
 import fs from 'node:fs'
@@ -23,7 +22,6 @@ import path from 'node:path'
 import process from 'node:process'
 import {
   getBinCandidates,
-  placeBinary,
   readWrapperManifest,
   resolveInstalledBinary,
   splitBinSpecifier,
@@ -66,24 +64,43 @@ function setup () {
     for (const name of BIN_NAMES) {
       // The existing shim points at the no-ext file, so it must become the
       // binary; the `.exe` twin + bin rewrite are for shims generated later.
-      placeBinaryOrExit(nativeBinary, path.join(wrapperDir, `${name}.exe`))
-      placeBinaryOrExit(nativeBinary, path.join(wrapperDir, name))
+      placeBinary(nativeBinary, path.join(wrapperDir, `${name}.exe`))
+      placeBinary(nativeBinary, path.join(wrapperDir, name))
       newBin[name] = `${name}.exe`
     }
     rewriteBin(newBin)
   } else {
-    placeBinaryOrExit(nativeBinary, path.join(wrapperDir, 'pnpm'), 0o755)
+    placeBinary(nativeBinary, path.join(wrapperDir, 'pnpm'), 0o755)
   }
 }
 
 /**
- * {@link placeBinary}, exiting the process on failure — without the binary
- * there is no working `pnpm`.
+ * Atomically place `nativeBinary` at `destPath` (hard link, falling back to a
+ * copy across filesystems, via a temp file + rename). Exits the process on
+ * failure — without the binary there is no working `pnpm`.
+ *
+ * @param {string} nativeBinary Absolute path to the resolved native binary.
+ * @param {string} destPath Absolute path to create.
+ * @param {number} [mode] chmod for the copy path only; a hard link shares the
+ *   source inode (the shared store blob under pnpm), so its mode must not change.
  */
-function placeBinaryOrExit (nativeBinary, destPath, mode) {
+function placeBinary (nativeBinary, destPath, mode) {
+  const tempPath = `${destPath}.pnpm-tmp`
   try {
-    placeBinary(nativeBinary, destPath, mode)
+    fs.rmSync(tempPath, { force: true })
+    let linked = false
+    try {
+      fs.linkSync(nativeBinary, tempPath)
+      linked = true
+    } catch {
+      fs.copyFileSync(nativeBinary, tempPath)
+    }
+    if (!linked && mode != null) {
+      fs.chmodSync(tempPath, mode)
+    }
+    fs.renameSync(tempPath, destPath)
   } catch (err) {
+    removeFileIfPossible(tempPath)
     fail(`Could not install the pnpm binary at ${destPath}: ${err.message}`)
   }
 }

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -2,12 +2,10 @@
 // (`install.js`), which links it over the placeholder bins, and by the Corepack
 // entry (`bin/pnpm.mjs`), which spawns it.
 import fs from 'node:fs'
-import { createRequire } from 'node:module'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
 
-const require = createRequire(import.meta.url)
 const { platform, arch } = process
 
 /** Directory of the published wrapper; the native binary lives next to it. */
@@ -69,7 +67,14 @@ export function splitBinSpecifier (specifier) {
 
 /**
  * Path to the native binary of whichever platform package the package manager
- * installed, or `null` when none is present (Corepack, `--no-optional`).
+ * installed with this wrapper, or `null` when none is present (Corepack,
+ * `--no-optional`).
+ *
+ * Only the wrapper's own `node_modules` and the one it was installed into are
+ * searched, which is where every package manager puts an optional dependency
+ * of the wrapper. A `require` walk would also reach the ancestors' `node_modules`,
+ * which belong to whatever project the wrapper sits under and are not to be
+ * run in its name.
  *
  * @returns {string | null}
  */
@@ -77,11 +82,25 @@ export function resolveInstalledBinary () {
   // Use whichever platform package the package manager installed: it already
   // filtered by `os`/`cpu`/`libc`, more reliable than re-deriving the host.
   for (const specifier of getBinCandidates()) {
-    try {
-      return require.resolve(specifier)
-    } catch {}
+    const { packageName, binFile } = splitBinSpecifier(specifier)
+    for (const modulesDir of installedModulesDirs()) {
+      const candidate = path.join(modulesDir, ...packageName.split('/'), binFile)
+      if (fs.statSync(candidate, { throwIfNoEntry: false })?.isFile() === true) {
+        return candidate
+      }
+    }
   }
   return null
+}
+
+/** The `node_modules` nested in the wrapper, then the one holding the wrapper. */
+function installedModulesDirs () {
+  const { name } = readWrapperManifest()
+  const segments = typeof name === 'string' ? name.split('/').length : 1
+  return [
+    path.join(wrapperDir, 'node_modules'),
+    path.resolve(wrapperDir, ...Array(segments).fill('..')),
+  ]
 }
 
 // A successful read with no optionalDependencies is the dev checkout (there is

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -114,12 +114,16 @@ export function readWrapperManifest () {
  *   source inode (the shared store blob under pnpm), so its mode must not change.
  */
 export function placeBinary (nativeBinary, destPath, mode) {
+  // Per process, so concurrent callers never share a temp file. What a crashed
+  // caller left under a reused pid is itself a hard link to a store blob, so
+  // it is removed, never written into.
   const tempPath = `${destPath}.${process.pid}.pnpm-tmp`
   try {
+    fs.rmSync(tempPath, { force: true })
     try {
       fs.linkSync(nativeBinary, tempPath)
     } catch {
-      fs.copyFileSync(nativeBinary, tempPath)
+      fs.copyFileSync(nativeBinary, tempPath, fs.constants.COPYFILE_EXCL)
       if (mode != null) {
         fs.chmodSync(tempPath, mode)
       }

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -93,7 +93,14 @@ export function resolveInstalledBinary () {
   return null
 }
 
-/** The `node_modules` nested in the wrapper, then the one holding the wrapper. */
+/**
+ * Where a platform package installed for this wrapper can be: the `node_modules`
+ * nested in the wrapper, then the one the wrapper was installed into (two levels
+ * up for the scoped `@pnpm/exe`). Neither need exist. Throws only when the
+ * wrapper's manifest is unreadable, see {@link readWrapperManifest}.
+ *
+ * @returns {string[]}
+ */
 function installedModulesDirs () {
   const { name } = readWrapperManifest()
   const segments = typeof name === 'string' ? name.split('/').length : 1

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -1,7 +1,6 @@
-// Where the host's native pnpm binary comes from, and how it takes a
-// placeholder bin's place. Shared by the preinstall (`install.js`), which links
-// it over the placeholder bins, and by the Node.js entry (`bin/pnpm.mjs`), which
-// spawns it.
+// Where the host's native pnpm binary comes from. Shared by the preinstall
+// (`install.js`), which links it over the placeholder bins, and by the Corepack
+// entry (`bin/pnpm.mjs`), which spawns it.
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
@@ -100,41 +99,6 @@ export function readWrapperManifest () {
     throw new Error(`Expected ${manifestPath} to contain a JSON object`)
   }
   return manifest
-}
-
-/**
- * Put `nativeBinary` at `destPath`, replacing whatever is there: a hard link,
- * or a copy across filesystems, renamed into place from a temp file so a
- * placeholder hard-linked from a content-addressable store is never written
- * in place, and so concurrent callers each land a whole file.
- *
- * @param {string} nativeBinary Absolute path to the resolved native binary.
- * @param {string} destPath Absolute path to create.
- * @param {number} [mode] chmod for the copy path only; a hard link shares the
- *   source inode (the shared store blob under pnpm), so its mode must not change.
- */
-export function placeBinary (nativeBinary, destPath, mode) {
-  // Per process, so concurrent callers never share a temp file. What a crashed
-  // caller left under a reused pid is itself a hard link to a store blob, so
-  // it is removed, never written into.
-  const tempPath = `${destPath}.${process.pid}.pnpm-tmp`
-  try {
-    fs.rmSync(tempPath, { force: true })
-    try {
-      fs.linkSync(nativeBinary, tempPath)
-    } catch {
-      fs.copyFileSync(nativeBinary, tempPath, fs.constants.COPYFILE_EXCL)
-      if (mode != null) {
-        fs.chmodSync(tempPath, mode)
-      }
-    }
-    fs.renameSync(tempPath, destPath)
-  } catch (err) {
-    try {
-      fs.rmSync(tempPath, { force: true })
-    } catch {}
-    throw err
-  }
 }
 
 function detectLinuxLibc () {

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -1,6 +1,7 @@
-// Where the host's native pnpm binary comes from. Shared by the preinstall
-// (`install.js`), which links it over the placeholder bins, and by the Corepack
-// entry (`bin/pnpm.mjs`), which spawns it.
+// Where the host's native pnpm binary comes from, and how it takes a
+// placeholder bin's place. Shared by the preinstall (`install.js`), which links
+// it over the placeholder bins, and by the Node.js entry (`bin/pnpm.mjs`), which
+// spawns it.
 import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
@@ -99,6 +100,37 @@ export function readWrapperManifest () {
     throw new Error(`Expected ${manifestPath} to contain a JSON object`)
   }
   return manifest
+}
+
+/**
+ * Put `nativeBinary` at `destPath`, replacing whatever is there: a hard link,
+ * or a copy across filesystems, renamed into place from a temp file so a
+ * placeholder hard-linked from a content-addressable store is never written
+ * in place, and so concurrent callers each land a whole file.
+ *
+ * @param {string} nativeBinary Absolute path to the resolved native binary.
+ * @param {string} destPath Absolute path to create.
+ * @param {number} [mode] chmod for the copy path only; a hard link shares the
+ *   source inode (the shared store blob under pnpm), so its mode must not change.
+ */
+export function placeBinary (nativeBinary, destPath, mode) {
+  const tempPath = `${destPath}.${process.pid}.pnpm-tmp`
+  try {
+    try {
+      fs.linkSync(nativeBinary, tempPath)
+    } catch {
+      fs.copyFileSync(nativeBinary, tempPath)
+      if (mode != null) {
+        fs.chmodSync(tempPath, mode)
+      }
+    }
+    fs.renameSync(tempPath, destPath)
+  } catch (err) {
+    try {
+      fs.rmSync(tempPath, { force: true })
+    } catch {}
+    throw err
+  }
 }
 
 function detectLinuxLibc () {

--- a/pnpm/npm/pnpm/pnpm
+++ b/pnpm/npm/pnpm/pnpm
@@ -1,4 +1,24 @@
-This is a placeholder. pnpm's native binary replaces this file during
-installation (see ./install.js). If you are reading this, the install/build
-script did not run — reinstall with build scripts enabled (e.g. allow-list
-pnpm's build under pnpm or Bun, or drop --ignore-scripts).
+# pnpm's native binary replaces this file during installation (see
+# ./install.js). If this is running, that install script did not: build
+# scripts were blocked (pnpm and Bun block them by default) or skipped
+# (`--ignore-scripts`). It hands over to the Node.js entry point, which runs
+# the installed binary — putting it in this file's place, so the next call is
+# native — or downloads one.
+#
+# Deliberately no `#!` line: npm generates the Windows shim from this file
+# before the install script rewrites it, and only a shebang-less file yields a
+# shim that still runs the native binary placed here afterwards. Shells and
+# libc run a `#!`-less executable as a `sh` script, so this must stay POSIX sh.
+self=$0
+while [ -h "$self" ]; do
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname "$self")/$link ;;
+  esac
+done
+if ! command -v node >/dev/null 2>&1; then
+  echo "pnpm's native binary was not installed: the install script that puts it in place did not run (build scripts were blocked or skipped), and Node.js, which could stand in for it, is not on PATH. Reinstall pnpm with its build scripts allowed, or install Node.js." >&2
+  exit 127
+fi
+PNPM_WRAPPER_PLACEHOLDER=1 exec node "$(dirname "$self")/bin/pnpm.mjs" "$@"

--- a/pnpm/npm/pnpm/pnpm
+++ b/pnpm/npm/pnpm/pnpm
@@ -1,24 +1,21 @@
-# pnpm's native binary replaces this file during installation (see
-# ./install.js). If this is running, that install script did not: build
-# scripts were blocked (pnpm and Bun block them by default) or skipped
-# (`--ignore-scripts`). It hands over to the Node.js entry point, which runs
-# the installed binary — putting it in this file's place, so the next call is
-# native — or downloads one.
-#
-# Deliberately no `#!` line: npm generates the Windows shim from this file
-# before the install script rewrites it, and only a shebang-less file yields a
-# shim that still runs the native binary placed here afterwards. Shells and
-# libc run a `#!`-less executable as a `sh` script, so this must stay POSIX sh.
-self=$0
-while [ -h "$self" ]; do
-  link=$(readlink "$self")
-  case $link in
-    /*) self=$link ;;
-    *) self=$(dirname "$self")/$link ;;
-  esac
-done
-if ! command -v node >/dev/null 2>&1; then
-  echo "pnpm's native binary was not installed: the install script that puts it in place did not run (build scripts were blocked or skipped), and Node.js, which could stand in for it, is not on PATH. Reinstall pnpm with its build scripts allowed, or install Node.js." >&2
-  exit 127
-fi
-PNPM_WRAPPER_PLACEHOLDER=1 exec node "$(dirname "$self")/bin/pnpm.mjs" "$@"
+#!/usr/bin/env node
+// pnpm's native binary replaces this file during installation (see
+// ./install.js). If this is running, that install script did not — build
+// scripts were blocked (pnpm and Bun block them by default) or skipped
+// (`--ignore-scripts`) — so pnpm runs through Node.js instead: `bin/pnpm.mjs`
+// finds the installed binary, or downloads one, and spawns it.
+//
+// Package managers write bin shims after preinstall has had its chance to run,
+// so a shim made from this file's shebang exists only where the binary never
+// arrived. That is also why this file is left in place once it is running: a
+// binary put here under such a shim would be run through `node`.
+import process from 'node:process'
+
+if (process.stderr.isTTY) {
+  process.stderr.write(
+    'pnpm is running through Node.js because the script that installs its native binary was skipped. ' +
+    'Reinstall pnpm with its build scripts allowed to run the binary directly.\n'
+  )
+}
+
+await import('./bin/pnpm.mjs')

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -15,6 +15,48 @@ const wrapperManifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'packag
 test('npm installs a shim that runs the native pnpm binary', (t) => {
   assert.equal(wrapperManifest.bin.pnpm, 'pnpm')
 
+  const { prefix } = installFixtureWithNpm(t, ['--dangerously-allow-all-scripts'])
+
+  if (process.platform === 'win32') {
+    const cmdShim = path.join(prefix, 'pnpm.cmd')
+    assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+
+    const powershellShim = path.join(prefix, 'pnpm.ps1')
+    assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+  } else {
+    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  }
+})
+
+test('the shim runs pnpm through Node.js when npm skipped the install scripts', (t) => {
+  const { prefix, fixtureDir } = installFixtureWithNpm(t, ['--ignore-scripts'])
+  const placeholder = fs.readFileSync(path.join(fixtureDir, 'pnpm'), 'utf8')
+  const installedPlaceholder = process.platform === 'win32'
+    ? path.join(prefix, 'node_modules', 'pnpm-install-fixture', 'pnpm')
+    : path.join(prefix, 'lib', 'node_modules', 'pnpm-install-fixture', 'pnpm')
+  assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
+
+  if (process.platform === 'win32') {
+    const cmdShim = path.join(prefix, 'pnpm.cmd')
+    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+    const powershellShim = path.join(prefix, 'pnpm.ps1')
+    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+  } else {
+    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  }
+  // The shim was made from the placeholder's shebang, so the placeholder stays.
+  assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
+})
+
+/**
+ * Install the wrapper fixture globally with npm into a prefix of its own, with
+ * the host's platform package as a `file:` optional dependency.
+ *
+ * @returns {{ prefix: string, fixtureDir: string }}
+ */
+function installFixtureWithNpm (t, npmFlags) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm wrapper install-'))
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
 
@@ -30,8 +72,8 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
   writeNativeFixture(path.join(nativePackageDir, binFile))
 
   const fixtureDir = path.join(tempDir, 'wrapper')
-  fs.mkdirSync(fixtureDir)
-  for (const file of ['install.js', 'native-binary.mjs', wrapperManifest.bin.pnpm]) {
+  fs.mkdirSync(path.join(fixtureDir, 'bin'), { recursive: true })
+  for (const file of ['install.js', 'native-binary.mjs', 'bin/pnpm.mjs', wrapperManifest.bin.pnpm]) {
     fs.copyFileSync(path.join(wrapperDir, file), path.join(fixtureDir, file))
   }
   fs.writeFileSync(path.join(fixtureDir, 'package.json'), JSON.stringify({
@@ -51,24 +93,13 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
     'install',
     '--global',
     '--install-links=true',
-    '--dangerously-allow-all-scripts',
+    ...npmFlags,
     '--prefix',
     prefix,
     fixtureDir,
   ], tempDir)
-
-  if (process.platform === 'win32') {
-    const cmdShim = path.join(prefix, 'pnpm.cmd')
-    assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
-
-    const powershellShim = path.join(prefix, 'pnpm.ps1')
-    assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
-  } else {
-    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
-  }
-})
+  return { prefix, fixtureDir }
+}
 
 function runNpm (args, cwd) {
   if (process.platform === 'win32') {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -52,9 +52,13 @@ test('the shim runs pnpm through Node.js when npm skipped the install scripts', 
 
 /**
  * Install the wrapper fixture globally with npm into a prefix of its own, with
- * the host's platform package as a `file:` optional dependency.
+ * the host's platform package as a `file:` optional dependency. Throws when npm
+ * fails; the temp tree is removed when `t` ends.
  *
- * @returns {{ prefix: string, fixtureDir: string }}
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {string[]} npmFlags Extra `npm install` flags, e.g. `--ignore-scripts`.
+ * @returns {{ prefix: string, fixtureDir: string }} The npm prefix the shims
+ *   landed in, and the fixture wrapper it was installed from.
  */
 function installFixtureWithNpm (t, npmFlags) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm wrapper install-'))

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -1,10 +1,9 @@
 // Exercises the `pnpm` placeholder bin the way a script-less install leaves it:
 // the install script never replaced it with the native binary, and it is what
-// the package manager's bin shim (or npm's symlink) runs. The placeholder is a
-// shebang-less `sh` script, so the tests that run it are Unix-only; what holds
-// it to that shape is asserted everywhere.
+// the package manager's bin shim runs — through Node.js, since its shebang
+// names it.
 import assert from 'node:assert/strict'
-import { execFileSync, spawn } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -16,103 +15,61 @@ import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
 
 const WRAPPER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 const WRAPPER_FILES = ['pnpm', 'native-binary.mjs', 'bin/pnpm.mjs']
-// A stand-in for the native binary: reports how it was called, and whether the
-// placeholder's own marker leaked into its environment.
-const FAKE_BINARY = `#!/bin/sh
-echo "installed: $*"
-echo "marker: \${PNPM_WRAPPER_PLACEHOLDER-unset}"
-`
+// A stand-in for the native binary. On Windows it is a copy of node itself,
+// which is why the tests ask for `--version`; elsewhere a script that echoes.
+const FAKE_BINARY_OUTPUT = process.platform === 'win32' ? /^v\d+/ : /^installed: --version\n$/
 
-const RUNS_SH = process.platform === 'win32' && 'the placeholder is a sh script, which Windows cannot run'
+const IS_UNIX = process.platform !== 'win32'
 
 describe('placeholder bin', () => {
-  // npm generates the Windows shim from this file before the install script
-  // rewrites it; a `#!` line would make that shim run an interpreter over the
-  // native binary placed here afterwards.
-  it('carries no shebang', () => {
-    assert.doesNotMatch(fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'), /^#!/)
+  // What every bin shim made from this file resolves it to.
+  it('names node in its shebang', () => {
+    assert.match(fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'), /^#!\/usr\/bin\/env node\n/)
   })
 
-  it('runs the installed native binary, then takes its place', { skip: RUNS_SH }, async () => {
+  it('runs the installed native binary through Node.js', async () => {
     const fixture = createFixture()
 
-    const first = await runThroughShell(fixture.placeholder, ['--version'])
-    assert.equal(first.status, 0, first.stderr)
-    assert.match(first.stdout, /^installed: --version\nmarker: unset\n$/)
-    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), FAKE_BINARY)
-
-    const second = await runThroughShell(fixture.placeholder, ['install'])
-    assert.equal(second.status, 0, second.stderr)
-    assert.match(second.stdout, /^installed: install\n/)
+    const result = await run(process.execPath, [fixture.placeholder, '--version'])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, FAKE_BINARY_OUTPUT)
+    // Not a terminal, so no notice.
+    assert.equal(result.stderr, '')
+    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'))
   })
 
-  // npm links `node_modules/.bin/pnpm` straight to the file, so the placeholder
-  // is entered under the link's name and has to find the wrapper from there.
-  it('finds the wrapper through a symlink to itself', { skip: RUNS_SH }, async () => {
+  // npm links `node_modules/.bin/pnpm` straight to the file and the kernel
+  // reads the shebang; Windows has neither, so this is Unix-only.
+  it('runs from a symlink to itself', { skip: !IS_UNIX && 'Windows bins are shims, not symlinks' }, async () => {
     const fixture = createFixture()
     const binDir = path.join(fixture.dir, 'node_modules', '.bin')
     fs.mkdirSync(binDir, { recursive: true })
     const link = path.join(binDir, 'pnpm')
     fs.symlinkSync(path.relative(binDir, fixture.placeholder), link)
 
-    const result = await runThroughShell(link, ['--version'])
+    const result = await run(link, ['--version'])
     assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /^installed: --version\n/)
+    assert.match(result.stdout, FAKE_BINARY_OUTPUT)
   })
 
-  it('keeps running when it cannot be replaced', { skip: RUNS_SH || (process.getuid?.() === 0 && 'root can write anywhere') }, async () => {
-    const fixture = createFixture()
-    const placeholderBefore = fs.readFileSync(fixture.placeholder, 'utf8')
-    fs.chmodSync(fixture.dir, 0o555)
-    let result
-    try {
-      result = await runThroughShell(fixture.placeholder, ['--version'])
-    } finally {
-      fs.chmodSync(fixture.dir, 0o755)
-    }
-    assert.equal(result.status, 0, result.stderr)
-    assert.match(result.stdout, /^installed: --version\n/)
-    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), placeholderBefore)
-  })
-
-  it('hands over to the entry point when no platform package is installed', { skip: RUNS_SH }, async () => {
+  it('hands over to the entry point when no platform package is installed', async () => {
     const fixture = createFixture({ installPlatformPackage: false })
 
-    const result = await runThroughShell(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    const result = await run(process.execPath, [fixture.placeholder, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /Network access is disabled/)
-    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'))
-  })
-
-  it('says what is missing when there is no Node.js to hand over to', { skip: RUNS_SH }, async () => {
-    const fixture = createFixture()
-    // Only what the placeholder itself runs, so `node` is not found.
-    const pathDir = path.join(fixture.dir, 'path')
-    fs.mkdirSync(pathDir)
-    for (const tool of ['readlink', 'dirname']) {
-      fs.symlinkSync(execFileSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' }).trim(), path.join(pathDir, tool))
-    }
-
-    const result = await runThroughShell(fixture.placeholder, ['--version'], { PATH: pathDir })
-    assert.equal(result.status, 127)
-    assert.match(result.stderr, /install script that puts it in place did not run/)
-    assert.match(result.stderr, /Node\.js, which could stand in for it, is not on PATH/)
   })
 })
 
 /**
- * Run `file` with `args` the way bin shims and shells do: `exec` from a POSIX
- * shell, which falls back to running a `#!`-less file as a `sh` script. `env`
- * overrides the inherited environment. Resolves once the child has exited,
- * with its exit status and decoded output; rejects only if it could not be
- * spawned.
+ * Spawn `command` with `args`, `env` overriding the inherited environment.
+ * Resolves once the child has exited, with its exit status and decoded output;
+ * rejects only if it could not be spawned.
  *
  * @returns {Promise<{status: number | null, stdout: string, stderr: string}>}
  */
-function runThroughShell (file, args, env) {
-  const child = spawn('/bin/sh', ['-c', 'exec "$0" "$@"', file, ...args], {
-    env: { ...process.env, ...env },
-  })
+function run (command, args, env) {
+  const child = spawn(command, args, { env: { ...process.env, ...env } })
 
   let stdout = ''
   let stderr = ''
@@ -139,14 +96,19 @@ function createFixture ({ installPlatformPackage = true } = {}) {
     fs.copyFileSync(path.join(WRAPPER_DIR, file), path.join(dir, file))
   }
   fs.chmodSync(path.join(dir, 'pnpm'), 0o755)
-  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0' }))
+  // `type` is what makes Node.js read the extensionless placeholder as ESM.
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0', type: 'module' }))
 
   if (installPlatformPackage) {
     const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
     const packageDir = path.join(dir, 'node_modules', packageName)
     fs.mkdirSync(packageDir, { recursive: true })
     fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
-    fs.writeFileSync(path.join(packageDir, binFile), FAKE_BINARY, { mode: 0o755 })
+    if (IS_UNIX) {
+      fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
+    } else {
+      fs.copyFileSync(process.execPath, path.join(packageDir, binFile))
+    }
   }
 
   return { dir, placeholder: path.join(dir, 'pnpm') }

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -1,0 +1,148 @@
+// Exercises the `pnpm` placeholder bin the way a script-less install leaves it:
+// the install script never replaced it with the native binary, and it is what
+// the package manager's bin shim (or npm's symlink) runs. The placeholder is a
+// shebang-less `sh` script, so the tests that run it are Unix-only; what holds
+// it to that shape is asserted everywhere.
+import assert from 'node:assert/strict'
+import { execFileSync, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { after, describe, it } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
+
+const WRAPPER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WRAPPER_FILES = ['pnpm', 'native-binary.mjs', 'bin/pnpm.mjs']
+// A stand-in for the native binary: reports how it was called, and whether the
+// placeholder's own marker leaked into its environment.
+const FAKE_BINARY = `#!/bin/sh
+echo "installed: $*"
+echo "marker: \${PNPM_WRAPPER_PLACEHOLDER-unset}"
+`
+
+const RUNS_SH = process.platform === 'win32' && 'the placeholder is a sh script, which Windows cannot run'
+
+describe('placeholder bin', () => {
+  // npm generates the Windows shim from this file before the install script
+  // rewrites it; a `#!` line would make that shim run an interpreter over the
+  // native binary placed here afterwards.
+  it('carries no shebang', () => {
+    assert.doesNotMatch(fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'), /^#!/)
+  })
+
+  it('runs the installed native binary, then takes its place', { skip: RUNS_SH }, async () => {
+    const fixture = createFixture()
+
+    const first = await runThroughShell(fixture.placeholder, ['--version'])
+    assert.equal(first.status, 0, first.stderr)
+    assert.match(first.stdout, /^installed: --version\nmarker: unset\n$/)
+    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), FAKE_BINARY)
+
+    const second = await runThroughShell(fixture.placeholder, ['install'])
+    assert.equal(second.status, 0, second.stderr)
+    assert.match(second.stdout, /^installed: install\n/)
+  })
+
+  // npm links `node_modules/.bin/pnpm` straight to the file, so the placeholder
+  // is entered under the link's name and has to find the wrapper from there.
+  it('finds the wrapper through a symlink to itself', { skip: RUNS_SH }, async () => {
+    const fixture = createFixture()
+    const binDir = path.join(fixture.dir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    const link = path.join(binDir, 'pnpm')
+    fs.symlinkSync(path.relative(binDir, fixture.placeholder), link)
+
+    const result = await runThroughShell(link, ['--version'])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /^installed: --version\n/)
+  })
+
+  it('keeps running when it cannot be replaced', { skip: RUNS_SH || (process.getuid?.() === 0 && 'root can write anywhere') }, async () => {
+    const fixture = createFixture()
+    const placeholderBefore = fs.readFileSync(fixture.placeholder, 'utf8')
+    fs.chmodSync(fixture.dir, 0o555)
+    let result
+    try {
+      result = await runThroughShell(fixture.placeholder, ['--version'])
+    } finally {
+      fs.chmodSync(fixture.dir, 0o755)
+    }
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /^installed: --version\n/)
+    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), placeholderBefore)
+  })
+
+  it('hands over to the entry point when no platform package is installed', { skip: RUNS_SH }, async () => {
+    const fixture = createFixture({ installPlatformPackage: false })
+
+    const result = await runThroughShell(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Network access is disabled/)
+    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'))
+  })
+
+  it('says what is missing when there is no Node.js to hand over to', { skip: RUNS_SH }, async () => {
+    const fixture = createFixture()
+    // Only what the placeholder itself runs, so `node` is not found.
+    const pathDir = path.join(fixture.dir, 'path')
+    fs.mkdirSync(pathDir)
+    for (const tool of ['readlink', 'dirname']) {
+      fs.symlinkSync(execFileSync('sh', ['-c', `command -v ${tool}`], { encoding: 'utf8' }).trim(), path.join(pathDir, tool))
+    }
+
+    const result = await runThroughShell(fixture.placeholder, ['--version'], { PATH: pathDir })
+    assert.equal(result.status, 127)
+    assert.match(result.stderr, /install script that puts it in place did not run/)
+    assert.match(result.stderr, /Node\.js, which could stand in for it, is not on PATH/)
+  })
+})
+
+/**
+ * Run `file` the way bin shims and shells do: `exec` from a POSIX shell, which
+ * falls back to running a `#!`-less file as a `sh` script.
+ */
+function runThroughShell (file, args, env) {
+  const child = spawn('/bin/sh', ['-c', 'exec "$0" "$@"', file, ...args], {
+    env: { ...process.env, ...env },
+  })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk })
+  child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk })
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject)
+    child.on('close', (status) => { resolve({ status, stdout, stderr }) })
+  })
+}
+
+/**
+ * A wrapper directory as a script-less install leaves it: the placeholder still
+ * in place, and — unless told otherwise — the platform package that carries the
+ * binary installed next to it, since only the scripts were skipped.
+ */
+function createFixture ({ installPlatformPackage = true } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-placeholder-'))
+  after(() => fs.rmSync(dir, { force: true, recursive: true }))
+
+  for (const file of WRAPPER_FILES) {
+    fs.mkdirSync(path.dirname(path.join(dir, file)), { recursive: true })
+    fs.copyFileSync(path.join(WRAPPER_DIR, file), path.join(dir, file))
+  }
+  fs.chmodSync(path.join(dir, 'pnpm'), 0o755)
+  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0' }))
+
+  if (installPlatformPackage) {
+    const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
+    const packageDir = path.join(dir, 'node_modules', packageName)
+    fs.mkdirSync(packageDir, { recursive: true })
+    fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
+    fs.writeFileSync(path.join(packageDir, binFile), FAKE_BINARY, { mode: 0o755 })
+  }
+
+  return { dir, placeholder: path.join(dir, 'pnpm') }
+}

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -121,7 +121,11 @@ function createFixture ({ installPlatformPackage = true, nestedUnder = [] } = {}
   return { dir, placeholder: path.join(wrapperDir, 'pnpm') }
 }
 
-/** The host's `@pnpm/exe.<target>` package, carrying the stand-in binary, under `modulesDir`. */
+/**
+ * Create the host's `@pnpm/exe.<target>` package under `modulesDir` (created if
+ * missing): a manifest and the stand-in binary — an executable `sh` script on
+ * Unix, a copy of the running node on Windows. Filesystem errors propagate.
+ */
 function writePlatformPackage (modulesDir) {
   const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
   const packageDir = path.join(modulesDir, packageName)

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -101,8 +101,13 @@ describe('placeholder bin', () => {
 })
 
 /**
- * Run `file` the way bin shims and shells do: `exec` from a POSIX shell, which
- * falls back to running a `#!`-less file as a `sh` script.
+ * Run `file` with `args` the way bin shims and shells do: `exec` from a POSIX
+ * shell, which falls back to running a `#!`-less file as a `sh` script. `env`
+ * overrides the inherited environment. Resolves once the child has exited,
+ * with its exit status and decoded output; rejects only if it could not be
+ * spawned.
+ *
+ * @returns {Promise<{status: number | null, stdout: string, stderr: string}>}
  */
 function runThroughShell (file, args, env) {
   const child = spawn('/bin/sh', ['-c', 'exec "$0" "$@"', file, ...args], {

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -59,6 +59,18 @@ describe('placeholder bin', () => {
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /Network access is disabled/)
   })
+
+  // A project the wrapper sits under can hold anything under the platform
+  // package's name; only what was installed with the wrapper is its binary.
+  it('does not run a platform package from an ancestor node_modules', async () => {
+    const fixture = createFixture({ installPlatformPackage: false, nestedUnder: ['node_modules', 'tool', 'node_modules'] })
+    writePlatformPackage(path.join(fixture.dir, 'node_modules'))
+
+    const result = await run(process.execPath, [fixture.placeholder, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Network access is disabled/)
+    assert.doesNotMatch(result.stdout, FAKE_BINARY_OUTPUT)
+  })
 })
 
 /**
@@ -85,31 +97,39 @@ function run (command, args, env) {
 /**
  * A wrapper directory as a script-less install leaves it: the placeholder still
  * in place, and — unless told otherwise — the platform package that carries the
- * binary installed next to it, since only the scripts were skipped.
+ * binary installed in the wrapper's own `node_modules`, since only the scripts
+ * were skipped. `nestedUnder` places the wrapper that many directories below
+ * the fixture root, which then stands for a project the wrapper sits under.
  */
-function createFixture ({ installPlatformPackage = true } = {}) {
+function createFixture ({ installPlatformPackage = true, nestedUnder = [] } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-placeholder-'))
   after(() => fs.rmSync(dir, { force: true, recursive: true }))
+  const wrapperDir = path.join(dir, ...nestedUnder, nestedUnder.length > 0 ? 'pnpm' : '')
 
   for (const file of WRAPPER_FILES) {
-    fs.mkdirSync(path.dirname(path.join(dir, file)), { recursive: true })
-    fs.copyFileSync(path.join(WRAPPER_DIR, file), path.join(dir, file))
+    fs.mkdirSync(path.dirname(path.join(wrapperDir, file)), { recursive: true })
+    fs.copyFileSync(path.join(WRAPPER_DIR, file), path.join(wrapperDir, file))
   }
-  fs.chmodSync(path.join(dir, 'pnpm'), 0o755)
+  fs.chmodSync(path.join(wrapperDir, 'pnpm'), 0o755)
   // `type` is what makes Node.js read the extensionless placeholder as ESM.
-  fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0', type: 'module' }))
+  fs.writeFileSync(path.join(wrapperDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0', type: 'module' }))
 
   if (installPlatformPackage) {
-    const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
-    const packageDir = path.join(dir, 'node_modules', packageName)
-    fs.mkdirSync(packageDir, { recursive: true })
-    fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
-    if (IS_UNIX) {
-      fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
-    } else {
-      fs.copyFileSync(process.execPath, path.join(packageDir, binFile))
-    }
+    writePlatformPackage(path.join(wrapperDir, 'node_modules'))
   }
 
-  return { dir, placeholder: path.join(dir, 'pnpm') }
+  return { dir, placeholder: path.join(wrapperDir, 'pnpm') }
+}
+
+/** The host's `@pnpm/exe.<target>` package, carrying the stand-in binary, under `modulesDir`. */
+function writePlatformPackage (modulesDir) {
+  const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
+  const packageDir = path.join(modulesDir, packageName)
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
+  if (IS_UNIX) {
+    fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
+  } else {
+    fs.copyFileSync(process.execPath, path.join(packageDir, binFile))
+  }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/pnpm/pnpm/issues/14346 (and the `self-update` report in https://github.com/pnpm/pnpm/issues/14346#issuecomment-5491521017).

The npm package's `pnpm` bin is a placeholder that the preinstall script replaces with the native binary. Any install that skips scripts — `--ignore-scripts`, pnpm's and Bun's default build-script block, Deno, `pnpm dlx pnpm`, script-less provisioning such as Vercel's, an older pnpm's `self-update` — kept the prose placeholder, so every command failed with `Syntax error: ")" unexpected`: shells run a shebang-less executable as a `sh` script, and the prose was not one.

The placeholder is now a `#!/usr/bin/env node` module that imports `bin/pnpm.mjs`, the Node.js entry point Corepack already uses, which runs the installed `@pnpm/exe.<target>` binary (present in these installs, since only scripts were skipped) or downloads one.

**Why a Node launcher is safe, on Windows too.** `install.js` claimed npm generates the Windows shim before preinstall, which is why the placeholder had to be shebang-less. That does not hold: every package manager writes bin shims after preinstall has had its chance to run, so a shim made from this shebang exists only where the binary never arrived, and a shim made after a successful preinstall sees the binary and execs it directly, as today.

- npm's build phase (`@npmcli/arborist` `rebuild.js`) is `preinstall` → link bins → `install` → `postinstall`, local and global alike.
- pnpm links the root project's `.bin` after `buildModules`, and inside `buildModules` a package's dependency bins are linked right before its own scripts, after its dependencies have built.
- pacquet shims importer bins in the link phase and relinks them after the build phase whenever a lifecycle script was attempted.

**Consequences.**

- Script-less installs now work everywhere, Windows included.
- The placeholder is left in place once it is running: a binary put there under a `node <file>` shim would be run through node. So such an install pays a Node.js startup on every call. When stderr is a terminal the placeholder prints one line saying so and how to fix it (reinstall with build scripts allowed); CI logs and piped output are untouched, and Corepack, which enters `bin/pnpm.mjs` directly, never sees it.
- `install.js`'s header now states the real constraint (npm does not re-read the rewritten `bin` in the same pass, hence the global Windows relink).
- `resolveInstalledBinary` no longer uses a `require` walk, which could reach an ancestor project's `node_modules` when the platform package is missing. It looks only in the wrapper's own `node_modules` and the one it was installed into, the same containment pacquet's `link_exe_platform_binary` applies. A test plants a platform package in an ancestor and asserts it is not run.

**Tests.** `test/placeholder.test.mjs` runs the placeholder through Node on every platform (installed binary, symlink entry on Unix, hand-over to the download path), and pins the shebang. `test/install.test.mjs` gains a real `npm install --global --ignore-scripts` of the wrapper fixture — the reporter's repro — driven through the generated shims: `bin/pnpm` on Unix, `pnpm.cmd` and `pnpm.ps1` on Windows. The suite (17 tests) passes locally on Node 26, 22 and 18; the Windows half runs in the existing CI job.

## Squash Commit Body

```text
The npm package's `pnpm` bin is a placeholder that the preinstall script
replaces with the native binary. Any install that skips scripts
(`--ignore-scripts`, pnpm's and Bun's default build-script block, an
older pnpm's `self-update`) kept the prose placeholder, and every command
then failed with a shell syntax error.

The placeholder is now a `#!/usr/bin/env node` module that imports the
Node.js entry point, `bin/pnpm.mjs`, which finds the installed
`@pnpm/exe.<target>` binary or downloads one and spawns it. This works
on Windows too: every package manager writes its bin shims after
preinstall has had its chance to run, so a shim made from this shebang
exists only where the binary never arrived, and a shim made after a
successful preinstall sees the binary. npm's build phase is preinstall,
bin links, install, postinstall; pnpm links the root project's bins after
`buildModules`; pacquet relinks importer bins after any lifecycle script
was attempted. The claim in install.js that npm generates the Windows
shim before preinstall did not hold.

The placeholder is left in place once it is running: a binary put there
under a `node <file>` shim would be run through node. So a script-less
install pays a Node.js startup on every call, and when stderr is a
terminal the placeholder says so, with the fix.

Fixes https://github.com/pnpm/pnpm/issues/14346
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (This is the Rust CLI's npm wrapper package; the TypeScript CLI ships a JS bin and has no placeholder.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (None needed.)

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NVbjeadNbk6aKH6pLx27dL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pnpm commands failing when installation scripts are skipped, including installs using `--ignore-scripts`, pnpm, or Bun.
  * pnpm now runs through Node.js when the native binary is unavailable.
  * Improved detection of the installed platform-specific binary.
  * Added a terminal warning recommending reinstallation with build scripts enabled for faster startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->