### PR TITLE
fix(package-manager): record a validation baseline that covers the validated manifests

### DIFF
--- a/.changeset/fix-pacquet-validated-timestamp.md
+++ b/.changeset/fix-pacquet-validated-timestamp.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` now records a freshness baseline that covers the manifests it validated on filesystems that keep sub-millisecond mtimes, such as NTFS. Previously, `pnpm run` and `pnpm exec` reinstalled before every run on those filesystems [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).
+`pnpm run` and `pnpm exec` now start without reinstalling on filesystems that keep sub-millisecond mtimes, such as NTFS. Previously, every run on those filesystems reinstalled first [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).

--- a/.changeset/fix-pacquet-validated-timestamp.md
+++ b/.changeset/fix-pacquet-validated-timestamp.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run` and `pnpm exec` no longer reinstall before every run on filesystems that keep sub-millisecond mtimes, such as NTFS. The freshness baseline that `pnpm install` records now covers the manifest it validated [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).
+`pnpm install` now records a freshness baseline that covers the manifests it validated on filesystems that keep sub-millisecond mtimes, such as NTFS. Previously, `pnpm run` and `pnpm exec` reinstalled before every run on those filesystems [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).

--- a/.changeset/fix-pacquet-validated-timestamp.md
+++ b/.changeset/fix-pacquet-validated-timestamp.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run` and `pnpm exec` no longer re-run install after a Rust `pnpm install` on filesystems with sub-millisecond mtimes [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).
+`pnpm run` and `pnpm exec` no longer reinstall before every run on filesystems that keep sub-millisecond mtimes, such as NTFS. The freshness baseline that `pnpm install` records now covers the manifest it validated [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).

--- a/.changeset/fix-pacquet-validated-timestamp.md
+++ b/.changeset/fix-pacquet-validated-timestamp.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm run` and `pnpm exec` no longer re-run install after a Rust `pnpm install` on filesystems with sub-millisecond mtimes [pnpm/pnpm#14486](https://github.com/pnpm/pnpm/issues/14486).

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -10,7 +10,7 @@ use super::{
     write_modules_manifest,
 };
 use crate::{
-    optimistic_repeat_install::{filesystem_now_ms, refreshed_validation_baseline_ms},
+    optimistic_repeat_install::filesystem_now_ms,
     peer_dependency_issues::report_peer_dependency_issues,
 };
 use pnpm_store_dir::VerifiedFileIntegrity;
@@ -916,22 +916,21 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
     // Writing it after both the `.modules.yaml` and the current
     // lockfile succeed keeps the file pointing at a fully committed
     // install.
-    let mut workspace_state = build_workspace_state::<Host>(
+    update_workspace_state(
         &workspace_root,
-        config,
-        node_linker,
-        included,
-        supported_architectures.as_ref(),
-        &catalogs,
-        &project_manifests,
-        filtered_install,
-    );
-    workspace_state.last_validated_timestamp = refreshed_validation_baseline_ms(
-        workspace_state.last_validated_timestamp,
-        filesystem_now_ms(&workspace_root),
-    );
-    update_workspace_state(&workspace_root, &workspace_state)
-        .map_err(InstallError::WriteWorkspaceState)?;
+        &build_workspace_state::<Host>(
+            &workspace_root,
+            config,
+            node_linker,
+            included,
+            supported_architectures.as_ref(),
+            &catalogs,
+            &project_manifests,
+            filtered_install,
+            filesystem_now_ms(&workspace_root),
+        ),
+    )
+    .map_err(InstallError::WriteWorkspaceState)?;
 
     let completion = report_install_completion::<Reporter>(ReportInstallCompletionInputs {
         config,

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -9,7 +9,10 @@ use super::{
     projects_running_own_scripts, run_projects_lifecycle_scripts, update_workspace_state,
     write_modules_manifest,
 };
-use crate::peer_dependency_issues::report_peer_dependency_issues;
+use crate::{
+    optimistic_repeat_install::{filesystem_now_ms, refreshed_validation_baseline_ms},
+    peer_dependency_issues::report_peer_dependency_issues,
+};
 use pnpm_store_dir::VerifiedFileIntegrity;
 use std::time::Duration;
 
@@ -913,20 +916,22 @@ pub(super) async fn apply_materialization_result<Reporter: self::Reporter + 'sta
     // Writing it after both the `.modules.yaml` and the current
     // lockfile succeed keeps the file pointing at a fully committed
     // install.
-    update_workspace_state(
+    let mut workspace_state = build_workspace_state::<Host>(
         &workspace_root,
-        &build_workspace_state::<Host>(
-            &workspace_root,
-            config,
-            node_linker,
-            included,
-            supported_architectures.as_ref(),
-            &catalogs,
-            &project_manifests,
-            filtered_install,
-        ),
-    )
-    .map_err(InstallError::WriteWorkspaceState)?;
+        config,
+        node_linker,
+        included,
+        supported_architectures.as_ref(),
+        &catalogs,
+        &project_manifests,
+        filtered_install,
+    );
+    workspace_state.last_validated_timestamp = refreshed_validation_baseline_ms(
+        workspace_state.last_validated_timestamp,
+        filesystem_now_ms(&workspace_root),
+    );
+    update_workspace_state(&workspace_root, &workspace_state)
+        .map_err(InstallError::WriteWorkspaceState)?;
 
     let completion = report_install_completion::<Reporter>(ReportInstallCompletionInputs {
         config,

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -7,6 +7,7 @@ use super::{
     modules_consistent_with, modules_layout_consistent_with, unapproved_recorded_ignored_builds,
     update_workspace_state, verify_lockfile_eagerly,
 };
+use crate::optimistic_repeat_install::filesystem_now_ms;
 
 pub(super) struct PrepareModulesStateInputs<'a, 'install> {
     pub(super) resolve_only: bool,
@@ -394,6 +395,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                 catalogs,
                 project_manifests,
                 filtered_install,
+                filesystem_now_ms(workspace_root),
             ),
         )
         .map_err(InstallError::WriteWorkspaceState)?;

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -1970,6 +1970,7 @@ mod build_workspace_state_tests {
             &BTreeMap::default(),
             &[],
             false,
+            None,
         );
         assert!(state.projects.is_empty());
         assert_eq!(state.last_validated_timestamp, FAKE_NOW_MS);
@@ -1991,11 +1992,47 @@ mod build_workspace_state_tests {
             &BTreeMap::default(),
             &[(dir.path().to_path_buf(), &manifest)],
             false,
+            None,
         );
         assert_eq!(
             state.last_validated_timestamp,
             pnpm_testing_utils::fs::mtime_ms(manifest.path()),
         );
+    }
+
+    /// A manifest mtime truncated to milliseconds reads as modified
+    /// against itself on a sub-millisecond filesystem, so the recorded
+    /// baseline is raised to the filesystem clock's `now`, which the
+    /// caller reads off a probe file.
+    #[test]
+    fn raises_the_manifest_mtime_baseline_to_the_filesystem_now() {
+        let dir = tempdir().unwrap();
+        let manifest = write_manifest(dir.path(), "root", "1.0.0");
+        pnpm_testing_utils::fs::set_mtime(
+            manifest.path(),
+            SystemTime::UNIX_EPOCH + Duration::new(1_600_000_000, 500_000),
+        );
+        let config = Config::new();
+        let build = |filesystem_now_ms| {
+            build_workspace_state::<FrozenClock>(
+                dir.path(),
+                &config,
+                pnpm_config::NodeLinker::default(),
+                IncludedDependencies::default(),
+                None,
+                &BTreeMap::default(),
+                &[(dir.path().to_path_buf(), &manifest)],
+                false,
+                filesystem_now_ms,
+            )
+        };
+
+        let now_ms = 1_600_000_001_000;
+        assert_eq!(build(Some(now_ms)).last_validated_timestamp, now_ms);
+        // A manifest dated ahead of the filesystem clock keeps its own
+        // mtime as the baseline.
+        let manifest_ms = pnpm_testing_utils::fs::mtime_ms(manifest.path());
+        assert_eq!(build(Some(manifest_ms - 1)).last_validated_timestamp, manifest_ms);
     }
 
     /// Every project in the list lands in `state.projects` keyed by its
@@ -2028,6 +2065,7 @@ mod build_workspace_state_tests {
             &BTreeMap::default(),
             &project_manifests,
             false,
+            None,
         );
 
         assert_eq!(state.projects.len(), packages.len());
@@ -2065,6 +2103,7 @@ mod build_workspace_state_tests {
             &BTreeMap::default(),
             &[],
             false,
+            None,
         );
         assert_eq!(state.config_dependencies, config.config_dependencies);
     }
@@ -7760,6 +7799,16 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
     };
     write_modules_manifest::<Host>(&modules_dir, seed_modules).expect("seed .modules.yaml");
     lockfile.save_current_to_virtual_store_dir(&virtual_store_dir).expect("seed current lockfile");
+    // Date the manifest inside a millisecond after the lockfile, as a
+    // sub-millisecond filesystem leaves a manifest edited after the last
+    // lockfile write: the manifest's truncated mtime alone would read as
+    // modified against itself on the next `pnpm run`.
+    let validated_at = std::time::SystemTime::UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+    pnpm_testing_utils::fs::set_mtime(
+        &virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME),
+        validated_at,
+    );
+    pnpm_testing_utils::fs::set_mtime(manifest.path(), validated_at + Duration::from_micros(500));
     // The short-circuit probes the tree it would skip; seed the one
     // direct-dep entry the lockfile records so the probe holds. A
     // marker *file* doubles as the materialization sentinel below:
@@ -7844,9 +7893,19 @@ async fn frozen_install_short_circuits_when_modules_and_lockfile_are_consistent(
     let written = load_workspace_state(&project_root)
         .expect("read workspace state")
         .expect("workspace state must be written");
+    let manifest_mtime = crate::optimistic_repeat_install::file_mtime(manifest.path())
+        .expect("manifest should have an mtime");
+    assert_eq!(
+        manifest_mtime.ns, 1_700_000_000_000_500_000,
+        "the short-circuit must leave the manifest untouched",
+    );
     assert!(
-        written.last_validated_timestamp > 0,
-        "last_validated_timestamp must be refreshed on the fast path",
+        !crate::optimistic_repeat_install::modified_at_or_after(
+            manifest_mtime,
+            written.last_validated_timestamp,
+        ),
+        "the refreshed state must cover the validated manifest mtime; got {}",
+        written.last_validated_timestamp,
     );
 
     drop(dir);

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -1787,6 +1787,10 @@ async fn install_writes_workspace_state() {
 
     let manifest_path = dir.path().join("package.json");
     let manifest = PackageManifest::create_if_needed(manifest_path).unwrap();
+    pnpm_testing_utils::fs::set_mtime(
+        manifest.path(),
+        std::time::SystemTime::UNIX_EPOCH + Duration::new(1_700_000_000, 500_000),
+    );
 
     let mut config = Config::new();
     config.lockfile = false;
@@ -1855,6 +1859,15 @@ async fn install_writes_workspace_state() {
         state.last_validated_timestamp > 0,
         "lastValidatedTimestamp should be populated, got {}",
         state.last_validated_timestamp,
+    );
+    let manifest_mtime = crate::optimistic_repeat_install::file_mtime(manifest.path())
+        .expect("manifest should have an mtime");
+    assert!(
+        !crate::optimistic_repeat_install::modified_at_or_after(
+            manifest_mtime,
+            state.last_validated_timestamp,
+        ),
+        "fresh install state should cover the validated manifest mtime",
     );
 
     // The state must record the project that pacquet just installed

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -6,6 +6,7 @@ use super::{
     gvs_build_marker_present, gvs_build_markers_may_require_recovery, load_workspace_projects,
     manifest_string_field, unapproved_recorded_ignored_builds,
 };
+use crate::optimistic_repeat_install::{refreshed_validation_baseline_ms, validation_baseline_ms};
 
 /// Inputs for [`install_already_up_to_date`].
 pub struct UpToDateFastPathCheck<'a> {
@@ -554,7 +555,10 @@ pub(super) fn build_projects_map(
 /// [`pnpm_workspace_state::update_workspace_state`].
 ///
 /// Records the projects pacquet just materialized plus the resolved
-/// settings the install used.
+/// settings the install used. `lastValidatedTimestamp` is the
+/// [`validation_baseline_ms`] of the lockfile and manifests raised to
+/// `filesystem_now_ms`, per [`refreshed_validation_baseline_ms`]; the
+/// wall clock stands in only when nothing can be stat'd.
 /// Settings pacquet does not track yet (e.g. `peersSuffixMaxLength`)
 /// are omitted; pnpm's `checkDepsStatus`
 /// only iterates fields present in the serialized object, so an
@@ -572,26 +576,14 @@ pub(crate) fn build_workspace_state<Sys: Clock>(
     catalogs: &Catalogs,
     project_manifests: &[(std::path::PathBuf, &PackageManifest)],
     filtered_install: bool,
+    filesystem_now_ms: Option<i64>,
 ) -> WorkspaceState {
     WorkspaceState {
-        // Record the freshness baseline from the lockfile this install
-        // just wrote, not the wall clock. The repeat-install fast path
-        // compares this timestamp against file mtimes, so the two must be
-        // on the same clock: on a runner whose wall clock runs ahead of
-        // the filesystem's mtime clock (observed ~2 ms on some CI
-        // microVMs), a wall-clock baseline can sit above the mtime of
-        // a manifest/pnpmfile edited moments later, hiding the edit and
-        // wrongly keeping the fast path. The lockfile's own mtime shares
-        // the filesystem clock with every file the check compares, so no
-        // skew is possible. Mirrors pnpm's `checkDepsStatus`, whose
-        // single-project path keys off the wanted lockfile's mtime. Fall
-        // back to the clock only when no lockfile was written.
-        last_validated_timestamp: crate::optimistic_repeat_install::validation_baseline_ms(
-            workspace_root,
-            config,
-            project_manifests,
-        )
-        .unwrap_or_else(|| pnpm_workspace_state::millis_since_epoch(Sys::now())),
+        last_validated_timestamp: refreshed_validation_baseline_ms(
+            validation_baseline_ms(workspace_root, config, project_manifests)
+                .unwrap_or_else(|| pnpm_workspace_state::millis_since_epoch(Sys::now())),
+            filesystem_now_ms,
+        ),
         projects: build_projects_map(project_manifests),
         pnpmfiles: crate::optimistic_repeat_install::current_pnpmfiles(workspace_root, config),
         filtered_install,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -381,7 +381,7 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                 // `filtered_install` forward: clearing it would claim every
                 // importer is materialized when a filtered install left the
                 // unselected ones untouched.
-                let mut new_state = crate::install::build_workspace_state::<Host>(
+                let new_state = crate::install::build_workspace_state::<Host>(
                     workspace_root,
                     config,
                     node_linker,
@@ -390,9 +390,6 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
                     catalogs,
                     project_manifests,
                     state.filtered_install,
-                );
-                new_state.last_validated_timestamp = refreshed_validation_baseline_ms(
-                    new_state.last_validated_timestamp,
                     filesystem_now,
                 );
                 if let Err(error) = update_workspace_state(workspace_root, &new_state) {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -7,8 +7,7 @@ use super::{
     filesystem_now_ms, first_lockfile_requiring_conflict_safe_install,
     first_project_missing_modules_dir, first_setting_drift, modified_at_or_after,
     modified_manifests_match_lockfile, patches_modified_since, pnpmfiles_drift,
-    project_structure_matches, refreshed_validation_baseline_ms, stat_manifests,
-    update_workspace_state, wanted_lockfile_modified,
+    project_structure_matches, stat_manifests, update_workspace_state, wanted_lockfile_modified,
 };
 
 /// Outcome of [`check_deps_status_before_run`].
@@ -172,9 +171,6 @@ pub fn check_deps_status_before_run(
                     catalogs,
                     project_manifests,
                     state.filtered_install,
-                );
-                new_state.last_validated_timestamp = refreshed_validation_baseline_ms(
-                    new_state.last_validated_timestamp,
                     filesystem_now,
                 );
                 // The gate ignored `dev`/`optional`/`production` drift

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
@@ -114,12 +114,15 @@ pub(crate) fn validation_baseline_ms(
 ///
 /// The probe is an unnamed temporary file in the directory holding the
 /// workspace state — pnpm's own, on the volume the state write lands on
-/// — so nothing else can observe it and it needs no cleanup. `None` when
-/// it cannot be created or stat'd, leaving the caller with the
-/// mtime-derived baseline.
+/// — so nothing else can observe it and it needs no cleanup. The state
+/// directory is created first because a fresh install may be about to
+/// write it for the first time. `None` when it cannot be created or
+/// stat'd, leaving the caller with the mtime-derived baseline.
 pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
     let state_path = pnpm_workspace_state::get_file_path(workspace_root);
-    let probe = tempfile::tempfile_in(state_path.parent()?).ok()?;
+    let parent = state_path.parent()?;
+    fs::create_dir_all(parent).ok()?;
+    let probe = tempfile::tempfile_in(parent).ok()?;
     file_mtime_from_metadata(&probe.metadata().ok()?).map(|mtime| mtime.ms)
 }
 

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/timestamps.rs
@@ -107,17 +107,19 @@ pub(crate) fn validation_baseline_ms(
 /// file the repeat-install check compares — the reason
 /// [`validation_baseline_ms`] cannot use the wall clock either.
 ///
-/// Read it *before* validating the contents it will later bless: a file
-/// written after the probe carries a later mtime and so still reads as
-/// modified, while one written before it is covered by the check that
-/// just passed.
+/// A repeat-install check reads it *before* validating the contents it
+/// will later bless: a file written after the probe carries a later
+/// mtime and so still reads as modified, while one written before it is
+/// covered by the check that just passed. An install reads it as it
+/// writes the workspace state, where pnpm records `Date.now()`.
 ///
 /// The probe is an unnamed temporary file in the directory holding the
 /// workspace state — pnpm's own, on the volume the state write lands on
-/// — so nothing else can observe it and it needs no cleanup. The state
-/// directory is created first because a fresh install may be about to
-/// write it for the first time. `None` when it cannot be created or
-/// stat'd, leaving the caller with the mtime-derived baseline.
+/// — so nothing else can observe it and it needs no cleanup. The
+/// directory is created first because an install may be about to write
+/// the state file for the first time. `None` when the probe cannot be
+/// created or stat'd, leaving the caller with the mtime-derived
+/// baseline.
 pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
     let state_path = pnpm_workspace_state::get_file_path(workspace_root);
     let parent = state_path.parent()?;
@@ -126,10 +128,11 @@ pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
     file_mtime_from_metadata(&probe.metadata().ok()?).map(|mtime| mtime.ms)
 }
 
-/// The `lastValidatedTimestamp` to record once a repeat-install content
-/// check has passed: `baseline_ms` — the mtimes of the files it
-/// validated, per [`validation_baseline_ms`] — raised to the filesystem
-/// clock's `now_ms`.
+/// The `lastValidatedTimestamp` to record once an install or a
+/// repeat-install content check has validated the manifests:
+/// `baseline_ms` — the mtimes of the files it validated, per
+/// [`validation_baseline_ms`] — raised to the filesystem clock's
+/// `now_ms`.
 ///
 /// `baseline_ms` on its own never converges. It is a file mtime
 /// truncated to milliseconds, and [`modified_at_or_after`] deliberately
@@ -138,7 +141,11 @@ pub(crate) fn filesystem_now_ms(workspace_root: &Path) -> Option<i64> {
 /// possibly-modified. The very file that forced this content check keeps
 /// forcing one on every later run, so the pure-mtime fast path becomes
 /// unreachable
-/// ([#13907](https://github.com/pnpm/pnpm/issues/13907)). Raising the
+/// ([#13907](https://github.com/pnpm/pnpm/issues/13907)). An install
+/// that leaves the lockfile alone records the newest manifest's mtime
+/// the same way, so on a sub-millisecond filesystem that manifest reads
+/// as modified against its own truncated mtime on every `pnpm run`
+/// ([#14486](https://github.com/pnpm/pnpm/issues/14486)). Raising the
 /// baseline to the filesystem's *now* closes that window without
 /// post-dating it into the future, which would hide an edit made in the
 /// interval it skipped over. Keeping `baseline_ms` as the floor


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14486.

The Rust install recorded `lastValidatedTimestamp` as the newest mtime among the lockfile it wrote and the manifests it validated, truncated to milliseconds. The later freshness check compares manifests at nanosecond precision, so on filesystems that keep sub-millisecond mtimes (NTFS, APFS, ext4 with 256-byte inodes) a manifest newer than the lockfile read as modified against its own truncated mtime, and `verifyDepsBeforeRun` reinstalled before every `pnpm run` / `pnpm exec`.

`build_workspace_state` now raises the mtime-derived baseline to the filesystem clock's *now*, read off a probe file, on every path that writes the workspace state: the post-materialization write, the "Lockfile is up to date" short-circuit (the path an install that changes nothing takes, which is the reproduction in the issue), and the two repeat-install checks that already did this refresh by hand.

The TypeScript CLI records `Date.now()` when it writes the state, so it does not have this bug and needs no change.

## Squash Commit Body

```text
A Rust install wrote `lastValidatedTimestamp` from the validated
manifest and lockfile mtimes. Those values are truncated to
milliseconds, while the later freshness check compares manifests at
nanosecond precision. On a sub-millisecond filesystem such as NTFS, a
manifest newer than the lockfile therefore read as modified against
its own truncated mtime and forced `verifyDepsBeforeRun` to reinstall
before every `pnpm run` and `pnpm exec`.

Move the filesystem-clock refresh the repeat-install checks already
applied into `build_workspace_state`, behind a `filesystem_now_ms`
parameter, so every writer of the workspace state records a baseline
that covers the manifests it validated. The repeat-install checks pass
the probe they read before validating; the two install paths (the
post-materialization write and the "Lockfile is up to date"
short-circuit) read it as they write the state, where pnpm records
`Date.now()`. The probe directory is created first so a fresh install
can take the same path before the state file exists.

The TypeScript CLI already stamps the wall clock after validation, so
no TypeScript-side behavior change is needed.

Closes pnpm/pnpm#14486.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package.
- [x] Added or updated tests.

Written by an agent (Codex, GPT-5), revised by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y7LCkWitEvfSj97o6WPryF


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unnecessary reinstalls triggered by sub-millisecond filesystem timestamps when using `pnpm run` or `pnpm exec`.
  * Improved install-state validation to accurately track filesystem timestamps and validated project manifests.
  * Prevented repeated install checks from treating unchanged dependencies as stale.

* **Documentation**
  * Added release notes describing the timestamp handling and reinstall behavior improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->