### PR TITLE
perf(install): share the parsed wanted lockfile and build its successor in parallel

### DIFF
--- a/.changeset/shared-lockfile-handle.md
+++ b/.changeset/shared-lockfile-handle.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces: the resolver now shares the already-parsed `pnpm-lock.yaml` instead of deep-copying it before every fresh resolution [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,6 +5409,7 @@ dependencies = [
  "pnpm-workspace-state",
  "pnpm-workspace-task-scheduler",
  "pretty_assertions",
+ "rayon",
  "reflink-copy",
  "rustc-hash 2.1.2",
  "serde",

--- a/pnpm/crates/lockfile/src/lazy_lockfile.rs
+++ b/pnpm/crates/lockfile/src/lazy_lockfile.rs
@@ -5,7 +5,7 @@ use crate::{
 use std::{
     collections::HashMap,
     path::PathBuf,
-    sync::{Mutex, OnceLock},
+    sync::{Arc, Mutex, OnceLock},
 };
 
 /// Wanted lockfile (`pnpm-lock.yaml`) whose read + parse are deferred
@@ -58,8 +58,11 @@ impl LazyLockfile {
     #[must_use]
     pub fn preloaded(lockfile: Option<Lockfile>) -> Self {
         let cell = OnceLock::new();
-        cell.set(LoadedWantedLockfile { lockfile, pre_merge_importers: None })
-            .expect("a fresh OnceLock accepts the first set");
+        cell.set(LoadedWantedLockfile {
+            lockfile: lockfile.map(Arc::new),
+            pre_merge_importers: None,
+        })
+        .expect("a fresh OnceLock accepts the first set");
         LazyLockfile { source: None, cell, fix_cell: OnceLock::new(), prefetch: Mutex::new(None) }
     }
 
@@ -92,7 +95,7 @@ impl LazyLockfile {
     /// error is returned without being cached, so a subsequent call
     /// retries — callers abort on the first error in practice.
     pub fn get(&self) -> Result<Option<&Lockfile>, LoadLockfileError> {
-        Ok(self.load()?.lockfile.as_ref())
+        Ok(self.load()?.lockfile.as_deref())
     }
 
     /// Load after discarding fields that a repairing resolution regenerates.
@@ -203,6 +206,19 @@ impl<'a> MaybeLazyLockfile<'a> {
             MaybeLazyLockfile::Loaded(lockfile) => Ok(lockfile),
             MaybeLazyLockfile::Lazy(lazy) => lazy.get(),
             MaybeLazyLockfile::Repair(lazy) => lazy.get_for_fix_merge(),
+        }
+    }
+
+    /// An `Arc` handle to the parsed wanted lockfile, for a consumer
+    /// that shares the document with long-lived machinery — the
+    /// resolver's lockfile-reuse seed above all — without deep-copying
+    /// a workspace-scale lockfile. `None` when no lockfile exists *or*
+    /// for the borrowed and repair variants, which hold no `Arc`;
+    /// callers fall back to cloning [`Self::get`]'s reference.
+    pub fn shared(self) -> Result<Option<Arc<Lockfile>>, LoadLockfileError> {
+        match self {
+            MaybeLazyLockfile::Lazy(lazy) => Ok(lazy.load()?.lockfile.clone()),
+            MaybeLazyLockfile::Loaded(_) | MaybeLazyLockfile::Repair(_) => Ok(None),
         }
     }
 

--- a/pnpm/crates/lockfile/src/load_lockfile.rs
+++ b/pnpm/crates/lockfile/src/load_lockfile.rs
@@ -11,6 +11,7 @@ use std::{
     env, fs,
     io::{self, ErrorKind},
     path::{Path, PathBuf},
+    sync::Arc,
 };
 
 const DEFAULT_YAML_MAX_EVENTS: usize = 1_000_000;
@@ -132,7 +133,9 @@ impl Lockfile {
         dir: &Path,
         selection: &WantedLockfileSelection,
     ) -> Result<Option<Self>, LoadLockfileError> {
-        Ok(Self::load_wanted_detailed(dir, selection)?.lockfile)
+        Ok(Self::load_wanted_detailed(dir, selection)?
+            .lockfile
+            .map(|lockfile| Arc::try_unwrap(lockfile).unwrap_or_else(|shared| (*shared).clone())))
     }
 
     /// [`Self::load_wanted`] keeping the importers the fold started from.
@@ -147,11 +150,14 @@ impl Lockfile {
                 let pre_merge_importers = lockfile.importers.clone();
                 let merged = merge_git_branch_lockfiles(lockfile, dir)?;
                 Ok(LoadedWantedLockfile {
-                    lockfile: Some(merged),
+                    lockfile: Some(Arc::new(merged)),
                     pre_merge_importers: Some(pre_merge_importers),
                 })
             } else {
-                Ok(LoadedWantedLockfile { lockfile: Some(lockfile), pre_merge_importers: None })
+                Ok(LoadedWantedLockfile {
+                    lockfile: Some(Arc::new(lockfile)),
+                    pre_merge_importers: None,
+                })
             };
         }
         Ok(LoadedWantedLockfile::default())
@@ -288,7 +294,11 @@ mod tests;
 /// manifests. `pre_merge_importers` is `None` when no fold was attempted.
 #[derive(Debug, Default, Clone)]
 pub struct LoadedWantedLockfile {
-    pub lockfile: Option<Lockfile>,
+    /// Behind an `Arc` so a consumer that seeds long-lived machinery
+    /// (the resolver's lockfile-reuse pass above all) can share the
+    /// parsed document instead of deep-copying a workspace-scale
+    /// lockfile.
+    pub lockfile: Option<Arc<Lockfile>>,
     pub pre_merge_importers: Option<HashMap<String, ProjectSnapshot>>,
 }
 
@@ -311,6 +321,7 @@ impl LoadedRepairLockfile {
     /// reads.
     pub(crate) fn from_loaded(loaded: LoadedWantedLockfile) -> Self {
         let views = loaded.lockfile.map(|merge| {
+            let merge = Arc::try_unwrap(merge).unwrap_or_else(|shared| (*shared).clone());
             let mut seed = merge.clone();
             seed.prepare_for_fix();
             RepairLockfileViews { seed, merge }

--- a/pnpm/crates/package-manager/Cargo.toml
+++ b/pnpm/crates/package-manager/Cargo.toml
@@ -75,6 +75,7 @@ is_ci           = { workspace = true }
 node-semver     = { workspace = true }
 pathdiff        = { workspace = true }
 pipe-trait      = { workspace = true }
+rayon                = { workspace = true }
 reflink-copy    = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/pnpm/crates/package-manager/Cargo.toml
+++ b/pnpm/crates/package-manager/Cargo.toml
@@ -75,7 +75,7 @@ is_ci           = { workspace = true }
 node-semver     = { workspace = true }
 pathdiff        = { workspace = true }
 pipe-trait      = { workspace = true }
-rayon                = { workspace = true }
+rayon           = { workspace = true }
 reflink-copy    = { workspace = true }
 serde           = { workspace = true }
 serde_json      = { workspace = true }

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -6,6 +6,7 @@
 //! graph rather than building one merged per-depPath snapshot and
 //! fanning it out on write.
 
+use rayon::prelude::*;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use derive_more::{Display, Error};
@@ -244,31 +245,45 @@ pub fn dependencies_graph_to_lockfile(
         },
     )?;
 
-    let mut importers: HashMap<String, ProjectSnapshot> =
-        HashMap::with_capacity(importer_inputs.len());
-    for (id, input) in &importer_inputs {
-        let previous_importer = previous_importers.and_then(|imps| imps.get(id));
-        // Effective update scope for this importer, mirroring the resolver's
-        // `update_reuse_scope_for`: a global `None` (bare `update`) applies to
-        // every importer; otherwise the per-importer entry wins, falling back
-        // to the global. This is what lets a `pacquet update <name> --recursive`
-        // target the named dependency in the importer that declares it while
-        // leaving untouched importers on their global scope.
-        let effective_update_reuse_scope = if matches!(update_reuse_scope, UpdateReuseScope::None) {
-            &update_reuse_scope
-        } else {
-            update_reuse_scopes_by_importer.get(id).unwrap_or(&update_reuse_scope)
-        };
-        importers.insert(
-            id.clone(),
-            build_importer(
+    // Each importer's snapshot reads only its own input plus the shared
+    // graph, so a workspace-scale importer list fans out across the
+    // rayon pool; the serial fold below keeps the first error in
+    // importer order, like the loop it replaces.
+    let importer_results: Vec<(
+        &String,
+        Result<ProjectSnapshot, DependenciesGraphToLockfileError>,
+    )> = importer_inputs
+        .iter()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(id, input)| {
+            let previous_importer = previous_importers.and_then(|imps| imps.get(id));
+            // Effective update scope for this importer, mirroring the resolver's
+            // `update_reuse_scope_for`: a global `None` (bare `update`) applies to
+            // every importer; otherwise the per-importer entry wins, falling back
+            // to the global. This is what lets a `pacquet update <name> --recursive`
+            // target the named dependency in the importer that declares it while
+            // leaving untouched importers on their global scope.
+            let effective_update_reuse_scope =
+                if matches!(update_reuse_scope, UpdateReuseScope::None) {
+                    &update_reuse_scope
+                } else {
+                    update_reuse_scopes_by_importer.get(id).unwrap_or(&update_reuse_scope)
+                };
+            let importer = build_importer(
                 input,
                 graph,
                 &ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers },
                 previous_importer,
                 effective_update_reuse_scope,
-            )?,
-        );
+            );
+            (id, importer)
+        })
+        .collect();
+    let mut importers: HashMap<String, ProjectSnapshot> =
+        HashMap::with_capacity(importer_inputs.len());
+    for (id, importer) in importer_results {
+        importers.insert(id.clone(), importer?);
     }
 
     let catalog_snapshots = build_catalog_snapshots(&importers, catalogs);
@@ -698,27 +713,43 @@ fn build_packages_and_snapshots(
     optional_overrides: &HashMap<DepPath, bool>,
     sources: &PackageMetadataSources<'_>,
 ) -> Result<PackagesAndSnapshots, DependenciesGraphToLockfileError> {
-    let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
-    let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
-
-    for node in graph.values() {
-        let dep_path = node.dep_path.as_str();
-        let snapshot_key = match dep_path.parse::<PackageKey>() {
-            Ok(snapshot_key) => snapshot_key,
-            // A workspace link is the one node with no row of its own —
-            // it resolves as its own importer and pnpm writes it none
-            // either.
-            Err(_) if dep_path.starts_with("link:") => continue,
-            Err(source) => {
-                return Err(DependenciesGraphToLockfileError::UnkeyedDepPath {
+    // Every node's snapshot and metadata read only that node plus the
+    // shared inputs, so the nodes fan out across the rayon pool; the
+    // serial fold below walks them in the graph's iteration order, so
+    // the first-of-a-key metadata insert and the first error stay the
+    // ones the serial loop would have kept.
+    struct BuiltNode<'graph> {
+        node: &'graph pnpm_resolving_deps_resolver::DependenciesGraphNode,
+        snapshot_key: PackageKey,
+        snapshot: SnapshotEntry,
+    }
+    let built: Vec<Result<Option<BuiltNode<'_>>, DependenciesGraphToLockfileError>> = graph
+        .values()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|node| {
+            let dep_path = node.dep_path.as_str();
+            let snapshot_key = match dep_path.parse::<PackageKey>() {
+                Ok(snapshot_key) => Ok(snapshot_key),
+                // A workspace link is the one node with no row of its own —
+                // it resolves as its own importer and pnpm writes it none
+                // either.
+                Err(_) if dep_path.starts_with("link:") => return Ok(None),
+                Err(source) => Err(DependenciesGraphToLockfileError::UnkeyedDepPath {
                     dep_path: dep_path.to_string(),
                     source: Box::new(source),
-                });
-            }
-        };
-        let metadata_key = snapshot_key.without_peer();
+                }),
+            }?;
+            let snapshot = build_snapshot_entry(node, graph, optional_overrides);
+            Ok(Some(BuiltNode { node, snapshot_key, snapshot }))
+        })
+        .collect();
 
-        let snapshot = build_snapshot_entry(node, graph, optional_overrides);
+    let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
+    let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
+    for built_node in built {
+        let Some(BuiltNode { node, snapshot_key, snapshot }) = built_node? else { continue };
+        let metadata_key = snapshot_key.without_peer();
         snapshots.insert(snapshot_key, snapshot);
 
         if let std::collections::hash_map::Entry::Vacant(entry) = packages.entry(metadata_key) {

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2921,3 +2921,99 @@ fn unchanged_resolutions_keep_their_previous_package_metadata() {
         "a changed resolution takes the freshly served metadata",
     );
 }
+
+/// With several unkeyable nodes, the reported failure must be the first
+/// one in the graph's own iteration order — the parallel node fan-out
+/// folds its results in that order, like the serial loop it replaced.
+#[test]
+fn the_first_unkeyable_node_in_graph_order_is_the_reported_one() {
+    let mut graph: DependenciesGraph = HashMap::default();
+    for name in ["alpha", "beta"] {
+        let mut node = make_node(
+            name,
+            "1.0.0",
+            json!({ "name": name, "version": "1.0.0" }),
+            BTreeMap::new(),
+            BTreeMap::new(),
+            HashSet::default(),
+        );
+        node.dep_path = DepPath::from(format!("!broken-{name}!"));
+        assert!(
+            node.dep_path.as_str().parse::<PackageKey>().is_err(),
+            "the fixture path must not key a snapshot row",
+        );
+        graph.insert(node.dep_path.clone(), node);
+    }
+    let expected = graph
+        .values()
+        .map(|node| node.dep_path.as_str().to_string())
+        .next()
+        .expect("two nodes were inserted");
+
+    let (_tmp, manifest) = write_manifest(json!({ "name": "root", "version": "1.0.0" }));
+    let result = try_dependencies_graph_to_lockfile(single_importer_opts(
+        &manifest,
+        &graph,
+        BTreeMap::new(),
+        false,
+        false,
+        None,
+        None,
+    ));
+
+    let Err(DependenciesGraphToLockfileError::UnkeyedDepPath { dep_path, .. }) = result else {
+        panic!("an unkeyable dep path must fail the conversion");
+    };
+    assert_eq!(dep_path, expected);
+}
+
+/// A multi-importer workspace built through the parallel importer
+/// fan-out must record every importer with the entries the serial loop
+/// recorded.
+#[test]
+fn every_importer_of_a_workspace_is_recorded() {
+    let node = make_node(
+        "dep",
+        "1.0.0",
+        json!({ "name": "dep", "version": "1.0.0" }),
+        BTreeMap::new(),
+        BTreeMap::new(),
+        HashSet::default(),
+    );
+    let dep_path = node.dep_path.clone();
+    let mut graph: DependenciesGraph = HashMap::default();
+    graph.insert(dep_path.clone(), node);
+
+    let manifests: Vec<(TempDir, PackageManifest)> = ["root", "a", "b"]
+        .into_iter()
+        .map(|name| {
+            write_manifest(json!({
+                "name": name, "version": "1.0.0", "dependencies": { "dep": "^1.0.0" },
+            }))
+        })
+        .collect();
+    let direct: BTreeMap<String, DepPath> = BTreeMap::from([("dep".to_string(), dep_path.clone())]);
+    let mut opts =
+        single_importer_opts(&manifests[0].1, &graph, direct.clone(), false, false, None, None);
+    opts.importers = [".", "packages/a", "packages/b"]
+        .into_iter()
+        .zip(&manifests)
+        .map(|(id, (_, manifest))| {
+            (
+                id.to_string(),
+                ImporterLockfileInput { manifest, direct_dependencies_by_alias: direct.clone() },
+            )
+        })
+        .collect();
+
+    let lockfile = dependencies_graph_to_lockfile(opts);
+    for id in [".", "packages/a", "packages/b"] {
+        let importer = lockfile.importers.get(id).expect("every importer must be recorded");
+        let recorded = importer
+            .dependencies
+            .as_ref()
+            .and_then(|deps| deps.get(&PkgName::parse("dep").expect("parse alias")))
+            .expect("the direct dependency must be recorded");
+        assert_eq!(recorded.specifier, "^1.0.0", "importer {id}");
+    }
+}

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -2992,7 +2992,7 @@ fn every_importer_of_a_workspace_is_recorded() {
             }))
         })
         .collect();
-    let direct: BTreeMap<String, DepPath> = BTreeMap::from([("dep".to_string(), dep_path.clone())]);
+    let direct: BTreeMap<String, DepPath> = BTreeMap::from([("dep".to_string(), dep_path)]);
     let mut opts =
         single_importer_opts(&manifests[0].1, &graph, direct.clone(), false, false, None, None);
     opts.importers = [".", "packages/a", "packages/b"]

--- a/pnpm/crates/package-manager/src/install/materialize.rs
+++ b/pnpm/crates/package-manager/src/install/materialize.rs
@@ -16,6 +16,11 @@ pub(super) struct MaterializationInputs<'a, 'install> {
     pub(super) config: &'static Config,
     pub(super) manifest: &'a PackageManifest,
     pub(super) lockfile: Option<&'a Lockfile>,
+    /// An `Arc` handle to the same document as [`Self::lockfile`], when
+    /// the lazy loader holds one. Lets the fresh path seed the resolver
+    /// without deep-copying a workspace-scale lockfile; `None` falls
+    /// back to the copy.
+    pub(super) lockfile_shared: Option<Arc<Lockfile>>,
     pub(super) merge_wanted_lockfile: Option<&'a Lockfile>,
     pub(super) take_frozen_path: bool,
     pub(super) lockfile_verification_override:
@@ -106,6 +111,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
         config,
         manifest,
         lockfile,
+        lockfile_shared,
         merge_wanted_lockfile,
         take_frozen_path,
         lockfile_verification_override,
@@ -398,6 +404,7 @@ pub(super) async fn materialize<Reporter: self::Reporter + 'static>(
             // entries keep their pins on rewrite (the `update: false`
             // mode). State 4 (no lockfile) passes `None`.
             wanted_lockfile: lockfile,
+            wanted_lockfile_shared: lockfile_shared,
             merge_wanted_lockfile,
             node_version: effective_node_version,
             early_host_detection,

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -1148,7 +1148,14 @@ where
             config,
             manifest,
             lockfile,
-            lockfile_shared,
+            // The dispatch above may have swapped `lockfile` for a
+            // synthesized, branch-pruned, or fast-updated document; the
+            // loader's handle is forwarded only while it still *is* the
+            // lockfile, so a downstream consumer can never seed from a
+            // superseded document.
+            lockfile_shared: lockfile_shared.filter(|shared| {
+                lockfile.is_some_and(|lockfile| std::ptr::eq(lockfile, &**shared))
+            }),
             merge_wanted_lockfile,
             take_frozen_path,
             lockfile_verification_override,

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -503,25 +503,29 @@ where
         // below: a load that failed leaves nothing cached, so asking later
         // would retry it and turn a lockfile this arm chose to ignore into
         // a fatal one.
-        let (lockfile, merge_wanted_lockfile, pre_merge_importers) = match lockfile_source.get() {
-            Ok(lockfile) => (
-                lockfile,
-                lockfile_source.get_for_merge().map_err(InstallError::LoadWantedLockfile)?,
-                lockfile_source.pre_merge_importers().map_err(InstallError::LoadWantedLockfile)?,
-            ),
-            Err(error) if !frozen_lockfile => {
-                Reporter::emit(&LogEvent::Pnpm(PnpmLog {
-                    level: LogLevel::Warn,
-                    message: format!(
-                        "Ignoring broken lockfile at {}: {error}",
-                        workspace_root.display(),
-                    ),
-                    prefix: prefix.clone(),
-                }));
-                (None, None, None)
-            }
-            Err(error) => return Err(InstallError::LoadWantedLockfile(error)),
-        };
+        let (lockfile, lockfile_shared, merge_wanted_lockfile, pre_merge_importers) =
+            match lockfile_source.get() {
+                Ok(lockfile) => (
+                    lockfile,
+                    lockfile_source.shared().map_err(InstallError::LoadWantedLockfile)?,
+                    lockfile_source.get_for_merge().map_err(InstallError::LoadWantedLockfile)?,
+                    lockfile_source
+                        .pre_merge_importers()
+                        .map_err(InstallError::LoadWantedLockfile)?,
+                ),
+                Err(error) if !frozen_lockfile => {
+                    Reporter::emit(&LogEvent::Pnpm(PnpmLog {
+                        level: LogLevel::Warn,
+                        message: format!(
+                            "Ignoring broken lockfile at {}: {error}",
+                            workspace_root.display(),
+                        ),
+                        prefix: prefix.clone(),
+                    }));
+                    (None, None, None, None)
+                }
+                Err(error) => return Err(InstallError::LoadWantedLockfile(error)),
+            };
         tracing::info!(
             target: "pacquet::install::phase",
             phase = "load_wanted_lockfile",
@@ -1144,6 +1148,7 @@ where
             config,
             manifest,
             lockfile,
+            lockfile_shared,
             merge_wanted_lockfile,
             take_frozen_path,
             lockfile_verification_override,

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -1154,7 +1154,7 @@ where
             // lockfile, so a downstream consumer can never seed from a
             // superseded document.
             lockfile_shared: lockfile_shared.filter(|shared| {
-                lockfile.is_some_and(|lockfile| std::ptr::eq(lockfile, &**shared))
+                lockfile.is_some_and(|lockfile| std::ptr::eq(lockfile, Arc::as_ptr(shared)))
             }),
             merge_wanted_lockfile,
             take_frozen_path,

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -135,6 +135,10 @@ pub struct InstallWithFreshLockfile<'a, DependencyGroupList> {
     /// pins. `None` on the no-lockfile path. Corresponds to the
     /// `update: false` resolver mode.
     pub wanted_lockfile: Option<&'a Lockfile>,
+    /// An `Arc` handle to the same document as [`Self::wanted_lockfile`],
+    /// when the loader holds one; `None` falls back to a deep copy where
+    /// the resolver needs an owned handle.
+    pub wanted_lockfile_shared: Option<Arc<Lockfile>>,
     /// Intact prior lockfile used to restore unselected projects after a
     /// filtered repair resolves against a sanitized seed.
     pub merge_wanted_lockfile: Option<&'a Lockfile>,
@@ -775,6 +779,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             workspace_packages,
             update_checksums,
             wanted_lockfile,
+            wanted_lockfile_shared,
             merge_wanted_lockfile,
             node_version,
             early_host_detection,
@@ -974,6 +979,10 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             None
         };
         let wanted_lockfile = fixed_wanted_lockfile.as_ref().or(wanted_lockfile);
+        // The repair copy above replaced the document, so the loader's
+        // handle no longer describes `wanted_lockfile`.
+        let wanted_lockfile_shared =
+            if fixed_wanted_lockfile.is_some() { None } else { wanted_lockfile_shared };
 
         let (preferred_versions_seed, preferred_versions_seeds_by_importer) =
             resolve::preferred_versions_seeds(
@@ -1087,6 +1096,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             config,
             catalogs: &catalogs,
             wanted_lockfile,
+            wanted_lockfile_shared: wanted_lockfile_shared.as_ref(),
             package_extensions_checksum: package_extensions_checksum.as_deref(),
             parsed_overrides: parsed_overrides.as_deref(),
             resolved_overrides: resolved_overrides.as_ref(),
@@ -1118,6 +1128,7 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // lockfile still pins the edges the drift does not reach (see
         // `WorkspaceResolveOptions::reuse_lockfile_subtrees`).
         let resolution_lockfile = lockfile_reuse_seed
+            .or_else(|| wanted_lockfile_shared.clone())
             .or_else(|| wanted_lockfile.map(|lockfile| Arc::new(lockfile.clone())));
 
         let phase_start = std::time::Instant::now();

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -223,6 +223,9 @@ pub(super) struct ReuseSeedInputs<'a> {
     pub catalogs: &'a Catalogs,
     /// The previous run's lockfile, the only reuse candidate.
     pub wanted_lockfile: Option<&'a Lockfile>,
+    /// An `Arc` handle to the same document, when the loader holds one;
+    /// the reuse-verbatim path shares it instead of deep-copying.
+    pub wanted_lockfile_shared: Option<&'a Arc<Lockfile>>,
     pub package_extensions_checksum: Option<&'a str>,
     pub parsed_overrides: Option<&'a [pnpm_config_parse_overrides::VersionOverride]>,
     pub resolved_overrides: Option<&'a IndexMap<String, String>>,
@@ -264,6 +267,7 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
         config,
         catalogs,
         wanted_lockfile,
+        wanted_lockfile_shared,
         package_extensions_checksum,
         parsed_overrides,
         resolved_overrides,
@@ -336,7 +340,15 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
     };
 
     if override_settings_match {
-        return Some(Arc::new(catalog_rewrite.unwrap_or_else(|| lockfile.clone())));
+        return Some(match catalog_rewrite {
+            Some(rewritten) => Arc::new(rewritten),
+            // `lockfile` is `wanted_lockfile` narrowed by the filter
+            // above, so the loader's handle to it reuses the parsed
+            // document verbatim.
+            None => {
+                wanted_lockfile_shared.map(Arc::clone).unwrap_or_else(|| Arc::new(lockfile.clone()))
+            }
+        });
     }
     if !fast_override_eligible {
         return None;

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -345,9 +345,7 @@ pub(super) async fn lockfile_reuse_seed(inputs: ReuseSeedInputs<'_>) -> Option<A
             // `lockfile` is `wanted_lockfile` narrowed by the filter
             // above, so the loader's handle to it reuses the parsed
             // document verbatim.
-            None => {
-                wanted_lockfile_shared.map(Arc::clone).unwrap_or_else(|| Arc::new(lockfile.clone()))
-            }
+            None => wanted_lockfile_shared.map_or_else(|| Arc::new(lockfile.clone()), Arc::clone),
         });
     }
     if !fast_override_eligible {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. The next chunk from the profile: two costs that scale with lockfile size rather than with what changed.

- **The resolver's reuse seed deep-copied the whole parsed `pnpm-lock.yaml`.** Both the reuse-verbatim path (`lockfile_reuse_seed`'s happy exit) and the withheld-seed fallback built their `Arc<Lockfile>` via `Arc::new(lockfile.clone())` — a full deep copy of a workspace-scale document, paid again at drop. The lazy loader now holds the parsed document behind an `Arc` (`LoadedWantedLockfile.lockfile: Option<Arc<Lockfile>>`), and a new `MaybeLazyLockfile::shared` hands installs an `Arc` handle threaded down to those two sites. The borrowed (`Loaded`) and repair variants hold no `Arc` and return `None`, keeping today's copy there; the `--fix-lockfile` arm explicitly invalidates the handle, since its repair copy replaces the document.
- **`dependencies_graph_to_lockfile` built everything serially.** Each importer snapshot and each package/snapshot row reads only its own input or node plus shared references, so both loops now fan out across the rayon pool. The serial folds walk the results in the original iteration order, so the first-of-a-key `packages:` insert and the first reported error stay exactly what the serial loops kept.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| whole warm update (fast-run cluster of 8) | ~1.32 s | ~1.27 s |

The written `pnpm-lock.yaml` is byte-identical, and all 1,029 lockfile + package-manager tests pass unchanged.

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.27 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
Two costs scaled with lockfile size rather than with what changed:

- Seeding the resolver's lockfile-reuse pass deep-copied the whole
  parsed pnpm-lock.yaml - once in the reuse-verbatim path and once in
  the withheld-seed fallback - and each copy paid again when dropped.
  The lazy loader now holds the parsed document behind an Arc, and a
  new MaybeLazyLockfile::shared hands installs an Arc handle; the
  borrowed and repair variants return None and keep today's copy. The
  fix-lockfile arm invalidates the handle, since its repair copy
  replaces the document.

- dependencies_graph_to_lockfile built every importer snapshot and
  every package/snapshot row serially. Each reads only its own node or
  input plus shared references, so both loops now fan out across the
  rayon pool; the serial folds walk the results in the original
  iteration order, keeping the first-of-a-key metadata insert and the
  first error exactly what the serial loops kept.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), whole-run wall time drops by ~60 ms to ~1.27 s
median and the written lockfile is byte-identical.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — the loader contracts and the
  generated lockfile are pinned by the existing suites, all passing unchanged;
  byte-identity was verified on the reproduction.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790947263&installation_model_id=426870&pr_number=14465&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14465&signature=9c94189e675ba12d208a298c21b6aaa5db267b2685b5d19acdbc26dd222a901f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved install speed in large workspaces by reusing parsed lockfile data instead of repeatedly copying it.
  * Parallelized dependency graph processing to accelerate lockfile generation and improve responsiveness.
* **Bug Fixes**
  * Preserved existing handling for repaired and invalid lockfiles while safely managing shared lockfile data during installation.
  * Improved consistency when processing workspace importers and reporting dependency graph errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->