### PR TITLE
fix(registry-access): answer OTP challenges in unpublish

### DIFF
--- a/.changeset/unpublish-otp-challenge.md
+++ b/.changeset/unpublish-otp-challenge.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/network.web-auth": minor
+"@pnpm/registry-access.client": patch
+"@pnpm/registry-access.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm unpublish` now completes the two-factor authentication a registry asks for instead of failing with `ERR_PNPM_UNAUTHORIZED` while logged in: a 401 that is an OTP challenge starts the web-based authentication flow (or prompts for a classic one-time password), and the obtained password is reused by every request of the run [#14464](https://github.com/pnpm/pnpm/issues/14464).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8303,6 +8303,9 @@ importers:
       '@pnpm/resolving.registry.types':
         specifier: workspace:*
         version: link:../../resolving/registry/types
+      '@pnpm/text.sanitize':
+        specifier: workspace:*
+        version: link:../../text/sanitize
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types

--- a/pnpm/crates/cli/src/cli_args/deprecate.rs
+++ b/pnpm/crates/cli/src/cli_args/deprecate.rs
@@ -5,8 +5,8 @@ use miette::{Context, Diagnostic, IntoDiagnostic};
 use node_semver::Range;
 use pnpm_config::Config;
 use pnpm_network::{
-    RetryOpts, ThrottledClient, encode_uri_component, read_limited_body, redact_url_credentials,
-    retry_async, send_with_retry,
+    LimitedBody, RetryOpts, ThrottledClient, encode_uri_component, read_limited_body,
+    redact_url_credentials, retry_async, send_with_retry,
 };
 use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
@@ -18,7 +18,7 @@ use std::{
 };
 
 const DEPRECATION_BODY_LIMIT: usize = 10 * 1024 * 1024;
-const DEPRECATION_ERROR_BODY_LIMIT: usize = 64 * 1024;
+pub(crate) const DEPRECATION_ERROR_BODY_LIMIT: usize = 64 * 1024;
 
 #[derive(Debug, Args)]
 pub struct DeprecateArgs {
@@ -420,28 +420,33 @@ async fn put_package_meta(
     }
 
     let action = if is_deprecate { "deprecate" } else { "undeprecate" }.to_string();
-    write_error_from_response(response, action).await
+    Err(registry_write_error(response, action).await.into())
 }
 
-pub(crate) async fn write_error_from_response(
-    response: Response,
-    action: String,
-) -> miette::Result<()> {
+/// The error a failed registry write maps to, once its body is read.
+pub(crate) async fn registry_write_error(response: Response, action: String) -> DeprecateError {
     let status = response.status();
+    match read_limited_body(response, DEPRECATION_ERROR_BODY_LIMIT).await {
+        Ok(body) => write_error_for_status(status, &body, action),
+        Err(source) => registry_operation_failed("reading the registry error response", source),
+    }
+}
+
+/// The error a failed registry write with an already-read `body` maps to.
+pub(crate) fn write_error_for_status(
+    status: StatusCode,
+    body: &LimitedBody,
+    action: String,
+) -> DeprecateError {
     let status_text = status.canonical_reason().unwrap_or_default().to_string();
-    let body =
-        read_limited_body(response, DEPRECATION_ERROR_BODY_LIMIT).await.map_err(|source| {
-            registry_operation_error("reading the registry error response", source)
-        })?;
-    let body = sanitize::body_display_string(&body);
+    let body = sanitize::body_display_string(body);
     if status == StatusCode::UNAUTHORIZED {
-        return Err(DeprecateError::Unauthorized { action, body }.into());
+        return DeprecateError::Unauthorized { action, body };
     }
     if status == StatusCode::FORBIDDEN {
-        return Err(DeprecateError::Forbidden { action, body }.into());
+        return DeprecateError::Forbidden { action, body };
     }
-    Err(DeprecateError::RegistryWriteFailed { action, status: status.as_u16(), status_text, body }
-        .into())
+    DeprecateError::RegistryWriteFailed { action, status: status.as_u16(), status_text, body }
 }
 
 pub(crate) fn registry_operation_error<ErrorType>(
@@ -451,11 +456,20 @@ pub(crate) fn registry_operation_error<ErrorType>(
 where
     ErrorType: std::fmt::Display,
 {
+    registry_operation_failed(operation, error).into()
+}
+
+pub(crate) fn registry_operation_failed<ErrorType>(
+    operation: &'static str,
+    error: ErrorType,
+) -> DeprecateError
+where
+    ErrorType: std::fmt::Display,
+{
     DeprecateError::RegistryOperationFailed {
         operation,
         reason: redact_url_credentials(&error.to_string()),
     }
-    .into()
 }
 
 pub(crate) fn registry_for_package(context: &DeprecateContext<'_>, package_name: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/dispatch_query.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_query.rs
@@ -317,16 +317,25 @@ pub(super) fn unpublish<'a>(
     args: UnpublishArgs,
 ) -> miette::Result<CommandFuture<'a>> {
     let cfg: &Config = (ctx.config)()?;
-    Ok(Box::pin(async move {
-        if let Some(output) = args.run(cfg).await? {
+    async fn print_output<Reporter: pnpm_reporter::Reporter>(
+        args: UnpublishArgs,
+        cfg: &Config,
+    ) -> miette::Result<()> {
+        if let Some(output) = args.run::<Reporter>(cfg).await? {
             let output = super::sanitize::sanitize(&output);
-            if output.is_empty() {
-                return Ok(());
+            if !output.is_empty() {
+                println!("{output}");
             }
-            println!("{output}");
         }
         Ok(())
-    }))
+    }
+    Ok(match ctx.reporter {
+        ReporterType::Default | ReporterType::AppendOnly => {
+            Box::pin(print_output::<DefaultReporter>(args, cfg))
+        }
+        ReporterType::Ndjson => Box::pin(print_output::<NdjsonReporter>(args, cfg)),
+        ReporterType::Silent => Box::pin(print_output::<SilentReporter>(args, cfg)),
+    })
 }
 
 pub(super) fn team<'a>(ctx: &RunCtx<'a>, args: TeamArgs) -> miette::Result<CommandFuture<'a>> {

--- a/pnpm/crates/cli/src/cli_args/unpublish.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish.rs
@@ -1,15 +1,22 @@
 use super::deprecate::{
-    DeprecateContext, DeprecateError, PackageSpec, auth_header_for_registry, fetch_package_meta,
-    package_url, parse_package_spec, registry_for_package, registry_operation_error,
-    write_error_from_response,
+    DEPRECATION_ERROR_BODY_LIMIT, DeprecateContext, DeprecateError, PackageSpec,
+    auth_header_for_registry, fetch_package_meta, package_url, parse_package_spec,
+    registry_for_package, registry_operation_error, registry_operation_failed,
+    registry_write_error, write_error_for_status,
 };
 use clap::Args;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use node_semver::{Range, Version};
 use pnpm_config::Config;
-use pnpm_network::send_with_retry;
-use reqwest::StatusCode;
+use pnpm_network::{read_limited_body, send_with_retry};
+use pnpm_network_web_auth::{
+    Clock, EnterKeyListener, Host as WebAuthHost, OpenUrl, OtpChallenge, OtpError, OtpSession,
+    PromptOtp, Sleep, StdinIsTty, StdoutIsTty, WebAuthFetch, WebAuthFetchOptions,
+    WebAuthRetryOptions, WithOtpError, otp_challenge_from_unauthorized_body,
+};
+use pnpm_reporter::Reporter;
+use reqwest::{Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashSet;
@@ -87,8 +94,99 @@ struct Packument {
     other: Map<String, Value>,
 }
 
+/// The web-auth capabilities an unpublish run drives its OTP challenges
+/// through: the real [`WebAuthHost`] in production, a scripted fake in tests.
+pub(crate) trait UnpublishHost:
+    Clock + Sleep + WebAuthFetch + StdinIsTty + StdoutIsTty + EnterKeyListener + OpenUrl + PromptOtp
+{
+}
+
+impl<Sys> UnpublishHost for Sys where
+    Sys: Clock
+        + Sleep
+        + WebAuthFetch
+        + StdinIsTty
+        + StdoutIsTty
+        + EnterKeyListener
+        + OpenUrl
+        + PromptOtp
+{
+}
+
+/// Mirrors npm's `auth-type`: `Web` opts into the web-based OTP challenge,
+/// `Legacy` is set when the user passes `--otp` so a classic code is
+/// accepted.
+#[derive(Clone, Copy)]
+enum AuthType {
+    Legacy,
+    Web,
+}
+
+impl AuthType {
+    fn header_value(self) -> &'static str {
+        match self {
+            AuthType::Legacy => "legacy",
+            AuthType::Web => "web",
+        }
+    }
+}
+
+/// Everything a registry mutation of one package needs. The OTP session is
+/// shared by every mutation of the run, so a partial unpublish (one `PUT`
+/// plus a tarball `DELETE` per removed version) authenticates once.
+struct MutationContext<'a> {
+    registry: &'a DeprecateContext<'a>,
+    auth_header: Option<&'a str>,
+    auth_type: AuthType,
+    session: OtpSession,
+}
+
+#[derive(Clone, Copy)]
+struct MutationRequest<'a> {
+    method: &'a Method,
+    url: &'a str,
+    json_body: Option<&'a str>,
+}
+
+/// An HTTP-level failure of an unpublish mutation, handed to the
+/// [`OtpSession`]. Only the [`Otp`](Self::Otp) arm is a challenge it acts on;
+/// the rest propagate.
+#[derive(Debug, Display, Error, Diagnostic)]
+enum UnpublishHttpError {
+    #[display("the registry requested a one-time password")]
+    Otp {
+        #[error(not(source))]
+        challenge: OtpChallenge,
+    },
+
+    #[display("{_0}")]
+    #[diagnostic(transparent)]
+    Registry(#[error(not(source))] DeprecateError),
+}
+
+impl OtpError for UnpublishHttpError {
+    fn as_otp_challenge(&self) -> Option<OtpChallenge> {
+        match self {
+            UnpublishHttpError::Otp { challenge } => Some(challenge.clone()),
+            UnpublishHttpError::Registry(_) => None,
+        }
+    }
+}
+
 impl UnpublishArgs {
-    pub async fn run(self, config: &Config) -> miette::Result<Option<String>> {
+    pub async fn run<Reporter: self::Reporter>(
+        self,
+        config: &Config,
+    ) -> miette::Result<Option<String>> {
+        self.execute::<WebAuthHost, Reporter>(config).await.map(Some)
+    }
+
+    /// Generic over the web-auth host `Sys` so tests can script the OTP
+    /// flow while the registry requests still go through a mocked server.
+    async fn execute<Sys: UnpublishHost, Reporter: self::Reporter>(
+        &self,
+        config: &Config,
+    ) -> miette::Result<String> {
         let context = DeprecateContext::new(config, self.registry.as_ref(), self.otp.clone())?;
 
         let spec = self.params.first().ok_or(UnpublishError::PackageRequired)?;
@@ -105,11 +203,15 @@ impl UnpublishArgs {
             return Err(DeprecateError::NoVersions { package_name }.into());
         }
 
+        let mut mutation = MutationContext {
+            registry: &context,
+            auth_header: auth_header.as_deref(),
+            auth_type: if context.otp.is_some() { AuthType::Legacy } else { AuthType::Web },
+            session: OtpSession::new(web_auth_fetch_options(config)),
+        };
+
         let Some(range) = version_range else {
-            return self
-                .unpublish_all(&context, &package_url, &pkg, auth_header.as_deref())
-                .await
-                .map(Some);
+            return self.unpublish_all::<Sys, Reporter>(&mut mutation, &package_url, &pkg).await;
         };
 
         let versions_to_unpublish = versions_matching_range(&pkg.versions, &range);
@@ -119,33 +221,27 @@ impl UnpublishArgs {
 
         // Removing every version is a full unpublish, protections included.
         if versions_to_unpublish.len() == pkg.versions.len() {
-            return self
-                .unpublish_all(&context, &package_url, &pkg, auth_header.as_deref())
-                .await
-                .map(Some);
+            return self.unpublish_all::<Sys, Reporter>(&mut mutation, &package_url, &pkg).await;
         }
 
-        unpublish_versions(
-            &context,
+        unpublish_versions::<Sys, Reporter>(
+            &mut mutation,
             &package_url,
             &registry_url,
             pkg,
             &versions_to_unpublish,
-            auth_header.as_deref(),
         )
         .await
-        .map(Some)
     }
 
     /// Delete the whole packument (`DELETE <package>/-rev/<rev>`). Refused
     /// without `--force`; a 405 from the registry means the package may only
     /// be deprecated, not removed.
-    async fn unpublish_all(
+    async fn unpublish_all<Sys: UnpublishHost, Reporter: self::Reporter>(
         &self,
-        context: &DeprecateContext<'_>,
+        mutation: &mut MutationContext<'_>,
         package_url: &str,
         pkg: &Packument,
-        auth_header: Option<&str>,
     ) -> miette::Result<String> {
         if !self.force {
             return Err(UnpublishError::ConfirmRequired {
@@ -156,12 +252,16 @@ impl UnpublishArgs {
         }
 
         let url = format!("{package_url}/-rev/{}", rev_str(pkg.rev.as_deref()));
-        let response = send_delete(context, &url, auth_header).await?;
+        let response = send_mutation::<Sys, Reporter>(
+            mutation,
+            MutationRequest { method: &Method::DELETE, url: &url, json_body: None },
+        )
+        .await?;
         if !response.status().is_success() {
             if response.status() == StatusCode::METHOD_NOT_ALLOWED {
                 return Err(UnpublishError::CompletelyForbidden.into());
             }
-            write_error_from_response(response, "unpublish".to_string()).await?;
+            return Err(registry_write_error(response, "unpublish".to_string()).await.into());
         }
 
         Ok(format!(
@@ -176,13 +276,12 @@ impl UnpublishArgs {
 /// referenced them, `PUT` the updated document back, then delete the
 /// orphaned tarballs (a 404 there is fine — some registries clean tarballs
 /// up on the packument update themselves).
-async fn unpublish_versions(
-    context: &DeprecateContext<'_>,
+async fn unpublish_versions<Sys: UnpublishHost, Reporter: self::Reporter>(
+    mutation: &mut MutationContext<'_>,
     package_url: &str,
     registry_url: &str,
     mut pkg: Packument,
     versions: &[String],
-    auth_header: Option<&str>,
 ) -> miette::Result<String> {
     let mut tarballs: Vec<String> = Vec::new();
     for version in versions {
@@ -215,75 +314,141 @@ async fn unpublish_versions(
     pkg.other.remove("_attachments");
 
     let put_url = format!("{package_url}/-rev/{}", rev_str(pkg.rev.as_deref()));
-    put_packument(context, &put_url, &pkg, auth_header).await?;
+    let put_body = serde_json::to_string(&pkg).expect("a struct serializes");
+    let response = send_mutation::<Sys, Reporter>(
+        mutation,
+        MutationRequest { method: &Method::PUT, url: &put_url, json_body: Some(&put_body) },
+    )
+    .await?;
+    if !response.status().is_success() {
+        return Err(registry_write_error(response, "unpublish".to_string()).await.into());
+    }
 
     let registry_origin = registry_origin(registry_url)?;
     for tarball in &tarballs {
         // Every delete bumps the packument revision; refetch for the current
         // one like the TypeScript CLI does.
         let updated: Packument =
-            fetch_package_meta(context, package_url, auth_header, &pkg.name).await?;
+            fetch_package_meta(mutation.registry, package_url, mutation.auth_header, &pkg.name)
+                .await?;
         let pathname = tarball_pathname(tarball, registry_url)?;
         let url = format!("{registry_origin}/{pathname}/-rev/{}", rev_str(updated.rev.as_deref()));
-        let response = send_delete(context, &url, auth_header).await?;
+        let response = send_mutation::<Sys, Reporter>(
+            mutation,
+            MutationRequest { method: &Method::DELETE, url: &url, json_body: None },
+        )
+        .await?;
         if !response.status().is_success() && response.status() != StatusCode::NOT_FOUND {
-            write_error_from_response(response, "unpublish".to_string()).await?;
+            return Err(registry_write_error(response, "unpublish".to_string()).await.into());
         }
     }
 
     Ok(format!("Successfully unpublished {} version(s) of {}", versions.len(), pkg.name))
 }
 
-async fn put_packument(
-    context: &DeprecateContext<'_>,
-    url: &str,
-    pkg: &Packument,
-    auth_header: Option<&str>,
-) -> miette::Result<()> {
-    let body = serde_json::to_string(pkg).expect("a struct serializes");
-    let (_guard, response) =
-        send_with_retry(&context.http_client, url, context.retry_opts, |client| {
-            let mut builder =
-                client.put(url).header("content-type", "application/json").body(body.clone());
-            if let Some(auth_header) = auth_header {
-                builder = builder.header("authorization", auth_header);
-            }
-            if let Some(otp) = context.otp.as_deref() {
-                builder = builder.header("npm-otp", otp);
-            }
-            builder
-        })
+/// Send one mutation through the OTP session: the first attempt carries any
+/// configured `--otp`; a 401 OTP challenge drives the interactive flow and
+/// the request is retried with the obtained password, while any other 401 is
+/// a plain authentication failure. Every other status is returned for the
+/// caller to classify.
+async fn send_mutation<Sys: UnpublishHost, Reporter: self::Reporter>(
+    mutation: &mut MutationContext<'_>,
+    request: MutationRequest<'_>,
+) -> miette::Result<reqwest::Response> {
+    let MutationContext { registry, auth_header, auth_type, session } = mutation;
+    let (registry, auth_header, auth_type) = (*registry, *auth_header, *auth_type);
+    session
+        .run::<Sys, Reporter, reqwest::Response, UnpublishHttpError, _, _>(
+            // A plain `FnMut` returning an `async move` block (not an
+            // `AsyncFnMut`) so the produced future carries an ordinary `Send`
+            // obligation — see `with_otp_handling`'s `Operation` bound.
+            move |challenge_otp: Option<String>| {
+                // The web-auth-provided OTP (a fresh challenge) takes precedence
+                // over any statically configured one.
+                let effective_otp = challenge_otp.or_else(|| registry.otp.clone());
+                async move {
+                    send_once(registry, auth_header, auth_type, request, effective_otp.as_deref())
+                        .await
+                }
+            },
+        )
         .await
-        .map_err(|source| {
-            registry_operation_error("requesting the registry put endpoint", source)
-        })?;
-    if response.status().is_success() {
-        return Ok(());
-    }
-    write_error_from_response(response, "unpublish".to_string()).await
+        .map_err(|error| match error {
+            // Unwrap the operation's own failure so the user sees the registry
+            // error once, not re-narrated through the OTP wrapper.
+            WithOtpError::Operation(UnpublishHttpError::Registry(registry_error)) => {
+                miette::Report::new(registry_error)
+            }
+            other => miette::Report::new(other),
+        })
 }
 
-async fn send_delete(
-    context: &DeprecateContext<'_>,
-    url: &str,
+/// Perform a single mutation request and classify a 401: an OTP challenge
+/// or a plain authentication failure.
+async fn send_once(
+    registry: &DeprecateContext<'_>,
     auth_header: Option<&str>,
-) -> miette::Result<reqwest::Response> {
+    auth_type: AuthType,
+    request: MutationRequest<'_>,
+    otp: Option<&str>,
+) -> Result<reqwest::Response, UnpublishHttpError> {
     let (_guard, response) =
-        send_with_retry(&context.http_client, url, context.retry_opts, |client| {
-            let mut builder = client.delete(url);
+        send_with_retry(&registry.http_client, request.url, registry.retry_opts, |client| {
+            let mut builder = client
+                .request(request.method.clone(), request.url)
+                .header("npm-auth-type", auth_type.header_value());
+            if let Some(json_body) = request.json_body {
+                builder =
+                    builder.header("content-type", "application/json").body(json_body.to_owned());
+            }
             if let Some(auth_header) = auth_header {
                 builder = builder.header("authorization", auth_header);
             }
-            if let Some(otp) = context.otp.as_deref() {
+            if let Some(otp) = otp {
                 builder = builder.header("npm-otp", otp);
             }
             builder
         })
         .await
         .map_err(|source| {
-            registry_operation_error("requesting the registry delete endpoint", source)
+            UnpublishHttpError::Registry(registry_operation_failed(
+                "requesting the registry",
+                source,
+            ))
         })?;
-    Ok(response)
+    if response.status() != StatusCode::UNAUTHORIZED {
+        return Ok(response);
+    }
+    let body =
+        read_limited_body(response, DEPRECATION_ERROR_BODY_LIMIT).await.map_err(|source| {
+            UnpublishHttpError::Registry(registry_operation_failed(
+                "reading the registry error response",
+                source,
+            ))
+        })?;
+    if !body.truncated
+        && let Some(challenge) = otp_challenge_from_unauthorized_body(&body.bytes)
+    {
+        return Err(UnpublishHttpError::Otp { challenge });
+    }
+    Err(UnpublishHttpError::Registry(write_error_for_status(
+        StatusCode::UNAUTHORIZED,
+        &body,
+        "unpublish".to_string(),
+    )))
+}
+
+fn web_auth_fetch_options(config: &Config) -> WebAuthFetchOptions {
+    WebAuthFetchOptions {
+        timeout: Some(config.fetch_timeout),
+        retry: Some(WebAuthRetryOptions {
+            factor: Some(f64::from(config.fetch_retry_factor)),
+            max_timeout: Some(config.fetch_retry_maxtimeout),
+            min_timeout: Some(config.fetch_retry_mintimeout),
+            randomize: None,
+            retries: Some(config.fetch_retries),
+        }),
+    }
 }
 
 /// The `-rev` path segment. A packument without `_rev` renders as the

--- a/pnpm/crates/cli/src/cli_args/unpublish.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish.rs
@@ -426,9 +426,7 @@ async fn send_once(
                 source,
             ))
         })?;
-    if !body.truncated
-        && let Some(challenge) = otp_challenge_from_unauthorized_body(&body.bytes)
-    {
+    if let Some(challenge) = otp_challenge_from_unauthorized_body(&body.bytes) {
         return Err(UnpublishHttpError::Otp { challenge });
     }
     Err(UnpublishHttpError::Registry(write_error_for_status(

--- a/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/unpublish/tests.rs
@@ -1,7 +1,11 @@
+use mockito::Matcher;
+use pnpm_config::Config;
+use pnpm_network_web_auth_testing::{InputResponse, ok_token, web_auth_fake};
 use serde_json::{Map, Value, json};
 
 use super::{
-    Packument, highest_version, registry_origin, rev_str, tarball_pathname, versions_matching_range,
+    Packument, UnpublishArgs, highest_version, registry_origin, rev_str, tarball_pathname,
+    versions_matching_range,
 };
 
 fn versions(keys: &[&str]) -> Map<String, Value> {
@@ -99,4 +103,131 @@ fn version_keys_keep_the_packument_order() {
     .expect("a packument deserializes");
     let keys: Vec<&String> = packument.versions.keys().collect();
     assert_eq!(keys, ["1.9.0", "1.10.0", "1.2.0"], "insertion order survives");
+}
+
+/// A two-version packument whose tarballs live on `server_url`.
+fn two_version_packument(server_url: &str) -> String {
+    json!({
+        "name": "test-pkg",
+        "_rev": "3-abc",
+        "dist-tags": { "latest": "0.0.2" },
+        "versions": {
+            "0.0.1": { "dist": { "tarball": format!("{server_url}/test-pkg/-/test-pkg-0.0.1.tgz") } },
+            "0.0.2": { "dist": { "tarball": format!("{server_url}/test-pkg/-/test-pkg-0.0.2.tgz") } },
+        },
+    })
+    .to_string()
+}
+
+fn unpublish_args(registry: &str, otp: Option<&str>, params: &[&str]) -> UnpublishArgs {
+    UnpublishArgs {
+        registry: Some(registry.to_owned()),
+        otp: otp.map(str::to_owned),
+        force: true,
+        params: params.iter().map(|param| (*param).to_owned()).collect(),
+    }
+}
+
+/// A 401 carrying `authUrl` / `doneUrl` starts the web-auth flow, and the
+/// token it yields is sent as `npm-otp` on the retried `DELETE` — still
+/// under `npm-auth-type: web`.
+#[tokio::test]
+async fn a_web_auth_challenge_is_answered_and_the_delete_retried_with_the_token() {
+    web_auth_fake!(FakeHost, RecordingReporter, set_fetch);
+    reset();
+    set_fetch(Box::new(|| Ok(ok_token("web-token"))));
+
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create_async()
+        .await;
+    let challenge_mock = server
+        .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "web")
+        .match_header("npm-otp", Matcher::Missing)
+        .with_status(401)
+        .with_body(
+            json!({
+                "error": "one-time pass required",
+                "authUrl": "https://auth.example/login",
+                "doneUrl": "https://auth.example/done",
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let retry_mock = server
+        .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "web")
+        .match_header("npm-otp", "web-token")
+        .with_status(200)
+        .with_body("{}")
+        .create_async()
+        .await;
+
+    let output = unpublish_args(&registry, None, &["test-pkg"])
+        .execute::<FakeHost, RecordingReporter>(&Config::default())
+        .await
+        .expect("the challenge is answered and the unpublish succeeds");
+
+    assert_eq!(output, "Successfully unpublished all 2 version(s) of test-pkg");
+    get_mock.assert_async().await;
+    challenge_mock.assert_async().await;
+    retry_mock.assert_async().await;
+}
+
+/// The one-time password a classic challenge yields is kept for the rest of
+/// the run: the tarball `DELETE` that follows the packument `PUT` carries it
+/// without a second prompt.
+#[tokio::test]
+async fn a_partial_unpublish_shares_one_otp_across_the_put_and_the_tarball_delete() {
+    web_auth_fake!(FakeHost, RecordingReporter, set_input);
+    reset();
+    set_input(InputResponse::Value(Some("123456".to_owned())));
+
+    let mut server = mockito::Server::new_async().await;
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .expect(2)
+        .create_async()
+        .await;
+    let challenge_mock = server
+        .mock("PUT", "/test-pkg/-rev/3-abc")
+        .match_header("npm-otp", Matcher::Missing)
+        .with_status(401)
+        .with_body(r#"{"error":"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA."}"#)
+        .create_async()
+        .await;
+    let put_mock = server
+        .mock("PUT", "/test-pkg/-rev/3-abc")
+        .match_header("npm-otp", "123456")
+        .with_status(200)
+        .with_body("{}")
+        .create_async()
+        .await;
+    let tarball_mock = server
+        .mock("DELETE", "/test-pkg/-/test-pkg-0.0.1.tgz/-rev/3-abc")
+        .match_header("npm-otp", "123456")
+        .with_status(200)
+        .with_body("{}")
+        .create_async()
+        .await;
+
+    let output = unpublish_args(&registry, None, &["test-pkg@0.0.1"])
+        .execute::<FakeHost, RecordingReporter>(&Config::default())
+        .await
+        .expect("the challenge is answered once and the unpublish succeeds");
+
+    assert_eq!(output, "Successfully unpublished 1 version(s) of test-pkg");
+    get_mock.assert_async().await;
+    challenge_mock.assert_async().await;
+    put_mock.assert_async().await;
+    tarball_mock.assert_async().await;
 }

--- a/pnpm/crates/cli/tests/suite/unpublish.rs
+++ b/pnpm/crates/cli/tests/suite/unpublish.rs
@@ -6,8 +6,8 @@
 //! no-versions / no-matching-versions errors, the `--force` protection for a
 //! full unpublish (also when a range matches every version), the partial
 //! unpublish `PUT` (versions removed, dist-tags re-pointed, `latest`
-//! reassigned), tolerated tarball-delete 404s, and the 405/401 registry
-//! answers.
+//! reassigned), tolerated tarball-delete 404s, the 405/401 registry
+//! answers, and the OTP challenge handling a 2FA-enforced account needs.
 //!
 //! The registry is a `mockito` server; an empty `--npmrc-auth-file` keeps the
 //! developer's real `~/.npmrc` from influencing the test.
@@ -335,6 +335,8 @@ fn an_unauthorized_delete_reports_unauthorized() {
         .create();
     let delete_mock = server
         .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "web")
+        .match_header("npm-otp", Matcher::Missing)
         .with_status(401)
         .with_body(r#"{"error":"unauthorized"}"#)
         .create();
@@ -348,6 +350,114 @@ fn an_unauthorized_delete_reports_unauthorized() {
     let stderr = stderr_of(&output);
     assert!(stderr.contains("ERR_PNPM_UNAUTHORIZED"), "{stderr}");
     assert!(stderr.contains("You must be logged in to unpublish packages"), "{stderr}");
+    drop((root, server));
+}
+
+/// A 2FA-enforced account gets a 401 carrying `authUrl` / `doneUrl`; that is
+/// an OTP challenge, not a missing login. The spawned binary has no TTY, so
+/// the flow stops at the non-interactive error instead of prompting.
+#[test]
+fn a_web_auth_challenge_without_a_terminal_reports_otp_non_interactive() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock = server
+        .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "web")
+        .with_status(401)
+        .with_body(
+            json!({
+                "error": "one-time pass required",
+                "authUrl": "https://auth.example/login",
+                "doneUrl": "https://auth.example/done",
+            })
+            .to_string(),
+        )
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg", "--force"]);
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(!output.status.success(), "an unanswered challenge must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_OTP_NON_INTERACTIVE"), "{stderr}");
+    assert!(!stderr.contains("ERR_PNPM_UNAUTHORIZED"), "{stderr}");
+    drop((root, server));
+}
+
+/// The classic `one-time pass` wording on the packument `PUT` of a partial
+/// unpublish is an OTP challenge too.
+#[test]
+fn a_classic_otp_challenge_without_a_terminal_reports_otp_non_interactive() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let put_mock = server
+        .mock("PUT", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "web")
+        .with_status(401)
+        .with_body(r#"{"error":"You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA."}"#)
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(&workspace, &auth_file, Some(&registry), &["test-pkg@0.0.1"]);
+
+    get_mock.assert();
+    put_mock.assert();
+    assert!(!output.status.success(), "an unanswered challenge must fail");
+    let stderr = stderr_of(&output);
+    assert!(stderr.contains("ERR_PNPM_OTP_NON_INTERACTIVE"), "{stderr}");
+    assert!(!stderr.contains("ERR_PNPM_UNAUTHORIZED"), "{stderr}");
+    drop((root, server));
+}
+
+/// `--otp` sends the code up front under the legacy auth type, so a classic
+/// 2FA setup needs no prompt.
+#[test]
+fn the_otp_flag_sends_the_code_under_the_legacy_auth_type() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    let mut server = mockito::Server::new();
+    let registry = format!("{}/", server.url());
+    let get_mock = server
+        .mock("GET", "/test-pkg")
+        .with_status(200)
+        .with_body(two_version_packument(&server.url()))
+        .create();
+    let delete_mock = server
+        .mock("DELETE", "/test-pkg/-rev/3-abc")
+        .match_header("npm-auth-type", "legacy")
+        .match_header("npm-otp", "123456")
+        .with_status(200)
+        .with_body("{}")
+        .create();
+    let auth_file = empty_auth_file(root.path());
+
+    let output = run_unpublish(
+        &workspace,
+        &auth_file,
+        Some(&registry),
+        &["test-pkg", "--force", "--otp", "123456"],
+    );
+
+    get_mock.assert();
+    delete_mock.assert();
+    assert!(output.status.success(), "stderr: {}", stderr_of(&output));
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout),
+        "Successfully unpublished all 2 version(s) of test-pkg\n",
+    );
     drop((root, server));
 }
 

--- a/pnpm/crates/network-web-auth/src/lib.rs
+++ b/pnpm/crates/network-web-auth/src/lib.rs
@@ -44,5 +44,6 @@ pub use prompt_browser_open::prompt_browser_open;
 pub use web_auth_timeout_error::WebAuthTimeoutError;
 pub use with_otp_handling::{
     OtpChallenge, OtpError, OtpErrorBody, OtpNonInteractiveError, OtpSecondChallengeError,
-    OtpSession, SyntheticOtpError, WithOtpError, with_otp_handling,
+    OtpSession, SyntheticOtpError, WithOtpError, otp_challenge_from_unauthorized_body,
+    with_otp_handling,
 };

--- a/pnpm/crates/network-web-auth/src/with_otp_handling.rs
+++ b/pnpm/crates/network-web-auth/src/with_otp_handling.rs
@@ -39,6 +39,28 @@ pub trait OtpError {
     fn as_otp_challenge(&self) -> Option<OtpChallenge>;
 }
 
+/// The challenge a `401` response body carries, or `None` when the body is
+/// a plain authentication failure: a JSON body with both `authUrl` and
+/// `doneUrl` is the web-based flow, a body mentioning `one-time pass` (npm's
+/// classic wording) is a classic OTP challenge.
+#[must_use]
+pub fn otp_challenge_from_unauthorized_body(body: &[u8]) -> Option<OtpChallenge> {
+    if let Ok(Value::Object(map)) = serde_json::from_slice::<Value>(body)
+        && let (Some(auth_url), Some(done_url)) = (map.get("authUrl"), map.get("doneUrl"))
+    {
+        return Some(OtpChallenge {
+            body: Some(OtpErrorBody {
+                auth_url: auth_url.as_str().map(str::to_owned),
+                done_url: done_url.as_str().map(str::to_owned),
+            }),
+        });
+    }
+    if String::from_utf8_lossy(body).to_ascii_lowercase().contains("one-time pass") {
+        return Some(OtpChallenge { body: None });
+    }
+    None
+}
+
 /// Synthetic EOTP error meant to be thrown by an operation passed to
 /// [`with_otp_handling`] and caught by it — never to propagate elsewhere.
 #[derive(Debug, derive_more::Display, derive_more::Error, Clone)]
@@ -363,3 +385,6 @@ where
         .run::<Sys, Reporter, Token, Error, Operation, Fut>(operation)
         .await
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/network-web-auth/src/with_otp_handling/tests.rs
+++ b/pnpm/crates/network-web-auth/src/with_otp_handling/tests.rs
@@ -1,0 +1,55 @@
+use super::{OtpChallenge, OtpErrorBody, otp_challenge_from_unauthorized_body};
+
+#[test]
+fn a_body_with_both_web_auth_urls_is_a_web_challenge() {
+    let body = br#"{"error":"one-time pass required","authUrl":"https://auth.example/login","doneUrl":"https://auth.example/done"}"#;
+    assert_eq!(
+        otp_challenge_from_unauthorized_body(body),
+        Some(OtpChallenge {
+            body: Some(OtpErrorBody {
+                auth_url: Some("https://auth.example/login".to_owned()),
+                done_url: Some("https://auth.example/done".to_owned()),
+            }),
+        }),
+    );
+}
+
+/// Both keys present but not both strings: still a challenge, so the flow
+/// falls back to the classic prompt instead of failing as unauthorized.
+#[test]
+fn non_string_web_auth_urls_are_dropped_from_the_challenge() {
+    let body = br#"{"authUrl":42,"doneUrl":"https://auth.example/done"}"#;
+    assert_eq!(
+        otp_challenge_from_unauthorized_body(body),
+        Some(OtpChallenge {
+            body: Some(OtpErrorBody {
+                auth_url: None,
+                done_url: Some("https://auth.example/done".to_owned()),
+            }),
+        }),
+    );
+}
+
+#[test]
+fn one_of_the_two_urls_is_not_a_web_challenge() {
+    let body = br#"{"authUrl":"https://auth.example/login"}"#;
+    assert_eq!(otp_challenge_from_unauthorized_body(body), None);
+}
+
+#[test]
+fn the_classic_wording_is_a_challenge_without_a_body() {
+    let body = br#"{"error":"You must provide a One-Time Pass. Upgrade your client to npm@latest in order to use 2FA."}"#;
+    assert_eq!(otp_challenge_from_unauthorized_body(body), Some(OtpChallenge { body: None }));
+    assert_eq!(
+        otp_challenge_from_unauthorized_body(b"one-time pass"),
+        Some(OtpChallenge { body: None }),
+        "the wording is recognized outside JSON too",
+    );
+}
+
+#[test]
+fn a_plain_unauthorized_body_is_no_challenge() {
+    assert_eq!(otp_challenge_from_unauthorized_body(br#"{"error":"unauthorized"}"#), None);
+    assert_eq!(otp_challenge_from_unauthorized_body(b"Bad token"), None);
+    assert_eq!(otp_challenge_from_unauthorized_body(b""), None);
+}

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -192,6 +192,26 @@ export class SyntheticOtpError extends Error implements OtpError {
     this.body = body
   }
 
+  /**
+   * The challenge a `401` response body carries, or `undefined` when the body
+   * is a plain authentication failure. A JSON body with both `authUrl` and
+   * `doneUrl` is the web-based flow; a body mentioning `one-time pass` (npm's
+   * classic wording) is a classic OTP challenge.
+   */
+  static fromUnauthorizedBody (body: string): SyntheticOtpError | undefined {
+    const parsed = tryParseJson(body)
+    if (parsed != null && typeof parsed === 'object' && 'authUrl' in parsed && 'doneUrl' in parsed) {
+      return new SyntheticOtpError({
+        authUrl: typeof parsed.authUrl === 'string' ? parsed.authUrl : undefined,
+        doneUrl: typeof parsed.doneUrl === 'string' ? parsed.doneUrl : undefined,
+      })
+    }
+    if (/one-time pass/i.test(body)) {
+      return new SyntheticOtpError(undefined)
+    }
+    return undefined
+  }
+
   static fromUnknownBody (globalWarn: OtpContext['globalWarn'], body: unknown): SyntheticOtpError {
     if (body == null || typeof body !== 'object') {
       return new SyntheticOtpError(undefined)
@@ -217,6 +237,14 @@ export class SyntheticOtpError extends Error implements OtpError {
     }
 
     return new SyntheticOtpError({ authUrl, doneUrl })
+  }
+}
+
+function tryParseJson (body: string): unknown {
+  try {
+    return JSON.parse(body)
+  } catch {
+    return undefined
   }
 }
 

--- a/pnpm11/network/web-auth/src/withOtpHandling.ts
+++ b/pnpm11/network/web-auth/src/withOtpHandling.ts
@@ -206,7 +206,7 @@ export class SyntheticOtpError extends Error implements OtpError {
         doneUrl: typeof parsed.doneUrl === 'string' ? parsed.doneUrl : undefined,
       })
     }
-    if (/one-time pass/i.test(body)) {
+    if (body.toLowerCase().includes('one-time pass')) {
       return new SyntheticOtpError(undefined)
     }
     return undefined

--- a/pnpm11/network/web-auth/test/withOtpHandling.test.ts
+++ b/pnpm11/network/web-auth/test/withOtpHandling.test.ts
@@ -565,3 +565,36 @@ describe('createOtpSession', () => {
     })).rejects.toThrow(OtpSecondChallengeError)
   })
 })
+
+describe('SyntheticOtpError.fromUnauthorizedBody', () => {
+  it('recognizes a body carrying both web-auth URLs', () => {
+    const error = SyntheticOtpError.fromUnauthorizedBody(JSON.stringify({
+      error: 'one-time pass required',
+      authUrl: 'https://auth.example/login',
+      doneUrl: 'https://auth.example/done',
+    }))
+    expect(error).toBeInstanceOf(SyntheticOtpError)
+    expect(error?.body).toEqual({
+      authUrl: 'https://auth.example/login',
+      doneUrl: 'https://auth.example/done',
+    })
+  })
+
+  it('drops a non-string URL but still reports a challenge', () => {
+    const error = SyntheticOtpError.fromUnauthorizedBody(JSON.stringify({ authUrl: 42, doneUrl: 'https://auth.example/done' }))
+    expect(error?.body).toEqual({ authUrl: undefined, doneUrl: 'https://auth.example/done' })
+  })
+
+  it('recognizes the classic "one-time pass" wording as a challenge without a body', () => {
+    const error = SyntheticOtpError.fromUnauthorizedBody('{"error":"You must provide a One-Time Pass. Upgrade your client to npm@latest in order to use 2FA."}')
+    expect(error).toBeInstanceOf(SyntheticOtpError)
+    expect(error?.body).toBeUndefined()
+  })
+
+  it('returns undefined for a plain authentication failure', () => {
+    expect(SyntheticOtpError.fromUnauthorizedBody('{"error":"unauthorized"}')).toBeUndefined()
+    expect(SyntheticOtpError.fromUnauthorizedBody('{"authUrl":"https://auth.example/login"}')).toBeUndefined()
+    expect(SyntheticOtpError.fromUnauthorizedBody('Bad token')).toBeUndefined()
+    expect(SyntheticOtpError.fromUnauthorizedBody('')).toBeUndefined()
+  })
+})

--- a/pnpm11/registry-access/client/src/setDistTag.ts
+++ b/pnpm11/registry-access/client/src/setDistTag.ts
@@ -36,34 +36,14 @@ export async function setDistTag (opts: SetDistTagOptions): Promise<void> {
   })
   if (response.ok) return
   const body = await response.text()
-  if (response.status === 401) {
-    throw parseAuthError(body, opts.distTag)
-  }
   const action = `set dist-tag "${opts.distTag}" on`
+  if (response.status === 401) {
+    throw SyntheticOtpError.fromUnauthorizedBody(body) ??
+      new PnpmError('UNAUTHORIZED', `You must be logged in to ${action} packages. ${body}`)
+  }
   if (response.status === 403) {
     throw new PnpmError('FORBIDDEN', `You do not have permission to ${action} this package. ${body}`)
   }
   throw new PnpmError('REGISTRY_ERROR', `Failed to ${action} package: ${response.status} ${response.statusText}. ${body}`)
 }
 
-function parseAuthError (body: string, distTag: string): Error {
-  const parsed = tryParseJson(body)
-  if (parsed != null && typeof parsed === 'object' && 'authUrl' in parsed && 'doneUrl' in parsed) {
-    return new SyntheticOtpError({
-      authUrl: typeof parsed.authUrl === 'string' ? parsed.authUrl : undefined,
-      doneUrl: typeof parsed.doneUrl === 'string' ? parsed.doneUrl : undefined,
-    })
-  }
-  if (/one-time pass/i.test(body)) {
-    return new SyntheticOtpError(undefined)
-  }
-  return new PnpmError('UNAUTHORIZED', `You must be logged in to set dist-tag "${distTag}" on packages. ${body}`)
-}
-
-function tryParseJson (body: string): unknown {
-  try {
-    return JSON.parse(body)
-  } catch {
-    return undefined
-  }
-}

--- a/pnpm11/registry-access/commands/package.json
+++ b/pnpm11/registry-access/commands/package.json
@@ -43,6 +43,7 @@
     "@pnpm/npm-package-arg": "catalog:",
     "@pnpm/registry-access.client": "workspace:*",
     "@pnpm/resolving.registry.types": "workspace:*",
+    "@pnpm/text.sanitize": "workspace:*",
     "@pnpm/types": "workspace:*",
     "chalk": "catalog:",
     "ramda": "catalog:",

--- a/pnpm11/registry-access/commands/src/common.ts
+++ b/pnpm11/registry-access/commands/src/common.ts
@@ -1,5 +1,12 @@
+import readline from 'node:readline'
+
+import { input } from '@inquirer/prompts'
 import { types as allTypes } from '@pnpm/config.reader'
 import { PnpmError } from '@pnpm/error'
+import { globalInfo, globalWarn } from '@pnpm/logger'
+import type { CreateFetchFromRegistryOptions } from '@pnpm/network.fetch'
+import { createFetchFromRegistry } from '@pnpm/network.fetch'
+import type { OtpContext, WebAuthFetchOptions } from '@pnpm/network.web-auth'
 import npa from '@pnpm/npm-package-arg'
 import { pick } from 'ramda'
 
@@ -62,4 +69,24 @@ export async function readErrorBody (response: Response): Promise<string> {
     body += '(response body truncated)'
   }
   return body
+}
+
+export const WEB_AUTH_FETCH_OPTIONS: WebAuthFetchOptions = {
+  method: 'GET',
+}
+
+// `withOtpHandling` polls `doneUrl` through `context.fetch`, so it must inherit
+// the command's proxy/TLS/`configByUri` config — otherwise the write succeeds
+// but the web-auth retry fails in custom-network environments.
+export function createOtpContext (opts: CreateFetchFromRegistryOptions): OtpContext {
+  return {
+    Date,
+    createReadlineInterface: readline.createInterface.bind(null, { input: process.stdin }),
+    enquirer: { input },
+    fetch: createFetchFromRegistry(opts),
+    globalInfo,
+    globalWarn,
+    process,
+    setTimeout,
+  }
 }

--- a/pnpm11/registry-access/commands/src/distTag.ts
+++ b/pnpm11/registry-access/commands/src/distTag.ts
@@ -1,25 +1,16 @@
-import readline from 'node:readline'
-
-import { input } from '@inquirer/prompts'
 import { docsUrl } from '@pnpm/cli.utils'
 import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { PnpmError } from '@pnpm/error'
-import { globalInfo, globalWarn } from '@pnpm/logger'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions, type FetchFromRegistry } from '@pnpm/network.fetch'
-import {
-  type OtpContext,
-  SyntheticOtpError,
-  type WebAuthFetchOptions,
-  withOtpHandling,
-} from '@pnpm/network.web-auth'
+import { SyntheticOtpError, withOtpHandling } from '@pnpm/network.web-auth'
 import npa from '@pnpm/npm-package-arg'
 import { setDistTag } from '@pnpm/registry-access.client'
 import type { RegistriesByScope, RegistryConfig } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
 
-import { parsePackageSpec, rcOptionsTypes } from './common.js'
+import { createOtpContext, parsePackageSpec, rcOptionsTypes, WEB_AUTH_FETCH_OPTIONS } from './common.js'
 
 export { rcOptionsTypes }
 
@@ -246,31 +237,13 @@ async function deleteDistTag ({
   const body = await response.text()
   const action = `remove dist-tag "${tag}" from`
   if (response.status === 401) {
-    throw parseAuthError(body, action)
+    throw SyntheticOtpError.fromUnauthorizedBody(body) ??
+      new PnpmError('UNAUTHORIZED', `You must be logged in to ${action} packages. ${body}`)
   }
   if (response.status === 403) {
     throw new PnpmError('FORBIDDEN', `You do not have permission to ${action} this package. ${body}`)
   }
   throw new PnpmError('REGISTRY_ERROR', `Failed to ${action} package: ${response.status} ${response.statusText}. ${body}`)
-}
-
-function parseAuthError (body: string, action: string): Error {
-  let parsed: unknown
-  try {
-    parsed = JSON.parse(body)
-  } catch {
-    parsed = undefined
-  }
-  if (parsed != null && typeof parsed === 'object' && 'authUrl' in parsed && 'doneUrl' in parsed) {
-    return new SyntheticOtpError({
-      authUrl: typeof parsed.authUrl === 'string' ? parsed.authUrl : undefined,
-      doneUrl: typeof parsed.doneUrl === 'string' ? parsed.doneUrl : undefined,
-    })
-  }
-  if (/one-time pass/i.test(body)) {
-    return new SyntheticOtpError(undefined)
-  }
-  return new PnpmError('UNAUTHORIZED', `You must be logged in to ${action} packages. ${body}`)
 }
 
 function getAuthHeaderForRegistry (
@@ -307,24 +280,4 @@ async function fetchDistTags (
   }
 
   return await response.json() as Record<string, string>
-}
-
-const WEB_AUTH_FETCH_OPTIONS: WebAuthFetchOptions = {
-  method: 'GET',
-}
-
-// `withOtpHandling` polls `doneUrl` through `context.fetch`, so it must inherit
-// the command's proxy/TLS/`configByUri` config — otherwise the write succeeds
-// but the web-auth retry fails in custom-network environments.
-function createOtpContext (opts: CreateFetchFromRegistryOptions): OtpContext {
-  return {
-    Date,
-    createReadlineInterface: readline.createInterface.bind(null, { input: process.stdin }),
-    enquirer: { input },
-    fetch: createFetchFromRegistry(opts),
-    globalInfo,
-    globalWarn,
-    process,
-    setTimeout,
-  }
 }

--- a/pnpm11/registry-access/commands/src/unpublish.ts
+++ b/pnpm11/registry-access/commands/src/unpublish.ts
@@ -5,6 +5,7 @@ import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions, type FetchFromRegistry } from '@pnpm/network.fetch'
 import { createOtpSession, type OtpSession, SyntheticOtpError } from '@pnpm/network.web-auth'
 import npa from '@pnpm/npm-package-arg'
+import { sanitizeInline } from '@pnpm/text.sanitize'
 import type { RegistriesByScope, RegistryConfig } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
@@ -312,7 +313,7 @@ async function sendMutation (
     if (response.status !== 401) return response
     const body = await readErrorBody(response)
     throw SyntheticOtpError.fromUnauthorizedBody(body) ??
-      new PnpmError('UNAUTHORIZED', `You must be logged in to unpublish packages. ${body}`)
+      new PnpmError('UNAUTHORIZED', `You must be logged in to unpublish packages. ${sanitizeInline(body)}`)
   })
 }
 

--- a/pnpm11/registry-access/commands/src/unpublish.ts
+++ b/pnpm11/registry-access/commands/src/unpublish.ts
@@ -3,12 +3,13 @@ import { pickRegistryForPackage } from '@pnpm/config.pick-registry-for-package'
 import { PnpmError } from '@pnpm/error'
 import { createGetAuthHeaderByURI } from '@pnpm/network.auth-header'
 import { createFetchFromRegistry, type CreateFetchFromRegistryOptions, type FetchFromRegistry } from '@pnpm/network.fetch'
+import { createOtpSession, type OtpSession, SyntheticOtpError } from '@pnpm/network.web-auth'
 import npa from '@pnpm/npm-package-arg'
 import type { RegistriesByScope, RegistryConfig } from '@pnpm/types'
 import { renderHelp } from 'render-help'
 import semver from 'semver'
 
-import { parsePackageSpec, rcOptionsTypes } from './common.js'
+import { createOtpContext, parsePackageSpec, rcOptionsTypes, readErrorBody, WEB_AUTH_FETCH_OPTIONS } from './common.js'
 
 export { rcOptionsTypes }
 
@@ -97,6 +98,24 @@ export async function handler (
   return unpublishPackage(name, versionRange, opts)
 }
 
+/**
+ * Everything a registry mutation of one package needs. The OTP session is
+ * shared by every mutation of the run, so a partial unpublish (one `PUT`
+ * plus a tarball `DELETE` per removed version) authenticates once.
+ */
+interface RegistryMutationContext {
+  authHeader: string | undefined
+  /** Mirrors npm's `auth-type`: `'web'` opts into the web-based OTP
+   * challenge, `'legacy'` is set when the user passes `--otp` so a classic
+   * code is accepted. */
+  authType: 'web' | 'legacy'
+  cliOtp: string | undefined
+  fetchFromRegistry: FetchFromRegistry
+  otpSession: OtpSession
+  packageUrl: string
+  registryUrl: string
+}
+
 async function unpublishPackage (
   packageName: string,
   versionRange: string | undefined,
@@ -118,10 +137,22 @@ async function unpublishPackage (
     throw new PnpmError('NO_VERSIONS', `Package "${packageName}" has no versions`)
   }
 
-  const otp = opts.cliOptions?.otp
+  const cliOtp = opts.cliOptions?.otp
+  const ctx: RegistryMutationContext = {
+    authHeader,
+    authType: cliOtp ? 'legacy' : 'web',
+    cliOtp,
+    fetchFromRegistry,
+    otpSession: createOtpSession({
+      context: createOtpContext(opts),
+      fetchOptions: WEB_AUTH_FETCH_OPTIONS,
+    }),
+    packageUrl,
+    registryUrl,
+  }
 
   if (!versionRange) {
-    return unpublishAll(packageUrl, pkg, fetchFromRegistry, authHeader, otp, opts.cliOptions)
+    return unpublishAll(ctx, pkg, opts.cliOptions)
   }
 
   const versionsToUnpublish = getVersionsMatchingRange(allVersions, versionRange)
@@ -131,10 +162,10 @@ async function unpublishPackage (
 
   // If removing all matched versions leaves none, treat as full unpublish
   if (versionsToUnpublish.length === Object.keys(allVersions).length) {
-    return unpublishAll(packageUrl, pkg, fetchFromRegistry, authHeader, otp, opts.cliOptions)
+    return unpublishAll(ctx, pkg, opts.cliOptions)
   }
 
-  return unpublishVersions(packageUrl, registryUrl, pkg, versionsToUnpublish, fetchFromRegistry, authHeader, otp)
+  return unpublishVersions(ctx, pkg, versionsToUnpublish)
 }
 
 async function fetchPackument (
@@ -160,13 +191,9 @@ async function fetchPackument (
 }
 
 async function unpublishVersions (
-  packageUrl: string,
-  registryUrl: string,
+  ctx: RegistryMutationContext,
   pkg: PackumentResponse,
-  versions: string[],
-  fetchFromRegistry: FetchFromRegistry,
-  authHeader: string | undefined,
-  otp: string | undefined
+  versions: string[]
 ): Promise<string> {
   // Collect tarball URLs before mutating
   const tarballs: string[] = []
@@ -199,14 +226,8 @@ async function unpublishVersions (
   delete pkg._revisions
   delete pkg._attachments
 
-  // PUT updated packument
-  const putResponse = await fetchFromRegistry(`${packageUrl}/-rev/${pkg._rev}`, {
-    authHeaderValue: authHeader,
+  const putResponse = await sendMutation(ctx, `${ctx.packageUrl}/-rev/${pkg._rev}`, {
     method: 'PUT',
-    headers: {
-      'content-type': 'application/json',
-      ...(otp ? { 'npm-otp': otp } : {}),
-    },
     body: JSON.stringify(pkg),
   })
 
@@ -215,17 +236,13 @@ async function unpublishVersions (
   }
 
   // Delete each tarball
-  const registryOrigin = new URL(registryUrl).origin
+  const registryOrigin = new URL(ctx.registryUrl).origin
   /* eslint-disable no-await-in-loop */
   for (const tarball of tarballs) {
-    const updated = await fetchPackument(packageUrl, fetchFromRegistry, authHeader)
-    const tarballPathname = getTarballPathname(tarball, registryUrl)
-    const deleteResponse = await fetchFromRegistry(`${registryOrigin}/${tarballPathname}/-rev/${updated._rev}`, {
-      authHeaderValue: authHeader,
+    const updated = await fetchPackument(ctx.packageUrl, ctx.fetchFromRegistry, ctx.authHeader)
+    const tarballPathname = getTarballPathname(tarball, ctx.registryUrl)
+    const deleteResponse = await sendMutation(ctx, `${registryOrigin}/${tarballPathname}/-rev/${updated._rev}`, {
       method: 'DELETE',
-      headers: {
-        ...(otp ? { 'npm-otp': otp } : {}),
-      },
     })
 
     // Some registries handle tarball cleanup automatically on packument update,
@@ -240,11 +257,8 @@ async function unpublishVersions (
 }
 
 async function unpublishAll (
-  packageUrl: string,
+  ctx: RegistryMutationContext,
   pkg: PackumentResponse,
-  fetchFromRegistry: FetchFromRegistry,
-  authHeader: string | undefined,
-  otp: string | undefined,
   cliOptions: UnpublishOptions['cliOptions']
 ): Promise<string> {
   const packageName = pkg.name
@@ -258,12 +272,8 @@ This is a protection mechanism to prevent accidental unpublish of packages with 
 If you want to unpublish a specific version, run pnpm unpublish ${packageName}@<version>`)
   }
 
-  const deleteResponse = await fetchFromRegistry(`${packageUrl}/-rev/${pkg._rev}`, {
-    authHeaderValue: authHeader,
+  const deleteResponse = await sendMutation(ctx, `${ctx.packageUrl}/-rev/${pkg._rev}`, {
     method: 'DELETE',
-    headers: {
-      ...(otp ? { 'npm-otp': otp } : {}),
-    },
   })
 
   if (!deleteResponse.ok) {
@@ -276,10 +286,37 @@ If you want to unpublish a specific version, run pnpm unpublish ${packageName}@<
   return `Successfully unpublished all ${versionCount} version(s) of ${packageName}`
 }
 
+/**
+ * Sends one authenticated mutation through the OTP session: a `401` that is
+ * an OTP challenge is answered (web flow or classic prompt) and the request
+ * retried with the one-time password; any other `401` is a plain
+ * authentication failure. Every other status is left to the caller.
+ */
+async function sendMutation (
+  ctx: RegistryMutationContext,
+  url: string,
+  init: { method: 'PUT' | 'DELETE', body?: string }
+): Promise<Response> {
+  return ctx.otpSession.run(async (challengeOtp) => {
+    const otp = challengeOtp ?? ctx.cliOtp
+    const response = await ctx.fetchFromRegistry(url, {
+      authHeaderValue: ctx.authHeader,
+      method: init.method,
+      headers: {
+        'npm-auth-type': ctx.authType,
+        ...(init.body != null ? { 'content-type': 'application/json' } : {}),
+        ...(otp ? { 'npm-otp': otp } : {}),
+      },
+      body: init.body,
+    })
+    if (response.status !== 401) return response
+    const body = await readErrorBody(response)
+    throw SyntheticOtpError.fromUnauthorizedBody(body) ??
+      new PnpmError('UNAUTHORIZED', `You must be logged in to unpublish packages. ${body}`)
+  })
+}
+
 async function throwRegistryError (response: Response, verb: string): Promise<never> {
-  if (response.status === 401) {
-    throw new PnpmError('UNAUTHORIZED', `You must be logged in to ${verb} packages`)
-  }
   if (response.status === 403) {
     throw new PnpmError('FORBIDDEN', `You do not have permission to ${verb} this package`)
   }

--- a/pnpm11/registry-access/commands/test/unpublish.ts
+++ b/pnpm11/registry-access/commands/test/unpublish.ts
@@ -1,8 +1,9 @@
-import { expect, test } from '@jest/globals'
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals'
 import { prepare } from '@pnpm/prepare'
 import { unpublish } from '@pnpm/registry-access.commands'
 import { publish } from '@pnpm/releasing.commands'
-import { DEFAULT_OPTS as BASE_OPTS } from '@pnpm/testing.command-defaults'
+import { DEFAULT_OPTS as BASE_OPTS, overrideTty } from '@pnpm/testing.command-defaults'
+import { getMockAgent, setupMockAgent, teardownMockAgent } from '@pnpm/testing.mock-agent'
 import { getRegistryMockToken, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import { safeExeca as execa } from 'execa'
 
@@ -128,4 +129,114 @@ test('unpublish: should throw error when version not found', async () => {
       configByUri: CONFIG_BY_URI,
     }, [`${pkgName}@9.9.9`])
   }).rejects.toThrow('No versions match')
+})
+
+describe('unpublish: OTP challenges', () => {
+  const MOCK_REGISTRY = 'https://unpublish.example'
+  // Only registry options: the TLS/proxy settings in DEFAULT_OPTS would build
+  // a private dispatcher that bypasses the mock agent.
+  const OPTS = {
+    configByUri: {},
+    registriesByScope: { default: `${MOCK_REGISTRY}/` },
+  }
+  const PACKUMENT = {
+    name: 'test-pkg',
+    _rev: '3-abc',
+    'dist-tags': { latest: '0.0.2' },
+    versions: {
+      '0.0.1': { name: 'test-pkg', version: '0.0.1', dist: { tarball: `${MOCK_REGISTRY}/test-pkg/-/test-pkg-0.0.1.tgz` } },
+      '0.0.2': { name: 'test-pkg', version: '0.0.2', dist: { tarball: `${MOCK_REGISTRY}/test-pkg/-/test-pkg-0.0.2.tgz` } },
+    },
+  }
+  const WEB_AUTH_CHALLENGE = {
+    error: 'one-time pass required',
+    authUrl: 'https://auth.example/login',
+    doneUrl: `${MOCK_REGISTRY}/-/v1/done`,
+  }
+  type Headers = Record<string, string | string[] | undefined>
+
+  beforeEach(async () => {
+    await setupMockAgent()
+  })
+
+  afterEach(async () => {
+    await teardownMockAgent()
+  })
+
+  test('a 401 carrying authUrl/doneUrl is an OTP challenge, not a missing login', async () => {
+    const restoreTty = overrideTty(false)
+    try {
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT)
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-rev/3-abc' }).reply(401, WEB_AUTH_CHALLENGE)
+
+      await expect(unpublish.handler({ ...OPTS, cliOptions: { force: true } }, ['test-pkg']))
+        .rejects.toMatchObject({ code: 'ERR_PNPM_OTP_NON_INTERACTIVE', authUrl: 'https://auth.example/login' })
+    } finally {
+      restoreTty()
+    }
+  })
+
+  test('the classic "one-time pass" wording on the packument PUT is an OTP challenge too', async () => {
+    const restoreTty = overrideTty(false)
+    try {
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT)
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'PUT', path: '/test-pkg/-rev/3-abc' })
+        .reply(401, { error: 'You must provide a one-time pass. Upgrade your client to npm@latest in order to use 2FA.' })
+
+      await expect(unpublish.handler({ ...OPTS, cliOptions: {} }, ['test-pkg@0.0.1']))
+        .rejects.toMatchObject({ code: 'ERR_PNPM_OTP_NON_INTERACTIVE' })
+    } finally {
+      restoreTty()
+    }
+  })
+
+  test('a plain 401 is reported as a missing login', async () => {
+    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT)
+    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-rev/3-abc' }).reply(401, { error: 'unauthorized' })
+
+    await expect(unpublish.handler({ ...OPTS, cliOptions: { force: true } }, ['test-pkg']))
+      .rejects.toMatchObject({ code: 'ERR_PNPM_UNAUTHORIZED', message: expect.stringContaining('You must be logged in to unpublish packages') })
+  })
+
+  test('--otp sends the code up front under the legacy auth type', async () => {
+    let deleteHeaders: Headers = {}
+    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT)
+    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-rev/3-abc' }).reply(({ headers }) => {
+      deleteHeaders = headers as Headers
+      return { statusCode: 200, data: {} }
+    })
+
+    await expect(unpublish.handler({ ...OPTS, cliOptions: { force: true, otp: '123456' } }, ['test-pkg']))
+      .resolves.toBe('Successfully unpublished all 2 version(s) of test-pkg')
+    expect(deleteHeaders['npm-auth-type']).toBe('legacy')
+    expect(deleteHeaders['npm-otp']).toBe('123456')
+  })
+
+  test('the web-auth flow answers the challenge and its token is reused by the tarball delete', async () => {
+    const restoreTty = overrideTty(true)
+    const putOtpHeaders: Array<string | string[] | undefined> = []
+    let tarballDeleteHeaders: Headers = {}
+    try {
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT).times(2)
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'PUT', path: '/test-pkg/-rev/3-abc' }).reply(({ headers }) => {
+        const otp = (headers as Headers)['npm-otp']
+        putOtpHeaders.push(otp)
+        if (otp === 'web-token') return { statusCode: 200, data: {} }
+        return { statusCode: 401, data: WEB_AUTH_CHALLENGE }
+      }).times(2)
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/-/v1/done' }).reply(200, { token: 'web-token' })
+      getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-/test-pkg-0.0.1.tgz/-rev/3-abc' }).reply(({ headers }) => {
+        tarballDeleteHeaders = headers as Headers
+        return { statusCode: 200, data: {} }
+      })
+
+      await expect(unpublish.handler({ ...OPTS, cliOptions: {} }, ['test-pkg@0.0.1']))
+        .resolves.toBe('Successfully unpublished 1 version(s) of test-pkg')
+      expect(putOtpHeaders).toEqual([undefined, 'web-token'])
+      expect(tarballDeleteHeaders['npm-auth-type']).toBe('web')
+      expect(tarballDeleteHeaders['npm-otp']).toBe('web-token')
+    } finally {
+      restoreTty()
+    }
+  })
 })

--- a/pnpm11/registry-access/commands/test/unpublish.ts
+++ b/pnpm11/registry-access/commands/test/unpublish.ts
@@ -190,12 +190,12 @@ describe('unpublish: OTP challenges', () => {
     }
   })
 
-  test('a plain 401 is reported as a missing login', async () => {
+  test('a plain 401 is reported as a missing login, with its body stripped of terminal control characters', async () => {
     getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'GET', path: '/test-pkg' }).reply(200, PACKUMENT)
-    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-rev/3-abc' }).reply(401, { error: 'unauthorized' })
+    getMockAgent().get(MOCK_REGISTRY).intercept({ method: 'DELETE', path: '/test-pkg/-rev/3-abc' }).reply(401, 'unauthorized \u001b[2J spoofed\r line')
 
     await expect(unpublish.handler({ ...OPTS, cliOptions: { force: true } }, ['test-pkg']))
-      .rejects.toMatchObject({ code: 'ERR_PNPM_UNAUTHORIZED', message: expect.stringContaining('You must be logged in to unpublish packages') })
+      .rejects.toMatchObject({ code: 'ERR_PNPM_UNAUTHORIZED', message: 'You must be logged in to unpublish packages. unauthorized [2J spoofed line' })
   })
 
   test('--otp sends the code up front under the legacy auth type', async () => {

--- a/pnpm11/registry-access/commands/tsconfig.json
+++ b/pnpm11/registry-access/commands/tsconfig.json
@@ -55,6 +55,9 @@
       "path": "../../testing/registry-mock"
     },
     {
+      "path": "../../text/sanitize"
+    },
+    {
       "path": "../client"
     }
   ]

--- a/pnpm11/releasing/commands/test/stage.test.ts
+++ b/pnpm11/releasing/commands/test/stage.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path'
 import { describe, expect, test } from '@jest/globals'
 import { prepare, preparePackages, tempDir } from '@pnpm/prepare'
 import { stage } from '@pnpm/releasing.commands'
-import { REGISTRY_URL } from '@pnpm/testing.command-defaults'
+import { overrideTty, REGISTRY_URL } from '@pnpm/testing.command-defaults'
 import { getRegistryMockToken, REGISTRY_MOCK_CREDENTIALS, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import tar from 'tar-stream'
 import { temporaryDirectory } from 'tempy'
@@ -245,7 +245,7 @@ describe('stage command against the registry mock', () => {
         doneUrl: 'https://registry.example.com/-/v1/done?authId=test-auth-id',
       },
     }))
-    const restoreTty = forceNonInteractiveTty()
+    const restoreTty = overrideTty(false)
     try {
       await expect(stage.handler({
         ...stageOpts(registry.url),
@@ -282,7 +282,7 @@ describe('stage command against the registry mock', () => {
       return { status: 404, body: { error: 'not found' } }
     })
     baseUrl = registry.url
-    const restoreTty = forceInteractiveTty()
+    const restoreTty = overrideTty(true)
     try {
       const result = await stage.handler({
         ...stageOpts(registry.url),
@@ -421,7 +421,7 @@ describe('stage command against the registry mock', () => {
       return { status: 404, body: { error: 'not found' } }
     })
     baseUrl = registry.url
-    const restoreTty = forceInteractiveTty()
+    const restoreTty = overrideTty(true)
     try {
       const result = await stage.handler({
         ...stageOpts(registry.url),
@@ -629,7 +629,7 @@ describe('stage command against the registry mock', () => {
 
   test('stage approve without a stage id requires an interactive terminal', async () => {
     const registry = await createRegistry(() => ({ status: 500, body: { error: 'nothing should be requested' } }))
-    const restoreTty = forceNonInteractiveTty()
+    const restoreTty = overrideTty(false)
     try {
       await expect(stage.handler(stageOpts(registry.url), ['approve']))
         .rejects.toMatchObject({ code: 'ERR_PNPM_STAGE_ID_REQUIRED' })
@@ -653,7 +653,7 @@ describe('stage command against the registry mock', () => {
       }
       return { status: 404, body: { error: 'not found' } }
     })
-    const restoreTty = forceInteractiveTty()
+    const restoreTty = overrideTty(true)
     try {
       await expect(stage.handler(stageOpts(registry.url), ['approve']))
         .resolves.toBe('There are no staged packages awaiting approval.')
@@ -670,7 +670,7 @@ describe('stage command against the registry mock', () => {
       }
       return { status: 404, body: { error: 'not found' } }
     })
-    const restoreTty = forceInteractiveTty()
+    const restoreTty = overrideTty(true)
     try {
       await expect(stage.handler(stageOpts(registry.url), ['approve']))
         .resolves.toBe('There are no staged packages awaiting approval.')
@@ -816,38 +816,6 @@ function createPackageTarball (manifest: { name: string, version: string }): Pro
 
 function headerValue (value: http.IncomingHttpHeaders[string]): string | undefined {
   return Array.isArray(value) ? value[0] : value
-}
-
-function forceInteractiveTty (): () => void {
-  return overrideTty(true)
-}
-
-function forceNonInteractiveTty (): () => void {
-  return overrideTty(false)
-}
-
-/**
- * Pins both terminal streams to `isTTY`, so a test exercises the interactive
- * or the non-interactive path whether or not the suite itself runs on a
- * terminal. Returns the restore function.
- */
-function overrideTty (isTTY: boolean): () => void {
-  const originalStdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
-  const originalStdout = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
-  Object.defineProperty(process.stdin, 'isTTY', { value: isTTY, configurable: true })
-  Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true })
-  return () => {
-    if (originalStdin) {
-      Object.defineProperty(process.stdin, 'isTTY', originalStdin)
-    } else {
-      delete (process.stdin as { isTTY?: boolean }).isTTY
-    }
-    if (originalStdout) {
-      Object.defineProperty(process.stdout, 'isTTY', originalStdout)
-    } else {
-      delete (process.stdout as { isTTY?: boolean }).isTTY
-    }
-  }
 }
 
 function readRequestBody (req: http.IncomingMessage): Promise<Buffer> {

--- a/pnpm11/testing/command-defaults/src/index.ts
+++ b/pnpm11/testing/command-defaults/src/index.ts
@@ -57,3 +57,27 @@ export const DEFAULT_OPTS = {
   workspaceConcurrency: 4,
   virtualStoreDirMaxLength: process.platform === 'win32' ? 60 : 120,
 }
+
+/**
+ * Pins both terminal streams to `isTTY`, so a test exercises the interactive
+ * or the non-interactive path whether or not the suite itself runs on a
+ * terminal. Returns the restore function.
+ */
+export function overrideTty (isTTY: boolean): () => void {
+  const originalStdin = Object.getOwnPropertyDescriptor(process.stdin, 'isTTY')
+  const originalStdout = Object.getOwnPropertyDescriptor(process.stdout, 'isTTY')
+  Object.defineProperty(process.stdin, 'isTTY', { value: isTTY, configurable: true })
+  Object.defineProperty(process.stdout, 'isTTY', { value: isTTY, configurable: true })
+  return () => {
+    if (originalStdin) {
+      Object.defineProperty(process.stdin, 'isTTY', originalStdin)
+    } else {
+      delete (process.stdin as { isTTY?: boolean }).isTTY
+    }
+    if (originalStdout) {
+      Object.defineProperty(process.stdout, 'isTTY', originalStdout)
+    } else {
+      delete (process.stdout as { isTTY?: boolean }).isTTY
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14464.

`pnpm unpublish` fails with `ERR_PNPM_UNAUTHORIZED` for a logged-in account that has 2FA enforced: the registry answers the mutation with an OTP challenge (`You must provide a one-time pass…`), and the command treated every 401 as a missing login. This makes both stacks answer the challenge the way `dist-tag`, `publish`, and `stage` already do.

- Every unpublish mutation (the packument `PUT`, the packument `DELETE`, each tarball `DELETE`) now goes through the shared OTP session. Without `--otp` the requests carry `npm-auth-type: web`; a 401 with `authUrl`/`doneUrl` starts the web-based authentication flow, and the classic "one-time pass" wording prompts for a code. The obtained one-time password is reused by the remaining requests of the run, so a partial unpublish authenticates once. With `--otp` the code is sent up front under `npm-auth-type: legacy`.
- A 401 that is not a challenge stays `ERR_PNPM_UNAUTHORIZED`, now carrying the registry's body like the other registry-access commands.
- The 401-body classification that `dist-tag` and `setDistTag` each duplicated moves into the web-auth packages (`SyntheticOtpError.fromUnauthorizedBody` / `otp_challenge_from_unauthorized_body`) and is shared by all three call sites. The `dist-tag` OTP context also moves into `registry-access/commands/src/common.ts` for reuse.
- Tests: mock-agent tests for the TypeScript handler (challenge detection, the non-interactive error, `--otp` headers, and the full web-auth retry with token reuse across `PUT` and tarball `DELETE`), `mockito` unit tests for the Rust command through the scripted web-auth host, e2e tests for the non-interactive error and the `--otp` headers, plus unit tests for the shared parser in both stacks. The `overrideTty` helper the stage tests defined locally moves to `@pnpm/testing.command-defaults` so the new tests can share it.

Not in scope, left for a follow-up: `deprecate`, `access`, `owner`, and `team` still only accept a static `--otp` in both stacks, and the Rust `dist-tag` still reports a web challenge as `ERR_PNPM_DIST_TAG_WEB_OTP_REQUIRED` instead of driving the flow. The shared parser makes those changes mechanical.

## Squash Commit Body

```text
`pnpm unpublish` sent every registry mutation without `npm-auth-type` and
turned any 401 into ERR_PNPM_UNAUTHORIZED, so an account with 2FA
enforced could never unpublish even though it was logged in: the registry
answered with an OTP challenge the command did not recognize.

Both stacks now run the packument PUT and every tarball/packument DELETE
through the shared OTP session: the first attempt carries a configured
`--otp` (under `npm-auth-type: legacy`), otherwise `npm-auth-type: web`
requests the web-based challenge; a 401 whose body carries
`authUrl`/`doneUrl` starts the browser flow, one mentioning the classic
"one-time pass" wording prompts for a code, and the obtained password is
reused by the remaining requests of the run. Any other 401 stays a plain
authentication failure, now including the registry's body.

The 401-body classification that `dist-tag` and `setDistTag` each carried
privately moves to the web-auth packages
(`SyntheticOtpError.fromUnauthorizedBody` in TypeScript,
`otp_challenge_from_unauthorized_body` in Rust) so all call sites share
it. The Rust unpublish command becomes generic over the web-auth host so
its unit tests can script the challenge flow against a mocked registry.

Closes pnpm/pnpm#14464
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Db5F7qF8CigbNJp4TMB6N4

---
Written by an agent (Claude Code, claude-fable-5-1).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790951540&installation_model_id=426870&pr_number=14472&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14472&signature=ba1fef3cf24f2125d55e187aef02bccf4cf0dfce0235b72ae7b14e873662f8c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `pnpm unpublish` now supports two-factor authentication challenges from registries.
  - Web-based authentication is available when no OTP is supplied.
  - Classic one-time passwords continue to work with `--otp`.
  - Authentication is reused across all requests in a single unpublish operation.
  - Improved handling distinguishes OTP challenges from other authorization failures.

- **Bug Fixes**
  - Resolved unauthorized errors when unpublishing from accounts protected by two-factor authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->