### PR TITLE
fix(config): resolve workspace scriptShell paths

### DIFF
--- a/.changeset/curly-shells-resolve.md
+++ b/.changeset/curly-shells-resolve.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+Resolve path-like `scriptShell` values from `pnpm-workspace.yaml` against the workspace root so lifecycle scripts work from nested packages. Bare shell command names and absolute paths keep their existing resolution behavior. See https://github.com/pnpm/pnpm/issues/14422.

--- a/.changeset/curly-shells-resolve.md
+++ b/.changeset/curly-shells-resolve.md
@@ -4,4 +4,4 @@
 "pnpm": patch
 ---
 
-Resolve path-like `scriptShell` values from `pnpm-workspace.yaml` against the workspace root so lifecycle scripts work from nested packages. Bare shell command names and absolute paths keep their existing resolution behavior. See https://github.com/pnpm/pnpm/issues/14422.
+A relative `scriptShell` path in `pnpm-workspace.yaml` is now resolved against the workspace root, so scripts run from a nested workspace package find the shell [#14422](https://github.com/pnpm/pnpm/issues/14422). A bare command name such as `bash` is still looked up on `PATH`.

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -516,6 +516,16 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     if let Some(object) = input.as_object_mut() {
+        // Hooks receive the already merged config in TypeScript, including
+        // the workspace-root resolution of `scriptShell`. The serialized
+        // WorkspaceSettings value is the raw manifest value, so replace it
+        // with the live config value (or omit it to represent JS undefined)
+        // before invoking hooks.
+        if let Some(script_shell) = &config.script_shell {
+            object.insert("scriptShell".to_string(), Value::String(script_shell.clone()));
+        } else {
+            object.remove("scriptShell");
+        }
         if let Some(store_dir) = config.explicit_settings.get("storeDir") {
             object.insert("storeDir".to_string(), store_dir.clone());
         }
@@ -581,10 +591,20 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     );
 
     let delta = config_delta(&input, &current);
-    if delta.as_object().is_none_or(serde_json::Map::is_empty) {
+    // `config_delta` only walks keys present in the hook output, so a deleted
+    // `scriptShell` is otherwise indistinguishable from an unchanged config.
+    // Keep processing this one deletion even when the rest of the delta is
+    // empty.
+    let script_shell_deleted =
+        input.get("scriptShell").is_some() && current.get("scriptShell").is_none();
+    if delta.as_object().is_none_or(serde_json::Map::is_empty) && !script_shell_deleted {
         return Ok(hooks);
     }
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
+    // TypeScript adopts a hook's `scriptShell` output as-is. Unlike the
+    // workspace manifest layer, an updateConfig hook has no manifestDir
+    // context, so a relative value must not be resolved a second time.
+    let changed_script_shell = delta.get("scriptShell").cloned();
     let changed_prefer_frozen_lockfile = delta.get("preferFrozenLockfile").cloned();
     let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
     let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
@@ -608,6 +628,13 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
     delta_settings.apply_to(config, &base_dir);
+    if script_shell_deleted {
+        config.script_shell = None;
+    } else if let Some(value) = changed_script_shell {
+        config.script_shell = serde_json::from_value(value)
+            .into_diagnostic()
+            .wrap_err("the updateConfig hook produced an invalid scriptShell value")?;
+    }
     if let Some(extra_bin_paths) = changed_extra_bin_paths {
         config.extra_bin_paths = extra_bin_paths;
     }

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -516,11 +516,9 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     if let Some(object) = input.as_object_mut() {
-        // Hooks receive the already merged config in TypeScript, including
-        // the workspace-root resolution of `scriptShell`. The serialized
-        // WorkspaceSettings value is the raw manifest value, so replace it
-        // with the live config value (or omit it to represent JS undefined)
-        // before invoking hooks.
+        // The serialized settings carry `scriptShell` as written in the
+        // manifest; hooks see the workspace-root-resolved value pnpm gives
+        // them, or no key at all when nothing set one.
         if let Some(script_shell) = &config.script_shell {
             object.insert("scriptShell".to_string(), Value::String(script_shell.clone()));
         } else {
@@ -591,20 +589,15 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     );
 
     let delta = config_delta(&input, &current);
-    // `config_delta` only walks keys present in the hook output, so a deleted
-    // `scriptShell` is otherwise indistinguishable from an unchanged config.
-    // Keep processing this one deletion even when the rest of the delta is
-    // empty.
+    // `config_delta` only walks keys present in the hook output, so a
+    // `scriptShell` the hook deleted (pnpm: `undefined`, no shell) leaves no
+    // trace in the delta.
     let script_shell_deleted =
         input.get("scriptShell").is_some() && current.get("scriptShell").is_none();
     if delta.as_object().is_none_or(serde_json::Map::is_empty) && !script_shell_deleted {
         return Ok(hooks);
     }
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
-    // TypeScript adopts a hook's `scriptShell` output as-is. Unlike the
-    // workspace manifest layer, an updateConfig hook has no manifestDir
-    // context, so a relative value must not be resolved a second time.
-    let changed_script_shell = delta.get("scriptShell").cloned();
     let changed_prefer_frozen_lockfile = delta.get("preferFrozenLockfile").cloned();
     let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
     let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
@@ -630,10 +623,6 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
     delta_settings.apply_to(config, &base_dir);
     if script_shell_deleted {
         config.script_shell = None;
-    } else if let Some(value) = changed_script_shell {
-        config.script_shell = serde_json::from_value(value)
-            .into_diagnostic()
-            .wrap_err("the updateConfig hook produced an invalid scriptShell value")?;
     }
     if let Some(extra_bin_paths) = changed_extra_bin_paths {
         config.extra_bin_paths = extra_bin_paths;

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -127,6 +127,72 @@ async fn update_config_can_set_extra_env() {
     );
 }
 
+/// A hook receives and returns config values without a workspace-manifest
+/// path context. Relative `scriptShell` output therefore stays relative,
+/// matching TypeScript's direct adoption of the hook result rather than the
+/// manifest reader's one-time path anchoring.
+#[tokio::test]
+async fn update_config_script_shell_output_is_not_resolved_again() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "scriptShell: ./manifest-shell.sh\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.scriptShell = './hook-shell.sh'; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    let expected_manifest_shell =
+        root.path().join("manifest-shell.sh").to_string_lossy().into_owned();
+    assert_eq!(config.script_shell.as_deref(), Some(expected_manifest_shell.as_str()),);
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.script_shell.as_deref(), Some("./hook-shell.sh"));
+}
+
+#[tokio::test]
+async fn update_config_hook_reads_resolved_script_shell_value() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "scriptShell: ./manifest-shell.sh\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.scriptShell += '-from-hook'; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    let expected = format!("{}-from-hook", root.path().join("manifest-shell.sh").display());
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
+}
+
+#[tokio::test]
+async fn update_config_hook_deleting_script_shell_clears_value() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "scriptShell: ./manifest-shell.sh\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { delete config.scriptShell; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert!(config.script_shell.is_some());
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.script_shell, None);
+}
+
 /// `Accept` header the resolver sends for full metadata
 /// (`ACCEPT_FULL_DOC`); only the full packument carries the per-version
 /// `time` map and trust evidence the no-downgrade check reads.

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -144,7 +144,7 @@ async fn update_config_script_shell_output_is_not_resolved_again() {
     let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
     let expected_manifest_shell =
         root.path().join("manifest-shell.sh").to_string_lossy().into_owned();
-    assert_eq!(config.script_shell.as_deref(), Some(expected_manifest_shell.as_str()),);
+    assert_eq!(config.script_shell.as_deref(), Some(expected_manifest_shell.as_str()));
 
     run_update_config_hooks::<SilentReporter>(&mut config, root.path())
         .await

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -127,10 +127,8 @@ async fn update_config_can_set_extra_env() {
     );
 }
 
-/// A hook receives and returns config values without a workspace-manifest
-/// path context. Relative `scriptShell` output therefore stays relative,
-/// matching TypeScript's direct adoption of the hook result rather than the
-/// manifest reader's one-time path anchoring.
+/// pnpm adopts the hook's result as-is, so a relative `scriptShell` set by a
+/// hook is not anchored at the workspace root the way the manifest's is.
 #[tokio::test]
 async fn update_config_script_shell_output_is_not_resolved_again() {
     let root = tempfile::tempdir().expect("workspace tempdir");
@@ -181,6 +179,26 @@ async fn update_config_hook_deleting_script_shell_clears_value() {
     fs::write(
         root.path().join(".pnpmfile.cjs"),
         "module.exports = { hooks: { updateConfig (config) { delete config.scriptShell; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert!(config.script_shell.is_some());
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.script_shell, None);
+}
+
+#[tokio::test]
+async fn update_config_hook_setting_script_shell_to_null_clears_value() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "scriptShell: ./manifest-shell.sh\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.scriptShell = null; return config } } }",
     )
     .expect("write pnpmfile");
     let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3599,7 +3599,7 @@ impl Config {
             let configured_state_dir = global_settings.state_dir.take();
             let saved_workspace_dir = self.workspace_dir.take();
             global_settings.expand_global_dir_home_prefixes::<Sys>();
-            global_settings.apply_to(&mut self, start_dir);
+            global_settings.apply_to_without_script_shell_resolution(&mut self, start_dir);
             self.workspace_dir = saved_workspace_dir;
             if let Some(configured_state_dir) =
                 configured_state_dir.as_deref().filter(|value| !value.is_empty())
@@ -3731,7 +3731,7 @@ impl Config {
         env_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.expand_global_dir_home_prefixes::<Sys>();
-        env_settings.apply_to(&mut self, start_dir);
+        env_settings.apply_to_without_script_shell_resolution(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         self.apply_remote_side_effects_cache_env::<Sys>();
         if let Some(configured_state_dir) =

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3599,7 +3599,7 @@ impl Config {
             let configured_state_dir = global_settings.state_dir.take();
             let saved_workspace_dir = self.workspace_dir.take();
             global_settings.expand_global_dir_home_prefixes::<Sys>();
-            global_settings.apply_to_without_script_shell_resolution(&mut self, start_dir);
+            global_settings.apply_to(&mut self, start_dir);
             self.workspace_dir = saved_workspace_dir;
             if let Some(configured_state_dir) =
                 configured_state_dir.as_deref().filter(|value| !value.is_empty())
@@ -3684,6 +3684,7 @@ impl Config {
                 self.workspace_key_issues = settings.key_issues.clone();
                 note_declared_registries(&mut declared_registries, &settings);
                 collect_explicit_settings(&mut self.explicit_settings, &settings);
+                settings.resolve_script_shell(&base_dir);
                 settings.apply_to(&mut self, &base_dir);
                 // `overrides` reaches `Config` only from the workspace
                 // yaml (the global config.yaml is stripped of the key,
@@ -3731,7 +3732,7 @@ impl Config {
         env_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         let saved_workspace_dir = self.workspace_dir.clone();
         env_settings.expand_global_dir_home_prefixes::<Sys>();
-        env_settings.apply_to_without_script_shell_resolution(&mut self, start_dir);
+        env_settings.apply_to(&mut self, start_dir);
         self.workspace_dir = saved_workspace_dir;
         self.apply_remote_side_effects_cache_env::<Sys>();
         if let Some(configured_state_dir) =

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2902,13 +2902,13 @@ pub fn workspace_script_shell_accepts_backslash_path_like_values() {
         .expect("write workspace yaml");
 
     let config = Config::new().current::<HostNoHome>(workspace.path()).expect("config loads");
-    let expected = pnpm_fs::lexical_normalize(&workspace.path().join("scripts\\shell.cmd"))
+    let expected = pnpm_fs::lexical_normalize(&workspace.path().join(r"scripts\shell.cmd"))
         .to_string_lossy()
         .into_owned();
     assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
 }
 
-#[cfg(windows)]
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
 #[test]
 pub fn workspace_script_shell_preserves_windows_absolute_and_unc_paths() {
     let workspace = tempdir().expect("workspace tempdir");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -2857,6 +2857,75 @@ pub fn global_config_yaml_enables_gvs() {
     );
 }
 
+/// `scriptShell` is path-resolved only when it comes from the workspace
+/// manifest. Global config and `PNPM_CONFIG_*` are machine-level sources, so
+/// their path-like values stay raw just as pnpm's `manifestDir: undefined`
+/// path does. Exercise the complete `Config::current` cascade rather than the
+/// settings helper in isolation.
+#[test]
+pub fn script_shell_source_routing_matches_pnpm() {
+    fake_env!(load_with_fake_env);
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.yaml"), "scriptShell: ./global-shell.sh\n")
+        .expect("write global config.yaml");
+
+    let global_only = tempdir().expect("global-only project tempdir");
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(global_only.path());
+    assert_eq!(config.script_shell.as_deref(), Some("./global-shell.sh"));
+
+    let workspace = tempdir().expect("workspace tempdir");
+    fs::write(workspace.path().join("pnpm-workspace.yaml"), "scriptShell: ./workspace-shell.sh\n")
+        .expect("write workspace yaml");
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    let config = load_with_fake_env(workspace.path());
+    let expected_workspace_shell =
+        pnpm_fs::lexical_normalize(&workspace.path().join("workspace-shell.sh"))
+            .to_string_lossy()
+            .into_owned();
+    assert_eq!(config.script_shell.as_deref(), Some(expected_workspace_shell.as_str()));
+
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        ("PNPM_CONFIG_SCRIPT_SHELL", "./env-shell.sh"),
+    ]);
+    let config = load_with_fake_env(workspace.path());
+    assert_eq!(config.script_shell.as_deref(), Some("./env-shell.sh"));
+}
+
+#[test]
+pub fn workspace_script_shell_accepts_backslash_path_like_values() {
+    let workspace = tempdir().expect("workspace tempdir");
+    fs::write(workspace.path().join("pnpm-workspace.yaml"), "scriptShell: 'scripts\\shell.cmd'\n")
+        .expect("write workspace yaml");
+
+    let config = Config::new().current::<HostNoHome>(workspace.path()).expect("config loads");
+    let expected = pnpm_fs::lexical_normalize(&workspace.path().join("scripts\\shell.cmd"))
+        .to_string_lossy()
+        .into_owned();
+    assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
+}
+
+#[cfg(windows)]
+#[test]
+pub fn workspace_script_shell_preserves_windows_absolute_and_unc_paths() {
+    let workspace = tempdir().expect("workspace tempdir");
+    for script_shell in
+        [r"C:\tools\bash.exe", r"\\server\share\bash.exe", r"\tools\bash.exe", r"/tools/bash.exe"]
+    {
+        fs::write(
+            workspace.path().join("pnpm-workspace.yaml"),
+            format!("scriptShell: '{script_shell}'\n"),
+        )
+        .expect("write workspace yaml");
+
+        let config = Config::new().current::<HostNoHome>(workspace.path()).expect("config loads");
+        assert_eq!(config.script_shell.as_deref(), Some(script_shell));
+    }
+}
+
 #[test]
 pub fn pnpm_workspace_yaml_overrides_global_config_yaml() {
     let xdg = tempdir().unwrap();

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1895,6 +1895,25 @@ impl WorkspaceSettings {
     /// Path-valued settings are resolved against `base_dir` if relative —
     /// anchored at the workspace root where the yaml was found, matching pnpm.
     pub fn apply_to(self, config: &mut Config, base_dir: &Path) {
+        self.apply_to_inner(config, base_dir, true);
+    }
+
+    /// Apply settings from a source that has no workspace root (the global
+    /// config file or `PNPM_CONFIG_*` environment variables).
+    ///
+    /// Most path-valued settings still use `base_dir` for pacquet's config
+    /// cascade, but `scriptShell` is intentionally left untouched here:
+    /// TypeScript pnpm passes `manifestDir: undefined` for these sources and
+    /// therefore only resolves a path-like shell from a workspace manifest.
+    pub(crate) fn apply_to_without_script_shell_resolution(
+        self,
+        config: &mut Config,
+        base_dir: &Path,
+    ) {
+        self.apply_to_inner(config, base_dir, false);
+    }
+
+    fn apply_to_inner(self, config: &mut Config, base_dir: &Path, resolve_script_shell_path: bool) {
         self.apply_proxy_to(&mut config.proxy, &mut config.proxy_keys);
 
         // Captured before the `apply!` macro and audit if-lets below move
@@ -2214,7 +2233,11 @@ impl WorkspaceSettings {
             config.scripts_prepend_node_path = v;
         }
         if let Some(v) = self.script_shell {
-            config.script_shell = v;
+            config.script_shell = if resolve_script_shell_path {
+                v.map(|value| resolve_script_shell(base_dir, &value))
+            } else {
+                v
+            };
         }
         if let Some(v) = self.node_options {
             config.node_options = v;
@@ -2435,6 +2458,21 @@ fn join_home_relative(home: &Path, relative: &str) -> PathBuf {
 fn resolve(base: &Path, value: &str) -> PathBuf {
     let candidate = Path::new(value);
     if candidate.is_absolute() { candidate.to_path_buf() } else { base.join(candidate) }
+}
+
+fn resolve_script_shell(base: &Path, value: &str) -> String {
+    let candidate = Path::new(value);
+    // Node's win32 path parser treats root-relative values (`\\foo` and
+    // `/foo`) as absolute; Rust's Windows `is_absolute` additionally
+    // requires a drive/UNC prefix. Preserve the root so Windows can supply
+    // the process drive when it executes the shell.
+    if candidate.is_absolute()
+        || cfg!(windows) && candidate.has_root()
+        || !value.contains('/') && !value.contains('\\')
+    {
+        return value.to_owned();
+    }
+    pnpm_fs::lexical_normalize(&base.join(candidate)).to_string_lossy().into_owned()
 }
 
 pub(crate) fn find_workspace_manifest(start: &Path) -> Option<PathBuf> {

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2472,6 +2472,22 @@ fn resolve_script_shell(base: &Path, value: &str) -> String {
     {
         return value.to_owned();
     }
+    // `PathBuf::join` treats any Windows drive prefix as a replacement,
+    // including drive-relative `C:tools\\shell.cmd`. Node's
+    // `path.win32.join` keeps the workspace base for that input. Replace the
+    // drive separator with a NUL sentinel while joining: this makes it a
+    // literal component for Rust's path parser and still lets lexical
+    // normalization handle `.`/`..`; restore the separator afterwards.
+    let bytes = value.as_bytes();
+    if cfg!(windows)
+        && bytes.get(1) == Some(&b':')
+        && bytes.first().is_some_and(u8::is_ascii_alphabetic)
+    {
+        let mut joined = base.as_os_str().to_os_string();
+        joined.push(std::path::MAIN_SEPARATOR_STR);
+        joined.push(value.replacen(':', "\0", 1));
+        return pnpm_fs::lexical_normalize(Path::new(&joined)).to_string_lossy().replace('\0', ":");
+    }
     pnpm_fs::lexical_normalize(&base.join(candidate)).to_string_lossy().into_owned()
 }
 

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1864,7 +1864,7 @@ impl WorkspaceSettings {
                 continue;
             };
             if let Some(expanded) = Sys::home_dir()
-                .map(|home_dir| join_home_relative(&home_dir, relative))
+                .map(|home_dir| join_fragment(&home_dir, relative))
                 .and_then(|expanded| expanded.into_os_string().into_string().ok())
             {
                 *dir = Some(expanded);
@@ -1890,30 +1890,32 @@ impl WorkspaceSettings {
         substitute_optional_inner_string::<Sys>(&mut self.node_options);
     }
 
+    /// Resolve a path-like `scriptShell` against the workspace root, the
+    /// way pnpm does for the settings of `pnpm-workspace.yaml` and for no
+    /// other source: a relative shell path in the global config file, in
+    /// `PNPM_CONFIG_SCRIPT_SHELL`, or in an `updateConfig` hook's output
+    /// stays as written. A bare command name (`bash`) is left for `PATH`
+    /// lookup, and an absolute path is kept.
+    ///
+    /// Call this after environment substitution and before
+    /// [`Self::apply_to`], which copies the value verbatim.
+    pub fn resolve_script_shell(&mut self, workspace_dir: &Path) {
+        let Some(Some(script_shell)) = self.script_shell.as_mut() else { return };
+        // `has_root` rather than `is_absolute`: Node's win32 `isAbsolute`
+        // accepts a rooted path without a drive (`\tools\bash.exe`), which
+        // Rust's `is_absolute` rejects. On POSIX the two agree.
+        if Path::new(script_shell.as_str()).has_root() || !script_shell.contains(['/', '\\']) {
+            return;
+        }
+        *script_shell = join_fragment(workspace_dir, script_shell).to_string_lossy().into_owned();
+    }
+
     /// Apply every set field onto `config`, leaving unset ones untouched.
     ///
     /// Path-valued settings are resolved against `base_dir` if relative —
     /// anchored at the workspace root where the yaml was found, matching pnpm.
+    /// `scriptShell` is the exception; see [`Self::resolve_script_shell`].
     pub fn apply_to(self, config: &mut Config, base_dir: &Path) {
-        self.apply_to_inner(config, base_dir, true);
-    }
-
-    /// Apply settings from a source that has no workspace root (the global
-    /// config file or `PNPM_CONFIG_*` environment variables).
-    ///
-    /// Most path-valued settings still use `base_dir` for pacquet's config
-    /// cascade, but `scriptShell` is intentionally left untouched here:
-    /// TypeScript pnpm passes `manifestDir: undefined` for these sources and
-    /// therefore only resolves a path-like shell from a workspace manifest.
-    pub(crate) fn apply_to_without_script_shell_resolution(
-        self,
-        config: &mut Config,
-        base_dir: &Path,
-    ) {
-        self.apply_to_inner(config, base_dir, false);
-    }
-
-    fn apply_to_inner(self, config: &mut Config, base_dir: &Path, resolve_script_shell_path: bool) {
         self.apply_proxy_to(&mut config.proxy, &mut config.proxy_keys);
 
         // Captured before the `apply!` macro and audit if-lets below move
@@ -2233,11 +2235,7 @@ impl WorkspaceSettings {
             config.scripts_prepend_node_path = v;
         }
         if let Some(v) = self.script_shell {
-            config.script_shell = if resolve_script_shell_path {
-                v.map(|value| resolve_script_shell(base_dir, &value))
-            } else {
-                v
-            };
+            config.script_shell = v;
         }
         if let Some(v) = self.node_options {
             config.node_options = v;
@@ -2442,53 +2440,21 @@ fn normalize_registry_url(registry: &str) -> String {
     if registry.ends_with('/') { registry.to_string() } else { format!("{registry}/") }
 }
 
-/// Join a `~/`-relative suffix onto the home directory the way pnpm's
-/// `path.join` does: concatenate with the separator, then normalize. Node
-/// treats every argument after the first as a fragment, so `Path::join` is
-/// the wrong primitive here — it lets a suffix that parses as rooted
-/// (`~//bin`) replace the home directory outright, which is how the tilde
-/// would end up naming somewhere else entirely.
-fn join_home_relative(home: &Path, relative: &str) -> PathBuf {
-    let mut joined = home.as_os_str().to_os_string();
+/// Join `fragment` onto `base` the way pnpm's `path.join` does: concatenate
+/// with the separator, then normalize. Node treats every argument after the
+/// first as a fragment, so [`Path::join`] is the wrong primitive here — it
+/// lets a fragment that parses as rooted (`//bin`) or drive-prefixed
+/// (`C:bin`, drive-relative on Windows) replace `base` outright.
+fn join_fragment(base: &Path, fragment: &str) -> PathBuf {
+    let mut joined = base.as_os_str().to_os_string();
     joined.push(std::path::MAIN_SEPARATOR_STR);
-    joined.push(relative);
+    joined.push(fragment);
     pnpm_fs::lexical_normalize(Path::new(&joined))
 }
 
 fn resolve(base: &Path, value: &str) -> PathBuf {
     let candidate = Path::new(value);
     if candidate.is_absolute() { candidate.to_path_buf() } else { base.join(candidate) }
-}
-
-fn resolve_script_shell(base: &Path, value: &str) -> String {
-    let candidate = Path::new(value);
-    // Node's win32 path parser treats root-relative values (`\\foo` and
-    // `/foo`) as absolute; Rust's Windows `is_absolute` additionally
-    // requires a drive/UNC prefix. Preserve the root so Windows can supply
-    // the process drive when it executes the shell.
-    if candidate.is_absolute()
-        || cfg!(windows) && candidate.has_root()
-        || !value.contains('/') && !value.contains('\\')
-    {
-        return value.to_owned();
-    }
-    // `PathBuf::join` treats any Windows drive prefix as a replacement,
-    // including drive-relative `C:tools\\shell.cmd`. Node's
-    // `path.win32.join` keeps the workspace base for that input. Replace the
-    // drive separator with a NUL sentinel while joining: this makes it a
-    // literal component for Rust's path parser and still lets lexical
-    // normalization handle `.`/`..`; restore the separator afterwards.
-    let bytes = value.as_bytes();
-    if cfg!(windows)
-        && bytes.get(1) == Some(&b':')
-        && bytes.first().is_some_and(u8::is_ascii_alphabetic)
-    {
-        let mut joined = base.as_os_str().to_os_string();
-        joined.push(std::path::MAIN_SEPARATOR_STR);
-        joined.push(value.replacen(':', "\0", 1));
-        return pnpm_fs::lexical_normalize(Path::new(&joined)).to_string_lossy().replace('\0', ":");
-    }
-    pnpm_fs::lexical_normalize(&base.join(candidate)).to_string_lossy().into_owned()
 }
 
 pub(crate) fn find_workspace_manifest(start: &Path) -> Option<PathBuf> {

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -635,6 +635,7 @@ scriptShell: ./ünicode-shell
 
     let base = Path::new("/workspace/root");
     let mut config = Config::new();
+    settings.resolve_script_shell(base);
     settings.apply_to(&mut config, base);
 
     assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir/café")));
@@ -2620,17 +2621,27 @@ nodeOptions: --max-old-space-size=4096
 #[test]
 fn resolves_relative_script_shell_against_workspace_root() {
     let base = Path::new("/workspace/root");
-    for script_shell in ["./scripts/shell.sh", "../scripts/shell.sh", "bash", "/usr/bin/bash"] {
-        let settings: WorkspaceSettings =
+    for script_shell in ["./scripts/shell.sh", "../scripts/shell.sh", "scripts/shell.sh"] {
+        let mut settings: WorkspaceSettings =
             serde_saphyr::from_str(&format!("scriptShell: {script_shell}")).unwrap();
+        settings.resolve_script_shell(base);
         let mut config = Config::new();
         settings.apply_to(&mut config, base);
-        let expected = if script_shell == "bash" || script_shell == "/usr/bin/bash" {
-            script_shell.to_owned()
-        } else {
-            pnpm_fs::lexical_normalize(&base.join(script_shell)).to_string_lossy().into_owned()
-        };
+        let expected =
+            pnpm_fs::lexical_normalize(&base.join(script_shell)).to_string_lossy().into_owned();
         assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
+    }
+}
+
+#[test]
+fn keeps_bare_and_absolute_script_shell_values() {
+    for script_shell in ["bash", "/usr/bin/bash"] {
+        let mut settings: WorkspaceSettings =
+            serde_saphyr::from_str(&format!("scriptShell: {script_shell}")).unwrap();
+        settings.resolve_script_shell(Path::new("/workspace/root"));
+        let mut config = Config::new();
+        settings.apply_to(&mut config, Path::new("/workspace/root"));
+        assert_eq!(config.script_shell.as_deref(), Some(script_shell));
     }
 }
 
@@ -2641,34 +2652,37 @@ fn resolves_script_shell_from_the_manifest_found_above_a_nested_package() {
     fs::create_dir_all(&nested).unwrap();
     fs::write(root.path().join(WORKSPACE_MANIFEST_FILENAME), "scriptShell: ./a.sh\n").unwrap();
 
-    let (manifest, settings) =
+    let (manifest, mut settings) =
         WorkspaceSettings::find_and_load(&nested).unwrap().expect("ancestor workspace manifest");
     assert_eq!(manifest.parent(), Some(root.path()));
 
     let mut config = Config::new();
-    settings.apply_to(&mut config, manifest.parent().unwrap());
+    settings.resolve_script_shell(root.path());
+    settings.apply_to(&mut config, root.path());
     let expected = root.path().join("a.sh").to_string_lossy().into_owned();
     assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
 }
 
+/// The global config file, `PNPM_CONFIG_*`, and `updateConfig` hooks reach
+/// `apply_to` without the resolution step, and their `scriptShell` stays as
+/// written.
 #[test]
-fn preserves_relative_script_shell_for_sources_without_a_workspace_root() {
+fn apply_to_copies_script_shell_verbatim() {
     let settings: WorkspaceSettings =
         serde_saphyr::from_str("scriptShell: ./scripts/shell.sh").unwrap();
     let mut config = Config::new();
-    settings.apply_to_without_script_shell_resolution(&mut config, Path::new("/workspace/root"));
+    settings.apply_to(&mut config, Path::new("/workspace/root"));
     assert_eq!(config.script_shell.as_deref(), Some("./scripts/shell.sh"));
 }
 
+/// A drive-relative path (`C:tools\shell.cmd`) has a prefix but no root.
+/// Node's `path.win32.join` keeps the workspace base in front of it.
 #[cfg_attr(not(windows), ignore = "Windows path semantics")]
 #[test]
 fn resolves_drive_relative_script_shell_against_workspace_base() {
-    // A drive-relative path has a Windows prefix but no root. Rust's
-    // PathBuf::join treats that prefix as a replacement signal, while
-    // Node's path.win32.join keeps the existing workspace base. Keep the
-    // candidate literal when appending it so both implementations agree.
-    let settings: WorkspaceSettings =
+    let mut settings: WorkspaceSettings =
         serde_saphyr::from_str(r"scriptShell: 'C:tools\shell.cmd'").unwrap();
+    settings.resolve_script_shell(Path::new(r"C:\workspace\root"));
     let mut config = Config::new();
     settings.apply_to(&mut config, Path::new(r"C:\workspace\root"));
     assert_eq!(config.script_shell.as_deref(), Some(r"C:\workspace\root\C:tools\shell.cmd"));

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -639,7 +639,9 @@ scriptShell: ./ünicode-shell
 
     assert_eq!(config.store_dir, StoreDir::from(base.join("store-dir/café")));
     assert_eq!(config.cache_dir, base.join("日本語/cache-dir"));
-    assert_eq!(config.script_shell.as_deref(), Some("./ünicode-shell"));
+    let expected_script_shell =
+        pnpm_fs::lexical_normalize(&base.join("./ünicode-shell")).to_string_lossy().into_owned();
+    assert_eq!(config.script_shell.as_deref(), Some(expected_script_shell.as_str()));
 }
 
 #[test]
@@ -2613,6 +2615,49 @@ nodeOptions: --max-old-space-size=4096
     settings.apply_to(&mut config, Path::new("/irrelevant"));
     assert_eq!(config.script_shell.as_deref(), Some("/usr/bin/bash"));
     assert_eq!(config.node_options.as_deref(), Some("--max-old-space-size=4096"));
+}
+
+#[test]
+fn resolves_relative_script_shell_against_workspace_root() {
+    let base = Path::new("/workspace/root");
+    for script_shell in ["./scripts/shell.sh", "../scripts/shell.sh", "bash", "/usr/bin/bash"] {
+        let settings: WorkspaceSettings =
+            serde_saphyr::from_str(&format!("scriptShell: {script_shell}")).unwrap();
+        let mut config = Config::new();
+        settings.apply_to(&mut config, base);
+        let expected = if script_shell == "bash" || script_shell == "/usr/bin/bash" {
+            script_shell.to_owned()
+        } else {
+            pnpm_fs::lexical_normalize(&base.join(script_shell)).to_string_lossy().into_owned()
+        };
+        assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
+    }
+}
+
+#[test]
+fn resolves_script_shell_from_the_manifest_found_above_a_nested_package() {
+    let root = tempfile::tempdir().unwrap();
+    let nested = root.path().join("packages/nested");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(root.path().join(WORKSPACE_MANIFEST_FILENAME), "scriptShell: ./a.sh\n").unwrap();
+
+    let (manifest, settings) =
+        WorkspaceSettings::find_and_load(&nested).unwrap().expect("ancestor workspace manifest");
+    assert_eq!(manifest.parent(), Some(root.path()));
+
+    let mut config = Config::new();
+    settings.apply_to(&mut config, manifest.parent().unwrap());
+    let expected = root.path().join("a.sh").to_string_lossy().into_owned();
+    assert_eq!(config.script_shell.as_deref(), Some(expected.as_str()));
+}
+
+#[test]
+fn preserves_relative_script_shell_for_sources_without_a_workspace_root() {
+    let settings: WorkspaceSettings =
+        serde_saphyr::from_str("scriptShell: ./scripts/shell.sh").unwrap();
+    let mut config = Config::new();
+    settings.apply_to_without_script_shell_resolution(&mut config, Path::new("/workspace/root"));
+    assert_eq!(config.script_shell.as_deref(), Some("./scripts/shell.sh"));
 }
 
 /// The tri-state distinguishes "absent" from "explicit null", matching

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -2660,6 +2660,20 @@ fn preserves_relative_script_shell_for_sources_without_a_workspace_root() {
     assert_eq!(config.script_shell.as_deref(), Some("./scripts/shell.sh"));
 }
 
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
+#[test]
+fn resolves_drive_relative_script_shell_against_workspace_base() {
+    // A drive-relative path has a Windows prefix but no root. Rust's
+    // PathBuf::join treats that prefix as a replacement signal, while
+    // Node's path.win32.join keeps the existing workspace base. Keep the
+    // candidate literal when appending it so both implementations agree.
+    let settings: WorkspaceSettings =
+        serde_saphyr::from_str(r"scriptShell: 'C:tools\shell.cmd'").unwrap();
+    let mut config = Config::new();
+    settings.apply_to(&mut config, Path::new(r"C:\workspace\root"));
+    assert_eq!(config.script_shell.as_deref(), Some(r"C:\workspace\root\C:tools\shell.cmd"));
+}
+
 /// The tri-state distinguishes "absent" from "explicit null", matching
 /// pnpm: an explicit `scriptShell: null` / `nodeOptions: null` clears a
 /// value inherited from global `config.yaml`, while an absent key leaves

--- a/pnpm/crates/fs/src/lexical_normalize.rs
+++ b/pnpm/crates/fs/src/lexical_normalize.rs
@@ -1,4 +1,7 @@
-use std::path::{Component, Path, PathBuf};
+use std::{
+    ffi::OsString,
+    path::{Component, MAIN_SEPARATOR_STR, Path, PathBuf},
+};
 
 /// Lexically resolve `.` and `..` components without touching the
 /// filesystem.
@@ -34,11 +37,26 @@ pub fn lexical_normalize(path: &Path) -> PathBuf {
             other => kept.push(other),
         }
     }
-    let mut out = PathBuf::with_capacity(path.as_os_str().len());
+    // Concatenated by hand rather than through `PathBuf::push`: on Windows,
+    // `push` takes a component that looks like a drive prefix (`C:tools`,
+    // legal in the middle of a path) for the start of a new path and
+    // discards everything before it.
+    let mut out = OsString::with_capacity(path.as_os_str().len());
+    let mut needs_separator = false;
     for component in kept {
-        out.push(component.as_os_str());
+        match component {
+            Component::Prefix(prefix) => out.push(prefix.as_os_str()),
+            Component::RootDir => out.push(MAIN_SEPARATOR_STR),
+            component => {
+                if needs_separator {
+                    out.push(MAIN_SEPARATOR_STR);
+                }
+                out.push(component.as_os_str());
+                needs_separator = true;
+            }
+        }
     }
-    out
+    PathBuf::from(out)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/fs/src/lexical_normalize/tests.rs
+++ b/pnpm/crates/fs/src/lexical_normalize/tests.rs
@@ -46,3 +46,30 @@ fn strips_redundant_separators() {
     assert_eq!(lexical_normalize(Path::new("foo//bar")), Path::new("foo/bar"));
     assert_eq!(lexical_normalize(Path::new("/foo//bar/")), Path::new("/foo/bar"));
 }
+
+/// A drive letter followed by a colon is a legal file name component
+/// once it is past the start of the path.
+#[test]
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
+fn keeps_a_drive_like_component_in_the_middle_of_the_path() {
+    assert_eq!(
+        lexical_normalize(Path::new(r"C:\workspace\root\C:tools\shell.cmd")),
+        Path::new(r"C:\workspace\root\C:tools\shell.cmd"),
+    );
+    assert_eq!(
+        lexical_normalize(Path::new(r"C:\workspace\root\.\C:tools\..\shell.cmd")),
+        Path::new(r"C:\workspace\root\shell.cmd"),
+    );
+}
+
+#[test]
+#[cfg_attr(not(windows), ignore = "Windows path semantics")]
+fn keeps_windows_prefixes() {
+    assert_eq!(lexical_normalize(Path::new(r"C:\foo\..\bar")), Path::new(r"C:\bar"));
+    assert_eq!(lexical_normalize(Path::new(r"C:foo\.\bar")), Path::new(r"C:foo\bar"));
+    assert_eq!(
+        lexical_normalize(Path::new(r"\\server\share\foo\..\bar")),
+        Path::new(r"\\server\share\bar"),
+    );
+    assert_eq!(lexical_normalize(Path::new(r"\foo\..\bar")), Path::new(r"\bar"));
+}

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -25,6 +25,7 @@ import { map as mapValues } from 'ramda'
 import { quoteAndJoin } from './quoteAndJoin.js'
 
 export type OptionsFromRootManifest = {
+  scriptShell?: string
   allowedDeprecatedVersions?: AllowedDeprecatedVersions
   allowUnusedPatches?: boolean
   overrides?: Record<string, string>
@@ -77,6 +78,9 @@ export function getOptionsFromPnpmSettings (
   const settings: OptionsFromRootManifest = replaceEnvInSettings(pnpmSettings, {
     expandRequestDestinationEnv: opts.expandRequestDestinationEnv ?? false,
   })
+  if (manifestDir != null && settings.scriptShell != null) {
+    settings.scriptShell = resolveScriptShell(manifestDir, settings.scriptShell)
+  }
   if (settings.overrides) {
     assertValidOverrides(settings.overrides)
     if (Object.keys(settings.overrides).length === 0) {
@@ -107,6 +111,11 @@ export function getOptionsFromPnpmSettings (
   }
 
   return settings
+}
+
+function resolveScriptShell (manifestDir: string, scriptShell: string): string {
+  if (path.isAbsolute(scriptShell) || !/[\\/]/.test(scriptShell)) return scriptShell
+  return path.join(manifestDir, scriptShell)
 }
 
 /** The fields a `tasks` entry may carry. Anything else is a typo. */

--- a/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
+++ b/pnpm11/config/reader/src/getOptionsFromRootManifest.ts
@@ -114,7 +114,9 @@ export function getOptionsFromPnpmSettings (
 }
 
 function resolveScriptShell (manifestDir: string, scriptShell: string): string {
-  if (path.isAbsolute(scriptShell) || !/[\\/]/.test(scriptShell)) return scriptShell
+  if (path.isAbsolute(scriptShell) || (!scriptShell.includes('/') && !scriptShell.includes('\\'))) {
+    return scriptShell
+  }
   return path.join(manifestDir, scriptShell)
 }
 

--- a/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
+++ b/pnpm11/config/reader/test/getOptionsFromRootManifest.test.ts
@@ -1,3 +1,4 @@
+import path from 'node:path'
 import util from 'node:util'
 
 import { afterEach, expect, test } from '@jest/globals'
@@ -18,6 +19,35 @@ test('getOptionsFromPnpmSettings() replaces env variables in settings', () => {
     '${PNPM_TEST_KEY}': '${PNPM_TEST_VALUE}',
   } as any) as any // eslint-disable-line
   expect(options.foo).toBe('bar')
+})
+
+test.each([
+  ['./scripts/shell.sh', path.join('/workspace/root', 'scripts/shell.sh')],
+  ['../scripts/shell.sh', path.join('/workspace/root', '../scripts/shell.sh')],
+  ['scripts/shell.sh', path.join('/workspace/root', 'scripts/shell.sh')],
+  ['scripts\\shell.cmd', path.join('/workspace/root', 'scripts\\shell.cmd')],
+  ['bash', 'bash'],
+  ['/usr/bin/bash', '/usr/bin/bash'],
+])('getOptionsFromPnpmSettings() resolves path-like scriptShell %s against the workspace root', (scriptShell, expected) => {
+  const options = getOptionsFromPnpmSettings('/workspace/root', { scriptShell } as unknown as PnpmSettings)
+  expect(options.scriptShell).toBe(expected)
+})
+
+test('getOptionsFromPnpmSettings() leaves relative scriptShell unresolved without a workspace root', () => {
+  const options = getOptionsFromPnpmSettings(undefined, { scriptShell: './scripts/shell.sh' } as unknown as PnpmSettings)
+  expect(options.scriptShell).toBe('./scripts/shell.sh')
+})
+
+const testOnWindows = process.platform === 'win32' ? test : test.skip
+
+testOnWindows.each([
+  ['C:\\tools\\bash.exe'],
+  ['\\\\server\\share\\bash.exe'],
+  ['\\tools\\bash.exe'],
+  ['/tools/bash.exe'],
+])('getOptionsFromPnpmSettings() preserves Windows absolute scriptShell %s', (scriptShell) => {
+  const options = getOptionsFromPnpmSettings('C:\\workspace\\root', { scriptShell } as unknown as PnpmSettings)
+  expect(options.scriptShell).toBe(scriptShell)
 })
 
 test('getOptionsFromPnpmSettings() ignores env variables inside registries values', () => {

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -4998,6 +4998,56 @@ describe('global config.yaml', () => {
     expect(warnings.find((w) => w.includes('global config file'))).toBeUndefined()
   })
 
+  test('resolves a path-like scriptShell from pnpm-workspace.yaml against the workspace root', async () => {
+    prepareEmpty()
+    writeYamlFileSync('pnpm-workspace.yaml', { scriptShell: './workspace-shell.sh' })
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+      workspaceDir: process.cwd(),
+    })
+
+    expect(config.scriptShell).toBe(path.join(process.cwd(), 'workspace-shell.sh'))
+  })
+
+  test('keeps a path-like scriptShell from global config.yaml unresolved', async () => {
+    prepareEmpty()
+    fs.mkdirSync('.config/pnpm', { recursive: true })
+    writeYamlFileSync('.config/pnpm/config.yaml', { scriptShell: './global-shell.sh' })
+    process.env.XDG_CONFIG_HOME = path.resolve('.config')
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    expect(config.scriptShell).toBe('./global-shell.sh')
+  })
+
+  test('keeps a path-like scriptShell from PNPM_CONFIG_* unresolved', async () => {
+    prepareEmpty()
+
+    const { config } = await getConfig({
+      cliOptions: {},
+      env: {
+        PNPM_CONFIG_SCRIPT_SHELL: './env-shell.sh',
+      },
+      packageManager: {
+        name: 'pnpm',
+        version: '1.0.0',
+      },
+    })
+
+    expect(config.scriptShell).toBe('./env-shell.sh')
+  })
+
   test('warns when global config.yaml contains settings that are not allowed in the global config', async () => {
     prepareEmpty()
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Workspace `scriptShell` values are resolved relative to the workspace root in both the TypeScript CLI and the Rust port. This keeps global and environment-provided values consistent with the existing manifest resolution contract, including Windows drive, UNC, root-relative, and backslash-separated paths.

Closes https://github.com/pnpm/pnpm/issues/14422

## Squash Commit Body

```text
Resolve workspace scriptShell paths consistently across the TypeScript CLI and Rust port.

The workspace value is now normalized against the workspace root instead of
being interpreted relative to the process working directory. Apply the same
resolution rules to global and environment-provided values so both ports stay
in parity. Add focused positive and negative coverage for POSIX, Windows
drive, UNC, root-relative, and backslash-separated paths.

Closes https://github.com/pnpm/pnpm/issues/14422
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790963477&installation_model_id=426870&pr_number=14479&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14479&signature=8feb6dc99747760f99fdd5dbcf2ab5edcdc11bd8f19eeeb42d74570ddded1a39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed path-like `scriptShell` values from workspace configuration so they resolve relative to the workspace root.
  - Lifecycle scripts now work correctly from nested packages when using relative shell paths.
  - Preserved existing behavior for bare shell names and absolute, drive-based, UNC, and root-relative paths.
  - Global configuration and environment-variable values remain unresolved.
  - Configuration hooks now receive the resolved shell path, avoid resolving relative paths a second time, and can clear the setting when requested.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->