### PR TITLE
fix(cli): keep global shims working across pnpm 12.2 and 12.3 updates

### DIFF
--- a/.changeset/legacy-shim-dispatch-compat.md
+++ b/.changeset/legacy-shim-dispatch-compat.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Global commands such as `node`, `npm`, and `yarn` no longer fail with `unexpected argument '--shim' found` after a self-update from pnpm 12.2 to 12.3. The first launch of such a command now migrates the global bin directory to the native shims that pnpm 12.3 writes.

--- a/.changeset/legacy-shim-dispatch-compat.md
+++ b/.changeset/legacy-shim-dispatch-compat.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-After a self-update from pnpm 12.2 to 12.3, global commands such as `node`, `npm`, and `yarn` failed with `unexpected argument '--shim' found`. Global commands now launch normally, and their first launch migrates the global bin directory to native shims.
+After a self-update from pnpm 12.2 to 12.3, global commands such as `node`, `npm`, and `yarn` failed with `unexpected argument '--shim' found`. Global commands now launch normally, and their first launch migrates the global bin directory to native shims. When self-update downgrades to pnpm 12.2 or older, it keeps the newer native shims so those commands continue to work.

--- a/.changeset/legacy-shim-dispatch-compat.md
+++ b/.changeset/legacy-shim-dispatch-compat.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Global commands such as `node`, `npm`, and `yarn` no longer fail with `unexpected argument '--shim' found` after a self-update from pnpm 12.2 to 12.3. The first launch of such a command now migrates the global bin directory to the native shims that pnpm 12.3 writes.
+After a self-update from pnpm 12.2 to 12.3, global commands such as `node`, `npm`, and `yarn` failed with `unexpected argument '--shim' found`. Global commands now launch normally, and their first launch migrates the global bin directory to native shims.

--- a/pnpm/crates/cli/src/cli_args/global_bin_lock.rs
+++ b/pnpm/crates/cli/src/cli_args/global_bin_lock.rs
@@ -7,6 +7,9 @@ use std::{
     time::Duration,
 };
 
+const WAIT: Duration = Duration::from_mins(5);
+const ABANDONED_AFTER: Duration = Duration::from_mins(30);
+
 #[derive(Debug, Display, Error, Diagnostic)]
 enum GlobalBinLockError {
     #[display("Failed to lock the global bin directory at {}", path.display())]
@@ -27,15 +30,20 @@ enum GlobalBinLockError {
 /// check and any rollback, so a failed transaction cannot restore over a
 /// later pnpm process's successful replacement.
 pub(crate) fn acquire_global_bin_lock(global_bin_dir: &Path) -> miette::Result<DirLock> {
-    const WAIT: Duration = Duration::from_mins(5);
-    const ABANDONED_AFTER: Duration = Duration::from_mins(30);
-
     let path = global_bin_dir.join(".pnpm-global-bin.lock");
     match DirLock::acquire(path.clone(), WAIT, ABANDONED_AFTER) {
         Ok(Some(lock)) => Ok(lock),
         Ok(None) => Err(GlobalBinLockError::TimedOut { path }.into()),
         Err(source) => Err(GlobalBinLockError::Failed { path, source }.into()),
     }
+}
+
+pub(crate) fn try_acquire_global_bin_lock(
+    global_bin_dir: &Path,
+) -> miette::Result<Option<DirLock>> {
+    let path = global_bin_dir.join(".pnpm-global-bin.lock");
+    DirLock::acquire(path.clone(), Duration::ZERO, ABANDONED_AFTER)
+        .map_err(|source| GlobalBinLockError::Failed { path, source }.into())
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cli_args/global_bin_lock/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/global_bin_lock/tests.rs
@@ -1,4 +1,4 @@
-use super::acquire_global_bin_lock;
+use super::{acquire_global_bin_lock, try_acquire_global_bin_lock};
 use std::{sync::mpsc, thread, time::Duration};
 
 #[test]
@@ -20,4 +20,14 @@ fn serializes_global_bin_writers() {
     let successor = receiver.recv_timeout(Duration::from_secs(2)).expect("second lock proceeds");
     drop(successor);
     waiter.join().expect("join lock waiter");
+}
+
+#[test]
+fn try_lock_does_not_wait_for_a_global_bin_writer() {
+    let global_bin_dir = tempfile::tempdir().expect("create global bin directory");
+    let held = acquire_global_bin_lock(global_bin_dir.path()).expect("take first lock");
+
+    assert!(try_acquire_global_bin_lock(global_bin_dir.path()).expect("try second lock").is_none());
+
+    drop(held);
 }

--- a/pnpm/crates/cli/src/cli_args/self_update.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update.rs
@@ -554,7 +554,12 @@ fn refresh_global_shims(
     installed: &install_pnpm::InstallPnpmResult,
     version: &str,
 ) -> miette::Result<()> {
-    if !node_semver::Version::parse(version).is_ok_and(|version| version.major >= 12) {
+    // Named native shims first shipped in pnpm 12.3. An older engine
+    // cannot interpret their sidecars, so leave the working shim engine
+    // in place when downgrading.
+    if !node_semver::Version::parse(version)
+        .is_ok_and(|version| (version.major, version.minor) >= (12, 3))
+    {
         return Ok(());
     }
     let executable =

--- a/pnpm/crates/cli/src/cli_args/self_update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/tests.rs
@@ -83,18 +83,15 @@ fn version_lt_compares_semver() {
     assert!(!version_lt("not-a-version", "1.0.0"));
 }
 
-/// A global bin dir holding the shim `node` published from an old engine,
-/// plus the engine a self-update installs. Returns the installed engine
-/// and the path of the shim executable.
 fn seed_shim_and_new_engine(root: &Path) -> (install_pnpm::InstallPnpmResult, std::path::PathBuf) {
     let global_bin = root.join("bin");
     let install_dir = root.join("engine");
     fs::create_dir_all(&global_bin).unwrap();
     let executable = install_pnpm::pnpm_executable_path(&install_dir, "pnpm");
     fs::create_dir_all(executable.parent().unwrap()).unwrap();
-    fs::write(&executable, b"new v12 engine").unwrap();
+    fs::write(&executable, b"new shim engine").unwrap();
     let old_engine = root.join("old-engine");
-    fs::write(&old_engine, b"old v12 engine").unwrap();
+    fs::write(&old_engine, b"old shim engine").unwrap();
     let target = ShimTarget::Installed(root.join("node-release/bin/node"));
     install_native_shim_from(&old_engine, &global_bin, "node", &target).unwrap();
     let installed = install_pnpm::InstallPnpmResult {
@@ -106,14 +103,14 @@ fn seed_shim_and_new_engine(root: &Path) -> (install_pnpm::InstallPnpmResult, st
 }
 
 #[test]
-fn self_update_republishes_the_global_shims_from_the_v12_engine() {
+fn self_update_republishes_global_shims_from_a_compatible_engine() {
     let root = tempfile::tempdir().unwrap();
     let (installed, node) = seed_shim_and_new_engine(root.path());
     let global_bin = root.path().join("bin");
 
-    refresh_global_shims(&global_bin, &installed, "12.0.0-alpha.1").unwrap();
+    refresh_global_shims(&global_bin, &installed, "12.3.0").unwrap();
 
-    assert_eq!(fs::read(node).unwrap(), b"new v12 engine");
+    assert_eq!(fs::read(node).unwrap(), b"new shim engine");
     assert_eq!(
         native_shim_target(&global_bin, "node").unwrap(),
         Some(ShimTarget::Installed(root.path().join("node-release/bin/node"))),
@@ -149,14 +146,14 @@ fn self_update_migrates_legacy_shell_shims() {
     fs::write(global_bin.join("direct"), "#!/bin/sh\nexec node\n# cmd-shim-target=/x/cli.js\n")
         .unwrap();
 
-    refresh_global_shims(&global_bin, &installed, "12.0.0").unwrap();
+    refresh_global_shims(&global_bin, &installed, "12.3.0").unwrap();
 
-    assert_eq!(fs::read(&legacy_shim).unwrap(), b"new v12 engine");
+    assert_eq!(fs::read(&legacy_shim).unwrap(), b"new shim engine");
     assert_eq!(
         native_shim_target(&global_bin, "tool").unwrap(),
         Some(ShimTarget::Installed("/global/tool/cli.js".into())),
     );
-    assert_eq!(fs::read(&legacy_virtual).unwrap(), b"new v12 engine");
+    assert_eq!(fs::read(&legacy_virtual).unwrap(), b"new shim engine");
     assert_eq!(
         native_shim_target(&global_bin, "yarn").unwrap(),
         Some(ShimTarget::Virtual("yarn".to_string())),
@@ -177,25 +174,25 @@ fn self_update_installs_no_shim_where_none_exists() {
         already_existed: false,
     };
 
-    refresh_global_shims(&global_bin, &installed, "12.0.0").unwrap();
+    refresh_global_shims(&global_bin, &installed, "12.3.0").unwrap();
 
     assert_eq!(fs::read_dir(&global_bin).unwrap().count(), 0);
 }
 
 #[test]
-fn self_update_to_pre_v12_leaves_the_global_shims_alone() {
+fn self_update_to_pnpm_without_native_shims_leaves_the_global_shims_alone() {
     let root = tempfile::tempdir().unwrap();
     let (_, node) = seed_shim_and_new_engine(root.path());
     let global_bin = root.path().join("bin");
     let installed = install_pnpm::InstallPnpmResult {
         install_dir: root.path().join("legacy-engine"),
-        package_name: "@pnpm/exe",
+        package_name: "pnpm",
         already_existed: false,
     };
 
-    refresh_global_shims(&global_bin, &installed, "11.10.0").unwrap();
+    refresh_global_shims(&global_bin, &installed, "12.2.1").unwrap();
 
-    assert_eq!(fs::read(node).unwrap(), b"old v12 engine");
+    assert_eq!(fs::read(node).unwrap(), b"old shim engine");
 }
 
 /// The engine is a native binary, so building a runnable and a non-runnable one

--- a/pnpm/crates/cli/src/shim_dispatch.rs
+++ b/pnpm/crates/cli/src/shim_dispatch.rs
@@ -59,7 +59,7 @@ pub(crate) use native_shim::{
 pub(crate) use runtime_env::materialize_runtime;
 
 use identity::{local_bin_identity, provider_of_target};
-use native_shim::try_native_dispatch;
+use native_shim::{dispatch_legacy_shim, try_native_dispatch};
 use runtime_env::{PACKAGE_MANAGER_ENVS_DIR_NAME, trusted_runtime_config};
 use trust::is_trusted;
 
@@ -68,11 +68,16 @@ use trust::is_trusted;
 /// sibling `node` shim included, inherit.
 const BYPASS_ENV: &str = "PNPM_SHIM_BYPASS";
 
-/// Intercept a launch under a shim name. `None` means this is pnpm itself
-/// and the regular CLI should proceed; `Some(code)` means the dispatch ran
-/// (or failed) and the process must exit with `code`. On Unix a successful
-/// dispatch never returns at all — the target is `exec`ed in place.
+/// Intercept a launch under a shim name, or a legacy shim's `--shim`
+/// invocation of the dispatcher it replaced. `None` means this is pnpm
+/// itself and the regular CLI should proceed; `Some(code)` means the
+/// dispatch ran (or failed) and the process must exit with `code`. On Unix
+/// a successful dispatch never returns at all — the target is `exec`ed in
+/// place.
 pub(crate) fn try_dispatch(argv: &[OsString]) -> Option<i32> {
+    if argv.get(1).and_then(|arg| arg.to_str()) == Some("--shim") {
+        return Some(dispatch_legacy_shim(&argv[2..]));
+    }
     try_native_dispatch(argv)
 }
 

--- a/pnpm/crates/cli/src/shim_dispatch/native_shim.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/native_shim.rs
@@ -12,15 +12,13 @@
 //! A legacy shim is a shell script carrying the marker line
 //! `# pnpm-shim-style=context-aware` and a `# cmd-shim-target=` trailer,
 //! dispatching through a `.pnpm-shim-v1` executable with
-//! `--shim <name> <shim> <target> -- <args...>`. Whenever shims are
-//! written or refreshed, every legacy shim in the bin dir is migrated into
-//! this shape and the `.pnpm-shim-v1` executable is removed. A self-update
-//! run by an earlier pnpm 12 puts this executable in the dispatcher's slot
-//! without touching the legacy shims that call it, so the executable also
-//! serves their `--shim` invocations and migrates the bin dir on the first
-//! one.
+//! `--shim <name> <shim> <target> -- <args...>`. An executable installed in
+//! that dispatcher slot continues to serve the protocol and migrates the bin
+//! directory before dispatching the target.
 
 use super::{dispatch_target, trusted_shim_settings};
+use crate::cli_args::global_bin_lock::try_acquire_global_bin_lock;
+use miette::{Context as _, IntoDiagnostic as _};
 use pnpm_cmd_shim::is_safe_bin_name;
 use pnpm_resolving_parse_wanted_dependency::is_valid_old_npm_package_name;
 use std::{
@@ -260,28 +258,61 @@ fn legacy_shim_target(path: &Path) -> io::Result<Option<ShimTarget>> {
     Ok(target)
 }
 
-/// Serve a legacy shim's `--shim` invocation: `rest` is everything after
-/// the `--shim` flag. The bin dir is migrated first, so the shim that
-/// made this launch is native by the time the target runs; a migration
-/// that fails leaves the legacy shims in place and is reported, since the
-/// launch itself does not depend on it.
+/// Serve a legacy shim's `--shim` invocation. A valid invocation identifies a
+/// shim beside the executing dispatcher. Migration is best-effort and does not
+/// prevent dispatch.
 pub(super) fn dispatch_legacy_shim(rest: &[OsString]) -> i32 {
     let Some((name, shim, target, args)) = parse_legacy_shim_argv(rest) else {
-        eprintln!(
-            "pnpm: malformed --shim invocation. Usage: pnpm --shim <name> <shim> <target> -- [args...]",
-        );
+        report_shim_error(&miette::miette!(
+            "malformed --shim invocation. Usage: pnpm --shim <name> <shim> <target> -- [args...]",
+        ));
         return 1;
     };
-    let Some(bin_dir) = shim.parent().filter(|dir| !dir.as_os_str().is_empty()) else {
-        eprintln!("pnpm: the shim path {} has no directory", shim.display());
+    let Some(bin_dir) = executing_dispatcher_bin_dir(shim) else {
+        let shim_display = shim.display();
+        report_shim_error(&miette::miette!(
+            "the legacy shim path {} is not beside the executing dispatcher",
+            shim_display,
+        ));
         return 1;
     };
-    if let Err(error) = migrate_legacy_shims(bin_dir) {
-        eprintln!("pnpm: cannot migrate the global shims in {}: {error}", bin_dir.display());
-    }
+    try_migrate_legacy_shims(&bin_dir);
     let settings = trusted_shim_settings();
-    let invocation = super::ShimInvocation { name, bin_dir, target: &target };
+    let invocation = super::ShimInvocation { name, bin_dir: &bin_dir, target: &target };
     dispatch_target(&invocation, args, &settings.shims, &settings.state_dir)
+}
+
+fn executing_dispatcher_bin_dir(shim: &Path) -> Option<PathBuf> {
+    let supplied_bin_dir = shim.parent().filter(|dir| !dir.as_os_str().is_empty())?;
+    let dispatcher = std::env::current_exe().ok()?;
+    let dispatcher_name = format!("{LEGACY_DISPATCHER_NAME}{}", std::env::consts::EXE_SUFFIX);
+    if dispatcher.file_name() != Some(OsStr::new(&dispatcher_name)) {
+        return None;
+    }
+    let bin_dir = dispatcher.parent()?.to_path_buf();
+    same_file::is_same_file(supplied_bin_dir, &bin_dir).unwrap_or(false).then_some(bin_dir)
+}
+
+fn try_migrate_legacy_shims(bin_dir: &Path) {
+    let lock = match try_acquire_global_bin_lock(bin_dir) {
+        Ok(Some(lock)) => lock,
+        Ok(None) => return,
+        Err(error) => {
+            report_shim_error(&error);
+            return;
+        }
+    };
+    if let Err(error) = migrate_legacy_shims(bin_dir)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("cannot migrate the global shims in {}", bin_dir.display()))
+    {
+        report_shim_error(&error);
+    }
+    drop(lock);
+}
+
+fn report_shim_error(error: &miette::Report) {
+    eprintln!("pnpm: {error:?}");
 }
 
 /// Split the machine-generated tail of a `--shim` invocation into the bin

--- a/pnpm/crates/cli/src/shim_dispatch/native_shim.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/native_shim.rs
@@ -11,9 +11,14 @@
 //!
 //! A legacy shim is a shell script carrying the marker line
 //! `# pnpm-shim-style=context-aware` and a `# cmd-shim-target=` trailer,
-//! dispatching through a `.pnpm-shim-v1` executable. Whenever shims are
+//! dispatching through a `.pnpm-shim-v1` executable with
+//! `--shim <name> <shim> <target> -- <args...>`. Whenever shims are
 //! written or refreshed, every legacy shim in the bin dir is migrated into
-//! this shape and the `.pnpm-shim-v1` executable is removed.
+//! this shape and the `.pnpm-shim-v1` executable is removed. A self-update
+//! run by an earlier pnpm 12 puts this executable in the dispatcher's slot
+//! without touching the legacy shims that call it, so the executable also
+//! serves their `--shim` invocations and migrates the bin dir on the first
+//! one.
 
 use super::{dispatch_target, trusted_shim_settings};
 use pnpm_cmd_shim::is_safe_bin_name;
@@ -70,7 +75,8 @@ impl ShimTarget {
         Some(ShimTarget::Installed(PathBuf::from(raw)))
     }
 
-    /// The target a legacy shell shim recorded in its trailer.
+    /// The target a legacy shell shim recorded in its trailer and passes
+    /// in its `--shim` invocation.
     fn from_legacy_marker(value: &str) -> Option<Self> {
         if let Some(package) = value.strip_prefix(VIRTUAL_TARGET_PREFIX) {
             return is_valid_old_npm_package_name(package)
@@ -252,6 +258,49 @@ fn legacy_shim_target(path: &Path) -> io::Result<Option<ShimTarget>> {
         .find_map(|line| line.strip_prefix(LEGACY_TARGET_MARKER))
         .and_then(ShimTarget::from_legacy_marker);
     Ok(target)
+}
+
+/// Serve a legacy shim's `--shim` invocation: `rest` is everything after
+/// the `--shim` flag. The bin dir is migrated first, so the shim that
+/// made this launch is native by the time the target runs; a migration
+/// that fails leaves the legacy shims in place and is reported, since the
+/// launch itself does not depend on it.
+pub(super) fn dispatch_legacy_shim(rest: &[OsString]) -> i32 {
+    let Some((name, shim, target, args)) = parse_legacy_shim_argv(rest) else {
+        eprintln!(
+            "pnpm: malformed --shim invocation. Usage: pnpm --shim <name> <shim> <target> -- [args...]",
+        );
+        return 1;
+    };
+    let Some(bin_dir) = shim.parent().filter(|dir| !dir.as_os_str().is_empty()) else {
+        eprintln!("pnpm: the shim path {} has no directory", shim.display());
+        return 1;
+    };
+    if let Err(error) = migrate_legacy_shims(bin_dir) {
+        eprintln!("pnpm: cannot migrate the global shims in {}: {error}", bin_dir.display());
+    }
+    let settings = trusted_shim_settings();
+    let invocation = super::ShimInvocation { name, bin_dir, target: &target };
+    dispatch_target(&invocation, args, &settings.shims, &settings.state_dir)
+}
+
+/// Split the machine-generated tail of a `--shim` invocation into the bin
+/// name, the shim's own path, its global target, and the forwarded
+/// arguments. The target slot carries what the shim's trailer would:
+/// a path, or `pkg:<package>` for a target-less shim.
+fn parse_legacy_shim_argv(rest: &[OsString]) -> Option<(&str, &Path, ShimTarget, &[OsString])> {
+    let [name, shim, target, separator, args @ ..] = rest else {
+        return None;
+    };
+    if separator.to_str() != Some("--") {
+        return None;
+    }
+    let name = name.to_str().filter(|name| is_safe_bin_name(name))?;
+    let target = match target.to_str() {
+        Some(target) => ShimTarget::from_legacy_marker(target)?,
+        None => ShimTarget::Installed(PathBuf::from(target)),
+    };
+    Some((name, Path::new(shim), target, args))
 }
 
 /// Intercept a launch under a shim name. `None` means this is pnpm

--- a/pnpm/crates/cli/src/shim_dispatch/tests.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/tests.rs
@@ -26,6 +26,24 @@ fn non_shim_argv_is_not_intercepted() {
 }
 
 #[test]
+fn malformed_legacy_shim_argv_fails_instead_of_running_the_cli() {
+    assert_eq!(try_dispatch(&strings(&["pnpm", "--shim"])), Some(1));
+    assert_eq!(try_dispatch(&strings(&["pnpm", "--shim", "tool", "/g/bin/tool"])), Some(1));
+    assert_eq!(
+        try_dispatch(&strings(&["pnpm", "--shim", "tool", "/g/bin/tool", "/g/pkg/cli", "x"])),
+        Some(1),
+    );
+    assert_eq!(
+        try_dispatch(&strings(&["pnpm", "--shim", "../tool", "/g/bin/tool", "/g/pkg/cli", "--"])),
+        Some(1),
+    );
+    assert_eq!(
+        try_dispatch(&strings(&["pnpm", "--shim", "tool", "/g/bin/tool", "pkg:not valid", "--"])),
+        Some(1),
+    );
+}
+
+#[test]
 fn configured_state_dir_resolves_relative_to_the_machine_state_root() {
     let root = tempfile::tempdir().unwrap();
     let default_state_dir = root.path().join("state/pnpm");

--- a/pnpm/crates/cli/tests/suite/global_shims.rs
+++ b/pnpm/crates/cli/tests/suite/global_shims.rs
@@ -616,6 +616,82 @@ fn native_shim_runs_the_global_executable_fallback() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("native-fallback"));
 }
 
+/// The bin dir a self-update by an earlier pnpm 12 leaves behind: the
+/// shell shims it wrote, dispatching through a `.pnpm-shim-v1` that is now
+/// the executable under test.
+#[cfg(unix)]
+fn install_legacy_shim(global_bin: &Path, name: &str, target: &str) -> std::path::PathBuf {
+    use std::os::unix::fs::PermissionsExt;
+    fs::create_dir_all(global_bin).unwrap();
+    let dispatcher = global_bin.join(".pnpm-shim-v1");
+    if !dispatcher.exists() {
+        fs::copy(assert_cmd::cargo::cargo_bin("pnpm"), &dispatcher).unwrap();
+    }
+    let shim = global_bin.join(name);
+    fs::write(
+        &shim,
+        format!(
+            "#!/bin/sh\nbasedir=$(dirname \"$0\")\nif [ -z \"$PNPM_SHIM_BYPASS\" ] && [ -x \"$basedir/.pnpm-shim-v1\" ]; then\n  exec \"$basedir/.pnpm-shim-v1\" --shim '{name}' \"$basedir/\"'{name}' \"{target}\" -- \"$@\"\nfi\n\"{target}\" \"$@\"\nexit $?\n# pnpm-shim-style=context-aware\n# cmd-shim-target={target}\n",
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+    shim
+}
+
+/// A shim an earlier pnpm 12 wrote keeps working after that pnpm's
+/// self-update replaced the dispatcher with this executable, and its first
+/// launch turns the whole bin dir native.
+#[cfg(unix)]
+#[test]
+fn legacy_shim_launch_dispatches_and_migrates_the_bin_dir() {
+    let root = tempfile::tempdir().unwrap();
+    let (project, global_target) = prepare_local_and_global(&root, "tool");
+    let global_bin = root.path().join("global-bin");
+    let other = install_legacy_shim(&global_bin, "other", "pkg:other");
+    let shim = install_legacy_shim(&global_bin, "tool", global_target.to_str().unwrap());
+    let launch = |shim: &Path| {
+        Command::new(shim)
+            .without_ambient_pnpm_config()
+            .with_current_dir(&project)
+            .with_env("PNPM_HOME", root.path().join("pnpm-home"))
+            .with_env("XDG_STATE_HOME", root.path().join("state"))
+            .with_env("XDG_CONFIG_HOME", root.path().join("config"))
+            .with_env("XDG_CACHE_HOME", root.path().join("cache-home"))
+            .with_env(AUTO_TRUST_ENV, "1")
+            .with_env("PNPM_CONFIG_GLOBAL_SHIMS", r#"{"tool": true}"#)
+            .with_args(["--flag", "value with spaces"])
+            .output()
+            .unwrap()
+    };
+
+    let first = launch(&shim);
+    assert!(first.status.success(), "stderr:\n{}", String::from_utf8_lossy(&first.stderr));
+    assert_eq!(String::from_utf8_lossy(&first.stdout).trim(), "local");
+
+    let executable_len = fs::metadata(assert_cmd::cargo::cargo_bin("pnpm")).unwrap().len();
+    for name in ["tool", "other"] {
+        assert_eq!(
+            fs::metadata(global_bin.join(name)).unwrap().len(),
+            executable_len,
+            "the legacy {name} shim must have become the executable",
+        );
+    }
+    assert_eq!(
+        fs::read(global_bin.join(".pnpm-shim-v1-tool-target")).unwrap(),
+        global_target.as_os_str().as_encoded_bytes(),
+    );
+    assert_eq!(fs::read(global_bin.join(".pnpm-shim-v1-other-target")).unwrap(), b"pkg:other");
+    assert!(!global_bin.join(".pnpm-shim-v1").exists());
+
+    let second = launch(&shim);
+    assert!(second.status.success(), "stderr:\n{}", String::from_utf8_lossy(&second.stderr));
+    assert_eq!(String::from_utf8_lossy(&second.stdout).trim(), "local");
+    let unprovided = launch(&other);
+    assert!(!unprovided.status.success());
+    assert!(String::from_utf8_lossy(&unprovided.stderr).contains("ERR_PNPM_SHIM_NO_TARGET"));
+}
+
 /// A shim an earlier pnpm 12 wrote for the package is migrated before the
 /// slot check, so re-adding the package repairs it instead of reporting a
 /// conflict.

--- a/pnpm/crates/cli/tests/suite/global_shims.rs
+++ b/pnpm/crates/cli/tests/suite/global_shims.rs
@@ -639,9 +639,6 @@ fn install_legacy_shim(global_bin: &Path, name: &str, target: &str) -> std::path
     shim
 }
 
-/// A shim an earlier pnpm 12 wrote keeps working after that pnpm's
-/// self-update replaced the dispatcher with this executable, and its first
-/// launch turns the whole bin dir native.
 #[cfg(unix)]
 #[test]
 fn legacy_shim_launch_dispatches_and_migrates_the_bin_dir() {
@@ -650,9 +647,12 @@ fn legacy_shim_launch_dispatches_and_migrates_the_bin_dir() {
     let global_bin = root.path().join("global-bin");
     let other = install_legacy_shim(&global_bin, "other", "pkg:other");
     let shim = install_legacy_shim(&global_bin, "tool", global_target.to_str().unwrap());
+    fs::write(project.join("node_modules/tool/cli.sh"), "#!/bin/sh\nprintf '<%s>\\n' \"$@\"\n")
+        .unwrap();
     let launch = |shim: &Path| {
         Command::new(shim)
             .without_ambient_pnpm_config()
+            .without_env("PNPM_SHIM_BYPASS")
             .with_current_dir(&project)
             .with_env("PNPM_HOME", root.path().join("pnpm-home"))
             .with_env("XDG_STATE_HOME", root.path().join("state"))
@@ -667,7 +667,7 @@ fn legacy_shim_launch_dispatches_and_migrates_the_bin_dir() {
 
     let first = launch(&shim);
     assert!(first.status.success(), "stderr:\n{}", String::from_utf8_lossy(&first.stderr));
-    assert_eq!(String::from_utf8_lossy(&first.stdout).trim(), "local");
+    assert_eq!(String::from_utf8_lossy(&first.stdout).trim(), "<--flag>\n<value with spaces>");
 
     let executable_len = fs::metadata(assert_cmd::cargo::cargo_bin("pnpm")).unwrap().len();
     for name in ["tool", "other"] {
@@ -686,10 +686,62 @@ fn legacy_shim_launch_dispatches_and_migrates_the_bin_dir() {
 
     let second = launch(&shim);
     assert!(second.status.success(), "stderr:\n{}", String::from_utf8_lossy(&second.stderr));
-    assert_eq!(String::from_utf8_lossy(&second.stdout).trim(), "local");
+    assert_eq!(String::from_utf8_lossy(&second.stdout).trim(), "<--flag>\n<value with spaces>");
     let unprovided = launch(&other);
     assert!(!unprovided.status.success());
     assert!(String::from_utf8_lossy(&unprovided.stderr).contains("ERR_PNPM_SHIM_NO_TARGET"));
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_dispatcher_rejects_a_shim_from_another_directory() {
+    let root = tempfile::tempdir().unwrap();
+    let dispatcher_bin = root.path().join("dispatcher-bin");
+    install_legacy_shim(&dispatcher_bin, "own", "pkg:own");
+    let foreign_bin = root.path().join("foreign-bin");
+    let foreign_shim = install_legacy_shim(&foreign_bin, "tool", "/bin/true");
+
+    let output = Command::new(dispatcher_bin.join(".pnpm-shim-v1"))
+        .arg("--shim")
+        .arg("tool")
+        .arg(&foreign_shim)
+        .arg("/bin/true")
+        .arg("--")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("legacy shim path") && stderr.contains("executing dispatcher"),
+        "stderr:\n{stderr}",
+    );
+    assert!(foreign_bin.join(".pnpm-shim-v1").exists());
+    assert!(fs::read(&foreign_shim).unwrap().starts_with(b"#!"));
+}
+
+#[cfg(unix)]
+#[test]
+fn legacy_shim_dispatches_without_waiting_for_the_migration_lock() {
+    let root = tempfile::tempdir().unwrap();
+    let target = root.path().join("target");
+    write_script(&target, "launched");
+    let global_bin = root.path().join("global-bin");
+    let shim = install_legacy_shim(&global_bin, "tool", target.to_str().unwrap());
+    let lock_dir = global_bin.join(".pnpm-global-bin.lock");
+    fs::create_dir(&lock_dir).unwrap();
+    fs::write(lock_dir.join("owner"), "held-by-test").unwrap();
+
+    let output = Command::new(&shim)
+        .without_ambient_pnpm_config()
+        .without_env("PNPM_SHIM_BYPASS")
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "stderr:\n{}", String::from_utf8_lossy(&output.stderr));
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "launched");
+    assert!(global_bin.join(".pnpm-shim-v1").exists());
+    assert!(fs::read(&shim).unwrap().starts_with(b"#!"));
 }
 
 /// A shim an earlier pnpm 12 wrote for the package is migrated before the


### PR DESCRIPTION
## Summary

Self-updates across the pnpm 12.2 and 12.3 shim-format boundary could break context-aware global commands such as `node`, `npm`, `npx`, `yarn`, `bun`, and `tsc`.

When upgrading from 12.2, legacy shell shims invoke `.pnpm-shim-v1 --shim`, a protocol removed in 12.3. This PR restores that compatibility path. A legacy invocation is accepted only when its shim is beside the executing `.pnpm-shim-v1`. The first launch tries to acquire the global-bin mutation lock without waiting and migrates the bin directory to native shims. If another process holds the lock, migration is deferred and the command still launches.

When downgrading to 12.2 or older, self-update now leaves existing native shims untouched instead of replacing them with an engine that cannot interpret their sidecars. The global commands continue using the newer compatible shim engine.

Rust-only: the TypeScript CLI has no native shim dispatcher.

## Squash Commit Body

```text
The pre-12.3 self-update flow can publish the new executable into the
`.pnpm-shim-v1` slot while leaving legacy shell shims that invoke it with
`--shim`. Since 12.3 removed that protocol, context-aware global commands
then fail before the new migration paths can run.

Recognize the legacy invocation before native dispatch and migrate the bin
directory on first launch. Bind migration to the directory of the executing
dispatcher, serialize it with the global-bin mutation lock, and defer it
without blocking command execution when another writer holds the lock.

Named native shims require a pnpm 12.3 or newer engine. Keep their existing
compatible engine when self-update activates an older pnpm version instead
of republishing them from an engine that cannot dispatch them.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users, since it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed global commands such as `node`, `npm`, and `yarn` failing with an unexpected `--shim` argument after updating pnpm.
  * Legacy global shims now continue working after self-updates and automatically migrate to the current native shim format on first use.
  * Downgrading to pnpm versions without native shim support preserves working global shims.
  * Malformed shim invocations now fail safely instead of unintentionally launching the pnpm CLI.
  * Legacy shim launches no longer wait for an ongoing global bin directory migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->