### PR TITLE
perf(install): link peer-free packages into the virtual store during resolution

### DIFF
--- a/.changeset/early-materialization.md
+++ b/.changeset/early-materialization.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs that have no lockfile. pnpm now links packages whose dependency subtree has no peer dependencies into the virtual store while resolution is still running, instead of linking every package after the lockfile is built.

--- a/.changeset/early-materialization.md
+++ b/.changeset/early-materialization.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up installs that have no lockfile. pnpm now links packages whose dependency subtree has no peer dependencies into the virtual store while resolution is still running, instead of linking every package after the lockfile is built.
+Sped up installs that have no lockfile. pnpm now links packages whose dependency subtree has no peer dependencies into the virtual store while resolution is still running.

--- a/pnpm/crates/package-manager/src/early_materializer.rs
+++ b/pnpm/crates/package-manager/src/early_materializer.rs
@@ -104,6 +104,10 @@ impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
         {
             return;
         }
+        // A patched package is imported and patched by the normal path.
+        if package.pkg_id.contains("(patch_hash=") {
+            return;
+        }
         let Ok(key) = package.pkg_id.parse::<PackageKey>() else { return };
         let slot_dir = self.shared.layout.slot_dir(&key);
         let virtual_node_modules_dir = slot_dir.join("node_modules");
@@ -137,8 +141,8 @@ impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
     }
 
     /// Stop scheduling, wait for the tasks in flight, and remove the
-    /// slots of packages the final lockfile does not carry. Returns the
-    /// number of slots materialized.
+    /// slots of packages the final install does not materialize.
+    /// Returns the number of slots materialized.
     pub(crate) async fn finish(
         &self,
         is_wanted: impl Fn(&PackageKey) -> bool,

--- a/pnpm/crates/package-manager/src/early_materializer.rs
+++ b/pnpm/crates/package-manager/src/early_materializer.rs
@@ -1,0 +1,267 @@
+//! Materializes packages into the virtual store while resolution is
+//! still running.
+//!
+//! The tree walk announces every package whose subtree has settled
+//! peer-free ([`FinalizedPackage`]); such a package's slot name and
+//! child edges are already final, and its tarball is on its way into
+//! the store through the prefetching resolver. Populating the slot
+//! now, with the CAS path map the prefetch leaves in the tarball
+//! [`MemCache`], moves the hardlink fan-out off the post-resolution
+//! critical path. The later `CreateVirtualStore` pass finds the
+//! completion marker, skips the import, and re-links the slot's edges
+//! from the lockfile, so a slot whose children were re-recorded after
+//! the announcement heals there.
+
+use pnpm_config::{Config, PackageImportMethod};
+use pnpm_deps_restorer::{
+    ImportIndexedDirOpts, SkippedSnapshots, VirtualStoreLayout, create_symlink_layout,
+    import_indexed_dir, install_package_from_registry::extract_tarball,
+    safe_join_modules_dir::safe_join_modules_dir,
+};
+use pnpm_lockfile::{
+    LockfileResolution, PackageKey, PkgName, SnapshotDepRef, is_git_hosted_tarball_url,
+};
+use pnpm_resolving_deps_resolver::{FinalizedPackage, FinalizedPackageFn};
+use pnpm_tarball::{CacheValue, MemCache};
+use std::{
+    collections::HashMap,
+    marker::PhantomData,
+    path::PathBuf,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+use tokio::{sync::Semaphore, task::JoinSet};
+
+/// How long a materialization task waits between looks at the tarball
+/// cache while the prefetch it depends on has not registered yet.
+const CACHE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+pub(crate) struct EarlyMaterializer<Reporter> {
+    shared: Arc<Shared>,
+    tasks: Mutex<JoinSet<()>>,
+    /// Every slot a task was spawned for, so slots the final lockfile
+    /// does not carry can be removed again.
+    slots: Mutex<Vec<(PackageKey, PathBuf)>>,
+    _reporter: PhantomData<fn() -> Reporter>,
+}
+
+struct Shared {
+    layout: VirtualStoreLayout,
+    import_method: PackageImportMethod,
+    symlink: bool,
+    /// Install-scoped dedupe state for the `pnpm:package-import-method`
+    /// log, merged into the install's own state at [`EarlyMaterializer::finish`].
+    logged_methods: AtomicU8,
+    mem_cache: Arc<MemCache>,
+    permits: Semaphore,
+    closing: AtomicBool,
+    materialized: AtomicUsize,
+}
+
+impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
+    pub(crate) fn new(config: &Config, mem_cache: Arc<MemCache>) -> Self {
+        let max_length = usize::try_from(config.virtual_store_dir_max_length).unwrap_or(usize::MAX);
+        let permits = std::thread::available_parallelism().map_or(4, std::num::NonZeroUsize::get);
+        EarlyMaterializer {
+            shared: Arc::new(Shared {
+                layout: VirtualStoreLayout::legacy(config.virtual_store_dir.clone(), max_length),
+                import_method: config.package_import_method,
+                symlink: config.symlink,
+                logged_methods: AtomicU8::new(0),
+                mem_cache,
+                permits: Semaphore::new(permits),
+                closing: AtomicBool::new(false),
+                materialized: AtomicUsize::new(0),
+            }),
+            tasks: Mutex::new(JoinSet::new()),
+            slots: Mutex::new(Vec::new()),
+            _reporter: PhantomData,
+        }
+    }
+
+    /// The sink to hand the resolver as
+    /// [`pnpm_resolving_deps_resolver::WorkspaceResolveOptions::finalized_package`].
+    pub(crate) fn hook(self: &Arc<Self>) -> FinalizedPackageFn {
+        let materializer = Arc::clone(self);
+        Arc::new(move |package| materializer.schedule(&package))
+    }
+
+    fn schedule(&self, package: &FinalizedPackage) {
+        let Some(name_ver) = package.result.name_ver.as_ref() else { return };
+        let Ok((package_url, _)) = extract_tarball(&package.result.resolution) else { return };
+        // The prefetch keys its cache by the plain URL and skips these
+        // shapes altogether; see `PrefetchingResolver::maybe_kickoff_download`.
+        let revision_addressed = matches!(
+            &package.result.resolution,
+            LockfileResolution::Tarball(tarball) if tarball.revision.is_some()
+        );
+        if revision_addressed
+            || package_url.starts_with("file:")
+            || is_git_hosted_tarball_url(package_url)
+        {
+            return;
+        }
+        let Ok(key) = package.pkg_id.parse::<PackageKey>() else { return };
+        let slot_dir = self.shared.layout.slot_dir(&key);
+        let virtual_node_modules_dir = slot_dir.join("node_modules");
+        let Ok(package_dir) =
+            safe_join_modules_dir(&virtual_node_modules_dir, &name_ver.name.to_string())
+        else {
+            return;
+        };
+        // Optional edges are left to the final pass, which knows which
+        // optional dependencies the installability pass skipped.
+        let dependencies: HashMap<PkgName, SnapshotDepRef> = package
+            .children
+            .iter()
+            .filter(|child| !child.optional)
+            .filter_map(|child| {
+                let alias = PkgName::parse(child.alias.as_str()).ok()?;
+                let key = child.pkg_id.parse::<PackageKey>().ok()?;
+                Some((alias, SnapshotDepRef::Alias(key)))
+            })
+            .collect();
+        let job = SlotJob {
+            package_url: package_url.to_string(),
+            self_name: name_ver.name.clone(),
+            virtual_node_modules_dir,
+            package_dir,
+            dependencies,
+        };
+        lock(&self.slots).push((key, slot_dir));
+        let shared = Arc::clone(&self.shared);
+        lock(&self.tasks).spawn(async move { job.run::<Reporter>(&shared).await });
+    }
+
+    /// Stop scheduling, wait for the tasks in flight, and remove the
+    /// slots of packages the final lockfile does not carry. Returns the
+    /// number of slots materialized.
+    pub(crate) async fn finish(
+        &self,
+        is_wanted: impl Fn(&PackageKey) -> bool,
+        logged_methods: &AtomicU8,
+    ) -> usize {
+        self.shared.closing.store(true, Ordering::Release);
+        let mut tasks = std::mem::take(&mut *lock(&self.tasks));
+        while tasks.join_next().await.is_some() {}
+        logged_methods
+            .fetch_or(self.shared.logged_methods.load(Ordering::Acquire), Ordering::AcqRel);
+        let orphans: Vec<PathBuf> = std::mem::take(&mut *lock(&self.slots))
+            .into_iter()
+            .filter(|(key, _)| !is_wanted(key))
+            .map(|(_, slot_dir)| slot_dir)
+            .collect();
+        if !orphans.is_empty() {
+            let _ = tokio::task::spawn_blocking(move || {
+                for slot_dir in orphans {
+                    let _ = std::fs::remove_dir_all(slot_dir);
+                }
+            })
+            .await;
+        }
+        self.shared.materialized.load(Ordering::Acquire)
+    }
+}
+
+struct SlotJob {
+    package_url: String,
+    self_name: PkgName,
+    virtual_node_modules_dir: PathBuf,
+    package_dir: PathBuf,
+    dependencies: HashMap<PkgName, SnapshotDepRef>,
+}
+
+impl SlotJob {
+    async fn run<Reporter: pnpm_reporter::Reporter>(self, shared: &Arc<Shared>) {
+        let Some(cas_paths) = wait_for_cas_paths(shared, &self.package_url).await else { return };
+        let Ok(_permit) = shared.permits.acquire().await else { return };
+        // Once the install is linking, the link phase's own parallel
+        // pass takes the slot; finishing it here would only delay that.
+        if shared.closing.load(Ordering::Acquire) {
+            return;
+        }
+        let shared = Arc::clone(shared);
+        let outcome = tokio::task::spawn_blocking(move || {
+            std::fs::create_dir_all(&self.virtual_node_modules_dir)
+                .map_err(|error| error.to_string())?;
+            import_indexed_dir::<Reporter>(
+                &shared.logged_methods,
+                shared.import_method,
+                &self.package_dir,
+                &cas_paths,
+                ImportIndexedDirOpts::default(),
+            )
+            .map_err(|error| error.to_string())?;
+            if shared.symlink {
+                create_symlink_layout(
+                    Some(&self.dependencies),
+                    None,
+                    false,
+                    &self.self_name,
+                    &SkippedSnapshots::new(),
+                    &shared.layout,
+                    &self.virtual_node_modules_dir,
+                )
+                .map_err(|error| error.to_string())?;
+            }
+            shared.materialized.fetch_add(1, Ordering::AcqRel);
+            Ok::<(), String>(())
+        })
+        .await;
+        match outcome {
+            Ok(Ok(())) => {}
+            Ok(Err(error)) => tracing::debug!(
+                target: "pacquet::install",
+                package_url = %self.package_url,
+                %error,
+                "early materialization failed; the link phase retries the slot",
+            ),
+            Err(error) => tracing::debug!(
+                target: "pacquet::install",
+                package_url = %self.package_url,
+                %error,
+                "early materialization task panicked; the link phase retries the slot",
+            ),
+        }
+    }
+}
+
+/// Wait for the prefetch of `package_url` to land its CAS path map in
+/// the tarball cache. `None` when the fetch failed or when the
+/// materializer closes first, which covers both a tarball the prefetch
+/// skipped (it never registers) and one still in flight when the
+/// install starts linking.
+async fn wait_for_cas_paths(
+    shared: &Shared,
+    package_url: &str,
+) -> Option<Arc<HashMap<String, PathBuf>>> {
+    loop {
+        let slot = shared.mem_cache.get(package_url).map(|entry| Arc::clone(entry.value()));
+        let Some(slot) = slot else {
+            if shared.closing.load(Ordering::Acquire) {
+                return None;
+            }
+            tokio::time::sleep(CACHE_POLL_INTERVAL).await;
+            continue;
+        };
+        let notify = match &*slot.read().await {
+            CacheValue::Available(cas_paths) => return Some(Arc::clone(cas_paths)),
+            CacheValue::Failed => return None,
+            CacheValue::InProgress(notify) => Arc::clone(notify),
+        };
+        // A bounded wait rather than a bare `notified()`: the owner
+        // notifies only once, on the flip, and this wait registers after
+        // the read above, so the flip may already have happened.
+        let _ = tokio::time::timeout(CACHE_POLL_INTERVAL * 5, notify.notified()).await;
+        if shared.closing.load(Ordering::Acquire) {
+            return None;
+        }
+    }
+}
+
+fn lock<Inner>(mutex: &Mutex<Inner>) -> std::sync::MutexGuard<'_, Inner> {
+    mutex.lock().unwrap_or_else(std::sync::PoisonError::into_inner)
+}

--- a/pnpm/crates/package-manager/src/early_materializer.rs
+++ b/pnpm/crates/package-manager/src/early_materializer.rs
@@ -96,7 +96,7 @@ impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
         // shapes altogether; see `PrefetchingResolver::maybe_kickoff_download`.
         let revision_addressed = matches!(
             &package.result.resolution,
-            LockfileResolution::Tarball(tarball) if tarball.revision.is_some()
+            LockfileResolution::Tarball(tarball) if tarball.revision.is_some(),
         );
         if revision_addressed
             || package_url.starts_with("file:")

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -927,6 +927,22 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         })
         .await?;
 
+        // Slots can only be populated ahead of the lockfile where their
+        // names do not depend on the whole graph (no global virtual
+        // store) and where the tarballs are prefetched into the cache
+        // the materializer waits on.
+        let early_materializer = (!lockfile_only
+            && !filtered_isolated
+            && !is_hoisted
+            && !config.enable_global_virtual_store
+            && custom_fetcher_session.is_none())
+        .then(|| {
+            Arc::new(crate::early_materializer::EarlyMaterializer::<Reporter>::new(
+                config,
+                Arc::clone(&tarball_mem_cache),
+            ))
+        });
+
         // `trustPolicy='no-downgrade'` config, threaded into every
         // resolve so the npm resolver re-applies the downgrade gate to
         // freshly picked versions. `full_metadata` above is already
@@ -1154,6 +1170,9 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
             overrides_hook,
             pnpmfile_hook,
             read_package_log,
+            finalized_package: early_materializer
+                .as_ref()
+                .map(crate::early_materializer::EarlyMaterializer::hook),
             pick_lowest_direct,
             time_based,
             published_by,
@@ -1523,6 +1542,23 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         // without regressing the cold-cache or frozen-lockfile paths.
         //
         let phase_start = std::time::Instant::now();
+        if let Some(materializer) = early_materializer.as_ref() {
+            let phase_start = std::time::Instant::now();
+            let wanted = built_lockfile.snapshots.as_ref();
+            let materialized = materializer
+                .finish(
+                    |key| wanted.is_some_and(|snapshots| snapshots.contains_key(key)),
+                    logged_methods,
+                )
+                .await;
+            tracing::info!(
+                target: "pacquet::install::phase",
+                phase = "early_materialization",
+                elapsed_ms = phase_start.elapsed().as_millis() as u64,
+                materialized,
+                "phase complete",
+            );
+        }
         let CreateVirtualStoreOutput {
             package_manifests,
             // Consumed by the build phase below to drive the

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -929,12 +929,15 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
 
         // Slots can only be populated ahead of the lockfile where their
         // names do not depend on the whole graph (no global virtual
-        // store) and where the tarballs are prefetched into the cache
-        // the materializer waits on.
+        // store), where the tarballs are prefetched into the cache the
+        // materializer waits on, and where the link phase imports
+        // straight from the CAS: the macOS directory-clone cache serves
+        // project slots from canonical slots it populates itself.
         let early_materializer = (!lockfile_only
             && !filtered_isolated
             && !is_hoisted
             && !config.enable_global_virtual_store
+            && !pnpm_deps_restorer::DirCloneCache::eligible(config, node_linker)
             && custom_fetcher_session.is_none())
         .then(|| {
             Arc::new(crate::early_materializer::EarlyMaterializer::<Reporter>::new(

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1547,10 +1547,13 @@ impl<DependencyGroupList> InstallWithFreshLockfile<'_, DependencyGroupList> {
         let phase_start = std::time::Instant::now();
         if let Some(materializer) = early_materializer.as_ref() {
             let phase_start = std::time::Instant::now();
-            let wanted = built_lockfile.snapshots.as_ref();
+            let wanted = initial_materialization_lockfile.snapshots.as_ref();
             let materialized = materializer
                 .finish(
-                    |key| wanted.is_some_and(|snapshots| snapshots.contains_key(key)),
+                    |key| {
+                        wanted.is_some_and(|snapshots| snapshots.contains_key(key))
+                            && !skipped.contains(key)
+                    },
                     logged_methods,
                 )
                 .await;

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolve.rs
@@ -430,6 +430,7 @@ pub(super) struct ResolvePassInputs<'a> {
     /// `afterAllResolved` hook.
     pub pnpmfile_hook: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
     pub read_package_log: Option<pnpm_hooks::LogFn>,
+    pub finalized_package: Option<pnpm_resolving_deps_resolver::FinalizedPackageFn>,
     /// See [`crate::resolution_policy::PickPolicy`].
     pub pick_lowest_direct: bool,
     pub time_based: bool,
@@ -478,6 +479,7 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
         overrides_hook,
         pnpmfile_hook,
         read_package_log,
+        finalized_package,
         pick_lowest_direct,
         time_based,
         published_by,
@@ -524,6 +526,7 @@ pub(super) async fn run_resolve_pass<Reporter: pnpm_reporter::Reporter>(
         pnpmfile_hook,
         read_package_log,
         skipped_optional_log: Some(super::skipped_optional_log_fn::<Reporter>()),
+        finalized_package,
         pick_lowest_direct,
         time_based,
         wanted_lockfile: resolution_lockfile,

--- a/pnpm/crates/package-manager/src/lib.rs
+++ b/pnpm/crates/package-manager/src/lib.rs
@@ -6,6 +6,7 @@ mod catalog_mode;
 mod check_custom_resolver_force_resolve;
 mod compat_package_extensions;
 mod dependencies_graph_to_lockfile;
+mod early_materializer;
 mod fast_update_catalog_versions;
 mod fast_update_catalogs;
 mod fast_update_compose;

--- a/pnpm/crates/resolving-deps-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/lib.rs
@@ -92,10 +92,11 @@ pub use node_id::NodeId;
 pub use parent_pkg_aliases::ParentPkgAliases;
 pub use pnpm_deps_path::DepPath;
 pub use resolve_dependency_tree::{
-    Deprecation, DeprecationLogFn, ManifestHook, ResolveDependencyTreeError,
-    ResolveDependencyTreeOptions, SkippedOptionalDependency, SkippedOptionalDependencyParent,
-    SkippedOptionalLogFn, TreeCtx, UpdateDepth, UpdateReuseScope, UpdateTargets, VersionLine,
-    WorkspaceTreeCtx, extend_tree, real_package_name_of, resolve_dependency_tree,
+    Deprecation, DeprecationLogFn, FinalizedChild, FinalizedPackage, FinalizedPackageFn,
+    ManifestHook, ResolveDependencyTreeError, ResolveDependencyTreeOptions,
+    SkippedOptionalDependency, SkippedOptionalDependencyParent, SkippedOptionalLogFn, TreeCtx,
+    UpdateDepth, UpdateReuseScope, UpdateTargets, VersionLine, WorkspaceTreeCtx, extend_tree,
+    real_package_name_of, resolve_dependency_tree,
 };
 pub use resolve_importer::{
     ResolveImporterError, ResolveImporterOptions, ResolveImporterResult, resolve_importer,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree.rs
@@ -24,6 +24,7 @@ use crate::{
 };
 
 mod catalogs;
+mod finalized;
 mod manifest;
 mod reuse;
 mod tree_ctx;
@@ -285,6 +286,36 @@ pub struct SkippedOptionalDependencyParent {
 /// the install's reporter so the resolver stays reporter-agnostic. See
 /// [`crate::WorkspaceResolveOptions::skipped_optional_log`].
 pub type SkippedOptionalLogFn = Arc<dyn Fn(SkippedOptionalDependency) + Send + Sync>;
+
+/// A package whose resolution and whole dependency subtree are settled
+/// and carry no `peerDependencies`, so its lockfile dep path is its
+/// package id and its child edges are known before peers resolve. See
+/// [`crate::WorkspaceResolveOptions::finalized_package`].
+#[derive(Debug, Clone)]
+pub struct FinalizedPackage {
+    /// The package id with its patch hash: the snapshot key the
+    /// package will have in the lockfile.
+    pub pkg_id: Arc<str>,
+    pub result: Arc<pnpm_resolving_resolver_base::ResolveResult>,
+    /// The package's resolved `dependencies` and `optionalDependencies`
+    /// edges.
+    pub children: Vec<FinalizedChild>,
+}
+
+/// One child edge of a [`FinalizedPackage`].
+#[derive(Debug, Clone)]
+pub struct FinalizedChild {
+    /// The name the child is linked under in the package's `node_modules`.
+    pub alias: String,
+    /// The child's package id, its lockfile snapshot key.
+    pub pkg_id: Arc<str>,
+    pub optional: bool,
+}
+
+/// Sink for [`FinalizedPackage`] notifications, called from the tree
+/// walk as soon as a package's subtree settles. The call must be cheap
+/// and must not block: it runs on the resolver's task between levels.
+pub type FinalizedPackageFn = Arc<dyn Fn(FinalizedPackage) + Send + Sync>;
 
 /// One deprecation notification from the tree walker: a newly-resolved
 /// package carries a non-empty `deprecated` field in its registry

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
@@ -23,6 +23,13 @@ use crate::resolved_tree::ResolvedPackage;
 /// layer's final pass re-links every slot's edges from the lockfile,
 /// so an announcement is a head start, not a promise about edges.
 ///
+/// A verdict can only change for a package written or re-recorded
+/// since the last sweep, or for a package depending on one that just
+/// became finalized, so the sweep starts from the former and walks up
+/// the recorded parent edges from every new announcement. Over the
+/// whole walk each package is inspected once per change to itself or
+/// to a direct child, not once per level.
+///
 /// A cycle of peer-free packages is finalized as a whole: a back edge
 /// into a package still under inspection adds no package the walk has
 /// not already checked.
@@ -35,8 +42,13 @@ pub(super) fn announce_finalized_packages(ctx: &TreeCtx) {
 }
 
 fn collect_finalized(ctx: &TreeCtx) -> Vec<FinalizedPackage> {
+    let mut worklist = std::mem::take(&mut *lock_recoverable(&ctx.workspace.finalization_pending));
+    if worklist.is_empty() {
+        return Vec::new();
+    }
     let packages = lock_recoverable(&ctx.workspace.packages);
     let children_by_id = lock_recoverable(&ctx.workspace.children_by_id);
+    let parents_by_id = lock_recoverable(&ctx.workspace.parents_by_id);
     let mut finalized_ids = lock_recoverable(&ctx.workspace.finalized_ids);
     let mut sweep = Sweep {
         packages: &packages,
@@ -45,12 +57,20 @@ fn collect_finalized(ctx: &TreeCtx) -> Vec<FinalizedPackage> {
         verdicts: HashMap::default(),
         inspecting: Vec::new(),
     };
-    let mut newly_finalized: Vec<Arc<str>> = packages
-        .keys()
-        .filter(|pkg_id| !finalized_ids.contains(*pkg_id))
-        .filter(|pkg_id| sweep.is_finalized(pkg_id))
-        .cloned()
-        .collect();
+    let mut newly_finalized: Vec<Arc<str>> = Vec::new();
+    let mut seen: HashSet<Arc<str>> = HashSet::default();
+    while let Some(pkg_id) = worklist.pop() {
+        if finalized_ids.contains(&pkg_id) || !seen.insert(Arc::clone(&pkg_id)) {
+            continue;
+        }
+        if !sweep.is_finalized(&pkg_id) {
+            continue;
+        }
+        if let Some(parents) = parents_by_id.get(&pkg_id) {
+            worklist.extend(parents.iter().cloned());
+        }
+        newly_finalized.push(pkg_id);
+    }
     // Announce in a stable order so the install layer's work queue does
     // not depend on hash-map iteration.
     newly_finalized.sort();

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/finalized.rs
@@ -1,0 +1,126 @@
+//! The per-level sweep behind [`super::FinalizedPackageFn`]: after a level
+//! settles, every package whose whole subtree is now settled and
+//! peer-free is announced once, so the install layer can materialize
+//! it before peer resolution.
+
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::sync::Arc;
+
+use super::{
+    FinalizedChild, FinalizedPackage, TreeCtx, lock_recoverable, workspace_ctx::RecordedChildren,
+};
+use crate::resolved_tree::ResolvedPackage;
+
+/// Announce every package that became finalized since the last sweep.
+///
+/// A package is finalized when it declares no `peerDependencies` (nor
+/// `peerDependenciesMeta`), its children are recorded, and every child
+/// is finalized. Nothing after the walk changes such a package: peer
+/// resolution suffixes only nodes whose subtree carries peers, and the
+/// dedupe passes only merge suffixed or injected nodes. A later
+/// occurrence that re-records the package's children (a shallower
+/// importer, a hoist round) can still change its edges; the install
+/// layer's final pass re-links every slot's edges from the lockfile,
+/// so an announcement is a head start, not a promise about edges.
+///
+/// A cycle of peer-free packages is finalized as a whole: a back edge
+/// into a package still under inspection adds no package the walk has
+/// not already checked.
+pub(super) fn announce_finalized_packages(ctx: &TreeCtx) {
+    let Some(finalized_package) = ctx.workspace.finalized_package.as_ref() else { return };
+    let announcements = collect_finalized(ctx);
+    for package in announcements {
+        finalized_package(package);
+    }
+}
+
+fn collect_finalized(ctx: &TreeCtx) -> Vec<FinalizedPackage> {
+    let packages = lock_recoverable(&ctx.workspace.packages);
+    let children_by_id = lock_recoverable(&ctx.workspace.children_by_id);
+    let mut finalized_ids = lock_recoverable(&ctx.workspace.finalized_ids);
+    let mut sweep = Sweep {
+        packages: &packages,
+        children_by_id: &children_by_id,
+        finalized_ids: &finalized_ids,
+        verdicts: HashMap::default(),
+        inspecting: Vec::new(),
+    };
+    let mut newly_finalized: Vec<Arc<str>> = packages
+        .keys()
+        .filter(|pkg_id| !finalized_ids.contains(*pkg_id))
+        .filter(|pkg_id| sweep.is_finalized(pkg_id))
+        .cloned()
+        .collect();
+    // Announce in a stable order so the install layer's work queue does
+    // not depend on hash-map iteration.
+    newly_finalized.sort();
+    let announcements = newly_finalized
+        .iter()
+        .map(|pkg_id| {
+            let package = &packages[pkg_id];
+            let children = children_by_id
+                .get(pkg_id)
+                .map(|recorded| recorded.edges.as_slice())
+                .unwrap_or_default()
+                .iter()
+                .map(|edge| FinalizedChild {
+                    alias: edge.alias.clone(),
+                    pkg_id: Arc::clone(&edge.pkg_id),
+                    optional: edge.optional,
+                })
+                .collect();
+            FinalizedPackage {
+                pkg_id: Arc::clone(pkg_id),
+                result: Arc::clone(&package.result),
+                children,
+            }
+        })
+        .collect();
+    finalized_ids.extend(newly_finalized);
+    announcements
+}
+
+/// One sweep's view of the graph. `verdicts` memoises this sweep's
+/// answers; `inspecting` is the DFS path, for cycle re-entry.
+struct Sweep<'a> {
+    packages: &'a HashMap<Arc<str>, ResolvedPackage>,
+    children_by_id: &'a HashMap<Arc<str>, RecordedChildren>,
+    finalized_ids: &'a HashSet<Arc<str>>,
+    verdicts: HashMap<Arc<str>, bool>,
+    inspecting: Vec<Arc<str>>,
+}
+
+impl Sweep<'_> {
+    fn is_finalized(&mut self, pkg_id: &Arc<str>) -> bool {
+        if self.finalized_ids.contains(pkg_id) {
+            return true;
+        }
+        if let Some(verdict) = self.verdicts.get(pkg_id) {
+            return *verdict;
+        }
+        if self.inspecting.iter().any(|inspected| inspected == pkg_id) {
+            return true;
+        }
+        let verdict = self.subtree_is_finalized(pkg_id);
+        self.verdicts.insert(Arc::clone(pkg_id), verdict);
+        verdict
+    }
+
+    fn subtree_is_finalized(&mut self, pkg_id: &Arc<str>) -> bool {
+        let Some(package) = self.packages.get(pkg_id) else { return false };
+        if !package.peer_dependencies.is_empty() || package.result.id.as_str().starts_with("link:")
+        {
+            return false;
+        }
+        let edges = match self.children_by_id.get(pkg_id) {
+            Some(recorded) => Arc::clone(&recorded.edges),
+            // A leaf never records children; anything else without a
+            // record has not settled yet.
+            None => return package.is_leaf,
+        };
+        self.inspecting.push(Arc::clone(pkg_id));
+        let finalized = edges.iter().all(|edge| self.is_finalized(&edge.pkg_id));
+        self.inspecting.pop();
+        finalized
+    }
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -855,6 +855,7 @@ fn settle_level(
             &grandchild_pkg_aliases,
         ));
     }
+    super::finalized::announce_finalized_packages(ctx);
     Ok(frontier)
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -492,10 +492,11 @@ pub struct WorkspaceTreeCtx {
     /// sweep: the only ones whose verdict can have changed on their own.
     /// Maintained only while `finalized_package` is set.
     pub(super) finalization_pending: Mutex<Vec<Arc<str>>>,
-    /// Every package that recorded an edge to the key, so a package's
-    /// finalization can be propagated to the packages depending on it.
-    /// Maintained only while `finalized_package` is set.
-    pub(super) parents_by_id: Mutex<HashMap<Arc<str>, Vec<Arc<str>>>>,
+    /// Every package whose recorded children include the key, so a
+    /// package's finalization can be propagated to the packages
+    /// depending on it. Maintained only while `finalized_package` is
+    /// set; see [`update_parent_index`].
+    pub(super) parents_by_id: Mutex<HashMap<Arc<str>, HashSet<Arc<str>>>>,
     /// The `pnpm.allowedDeprecatedVersions` map. See
     /// [`crate::WorkspaceResolveOptions::allowed_deprecated_versions`].
     pub(super) allowed_deprecated_versions: BTreeMap<String, String>,
@@ -1609,10 +1610,12 @@ pub(super) fn record_children(
         };
         let edges = Arc::new(edges);
         if ctx.workspace.finalized_package.is_some() {
-            let mut parents = lock_recoverable(&ctx.workspace.parents_by_id);
-            for edge in edges.iter() {
-                parents.entry(Arc::clone(&edge.pkg_id)).or_default().push(Arc::from(pkg_id));
-            }
+            update_parent_index(
+                &mut lock_recoverable(&ctx.workspace.parents_by_id),
+                pkg_id,
+                children.get(pkg_id).map(|recorded| recorded.edges.as_slice()),
+                &edges,
+            );
         }
         children.insert(Arc::from(pkg_id.to_string()), RecordedChildren { edges, context });
         recording
@@ -1620,6 +1623,32 @@ pub(super) fn record_children(
     ctx.workspace.record_children_by_id_write(pkg_id);
     ctx.workspace.note_finalization_candidate(pkg_id);
     recording
+}
+
+/// Move `pkg_id` in the reverse parent index from the children it
+/// recorded before (`previous`) to the ones it records now (`next`).
+/// Recording the same edges again is a no-op, and a child dropped
+/// from the record no longer lists `pkg_id` as a parent.
+fn update_parent_index(
+    parents_by_id: &mut HashMap<Arc<str>, HashSet<Arc<str>>>,
+    pkg_id: &str,
+    previous: Option<&[crate::resolved_tree::ChildEdge]>,
+    next: &[crate::resolved_tree::ChildEdge],
+) {
+    for edge in previous.into_iter().flatten() {
+        if next.iter().any(|kept| kept.pkg_id == edge.pkg_id) {
+            continue;
+        }
+        if let Some(parents) = parents_by_id.get_mut(&edge.pkg_id) {
+            parents.remove(pkg_id);
+            if parents.is_empty() {
+                parents_by_id.remove(&edge.pkg_id);
+            }
+        }
+    }
+    for edge in next {
+        parents_by_id.entry(Arc::clone(&edge.pkg_id)).or_default().insert(Arc::from(pkg_id));
+    }
 }
 
 /// Seed the peer-walker's `parentPkgs` filter with the names a
@@ -1746,3 +1775,6 @@ fn take_locked<Value: Default>(cell: &mut Mutex<Value>) -> Value {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod parent_index_tests;

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -24,8 +24,8 @@ use crate::{
 };
 
 use super::{
-    DeprecationLogFn, ManifestHook, SkippedOptionalLogFn, UpdateDepth, UpdateReuseScope,
-    lock_recoverable, tree_ctx::TreeCtx,
+    DeprecationLogFn, FinalizedPackageFn, ManifestHook, SkippedOptionalLogFn, UpdateDepth,
+    UpdateReuseScope, lock_recoverable, tree_ctx::TreeCtx,
 };
 
 /// Cache key for [`WorkspaceTreeCtx`]'s `resolved_by_wanted` map.
@@ -482,6 +482,12 @@ pub struct WorkspaceTreeCtx {
     /// keeps the skip behavior but drops the notification. See
     /// [`SkippedOptionalLogFn`].
     pub(super) skipped_optional_log: Option<SkippedOptionalLogFn>,
+    /// Sink for finalized-package notifications. `None` skips the
+    /// per-level subtree sweep entirely. See [`FinalizedPackageFn`].
+    pub(super) finalized_package: Option<FinalizedPackageFn>,
+    /// The package ids already handed to `finalized_package`, so every
+    /// package is announced once across importers and hoist rounds.
+    pub(super) finalized_ids: Mutex<HashSet<Arc<str>>>,
     /// The `pnpm.allowedDeprecatedVersions` map. See
     /// [`crate::WorkspaceResolveOptions::allowed_deprecated_versions`].
     pub(super) allowed_deprecated_versions: BTreeMap<String, String>,
@@ -680,6 +686,8 @@ impl Default for WorkspaceTreeCtx {
             pnpmfile_hook: None,
             read_package_log: None,
             skipped_optional_log: None,
+            finalized_package: None,
+            finalized_ids: Mutex::new(HashSet::default()),
             allowed_deprecated_versions: BTreeMap::new(),
             deprecation_log: None,
             auto_install_peers: false,
@@ -1304,6 +1312,13 @@ impl WorkspaceTreeCtx {
         skipped_optional_log: Option<SkippedOptionalLogFn>,
     ) -> Self {
         self.skipped_optional_log = skipped_optional_log;
+        self
+    }
+
+    /// Attach the finalized-package sink. See [`FinalizedPackageFn`].
+    #[must_use]
+    pub fn with_finalized_package(mut self, finalized_package: Option<FinalizedPackageFn>) -> Self {
+        self.finalized_package = finalized_package;
         self
     }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -488,6 +488,14 @@ pub struct WorkspaceTreeCtx {
     /// The package ids already handed to `finalized_package`, so every
     /// package is announced once across importers and hoist rounds.
     pub(super) finalized_ids: Mutex<HashSet<Arc<str>>>,
+    /// Packages written or re-recorded since the last finalization
+    /// sweep: the only ones whose verdict can have changed on their own.
+    /// Maintained only while `finalized_package` is set.
+    pub(super) finalization_pending: Mutex<Vec<Arc<str>>>,
+    /// Every package that recorded an edge to the key, so a package's
+    /// finalization can be propagated to the packages depending on it.
+    /// Maintained only while `finalized_package` is set.
+    pub(super) parents_by_id: Mutex<HashMap<Arc<str>, Vec<Arc<str>>>>,
     /// The `pnpm.allowedDeprecatedVersions` map. See
     /// [`crate::WorkspaceResolveOptions::allowed_deprecated_versions`].
     pub(super) allowed_deprecated_versions: BTreeMap<String, String>,
@@ -688,6 +696,8 @@ impl Default for WorkspaceTreeCtx {
             skipped_optional_log: None,
             finalized_package: None,
             finalized_ids: Mutex::new(HashSet::default()),
+            finalization_pending: Mutex::new(Vec::new()),
+            parents_by_id: Mutex::new(HashMap::default()),
             allowed_deprecated_versions: BTreeMap::new(),
             deprecation_log: None,
             auto_install_peers: false,
@@ -1063,6 +1073,15 @@ impl WorkspaceTreeCtx {
     /// invisible to the discovery engine's view.
     pub(super) fn record_package_write(&self, pkg_id: &str) {
         lock_recoverable(&self.sync_log).packages.push(pkg_id.to_string());
+        self.note_finalization_candidate(pkg_id);
+    }
+
+    /// Queue `pkg_id` for the next finalization sweep. See
+    /// [`Self::finalization_pending`].
+    fn note_finalization_candidate(&self, pkg_id: &str) {
+        if self.finalized_package.is_some() {
+            lock_recoverable(&self.finalization_pending).push(Arc::from(pkg_id));
+        }
     }
 
     /// See [`Self::record_package_write`].
@@ -1588,13 +1607,18 @@ pub(super) fn record_children(
             Some(recorded) if *recorded.edges == edges => ChildrenRecording::Published,
             Some(_) => ChildrenRecording::PublishedOverStale,
         };
-        children.insert(
-            Arc::from(pkg_id.to_string()),
-            RecordedChildren { edges: Arc::new(edges), context },
-        );
+        let edges = Arc::new(edges);
+        if ctx.workspace.finalized_package.is_some() {
+            let mut parents = lock_recoverable(&ctx.workspace.parents_by_id);
+            for edge in edges.iter() {
+                parents.entry(Arc::clone(&edge.pkg_id)).or_default().push(Arc::from(pkg_id));
+            }
+        }
+        children.insert(Arc::from(pkg_id.to_string()), RecordedChildren { edges, context });
         recording
     };
     ctx.workspace.record_children_by_id_write(pkg_id);
+    ctx.workspace.note_finalization_candidate(pkg_id);
     recording
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -1635,8 +1635,12 @@ fn update_parent_index(
     previous: Option<&[crate::resolved_tree::ChildEdge]>,
     next: &[crate::resolved_tree::ChildEdge],
 ) {
+    if previous.is_some_and(|previous| previous == next) {
+        return;
+    }
+    let kept: HashSet<&str> = next.iter().map(|edge| edge.pkg_id.as_ref()).collect();
     for edge in previous.into_iter().flatten() {
-        if next.iter().any(|kept| kept.pkg_id == edge.pkg_id) {
+        if kept.contains(edge.pkg_id.as_ref()) {
             continue;
         }
         if let Some(parents) = parents_by_id.get_mut(&edge.pkg_id) {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/parent_index_tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx/parent_index_tests.rs
@@ -1,0 +1,41 @@
+use rustc_hash::{FxHashMap as HashMap, FxHashSet as HashSet};
+use std::sync::Arc;
+
+use super::update_parent_index;
+use crate::resolved_tree::ChildEdge;
+
+fn edge(pkg_id: &str) -> ChildEdge {
+    ChildEdge { alias: pkg_id.to_string(), pkg_id: Arc::from(pkg_id), optional: false }
+}
+
+fn parents_of<'index>(
+    index: &'index HashMap<Arc<str>, HashSet<Arc<str>>>,
+    pkg_id: &str,
+) -> Vec<&'index str> {
+    let mut parents: Vec<&str> =
+        index.get(pkg_id).into_iter().flatten().map(AsRef::as_ref).collect();
+    parents.sort_unstable();
+    parents
+}
+
+#[test]
+fn recording_the_same_edges_again_keeps_one_parent_entry() {
+    let mut index = HashMap::default();
+    let edges = [edge("child@1.0.0")];
+    update_parent_index(&mut index, "parent@1.0.0", None, &edges);
+    update_parent_index(&mut index, "parent@1.0.0", Some(&edges), &edges);
+    assert_eq!(parents_of(&index, "child@1.0.0"), ["parent@1.0.0"]);
+}
+
+#[test]
+fn replacing_children_drops_the_stale_reverse_edge() {
+    let mut index = HashMap::default();
+    let before = [edge("old@1.0.0"), edge("kept@1.0.0")];
+    let after = [edge("kept@1.0.0"), edge("new@1.0.0")];
+    update_parent_index(&mut index, "other@1.0.0", None, &before[..1]);
+    update_parent_index(&mut index, "parent@1.0.0", None, &before);
+    update_parent_index(&mut index, "parent@1.0.0", Some(&before), &after);
+    assert_eq!(parents_of(&index, "old@1.0.0"), ["other@1.0.0"]);
+    assert_eq!(parents_of(&index, "kept@1.0.0"), ["parent@1.0.0"]);
+    assert_eq!(parents_of(&index, "new@1.0.0"), ["parent@1.0.0"]);
+}

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace.rs
@@ -141,6 +141,12 @@ pub struct WorkspaceResolveOptions {
     /// log). `None` keeps the skip behavior but drops the notification.
     pub skipped_optional_log: Option<crate::SkippedOptionalLogFn>,
 
+    /// Sink told about every package whose subtree has settled peer-free,
+    /// so the install layer can materialize it into the virtual store
+    /// before peer resolution. `None` skips the sweep. See
+    /// [`crate::FinalizedPackageFn`].
+    pub finalized_package: Option<crate::FinalizedPackageFn>,
+
     /// Package-name → semver-range map from the
     /// `pnpm.allowedDeprecatedVersions` setting. When a newly-resolved
     /// package is deprecated and its `name@version` satisfies an entry
@@ -213,6 +219,7 @@ where
         pnpmfile_hook,
         read_package_log,
         skipped_optional_log,
+        finalized_package,
         allowed_deprecated_versions,
         deprecation_log,
         pick_lowest_direct,
@@ -245,6 +252,7 @@ where
             .with_pnpmfile_hook(pnpmfile_hook)
             .with_read_package_log(read_package_log)
             .with_skipped_optional_log(skipped_optional_log)
+            .with_finalized_package(finalized_package)
             .with_allowed_deprecated_versions(allowed_deprecated_versions)
             .with_deprecation_log(deprecation_log)
             .with_auto_install_peers(auto_install_peers)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -3621,7 +3621,7 @@ async fn finalized_packages_are_announced_once_their_peer_free_subtree_settles()
         vec![
             ("leaf@1.0.0".to_string(), vec![]),
             ("pure@1.0.0".to_string(), vec!["leaf@1.0.0".to_string()]),
-        ]
+        ],
     );
 }
 

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_workspace/tests.rs
@@ -238,6 +238,7 @@ fn workspace_opts(pick_lowest_direct: bool, time_based: bool) -> WorkspaceResolv
         pnpmfile_hook: None,
         read_package_log: None,
         skipped_optional_log: None,
+        finalized_package: None,
         allowed_deprecated_versions: BTreeMap::new(),
         deprecation_log: None,
         pick_lowest_direct,
@@ -3559,4 +3560,81 @@ async fn importer_waves_do_not_overlap() {
         "importers resolved concurrently: {:?}",
         overlaps.first().expect("checked non-empty"),
     );
+}
+
+/// Package ids announced as finalized, each with its child ids.
+type Announcements = Vec<(String, Vec<String>)>;
+
+/// Resolve `manifest_deps` through `table` and return every package the
+/// walk announced as finalized, in announcement order, with the child
+/// ids each announcement carried.
+async fn announced_finalized_packages(
+    manifest_deps: serde_json::Value,
+    table: HashMap<(String, String), ResolveResult>,
+) -> Announcements {
+    let (_tmp, manifest) = fake_manifest(manifest_deps);
+    let resolver = RecordingResolver { table, seen: Mutex::new(HashMap::default()) };
+    let importers = vec![WorkspaceImporter { id: ".".to_string(), manifest: &manifest }];
+    let announced: Arc<Mutex<Announcements>> = Arc::new(Mutex::new(Vec::new()));
+    let mut opts = workspace_opts(false, false);
+    let sink = Arc::clone(&announced);
+    opts.finalized_package = Some(Arc::new(move |package| {
+        let children =
+            package.children.iter().map(|child| child.pkg_id.to_string()).collect::<Vec<_>>();
+        sink.lock().unwrap().push((package.pkg_id.to_string(), children));
+    }));
+    resolve_workspace(&resolver, &importers, &[DependencyGroup::Prod], opts, |_| {
+        importer_opts(std::path::PathBuf::from("/repo"), None)
+    })
+    .await
+    .expect("resolve");
+    let announced = announced.lock().unwrap();
+    announced.clone()
+}
+
+fn table_entry(name: &str, manifest: serde_json::Value) -> ((String, String), ResolveResult) {
+    ((name.to_string(), "^1.0.0".to_string()), fake_result(name, "1.0.0", None, manifest))
+}
+
+#[tokio::test]
+async fn finalized_packages_are_announced_once_their_peer_free_subtree_settles() {
+    let announced = announced_finalized_packages(
+        serde_json::json!({ "pure": "^1.0.0", "peered": "^1.0.0" }),
+        HashMap::from_iter([
+            table_entry("pure", serde_json::json!({ "dependencies": { "leaf": "^1.0.0" } })),
+            table_entry("leaf", serde_json::json!({})),
+            table_entry(
+                "peered",
+                serde_json::json!({
+                    "dependencies": { "leaf": "^1.0.0" },
+                    "peerDependencies": { "react": "*" },
+                    "peerDependenciesMeta": { "react": { "optional": true } },
+                }),
+            ),
+        ]),
+    )
+    .await;
+    // `peered` declares a peer, so neither it nor its dep path is final;
+    // `pure` and `leaf` are, and `pure` is announced with its edge.
+    assert_eq!(
+        announced,
+        vec![
+            ("leaf@1.0.0".to_string(), vec![]),
+            ("pure@1.0.0".to_string(), vec!["leaf@1.0.0".to_string()]),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn finalized_packages_include_peer_free_cycles() {
+    let announced = announced_finalized_packages(
+        serde_json::json!({ "ping": "^1.0.0" }),
+        HashMap::from_iter([
+            table_entry("ping", serde_json::json!({ "dependencies": { "pong": "^1.0.0" } })),
+            table_entry("pong", serde_json::json!({ "dependencies": { "ping": "^1.0.0" } })),
+        ]),
+    )
+    .await;
+    let ids = announced.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>();
+    assert_eq!(ids, ["ping@1.0.0", "pong@1.0.0"]);
 }

--- a/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
+++ b/pnpm/tasks/micro-benchmark/src/workspace_resolution.rs
@@ -297,6 +297,7 @@ fn workspace_options() -> WorkspaceResolveOptions {
         pnpmfile_hook: None,
         read_package_log: None,
         skipped_optional_log: None,
+        finalized_package: None,
         allowed_deprecated_versions: BTreeMap::new(),
         deprecation_log: None,
         auto_install_peers: true,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Rust CLI only. On a fresh resolve (no usable lockfile), pnpm now links packages into `node_modules/.pnpm` while resolution is still running, for every package whose dependency subtree carries no `peerDependencies`. Related to the resolver warm-up in https://github.com/pnpm/pnpm/pull/14496; the two are independent and measured separately below.

### Why

The prefetching resolver already streams every tarball into the store during resolution, but the hardlink fan-out into the virtual store waited for the lockfile, because a slot's directory name carries the package's resolved peers. For a package whose own manifest declares no peers and whose whole subtree declares none, the dep path is just the package id and the child edges are final the moment the subtree settles. In the alotta-files fixture that is 1142 of 1349 snapshots (84%). Materialising those during the download window takes the bulk of the link work off the post-resolution critical path.

### How

- `resolving-deps-resolver`: after each level settles, `finalized.rs` announces every newly finalized package (peer-free, children recorded, all children finalized; peer-free cycles count as a whole) through the new `WorkspaceResolveOptions::finalized_package` sink, once per package id across importers and hoist rounds. The sweep is incremental: it starts from the packages written or re-recorded since the previous level and walks up recorded parent edges from each new announcement, so each package is inspected once per change to itself or a direct child.
- `package-manager`: `early_materializer.rs` receives the announcements, waits for the package's tarball to land in the prefetch `MemCache`, and populates the slot on a blocking task: files via `import_indexed_dir` (which places the `package.json` completion marker last) and the non-optional sibling symlinks via `create_symlink_layout`, under a flat `VirtualStoreLayout`.
- The existing `CreateVirtualStore` pass is unchanged: it sees the completion marker and skips the import, still re-links the slot's edges from the lockfile (so children re-recorded by a shallower importer or a hoist round after the announcement heal there), and still emits the per-slot progress event, so reporter counts are unaffected.
- `finish` runs right before that pass, after the installability skip set is known: it stops scheduling, lets tasks that are only waiting on an in-flight download give up, joins the rest, and removes slots that are not in the materialization closure or that the skip set excludes. Patch-qualified package ids are left to the normal import.
- Disabled for the hoisted linker, the global virtual store (its slot names hash the whole graph), filtered installs, `--lockfile-only`, custom fetchers (matching when the prefetch itself is off), and wherever the macOS directory-clone cache is eligible, since that cache populates canonical slots under the store and clones them into the project; integrating the two is a follow-up.

### Measurements

alotta-files, `install --ignore-scripts`, no lockfile, empty store and cache, local pnpr behind the `pnpm/benchmarks` latency proxy. "main" is this branch with the materializer disabled. Two runs each unless noted; spread under 3%.

| link | cores | main | this PR |
|---|---|---|---|
| 200 Mbit / 50 ms | 32 | 4.23 s | 3.89 s |
| 200 Mbit / 50 ms | 4 | 4.45 s | 4.23 s |
| 200 Mbit / 50 ms | 2 | 4.48 s | 4.27 s |
| uncapped / 10 ms | 32 | 1.90 s | 1.46 s |
| uncapped / 10 ms | 4 | 1.79 s | 1.82 s |
| uncapped / 10 ms | 2 | 1.98 s | 1.90 s |

On top of the warm-up from pull 14496: 200 Mbit 32 cores 3.66 → 3.59 s, 2 cores 3.99 → 3.95 s; uncapped 32 cores 1.27 → 1.13 s. The warm-up moves resolution earlier, which already lets the link phase overlap the download tail, so the two gains overlap on the slow link and add up on the fast one. The `create_virtual_store` phase itself drops from 787 ms to 406 ms (32 cores) and 875 ms to 244 ms (2 cores); the warm link batch handles 1120 to 1140 pre-populated slots.

On few cores with a fast link the extra filesystem work competes with the download pipeline, which is why those rows are flat; the closing rule (stop once the lockfile exists) keeps it from becoming a loss.

Verification: installed tree identical to main (1347 slots, 39 851 files, 3 827 symlinks, none dangling; `require` of react and webpack works); `cargo nextest run -p pnpm-resolving-deps-resolver -p pnpm-package-manager` passes (1034 tests, two new ones cover the announcement rule and peer-free cycles); clippy clean on both crates; the `install::` and `add::` CLI e2e groups pass.

### Follow-up

The remaining 16% of slots (suffixed packages and their peer-carrying ancestors) could be staged under their package id and renamed to the final dep path once peers resolve. On the fast link that would remove most of the remaining 150 ms link batch.

## Squash Commit Body

```text
A fresh resolve prefetches every tarball into the store while the
graph is still being walked, but nothing is linked into
node_modules/.pnpm until the lockfile exists, because a slot's name
carries the package's resolved peers. Most packages never get a peer
suffix: a package whose own manifest declares no peers and whose whole
dependency subtree declares none has a final dep path (its package id)
and final child edges as soon as that subtree settles. 84% of the
alotta-files graph qualifies.

The tree walk now sweeps the settled packages after every level and
announces each newly finalized one once, through a sink on
WorkspaceResolveOptions. The install layer's EarlyMaterializer waits
for the package's tarball to land in the prefetch cache and populates
the slot from there: the files through import_indexed_dir, which
leaves the package.json completion marker last, and the non-optional
sibling symlinks through create_symlink_layout. The later
CreateVirtualStore pass finds the marker, skips the import and re-links
every slot's edges from the lockfile, so a slot whose children a later
importer or hoist round re-recorded heals there. Slots for packages the
final lockfile does not carry are removed before that pass runs.

The materializer stops scheduling once the lockfile is built: from
then on the link phase's own parallel pass takes every remaining slot,
and a task still waiting on an in-flight download gives up rather than
delaying that pass. It is off for the hoisted linker, the global
virtual store (slot names need the whole graph), filtered installs,
--lockfile-only, and custom fetchers, which the prefetch skips too.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (Internal performance change to the Rust install pipeline; nothing to port.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed. (Not needed.)

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4vkqo9LyR5PG1HAJ3zUtP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved install speed when no lockfile is present by materializing eligible packages in the virtual store during dependency resolution.
  - Reduced work deferred until the lockfile is fully built, helping installations complete sooner.

- **Bug Fixes**
  - Prevented packages excluded by platform, engine, or optional-dependency settings from being left in the virtual store.
  - Preserved correct handling for peer-dependent, patched, linked, and unsupported package sources.
  - Improved cleanup and retry behavior when early package materialization cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->