### PR TITLE
fix: accept --ignore-scripts on update

### DIFF
--- a/.changeset/update-ignore-scripts.md
+++ b/.changeset/update-ignore-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm update` now accepts `--ignore-scripts` and skips lifecycle scripts during the update [pnpm/pnpm#14512](https://github.com/pnpm/pnpm/issues/14512).

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -1,6 +1,7 @@
 use crate::{
     State,
     cli_args::{
+        install::resolve_bool_override,
         lockfile_dir::LockfileDirArg,
         pipelines::InstallFamilySelection,
         recursive,
@@ -148,6 +149,14 @@ pub struct UpdateArgs {
     #[clap(long = "ignore-pnpmfile")]
     pub ignore_pnpmfile: bool,
 
+    /// Don't run lifecycle scripts of the project or its dependencies.
+    #[clap(long = "ignore-scripts", overrides_with = "no_ignore_scripts")]
+    pub ignore_scripts: bool,
+
+    /// Run lifecycle scripts even when the configuration disables them.
+    #[clap(long = "no-ignore-scripts", overrides_with = "ignore_scripts")]
+    pub no_ignore_scripts: bool,
+
     /// URL of a pnpr server to offload revision refresh resolution to.
     #[clap(long = "pnpr-server")]
     pub pnpr_server: Option<String>,
@@ -179,6 +188,11 @@ struct PatchesWithSelectorError;
 
 impl UpdateArgs {
     pub(crate) fn apply_cli_config(&self, config: &mut Config) {
+        config.ignore_scripts = resolve_bool_override(
+            self.ignore_scripts,
+            self.no_ignore_scripts,
+            config.ignore_scripts,
+        );
         config.ignore_pnpmfile = self.ignore_pnpmfile || config.ignore_pnpmfile;
         if let Some(pnpr_server) = self.pnpr_server.clone() {
             config.pnpr_server = Some(pnpr_server);

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -133,9 +133,13 @@ fn ignore_pnpmfile_flag_applies_to_config() {
 #[test]
 fn ignore_scripts_flags_apply_to_config() {
     let mut config = Config::default();
-    update_args(&[]).apply_cli_config(&mut config);
-    assert!(!config.ignore_scripts, "flags absent -> config unchanged");
+    assert!(!config.ignore_scripts);
 
+    config.ignore_scripts = true;
+    update_args(&[]).apply_cli_config(&mut config);
+    assert!(config.ignore_scripts, "flags absent -> config unchanged");
+
+    config.ignore_scripts = false;
     update_args(&["--ignore-scripts"]).apply_cli_config(&mut config);
     assert!(config.ignore_scripts, "--ignore-scripts enables the setting");
 

--- a/pnpm/crates/cli/src/cli_args/update/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/update/tests.rs
@@ -131,6 +131,19 @@ fn ignore_pnpmfile_flag_applies_to_config() {
 }
 
 #[test]
+fn ignore_scripts_flags_apply_to_config() {
+    let mut config = Config::default();
+    update_args(&[]).apply_cli_config(&mut config);
+    assert!(!config.ignore_scripts, "flags absent -> config unchanged");
+
+    update_args(&["--ignore-scripts"]).apply_cli_config(&mut config);
+    assert!(config.ignore_scripts, "--ignore-scripts enables the setting");
+
+    update_args(&["--no-ignore-scripts"]).apply_cli_config(&mut config);
+    assert!(!config.ignore_scripts, "--no-ignore-scripts disables the setting");
+}
+
+#[test]
 fn pnpr_server_flag_applies_to_config() {
     let mut config = Config::default();
 

--- a/pnpm/crates/cli/tests/suite/update.rs
+++ b/pnpm/crates/cli/tests/suite/update.rs
@@ -972,6 +972,28 @@ fn update_workspace_that_links_nothing_still_runs_project_scripts() {
     drop((root, anchor));
 }
 
+#[test]
+fn update_ignore_scripts_skips_project_scripts() {
+    let root = TempDir::new().expect("create temp directory");
+    let workspace = root.path().to_path_buf();
+
+    fs::write(
+        workspace.join("package.json"),
+        r#"{ "name": "test-update", "version": "1.0.0",
+              "scripts": { "postinstall": "node -e \"require('fs').writeFileSync('postinstall-ran', '')\"" } }"#,
+    )
+    .expect("write package.json");
+
+    pacquet(&workspace, ["update", "--ignore-scripts"]).assert().success();
+
+    assert!(
+        !workspace.join("postinstall-ran").exists(),
+        "--ignore-scripts should skip the project's lifecycle scripts",
+    );
+
+    drop(root);
+}
+
 /// Naming a dependency that no workspace project publishes fails, since
 /// there is nothing to link it to.
 #[test]

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it, test } from '@jest/globals'
 import type { PnpmError } from '@pnpm/error'
 import { install, update } from '@pnpm/installing.commands'
 import { prepare, preparePackages } from '@pnpm/prepare'
+import { createTestIpcServer } from '@pnpm/test-ipc-server'
 import { addDistTag } from '@pnpm/testing.registry-mock'
 import type { ProjectManifest } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
@@ -23,6 +24,24 @@ test.each([
   }, dependencies)).rejects.toMatchObject({
     code: 'ERR_PNPM_PATCHES_WITH_SELECTOR',
   })
+})
+
+test('update ignores lifecycle scripts when --ignore-scripts is used', async () => {
+  await using server = await createTestIpcServer()
+
+  prepare({
+    scripts: {
+      postinstall: server.sendLineScript('postinstall'),
+    },
+  })
+
+  await update.handler({
+    ...DEFAULT_OPTS,
+    dir: process.cwd(),
+    ignoreScripts: true,
+  }, [])
+
+  expect(server.getLines()).toStrictEqual([])
 })
 
 test('update with "*" pattern', async () => {

--- a/pnpm11/installing/commands/test/update/update.ts
+++ b/pnpm11/installing/commands/test/update/update.ts
@@ -1,15 +1,21 @@
+import { execFile } from 'node:child_process'
 import path from 'node:path'
+import { promisify } from 'node:util'
 
 import { beforeAll, describe, expect, it, test } from '@jest/globals'
 import type { PnpmError } from '@pnpm/error'
 import { install, update } from '@pnpm/installing.commands'
 import { prepare, preparePackages } from '@pnpm/prepare'
 import { createTestIpcServer } from '@pnpm/test-ipc-server'
-import { addDistTag } from '@pnpm/testing.registry-mock'
+import { addDistTag, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
 import type { ProjectManifest } from '@pnpm/types'
 import { loadJsonFileSync } from 'load-json-file'
 
 import { DEFAULT_OPTS } from '../utils/index.js'
+
+const execFileAsync = promisify(execFile)
+const pnpmBin = path.join(import.meta.dirname, '../../../../pnpm/bin/pnpm.mjs')
+const registry = `http://localhost:${REGISTRY_MOCK_PORT}/`
 
 test.each([
   { dependencies: ['is-positive'], options: { patches: true } },
@@ -29,18 +35,36 @@ test.each([
 test('update ignores lifecycle scripts when --ignore-scripts is used', async () => {
   await using server = await createTestIpcServer()
 
-  prepare({
+  const project = prepare({
+    dependencies: {
+      '@pnpm.e2e/foo': '1.0.0',
+    },
+  })
+
+  await execFileAsync(process.execPath, [
+    pnpmBin,
+    'install',
+    `--registry=${registry}`,
+  ])
+
+  project.writePackageJson({
+    dependencies: {
+      '@pnpm.e2e/foo': '1.0.0',
+    },
     scripts: {
       postinstall: server.sendLineScript('postinstall'),
     },
   })
 
-  await update.handler({
-    ...DEFAULT_OPTS,
-    dir: process.cwd(),
-    ignoreScripts: true,
-  }, [])
+  await execFileAsync(process.execPath, [
+    pnpmBin,
+    'update',
+    '@pnpm.e2e/foo@2.0.0',
+    '--ignore-scripts',
+    `--registry=${registry}`,
+  ])
 
+  expect(loadJsonFileSync<ProjectManifest>('package.json').dependencies?.['@pnpm.e2e/foo']).toBe('2.0.0')
   expect(server.getLines()).toStrictEqual([])
 })
 


### PR DESCRIPTION
## Summary

Pacquet now accepts `--ignore-scripts` and `--no-ignore-scripts` on `pnpm update`. The flags use the same merged-config override semantics as `pnpm install` and `pnpm add`, restoring parity with the TypeScript CLI and allowing Renovate update commands to complete.

Fixes pnpm/pnpm#14512.

## Squash Commit Body

```text
Pacquet omitted the lifecycle-script flags from its update argument set even though the TypeScript CLI accepts them. Add both boolean forms and merge them into the update config before dispatch, matching the existing install-family behavior.

Fixes pnpm/pnpm#14512.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14513"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791056794&installation_model_id=426870&pr_number=14513&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14513&signature=a436e9559f702f784248eb40e31cfd1072a94490141e782a84b190dd89bda087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--ignore-scripts` to skip lifecycle scripts during package updates.
  * Added `--no-ignore-scripts` to explicitly enable lifecycle scripts during updates.
  * Command-line options can override the existing script-execution setting for a single update.
  * When neither option is provided, the existing setting is preserved.

* **Documentation**
  * Documented support for `pnpm update --ignore-scripts`.

* **Tests**
  * Added coverage confirming lifecycle scripts are skipped or executed according to the selected option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->