### PR TITLE
perf(resolver): trim the per-edge allocations of the walk and peer pass

### DIFF
--- a/.changeset/leaner-edges.md
+++ b/.changeset/leaner-edges.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs in large workspaces. The resolver and the peer pass allocate less for every dependency edge [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -58,9 +58,6 @@ impl ImporterAnchor {
     /// target, or one that carries `..` components.
     pub(crate) fn target_relative_to_importer(&self, target: &str) -> Option<String> {
         let rel = self.rel_components.as_deref()?;
-        // Two passes over the segment split, so no segment list is
-        // collected: the first validates every segment and finds the
-        // shared prefix, the second renders the survivors.
         let segments = relative_segments(target)?;
         let mut shared = 0;
         let mut still_shared = true;

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -58,21 +58,25 @@ impl ImporterAnchor {
     /// target, or one that carries `..` components.
     pub(crate) fn target_relative_to_importer(&self, target: &str) -> Option<String> {
         let rel = self.rel_components.as_deref()?;
-        let mut target_segments = Vec::new();
-        for segment in relative_segments(target)? {
+        // Two passes over the segment split, so no segment list is
+        // collected: the first validates every segment and finds the
+        // shared prefix, the second renders the survivors.
+        let segments = relative_segments(target)?;
+        let mut shared = 0;
+        let mut still_shared = true;
+        for segment in segments.clone() {
             if segment == ".." {
                 return None;
             }
-            target_segments.push(segment);
+            if still_shared && rel.get(shared).is_some_and(|name| name == segment) {
+                shared += 1;
+            } else {
+                still_shared = false;
+            }
         }
-        let shared = rel
-            .iter()
-            .zip(&target_segments)
-            .take_while(|(rel_name, target_name)| rel_name.as_str() == **target_name)
-            .count();
         Some(render(
-            std::iter::repeat_n("..", rel.len() - shared)
-                .chain(target_segments[shared..].iter().copied()),
+            std::iter::repeat_n("..", rel.len() - shared).chain(segments.skip(shared)),
+            3 * (rel.len() - shared) + target.len(),
         ))
     }
 
@@ -97,7 +101,10 @@ impl ImporterAnchor {
                 descended.push(segment);
             }
         }
-        Some(render(rel[..kept].iter().map(String::as_str).chain(descended)))
+        Some(render(
+            rel[..kept].iter().map(String::as_str).chain(descended),
+            rel[..kept].iter().map(|name| name.len() + 1).sum::<usize>() + target.len(),
+        ))
     }
 }
 
@@ -114,7 +121,7 @@ const SEPARATORS: &[char] = &['/'];
 /// (on Windows) whose first segment carries a `:` and so may be a
 /// prefix — where suffix math does not apply; the caller's
 /// absolute-space fallback handles those.
-fn relative_segments(target: &str) -> Option<impl Iterator<Item = &str>> {
+fn relative_segments(target: &str) -> Option<impl Iterator<Item = &str> + Clone> {
     if target.starts_with(SEPARATORS) {
         return None;
     }
@@ -127,8 +134,11 @@ fn relative_segments(target: &str) -> Option<impl Iterator<Item = &str>> {
 
 /// Join components with `/` and normalize any backslash inside one, the
 /// way the callers' former `display` + `replace('\\', "/")` pass did.
-fn render<'component>(components: impl Iterator<Item = &'component str>) -> String {
-    let mut rendered = String::new();
+fn render<'component>(
+    components: impl Iterator<Item = &'component str>,
+    capacity: usize,
+) -> String {
+    let mut rendered = String::with_capacity(capacity);
     for component in components {
         if !rendered.is_empty() {
             rendered.push('/');

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1245,9 +1245,22 @@ fn shared_workspace_key(
     }
     // The consumer scope is exactly what the shared key drops. Every
     // `workspace:` selector carries one, so its absence means this edge is not
-    // the shape assumed here.
-    let mut wanted_key = cache_key.clone();
-    wanted_key.6.take()?;
+    // the shape assumed here. Checked before the clone so the dropped
+    // slot's path is never copied just to be discarded.
+    cache_key.6.as_ref()?;
+    let wanted_key = (
+        cache_key.0.clone(),
+        cache_key.1.clone(),
+        cache_key.2,
+        cache_key.3,
+        cache_key.4,
+        cache_key.5,
+        None,
+        cache_key.7.clone(),
+        cache_key.8.clone(),
+        cache_key.9.clone(),
+        cache_key.10,
+    );
     Some(SharedWorkspaceWantedKey::new(
         wanted_key,
         wanted.prev_specifier.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -1245,8 +1245,7 @@ fn shared_workspace_key(
     }
     // The consumer scope is exactly what the shared key drops. Every
     // `workspace:` selector carries one, so its absence means this edge is not
-    // the shape assumed here. Checked before the clone so the dropped
-    // slot's path is never copied just to be discarded.
+    // the shape assumed here.
     cache_key.6.as_ref()?;
     let wanted_key = (
         cache_key.0.clone(),

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -190,29 +190,40 @@ impl<'tree> Walker<'tree> {
             peer_provider_children_by_pkg_id.clear();
             peer_provider_index_peer_names.clone_from(&tree.all_peer_dep_names);
         }
+        // With no peer names in the tree, no edge can index as a
+        // provider, and rendering every edge's real name (an allocation
+        // each) would be the loop's only work — every entry stays the
+        // empty default.
+        let tree_declares_peers = !tree.all_peer_dep_names.is_empty();
         for (pkg_id, children) in &tree.children_by_id {
             if peer_provider_children_by_pkg_id.contains_key(&**pkg_id) {
                 continue;
             }
             let mut providers = PeerProviderChildren::default();
-            for (edge_index, edge) in children.iter().enumerate() {
-                let Some(pkg) = tree.packages.get(&edge.pkg_id) else { continue };
-                let real_name = pkg_name_version(&pkg.result).0;
-                let alias_is_peer = tree.all_peer_dep_names.contains(&edge.alias);
-                let real_name_is_peer = tree.all_peer_dep_names.contains(&real_name);
-                if !alias_is_peer && !real_name_is_peer {
-                    continue;
-                }
-                providers.relevant_edge_indices.push(edge_index);
-                if alias_is_peer {
-                    providers
-                        .edge_indices_by_name
-                        .entry(edge.alias.clone())
-                        .or_default()
-                        .push(edge_index);
-                }
-                if real_name_is_peer && real_name != edge.alias {
-                    providers.edge_indices_by_name.entry(real_name).or_default().push(edge_index);
+            if tree_declares_peers {
+                for (edge_index, edge) in children.iter().enumerate() {
+                    let Some(pkg) = tree.packages.get(&edge.pkg_id) else { continue };
+                    let real_name = pkg_name_version(&pkg.result).0;
+                    let alias_is_peer = tree.all_peer_dep_names.contains(&edge.alias);
+                    let real_name_is_peer = tree.all_peer_dep_names.contains(&real_name);
+                    if !alias_is_peer && !real_name_is_peer {
+                        continue;
+                    }
+                    providers.relevant_edge_indices.push(edge_index);
+                    if alias_is_peer {
+                        providers
+                            .edge_indices_by_name
+                            .entry(edge.alias.clone())
+                            .or_default()
+                            .push(edge_index);
+                    }
+                    if real_name_is_peer && real_name != edge.alias {
+                        providers
+                            .edge_indices_by_name
+                            .entry(real_name)
+                            .or_default()
+                            .push(edge_index);
+                    }
                 }
             }
             peer_provider_children_by_pkg_id
@@ -633,6 +644,9 @@ impl Walker<'_> {
     pub(super) fn is_peer_relevant(&self, alias: &str, pkg: &ResolvedPackage) -> bool {
         if self.tree.all_peer_dep_names.contains(alias) {
             return true;
+        }
+        if self.tree.all_peer_dep_names.is_empty() {
+            return false;
         }
         let (real_name, _) = pkg_name_version(&pkg.result);
         self.tree.all_peer_dep_names.contains(&real_name)

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_peers/walker.rs
@@ -191,9 +191,7 @@ impl<'tree> Walker<'tree> {
             peer_provider_index_peer_names.clone_from(&tree.all_peer_dep_names);
         }
         // With no peer names in the tree, no edge can index as a
-        // provider, and rendering every edge's real name (an allocation
-        // each) would be the loop's only work — every entry stays the
-        // empty default.
+        // provider: every entry stays the empty default.
         let tree_declares_peers = !tree.all_peer_dep_names.is_empty();
         for (pkg_id, children) in &tree.children_by_id {
             if peer_provider_children_by_pkg_id.contains_key(&**pkg_id) {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14352. Three per-edge costs in the warm update scaled with the workspace's ~87k dependency edges:

- **The link anchor's importer-direction rendering** collected the target's segments into a `Vec` before diffing them against the importer suffix, and grew its output string from empty. Two passes over the (cloneable) segment split find the shared prefix first, so the render is allocation-free apart from an exactly-sized output string.
- **The peer pass rendered every edge's real package name** — an allocation each, via `pkg_name_version` — just to probe the tree's peer-name set, even when the tree declares no peer dependencies at all (this reproduction, and any workspace without peers). The provider index and `is_peer_relevant` now skip the rendering when no peer name could match; a tree with peer names behaves exactly as before.
- **`shared_workspace_key` cloned the full per-consumer cache key** — two strings, a prior-lockfile key, and the consumer-scope path — and then immediately discarded the path it had just cloned. The eligibility check moved ahead of the clone and the key is assembled without that slot.

### Measurements

On the issue's [reproduction](https://github.com/jamenh/pnpm-workspace-performance-reproduction) (6,833 projects, ~87k workspace edges; warm non-noop lockfile-only update per its README protocol; M-series Mac), main-thread profile samples (≈ ms):

| Site | before | after |
| --- | ---: | ---: |
| `pkg_name_version` (peer pass) | 23 | 0 |
| anchor `target_relative_to_importer` | 50 | 37 |
| `resolve_wanted_cached` (inclusive) | 143 | 122 |
| whole warm update (quiet cluster of 8) | 0.97–1.00 s | 0.93–0.97 s |

The written `pnpm-lock.yaml` is byte-identical, and all 370 resolver tests pass unchanged.

Cumulative for pnpm/pnpm#14352: the warm lockfile-only update has gone from ~2.43 s (before pnpm/pnpm#14379) to ~0.95 s, versus the ~1.6 s the issue reports for Yarn 4.18 on the same protocol.

## Squash Commit Body

```text
Three per-edge costs scaled with the workspace's edge count:

- The link anchor's importer-direction rendering collected the
  target's segments into a Vec before diffing them against the
  importer suffix. Two passes over the segment split make the render
  allocation-free apart from the exactly-sized output string.
- The peer pass rendered every edge's real package name (an
  allocation each) to probe the tree's peer-name set, even when the
  tree declares no peer dependencies at all. The provider index and
  is_peer_relevant now skip the rendering when no peer name could
  match.
- shared_workspace_key cloned the full per-consumer cache key and then
  discarded the consumer-scope path it had just cloned. The
  eligibility check moved ahead of the clone and the key is assembled
  without that slot.

On the 6,833-project reproduction from pnpm/pnpm#14352 (warm non-noop
lockfile-only update), the peer pass's name renders leave the profile,
quiet-run wall time drops by ~40 ms, and the written lockfile is
byte-identical. Related to pnpm/pnpm#14352.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. *(Rust-only
  internal perf work with no user-visible behavior change; no TypeScript-side
  port is needed.)*
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. *(No new behavior — the anchor's renderings are
  pinned by the link-target round-trip suite, the peer index by the peers
  suites, all 370 resolver tests passing unchanged, plus the byte-identical
  reproduction lockfile.)*

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14509"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791043969&installation_model_id=426870&pr_number=14509&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14509&signature=6a1daaceab97b37ca90f6b78174cd294a2b67e1dcc2977993c1bee2615ac139a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved installation speed in large workspaces by reducing resolver overhead for dependency and peer relationships.
  * Reduced unnecessary processing when projects do not define peer dependencies.
  * Lowered memory allocation during dependency resolution for more efficient installs.
* **Bug Fixes**
  * Preserved existing dependency and peer resolution behavior while improving efficiency.
* **Release**
  * Included in a patch release for the pacquet package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->