### PR TITLE
fix(cli): skip project checks for global config

### DIFF
--- a/.changeset/quiet-pumas-configure.md
+++ b/.changeset/quiet-pumas-configure.md
@@ -1,0 +1,6 @@
+---
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed `pnpm config` commands targeting global configuration to skip project package manager version switching, allowing registry authentication to be configured before pnpm downloads a project-pinned version [pnpm/pnpm#14463](https://github.com/pnpm/pnpm/issues/14463).

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -11,7 +11,7 @@ mod system_runtime_version;
 
 use super::{
     cli_command::{CliArgs, CliCommand},
-    config::ConfigSubcommand,
+    config::{ConfigLocation, ConfigSubcommand},
     package_manager::{
         PACKAGE_MANAGER_SWITCH_ENV_VARS, PackageManagerToSync, WantedPackageManager,
         package_manager_to_sync, read_manifest_json, should_persist_package_manager_lockfile,
@@ -63,6 +63,7 @@ pub(crate) fn pre_command_plan(
         &PreCommandInput {
             switch: SwitchInput::from_cli_args(args),
             global: is_global(&args.command),
+            skip_pm_handling: should_skip_pm_handling(&args.command),
             check_runtimes: true,
             syncs_env_lockfile_in_pipeline: syncs_env_lockfile_in_pipeline(&args.command),
             emit: reporter_emit(args.reporter),
@@ -85,6 +86,7 @@ pub(crate) fn pre_command_plan_for_version_flag(
         &PreCommandInput {
             switch: SwitchInput::from_version_argv(argv),
             global: false,
+            skip_pm_handling: false,
             check_runtimes: false,
             // No install pipeline runs behind `--version`, so nothing else
             // would record the pin.
@@ -240,7 +242,8 @@ fn pre_command_plan_from_input(
             && pm.version.as_deref().is_some_and(|version| version_satisfies(PNPM_VERSION, version))
     });
     let mut package_manager_to_sync = None;
-    if let Some(root_manifest) = manifest.as_ref()
+    if !input.skip_pm_handling
+        && let Some(root_manifest) = manifest.as_ref()
         && let Some(pm) = wanted_pm
     {
         let on_fail = effective_on_fail(&config, &pm);
@@ -301,6 +304,7 @@ fn pre_command_plan_from_input(
     }
 
     if input.check_runtimes
+        && !input.skip_pm_handling
         && !input.global
         && let Some(manifest) = manifest
     {
@@ -571,6 +575,7 @@ pub(crate) enum PreCommandError {
 struct PreCommandInput {
     switch: SwitchInput,
     global: bool,
+    skip_pm_handling: bool,
     check_runtimes: bool,
     syncs_env_lockfile_in_pipeline: bool,
     emit: fn(&LogEvent),
@@ -918,6 +923,15 @@ fn should_skip_command(command: &CliCommand) -> bool {
             | CliCommand::Store(_)
             | CliCommand::With(_),
     )
+}
+
+fn should_skip_pm_handling(command: &CliCommand) -> bool {
+    match command {
+        CliCommand::Config(args) => args.flags.location != Some(ConfigLocation::Project),
+        CliCommand::Get(args) => args.flags.location != Some(ConfigLocation::Project),
+        CliCommand::Set(args) => args.flags.location != Some(ConfigLocation::Project),
+        _ => false,
+    }
 }
 
 fn should_skip_command_name(command: &str) -> bool {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -389,6 +389,7 @@ fn pre_command_input(dir: &Path) -> PreCommandInput {
             color: None,
         },
         global: false,
+        skip_pm_handling: false,
         check_runtimes: true,
         syncs_env_lockfile_in_pipeline: false,
         emit: SilentReporter::emit,

--- a/pnpm/crates/cli/tests/suite/config_get_set.rs
+++ b/pnpm/crates/cli/tests/suite/config_get_set.rs
@@ -87,6 +87,7 @@ fn config_set_checks_the_package_manager_when_writing_project_configuration() {
         .output()
         .expect("run pacquet config set");
     let stderr = String::from_utf8_lossy(&output.stderr);
+    eprintln!("stderr={stderr}");
     assert!(!output.status.success(), "unexpected success: {stderr}");
     assert!(stderr.contains("This project is configured to use yarn"), "stderr={stderr}");
 

--- a/pnpm/crates/cli/tests/suite/config_get_set.rs
+++ b/pnpm/crates/cli/tests/suite/config_get_set.rs
@@ -47,3 +47,48 @@ fn get_keeps_stdout_to_the_value() {
 
     drop(root);
 }
+
+#[test]
+fn config_set_can_bootstrap_auth_for_a_global_custom_registry_before_switching_versions() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "packageManager": "pnpm@0.0.0" }"#)
+        .expect("write package.json");
+    let config_home = root.path().join("xdg-config");
+    let config_dir = config_home.join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create global config directory");
+    fs::write(config_dir.join("auth.ini"), "registry=http://127.0.0.1:1/\n")
+        .expect("write global config");
+
+    let output = pacquet
+        .with_env("XDG_CONFIG_HOME", &config_home)
+        .with_env("PNPM_CONFIG_FETCH_RETRIES", "0")
+        .with_args(["config", "set", "//127.0.0.1:1/:_auth", "secret"])
+        .output()
+        .expect("run pacquet config set");
+    eprintln!("stderr={}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.status.success());
+    assert!(
+        fs::read_to_string(config_dir.join("auth.ini"))
+            .expect("read global auth config")
+            .contains("//127.0.0.1:1/:_auth=secret"),
+    );
+
+    drop(root);
+}
+
+#[test]
+fn config_set_checks_the_package_manager_when_writing_project_configuration() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "packageManager": "yarn@4.0.0" }"#)
+        .expect("write package.json");
+
+    let output = pacquet
+        .with_args(["config", "set", "--location=project", "node-linker", "hoisted"])
+        .output()
+        .expect("run pacquet config set");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(!output.status.success(), "unexpected success: {stderr}");
+    assert!(stderr.contains("This project is configured to use yarn"), "stderr={stderr}");
+
+    drop(root);
+}

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -427,11 +427,12 @@ function printError (message: string, hint?: string): void {
 }
 
 /**
- * Whether to skip the packageManager/runtime handling block (both auto
- * download and warn/error checks). Global config operations do not act on
- * the project. Commands can also opt out via `skipPackageManagerCheck: true`;
- * help for those commands is skipped too so rendering it does not download
- * an older pinned pnpm that may not have the command.
+ * Returns whether the command may bypass project package-manager and runtime
+ * handling. Config command aliases bypass it unless `location` is exactly
+ * `project`; an absent or unrecognized location therefore retains config's
+ * global default. Commands marked with `skipPackageManagerCheck`, and help
+ * requests targeting those commands, also bypass it. A missing command does
+ * not.
  */
 function shouldSkipPmHandling (cmd: string | null, cliParams: string[], location: unknown): boolean {
   if (cmd == null) return false

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -115,7 +115,7 @@ export async function main (inputArgv: string[]): Promise<void> {
       forSelfUpdate: cmd === 'self-update',
       printWarnings: !isSingleSettingRead(cmd, cliParams),
     }) as { config: typeof config, context: ConfigContext })
-    if (cmd !== 'setup' && !shouldSkipPmHandling(cmd, cliParams)) {
+    if (cmd !== 'setup' && !shouldSkipPmHandling(cmd, cliParams, cliOptions.location)) {
       if (context.wantedPackageManager != null) {
         const pm = context.wantedPackageManager
         if (pm.onFail !== 'ignore') {
@@ -428,15 +428,14 @@ function printError (message: string, hint?: string): void {
 
 /**
  * Whether to skip the packageManager/runtime handling block (both auto
- * download and warn/error checks). Returns true when the command itself
- * opts out via `skipPackageManagerCheck: true`, or when the user is asking
- * for help on such a command — `pnpm help <skippable>` and
- * `pnpm <skippable> --help` (which parse-cli-args rewrites to the same
- * cmd='help' form) shouldn't download an older pinned pnpm just to render
- * help for a command that older pnpm may not even have.
+ * download and warn/error checks). Global config operations do not act on
+ * the project. Commands can also opt out via `skipPackageManagerCheck: true`;
+ * help for those commands is skipped too so rendering it does not download
+ * an older pinned pnpm that may not have the command.
  */
-function shouldSkipPmHandling (cmd: string | null, cliParams: string[]): boolean {
+function shouldSkipPmHandling (cmd: string | null, cliParams: string[], location: unknown): boolean {
   if (cmd == null) return false
+  if ((cmd === 'config' || cmd === 'c' || cmd === 'get' || cmd === 'set') && location !== 'project') return true
   if (skipPackageManagerCheckForCommand.has(cmd)) return true
   if (cmd === 'help' && cliParams[0] != null && skipPackageManagerCheckForCommand.has(cliParams[0])) return true
   return false

--- a/pnpm11/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm11/pnpm/test/packageManagerCheck.test.ts
@@ -1,3 +1,6 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
 import { describe, expect, test } from '@jest/globals'
 import { prepare, prepareEmpty } from '@pnpm/prepare'
 import { writeYamlFileSync } from 'write-yaml-file'
@@ -89,6 +92,50 @@ test('some commands should not fail if the required package manager is not pnpm'
 
   const { status } = execPnpmSync(['store', 'path'])
   expect(status).toBe(0)
+})
+
+test('config set can bootstrap auth for a global custom registry before switching pnpm versions', () => {
+  prepare({
+    packageManager: 'pnpm@0.0.0',
+  })
+
+  const configHome = path.resolve('.config')
+  const configDir = path.join(configHome, 'pnpm')
+  fs.mkdirSync(configDir, { recursive: true })
+  fs.writeFileSync(path.join(configDir, 'auth.ini'), 'registry=http://127.0.0.1:1/\n')
+
+  const { status } = execPnpmSync([
+    'config',
+    'set',
+    '//127.0.0.1:1/:_auth',
+    'secret',
+  ], {
+    env: {
+      XDG_CONFIG_HOME: configHome,
+      pnpm_config_fetch_retries: '0',
+    },
+    omitEnvDefaults: ['pnpm_config_registry'],
+  })
+
+  expect(status).toBe(0)
+  expect(fs.readFileSync(path.join(configDir, 'auth.ini'), 'utf8')).toContain('//127.0.0.1:1/:_auth=secret')
+})
+
+test('config set checks the package manager when writing project configuration', () => {
+  prepare({
+    packageManager: 'yarn@4.0.0',
+  })
+
+  const { status, stderr } = execPnpmSync([
+    'config',
+    'set',
+    '--location=project',
+    'node-linker',
+    'hoisted',
+  ])
+
+  expect(status).toBe(1)
+  expect(stderr.toString()).toContain('This project is configured to use yarn')
 })
 
 test('devEngines.packageManager with onFail=error should fail on version mismatch', async () => {


### PR DESCRIPTION
## Summary

- Skip project package-manager and runtime handling for `config`, `get`, and `set` unless `--location=project` is selected.
- Keep configuration diagnostics active while allowing global registry authentication to be configured before pnpm downloads a project-pinned version.
- Implement the behavior in both the TypeScript and Rust CLIs, with matching regression coverage.

Fixes pnpm/pnpm#14463.

## Squash Commit Body

```text
Global config commands run before project package-manager selection because they may be needed to configure credentials for the registry used to download the selected pnpm version.

Limit the exemption to config commands whose effective location is global. Keep project-local config operations subject to project package-manager and runtime requirements, and preserve config diagnostics.

Implement the same behavior and regression coverage in both CLI stacks.

Fixes pnpm/pnpm#14463.
```

## Checklist

- [x] The change works on Linux, macOS, and Windows.
- [x] The change follows the repository's code style and conventions.
- [x] The TypeScript and Rust implementations remain behaviorally aligned.
- [x] A changeset covers both `pnpm` and `pacquet`.
- [x] Regression tests cover global authentication bootstrapping and the project-local control case.
- [x] Documentation remains accurate; this fixes command initialization without changing the documented CLI surface.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948626&installation_model_id=426870&pr_number=14468&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14468&signature=683ed2b336b7a428594b7eeb661dd234fd5f0eee22392c41aa71f3e1a51b2943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Global and other non-project `pnpm config`, `get`, and `set` commands now work without switching to a project-pinned package manager version.
  * Registry authentication can be configured before downloading a project-specific pnpm version.
  * Project-level configuration continues to validate the package manager specified by the project.

* **Tests**
  * Added coverage for global authentication setup and project package-manager validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->