### PR TITLE
perf(install): parallelize the freshness gates and unload the dedup caches off-thread

### DIFF
--- a/.changeset/quiet-install-tail.md
+++ b/.changeset/quiet-install-tail.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces. The check that verifies each project against the lockfile now runs the projects in parallel [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -1,3 +1,5 @@
+use rayon::prelude::*;
+
 use super::{
     Arc, Catalogs, Config, DependencyGroup, Diagnostic, Display, Error, InstallError,
     InstallWithFreshLockfileError, Lockfile, PackageManifest, Path, PathBuf, PnpmfileChecksumCheck,
@@ -190,10 +192,12 @@ pub(super) fn removed_importer_id<'a>(
     lockfile: &'a Lockfile,
     manifest_freshness_inputs: &[(String, &PackageManifest)],
 ) -> Option<&'a str> {
+    let manifest_ids: std::collections::HashSet<&str> =
+        manifest_freshness_inputs.iter().map(|(id, _)| id.as_str()).collect();
     lockfile
         .importers
         .keys()
-        .find(|importer_id| !manifest_freshness_inputs.iter().any(|(id, _)| id == *importer_id))
+        .find(|importer_id| !manifest_ids.contains(importer_id.as_str()))
         .map(String::as_str)
 }
 
@@ -271,21 +275,31 @@ pub(super) async fn check_lockfile_freshness(
     let ignored_optional_matcher = pnpm_config::matcher::create_matcher(
         config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
     );
-    for (importer_id, manifest) in manifest_freshness_inputs {
-        if allow_missing_dependency_free_importers
-            && !lockfile.importers.contains_key(importer_id)
-            && !manifest_has_effective_dependencies(manifest, &ignored_optional_matcher)
-        {
-            continue;
-        }
-        check_importer_satisfies(
-            lockfile,
-            manifest,
-            importer_id,
-            config,
-            &ignored_optional_matcher,
-            parsed_overrides_opt.as_deref(),
-        )?;
+    // Each importer's check reads only shared references, so a
+    // workspace-scale importer list fans out across the rayon pool; the
+    // serial fold keeps the first error in importer order, like the
+    // loop it replaces.
+    let results: Vec<Result<(), FreshnessCheckError>> = manifest_freshness_inputs
+        .par_iter()
+        .map(|(importer_id, manifest)| {
+            if allow_missing_dependency_free_importers
+                && !lockfile.importers.contains_key(importer_id)
+                && !manifest_has_effective_dependencies(manifest, &ignored_optional_matcher)
+            {
+                return Ok(());
+            }
+            check_importer_satisfies(
+                lockfile,
+                manifest,
+                importer_id,
+                config,
+                &ignored_optional_matcher,
+                parsed_overrides_opt.as_deref(),
+            )
+        })
+        .collect();
+    for result in results {
+        result?;
     }
     Ok(())
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1369,7 +1369,10 @@ impl WorkspaceTreeCtx {
             take_locked(&mut self.resolved_workspace_final_by_wanted),
             take_locked(&mut self.children_specs_by_id),
         );
-        std::thread::spawn(move || drop(dedup_caches));
+        // A spawn failure drops the closure — caches and all — right
+        // here, so a host that cannot take another thread just pays the
+        // drop inline, as before.
+        drop(std::thread::Builder::new().spawn(move || drop(dedup_caches)));
         tree
     }
 }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1345,34 +1345,32 @@ impl WorkspaceTreeCtx {
     /// [`TreeCtx::into_resolved_tree`], which routes through here once
     /// the last `Arc<WorkspaceTreeCtx>` reference is the [`TreeCtx`]'s
     /// own.
-    pub fn into_resolved_tree(self, direct: Vec<DirectDep>) -> ResolvedTree {
-        ResolvedTree {
+    pub fn into_resolved_tree(mut self, direct: Vec<DirectDep>) -> ResolvedTree {
+        let tree = ResolvedTree {
             direct,
-            packages: self.packages.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner),
-            dependencies_tree: self
-                .dependencies_tree
-                .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-            all_peer_dep_names: self
-                .all_peer_dep_names
-                .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-            policy_violations: self
-                .policy_violations
-                .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-            applied_patches: self
-                .applied_patches
-                .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-            children_by_id: self
-                .children_by_id
-                .into_inner()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
+            packages: take_locked(&mut self.packages),
+            dependencies_tree: take_locked(&mut self.dependencies_tree),
+            all_peer_dep_names: take_locked(&mut self.all_peer_dep_names),
+            policy_violations: take_locked(&mut self.policy_violations),
+            applied_patches: take_locked(&mut self.applied_patches),
+            children_by_id: take_locked(&mut self.children_by_id)
                 .into_iter()
                 .map(|(pkg_id, recorded)| (pkg_id, recorded.edges))
                 .collect(),
-        }
+        };
+        // The per-edge dedup caches hold an entry per resolved wanted
+        // dependency; freeing a workspace-scale map costs long enough
+        // to show up in the install's tail, and nothing reads them
+        // again, so a background thread takes the drop off the
+        // critical path.
+        let dedup_caches = (
+            take_locked(&mut self.resolved_by_wanted),
+            take_locked(&mut self.resolved_workspace_by_wanted),
+            take_locked(&mut self.resolved_workspace_final_by_wanted),
+            take_locked(&mut self.children_specs_by_id),
+        );
+        std::thread::spawn(move || drop(dedup_caches));
+        tree
     }
 }
 
@@ -1696,6 +1694,12 @@ pub(super) fn make_non_owner_nodes_lazy(ctx: &TreeCtx, pkg_id: &str, owner_node_
     if rewrote_any {
         ctx.workspace.record_children_rewrite();
     }
+}
+
+/// Take a mutex-held map out of a context this thread solely owns,
+/// recovering from poisoning like every other read of these maps.
+fn take_locked<Value: Default>(cell: &mut Mutex<Value>) -> Value {
+    std::mem::take(cell.get_mut().unwrap_or_else(std::sync::PoisonError::into_inner))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. This chunk trims the install tail — three costs that scale with workspace size but not with what changed:

- **Another O(n²) importer scan.** `removed_importer_id` in the freshness gates compared every lockfile importer against every manifest by linear search — the same shape as the fast-update composer's stale scan fixed in pnpm/pnpm#14453, with the same fix: probe a `HashSet` of manifest ids.
- **Serial per-importer freshness checks.** `check_lockfile_freshness` verified each importer's manifest against the lockfile one at a time. Each check reads only shared references, so the importers now fan out across the rayon pool; the serial fold keeps the first error in importer order, like the loop it replaces.
- **Inline teardown of the walk's dedup caches.** `into_resolved_tree` dropped the per-edge caches (one entry per resolved wanted dependency — ~87k on the reproduction) on the critical path between resolution and the peer pass. Nothing reads them again, so a background thread now takes the drop.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac):

| Metric | before | after |
| --- | ---: | ---: |
| whole warm update (quiet-run cluster of 8) | ~1.20 s | ~1.13 s |

The written `pnpm-lock.yaml` is byte-identical, and all 1,032 resolver + package-manager tests pass unchanged.

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.13 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

### Unrelated finding while committing

With today's `packageManager: pnpm@12.3.0` pin, `pnpm <anything>` breaks on my machine under the pnpm 11 version manager (`@pnpm/exe` 11.13.1 on PATH): something in the delegation runs the store-linked native binary through `node`, which fails with `SyntaxError: Invalid or unexpected token` while parsing the Mach-O as an ES module. The store links themselves are correctly relinked (both hash dirs hold the native binary), and 12.2.1 delegated fine yesterday, so this smells like an interaction with pnpm/pnpm#14462's placeholder change. I worked around it locally by putting a freshly built binary first on `PATH` for the hooks; likely worth its own issue.

## Squash Commit Body

```text
Three costs in the install tail scaled with workspace size but not
with what changed:

- removed_importer_id compared every lockfile importer against every
  manifest by linear search, O(n^2) string comparisons on a workspace
  where n is in the thousands. It now probes a set of manifest ids,
  the same fix the fast-update composer's stale scan received.
- The freshness check verified each importer against the lockfile
  serially. Each check reads only shared references, so the importers
  fan out across the rayon pool, with the serial fold keeping the
  first error in importer order.
- into_resolved_tree dropped the walk's per-edge dedup caches inline.
  They hold one entry per resolved wanted dependency, so freeing them
  sat on the critical path between resolution and the peer pass, and
  nothing reads them again; a background thread takes the drop.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), whole-run wall time drops by ~70 ms to ~1.13 s
on quiet runs and the written lockfile is byte-identical.
Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — the freshness gates' verdicts
  and error ordering, and the resolved tree's contents, are pinned by the
  existing suites, all passing unchanged; byte-identity was verified on the
  reproduction.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790974086&installation_model_id=426870&pr_number=14482&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14482&signature=1cd6f065eb0f1291c61deaeeff46c65b11fd20906ccf786029db6d714a3aaed3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved installation speed in large workspaces by checking projects against the lockfile in parallel.
  - Reduced overhead when resolving workspace dependencies, helping installations complete more efficiently.

- **Bug Fixes**
  - Preserved lockfile validation error ordering while using parallel checks.
  - Improved resilience when workspace processing is interrupted, allowing cleanup to complete without an unexpected failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->