### PR TITLE
perf(resolver): derive the link-target anchor once per importer

### DIFF
--- a/.changeset/anchored-links.md
+++ b/.changeset/anchored-links.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces: the anchor for re-rendering workspace `link:` targets is now derived once per project instead of once per dependency edge, and project ordering hashes paths by their raw bytes [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -26,7 +26,7 @@ use crate::{
 use indexmap::IndexMap;
 use miette::Context;
 use pnpm_config::{Config, Host};
-use pnpm_package_manager::graph_sequencer;
+use pnpm_package_manager::{PathNode, graph_sequencer};
 use pnpm_reporter::{LogEvent, LogLevel, Reporter, ScopeLog};
 use pnpm_workspace_task_scheduler::{
     ScheduleGraphAsyncOptions, TaskCompletion, schedule_graph_async,
@@ -251,14 +251,17 @@ fn select_workspace_projects_with_cycles(
             &project_dependencies
                 .iter()
                 .map(|(key, value)| {
-                    (key.as_path(), value.iter().map(PathBuf::as_path).collect::<Vec<_>>())
+                    (
+                        PathNode(key.as_path()),
+                        value.iter().map(|dir| PathNode(dir)).collect::<Vec<_>>(),
+                    )
                 })
                 .collect(),
-            &project_dependencies.keys().map(PathBuf::as_path).collect::<Vec<_>>(),
+            &project_dependencies.keys().map(|dir| PathNode(dir)).collect::<Vec<_>>(),
         )
         .order
         .into_iter()
-        .map(Path::to_path_buf)
+        .map(|node| node.0.to_path_buf())
         .collect();
         let selected_dirs: Arc<HashSet<PathBuf>> =
             Arc::new(selection.selected.keys().cloned().collect());

--- a/pnpm/crates/deps-restorer/src/lib.rs
+++ b/pnpm/crates/deps-restorer/src/lib.rs
@@ -59,7 +59,7 @@ pub use link_hoisted_modules::*;
 pub use link_root_component_members::*;
 pub use package_map::*;
 pub use pnp::*;
-pub use pnpm_workspace_task_scheduler::{GraphSequencerResult, graph_sequencer};
+pub use pnpm_workspace_task_scheduler::{GraphSequencerResult, PathNode, graph_sequencer};
 pub use prune_direct_deps::*;
 pub use prune_stale_modules::*;
 pub use safe_join_modules_dir::*;

--- a/pnpm/crates/package-manager/src/workspace_cycles.rs
+++ b/pnpm/crates/package-manager/src/workspace_cycles.rs
@@ -8,7 +8,7 @@
 //! its own check in that case.
 
 use pnpm_config::{Config, LinkWorkspacePackages};
-use pnpm_deps_restorer::graph_sequencer;
+use pnpm_deps_restorer::{PathNode, graph_sequencer};
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_workspace::{GraphPkg, Project};
 use pnpm_workspace_projects_graph::{
@@ -33,25 +33,25 @@ pub fn workspace_cycles<Pkg>(graph: &ProjectGraph<Pkg>) -> Option<Vec<Vec<PathBu
     // The sequencer runs over borrowed paths: a workspace-scale graph
     // holds tens of thousands of edges, and cloning every `PathBuf`
     // into a throwaway map cost more than the sort itself.
-    let dirs: Vec<&Path> = graph.keys().map(PathBuf::as_path).collect();
-    let included: HashSet<&Path> = dirs.iter().copied().collect();
-    let edges: HashMap<&Path, Vec<&Path>> = graph
+    let dirs: Vec<PathNode<'_>> = graph.keys().map(|dir| PathNode(dir)).collect();
+    let included: HashSet<PathNode<'_>> = dirs.iter().copied().collect();
+    let edges: HashMap<PathNode<'_>, Vec<PathNode<'_>>> = graph
         .iter()
         .map(|(dir, node)| {
             let dependencies = node
                 .dependencies
                 .iter()
-                .map(PathBuf::as_path)
+                .map(|dependency| PathNode(dependency))
                 .filter(|dependency| included.contains(dependency))
                 .collect();
-            (dir.as_path(), dependencies)
+            (PathNode(dir), dependencies)
         })
         .collect();
     let cycles = graph_sequencer(&edges, &dirs)
         .cycles
         .into_iter()
         .filter(|cycle| cycle.len() > 1)
-        .map(|cycle| cycle.into_iter().map(Path::to_path_buf).collect())
+        .map(|cycle| cycle.into_iter().map(|node| node.0.to_path_buf()).collect())
         .collect::<Vec<Vec<PathBuf>>>();
     (!cycles.is_empty()).then_some(cycles)
 }

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -25,7 +25,7 @@ use std::path::{Component, Path, PathBuf};
 /// The importer-side inputs of `link:` re-anchoring, derived once per
 /// importer: its directory as a clean relative suffix of the lockfile
 /// root. The workspace root importer holds the empty suffix.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default, Clone)]
 pub(crate) struct ImporterAnchor {
     /// `None` — an anchor carries dot components, is not truly
     /// absolute, or the importer is not under the lockfile root — turns

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -6,19 +6,72 @@
 //! absolute paths walks and re-allocates the anchors' long common
 //! prefix on every edge; both anchors hang off the same lockfile root,
 //! so the prefix always cancels out. The helpers here run the same
-//! component math on the root-relative suffixes instead.
+//! component math on the root-relative suffixes instead — and since
+//! both anchors are constant per importer, [`ImporterAnchor`] derives
+//! the suffix once so the per-edge work is the suffix math alone.
 //!
-//! Every helper is a *fast path*: it returns `None` for any input where
+//! The anchor is a *fast path*: it disarms itself for any input where
 //! the relative-space result is not trivially the same as the
-//! absolute-space one — a dot-carrying anchor or target, an importer
-//! outside the lockfile root, an absolute target — and the caller falls
-//! back to the absolute-space math. Within the guarded domain (a clean
-//! absolute lockfile root, an importer on a clean path under it) the
-//! two computations agree component-for-component, because
+//! absolute-space one — a dot-carrying anchor, a driveless-yet-rooted
+//! Windows anchor, an importer outside the lockfile root — and each
+//! rendering falls back to the caller's absolute-space math the same
+//! way for an absolute or escaping target. Within the guarded domain
+//! the two computations agree component-for-component, because
 //! `diff_paths` and `lexical_normalize` are lexical: prefixing both
 //! arguments with the same clean root never changes the outcome.
 
 use std::path::{Component, Path, PathBuf};
+
+/// The importer-side inputs of `link:` re-anchoring, derived once per
+/// importer: its directory as a clean relative suffix of the lockfile
+/// root. The workspace root importer holds the empty suffix.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ImporterAnchor {
+    /// `None` — an anchor carries dot components, is not truly
+    /// absolute, or the importer is not under the lockfile root — turns
+    /// every rendering into the caller's fallback.
+    rel_dir: Option<PathBuf>,
+}
+
+impl ImporterAnchor {
+    pub(crate) fn new(project_dir: &Path, lockfile_dir: &Path) -> Self {
+        ImporterAnchor {
+            rel_dir: importer_rel_dir(project_dir, lockfile_dir).map(Path::to_path_buf),
+        }
+    }
+
+    /// Express a lockfile-root-relative `target` relative to the
+    /// importer. `None` for a disarmed anchor, or a target that is
+    /// absolute or carries dot components.
+    pub(crate) fn target_relative_to_importer(&self, target: &Path) -> Option<PathBuf> {
+        let rel_dir = self.rel_dir.as_deref()?;
+        if !all_normal(target) {
+            return None;
+        }
+        pathdiff::diff_paths(target, rel_dir)
+    }
+
+    /// Express an importer-relative `target` (which typically climbs
+    /// out of the importer via `..` components) relative to the
+    /// lockfile root. `None` for a disarmed anchor, a target that
+    /// carries a root or prefix component — on Windows a rooted `\abs`
+    /// path is not `is_absolute`, yet `join` would silently replace the
+    /// base with it — or one that still escapes the lockfile root after
+    /// normalization.
+    pub(crate) fn target_relative_to_lockfile_root(&self, target: &Path) -> Option<PathBuf> {
+        let rel_dir = self.rel_dir.as_deref()?;
+        if !target.components().all(|component| {
+            matches!(component, Component::Normal(_) | Component::ParentDir | Component::CurDir)
+        }) {
+            return None;
+        }
+        let normalized = pnpm_fs::lexical_normalize(&rel_dir.join(target));
+        match normalized.components().next() {
+            Some(Component::ParentDir) => None,
+            _ => Some(normalized),
+        }
+    }
+}
 
 /// The importer's directory as a clean relative suffix of the lockfile
 /// root. `None` — an anchor carries `.` / `..` components, or the
@@ -34,41 +87,6 @@ pub(crate) fn importer_rel_dir<'dir>(
     }
     let rel = project_dir.strip_prefix(lockfile_dir).ok()?;
     all_normal(rel).then_some(rel)
-}
-
-/// Express a lockfile-root-relative `target` relative to the importer
-/// at [`importer_rel_dir`]. `None` for a target that is absolute or
-/// carries dot components.
-pub(crate) fn target_relative_to_importer(
-    target: &Path,
-    importer_rel_dir: &Path,
-) -> Option<PathBuf> {
-    if !all_normal(target) {
-        return None;
-    }
-    pathdiff::diff_paths(target, importer_rel_dir)
-}
-
-/// Express an importer-relative `target` (which typically climbs out
-/// of the importer via `..` components) relative to the lockfile root.
-/// `None` for a target that carries a root or prefix component — on
-/// Windows a rooted `\abs` path is not `is_absolute`, yet `join` would
-/// silently replace the base with it — or one that still escapes the
-/// lockfile root after normalization.
-pub(crate) fn target_relative_to_lockfile_root(
-    target: &Path,
-    importer_rel_dir: &Path,
-) -> Option<PathBuf> {
-    if !target.components().all(|component| {
-        matches!(component, Component::Normal(_) | Component::ParentDir | Component::CurDir)
-    }) {
-        return None;
-    }
-    let normalized = pnpm_fs::lexical_normalize(&importer_rel_dir.join(target));
-    match normalized.components().next() {
-        Some(Component::ParentDir) => None,
-        _ => Some(normalized),
-    }
 }
 
 fn is_clean_absolute(path: &Path) -> bool {

--- a/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
@@ -1,4 +1,4 @@
-use super::{importer_rel_dir, target_relative_to_importer, target_relative_to_lockfile_root};
+use super::{ImporterAnchor, importer_rel_dir};
 use pretty_assertions::assert_eq;
 use std::path::{Path, PathBuf};
 
@@ -17,16 +17,19 @@ fn rel_space_matches_absolute_space() {
         let project_dir = lockfile_dir.join(importer);
         let rel = importer_rel_dir(&project_dir, lockfile_dir).expect("importer under the root");
         assert_eq!(rel, Path::new(importer));
+        let anchor = ImporterAnchor::new(&project_dir, lockfile_dir);
         for target in ["packages/lib", "packages/group/other", "tools"] {
-            let via_rel =
-                target_relative_to_importer(Path::new(target), rel).expect("clean target renders");
+            let via_rel = anchor
+                .target_relative_to_importer(Path::new(target))
+                .expect("clean target renders");
             let via_abs =
                 pathdiff::diff_paths(lockfile_dir.join(target), &project_dir).expect("diff");
             assert_eq!(via_rel, via_abs, "importer {importer:?} target {target:?}");
 
             // And the inverse direction round-trips back to the
             // lockfile-root-relative form.
-            let back = target_relative_to_lockfile_root(&via_rel, rel)
+            let back = anchor
+                .target_relative_to_lockfile_root(&via_rel)
                 .expect("internal target stays under the root");
             assert_eq!(back, PathBuf::from(target));
         }
@@ -44,25 +47,31 @@ fn guards_send_unclean_inputs_to_the_fallback() {
         "a dot-carrying anchor must not pass the clean-absolute guard",
     );
 
-    let rel = Path::new("packages/app");
-    assert_eq!(target_relative_to_importer(Path::new("../outside"), rel), None);
-    assert_eq!(target_relative_to_importer(&root.join("target"), rel), None);
+    let anchor = ImporterAnchor::new(&root.join("packages/app"), root);
+    assert_eq!(anchor.target_relative_to_importer(Path::new("../outside")), None);
+    assert_eq!(anchor.target_relative_to_importer(&root.join("target")), None);
 
-    assert_eq!(target_relative_to_lockfile_root(&root.join("target"), rel), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(&root.join("target")), None);
     // Escapes the lockfile root: `packages/app` + `../../../outside`.
-    assert_eq!(target_relative_to_lockfile_root(Path::new("../../../outside"), rel), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new("../../../outside")), None);
+
+    // A disarmed anchor renders nothing at all.
+    let disarmed = ImporterAnchor::new(&root.parent().unwrap().join("other/app"), root);
+    assert_eq!(disarmed.target_relative_to_importer(Path::new("packages/lib")), None);
+    assert_eq!(disarmed.target_relative_to_lockfile_root(Path::new("packages/lib")), None);
 }
 
 #[test]
 fn root_importer_uses_the_empty_suffix() {
     let rel = importer_rel_dir(abs_root(), abs_root()).expect("same dir");
     assert_eq!(rel, Path::new(""));
+    let anchor = ImporterAnchor::new(abs_root(), abs_root());
     assert_eq!(
-        target_relative_to_importer(Path::new("packages/lib"), rel),
+        anchor.target_relative_to_importer(Path::new("packages/lib")),
         Some(PathBuf::from("packages/lib")),
     );
     assert_eq!(
-        target_relative_to_lockfile_root(Path::new("packages/lib"), rel),
+        anchor.target_relative_to_lockfile_root(Path::new("packages/lib")),
         Some(PathBuf::from("packages/lib")),
     );
 }
@@ -74,6 +83,7 @@ fn root_importer_uses_the_empty_suffix() {
 fn windows_drive_relative_and_rootless_anchors_use_the_fallback() {
     assert_eq!(importer_rel_dir(Path::new(r"C:ws\root\app"), Path::new(r"C:ws\root")), None);
     assert_eq!(importer_rel_dir(Path::new(r"\ws\root\app"), Path::new(r"\ws\root")), None);
-    assert_eq!(target_relative_to_lockfile_root(Path::new(r"\abs\target"), Path::new("app")), None);
-    assert_eq!(target_relative_to_lockfile_root(Path::new(r"C:abs"), Path::new("app")), None);
+    let anchor = ImporterAnchor::new(Path::new(r"C:\ws\root\app"), Path::new(r"C:\ws\root"));
+    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new(r"\abs\target")), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new(r"C:abs")), None);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -42,9 +42,7 @@ pub(super) async fn build_pkg_id_with_patch_hash(
     let raw_id = result.id.as_str();
     if let Some(target) = raw_id.strip_prefix("link:") {
         let target = std::path::Path::new(target);
-        let rel_space_target =
-            crate::link_target::importer_rel_dir(&ctx.base_opts.project_dir, &ctx.lockfile_dir)
-                .and_then(|rel| crate::link_target::target_relative_to_lockfile_root(target, rel));
+        let rel_space_target = ctx.link_anchor.target_relative_to_lockfile_root(target);
         let relative_target = rel_space_target.unwrap_or_else(|| {
             let absolute_target = if target.is_absolute() {
                 pnpm_fs::lexical_normalize(target)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/tree_ctx.rs
@@ -135,6 +135,15 @@ pub struct TreeCtx {
     /// See [`super::workspace_ctx::WorkspaceResolutionOptionsKey`].
     pub(super) workspace_resolution_options_key:
         Arc<super::workspace_ctx::WorkspaceResolutionOptionsKey>,
+    /// Importer anchor for re-rendering `link:` targets against
+    /// [`Self::lockfile_dir`], derived once here — the per-edge
+    /// `pkgIdWithPatchHash` fold reads it for every workspace edge.
+    pub(super) link_anchor: crate::link_target::ImporterAnchor,
+    /// Like [`Self::link_anchor`], but against `base_opts.lockfile_dir`
+    /// verbatim — the pair the per-edge canonical-resolution rendering
+    /// computed from, kept separate so the cache changes no behavior
+    /// even when the two lockfile-dir spellings differ.
+    pub(super) base_link_anchor: crate::link_target::ImporterAnchor,
 }
 
 impl TreeCtx {
@@ -149,14 +158,23 @@ impl TreeCtx {
         } else {
             base_opts.lockfile_dir.clone()
         };
+        let lockfile_dir = pnpm_fs::lexical_normalize(&lockfile_dir);
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
             workspace_resolution_options_key: Arc::new(
                 super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
             ),
+            link_anchor: crate::link_target::ImporterAnchor::new(
+                &base_opts.project_dir,
+                &lockfile_dir,
+            ),
+            base_link_anchor: crate::link_target::ImporterAnchor::new(
+                &base_opts.project_dir,
+                &base_opts.lockfile_dir,
+            ),
             base_opts,
-            lockfile_dir: pnpm_fs::lexical_normalize(&lockfile_dir),
+            lockfile_dir,
             catalogs: Catalogs::new(),
             workspace: Arc::new(WorkspaceTreeCtx::default()),
             patched_dependencies: None,
@@ -175,14 +193,23 @@ impl TreeCtx {
         } else {
             base_opts.lockfile_dir.clone()
         };
+        let lockfile_dir = pnpm_fs::lexical_normalize(&lockfile_dir);
         TreeCtx {
             direct_opts: base_opts.clone(),
             subdep_opts: base_opts.clone(),
             workspace_resolution_options_key: Arc::new(
                 super::workspace_ctx::WorkspaceResolutionOptionsKey::new(&base_opts),
             ),
+            link_anchor: crate::link_target::ImporterAnchor::new(
+                &base_opts.project_dir,
+                &lockfile_dir,
+            ),
+            base_link_anchor: crate::link_target::ImporterAnchor::new(
+                &base_opts.project_dir,
+                &base_opts.lockfile_dir,
+            ),
             base_opts,
-            lockfile_dir: pnpm_fs::lexical_normalize(&lockfile_dir),
+            lockfile_dir,
             catalogs: Catalogs::new(),
             workspace,
             patched_dependencies: None,
@@ -194,6 +221,10 @@ impl TreeCtx {
     #[must_use]
     pub(crate) fn with_lockfile_dir(mut self, lockfile_dir: &Path) -> Self {
         self.lockfile_dir = pnpm_fs::lexical_normalize(lockfile_dir);
+        self.link_anchor = crate::link_target::ImporterAnchor::new(
+            &self.base_opts.project_dir,
+            &self.lockfile_dir,
+        );
         self
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1187,6 +1187,7 @@ fn canonical_workspace_resolution(
 /// its manifest hooks run.
 fn render_workspace_resolution(
     canonical: &pnpm_resolving_resolver_base::ResolveResult,
+    anchor: &crate::link_target::ImporterAnchor,
     project_dir: &Path,
     lockfile_dir: &Path,
 ) -> pnpm_resolving_resolver_base::ResolveResult {
@@ -1201,9 +1202,7 @@ fn render_workspace_resolution(
     }
 
     let target = Path::new(&directory_resolution.directory);
-    let rel_space_target = crate::link_target::importer_rel_dir(project_dir, lockfile_dir)
-        .and_then(|rel| crate::link_target::target_relative_to_importer(target, rel));
-    let consumer_target = rel_space_target.unwrap_or_else(|| {
+    let consumer_target = anchor.target_relative_to_importer(target).unwrap_or_else(|| {
         let absolute_target = if target.is_absolute() {
             pnpm_fs::lexical_normalize(target)
         } else {
@@ -1310,7 +1309,24 @@ where
     });
     let mut canonical_workspace = cached_workspace.clone();
     let mut result = if let Some(canonical) = cached_workspace {
-        render_workspace_resolution(&canonical, &opts.project_dir, &opts.lockfile_dir)
+        // A `workspace:` edge never runs under the per-edge project-dir
+        // override (that fires for `file:` specifiers only), so the
+        // importer-wide anchor is exactly this edge's anchor.
+        #[cfg(debug_assertions)]
+        {
+            let anchor_inputs_describe_this_edge = opts.project_dir == ctx.base_opts.project_dir
+                && opts.lockfile_dir == ctx.base_opts.lockfile_dir;
+            debug_assert!(
+                anchor_inputs_describe_this_edge,
+                "the importer-wide link anchor must describe every workspace edge",
+            );
+        }
+        render_workspace_resolution(
+            &canonical,
+            &ctx.base_link_anchor,
+            &opts.project_dir,
+            &opts.lockfile_dir,
+        )
     } else {
         let result = resolver.resolve(wanted, opts).await.map_err(map_resolve_error)?;
         let Some(result) = result else {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
@@ -64,10 +64,15 @@ fn directory_result(id: &str, resolved_via: &str) -> ResolveResult {
 }
 
 fn rendered_link(canonical: &ResolveResult, project_dir: &str) -> String {
-    render_workspace_resolution(canonical, Path::new(project_dir), Path::new("/repo"))
-        .id
-        .as_str()
-        .to_string()
+    render_workspace_resolution(
+        canonical,
+        &crate::link_target::ImporterAnchor::new(Path::new(project_dir), Path::new("/repo")),
+        Path::new(project_dir),
+        Path::new("/repo"),
+    )
+    .id
+    .as_str()
+    .to_string()
 }
 
 #[test]

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers.rs
@@ -450,6 +450,7 @@ pub fn resolve_peers_workspace(
     // importer's direct deps.
     let final_dep_paths = walker.build_final_dep_paths();
     for importer in &importers {
+        let anchor = crate::link_target::ImporterAnchor::new(&importer.root_dir, lockfile_dir);
         let direct_by_alias: BTreeMap<String, DepPath> = importer
             .direct
             .iter()
@@ -457,6 +458,7 @@ pub fn resolve_peers_workspace(
                 let dep_path = walker.final_dep_path_of(&dep.node_id, &final_dep_paths);
                 let dep_path = importer_relative_link_dep_path(
                     &dep_path,
+                    &anchor,
                     Some(lockfile_dir),
                     Some(&importer.root_dir),
                 );

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -397,6 +397,7 @@ pub(super) fn link_node_id_as_dep_path(node_id: &NodeId) -> Option<DepPath> {
 
 pub(super) fn importer_relative_link_dep_path(
     dep_path: &DepPath,
+    anchor: &crate::link_target::ImporterAnchor,
     lockfile_dir: Option<&Path>,
     project_dir: Option<&Path>,
 ) -> DepPath {
@@ -407,9 +408,7 @@ pub(super) fn importer_relative_link_dep_path(
         return dep_path.clone();
     };
     let target = Path::new(target);
-    let rel_space_target = crate::link_target::importer_rel_dir(project_dir, lockfile_dir)
-        .and_then(|rel| crate::link_target::target_relative_to_importer(target, rel));
-    let relative_target = rel_space_target.unwrap_or_else(|| {
+    let relative_target = anchor.target_relative_to_importer(target).unwrap_or_else(|| {
         let absolute_target = if target.is_absolute() {
             pnpm_fs::lexical_normalize(target)
         } else {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context/tests.rs
@@ -23,7 +23,12 @@ const PATCHED_WORKFLOWS_SDK: &str = concat!(
 fn importer_relative_self_link_keeps_an_empty_target() {
     let workspace = Path::new("workspace");
     assert_eq!(
-        importer_relative_link_dep_path(&DepPath::from("link:."), Some(workspace), Some(workspace),),
+        importer_relative_link_dep_path(
+            &DepPath::from("link:."),
+            &crate::link_target::ImporterAnchor::new(workspace, workspace),
+            Some(workspace),
+            Some(workspace),
+        ),
         DepPath::from("link:"),
     );
 }
@@ -41,6 +46,10 @@ fn importer_relative_link_normalizes_the_project_dir() {
         assert_eq!(
             importer_relative_link_dep_path(
                 &DepPath::from("link:packages/lib"),
+                &crate::link_target::ImporterAnchor::new(
+                    Path::new(project_dir),
+                    Path::new("workspace"),
+                ),
                 Some(Path::new("workspace")),
                 Some(Path::new(project_dir)),
             ),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -555,10 +555,17 @@ impl Walker<'_> {
         // that are walk-ancestors), then rebuild the graph from the
         // per-node records keyed by the corrected depPaths.
         let final_dep_paths = self.build_final_dep_paths();
+        let anchor = match (self.opts.project_dir.as_deref(), self.opts.lockfile_dir.as_deref()) {
+            (Some(project_dir), Some(lockfile_dir)) => {
+                crate::link_target::ImporterAnchor::new(project_dir, lockfile_dir)
+            }
+            _ => crate::link_target::ImporterAnchor::default(),
+        };
         for dep in &direct {
             let dep_path = self.final_dep_path_of(&dep.node_id, &final_dep_paths);
             let dep_path = importer_relative_link_dep_path(
                 &dep_path,
+                &anchor,
                 self.opts.lockfile_dir.as_deref(),
                 self.opts.project_dir.as_deref(),
             );

--- a/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/graph_sequencer.rs
@@ -1,8 +1,33 @@
 use rustc_hash::FxHashMap;
 use std::{
     collections::{HashMap, VecDeque},
-    hash::Hash,
+    hash::{Hash, Hasher},
+    path::Path,
 };
+
+/// A path node for [`graph_sequencer`], compared and hashed by the
+/// underlying `OsStr`'s bytes. `Path`'s own `Hash` and `Eq` walk the
+/// path component by component, and on a workspace-scale graph the
+/// interner's hashing dominated the sort. Byte equality is stricter
+/// than component equality, which for node identity can only split a
+/// node the caller spelled two ways — the callers here key their
+/// graphs by one canonical `PathBuf` per project.
+#[derive(Debug, Clone, Copy)]
+pub struct PathNode<'graph>(pub &'graph Path);
+
+impl PartialEq for PathNode<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_os_str() == other.0.as_os_str()
+    }
+}
+
+impl Eq for PathNode<'_> {}
+
+impl Hash for PathNode<'_> {
+    fn hash<State: Hasher>(&self, state: &mut State) {
+        self.0.as_os_str().hash(state);
+    }
+}
 
 /// Output of [`graph_sequencer`].
 #[derive(Debug)]

--- a/pnpm/crates/workspace-task-scheduler/src/lib.rs
+++ b/pnpm/crates/workspace-task-scheduler/src/lib.rs
@@ -21,7 +21,7 @@ use std::{
 };
 
 mod graph_sequencer;
-pub use graph_sequencer::{GraphSequencerResult, graph_sequencer};
+pub use graph_sequencer::{GraphSequencerResult, PathNode, graph_sequencer};
 
 /// The stable identifier of a task: the project directory and the task
 /// (script) name. The scheduler, the summary, and the dry-run output agree


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. A fresh profile puts the largest remaining resolution cost in the `link:` re-rendering introduced by pnpm/pnpm#14396's rel-space fast paths: the importer-side anchor — the consuming project's directory expressed as a suffix of the lockfile root — was re-derived (absolute-path validation plus prefix strip) **once per dependency edge** at all three rendering sites, though both anchors are constant per importer. On the reproduction that's ~87k derivations of a value with 6,833 distinct results.

- **`ImporterAnchor`** derives the suffix once and serves the per-edge renderings. `TreeCtx` holds one per importer for the walk's canonical-resolution rendering and the `pkgIdWithPatchHash` fold — two anchors, one per lockfile-dir spelling those sites used, so the cache changes no behavior even where the spellings differ — and the peer pass builds one per importer around its direct-deps loop. A disarmed anchor (dot-carrying, non-absolute, or outside-root inputs) renders nothing, keeping every absolute-space fallback exactly where it was. A debug assertion pins the one equivalence this relies on: a `workspace:` edge never runs under the per-edge project-dir override, which fires for `file:` specifiers only — exercised by the whole debug-mode suite.
- **`PathNode`** gives the graph sequencer's interner byte-based path hashing/equality (`Path`'s own `Hash`/`Eq` walk component by component), used by the plan ordering and the cycle search.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, 87,630 `workspace:*` edges; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| `resolution` stage (median of 8, σ ≈ 4 ms) | 581 ms | 505 ms |
| whole warm update (median of 8) | 1.30 s | 1.21 s |

The written `pnpm-lock.yaml` is byte-identical, and all 406 resolver + scheduler tests pass (the anchor-API rewrite included).

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.21 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
Re-rendering a workspace link: target starts from the consuming
importer's directory expressed as a suffix of the lockfile root - and
that suffix was re-derived (validated, prefix-stripped) once per
dependency edge at all three rendering sites, though both anchors are
constant per importer. ImporterAnchor now derives it once: TreeCtx
holds one per importer for the walk's canonical-resolution rendering
and the pkgIdWithPatchHash fold (with a debug assertion pinning that a
workspace edge never runs under the per-edge project-dir override,
which fires for file: specifiers only), and the peer pass builds one
per importer around its direct-deps loop. A disarmed anchor renders
nothing, keeping every fallback exactly where it was.

The graph sequencer's interner also stops hashing paths component by
component: a PathNode wrapper compares and hashes the underlying
OsStr's bytes, used by the plan ordering and the cycle search.

On the 6,833-project reproduction from pnpm/pnpm#14352 (87,630
workspace edges, warm non-noop lockfile-only update), the resolution
stage drops from ~581 ms to ~505 ms (median of 8, sigma 4 ms),
whole-run wall time from ~1.30 s to ~1.21 s, and the written lockfile
is byte-identical. Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790960551&installation_model_id=426870&pr_number=14478&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14478&signature=dd0d98d7614d2b1bb4980b2243da03e42ea58536a0e01c5ceea1f09867ec805d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved install performance in large workspaces by reusing workspace link-target calculations per project.
  - Improved workspace project ordering and graph handling for paths with differing byte representations.

- **Bug Fixes**
  - Improved consistency when resolving workspace links across normalized and non-normalized paths.
  - Preserved correct link-target behavior for root projects, cached resolutions, and platform-specific paths.
  - Improved reliability when resolving workspace dependency cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->