### PR TITLE
perf(resolver): warm the whole subtree's metadata on resolve

### DIFF
--- a/.changeset/resolver-recursive-warmup.md
+++ b/.changeset/resolver-recursive-warmup.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up dependency resolution when there is no lockfile. pnpm now requests the metadata of a package's whole dependency subtree as soon as the package resolves, instead of one level at a time, so a cold resolve pays far fewer network round trips.
+Sped up dependency resolution when there is no lockfile, and for the dependencies a lockfile does not cover.

--- a/.changeset/resolver-recursive-warmup.md
+++ b/.changeset/resolver-recursive-warmup.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up dependency resolution when there is no lockfile. pnpm now requests the metadata of a package's whole dependency subtree as soon as the package resolves, instead of one level at a time, so a cold resolve pays far fewer network round trips.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5494,6 +5494,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
-tracing = { workspace = true }
+tracing                                = { workspace = true }
 rustc-hash                             = { workspace = true }
 pnpm-catalogs-resolver                 = { workspace = true }
 pnpm-catalogs-types                    = { workspace = true }

--- a/pnpm/crates/resolving-deps-resolver/Cargo.toml
+++ b/pnpm/crates/resolving-deps-resolver/Cargo.toml
@@ -11,6 +11,7 @@ license.workspace     = true
 repository.workspace  = true
 
 [dependencies]
+tracing = { workspace = true }
 rustc-hash                             = { workspace = true }
 pnpm-catalogs-resolver                 = { workspace = true }
 pnpm-catalogs-types                    = { workspace = true }

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -696,7 +696,7 @@ where
             parents = frontier_len,
             next = frontier.len(),
             elapsed_ms = level_started.elapsed().as_millis() as u64,
-            "phase complete"
+            "phase complete",
         );
     }
     Ok(direct)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -678,13 +678,26 @@ where
     assign_level_owners(ctx, seeds.iter_mut())?;
     let direct: Vec<DirectDep> = seeds.iter().filter_map(seeded_dep).collect();
     let mut frontier = settle_seeds(ctx, seeds, children_overlay.as_ref(), &children_pkg_aliases);
+    let mut level = 0usize;
     while !frontier.is_empty() {
+        let level_started = std::time::Instant::now();
+        let frontier_len = frontier.len();
         let seeded = frontier
             .into_iter()
             .map(|node| seed_node_children(ctx, resolver, node))
             .pipe(future::try_join_all)
             .await?;
         frontier = settle_level(ctx, seeded)?;
+        level += 1;
+        tracing::info!(
+            target: "pacquet::install::phase",
+            phase = "resolve_level",
+            level,
+            parents = frontier_len,
+            next = frontier.len(),
+            elapsed_ms = level_started.elapsed().as_millis() as u64,
+            "phase complete"
+        );
     }
     Ok(direct)
 }
@@ -1489,15 +1502,14 @@ fn map_resolve_error(err: ResolveError) -> ResolveDependencyTreeError {
     }
 }
 
-/// Speculatively warm a freshly-seeded node's children resolutions so
-/// their packuments download while the sibling level's barrier waits
-/// for its slowest member. Results are discarded — the real picks run
-/// in the walk phase with the level's preferred-versions overlay and
-/// hit the warm metadata caches — and errors are swallowed: a
-/// speculative fetch must never fail the install (the real resolve
-/// will surface it). Recovers the cross-level pipelining the
-/// postponed-resolution barrier otherwise serializes; pure overlap,
-/// no behavioral effect.
+/// Speculatively warm a freshly-seeded node's whole subtree so its
+/// packuments download while the level barriers wait for their
+/// slowest members. Results are discarded — the real picks run in the
+/// walk phase with the level's preferred-versions overlay and hit the
+/// warm metadata caches — and errors are swallowed: a speculative
+/// fetch must never fail the install (the real resolve will surface
+/// it). Recovers the cross-level pipelining the postponed-resolution
+/// barrier otherwise serializes; pure overlap, no behavioral effect.
 pub(super) async fn warm_children_resolutions<Chain>(
     ctx: &TreeCtx,
     resolver: &Chain,
@@ -1518,25 +1530,52 @@ pub(super) async fn warm_children_resolutions<Chain>(
     if pending.is_link || !claim_children_warmup(ctx, &pending.id) {
         return;
     }
-    let Ok(specs) = extract_children(&pending.result) else { return };
-    let specs = if pending.peer_shadowed.is_empty() {
+    warm_result_children(
+        ctx,
+        resolver,
+        &pending.result,
+        &pending.peer_shadowed,
+        pending.resolves_children_through_catalogs,
+        pending.depth,
+    )
+    .await;
+}
+
+/// Warm every child of `result`, then recurse into each child the
+/// moment it resolves, so a subtree's metadata is requested as soon
+/// as its parent's arrives rather than one level per barrier. The
+/// per-package-id claim ([`claim_children_warmup`]) bounds the
+/// recursion to one visit per package across the whole walk, real
+/// seeds included, so the fan-out is the graph's size, not its path
+/// count.
+#[async_recursion]
+async fn warm_result_children<Chain>(
+    ctx: &TreeCtx,
+    resolver: &Chain,
+    result: &pnpm_resolving_resolver_base::ResolveResult,
+    peer_shadowed: &HashSet<String>,
+    through_catalogs: bool,
+    depth: i32,
+) where
+    Chain: Resolver + ?Sized,
+{
+    let Ok(specs) = extract_children(result) else { return };
+    let specs = if peer_shadowed.is_empty() {
         specs
     } else {
         specs
             .into_iter()
-            .filter(|(name, _, optional, _)| *optional || !pending.peer_shadowed.contains(name))
+            .filter(|(name, _, optional, _)| *optional || !peer_shadowed.contains(name))
             .collect()
     };
-    let specs = if let Some(catalogs) =
-        catalogs_for_children(ctx, pending.resolves_children_through_catalogs)
-    {
+    let specs = if let Some(catalogs) = catalogs_for_children(ctx, through_catalogs) {
         let Ok(specs) = resolve_catalog_child_specs(specs, catalogs) else { return };
         specs
     } else {
         specs
     };
-    let opts = ctx.opts_for_depth(pending.depth + 1);
-    let declaring_dir = declaring_manifest_dir(ctx, &pending.result);
+    let opts = ctx.opts_for_depth(depth + 1);
+    let declaring_dir = declaring_manifest_dir(ctx, result);
     specs
         .iter()
         .map(|(name, range, optional, injected)| {
@@ -1570,9 +1609,28 @@ pub(super) async fn warm_children_resolutions<Chain>(
                     None,
                     Vec::new(),
                     ctx.update_cache_scope(),
-                    is_update_target(ctx.update_scope(), &wanted, None, pending.depth + 1),
+                    is_update_target(ctx.update_scope(), &wanted, None, depth + 1),
                 );
-                let _ = resolve_wanted_cached(ctx, resolver, &wanted, opts, None, cache_key).await;
+                let Ok(child) =
+                    resolve_wanted_cached(ctx, resolver, &wanted, opts, None, cache_key).await
+                else {
+                    return;
+                };
+                let Ok(child_id) = build_pkg_id_with_patch_hash(ctx, &child).await else {
+                    return;
+                };
+                if child_id.starts_with("link:") || !claim_children_warmup(ctx, &child_id) {
+                    return;
+                }
+                warm_result_children(
+                    ctx,
+                    resolver,
+                    &child,
+                    &HashSet::default(),
+                    resolves_children_through_catalogs(&child),
+                    depth + 1,
+                )
+                .await;
             }
         })
         .pipe(future::join_all)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1541,13 +1541,10 @@ pub(super) async fn warm_children_resolutions<Chain>(
     .await;
 }
 
-/// Warm every child of `result`, then recurse into each child the
-/// moment it resolves, so a subtree's metadata is requested as soon
-/// as its parent's arrives rather than one level per barrier. The
-/// per-package-id claim ([`claim_children_warmup`]) bounds the
-/// recursion to one visit per package across the whole walk, real
-/// seeds included, so the fan-out is the graph's size, not its path
-/// count.
+/// Warm the resolutions of `result`'s whole subtree. Speculative only:
+/// nothing is recorded in the tree, every package is visited at most
+/// once across the walk, and a child whose own peers shadow it is
+/// skipped the way the real seed path skips it.
 #[async_recursion]
 async fn warm_result_children<Chain>(
     ctx: &TreeCtx,
@@ -1616,17 +1613,26 @@ async fn warm_result_children<Chain>(
                 else {
                     return;
                 };
-                let Ok(child_id) = build_pkg_id_with_patch_hash(ctx, &child).await else {
-                    return;
-                };
-                if child_id.starts_with("link:") || !claim_children_warmup(ctx, &child_id) {
+                // Claimed by the resolver's raw id: the patch-qualified
+                // id is only built on the real walk, whose bookkeeping
+                // decides which patches count as applied.
+                let child_id = child.id.as_str();
+                if child_id.starts_with("link:") || !claim_children_warmup(ctx, child_id) {
                     return;
                 }
+                // The parent alias scope is not tracked speculatively;
+                // with `autoInstallPeers` off nothing is shadowed and
+                // the real walk drops the edge instead.
+                let child_peer_shadowed = peer_shadowed_dependencies(
+                    child.manifest.as_deref(),
+                    &ParentPkgAliases::root(HashSet::default()),
+                    ctx.workspace.auto_install_peers,
+                );
                 warm_result_children(
                     ctx,
                     resolver,
                     &child,
-                    &HashSet::default(),
+                    &child_peer_shadowed,
                     resolves_children_through_catalogs(&child),
                     depth + 1,
                 )

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -3638,3 +3638,228 @@ async fn finalized_packages_include_peer_free_cycles() {
     let ids = announced.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>();
     assert_eq!(ids, ["ping@1.0.0", "pong@1.0.0"]);
 }
+
+/// Resolver fed from an `(alias, range)` table that records every call
+/// in order and can hold one alias back until another has been asked
+/// for, which is how a test observes work the walk does before a level
+/// barrier lifts.
+struct WarmupProbeResolver {
+    table: HashMap<(String, String), ResolveResult>,
+    calls: Mutex<Vec<(String, String)>>,
+    /// `(held, release)`: resolving `held` completes only once `release`
+    /// has been requested.
+    gate: Option<(String, String)>,
+    released: std::sync::atomic::AtomicBool,
+}
+
+impl WarmupProbeResolver {
+    fn new(table: HashMap<(String, String), ResolveResult>) -> Self {
+        WarmupProbeResolver {
+            table,
+            calls: Mutex::new(Vec::new()),
+            gate: None,
+            released: std::sync::atomic::AtomicBool::new(false),
+        }
+    }
+
+    fn calls_for(&self, alias: &str, range: &str) -> usize {
+        self.calls.lock().unwrap().iter().filter(|(a, r)| a == alias && r == range).count()
+    }
+}
+
+impl Resolver for WarmupProbeResolver {
+    fn resolve<'a>(
+        &'a self,
+        wanted: &'a WantedDependency,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveFuture<'a> {
+        let alias = wanted.alias.clone().unwrap_or_default();
+        let range = wanted.bare_specifier.clone().unwrap_or_default();
+        self.calls.lock().unwrap().push((alias.clone(), range.clone()));
+        let result = self.table.get(&(alias.clone(), range)).cloned();
+        let (held, release) = self
+            .gate
+            .as_ref()
+            .map_or((false, false), |(held, release)| (*held == alias, *release == alias));
+        if release {
+            self.released.store(true, std::sync::atomic::Ordering::Release);
+        }
+        Box::pin(async move {
+            while held && !self.released.load(std::sync::atomic::Ordering::Acquire) {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+            Ok::<_, ResolveError>(result)
+        })
+    }
+
+    fn resolve_latest<'a>(
+        &'a self,
+        _query: &'a LatestQuery,
+        _opts: &'a ResolveOptions,
+    ) -> ResolveLatestFuture<'a> {
+        Box::pin(async { Ok(None) })
+    }
+}
+
+fn caret_entry(name: &str, manifest: serde_json::Value) -> ((String, String), ResolveResult) {
+    ((name.to_string(), "^1.0.0".to_string()), fake_result(name, "1.0.0", None, manifest))
+}
+
+fn deps(entries: &[(&str, &str)]) -> serde_json::Value {
+    let map: serde_json::Map<String, serde_json::Value> = entries
+        .iter()
+        .map(|(name, range)| ((*name).to_string(), serde_json::Value::from(*range)))
+        .collect();
+    serde_json::json!({ "dependencies": map })
+}
+
+async fn resolve_single_importer(
+    resolver: &WarmupProbeResolver,
+    manifest_deps: serde_json::Value,
+    opts: WorkspaceResolveOptions,
+    patched: Option<Arc<pnpm_patching::PatchGroupRecord>>,
+) -> Result<super::ResolveWorkspaceResult, tokio::time::error::Elapsed> {
+    let (_tmp, manifest) = fake_manifest(manifest_deps);
+    let importers = vec![WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        resolve_workspace(resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+            let mut opts = importer_opts(std::path::PathBuf::from("/repo"), None);
+            opts.patched_dependencies = patched.clone();
+            opts
+        }),
+    )
+    .await
+    .map(|result| result.expect("resolve"))
+}
+
+#[tokio::test]
+async fn warm_up_requests_descendants_beyond_one_level_before_the_level_barrier_lifts() {
+    // `slow` is a direct dep that resolves only once the grandchild `c`
+    // has been requested. The level barrier waits for `slow`, so only a
+    // warm-up that recurses past `a`'s children can ever ask for `c`.
+    let mut resolver = WarmupProbeResolver::new(HashMap::from_iter([
+        caret_entry("slow", serde_json::json!({})),
+        caret_entry("a", deps(&[("b", "^1.0.0")])),
+        caret_entry("b", deps(&[("c", "^1.0.0")])),
+        caret_entry("c", serde_json::json!({})),
+    ]));
+    resolver.gate = Some(("slow".to_string(), "c".to_string()));
+    let result = resolve_single_importer(
+        &resolver,
+        serde_json::json!({ "slow": "^1.0.0", "a": "^1.0.0" }),
+        workspace_opts(false, false),
+        None,
+    )
+    .await
+    .expect("the grandchild is warmed while the first level is still resolving");
+    assert_eq!(graph_versions_of(&result, "c"), ["1.0.0"]);
+}
+
+#[tokio::test]
+async fn warm_up_resolves_each_edge_once_across_a_diamond() {
+    let resolver = WarmupProbeResolver::new(HashMap::from_iter([
+        caret_entry("x", deps(&[("z", "^1.0.0")])),
+        caret_entry("y", deps(&[("z", ">=1.0.0")])),
+        caret_entry("z", deps(&[("w", "^1.0.0")])),
+        (
+            ("z".to_string(), ">=1.0.0".to_string()),
+            fake_result("z", "1.0.0", None, deps(&[("w", "^1.0.0")])),
+        ),
+        caret_entry("w", serde_json::json!({})),
+    ]));
+    let result = resolve_single_importer(
+        &resolver,
+        serde_json::json!({ "x": "^1.0.0", "y": "^1.0.0" }),
+        workspace_opts(false, false),
+        None,
+    )
+    .await
+    .expect("resolve");
+    assert_eq!(graph_versions_of(&result, "z"), ["1.0.0"]);
+    // Two ranges reach `z`, so it is asked for once per range; its own
+    // child is asked for once however many branches reach `z`.
+    assert_eq!(resolver.calls_for("z", "^1.0.0"), 1);
+    assert_eq!(resolver.calls_for("z", ">=1.0.0"), 1);
+    assert_eq!(resolver.calls_for("w", "^1.0.0"), 1);
+}
+
+#[tokio::test]
+async fn warm_up_skips_dependencies_a_package_declares_as_its_own_peers() {
+    // `p` lists `q` both as a dependency and as a peer. Under
+    // autoInstallPeers the walk drops the dependency edge and resolves
+    // the peer at the importer, so the dependency range must never be
+    // asked for, not even speculatively two levels down.
+    let resolver = WarmupProbeResolver::new(HashMap::from_iter([
+        caret_entry("a", deps(&[("p", "^1.0.0")])),
+        caret_entry(
+            "p",
+            serde_json::json!({
+                "dependencies": { "q": "^2.0.0" },
+                "peerDependencies": { "q": "^1.0.0" },
+            }),
+        ),
+        caret_entry("q", serde_json::json!({})),
+        (
+            ("q".to_string(), "^2.0.0".to_string()),
+            fake_result("q", "2.0.0", None, serde_json::json!({})),
+        ),
+    ]));
+    let mut opts = workspace_opts(false, false);
+    opts.auto_install_peers = true;
+    let result =
+        resolve_single_importer(&resolver, serde_json::json!({ "a": "^1.0.0" }), opts, None)
+            .await
+            .expect("resolve");
+    assert_eq!(graph_versions_of(&result, "q"), ["1.0.0"]);
+    assert_eq!(resolver.calls_for("q", "^2.0.0"), 0);
+}
+
+#[tokio::test]
+async fn warm_up_of_a_speculative_only_edge_leaves_patch_bookkeeping_alone() {
+    // Without autoInstallPeers a dependency shadowed by a peer is dropped
+    // only when the parent scope supplies the peer; the warm-up does not
+    // know that scope and asks for `q@^2.0.0` speculatively. The real
+    // walk never accepts that edge, so its patch must not count as
+    // applied.
+    let resolver = WarmupProbeResolver::new(HashMap::from_iter([
+        caret_entry("a", deps(&[("p", "^1.0.0")])),
+        caret_entry(
+            "p",
+            serde_json::json!({
+                "dependencies": { "q": "^2.0.0" },
+                "peerDependencies": { "q": "^1.0.0" },
+            }),
+        ),
+        caret_entry("q", serde_json::json!({})),
+        (
+            ("q".to_string(), "^2.0.0".to_string()),
+            fake_result("q", "2.0.0", None, serde_json::json!({})),
+        ),
+    ]));
+    let mut groups = pnpm_patching::PatchGroupRecord::new();
+    let mut group = pnpm_patching::PatchGroup::default();
+    group.exact.insert(
+        "2.0.0".to_string(),
+        pnpm_patching::ExtendedPatchInfo {
+            hash: "abc123".to_string(),
+            patch_file_path: None,
+            key: "q@2.0.0".to_string(),
+        },
+    );
+    groups.insert("q".to_string(), group);
+    let result = resolve_single_importer(
+        &resolver,
+        serde_json::json!({ "a": "^1.0.0", "q": "^1.0.0" }),
+        workspace_opts(false, false),
+        Some(Arc::new(groups)),
+    )
+    .await
+    .expect("resolve");
+    assert_eq!(resolver.calls_for("q", "^2.0.0"), 1, "the edge was warmed speculatively");
+    assert_eq!(graph_versions_of(&result, "q"), ["1.0.0"], "and never entered the graph");
+    assert!(
+        !result.merged_tree.applied_patches.contains("q@2.0.0"),
+        "a patch the real walk never applied must not count as applied",
+    );
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Speeds up dependency resolution when there is no lockfile by making the resolver's speculative metadata warm-up recursive. Rust CLI only (`pacquet`); no user-visible behaviour changes, the produced lockfile is byte-identical.

### Background

`walk_from_seeds` in `resolving-deps-resolver` resolves the graph level by level: every node of depth N resolves before any node of depth N+1 is seeded, so that children ownership (and with it the lockfile) does not depend on the order concurrent subtrees finish in. To hide that barrier, `warm_children_resolutions` speculatively resolved the children of each freshly-seeded node so the next level's packuments were already cached when the barrier lifted. It only reached one level ahead, and its results were discarded.

Measured on the `pnpm/benchmarks` alotta-files fixture (1349 packages, 1081 packuments, 1348 tarballs) against a local pnpr behind the harness's 200 Mbit / 50 ms latency proxy, the barrier was the dominant client-side cost of a clean install: each level waited for its slowest packument while tarball prefetch traffic queued in front of it, and the direct-dependency level alone took 1.6 s. Resolution ended after 3.4 s in a 3.95 s install.

### Change

The warm-up now recurses. When a speculative child resolves, its own children are warmed immediately, under the same per-package-id claim (`claim_children_warmup`) that the level walk uses, so every package is warmed at most once across the whole walk regardless of how many paths reach it. The whole reachable metadata graph is therefore requested within a handful of round trips instead of one level per barrier, and the real walk hits warm caches at every level.

Semantics are untouched:

- The warm resolutions use the same empty-overlay cache key as before. When the real pick's overlay view is empty (the common case) it reuses the entry; otherwise it misses into its own bucket and re-picks from the warm metadata cache, exactly as the one-level warm-up did.
- Children ownership is still decided by `assign_level_owners` on the real walk; the warm-up records nothing in the tree.
- The warm-up still skips when a pnpmfile hook is configured (hooks are observable per call) and skips `link:` packages.
- Speculative picks matched the real picks in every measured run, so the tarball prefetch that rides on the warm resolutions downloaded no extra tarballs (1348 both before and after).

A per-level phase log (`phase = "resolve_level"` under `pacquet::install::phase`, visible with `TRACE=pacquet::install=info`) records each barrier's fan-out and duration, which is what made the cost visible.

### Measurements

alotta-files, `install --ignore-scripts` with no lockfile and an empty store and cache, local pnpr behind the benchmark harness's latency proxy. Rebased on main after the early materialization of peer-free packages (pull 14497) landed, so "main" already includes it. Two runs each; spread under 3%. The same 1348 tarballs are fetched either way, and under the warm-up the last one lands about 0.7 s earlier on the slow link.

| link | cores | main | this PR |
|---|---|---|---|
| 200 Mbit / 50 ms | 32 | 3.93 s | 3.58 s |
| 200 Mbit / 50 ms | 2 | 4.34 s | 3.98 s |
| 200 Mbit / 50 ms, `--lockfile-only` | 32 | 1.72 s | 1.24 s |
| uncapped / 10 ms | 32 | 1.37 to 1.47 s | 1.40 to 1.53 s |
| uncapped / 10 ms, `--lockfile-only` | 32 | 0.73 s | 0.49 s |

Per-level timings before: the direct-deps level took ~1.6 s and levels 2 to 4 took 640, 360 and 110 ms. After: all metadata is fetched by ~0.9 s and every level barrier completes in under 5 ms. On the uncapped link the install is bound by the hardlink fan-out (about 5 s of kernel time on btrfs at every materializer concurrency tried), so the earlier resolution does not move the total there; the runs overlap within noise.

Verification: the lockfile written with and without the change is byte-identical (12 050 lines); `cargo nextest run -p pnpm-resolving-deps-resolver -p pnpm-package-manager` passes; clippy is clean on the crate.

### Not included

Warming `peerDependencies` names as well removes the remaining ~0.3 s auto-install-peer round in resolution-only runs, but because the warm path shares the tarball-prefetching resolver it also downloads a handful of wrong-version tarballs and made the full install slower. That needs a metadata-only warm path first and is left for a follow-up, as is materialising peer-free subtrees into the virtual store during resolution.

## Squash Commit Body

```text
The fresh-resolve walk is level-synchronous: every node of depth N
resolves before any node of depth N+1 is seeded, so children ownership
does not depend on arrival order. The speculative warm-up that hides
that barrier only reached one level ahead. Under tarball load each
barrier waited for its slowest packument, and the direct-deps level of
a 1350-package graph alone took 1.6 s on a 200 Mbit / 50 ms link.

The warm-up now recurses: as soon as a speculative child resolves, its
own children are warmed, claiming each package id once across the walk.
The whole reachable metadata graph is requested within a few round
trips and the real walk hits warm caches at every level. The picks are
unchanged (same empty-overlay cache key as before, the real walk still
re-picks under its level overlay), the lockfile is byte-identical, and
no extra tarballs are prefetched because the speculative picks match
the real ones.

A per-level phase log under pacquet::install::phase records each
barrier's fan-out and duration.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Internal performance change to the Rust resolver; nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests. (The resolver's existing 366 tests cover the walk; no new test isolates the warm-up depth yet.)
- [x] Updated the documentation if needed. (Not needed.)

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4vkqo9LyR5PG1HAJ3zUtP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Improvements**
  - Improved dependency resolution when no lockfile is present or when dependencies are not covered by a lockfile.
  - Reduced network round trips during fresh dependency resolution by warming complete dependency subtrees.
  - Improved handling of complex dependency graphs, including shared dependencies and peer dependencies.

- **Bug Fixes**
  - Prevented speculative dependency resolution from incorrectly affecting applied patch tracking.

- **Release**
  - Included these improvements in a patch release of the `pacquet` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->