### PR TITLE
perf(workspace): discover projects without enumerating child directories

### DIFF
--- a/.changeset/lean-discovery.md
+++ b/.changeset/lean-discovery.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces. Discovering the workspace projects no longer enumerates every matched directory to learn which manifest files it holds [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -298,9 +298,7 @@ impl PackageManifest {
         // paying a stat before every successful read.
         let rendered_path = path.display().to_string();
         PackageManifest::read_from_file(path).map_err(|error| match error {
-            PackageManifestError::Io(io_error)
-                if io_error.kind() == io::ErrorKind::NotFound =>
-            {
+            PackageManifestError::Io(io_error) if io_error.kind() == io::ErrorKind::NotFound => {
                 PackageManifestError::NoImporterManifestFound(rendered_path)
             }
             other => other,

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -293,11 +293,18 @@ impl PackageManifest {
     }
 
     pub fn from_path(path: PathBuf) -> Result<PackageManifest, PackageManifestError> {
-        if !path.exists() {
-            return Err(PackageManifestError::NoImporterManifestFound(path.display().to_string()));
-        }
-
-        PackageManifest::read_from_file(path)
+        // The read itself answers existence: a NotFound maps to the
+        // same missing-manifest error a pre-check would raise, without
+        // paying a stat before every successful read.
+        let rendered_path = path.display().to_string();
+        PackageManifest::read_from_file(path).map_err(|error| match error {
+            PackageManifestError::Io(io_error)
+                if io_error.kind() == io::ErrorKind::NotFound =>
+            {
+                PackageManifestError::NoImporterManifestFound(rendered_path)
+            }
+            other => other,
+        })
     }
 
     pub fn create_if_needed(path: PathBuf) -> Result<PackageManifest, PackageManifestError> {

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -151,7 +151,6 @@ pub fn find_workspace_projects_no_check(
             message: err.to_string(),
         })
     };
-    let ignore_template = build_ignores(&mut IGNORE_PATTERNS.iter().copied())?;
     let dot_pruning_ignore_template =
         build_ignores(&mut IGNORE_PATTERNS.iter().copied().chain([DOT_COMPONENT_IGNORE_PATTERN]))?;
 
@@ -196,7 +195,6 @@ pub fn find_workspace_projects_no_check(
             match collect_pattern_manifests(
                 pattern,
                 workspace_root,
-                &ignore_template,
                 &dot_pruning_ignore_template,
                 &user_negations,
             ) {
@@ -266,7 +264,6 @@ pub fn find_workspace_projects_no_check(
 fn collect_pattern_manifests(
     pattern: &str,
     workspace_root: &Path,
-    ignore_template: &wax::Any<'_>,
     dot_pruning_ignore_template: &wax::Any<'_>,
     user_negations: &wax::Any<'_>,
 ) -> Result<BTreeSet<PathBuf>, FindWorkspaceProjectsError> {
@@ -276,7 +273,6 @@ fn collect_pattern_manifests(
             collect_manifests_in_children(
                 &workspace_root.join(parent),
                 workspace_root,
-                ignore_template,
                 user_negations,
                 &mut manifest_paths,
             )?;
@@ -286,7 +282,6 @@ fn collect_pattern_manifests(
             collect_literal_manifests_in(
                 &workspace_root.join(directory),
                 workspace_root,
-                ignore_template,
                 user_negations,
                 &mut manifest_paths,
             );
@@ -420,7 +415,6 @@ fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
 fn collect_manifests_in_children(
     parent: &Path,
     workspace_root: &Path,
-    built_in_ignores: &wax::Any<'_>,
     user_negations: &wax::Any<'_>,
     manifest_paths: &mut BTreeSet<PathBuf>,
 ) -> Result<(), FindWorkspaceProjectsError> {
@@ -434,55 +428,43 @@ fn collect_manifests_in_children(
         {
             return Ok(());
         }
-        collect_manifests_in_child(
-            &entry.path(),
-            workspace_root,
-            built_in_ignores,
-            user_negations,
-            manifest_paths,
-        )
+        collect_candidate_manifests_in(&entry.path(), workspace_root, user_negations, manifest_paths);
+        Ok(())
     })
+}
+
+/// Record the child directory's manifest candidates without checking
+/// which exist: the read phase absorbs a candidate that is not there,
+/// so learning the answer here would pay a directory enumeration for
+/// what one failed open later reports for free.
+fn collect_candidate_manifests_in(
+    directory: &Path,
+    workspace_root: &Path,
+    user_negations: &wax::Any<'_>,
+    manifest_paths: &mut BTreeSet<PathBuf>,
+) {
+    for basename in PROJECT_MANIFEST_BASENAMES {
+        let manifest_path = directory.join(basename);
+        if !is_ignored_manifest(&manifest_path, workspace_root, user_negations) {
+            manifest_paths.insert(manifest_path);
+        }
+    }
 }
 
 fn collect_literal_manifests_in(
     directory: &Path,
     workspace_root: &Path,
-    built_in_ignores: &wax::Any<'_>,
     user_negations: &wax::Any<'_>,
     manifest_paths: &mut BTreeSet<PathBuf>,
 ) {
     for basename in PROJECT_MANIFEST_BASENAMES {
         let manifest_path = directory.join(basename);
         if manifest_path.is_file()
-            && !is_ignored_manifest(
-                &manifest_path,
-                workspace_root,
-                built_in_ignores,
-                user_negations,
-            )
+            && !is_ignored_manifest(&manifest_path, workspace_root, user_negations)
         {
             manifest_paths.insert(manifest_path);
         }
     }
-}
-
-fn collect_manifests_in_child(
-    directory: &Path,
-    workspace_root: &Path,
-    built_in_ignores: &wax::Any<'_>,
-    user_negations: &wax::Any<'_>,
-    manifest_paths: &mut BTreeSet<PathBuf>,
-) -> Result<(), FindWorkspaceProjectsError> {
-    for_each_directory_entry(directory, workspace_root, |entry| {
-        if !PROJECT_MANIFEST_BASENAMES.iter().any(|basename| entry.file_name() == *basename) {
-            return Ok(());
-        }
-        let manifest_path = entry.path();
-        if !is_ignored_manifest(&manifest_path, workspace_root, built_in_ignores, user_negations) {
-            manifest_paths.insert(manifest_path);
-        }
-        Ok(())
-    })
 }
 
 fn for_each_directory_entry(
@@ -523,11 +505,25 @@ fn workspace_walk_error(
 fn is_ignored_manifest(
     manifest_path: &Path,
     workspace_root: &Path,
-    built_in_ignores: &wax::Any<'_>,
     user_negations: &wax::Any<'_>,
 ) -> bool {
     let relative = manifest_path.strip_prefix(workspace_root).unwrap_or(manifest_path);
-    built_in_ignores.is_match(relative) || user_negations.is_match(relative)
+    has_always_ignored_component(relative) || user_negations.is_match(relative)
+}
+
+/// [`IGNORE_PATTERNS`] by hand: `**/node_modules/**` and
+/// `**/bower_components/**` hold exactly when some non-final component
+/// bears one of those names, and a manifest candidate's final component
+/// is always a manifest basename, so any-component equality answers the
+/// match without running the glob engine once per candidate.
+fn has_always_ignored_component(path: &Path) -> bool {
+    use std::path::Component;
+    path.components().any(|component| {
+        matches!(
+            component,
+            Component::Normal(name) if name == "node_modules" || name == "bower_components"
+        )
+    })
 }
 
 /// Strip the pattern's leading `../` components, walking `workspace_root`

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -428,7 +428,12 @@ fn collect_manifests_in_children(
         {
             return Ok(());
         }
-        collect_candidate_manifests_in(&entry.path(), workspace_root, user_negations, manifest_paths);
+        collect_candidate_manifests_in(
+            &entry.path(),
+            workspace_root,
+            user_negations,
+            manifest_paths,
+        );
         Ok(())
     })
 }
@@ -521,7 +526,7 @@ fn has_always_ignored_component(path: &Path) -> bool {
     path.components().any(|component| {
         matches!(
             component,
-            Component::Normal(name) if name == "node_modules" || name == "bower_components"
+            Component::Normal(name) if name == "node_modules" || name == "bower_components",
         )
     })
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. A wall-clock timeline of the warm update showed workspace project discovery as the largest single block after resolution: the main thread parks twice while the rayon pool walks and reads the workspace, and the workers spend most of that window in syscalls. This chunk removes the syscalls that were only re-deriving answers the read phase already produces:

- **A children pattern (`dir/*`) no longer enumerates each child directory.** It read every child's full directory listing just to learn whether `package.json` / `package.yaml` exist. The read phase already absorbs a missing candidate (a `NotFound` moves it to the next candidate, an empty root drops out), so both candidate paths are now recorded unchecked and one failed open later answers what the enumeration did. On the reproduction that deletes ~6.8k directory enumerations.
- **`PackageManifest::from_path` stops pre-checking existence with a stat.** The read itself reports `NotFound`, which maps to the same missing-manifest error the pre-check raised. This was one stat per manifest read, on every manifest-read path in the CLI.
- **The built-in ignores match by component equality.** `**/node_modules/**` and `**/bower_components/**` hold exactly when a non-final component bears one of those names, and a candidate's final component is always a manifest basename, so a component scan replaces a glob-engine run per candidate (~0.7 s of pool CPU on the reproduction).

One error-surface corner moves: an unreadable child directory under a `dir/*` pattern now fails as a manifest read error rather than a workspace walk error, since the directory is no longer opened. A missing or manifest-less child behaves as before.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects; warm non-noop lockfile-only update per its README protocol; M-series Mac), quiet-run clusters, before measured on main with only this PR's two files reverted:

| Metric | before | after |
| --- | ---: | ---: |
| start → `pnpm:scope` (startup + config + discovery + plan) | 281–301 ms | 220–231 ms |
| whole warm update | 1.07–1.13 s | 0.95–1.00 s |

The written `pnpm-lock.yaml` is byte-identical. The workspace and package-manifest suites pass (136 tests), plus the CLI filtering, pack, install, recursive, and workspace modules (212 tests; the three bail-cancellation timing tests that fail on this machine fail identically on clean main and are green in CI).

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~0.98 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
A children pattern learned which manifests a child directory holds by
reading the whole directory listing; the read phase already absorbs a
missing candidate, so both candidate paths are now recorded unchecked
and one failed open later answers what the enumeration did - about
6.8k directory enumerations on a workspace-scale reproduction.

PackageManifest::from_path also stops pre-checking existence with a
stat: the read itself reports NotFound, which maps to the same
missing-manifest error the pre-check raised.

The built-in ignore patterns are matched by component equality instead
of the glob engine: **/node_modules/** and **/bower_components/**
hold exactly when a non-final component bears one of those names, and
a candidate's final component is always a manifest basename.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), the startup-through-plan segment drops from
~290 ms to ~225 ms, whole-run wall time from ~1.10 s to ~0.98 s, and
the written lockfile is byte-identical. Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work; the TypeScript CLI discovers projects through fast-glob
  and has no counterpart to these code paths.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior on the covered surface — the
  discovered project set, ordering, and precedence are pinned by the workspace
  crate's 68-test suite and the CLI's filtering/workspace modules, all passing
  unchanged, plus the byte-identical reproduction lockfile.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791028798&installation_model_id=426870&pr_number=14501&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14501&signature=aef345a8632604b06afa3b9072f113cdaf083603c4d58de8e8006494f3c3ec5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved install speed in large workspaces by streamlining workspace project discovery.
  * Reduced unnecessary filesystem checks while locating package manifests.
  * Workspace scanning now avoids traversing directories that are always excluded, such as dependency folders.

* **Bug Fixes**
  * Preserved clear handling for missing package manifests during workspace discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->