### PR TITLE
fix(cli): open repo and docs URLs on WSL

### DIFF
--- a/.changeset/tidy-browsers-open.md
+++ b/.changeset/tidy-browsers-open.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm repo` and `pnpm docs` failing to open the Windows browser from WSL [pnpm/pnpm#14467](https://github.com/pnpm/pnpm/issues/14467).

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -121,8 +121,6 @@ windows-sys = { workspace = true, features = [
   "Win32_Storage_FileSystem",
   "Win32_System_Console",
   "Win32_System_SystemInformation",
-  "Win32_UI_Shell",
-  "Win32_UI_WindowsAndMessaging",
 ] }
 
 [target.'cfg(unix)'.dependencies]

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -610,17 +610,21 @@ pub(super) fn repo<'a>(ctx: &RunCtx<'a>, args: RepoArgs) -> miette::Result<Comma
     let cfg = (ctx.config)()?;
     let dir = ctx.dir;
     Ok(match ctx.reporter {
-        ReporterType::Default | ReporterType::AppendOnly => {
-            Box::pin(async move { args.run::<DefaultReporter>(cfg, dir).await })
-        }
-        ReporterType::Ndjson => Box::pin(async move { args.run::<NdjsonReporter>(cfg, dir).await }),
-        ReporterType::Silent => Box::pin(async move { args.run::<SilentReporter>(cfg, dir).await }),
+        ReporterType::Default | ReporterType::AppendOnly => Box::pin(async move {
+            args.run::<pnpm_network_web_auth::Host, DefaultReporter>(cfg, dir).await
+        }),
+        ReporterType::Ndjson => Box::pin(async move {
+            args.run::<pnpm_network_web_auth::Host, NdjsonReporter>(cfg, dir).await
+        }),
+        ReporterType::Silent => Box::pin(async move {
+            args.run::<pnpm_network_web_auth::Host, SilentReporter>(cfg, dir).await
+        }),
     })
 }
 
 pub(super) fn docs<'a>(ctx: &RunCtx<'a>, args: DocsArgs) -> miette::Result<CommandFuture<'a>> {
     let cfg = (ctx.config)()?;
-    Ok(Box::pin(async move { args.run(cfg).await }))
+    Ok(Box::pin(async move { args.run::<pnpm_network_web_auth::Host>(cfg).await }))
 }
 
 pub(super) fn with<'a>(ctx: &RunCtx<'a>, args: WithArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/docs.rs
+++ b/pnpm/crates/cli/src/cli_args/docs.rs
@@ -1,5 +1,6 @@
 use clap::Args;
 use pnpm_config::Config;
+use pnpm_network_web_auth::OpenUrl;
 use pnpm_registry::PackageVersion;
 
 /// Open the documentation page of a package in a browser.
@@ -10,9 +11,9 @@ pub struct DocsArgs {
 }
 
 impl DocsArgs {
-    pub async fn run(self, config: &Config) -> miette::Result<()> {
+    pub async fn run<Sys: OpenUrl>(self, config: &Config) -> miette::Result<()> {
         let url = self.documentation_url(config).await?;
-        open_url(&url)
+        open_url::<Sys>(&url)
     }
 
     async fn documentation_url(&self, config: &Config) -> miette::Result<String> {
@@ -39,47 +40,9 @@ fn is_http_url(value: &str) -> bool {
         .is_ok_and(|parsed| parsed.scheme() == "http" || parsed.scheme() == "https")
 }
 
-fn open_url(url: &str) -> miette::Result<()> {
-    let result = {
-        #[cfg(target_os = "linux")]
-        {
-            std::process::Command::new("xdg-open").arg(url).spawn()
-        }
-        #[cfg(target_os = "macos")]
-        {
-            std::process::Command::new("open").arg(url).spawn()
-        }
-        #[cfg(target_os = "windows")]
-        {
-            // SAFETY: ShellExecuteW invokes the default handler for the
-            // URL protocol without going through cmd, avoiding the shell
-            // metacharacter injection that `cmd /c start` is vulnerable to.
-            use std::ffi::OsStr;
-            use std::os::windows::ffi::OsStrExt;
-
-            let url_wide: Vec<u16> =
-                OsStr::new(url).encode_wide().chain(std::iter::once(0)).collect();
-
-            let result = unsafe {
-                windows_sys::Win32::UI::Shell::ShellExecuteW(
-                    std::ptr::null_mut(), // hwnd
-                    std::ptr::null(),     // lpOperation (null => "open")
-                    url_wide.as_ptr(),    // lpFile
-                    std::ptr::null(),     // lpParameters
-                    std::ptr::null(),     // lpDirectory
-                    windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
-                )
-            };
-            if (result as isize) > 32 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
-        }
-        #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-        {
-            // On unsupported platforms, just print the URL.
-            Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported platform"))
-        }
-    };
-    match result {
-        Ok(_) => Ok(()),
+fn open_url<Sys: OpenUrl>(url: &str) -> miette::Result<()> {
+    match Sys::open_url(url) {
+        Ok(()) => Ok(()),
         Err(e) => {
             let redacted = url::Url::parse(url).map_or_else(
                 |_| url.to_string(),

--- a/pnpm/crates/cli/src/cli_args/docs/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/docs/tests.rs
@@ -1,4 +1,7 @@
+use std::{io, sync::Mutex};
+
 use pnpm_config::Config;
+use pnpm_network_web_auth::OpenUrl;
 use pnpm_registry::PackageVersion;
 use serde_json::json;
 
@@ -30,6 +33,17 @@ fn packument() -> String {
 
 fn config_for(registry: &str) -> Config {
     Config { registry: format!("{registry}/"), ..Config::default() }
+}
+
+static OPENED_URLS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+struct RecordingBrowser;
+
+impl OpenUrl for RecordingBrowser {
+    fn open_url(url: &str) -> io::Result<()> {
+        OPENED_URLS.lock().unwrap().push(url.to_owned());
+        Ok(())
+    }
 }
 
 #[test]
@@ -64,6 +78,7 @@ fn test_is_http_url_spaces() {
 
 #[tokio::test]
 async fn requested_version_uses_its_homepage() {
+    OPENED_URLS.lock().unwrap().clear();
     let mut server = mockito::Server::new_async().await;
     let mock = server
         .mock("GET", "/is-negative")
@@ -73,11 +88,10 @@ async fn requested_version_uses_its_homepage() {
         .await;
     let args = DocsArgs { package: "is-negative@1.0.0".to_string() };
 
-    let url =
-        args.documentation_url(&config_for(&server.url())).await.expect("docs URL must resolve");
+    args.run::<RecordingBrowser>(&config_for(&server.url())).await.expect("docs URL must open");
 
     mock.assert_async().await;
-    assert_eq!(url, "https://v1.example/docs");
+    assert_eq!(OPENED_URLS.lock().unwrap().as_slice(), ["https://v1.example/docs"]);
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cli_args/repo.rs
+++ b/pnpm/crates/cli/src/cli_args/repo.rs
@@ -5,6 +5,7 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_network::{RetryOpts, ThrottledClient};
+use pnpm_network_web_auth::OpenUrl;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_npm_resolver::{
@@ -21,7 +22,7 @@ pub struct RepoArgs {
 }
 
 impl RepoArgs {
-    pub async fn run<Rep: Reporter>(
+    pub async fn run<Sys: OpenUrl, Rep: Reporter>(
         self,
         config: &Config,
         dir: &std::path::Path,
@@ -59,7 +60,7 @@ impl RepoArgs {
             urls
         };
         for url in urls {
-            match open_url(&url) {
+            match Sys::open_url(&url) {
                 Ok(()) => {}
                 Err(e) => {
                     let redacted = redact_url(&url);
@@ -385,42 +386,6 @@ fn try_extract_fragment(raw_url: &str) -> Option<String> {
     let (_, after_hash) = raw_url.split_once('#')?;
     let fragment = after_hash.split('?').next()?;
     if fragment.is_empty() { None } else { Some(fragment.to_string()) }
-}
-
-fn open_url(url: &str) -> std::io::Result<()> {
-    #[cfg(target_os = "linux")]
-    {
-        let status = std::process::Command::new("xdg-open").arg(url).status()?;
-        if status.success() { Ok(()) } else { Err(std::io::Error::other("xdg-open failed")) }
-    }
-    #[cfg(target_os = "macos")]
-    {
-        let status = std::process::Command::new("open").arg(url).status()?;
-        if status.success() { Ok(()) } else { Err(std::io::Error::other("open failed")) }
-    }
-    #[cfg(target_os = "windows")]
-    {
-        use std::ffi::OsStr;
-        use std::os::windows::ffi::OsStrExt;
-
-        let url_wide: Vec<u16> = OsStr::new(url).encode_wide().chain(std::iter::once(0)).collect();
-
-        let result = unsafe {
-            windows_sys::Win32::UI::Shell::ShellExecuteW(
-                std::ptr::null_mut(),
-                std::ptr::null(),
-                url_wide.as_ptr(),
-                std::ptr::null(),
-                std::ptr::null(),
-                windows_sys::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL,
-            )
-        };
-        if (result as isize) > 32 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
-    }
-    #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
-    {
-        Err(std::io::Error::new(std::io::ErrorKind::Unsupported, "unsupported platform"))
-    }
 }
 
 fn redact_url(url: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/repo.rs
+++ b/pnpm/crates/cli/src/cli_args/repo.rs
@@ -5,7 +5,7 @@ use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_network::{RetryOpts, ThrottledClient};
-use pnpm_network_web_auth::OpenUrl;
+use pnpm_network_web_auth::OpenUrlAndWait;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_npm_resolver::{
@@ -22,7 +22,7 @@ pub struct RepoArgs {
 }
 
 impl RepoArgs {
-    pub async fn run<Sys: OpenUrl, Rep: Reporter>(
+    pub async fn run<Sys: OpenUrlAndWait, Rep: Reporter>(
         self,
         config: &Config,
         dir: &std::path::Path,
@@ -60,7 +60,7 @@ impl RepoArgs {
             urls
         };
         for url in urls {
-            match Sys::open_url(&url) {
+            match Sys::open_url_and_wait(&url) {
                 Ok(()) => {}
                 Err(e) => {
                     let redacted = redact_url(&url);

--- a/pnpm/crates/cli/src/cli_args/repo/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/repo/tests.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, io, sync::Mutex};
 
 use pnpm_config::Config;
 use pnpm_network::{RetryOpts, ThrottledClient};
-use pnpm_network_web_auth::OpenUrl;
+use pnpm_network_web_auth::OpenUrlAndWait;
 use pnpm_reporter::SilentReporter;
 
 use super::{
@@ -71,8 +71,8 @@ async fn test_opens_repository_url_from_local_manifest() {
 
     struct RecordingBrowser;
 
-    impl OpenUrl for RecordingBrowser {
-        fn open_url(url: &str) -> io::Result<()> {
+    impl OpenUrlAndWait for RecordingBrowser {
+        fn open_url_and_wait(url: &str) -> io::Result<()> {
             OPENED_URLS.lock().unwrap().push(url.to_owned());
             Ok(())
         }

--- a/pnpm/crates/cli/src/cli_args/repo/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/repo/tests.rs
@@ -1,11 +1,13 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, io, sync::Mutex};
 
 use pnpm_config::Config;
 use pnpm_network::{RetryOpts, ThrottledClient};
+use pnpm_network_web_auth::OpenUrl;
+use pnpm_reporter::SilentReporter;
 
 use super::{
-    get_repo_url_from_current_project, get_repo_url_from_registry, pick_repo_url, redact_url,
-    repository_to_web_url,
+    RepoArgs, get_repo_url_from_current_project, get_repo_url_from_registry, pick_repo_url,
+    redact_url, repository_to_web_url,
 };
 
 #[tokio::test]
@@ -62,16 +64,32 @@ async fn test_registry_package_name_defaults_to_latest() {
     mock.assert_async().await;
 }
 
-#[test]
-fn test_opens_repository_url_from_local_manifest() {
+#[tokio::test]
+async fn test_opens_repository_url_from_local_manifest() {
+    static OPENED_URLS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    OPENED_URLS.lock().unwrap().clear();
+
+    struct RecordingBrowser;
+
+    impl OpenUrl for RecordingBrowser {
+        fn open_url(url: &str) -> io::Result<()> {
+            OPENED_URLS.lock().unwrap().push(url.to_owned());
+            Ok(())
+        }
+    }
+
     let dir = tempfile::tempdir().expect("tempdir");
     std::fs::write(
         dir.path().join("package.json"),
         r#"{"name": "test-pkg", "repository": "https://github.com/test/pkg"}"#,
     )
     .unwrap();
-    let url = get_repo_url_from_current_project(dir.path());
-    assert_eq!(url.unwrap(), "https://github.com/test/pkg");
+    RepoArgs { packages: Vec::new() }
+        .run::<RecordingBrowser, SilentReporter>(&Config::default(), dir.path())
+        .await
+        .expect("open repository URL");
+
+    assert_eq!(OPENED_URLS.lock().unwrap().as_slice(), ["https://github.com/test/pkg"]);
 }
 
 #[test]

--- a/pnpm/crates/network-web-auth/src/capabilities.rs
+++ b/pnpm/crates/network-web-auth/src/capabilities.rs
@@ -86,6 +86,12 @@ pub trait OpenUrl {
     fn open_url(url: &str) -> io::Result<()>;
 }
 
+/// Open `url` in the user's default browser and wait for the launcher to
+/// report success or failure.
+pub trait OpenUrlAndWait {
+    fn open_url_and_wait(url: &str) -> io::Result<()>;
+}
+
 /// Set up an interactive "press Enter" listener on stdin. Mirrors TS
 /// `createReadlineInterface` plus its `once('line', ...)` registration.
 ///
@@ -214,6 +220,12 @@ impl OpenUrl for Host {
         // Detached so the call returns as soon as the browser is launched
         // rather than blocking the async task until the launcher exits.
         open::that_detached(url)
+    }
+}
+
+impl OpenUrlAndWait for Host {
+    fn open_url_and_wait(url: &str) -> io::Result<()> {
+        open::that(url)
     }
 }
 

--- a/pnpm/crates/network-web-auth/src/lib.rs
+++ b/pnpm/crates/network-web-auth/src/lib.rs
@@ -14,12 +14,12 @@
 //! browser opener — as a bag of closures on a `context` object. This crate
 //! ports that seam to pacquet's convention: one `self`-less capability
 //! trait per effect ([`Clock`], [`Sleep`], [`WebAuthFetch`], [`OpenUrl`],
-//! [`EnterKeyListener`], [`PromptOtp`], and the [`StdinIsTty`] /
-//! [`StdoutIsTty`] probes), composed as bounds on a single `Sys` type
-//! parameter, with the real OS behind [`Host`] and `fn`-bound unit-struct
-//! fakes in tests. User-facing messages flow through the `R: Reporter` seam
-//! on pacquet's `pnpm:global` channel rather than a capability, matching
-//! pnpm's `globalInfo` / `globalWarn`.
+//! [`OpenUrlAndWait`], [`EnterKeyListener`], [`PromptOtp`], and the
+//! [`StdinIsTty`] / [`StdoutIsTty`] probes), composed as bounds on a single
+//! `Sys` type parameter, with the real OS behind [`Host`] and `fn`-bound
+//! unit-struct fakes in tests. User-facing messages flow through the
+//! `R: Reporter` seam on pacquet's `pnpm:global` channel rather than a
+//! capability, matching pnpm's `globalInfo` / `globalWarn`.
 
 mod capabilities;
 mod format_auth_url_message;
@@ -31,8 +31,8 @@ mod web_auth_timeout_error;
 mod with_otp_handling;
 
 pub use capabilities::{
-    Clock, EnterKeyListener, Host, OpenUrl, PromptError, PromptOtp, Sleep, StdinIsTty, StdoutIsTty,
-    WebAuthFetch, WebAuthFetchError,
+    Clock, EnterKeyListener, Host, OpenUrl, OpenUrlAndWait, PromptError, PromptOtp, Sleep,
+    StdinIsTty, StdoutIsTty, WebAuthFetch, WebAuthFetchError,
 };
 pub use format_auth_url_message::{AuthUrlMessage, format_auth_url_message};
 pub use generate_qr_code::{GenerateQrCodeError, generate_qr_code};


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Route the Rust `repo` and `docs` commands through the existing shared browser
opener so WSL delegates URLs to the Windows default handler instead of
requiring `xdg-open`.

The TypeScript CLI already uses its `open` dependency, so this is a Rust-only
parity fix.

Closes pnpm/pnpm#14467.

## Squash Commit Body

```text
Route the Rust `repo` and `docs` commands through the shared browser-opening capability. Its production implementation uses the existing `open` crate, which delegates WSL URLs to the Windows default handler before trying Linux desktop launchers.

Remove the duplicated platform launch code and cover both commands with injected browser fakes.

Closes pnpm/pnpm#14467.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) because this PR changes a published
  package. It is short and written for pnpm users.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950184&installation_model_id=426870&pr_number=14470&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14470&signature=fbc3d8e2b1a5768467e33e72341844da797ad05bdf7ab827d285e7fefa65039e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm repo` and `pnpm docs` so repository and documentation links open correctly in a Windows browser when commands run from WSL.
  * Improved browser-launching reliability across supported platforms for these commands.
  * Ensured documentation links use the expected package homepage, including when a specific package version is requested.
  * Updated repository link handling to wait for the browser launcher to complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->