### PR TITLE
perf(resolver): render link anchors and importer ids by string suffix math

### DIFF
--- a/.changeset/string-space-anchors.md
+++ b/.changeset/string-space-anchors.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces. Workspace `link:` targets and importer ids are now derived from the paths' suffixes under the workspace root, without walking their shared prefix [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/.changeset/string-space-anchors.md
+++ b/.changeset/string-space-anchors.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up installs in large workspaces. Workspace `link:` targets and importer ids are now derived from the paths' suffixes under the workspace root, without walking their shared prefix [#14352](https://github.com/pnpm/pnpm/issues/14352).
+Sped up installs in large workspaces. Workspace `link:` targets and importer ids are now derived from the paths' suffixes under the workspace root [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/cli/src/cli_args/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/recursive.rs
@@ -23,6 +23,7 @@ use pnpm_workspace_projects_filter::{
 use pnpm_workspace_projects_graph::{
     BaseProject, CreateProjectsGraphOptions, ProjectGraph, create_projects_graph,
 };
+use rayon::prelude::*;
 use serde::Serialize;
 use std::{
     collections::{HashMap, HashSet},
@@ -62,22 +63,29 @@ pub struct NoMatchingProjects {
 /// through the full workspace graph so a relationship between two selected
 /// projects via an unselected one becomes a direct edge. Keys keep the
 /// selection order.
-pub fn filtered_projects_dependencies<Pkg>(
+pub fn filtered_projects_dependencies<Pkg: Sync>(
     selected: &ProjectGraph<Pkg>,
     all: &ProjectGraph<Pkg>,
     prod_all: Option<&ProjectGraph<Pkg>>,
     prod_only_selected: &HashSet<PathBuf>,
 ) -> IndexMap<PathBuf, Vec<PathBuf>> {
     let sorted: HashSet<&Path> = selected.keys().map(PathBuf::as_path).collect();
+    // Each project's tunneling walk reads only shared references, so
+    // the projects fan out across the rayon pool; collecting the
+    // parallel iterator into a `Vec` keeps the selection order.
     selected
         .keys()
-        .map(|project_dir| {
+        .collect::<Vec<_>>()
+        .par_iter()
+        .map(|&project_dir| {
             let full_graph = match prod_all {
                 Some(prod_all) if prod_only_selected.contains(project_dir) => prod_all,
                 _ => all,
             };
             (project_dir.clone(), sorted_dependencies(selected, full_graph, project_dir, &sorted))
         })
+        .collect::<Vec<_>>()
+        .into_iter()
         .collect()
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -19,58 +19,126 @@
 //! the two computations agree component-for-component, because
 //! `diff_paths` and `lexical_normalize` are lexical: prefixing both
 //! arguments with the same clean root never changes the outcome.
+//!
+//! Each rendering returns the final `link:`-body string — the
+//! forward-slashed form every caller previously produced from the
+//! `PathBuf` via `display` + `replace` — so the per-edge cost is one
+//! pass over the target's components and a single allocation.
 
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 /// The importer-side inputs of `link:` re-anchoring, derived once per
 /// importer: its directory as a clean relative suffix of the lockfile
-/// root. The workspace root importer holds the empty suffix.
+/// root, pre-split into components. The workspace root importer holds
+/// the empty suffix.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct ImporterAnchor {
     /// `None` — an anchor carries dot components, is not truly
-    /// absolute, or the importer is not under the lockfile root — turns
-    /// every rendering into the caller's fallback.
-    rel_dir: Option<PathBuf>,
+    /// absolute, is not valid UTF-8, or the importer is not under the
+    /// lockfile root — turns every rendering into the caller's
+    /// fallback.
+    rel_components: Option<Vec<String>>,
 }
 
 impl ImporterAnchor {
     pub(crate) fn new(project_dir: &Path, lockfile_dir: &Path) -> Self {
         ImporterAnchor {
-            rel_dir: importer_rel_dir(project_dir, lockfile_dir).map(Path::to_path_buf),
+            rel_components: importer_rel_dir(project_dir, lockfile_dir).and_then(|rel| {
+                rel.components()
+                    .map(|component| component.as_os_str().to_str().map(str::to_owned))
+                    .collect()
+            }),
         }
     }
 
     /// Express a lockfile-root-relative `target` relative to the
-    /// importer. `None` for a disarmed anchor, or a target that is
-    /// absolute or carries dot components.
-    pub(crate) fn target_relative_to_importer(&self, target: &Path) -> Option<PathBuf> {
-        let rel_dir = self.rel_dir.as_deref()?;
-        if !all_normal(target) {
-            return None;
+    /// importer, as `diff_paths` against the importer suffix would:
+    /// climb out of the suffix past the shared prefix, then descend
+    /// into the target. `None` for a disarmed anchor, an anchored
+    /// target, or one that carries `..` components.
+    pub(crate) fn target_relative_to_importer(&self, target: &str) -> Option<String> {
+        let rel = self.rel_components.as_deref()?;
+        let mut target_segments = Vec::new();
+        for segment in relative_segments(target)? {
+            if segment == ".." {
+                return None;
+            }
+            target_segments.push(segment);
         }
-        pathdiff::diff_paths(target, rel_dir)
+        let shared = rel
+            .iter()
+            .zip(&target_segments)
+            .take_while(|(rel_name, target_name)| rel_name.as_str() == **target_name)
+            .count();
+        Some(render(
+            std::iter::repeat_n("..", rel.len() - shared)
+                .chain(target_segments[shared..].iter().copied()),
+        ))
     }
 
     /// Express an importer-relative `target` (which typically climbs
     /// out of the importer via `..` components) relative to the
-    /// lockfile root. `None` for a disarmed anchor, a target that
-    /// carries a root or prefix component — on Windows a rooted `\abs`
-    /// path is not `is_absolute`, yet `join` would silently replace the
-    /// base with it — or one that still escapes the lockfile root after
-    /// normalization.
-    pub(crate) fn target_relative_to_lockfile_root(&self, target: &Path) -> Option<PathBuf> {
-        let rel_dir = self.rel_dir.as_deref()?;
-        if !target.components().all(|component| {
-            matches!(component, Component::Normal(_) | Component::ParentDir | Component::CurDir)
-        }) {
-            return None;
+    /// lockfile root, as `lexical_normalize` over the joined suffix
+    /// would: `..` pops the nearest kept component. `None` for a
+    /// disarmed anchor, an anchored target, or one that escapes the
+    /// lockfile root. The suffix components are all normal, so the
+    /// first climb past them pins a leading `..` that nothing later
+    /// can remove.
+    pub(crate) fn target_relative_to_lockfile_root(&self, target: &str) -> Option<String> {
+        let rel = self.rel_components.as_deref()?;
+        let mut kept = rel.len();
+        let mut descended: Vec<&str> = Vec::new();
+        for segment in relative_segments(target)? {
+            if segment == ".." {
+                if descended.pop().is_none() {
+                    kept = kept.checked_sub(1)?;
+                }
+            } else {
+                descended.push(segment);
+            }
         }
-        let normalized = pnpm_fs::lexical_normalize(&rel_dir.join(target));
-        match normalized.components().next() {
-            Some(Component::ParentDir) => None,
-            _ => Some(normalized),
-        }
+        Some(render(rel[..kept].iter().map(String::as_str).chain(descended)))
     }
+}
+
+#[cfg(windows)]
+const SEPARATORS: &[char] = &['/', '\\'];
+#[cfg(not(windows))]
+const SEPARATORS: &[char] = &['/'];
+
+/// Split a relative `target` into the segments `Path::components`
+/// would yield, without the per-component `OsStr` machinery:
+/// separators collapse and `.` segments vanish (`lexical_normalize`
+/// erases a leading one too, so the two directions agree on it).
+/// `None` for an anchored target — one starting with a separator, or
+/// (on Windows) whose first segment carries a `:` and so may be a
+/// prefix — where suffix math does not apply; the caller's
+/// absolute-space fallback handles those.
+fn relative_segments(target: &str) -> Option<impl Iterator<Item = &str>> {
+    if target.starts_with(SEPARATORS) {
+        return None;
+    }
+    #[cfg(windows)]
+    if target.split(SEPARATORS).next().is_some_and(|first| first.contains(':')) {
+        return None;
+    }
+    Some(target.split(SEPARATORS).filter(|segment| !segment.is_empty() && *segment != "."))
+}
+
+/// Join components with `/` and normalize any backslash inside one, the
+/// way the callers' former `display` + `replace('\\', "/")` pass did.
+fn render<'component>(components: impl Iterator<Item = &'component str>) -> String {
+    let mut rendered = String::new();
+    for component in components {
+        if !rendered.is_empty() {
+            rendered.push('/');
+        }
+        rendered.push_str(component);
+    }
+    if rendered.contains('\\') {
+        rendered = rendered.replace('\\', "/");
+    }
+    rendered
 }
 
 /// The importer's directory as a clean relative suffix of the lockfile

--- a/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
@@ -1,6 +1,6 @@
 use super::{ImporterAnchor, importer_rel_dir};
 use pretty_assertions::assert_eq;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 /// An anchor that is absolute on every platform — a bare `/ws/root` is
 /// not absolute on Windows (no drive prefix), which the guards reject.
@@ -19,11 +19,13 @@ fn rel_space_matches_absolute_space() {
         assert_eq!(rel, Path::new(importer));
         let anchor = ImporterAnchor::new(&project_dir, lockfile_dir);
         for target in ["packages/lib", "packages/group/other", "tools"] {
-            let via_rel = anchor
-                .target_relative_to_importer(Path::new(target))
-                .expect("clean target renders");
-            let via_abs =
-                pathdiff::diff_paths(lockfile_dir.join(target), &project_dir).expect("diff");
+            let via_rel =
+                anchor.target_relative_to_importer(target).expect("clean target renders");
+            let via_abs = pathdiff::diff_paths(lockfile_dir.join(target), &project_dir)
+                .expect("diff")
+                .display()
+                .to_string()
+                .replace('\\', "/");
             assert_eq!(via_rel, via_abs, "importer {importer:?} target {target:?}");
 
             // And the inverse direction round-trips back to the
@@ -31,7 +33,7 @@ fn rel_space_matches_absolute_space() {
             let back = anchor
                 .target_relative_to_lockfile_root(&via_rel)
                 .expect("internal target stays under the root");
-            assert_eq!(back, PathBuf::from(target));
+            assert_eq!(back, target);
         }
     }
 }
@@ -48,17 +50,19 @@ fn guards_send_unclean_inputs_to_the_fallback() {
     );
 
     let anchor = ImporterAnchor::new(&root.join("packages/app"), root);
-    assert_eq!(anchor.target_relative_to_importer(Path::new("../outside")), None);
-    assert_eq!(anchor.target_relative_to_importer(&root.join("target")), None);
+    let abs_target = root.join("target");
+    let abs_target = abs_target.to_str().unwrap();
+    assert_eq!(anchor.target_relative_to_importer("../outside"), None);
+    assert_eq!(anchor.target_relative_to_importer(abs_target), None);
 
-    assert_eq!(anchor.target_relative_to_lockfile_root(&root.join("target")), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(abs_target), None);
     // Escapes the lockfile root: `packages/app` + `../../../outside`.
-    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new("../../../outside")), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root("../../../outside"), None);
 
     // A disarmed anchor renders nothing at all.
     let disarmed = ImporterAnchor::new(&root.parent().unwrap().join("other/app"), root);
-    assert_eq!(disarmed.target_relative_to_importer(Path::new("packages/lib")), None);
-    assert_eq!(disarmed.target_relative_to_lockfile_root(Path::new("packages/lib")), None);
+    assert_eq!(disarmed.target_relative_to_importer("packages/lib"), None);
+    assert_eq!(disarmed.target_relative_to_lockfile_root("packages/lib"), None);
 }
 
 #[test]
@@ -67,12 +71,12 @@ fn root_importer_uses_the_empty_suffix() {
     assert_eq!(rel, Path::new(""));
     let anchor = ImporterAnchor::new(abs_root(), abs_root());
     assert_eq!(
-        anchor.target_relative_to_importer(Path::new("packages/lib")),
-        Some(PathBuf::from("packages/lib")),
+        anchor.target_relative_to_importer("packages/lib"),
+        Some("packages/lib".to_string()),
     );
     assert_eq!(
-        anchor.target_relative_to_lockfile_root(Path::new("packages/lib")),
-        Some(PathBuf::from("packages/lib")),
+        anchor.target_relative_to_lockfile_root("packages/lib"),
+        Some("packages/lib".to_string()),
     );
 }
 
@@ -84,6 +88,6 @@ fn windows_drive_relative_and_rootless_anchors_use_the_fallback() {
     assert_eq!(importer_rel_dir(Path::new(r"C:ws\root\app"), Path::new(r"C:ws\root")), None);
     assert_eq!(importer_rel_dir(Path::new(r"\ws\root\app"), Path::new(r"\ws\root")), None);
     let anchor = ImporterAnchor::new(Path::new(r"C:\ws\root\app"), Path::new(r"C:\ws\root"));
-    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new(r"\abs\target")), None);
-    assert_eq!(anchor.target_relative_to_lockfile_root(Path::new(r"C:abs")), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(r"\abs\target"), None);
+    assert_eq!(anchor.target_relative_to_lockfile_root(r"C:abs"), None);
 }

--- a/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
@@ -19,8 +19,7 @@ fn rel_space_matches_absolute_space() {
         assert_eq!(rel, Path::new(importer));
         let anchor = ImporterAnchor::new(&project_dir, lockfile_dir);
         for target in ["packages/lib", "packages/group/other", "tools"] {
-            let via_rel =
-                anchor.target_relative_to_importer(target).expect("clean target renders");
+            let via_rel = anchor.target_relative_to_importer(target).expect("clean target renders");
             let via_abs = pathdiff::diff_paths(lockfile_dir.join(target), &project_dir)
                 .expect("diff")
                 .display()

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/manifest.rs
@@ -41,17 +41,20 @@ pub(super) async fn build_pkg_id_with_patch_hash(
 ) -> Result<String, ResolveDependencyTreeError> {
     let raw_id = result.id.as_str();
     if let Some(target) = raw_id.strip_prefix("link:") {
-        let target = std::path::Path::new(target);
-        let rel_space_target = ctx.link_anchor.target_relative_to_lockfile_root(target);
-        let relative_target = rel_space_target.unwrap_or_else(|| {
-            let absolute_target = if target.is_absolute() {
-                pnpm_fs::lexical_normalize(target)
-            } else {
-                pnpm_fs::lexical_normalize(&ctx.base_opts.project_dir.join(target))
-            };
-            pathdiff::diff_paths(&absolute_target, &ctx.lockfile_dir).unwrap_or(absolute_target)
-        });
-        let relative_target = relative_target.display().to_string().replace('\\', "/");
+        let relative_target =
+            ctx.link_anchor.target_relative_to_lockfile_root(target).unwrap_or_else(|| {
+                let target = std::path::Path::new(target);
+                let absolute_target = if target.is_absolute() {
+                    pnpm_fs::lexical_normalize(target)
+                } else {
+                    pnpm_fs::lexical_normalize(&ctx.base_opts.project_dir.join(target))
+                };
+                pathdiff::diff_paths(&absolute_target, &ctx.lockfile_dir)
+                    .unwrap_or(absolute_target)
+                    .display()
+                    .to_string()
+                    .replace('\\', "/")
+            });
         let relative_target = if relative_target.is_empty() { "." } else { &relative_target };
         return Ok(format!("link:{relative_target}"));
     }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1201,17 +1201,21 @@ fn render_workspace_resolution(
         return rendered;
     }
 
-    let target = Path::new(&directory_resolution.directory);
+    let target = directory_resolution.directory.as_str();
     let consumer_target = anchor.target_relative_to_importer(target).unwrap_or_else(|| {
+        let target = Path::new(target);
         let absolute_target = if target.is_absolute() {
             pnpm_fs::lexical_normalize(target)
         } else {
             pnpm_fs::lexical_normalize(&lockfile_dir.join(target))
         };
         let project_dir = pnpm_fs::lexical_normalize(project_dir);
-        pathdiff::diff_paths(&absolute_target, project_dir).unwrap_or(absolute_target)
+        pathdiff::diff_paths(&absolute_target, project_dir)
+            .unwrap_or(absolute_target)
+            .display()
+            .to_string()
+            .replace('\\', "/")
     });
-    let consumer_target = consumer_target.display().to_string().replace('\\', "/");
     rendered.id =
         pnpm_resolving_resolver_base::PkgResolutionId::from(format!("link:{consumer_target}"));
     directory_resolution.directory = consumer_target;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/context.rs
@@ -407,8 +407,8 @@ pub(super) fn importer_relative_link_dep_path(
     let (Some(lockfile_dir), Some(project_dir)) = (lockfile_dir, project_dir) else {
         return dep_path.clone();
     };
-    let target = Path::new(target);
     let relative_target = anchor.target_relative_to_importer(target).unwrap_or_else(|| {
+        let target = Path::new(target);
         let absolute_target = if target.is_absolute() {
             pnpm_fs::lexical_normalize(target)
         } else {
@@ -418,9 +418,12 @@ pub(super) fn importer_relative_link_dep_path(
         // carrying `.` / `..` segments would consume them as real directories
         // and count the wrong number of `..` hops back out.
         let project_dir = pnpm_fs::lexical_normalize(project_dir);
-        pathdiff::diff_paths(&absolute_target, project_dir).unwrap_or(absolute_target)
+        pathdiff::diff_paths(&absolute_target, project_dir)
+            .unwrap_or(absolute_target)
+            .display()
+            .to_string()
+            .replace('\\', "/")
     });
-    let relative_target = relative_target.display().to_string().replace('\\', "/");
     DepPath::from(format!("link:{relative_target}"))
 }
 

--- a/pnpm/crates/workspace/src/importer_id.rs
+++ b/pnpm/crates/workspace/src/importer_id.rs
@@ -16,6 +16,18 @@ pub fn importer_id_from_root_dir(lockfile_dir: &Path, project_dir: &Path) -> Str
     if project_dir == lockfile_dir {
         return ".".to_string();
     }
+    // The overwhelmingly common shape — the project directly under the
+    // root, both spelled cleanly — needs no `diff_paths` walk over the
+    // two paths' long shared prefix: the suffix is the id. A suffix
+    // carrying dot components (or a raw form that disagrees with its
+    // components, like a trailing separator) takes the full math below.
+    if let Ok(rel) = project_dir.strip_prefix(lockfile_dir)
+        && let Some(rel_str) = rel.to_str()
+        && !rel_str.is_empty()
+        && rel_str.split(['/', '\\']).all(|segment| !matches!(segment, "" | "." | ".."))
+    {
+        return rel_str.replace('\\', "/");
+    }
     match pathdiff::diff_paths(project_dir, lockfile_dir) {
         Some(rel) => {
             let rendered = rel.to_string_lossy().into_owned();


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. This chunk removes the remaining per-edge path machinery from the warm-update critical path:

- **`ImporterAnchor` renders by string suffix math.** The pnpm/pnpm#14478 anchor still parsed every `link:` target with `Path::components` and ran `diff_paths` / `join` + `lexical_normalize` against the importer suffix, then re-rendered the `PathBuf` through `display` + `replace('\\', "/")` — per edge, at all three rendering sites. The anchor now keeps its suffix pre-split into UTF-8 components; both renderings make one string pass over the target and produce the final forward-slashed form directly. The split mirrors `Path::components` inside the guarded domain (separators collapse, `.` segments vanish), and anything it cannot mirror exactly — an anchored target, a Windows first segment carrying `:`, a non-UTF-8 suffix — returns `None` into the same absolute-space fallback as before.
- **`importer_id_from_root_dir` gains the matching fast path.** A project spelled cleanly under the workspace root takes its id from `strip_prefix` instead of walking both absolute paths through `diff_paths`; dot-carrying or non-UTF-8 shapes keep the full math.
- **The plan's `filtered_projects_dependencies` runs per-project walks on the rayon pool.** Each tunneling walk reads only shared references; collecting the parallel iterator into a `Vec` keeps the selection order, so the resulting map is byte-for-byte the serial one.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, 87,630 workspace edges; warm non-noop lockfile-only update per its README protocol; M-series Mac), main-thread profile samples (≈ ms):

| Site | before | after |
| --- | ---: | ---: |
| `pathdiff::diff_paths` (all sites) | 49 | 1 |
| `build_pkg_id_with_patch_hash` | 56 | 23 |
| `importer_id_from_root_dir` | 20 | 11 |
| plan selection (`select_workspace_projects_with_cycles`) | 98 | 69 |
| whole main thread | 832 | 777 |

Quiet-run wall times cluster at ~1.07–1.15 s (the machine's endpoint-protection bursts inflate outliers). The written `pnpm-lock.yaml` is byte-identical, and the resolver + package-manager suites pass (1,032 tests), as do the anchor and workspace-crate suites and the CLI recursive/filtering subset. The three bail-cancellation timing tests that fail on this machine fail identically on clean main (they exercise `sequence_graph`, which this PR does not touch) and are green in CI.

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~1.1 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
The per-edge link: renderings still parsed every target with
Path::components and diffed or normalized it against the importer
suffix, allocating a PathBuf and re-rendering it to a string on each
of the workspace's 87k edges. The anchor now keeps its suffix
pre-split into UTF-8 components and both renderings run one string
pass over the target, producing the final forward-slashed form
directly; any shape the split cannot mirror exactly falls back to the
absolute-space math as before.

importer_id_from_root_dir gains the matching fast path: a project
spelled cleanly under the workspace root takes its id from
strip_prefix instead of walking both absolute paths through
diff_paths.

The plan's filtered_projects_dependencies fans its per-project
tunneling walks across the rayon pool; collecting into a Vec keeps
the selection order.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), diff_paths disappears from the profile, the
plan selection drops by a third, and the written lockfile is
byte-identical. Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(The anchor suite's round-trip test now runs
  against the string renderer and pins agreement with `diff_paths`; the
  renderings' outputs are further pinned by the byte-identical lockfile and the
  1,032 resolver + package-manager tests, all passing unchanged.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790988589&installation_model_id=426870&pr_number=14492&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14492&signature=b60d2dc1bf7ca7028895a7cc0adb4a05282b4c13896c3141054d6c3bc0f4402a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved installation speed for large workspaces by accelerating workspace dependency processing and importer identification.

- **Bug Fixes**
  - Improved handling of workspace and linked dependency paths across platforms.
  - Added more reliable normalization of relative paths and slash formatting, including Windows-style paths.
  - Strengthened validation for invalid or escaping link targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->