### PR TITLE
fix(peers): hoist optional peers into locked direct deps in one pass

### DIFF
--- a/.changeset/dedupe-hoisted-optional-peer-one-pass.md
+++ b/.changeset/dedupe-hoisted-optional-peer-one-pass.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dedupe` converges in one pass when it re-resolves a lockfile written before optional peers were hoisted: a direct dependency whose locked peer suffix did not record a hoisted optional peer now gains it in the same run as its transitive dependencies, so a second `pnpm dedupe` no longer changes the lockfile [#14455](https://github.com/pnpm/pnpm/issues/14455).

--- a/.changeset/dedupe-hoisted-optional-peer-one-pass.md
+++ b/.changeset/dedupe-hoisted-optional-peer-one-pass.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm dedupe` converges in one pass when it re-resolves a lockfile written before optional peers were hoisted: a direct dependency whose locked peer suffix did not record a hoisted optional peer now gains it in the same run as its transitive dependencies, so a second `pnpm dedupe` no longer changes the lockfile [#14455](https://github.com/pnpm/pnpm/issues/14455).
+`pnpm dedupe` now converges in one pass when it re-resolves a lockfile created by pnpm 11, so a second run no longer changes the lockfile [#14455](https://github.com/pnpm/pnpm/issues/14455).

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -484,8 +484,9 @@ fn dedupe_check_does_not_persist_minimum_release_age_excludes() {
     drop((root, mock_instance));
 }
 
-/// A lockfile written before optional peers were hoisted records no
-/// `(peer)` segment for a peer that only a sibling's subtree provides.
+/// A lockfile whose snapshot keys carry no `(peer)` segment for an
+/// optional peer that only a sibling's subtree provides — the shape
+/// pnpm 11 writes for this graph — must be re-keyed completely.
 /// The graph mirrors pnpm/pnpm#14455: `optional-peer-c-consumer` and its
 /// auto-installed peer both reach `optional-peer-c-host`, whose optional
 /// `peer-c` is provided by `abc-regular-deps`. One `dedupe` pass must

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -1,7 +1,17 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
-use std::{fs, process::Command};
+use pnpm_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    command_env::CommandTestExt,
+};
+use std::{fs, path::Path, process::Command};
+
+fn pacquet_at(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .without_ambient_pnpm_config()
+}
 
 #[test]
 fn dedupe_writes_lockfile() {
@@ -470,6 +480,66 @@ fn dedupe_check_does_not_persist_minimum_release_age_excludes() {
         manifest_before, manifest_after,
         "dedupe --check must not modify pnpm-workspace.yaml",
     );
+
+    drop((root, mock_instance));
+}
+
+/// A lockfile written before optional peers were hoisted records no
+/// `(peer)` segment for a peer that only a sibling's subtree provides.
+/// The graph mirrors pnpm/pnpm#14455: `optional-peer-c-consumer` and its
+/// auto-installed peer both reach `optional-peer-c-host`, whose optional
+/// `peer-c` is provided by `abc-regular-deps`. One `dedupe` pass must
+/// re-key every affected snapshot — the consumer's own key included —
+/// and a second pass must change nothing.
+#[test]
+fn dedupe_re_keys_a_hoisted_optional_peer_in_one_pass() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/abc-regular-deps": "1.0.0",
+                "@pnpm.e2e/optional-peer-c-consumer": "1.0.0",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    let converged = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    let consumer_key = concat!(
+        "@pnpm.e2e/optional-peer-c-consumer@1.0.0",
+        "(@pnpm.e2e/optional-peer-c-consumer-peer@1.0.0(@pnpm.e2e/peer-c@1.0.0))",
+        "(@pnpm.e2e/peer-c@1.0.0)",
+    );
+    assert!(
+        converged.contains(consumer_key),
+        "a fresh resolution must hoist peer-c into the consumer's key:\n{converged}",
+    );
+
+    let hoisted_host_snapshot = concat!(
+        "  '@pnpm.e2e/optional-peer-c-host@1.0.0(@pnpm.e2e/peer-c@1.0.0)':\n",
+        "    optionalDependencies:\n",
+        "      '@pnpm.e2e/peer-c': 1.0.0\n",
+    );
+    assert!(converged.contains(hoisted_host_snapshot), "unexpected lockfile shape:\n{converged}");
+    let stale = converged
+        .replace(hoisted_host_snapshot, "  '@pnpm.e2e/optional-peer-c-host@1.0.0': {}\n")
+        .replace("(@pnpm.e2e/peer-c@1.0.0)", "");
+    fs::write(&lockfile_path, &stale).expect("write the pre-hoisting lockfile");
+
+    pacquet_at(&workspace).with_args(["dedupe", "--lockfile-only"]).assert().success();
+    let first_pass = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert_eq!(first_pass, converged, "one dedupe pass must reach the fresh resolution");
+
+    pacquet_at(&workspace).with_args(["dedupe", "--lockfile-only"]).assert().success();
+    let second_pass = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    assert_eq!(second_pass, first_pass, "a second dedupe pass must change nothing");
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -535,10 +535,12 @@ fn dedupe_re_keys_a_hoisted_optional_peer_in_one_pass() {
 
     pacquet_at(&workspace).with_args(["dedupe", "--lockfile-only"]).assert().success();
     let first_pass = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    eprintln!("first pass:\n{first_pass}\nfresh resolution:\n{converged}");
     assert_eq!(first_pass, converged, "one dedupe pass must reach the fresh resolution");
 
     pacquet_at(&workspace).with_args(["dedupe", "--lockfile-only"]).assert().success();
     let second_pass = fs::read_to_string(&lockfile_path).expect("read pnpm-lock.yaml");
+    eprintln!("second pass:\n{second_pass}");
     assert_eq!(second_pass, first_pass, "a second dedupe pass must change nothing");
 
     drop((root, mock_instance));

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1250,22 +1250,6 @@ impl WorkspaceTreeCtx {
             .collect()
     }
 
-    pub(crate) fn set_direct_locked_peer_names(
-        &self,
-        direct: &[DirectDep],
-        names_by_alias: &HashMap<String, Arc<HashSet<String>>>,
-    ) {
-        let mut tree = lock_recoverable(&self.dependencies_tree);
-        for dep in direct {
-            let Some(names) = names_by_alias.get(&dep.alias) else {
-                continue;
-            };
-            if let Some(node) = tree.get_mut(&dep.node_id) {
-                node.locked_mut().locked_peer_names = Some(Arc::clone(names));
-            }
-        }
-    }
-
     /// Set which dependencies `pacquet update` excludes from reuse. See
     /// [`UpdateReuseScope`].
     #[must_use]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer.rs
@@ -342,7 +342,6 @@ pub(crate) struct ImporterHoistState {
     /// peer walk resolves them at their tree position instead of the
     /// importer root.
     hoisted_peer_provider_node_ids: HashSet<crate::NodeId>,
-    hoisted_optional_peer_node_ids: HashSet<crate::NodeId>,
     /// Whether the last required round converged with no missing
     /// required peers left. A converged importer's next required round
     /// is a no-op unless its inputs changed since: an optional hoist
@@ -467,20 +466,12 @@ impl ImporterHoistState {
             .with_patched_dependencies(patched_dependencies)
             .with_resolution_mode(pick_lowest_direct, subdep_published_by)
             .with_catalogs(catalogs);
-        let ImporterLockedPeerContext {
-            versions: locked_peer_versions,
-            names_by_alias: mut locked_peer_names_by_alias,
-        } = importer_locked_peer_context(
+        let locked_peer_versions = Arc::new(importer_locked_peer_versions(
             ctx.workspace().wanted_lockfile().map(AsRef::as_ref),
             importer_id,
-        );
-        let locked_peer_versions = Arc::new(locked_peer_versions);
+        ));
         let locked_peer_names = Arc::new(locked_peer_versions.keys().cloned().collect());
-        let changed_direct_deps = record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
-        discard_changed_direct_dep_peer_context(
-            &mut locked_peer_names_by_alias,
-            &changed_direct_deps,
-        );
+        record_changed_direct_deps(&ctx, importer_id, &initial_wanted);
         let wanted_specifier_by_alias: BTreeMap<String, String> = initial_wanted
             .iter()
             .map(|(alias, range, ..)| (alias.clone(), range.clone()))
@@ -500,7 +491,6 @@ impl ImporterHoistState {
             &ParentPkgAliases::root(parent_pkg_aliases.clone()),
         )
         .await?;
-        ctx.workspace().set_direct_locked_peer_names(&direct, &locked_peer_names_by_alias);
         parent_pkg_aliases.extend(direct.iter().map(|dep| dep.alias.clone()));
         ctx.resolve_new_direct_deps_as_subdeps();
         Ok(ImporterHoistState {
@@ -510,7 +500,6 @@ impl ImporterHoistState {
             workspace_root_deps: Arc::default(),
             wanted_specifier_by_alias,
             hoisted_peer_provider_node_ids: HashSet::default(),
-            hoisted_optional_peer_node_ids: HashSet::default(),
             discovery_converged: false,
             converged_children_rewrites: 0,
             walked_direct_len: 0,
@@ -565,7 +554,6 @@ impl ImporterHoistState {
             modules_dir: self.modules_dir.clone(),
             hoist_missing_scope: None,
             hoisted_peer_provider_node_ids: self.hoisted_peer_provider_node_ids.clone(),
-            hoisted_optional_peer_node_ids: self.hoisted_optional_peer_node_ids.clone(),
             ..ResolvePeersOptions::default()
         }
     }
@@ -869,8 +857,6 @@ impl ImporterHoistState {
             &ParentPkgAliases::root(self.parent_pkg_aliases.clone()),
         )
         .await?;
-        self.hoisted_optional_peer_node_ids
-            .extend(new_direct.iter().map(|dep| dep.node_id.clone()));
         self.direct.extend(new_direct);
         // The direct set changed; the next required round must
         // re-discover so the hoisted names leave the missing buckets.
@@ -883,10 +869,8 @@ impl ImporterHoistState {
     /// pass would be discarded), together with the `NodeIds` of the peer
     /// providers among them (see
     /// [`ResolvePeersOptions::hoisted_peer_provider_node_ids`]).
-    pub(crate) fn into_direct(
-        self,
-    ) -> (Vec<DirectDep>, HashSet<crate::NodeId>, HashSet<crate::NodeId>) {
-        (self.direct, self.hoisted_peer_provider_node_ids, self.hoisted_optional_peer_node_ids)
+    pub(crate) fn into_direct(self) -> (Vec<DirectDep>, HashSet<crate::NodeId>) {
+        (self.direct, self.hoisted_peer_provider_node_ids)
     }
 
     /// Run the final per-importer peer pass and emit the result. Used
@@ -899,41 +883,27 @@ impl ImporterHoistState {
     }
 }
 
-fn discard_changed_direct_dep_peer_context(
-    names_by_alias: &mut HashMap<String, Arc<HashSet<String>>>,
-    changed_direct_deps: &HashSet<PkgName>,
-) {
-    names_by_alias.retain(|alias, _| {
-        alias.parse::<PkgName>().is_ok_and(|name| !changed_direct_deps.contains(&name))
-    });
-}
-
-struct ImporterLockedPeerContext {
-    versions: HashMap<String, HashSet<String>>,
-    names_by_alias: HashMap<String, Arc<HashSet<String>>>,
-}
-
-fn importer_locked_peer_context(
+/// The peer versions the wanted lockfile pinned, by peer name: those on
+/// the importer's direct dependencies, or on every snapshot for an
+/// importer the lockfile does not know yet. The optional-peer hoist
+/// only picks versions from this set, and its names stay eligible for
+/// importer-local hoisting (see [`HoistMissingScope::locked_peer_names`]).
+fn importer_locked_peer_versions(
     wanted_lockfile: Option<&pnpm_lockfile::Lockfile>,
     importer_id: &str,
-) -> ImporterLockedPeerContext {
+) -> HashMap<String, HashSet<String>> {
     let Some(lockfile) = wanted_lockfile else {
-        return ImporterLockedPeerContext {
-            versions: HashMap::default(),
-            names_by_alias: HashMap::default(),
-        };
+        return HashMap::default();
     };
+    let mut versions = HashMap::<String, HashSet<String>>::default();
     let Some(importer) = lockfile.importers.get(importer_id) else {
-        let mut versions = HashMap::<String, HashSet<String>>::default();
         for (key, snapshot) in lockfile.snapshots.iter().flatten() {
             for (name, version) in locked_peer_versions_for_key(lockfile, key, Some(snapshot)) {
                 versions.entry(name).or_default().insert(version);
             }
         }
-        return ImporterLockedPeerContext { versions, names_by_alias: HashMap::default() };
+        return versions;
     };
-    let mut versions = HashMap::<String, HashSet<String>>::default();
-    let mut names_by_alias = HashMap::default();
     for (alias, dependency) in importer.dependencies_by_groups([
         DependencyGroup::Prod,
         DependencyGroup::Optional,
@@ -942,17 +912,12 @@ fn importer_locked_peer_context(
         let Some(key) = dependency.version.resolved_key(alias) else {
             continue;
         };
-        let mut names = HashSet::default();
         let snapshot = lockfile.snapshots.as_ref().and_then(|snapshots| snapshots.get(&key));
         for (name, version) in locked_peer_versions_for_key(lockfile, &key, snapshot) {
-            names.insert(name.clone());
             versions.entry(name).or_default().insert(version);
         }
-        if !names.is_empty() {
-            names_by_alias.insert(alias.to_string(), Arc::new(names));
-        }
     }
-    ImporterLockedPeerContext { versions, names_by_alias }
+    versions
 }
 
 /// The peer name/version pairs the wanted lockfile pinned for `key`.

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_importer/tests.rs
@@ -13,17 +13,14 @@ use pnpm_resolving_resolver_base::{
 use pretty_assertions::assert_eq;
 use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 
-use super::{
-    ImporterLockedPeerContext, discard_changed_direct_dep_peer_context,
-    importer_locked_peer_context, merge_ranges,
-};
+use super::{importer_locked_peer_versions, merge_ranges};
 use crate::{
     DepPath, ResolveDependencyTreeError, resolve_importer,
     resolve_importer::{ResolveImporterError, ResolveImporterOptions},
 };
 
 #[test]
-fn locked_peer_context_is_recorded_by_direct_alias() {
+fn locked_peer_versions_are_recorded_for_direct_deps() {
     use pnpm_lockfile::{
         ComVer, ImporterDepVersion, Lockfile, LockfileVersion, PkgName, PkgVerPeer,
         ProjectSnapshot, ResolvedDependencySpec,
@@ -60,35 +57,9 @@ fn locked_peer_context_is_recorded_by_direct_alias() {
         extra: pnpm_lockfile::LockfileExtra::default(),
     };
 
-    let ImporterLockedPeerContext { versions, names_by_alias } =
-        importer_locked_peer_context(Some(&lockfile), "app");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "app");
 
     assert_eq!(versions["peer"], HashSet::from_iter(["2.0.0".to_string()]));
-    assert_eq!(names_by_alias["consumer"].as_ref(), &HashSet::from_iter(["peer".to_string()]));
-}
-
-#[test]
-fn changed_direct_dependency_discards_prior_peer_context() {
-    use pnpm_lockfile::PkgName;
-    use std::sync::Arc;
-
-    let mut names_by_alias = HashMap::from_iter([
-        ("changed".to_string(), Arc::new(HashSet::from_iter(["old-peer".to_string()]))),
-        ("unchanged".to_string(), Arc::new(HashSet::from_iter(["peer".to_string()]))),
-    ]);
-
-    discard_changed_direct_dep_peer_context(
-        &mut names_by_alias,
-        &HashSet::from_iter([PkgName::parse("changed").unwrap()]),
-    );
-
-    assert_eq!(
-        names_by_alias,
-        HashMap::from_iter([(
-            "unchanged".to_string(),
-            Arc::new(HashSet::from_iter(["peer".to_string()])),
-        )]),
-    );
 }
 
 #[test]
@@ -125,13 +96,11 @@ fn hashed_peer_suffix_uses_package_peer_metadata() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, names_by_alias } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
     );
-    assert!(names_by_alias.is_empty());
 }
 
 #[test]
@@ -144,13 +113,11 @@ fn explicit_peer_suffix_uses_the_dependency_alias() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, names_by_alias } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
     );
-    assert!(names_by_alias.is_empty());
 }
 
 /// An ordinary dependency may be aliased onto the very package and
@@ -169,8 +136,7 @@ fn an_ordinary_alias_onto_a_peers_provider_does_not_rename_it() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
@@ -193,8 +159,7 @@ fn a_declared_peer_alias_outranks_a_competing_ordinary_alias() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
@@ -216,8 +181,7 @@ fn declared_peers_sharing_a_provider_each_get_their_alias_back() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([
@@ -243,8 +207,7 @@ fn a_declared_peer_does_not_consume_the_propagated_peers_segment() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([
@@ -269,8 +232,7 @@ fn competing_ordinary_aliases_do_not_rename_the_segment() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([(
@@ -295,8 +257,7 @@ fn a_linked_dependency_is_not_a_peer_provider() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["1.0.0".to_string()]))]),
@@ -315,8 +276,7 @@ fn a_hashed_peer_suffix_without_package_metadata_records_nothing() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert!(versions.is_empty());
 }
 
@@ -333,8 +293,7 @@ fn explicit_peer_suffix_of_an_undeclared_peer_is_kept() {
         )],
     );
 
-    let ImporterLockedPeerContext { versions, .. } =
-        importer_locked_peer_context(Some(&lockfile), "missing-importer");
+    let versions = importer_locked_peer_versions(Some(&lockfile), "missing-importer");
     assert_eq!(
         versions,
         HashMap::from_iter([("peer".to_string(), HashSet::from_iter(["2.0.0".to_string()]))]),
@@ -439,7 +398,7 @@ fn link_dependency(target: &str) -> pnpm_lockfile::SnapshotDepRef {
 /// list — the union `importer_locked_peer_context` folds over every
 /// snapshot.
 fn locked_peer_names(wanted_lockfile: Option<&pnpm_lockfile::Lockfile>) -> HashSet<String> {
-    importer_locked_peer_context(wanted_lockfile, "missing-importer").versions.into_keys().collect()
+    importer_locked_peer_versions(wanted_lockfile, "missing-importer").into_keys().collect()
 }
 
 struct StubResolver {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -120,11 +120,6 @@ pub struct ResolvePeersOptions {
     /// resolved them.
     pub hoisted_peer_provider_node_ids: HashSet<NodeId>,
 
-    /// Importer-level dependencies installed solely to satisfy optional
-    /// peers. A reused direct dependency only sees these providers when
-    /// its wanted-lockfile peer suffix recorded the same peer name.
-    pub hoisted_optional_peer_node_ids: HashSet<NodeId>,
-
     /// Final `NodeId → DepPath` map produced by a previous
     /// peer-resolution pass over the same tree
     /// ([`ResolvePeersResult::paths_by_node_id`]). `Some` activates
@@ -162,7 +157,6 @@ impl Default for ResolvePeersOptions {
             project_dir: None,
             modules_dir: None,
             hoist_missing_scope: None,
-            hoisted_optional_peer_node_ids: HashSet::default(),
             hoisted_peer_provider_node_ids: HashSet::default(),
             resolved_peer_provider_paths: None,
             collect_paths_by_node_id: false,
@@ -269,7 +263,6 @@ pub struct ResolvePeersResult {
 pub struct ImporterPeerInput {
     pub id: String,
     pub direct: Vec<DirectDep>,
-    pub hoisted_optional_peer_node_ids: HashSet<NodeId>,
     /// Absolute root of this importer. Threaded into
     /// [`ResolvePeersOptions::project_dir`] while this importer is being
     /// walked, and used to render its direct `link:` deps relative to
@@ -389,10 +382,6 @@ pub fn resolve_peers_workspace(
         // importer and encodes the correct importer-scoped target.
         walker.opts.project_dir = Some(importer.root_dir.clone());
         walker.opts.modules_dir.clone_from(&importer.modules_dir);
-        walker
-            .opts
-            .hoisted_optional_peer_node_ids
-            .clone_from(&importer.hoisted_optional_peer_node_ids);
         walker.current_provider_sources = importer_provider_sources(importer, root_importer);
         let importer_parents =
             Arc::new(if root_importer.is_some_and(|root| root.id != importer.id) {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -383,23 +383,6 @@ fn version_gte(left: &str, right: &str) -> bool {
     }
 }
 
-pub(super) fn scoped_hoisted_optional_parent_refs(
-    parent_refs: &ParentRefs,
-    locked_peer_names: &HashSet<String>,
-    hoisted_optional_peer_node_ids: &HashSet<NodeId>,
-) -> ParentRefs {
-    parent_refs
-        .iter()
-        .filter(|(name, parent)| {
-            parent.node_id.as_ref().is_none_or(|parent_node_id| {
-                !hoisted_optional_peer_node_ids.contains(parent_node_id)
-                    || locked_peer_names.contains(*name)
-            })
-        })
-        .map(|(name, parent)| (name.clone(), parent.clone()))
-        .collect()
-}
-
 /// Reinterpret a `link:<rel>` [`NodeId`] as a [`DepPath`].
 ///
 /// Linked top-parent `NodeIds` (whether the workspace-link arm or the

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
@@ -1,15 +1,14 @@
 //! Unit tests for the peer-resolution context helpers.
 
 use super::{
-    ChainSuffixMemo, ParentRef, SharedChain, importer_relative_link_dep_path, peer_segment_names,
-    remap_link_node_id, satisfies_with_prereleases, scoped_hoisted_optional_parent_refs,
+    ChainSuffixMemo, SharedChain, importer_relative_link_dep_path, peer_segment_names,
+    remap_link_node_id, satisfies_with_prereleases,
 };
 use crate::{
     node_id::NodeId,
     resolve_peers::{ResolvePeersOptions, test_support::linked_package},
 };
 use pnpm_deps_path::DepPath;
-use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
 use std::path::{Path, PathBuf};
 
 const PATCHED_WORKFLOWS_SDK: &str = concat!(
@@ -19,35 +18,6 @@ const PATCHED_WORKFLOWS_SDK: &str = concat!(
     "(better-sqlite3@12.8.0)",
     "(express@4.21.2)",
 );
-
-#[test]
-fn locked_direct_dep_only_sees_its_locked_hoisted_optional_peers() {
-    let debug = NodeId::next();
-    let supports_color = NodeId::next();
-    let regular = NodeId::next();
-    let parent = |version: &str, node_id| ParentRef {
-        version: version.to_string(),
-        node_id: Some(node_id),
-        alias: None,
-        depth: 0,
-        occurrence: 0,
-    };
-    let parent_refs = HashMap::from_iter([
-        ("debug".to_string(), parent("4.4.3", debug.clone())),
-        ("supports-color".to_string(), parent("8.1.1", supports_color.clone())),
-        ("regular".to_string(), parent("1.0.0", regular)),
-    ]);
-
-    let scoped = scoped_hoisted_optional_parent_refs(
-        &parent_refs,
-        &HashSet::from_iter(["supports-color".to_string()]),
-        &HashSet::from_iter([debug, supports_color]),
-    );
-
-    assert!(!scoped.contains_key("debug"));
-    assert!(scoped.contains_key("supports-color"));
-    assert!(scoped.contains_key("regular"));
-}
 
 #[test]
 fn importer_relative_self_link_keeps_an_empty_target() {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/tests.rs
@@ -1034,7 +1034,6 @@ fn pruned_hoisted_provider_falls_back_in_workspace_pass() {
 
     let importer = ImporterPeerInput {
         id: ".".to_string(),
-        hoisted_optional_peer_node_ids: HashSet::default(),
         direct: vec![
             DirectDep {
                 alias: "consumer".to_string(),
@@ -1100,7 +1099,6 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
     let importers = [
         ImporterPeerInput {
             id: "project-a".to_string(),
-            hoisted_optional_peer_node_ids: HashSet::default(),
             direct: vec![
                 DirectDep {
                     alias: "consumer".to_string(),
@@ -1118,7 +1116,6 @@ fn workspace_importers_get_distinct_instances_for_different_peer_versions() {
         },
         ImporterPeerInput {
             id: "project-b".to_string(),
-            hoisted_optional_peer_node_ids: HashSet::default(),
             direct: vec![
                 DirectDep {
                     alias: "consumer".to_string(),
@@ -1187,7 +1184,6 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
     let importers = [
         ImporterPeerInput {
             id: ".".to_string(),
-            hoisted_optional_peer_node_ids: HashSet::default(),
             direct: vec![
                 DirectDep {
                     alias: "plugin".to_string(),
@@ -1210,7 +1206,6 @@ fn a_shared_consumer_keeps_the_first_importers_peer_provider_variant() {
         },
         ImporterPeerInput {
             id: "app".to_string(),
-            hoisted_optional_peer_node_ids: HashSet::default(),
             direct: vec![
                 DirectDep {
                     alias: "plugin".to_string(),
@@ -1324,7 +1319,6 @@ fn linked_peer_provider_uses_root_relative_snapshot_ref_in_workspace_fallback() 
     let consumer = NodeId::next();
     let importer = ImporterPeerInput {
         id: "apps/nested/app".to_string(),
-        hoisted_optional_peer_node_ids: HashSet::default(),
         direct: vec![
             DirectDep {
                 alias: "consumer".to_string(),
@@ -1395,7 +1389,6 @@ fn workspace_internal_link_peer_keeps_its_node_id_when_exclude_links_on() {
     let consumer = NodeId::next();
     let importer = ImporterPeerInput {
         id: "apps/app".to_string(),
-        hoisted_optional_peer_node_ids: HashSet::default(),
         direct: vec![
             DirectDep {
                 alias: "consumer".to_string(),
@@ -2361,7 +2354,6 @@ fn backedge_bindings_do_not_depend_on_importer_order() {
         let importer = |id: &str, direct: Vec<DirectDep>| ImporterPeerInput {
             id: id.to_string(),
             direct,
-            hoisted_optional_peer_node_ids: HashSet::default(),
             root_dir: std::path::PathBuf::from(format!("/repo/{id}")),
             modules_dir: None,
         };

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -18,7 +18,6 @@ use crate::{
             CurrentProviderSource, ParentPkgInfo, ParentRef, ParentRefs, SharedChain,
             importer_relative_link_dep_path, insert_parent_ref, link_node_id_as_dep_path,
             peer_id_pair, pkg_name_version, remap_link_node_id, satisfies_with_prereleases,
-            scoped_hoisted_optional_parent_refs,
         },
         discovery::PeerDiscoveryCaches,
         finalize::{NodeRecord, PendingPeerEdge, WalkedNode},
@@ -714,7 +713,7 @@ impl Walker<'_> {
         let fast_cached = {
             let tree_node = &self.tree.dependencies_tree[node_id];
             tree_node
-                .has_no_locked_peers()
+                .has_no_locked_peer_context()
                 .then(|| {
                     self.find_fast_hit(node_id, parent_parent_refs, &tree_node.resolved_package_id)
                 })
@@ -734,13 +733,12 @@ impl Walker<'_> {
                 },
             );
         }
-        let (pkg_id, tree_node_depth, tree_node_installable, locked_peer_names) = {
+        let (pkg_id, tree_node_depth, tree_node_installable) = {
             let tree_node = &self.tree.dependencies_tree[node_id];
             (
                 std::sync::Arc::<str>::clone(&tree_node.resolved_package_id),
                 tree_node.depth,
                 tree_node.installable,
-                tree_node.locked_peer_names().cloned(),
             )
         };
         let pkg = self.owned_package(&pkg_id);
@@ -754,7 +752,6 @@ impl Walker<'_> {
             node_id,
             &pkg,
             parent_parent_refs,
-            locked_peer_names.as_deref(),
             &provider_children,
             parent_node_ids,
         );
@@ -1031,32 +1028,22 @@ impl Walker<'_> {
     }
 
     /// Build the [`ParentRefs`] map that descendants of this node see:
-    /// the parent's view (scoped down when the node's locked peer names
-    /// exclude hoisted optional providers), plus the node's own
-    /// peer-relevant children, plus the pins the wanted lockfile locked
-    /// in. Kept behind `Arc` copy-on-write: most nodes contribute
-    /// nothing, so they pass the parent's map down by refcount instead
-    /// of cloning it — the per-node map clones dominated the walker's
-    /// CPU time on peer-heavy workspaces.
+    /// the parent's view, plus the node's own peer-relevant children,
+    /// plus the pins the wanted lockfile locked in. Kept behind `Arc`
+    /// copy-on-write: most nodes contribute nothing, so they pass the
+    /// parent's map down by refcount instead of cloning it — the
+    /// per-node map clones dominated the walker's CPU time on
+    /// peer-heavy workspaces.
     fn build_child_parent_refs(
         &self,
         node_id: &NodeId,
         pkg: &ResolvedPackage,
         parent_parent_refs: &Arc<ParentRefs>,
-        locked_peer_names: Option<&HashSet<String>>,
         provider_children: &BTreeMap<String, NodeId>,
         parent_node_ids: &SharedChain<NodeId>,
     ) -> ChildParentRefs {
-        let mut refs_changed = locked_peer_names.is_some();
-        let mut child_parent_refs = if let Some(locked_peer_names) = locked_peer_names {
-            Arc::new(scoped_hoisted_optional_parent_refs(
-                parent_parent_refs,
-                locked_peer_names,
-                &self.opts.hoisted_optional_peer_node_ids,
-            ))
-        } else {
-            Arc::clone(parent_parent_refs)
-        };
+        let mut refs_changed = false;
+        let mut child_parent_refs = Arc::clone(parent_parent_refs);
 
         let mut new_parent_refs = ParentRefs::default();
         for (alias, child_node_id) in provider_children {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -397,12 +397,11 @@ where
     for ((importer, state), (project_dir, modules_dir)) in
         importers.iter().zip(states).zip(input_dirs)
     {
-        let (direct, importer_provider_node_ids, importer_optional_node_ids) = state.into_direct();
+        let (direct, importer_provider_node_ids) = state.into_direct();
         hoisted_peer_provider_node_ids.extend(importer_provider_node_ids);
         per_importer_inputs.push(ImporterPeerInput {
             id: importer.id.clone(),
             direct,
-            hoisted_optional_peer_node_ids: importer_optional_node_ids,
             root_dir: project_dir,
             modules_dir,
         });

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree.rs
@@ -210,9 +210,6 @@ pub struct LockedResolution {
     /// TODO: the resolver does not compute this yet; only
     /// `resolve_peers` consumes it.
     pub dependency_names_whose_current_provider_must_win: Option<HashSet<String>>,
-    /// Peer names recorded on this direct dependency's wanted-lockfile
-    /// suffix. `None` for transitive or freshly resolved occurrences.
-    pub locked_peer_names: Option<Arc<HashSet<String>>>,
 }
 
 /// One per-occurrence node in the dependencies tree.
@@ -233,8 +230,8 @@ pub struct DependenciesTreeNode {
     pub installable: bool,
     /// Wanted-lockfile carry-over for this occurrence, boxed because it
     /// is `None` for every fresh resolution — which is every node the
-    /// resolver produces today. Inline, its four rarely-set fields cost
-    /// ~88 bytes on each of the millions of nodes the peer walk realizes.
+    /// resolver produces today. Inline, its three rarely-set fields cost
+    /// ~80 bytes on each of the millions of nodes the peer walk realizes.
     pub locked: Option<Box<LockedResolution>>,
 }
 
@@ -268,19 +265,11 @@ impl DependenciesTreeNode {
         self.locked.as_ref()?.dependency_names_whose_current_provider_must_win.as_ref()
     }
 
-    /// Peer names from this direct dependency's wanted-lockfile suffix.
+    /// `true` when no locked peer context is recorded — the fast-cache
+    /// precondition.
     #[must_use]
-    pub fn locked_peer_names(&self) -> Option<&Arc<HashSet<String>>> {
-        self.locked.as_ref()?.locked_peer_names.as_ref()
-    }
-
-    /// `true` when neither locked peer names nor a locked peer context is
-    /// recorded — the fast-cache precondition.
-    #[must_use]
-    pub fn has_no_locked_peers(&self) -> bool {
-        self.locked.as_ref().is_none_or(|locked| {
-            locked.locked_peer_names.is_none() && locked.locked_peer_context.is_none()
-        })
+    pub fn has_no_locked_peer_context(&self) -> bool {
+        self.locked.as_ref().is_none_or(|locked| locked.locked_peer_context.is_none())
     }
 
     /// The carry-over slot, allocated on first write.

--- a/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolved_tree/tests.rs
@@ -22,8 +22,7 @@ fn locked_resolution_is_unallocated_until_written() {
     assert!(node.previous_dep_path().is_none());
     assert!(node.locked_peer_context().is_none());
     assert!(node.must_win_dependency_names().is_none());
-    assert!(node.locked_peer_names().is_none());
-    assert!(node.has_no_locked_peers());
+    assert!(node.has_no_locked_peer_context());
 
     node.locked_mut().previous_dep_path = Some(pnpm_deps_path::DepPath::from("a@1.0.0"));
 
@@ -32,5 +31,5 @@ fn locked_resolution_is_unallocated_until_written() {
         Some(&pnpm_deps_path::DepPath::from("a@1.0.0")),
         "the accessor reads back what `locked_mut` wrote",
     );
-    assert!(node.has_no_locked_peers(), "a previous depPath is not a locked peer");
+    assert!(node.has_no_locked_peer_context(), "a previous depPath is not a locked peer");
 }

--- a/pnpr/.fixtures/packages/@pnpm.e2e/depends-on-optional-peer-c-host/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/depends-on-optional-peer-c-host/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/depends-on-optional-peer-c-host",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/optional-peer-c-host": "1.0.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-consumer-peer/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-consumer-peer/1.0.0/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@pnpm.e2e/optional-peer-c-consumer-peer",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/depends-on-optional-peer-c-host": "1.0.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-consumer/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-consumer/1.0.0/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@pnpm.e2e/optional-peer-c-consumer",
+  "version": "1.0.0",
+  "dependencies": {
+    "@pnpm.e2e/depends-on-optional-peer-c-host": "1.0.0"
+  },
+  "peerDependencies": {
+    "@pnpm.e2e/optional-peer-c-consumer-peer": "^1.0.0"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-host/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/optional-peer-c-host/1.0.0/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@pnpm.e2e/optional-peer-c-host",
+  "version": "1.0.0",
+  "peerDependencies": {
+    "@pnpm.e2e/peer-c": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@pnpm.e2e/peer-c": {
+      "optional": true
+    }
+  }
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14455.

`pnpm dedupe` on the reporter's pnpm 11 lockfile changed the lockfile again on the second run: the first pass re-keyed `@babel/core`, `debug`, and the rest of the chain with `(supports-color@10.2.2)`, but `babel-plugin-styled-components` — the direct dependency whose subtree carries that optional peer — only gained the segment on the next run.

Root cause is a pacquet-only step in the peer walk (`scoped_hoisted_optional_parent_refs`, from pnpm/pnpm#13473): a reused direct dependency whose wanted-lockfile suffix did not name a hoisted optional peer had that importer-level provider hidden from its whole subtree. Its `@babel/helper-module-imports` therefore resolved bare, while the same package under `@babel/core` (an auto-installed peer provider walked at the importer root, so unscoped) resolved against the hoisted `supports-color`. The finalized graph carried the suffixed child edge under the unsuffixed parent key, and the next run read the peer back from that edge as a locked pin and re-keyed the parent. The TypeScript CLI has no such scoping and reaches the final lockfile in one pass.

The scoping predates the locked-peer-context pins (`locked_peer_context_pins`, pnpm/pnpm#13492), which are the counterpart of the TypeScript `lockedPeerContext` replay and cover the per-dependent context preservation the scoping was added for. This PR removes the scoping and everything that only fed it (`LockedResolution::locked_peer_names`, `ImporterPeerInput::hoisted_optional_peer_node_ids`, `ResolvePeersOptions::hoisted_optional_peer_node_ids`). The per-importer locked peer versions still filter the optional-peer hoist and feed `HoistMissingScope`.

Verification:

- The reporter's fixture now converges in one `dedupe` pass, and that pass is byte-identical to what the published TypeScript `pnpm@11` writes for the same input.
- Re-running the n8n `dedupe --lockfile-only` comparison (the workspace pnpm/pnpm#13473 was validated on) against the TypeScript CLI: every snapshot key the scoping had affected now matches the TypeScript output (`express-rate-limit`, `langchain`, `@langchain/community`, `@langchain/mcp-adapters`, `@getzep/zep-cloud`, `@microsoft/agents-a365-tooling-extensions-langchain`). The one `jsdom` variant that still differs from the TypeScript output differs with and without the scoping, so it is a separate pre-existing divergence.
- New e2e test `dedupe_re_keys_a_hoisted_optional_peer_in_one_pass` mirrors the issue's graph with four new `@pnpm.e2e` fixture packages; it fails on `main` with exactly the reporter's first-pass lockfile and passes here.

No TypeScript change: the TypeScript CLI never had the scoping.

## Squash Commit Body

```text
Drop the walk-time scoping that hid an importer's hoisted optional peer
providers from a reused direct dependency whose wanted-lockfile suffix
did not name the peer. The scoping made `pnpm dedupe` (and any
re-resolution of a lockfile written before optional peers were hoisted)
non-convergent: the direct dependency's subtree resolved its optional
peer bare, while the same package under an unscoped occurrence (an
auto-installed peer provider at the importer root) resolved it against
the hoisted provider. The finalized graph then carried the suffixed
child edge under the unsuffixed parent key, and only the next run —
which read the peer back from that edge as a locked pin — re-keyed the
parent. The TypeScript CLI has no such scoping and converges in one
pass.

The scoping predates the locked-peer-context pins
(`locked_peer_context_pins`, pnpm/pnpm#13492), which are the counterpart
of the TypeScript `lockedPeerContext` replay and cover the per-dependent
context preservation it was added for in pnpm/pnpm#13473. Re-running the
n8n `dedupe --lockfile-only` comparison against the TypeScript CLI with
the scoping removed leaves every snapshot key the scoping had affected
matching the TypeScript output; the one remaining `jsdom` variant
divergence exists with and without the scoping.

With the scoping gone, `LockedResolution::locked_peer_names`,
`ImporterPeerInput::hoisted_optional_peer_node_ids`, and
`ResolvePeersOptions::hoisted_optional_peer_node_ids` had no consumers
and are removed. The per-importer locked peer versions still feed the
optional-peer hoist filter and `HoistMissingScope`.

Fixes pnpm/pnpm#14455.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BTVpbg4osExw3VnRUcmGsg

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948135&installation_model_id=426870&pr_number=14466&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14466&signature=cc67d92fd412e2b35749142bd103ecf68ae55d19dbe6311e23371fd0d028597a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm dedupe` so lockfiles involving hoisted optional peers converge in a single pass.
  - Ensured direct and transitive dependencies receive consistent peer resolution during deduplication.
  - A subsequent deduplication pass now makes no further lockfile changes in affected scenarios.

- **Tests**
  - Added coverage for one-pass deduplication and stable repeated runs.
  - Added fixtures covering optional peer dependency scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->