### PR TITLE
fix(audit): keep `--fix update` going when no version in range is safe

### DIFF
--- a/.changeset/audit-fix-update-keeps-going.md
+++ b/.changeset/audit-fix-update-keeps-going.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm audit --fix update` no longer aborts when a vulnerable package has no safe version inside its declared range [#14508](https://github.com/pnpm/pnpm/issues/14508). The run updates every package it can and lists the rest as remaining.

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -20,8 +20,8 @@ use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::Reporter;
 use pnpm_resolving_resolver_base::{
-    PackageVersionGuard, PackageVersionGuardDecision, PackageVersionGuardFuture,
-    parse_packument_timestamp,
+    GuardExhaustionPolicy, PackageVersionGuard, PackageVersionGuardDecision,
+    PackageVersionGuardFuture, parse_packument_timestamp,
 };
 use serde::{Deserialize, Serialize};
 use std::{
@@ -729,6 +729,13 @@ impl PackageVersionGuard for VulnerabilityGuard {
                 PackageVersionGuardDecision::Allow
             })
         })
+    }
+
+    /// A package whose every in-range version is vulnerable stays on the
+    /// version it would have resolved to anyway; `--fix update` then reports
+    /// its advisories as remaining instead of failing the whole run.
+    fn exhaustion_policy(&self) -> GuardExhaustionPolicy {
+        GuardExhaustionPolicy::AcceptRejected
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    BTreeMap, Config, ConfigAuditLevel, HashMap, MAX_PATHS_PER_FINDING, PackageVersionGuard,
-    PackageVersionGuardDecision, Range, SnapshotDepRef, filter_ignored_advisories,
+    BTreeMap, Config, ConfigAuditLevel, GuardExhaustionPolicy, HashMap, MAX_PATHS_PER_FINDING,
+    PackageVersionGuard, PackageVersionGuardDecision, Range, SnapshotDepRef,
+    filter_ignored_advisories,
     fix::{
         InstalledPackages, PackumentPublishInfo, VulnerabilityGuard, classify_for_update,
         create_overrides, filter_advisories_for_fix, format_fix_with_update_output,
@@ -1220,6 +1221,10 @@ async fn vulnerability_guard_rejects_only_vulnerable_versions() {
 
     let allowed_other = guard.check("unrelated", "1.0.0").await.expect("guard check");
     assert_eq!(allowed_other, PackageVersionGuardDecision::Allow);
+
+    // A package with no safe version in range keeps resolving; `--fix update`
+    // reports it as remaining rather than failing the run.
+    assert_eq!(guard.exhaustion_policy(), GuardExhaustionPolicy::AcceptRejected);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -1398,6 +1398,74 @@ fn audit_fix_update_moves_to_a_non_vulnerable_version() {
     drop((root, npmrc_info));
 }
 
+/// A package whose every in-range version is vulnerable has no update that
+/// fixes it. The run must still fix what it can elsewhere and report the rest
+/// as remaining, rather than failing resolution outright.
+#[test]
+fn audit_fix_update_keeps_going_when_no_version_in_range_is_safe() {
+    const PKG: &str = "@pnpm.e2e/audit-multi-version";
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let pnpr_url = npmrc_info.mock_instance.url();
+
+    // `^2.0.0` admits only the 2.x versions, every one of them vulnerable.
+    fs::write(
+        workspace.join("package.json"),
+        format!(
+            r#"{{"name":"audit-fix-update","version":"1.0.0","dependencies":{{"{PKG}":"^2.0.0"}}}}"#,
+        ),
+    )
+    .expect("write package.json");
+    pacquet_cmd(&workspace, ["install"]).assert().success();
+
+    let mut audit_registry = mockito::Server::new();
+    let mock = audit_registry
+        .mock("POST", "/-/npm/v1/security/advisories/bulk")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(advisory_response(
+            PKG,
+            9001,
+            "high",
+            ">=2.0.0",
+            "vulnerable 2.x",
+            "GHSA-mult-1111-2222",
+        ))
+        .create();
+    fs::write(
+        workspace.join(".npmrc"),
+        format!(
+            "registry={audit}\n@pnpm.e2e:registry={pnpr}\nstore-dir=../pacquet-store\ncache-dir=../pacquet-cache\nfetchRetries=0\n",
+            audit = audit_registry.url(),
+            pnpr = pnpr_url,
+        ),
+    )
+    .expect("rewrite .npmrc");
+
+    let output = pacquet_cmd(&workspace, ["audit", "--fix", "update"])
+        .output()
+        .expect("run audit --fix update");
+
+    // Remaining vulnerabilities still exit 1; what must not happen is the
+    // resolver aborting the run.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(1), "stderr:\n{stderr}");
+    assert!(stderr.is_empty(), "the run should report no error:\n{stderr}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 vulnerabilities were fixed, 1 vulnerability remains."),
+        "stdout should report the vulnerability as remaining:\n{stdout}",
+    );
+
+    let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
+    assert!(
+        lockfile.contains("audit-multi-version@2.0.1"),
+        "the vulnerable pick should stay in the lockfile:\n{lockfile}",
+    );
+    mock.assert();
+    drop((root, npmrc_info));
+}
+
 /// `--fix update` with `minimumReleaseAge`: the inferred patched version
 /// (3.0.0) has no entry in the packument's `time` map because it was never
 /// published, so no exclusion entry is written for it.

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -1403,34 +1403,45 @@ fn audit_fix_update_moves_to_a_non_vulnerable_version() {
 /// as remaining, rather than failing resolution outright.
 #[test]
 fn audit_fix_update_keeps_going_when_no_version_in_range_is_safe() {
-    const PKG: &str = "@pnpm.e2e/audit-multi-version";
+    const STUCK_PKG: &str = "@pnpm.e2e/audit-multi-version";
+    const FIXABLE_PKG: &str = "@pnpm.e2e/multi-version-b";
     let CommandTempCwd { workspace, root, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
     let pnpr_url = npmrc_info.mock_instance.url();
 
-    // `^2.0.0` admits only the 2.x versions, every one of them vulnerable.
+    // `^2.0.0` admits only vulnerable 2.x versions of the first package, while
+    // `>=1.0.0` leaves the second one a safe 2.0.0 to fall back to.
     fs::write(
         workspace.join("package.json"),
         format!(
-            r#"{{"name":"audit-fix-update","version":"1.0.0","dependencies":{{"{PKG}":"^2.0.0"}}}}"#,
+            r#"{{"name":"audit-fix-update","version":"1.0.0","dependencies":{{"{STUCK_PKG}":"^2.0.0","{FIXABLE_PKG}":">=1.0.0"}}}}"#,
         ),
     )
     .expect("write package.json");
     pacquet_cmd(&workspace, ["install"]).assert().success();
+    assert!(
+        workspace.join("node_modules/.pnpm").join("@pnpm.e2e+multi-version-b@3.1.0").exists(),
+        "install should pick the highest in-range version",
+    );
 
     let mut audit_registry = mockito::Server::new();
+    let body = format!(
+        "{{\n{},\n{}\n}}",
+        advisory_entry(STUCK_PKG, 9001, "high", ">=2.0.0", "vulnerable 2.x", "GHSA-mult-1111-2222",),
+        advisory_entry(
+            FIXABLE_PKG,
+            9002,
+            "high",
+            ">=3.0.0",
+            "vulnerable 3.x",
+            "GHSA-mult-3333-4444",
+        ),
+    );
     let mock = audit_registry
         .mock("POST", "/-/npm/v1/security/advisories/bulk")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(advisory_response(
-            PKG,
-            9001,
-            "high",
-            ">=2.0.0",
-            "vulnerable 2.x",
-            "GHSA-mult-1111-2222",
-        ))
+        .with_body(body)
         .create();
     fs::write(
         workspace.join(".npmrc"),
@@ -1453,14 +1464,18 @@ fn audit_fix_update_keeps_going_when_no_version_in_range_is_safe() {
     assert!(stderr.is_empty(), "the run should report no error:\n{stderr}");
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("0 vulnerabilities were fixed, 1 vulnerability remains."),
-        "stdout should report the vulnerability as remaining:\n{stdout}",
+        stdout.contains("1 vulnerability was fixed, 1 vulnerability remains."),
+        "stdout should report one fix and one remaining:\n{stdout}",
     );
 
     let lockfile = fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read lockfile");
     assert!(
         lockfile.contains("audit-multi-version@2.0.1"),
-        "the vulnerable pick should stay in the lockfile:\n{lockfile}",
+        "the vulnerable pick with no safe alternative should stay:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("multi-version-b@2.0.0"),
+        "the package with a safe version in range should still be updated:\n{lockfile}",
     );
     mock.assert();
     drop((root, npmrc_info));
@@ -1551,9 +1566,22 @@ fn advisory_response(
     title: &str,
     ghsa: &str,
 ) -> String {
+    let entry = advisory_entry(package, id, severity, vulnerable_versions, title, ghsa);
+    format!("{{\n{entry}\n}}")
+}
+
+/// One `"<package>": [ … ]` member of a bulk-advisory response body, so a
+/// test can serve advisories for several packages at once.
+fn advisory_entry(
+    package: &str,
+    id: u64,
+    severity: &str,
+    vulnerable_versions: &str,
+    title: &str,
+    ghsa: &str,
+) -> String {
     format!(
-        r#"{{
-  "{package}": [
+        r#"  "{package}": [
     {{
       "id": {id},
       "url": "https://github.com/advisories/{ghsa}",
@@ -1562,8 +1590,7 @@ fn advisory_response(
       "vulnerable_versions": "{vulnerable_versions}",
       "cwe": []
     }}
-  ]
-}}"#,
+  ]"#,
     )
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -37,10 +37,11 @@ use pnpm_lockfile::{
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient, redact_and_sanitize};
 use pnpm_registry::{Package, PackageDistribution, PackageVersion, RangeSpecStyle};
 use pnpm_resolving_resolver_base::{
-    LatestInfo, LatestQuery, NoMatchingVersionError, PackageVersionGuardDecision, PkgResolutionId,
-    RegistryResponseError, RegistryResponseErrorOptions, ResolutionPolicyViolation, ResolveError,
-    ResolveFuture, ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior,
-    WantedDependency, WorkspacePackages, parse_packument_timestamp,
+    GuardExhaustionPolicy, LatestInfo, LatestQuery, NoMatchingVersionError,
+    PackageVersionGuardDecision, PkgResolutionId, RegistryResponseError,
+    RegistryResponseErrorOptions, ResolutionPolicyViolation, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, UpdateBehavior, WantedDependency,
+    WorkspacePackages, parse_packument_timestamp,
 };
 use ssri::{Algorithm, Integrity};
 
@@ -699,6 +700,10 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
 ) -> Result<RegistryPick, ResolveError> {
     let mut blocked_versions = std::collections::HashSet::new();
     let mut last_rejection: Option<String> = None;
+    // The first candidate the guard turned down, i.e. the one the picker
+    // would have returned with no guard at all. Kept for the guards whose
+    // rejections are a preference rather than a requirement.
+    let mut first_rejected: Option<PickedFromRegistry> = None;
     loop {
         let pick_opts = PickPackageOptions {
             registry: opts.registry,
@@ -720,10 +725,11 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
         let Some(version) = pick_result.picked_package else {
             // No candidate left. With no prior guard rejection this is the
             // ordinary "no matching version" outcome; once the guard has
-            // rejected every match, surface that as a distinct error rather
-            // than blaming the range the user wrote.
+            // rejected every match, the guard's own policy decides, and a
+            // failure names the guard rather than blaming the range the user
+            // wrote.
             return match last_rejection {
-                Some(reason) => Err(all_versions_blocked(opts.spec, reason)),
+                Some(reason) => exhausted(&opts, first_rejected, reason),
                 None => Ok(RegistryPick::NoMatchingVersion(pick_result.meta)),
             };
         };
@@ -761,7 +767,7 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // already blocked, so it can't be excluded; stop rather than
                 // loop forever — every match really is blocked.
                 if !blocked_versions.insert(blocked_key) {
-                    return Err(all_versions_blocked(opts.spec, reason));
+                    return exhausted(&opts, first_rejected, reason);
                 }
                 // Each rejection re-runs the picker over the packument, so an
                 // unbounded run is O(versions²). Cap it well above any real
@@ -770,13 +776,18 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // proof every version is blocked, so report it as its own
                 // error rather than "all versions blocked".
                 if blocked_versions.len() >= GUARD_REPICK_LIMIT {
-                    return Err(Box::new(GuardRepickLimitError {
-                        name: opts.spec.name.clone(),
-                        limit: GUARD_REPICK_LIMIT,
-                        reason,
-                    }));
+                    return match accepted_fallback(&opts, first_rejected, &reason) {
+                        Some(picked) => Ok(RegistryPick::Picked(picked)),
+                        None => Err(Box::new(GuardRepickLimitError {
+                            name: opts.spec.name.clone(),
+                            limit: GUARD_REPICK_LIMIT,
+                            reason,
+                        })),
+                    };
                 }
                 last_rejection = Some(reason);
+                first_rejected
+                    .get_or_insert(PickedFromRegistry { meta: pick_result.meta, version });
             }
         }
     }
@@ -801,8 +812,41 @@ fn blocked_packument_key(
         .unwrap_or_else(|| version_str.to_string())
 }
 
-fn all_versions_blocked(spec: &RegistryPackageSpec, reason: String) -> ResolveError {
-    Box::new(AllVersionsBlockedError { name: spec.name.clone(), reason })
+/// Answer a request whose every matching version the guard rejected, per the
+/// guard's [`GuardExhaustionPolicy`]: either fail, or hand back the candidate
+/// the picker would have chosen with no guard.
+fn exhausted(
+    opts: &PickFromRegistryOptions<'_>,
+    first_rejected: Option<PickedFromRegistry>,
+    reason: String,
+) -> Result<RegistryPick, ResolveError> {
+    match accepted_fallback(opts, first_rejected, &reason) {
+        Some(picked) => Ok(RegistryPick::Picked(picked)),
+        None => Err(Box::new(AllVersionsBlockedError { name: opts.spec.name.clone(), reason })),
+    }
+}
+
+/// The pick to resolve to instead of failing, for a guard whose rejections
+/// are a preference. `None` when the guard demands a clean candidate, or
+/// when it rejected nothing and so has nothing to fall back to.
+fn accepted_fallback(
+    opts: &PickFromRegistryOptions<'_>,
+    first_rejected: Option<PickedFromRegistry>,
+    reason: &str,
+) -> Option<PickedFromRegistry> {
+    let guard = opts.package_version_guard?;
+    if guard.exhaustion_policy() != GuardExhaustionPolicy::AcceptRejected {
+        return None;
+    }
+    let picked = first_rejected?;
+    tracing::debug!(
+        target: "pnpm_resolving_npm_resolver",
+        name = %opts.spec.name,
+        version = %picked.version.version,
+        reason = %reason,
+        "every matching version was rejected by the resolver guard; keeping the unguarded pick",
+    );
+    Some(picked)
 }
 
 /// Box a picker failure for the resolver chain, restating a non-2xx registry

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -810,9 +810,10 @@ fn blocked_packument_key(
         .unwrap_or_else(|| version_str.to_string())
 }
 
-/// Answer a request the guard left with no acceptable candidate, per the
-/// guard's [`GuardExhaustionPolicy`]. `fail` builds the error naming why the
-/// picker gave up, for a guard whose rejections are a hard requirement.
+/// Answer a request the picker gave up on — every matching version rejected,
+/// or the re-pick cap reached first — per the guard's
+/// [`GuardExhaustionPolicy`]. `fail` builds the error naming which of the two
+/// it was, for a guard whose rejections are a hard requirement.
 fn exhausted(
     opts: &PickFromRegistryOptions<'_>,
     first_rejected: Option<PickedFromRegistry>,

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -701,8 +701,7 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
     let mut blocked_versions = std::collections::HashSet::new();
     let mut last_rejection: Option<String> = None;
     // The first candidate the guard turned down, i.e. the one the picker
-    // would have returned with no guard at all. Kept for the guards whose
-    // rejections are a preference rather than a requirement.
+    // would have returned with no guard at all.
     let mut first_rejected: Option<PickedFromRegistry> = None;
     loop {
         let pick_opts = PickPackageOptions {
@@ -773,17 +772,15 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // unbounded run is O(versions²). Cap it well above any real
                 // run of consecutive rejected versions to bound the work a
                 // hostile packument can force. This is a safety cutoff, not
-                // proof every version is blocked, so report it as its own
-                // error rather than "all versions blocked".
+                // proof every version is blocked: an acceptable candidate may
+                // sit below the cap, so this fails for every guard rather
+                // than settling for a rejected pick that would hide it.
                 if blocked_versions.len() >= GUARD_REPICK_LIMIT {
-                    return match accepted_fallback(&opts, first_rejected, &reason) {
-                        Some(picked) => Ok(RegistryPick::Picked(picked)),
-                        None => Err(Box::new(GuardRepickLimitError {
-                            name: opts.spec.name.clone(),
-                            limit: GUARD_REPICK_LIMIT,
-                            reason,
-                        })),
-                    };
+                    return Err(Box::new(GuardRepickLimitError {
+                        name: opts.spec.name.clone(),
+                        limit: GUARD_REPICK_LIMIT,
+                        reason,
+                    }));
                 }
                 last_rejection = Some(reason);
                 first_rejected
@@ -813,40 +810,28 @@ fn blocked_packument_key(
 }
 
 /// Answer a request whose every matching version the guard rejected, per the
-/// guard's [`GuardExhaustionPolicy`]: either fail, or hand back the candidate
-/// the picker would have chosen with no guard.
+/// guard's [`GuardExhaustionPolicy`].
 fn exhausted(
     opts: &PickFromRegistryOptions<'_>,
     first_rejected: Option<PickedFromRegistry>,
     reason: String,
 ) -> Result<RegistryPick, ResolveError> {
-    match accepted_fallback(opts, first_rejected, &reason) {
-        Some(picked) => Ok(RegistryPick::Picked(picked)),
+    let accepts_rejected = opts
+        .package_version_guard
+        .is_some_and(|guard| guard.exhaustion_policy() == GuardExhaustionPolicy::AcceptRejected);
+    match first_rejected.filter(|_| accepts_rejected) {
+        Some(picked) => {
+            tracing::debug!(
+                target: "pnpm_resolving_npm_resolver",
+                name = %opts.spec.name,
+                version = %picked.version.version,
+                reason = %reason,
+                "every matching version was rejected by the resolver guard; keeping the unguarded pick",
+            );
+            Ok(RegistryPick::Picked(picked))
+        }
         None => Err(Box::new(AllVersionsBlockedError { name: opts.spec.name.clone(), reason })),
     }
-}
-
-/// The pick to resolve to instead of failing, for a guard whose rejections
-/// are a preference. `None` when the guard demands a clean candidate, or
-/// when it rejected nothing and so has nothing to fall back to.
-fn accepted_fallback(
-    opts: &PickFromRegistryOptions<'_>,
-    first_rejected: Option<PickedFromRegistry>,
-    reason: &str,
-) -> Option<PickedFromRegistry> {
-    let guard = opts.package_version_guard?;
-    if guard.exhaustion_policy() != GuardExhaustionPolicy::AcceptRejected {
-        return None;
-    }
-    let picked = first_rejected?;
-    tracing::debug!(
-        target: "pnpm_resolving_npm_resolver",
-        name = %opts.spec.name,
-        version = %picked.version.version,
-        reason = %reason,
-        "every matching version was rejected by the resolver guard; keeping the unguarded pick",
-    );
-    Some(picked)
 }
 
 /// Box a picker failure for the resolver chain, restating a non-2xx registry

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver.rs
@@ -728,7 +728,9 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
             // failure names the guard rather than blaming the range the user
             // wrote.
             return match last_rejection {
-                Some(reason) => exhausted(&opts, first_rejected, reason),
+                Some(reason) => exhausted(&opts, first_rejected, reason, |name, reason| {
+                    Box::new(AllVersionsBlockedError { name, reason })
+                }),
                 None => Ok(RegistryPick::NoMatchingVersion(pick_result.meta)),
             };
         };
@@ -766,21 +768,20 @@ pub(crate) async fn pick_from_registry_with_guard<Cache: PackageMetaCache>(
                 // already blocked, so it can't be excluded; stop rather than
                 // loop forever — every match really is blocked.
                 if !blocked_versions.insert(blocked_key) {
-                    return exhausted(&opts, first_rejected, reason);
+                    return exhausted(&opts, first_rejected, reason, |name, reason| {
+                        Box::new(AllVersionsBlockedError { name, reason })
+                    });
                 }
                 // Each rejection re-runs the picker over the packument, so an
                 // unbounded run is O(versions²). Cap it well above any real
                 // run of consecutive rejected versions to bound the work a
-                // hostile packument can force. This is a safety cutoff, not
-                // proof every version is blocked: an acceptable candidate may
-                // sit below the cap, so this fails for every guard rather
-                // than settling for a rejected pick that would hide it.
+                // hostile packument can force. The cap bounds work rather
+                // than proving every version is blocked, so it carries its
+                // own error for a guard that demands a clean candidate.
                 if blocked_versions.len() >= GUARD_REPICK_LIMIT {
-                    return Err(Box::new(GuardRepickLimitError {
-                        name: opts.spec.name.clone(),
-                        limit: GUARD_REPICK_LIMIT,
-                        reason,
-                    }));
+                    return exhausted(&opts, first_rejected, reason, |name, reason| {
+                        Box::new(GuardRepickLimitError { name, limit: GUARD_REPICK_LIMIT, reason })
+                    });
                 }
                 last_rejection = Some(reason);
                 first_rejected
@@ -809,12 +810,14 @@ fn blocked_packument_key(
         .unwrap_or_else(|| version_str.to_string())
 }
 
-/// Answer a request whose every matching version the guard rejected, per the
-/// guard's [`GuardExhaustionPolicy`].
+/// Answer a request the guard left with no acceptable candidate, per the
+/// guard's [`GuardExhaustionPolicy`]. `fail` builds the error naming why the
+/// picker gave up, for a guard whose rejections are a hard requirement.
 fn exhausted(
     opts: &PickFromRegistryOptions<'_>,
     first_rejected: Option<PickedFromRegistry>,
     reason: String,
+    fail: impl FnOnce(String, String) -> ResolveError,
 ) -> Result<RegistryPick, ResolveError> {
     let accepts_rejected = opts
         .package_version_guard
@@ -830,7 +833,7 @@ fn exhausted(
             );
             Ok(RegistryPick::Picked(picked))
         }
-        None => Err(Box::new(AllVersionsBlockedError { name: opts.spec.name.clone(), reason })),
+        None => Err(fail(opts.spec.name.clone(), reason)),
     }
 }
 

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -9,9 +9,10 @@ use pnpm_config::{TrustPolicy, version_policy::create_package_version_policy};
 use pnpm_lockfile::{LockfileResolution, RegistryResolution, TarballRevision};
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_resolving_resolver_base::{
-    CurrentPkg, LatestQuery, PackageVersionGuard, PackageVersionGuardDecision,
-    PackageVersionGuardFuture, PkgResolutionId, ResolveOptions, Resolver, UpdateBehavior,
-    WantedDependency, WorkspacePackage, WorkspacePackages, WorkspacePackagesByVersion,
+    CurrentPkg, GuardExhaustionPolicy, LatestQuery, PackageVersionGuard,
+    PackageVersionGuardDecision, PackageVersionGuardFuture, PkgResolutionId, ResolveOptions,
+    Resolver, UpdateBehavior, WantedDependency, WorkspacePackage, WorkspacePackages,
+    WorkspacePackagesByVersion,
 };
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -103,6 +104,7 @@ fn build_resolver_with_registries(
 #[derive(Debug)]
 struct RejectVersions {
     versions: HashSet<String>,
+    exhaustion_policy: GuardExhaustionPolicy,
 }
 
 impl PackageVersionGuard for RejectVersions {
@@ -115,12 +117,24 @@ impl PackageVersionGuard for RejectVersions {
             }
         })
     }
+
+    fn exhaustion_policy(&self) -> GuardExhaustionPolicy {
+        self.exhaustion_policy
+    }
+}
+
+fn guard_rejecting(
+    versions: &[&str],
+    exhaustion_policy: GuardExhaustionPolicy,
+) -> Arc<dyn PackageVersionGuard> {
+    Arc::new(RejectVersions {
+        versions: versions.iter().map(|version| (*version).to_string()).collect(),
+        exhaustion_policy,
+    })
 }
 
 fn reject_versions(versions: &[&str]) -> Arc<dyn PackageVersionGuard> {
-    Arc::new(RejectVersions {
-        versions: versions.iter().map(|version| (*version).to_string()).collect(),
-    })
+    guard_rejecting(versions, GuardExhaustionPolicy::Fail)
 }
 
 /// Packument body for `@jsr/foo__bar` — the npm-shaped name JSR
@@ -336,6 +350,33 @@ async fn package_version_guard_blocking_every_version_errors() {
     let message = err.to_string();
     assert!(message.contains("acme"), "{message}");
     assert!(message.contains("rejected by the resolver guard"), "{message}");
+}
+
+#[tokio::test]
+async fn package_version_guard_accepting_rejected_falls_back_to_the_unguarded_pick() {
+    let mut server = mockito::Server::new_async().await;
+    let _mock =
+        server.mock("GET", "/acme").with_status(200).with_body(PACKAGE_BODY).create_async().await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let opts = ResolveOptions {
+        package_version_guard: Some(guard_rejecting(
+            &["1.0.0", "1.1.0"],
+            GuardExhaustionPolicy::AcceptRejected,
+        )),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    // The guard states a preference, so the request resolves to the version
+    // it would have picked with no guard at all.
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
 }
 
 /// Packument whose `1.5.0+build` key carries a manifest `version` of

--- a/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/npm_resolver/tests.rs
@@ -379,6 +379,76 @@ async fn package_version_guard_accepting_rejected_falls_back_to_the_unguarded_pi
     assert_eq!(result.name_ver.as_ref().expect("name_ver").suffix.to_string(), "1.1.0");
 }
 
+/// Packument with more in-range versions than the guard's re-pick cap, so a
+/// guard rejecting all of them stops at the cap rather than at genuine
+/// exhaustion.
+fn packument_with_many_versions(count: u32) -> String {
+    let versions = (0..count)
+        .map(|patch| {
+            format!(
+                r#""1.0.{patch}": {{
+            "name": "acme",
+            "version": "1.0.{patch}",
+            "dist": {{
+                "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==",
+                "shasum": "0000000000000000000000000000000000000000",
+                "tarball": "https://registry/acme-1.0.{patch}.tgz"
+            }}
+        }}"#,
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",\n        ");
+    format!(
+        r#"{{
+    "name": "acme",
+    "dist-tags": {{ "latest": "1.0.{last}" }},
+    "modified": "2025-01-15T12:00:00.000Z",
+    "versions": {{
+        {versions}
+    }}
+}}"#,
+        last = count - 1,
+    )
+}
+
+#[tokio::test]
+async fn package_version_guard_accepting_rejected_falls_back_at_the_repick_limit() {
+    const VERSION_COUNT: u32 = 1005;
+    let mut server = mockito::Server::new_async().await;
+    let _mock = server
+        .mock("GET", "/acme")
+        .with_status(200)
+        .with_body(packument_with_many_versions(VERSION_COUNT))
+        .create_async()
+        .await;
+    let registry = format!("{}/", server.url());
+    let (resolver, _tempdir) = build_resolver(&registry);
+
+    let blocked: Vec<String> = (0..VERSION_COUNT).map(|patch| format!("1.0.{patch}")).collect();
+    let opts = ResolveOptions {
+        package_version_guard: Some(guard_rejecting(
+            &blocked.iter().map(String::as_str).collect::<Vec<_>>(),
+            GuardExhaustionPolicy::AcceptRejected,
+        )),
+        ..ResolveOptions::default()
+    };
+    let wanted = WantedDependency {
+        alias: Some("acme".to_string()),
+        bare_specifier: Some("^1.0.0".to_string()),
+        ..WantedDependency::default()
+    };
+
+    // The re-pick cap stops the search well before the candidates run out.
+    // A guard whose rejections are a preference must still get an answer
+    // there, not lose the whole resolve to the cap.
+    let result = resolver.resolve(&wanted, &opts).await.unwrap().unwrap();
+    assert_eq!(
+        result.name_ver.as_ref().expect("name_ver").suffix.to_string(),
+        format!("1.0.{}", VERSION_COUNT - 1),
+    );
+}
+
 /// Packument whose `1.5.0+build` key carries a manifest `version` of
 /// `1.5.0` — i.e. the version-map key differs from the parsed manifest
 /// version, the case a malformed/malicious registry can produce.

--- a/pnpm/crates/resolving-resolver-base/src/lib.rs
+++ b/pnpm/crates/resolving-resolver-base/src/lib.rs
@@ -31,12 +31,13 @@ pub use peer_range::{get_peer_version_range, is_acceptable_peer_spec, is_valid_p
 pub use publish_time::parse_packument_timestamp;
 pub use resolve::{
     CurrentPkg, DIRECT_DEP_SELECTOR_WEIGHT, DependencyManifest, EXISTING_VERSION_SELECTOR_WEIGHT,
-    LatestInfo, LatestQuery, PackageVersionGuard, PackageVersionGuardDecision,
-    PackageVersionGuardError, PackageVersionGuardFuture, PkgResolutionId, PreferredVersions,
-    PreferredVersionsOverlay, ResolveError, ResolveFuture, ResolveLatestFuture, ResolveOptions,
-    ResolveResult, Resolver, SharedDependencyManifest, UpdateBehavior, VersionSelectorEntry,
-    VersionSelectorType, VersionSelectorWithWeight, VersionSelectors, WantedDependency,
-    WorkspacePackage, WorkspacePackages, WorkspacePackagesByVersion,
+    GuardExhaustionPolicy, LatestInfo, LatestQuery, PackageVersionGuard,
+    PackageVersionGuardDecision, PackageVersionGuardError, PackageVersionGuardFuture,
+    PkgResolutionId, PreferredVersions, PreferredVersionsOverlay, ResolveError, ResolveFuture,
+    ResolveLatestFuture, ResolveOptions, ResolveResult, Resolver, SharedDependencyManifest,
+    UpdateBehavior, VersionSelectorEntry, VersionSelectorType, VersionSelectorWithWeight,
+    VersionSelectors, WantedDependency, WorkspacePackage, WorkspacePackages,
+    WorkspacePackagesByVersion,
 };
 pub use semver_range::{ANY_VERSION_RANGE, is_any_version_range, is_valid_semver_range};
 pub use verifier::{

--- a/pnpm/crates/resolving-resolver-base/src/resolve.rs
+++ b/pnpm/crates/resolving-resolver-base/src/resolve.rs
@@ -239,6 +239,20 @@ pub type PackageVersionGuardFuture<'a> = Pin<
     >,
 >;
 
+/// What the resolver does for a package whose every matching version the
+/// guard rejected.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum GuardExhaustionPolicy {
+    /// Fail the resolve. The guard states a hard requirement, so a request
+    /// that cannot meet it has no acceptable answer.
+    #[default]
+    Fail,
+    /// Resolve to the candidate the picker would have chosen with no guard
+    /// in place. The guard states a preference, and the caller is expected
+    /// to report the packages it could not move off.
+    AcceptRejected,
+}
+
 /// Optional resolver-time policy that can reject a concrete
 /// `name@version` candidate before it is committed to the lockfile.
 ///
@@ -248,6 +262,12 @@ pub type PackageVersionGuardFuture<'a> = Pin<
 /// don't multiply network traffic.
 pub trait PackageVersionGuard: Send + Sync + std::fmt::Debug {
     fn check<'a>(&'a self, name: &'a str, version: &'a str) -> PackageVersionGuardFuture<'a>;
+
+    /// What the resolver does for a request whose every matching version
+    /// [`Self::check`] rejected.
+    fn exhaustion_policy(&self) -> GuardExhaustionPolicy {
+        GuardExhaustionPolicy::Fail
+    }
 }
 
 /// Reload behavior the dispatcher passes per-resolve.


### PR DESCRIPTION
## Summary

`pnpm audit --fix update` installs a resolver-time `PackageVersionGuard` that rejects every candidate matching a known vulnerable range, so the picker falls back to a safe version. When a package's declared semver range admits no safe version, the guard exhausted the picker and the resulting `AllVersionsBlockedError` aborted the whole run — nothing else got fixed either, and `--ignore-unfixable` (which only applies to `--fix ignore`) did not help.

pnpm 11 expresses the same policy as weighted preferred versions rather than a hard reject. Those degrade gracefully: the vulnerable version is picked anyway, and the post-update lockfile comparison reports the advisory as remaining.

This PR restores that behavior. `PackageVersionGuard` gains a `GuardExhaustionPolicy`, defaulting to `Fail` so the guard stays a hard requirement for any future caller that wants one. The audit guard opts into `AcceptRejected`, so an exhausted request resolves to the candidate the picker would have chosen with no guard in place. The existing fixed-vs-remaining comparison then classifies the package as remaining, exactly as it already does for advisories whose vulnerable range is `>=0.0.0`.

The repick safety limit is handled the same way: under `AcceptRejected` the picker stops and returns the unguarded pick instead of raising `GuardRepickLimitError`.

Closes pnpm/pnpm#14508

## Squash Commit Body

```text
`audit --fix update` installs a resolver-time vulnerability guard that rejects
every candidate matching a known vulnerable range. A package whose declared
range admits no safe version exhausted the picker, and the resulting
`AllVersionsBlockedError` aborted the whole run, so nothing else got fixed
either. pnpm 11 expresses the same policy as weighted preferred versions, which
degrade to the vulnerable pick and leave the advisory reported as remaining.

Give `PackageVersionGuard` a `GuardExhaustionPolicy`. It defaults to `Fail`,
keeping the guard a hard requirement for any future caller that wants one; the
audit guard opts into `AcceptRejected`, so an exhausted request resolves to the
candidate the picker would have chosen with no guard in place. The existing
post-update lockfile comparison then classifies the package as remaining, as it
already does for advisories whose vulnerable range is `>=0.0.0`.

Closes pnpm/pnpm#14508
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  The TypeScript CLI is already correct — the resolver-level guard is a
  pacquet-only mechanism, so this is a Rust-only fix with no TS counterpart.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8PMdB8KpTMPLK7HV8b6iJ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791056962&installation_model_id=426870&pr_number=14514&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14514&signature=0574414aa8ab4e8a70c09e3e78922a7f01fc9a57ca0bc97acee239b1ed6449b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm audit --fix update` now continues when every available version within a package’s declared range is vulnerable.
  * Vulnerable packages remain in the lockfile and are clearly reported as unresolved instead of causing the update process to fail.
  * Safe updates continue to be applied to other packages where possible.

* **Documentation**
  * Added a patch changeset describing the updated audit fix behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->