### PR TITLE
fix(package-manager): keep unchanged tarballs on fast path

### DIFF
--- a/.changeset/unchanged-local-tarballs.md
+++ b/.changeset/unchanged-local-tarballs.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now reports "Already up to date" when local tarball dependencies have not changed. This avoids re-importing hoisted `node_modules` trees on repeat installs [#14495](https://github.com/pnpm/pnpm/issues/14495).

--- a/.changeset/unchanged-local-tarballs.md
+++ b/.changeset/unchanged-local-tarballs.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` now reports "Already up to date" when local tarball dependencies have not changed. This avoids re-importing hoisted `node_modules` trees on repeat installs [#14495](https://github.com/pnpm/pnpm/issues/14495).
+`pnpm install` now reports "Already up to date" when local tarball dependencies have not changed [#14495](https://github.com/pnpm/pnpm/issues/14495).

--- a/pnpm/crates/cli/tests/suite/repeat_install.rs
+++ b/pnpm/crates/cli/tests/suite/repeat_install.rs
@@ -12,7 +12,10 @@ pub use _utils::*;
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pnpm_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fixtures::tarball_with_manifest,
+};
 use std::{fs, os::unix::fs::MetadataExt, path::Path};
 
 /// `version` field of the `package.json` under `workspace/relative`.
@@ -419,6 +422,67 @@ fn repeat_hoisted_install_with_workspace_member_deps_is_up_to_date() {
     assert!(
         second_output.contains("Already up to date"),
         "the repeat install must short-circuit: {second_output}",
+    );
+    assert_eq!(
+        fs::metadata(&hoisted_manifest).expect("stat the hoisted dep").ino(),
+        inode_before,
+        "the second install must re-import nothing",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// pnpm/pnpm#14495: an unchanged local tarball does not make a hoisted
+/// workspace reinstall its registry dependency tree.
+#[test]
+fn repeat_hoisted_install_with_unchanged_local_tarball_is_up_to_date() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let workspace_yaml = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&workspace_yaml).expect("read pnpm-workspace.yaml");
+    yaml.push_str("nodeLinker: hoisted\npackages:\n  - member\n");
+    fs::write(&workspace_yaml, yaml).expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "ws-root", "private": true }).to_string(),
+    )
+    .expect("write the root package.json");
+    fs::create_dir_all(workspace.join("member")).expect("mkdir member");
+    fs::write(
+        workspace.join("member/package.json"),
+        serde_json::json!({
+            "name": "member",
+            "version": "1.0.0",
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-1-dep": "100.0.0",
+                "local-pkg": "file:../vendor/local-pkg.tgz",
+            },
+        })
+        .to_string(),
+    )
+    .expect("write the member package.json");
+    fs::create_dir_all(workspace.join("vendor")).expect("mkdir vendor");
+    fs::write(
+        workspace.join("vendor/local-pkg.tgz"),
+        tarball_with_manifest(&serde_json::json!({
+            "name": "local-pkg",
+            "version": "1.0.0",
+        })),
+    )
+    .expect("write local tarball");
+
+    pacquet.with_arg("install").assert().success();
+    let hoisted_manifest =
+        workspace.join("node_modules/@pnpm.e2e/dep-of-pkg-with-1-dep/package.json");
+    let inode_before = fs::metadata(&hoisted_manifest).expect("stat the hoisted dep").ino();
+
+    let second = pacquet_in(&workspace).with_arg("install").assert().success();
+    let second_output = String::from_utf8_lossy(&second.get_output().stdout).into_owned();
+    assert!(
+        second_output.contains("Already up to date"),
+        "the unchanged tarball must leave the fast path available: {second_output}",
     );
     assert_eq!(
         fs::metadata(&hoisted_manifest).expect("stat the hoisted dep").ino(),

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -1955,12 +1955,18 @@ mod build_workspace_state_tests {
         PackageManifest::from_path(manifest_path).unwrap()
     }
 
+    fn config_for(workspace_root: &std::path::Path) -> Config {
+        let mut config = Config::new();
+        config.virtual_store_dir = workspace_root.join("node_modules/.pnpm");
+        config
+    }
+
     /// With nothing on disk to take an mtime from, the timestamp falls
     /// back to the clock.
     #[test]
     fn empty_project_list_produces_empty_projects_map() {
         let dir = tempdir().unwrap();
-        let config = Config::new();
+        let config = config_for(dir.path());
         let state = build_workspace_state::<FrozenClock>(
             dir.path(),
             &config,
@@ -1982,7 +1988,7 @@ mod build_workspace_state_tests {
     fn prefers_the_manifest_mtime_over_the_clock() {
         let dir = tempdir().unwrap();
         let manifest = write_manifest(dir.path(), "root", "1.0.0");
-        let config = Config::new();
+        let config = config_for(dir.path());
         let state = build_workspace_state::<FrozenClock>(
             dir.path(),
             &config,
@@ -2012,7 +2018,7 @@ mod build_workspace_state_tests {
             manifest.path(),
             SystemTime::UNIX_EPOCH + Duration::new(1_600_000_000, 500_000),
         );
-        let config = Config::new();
+        let config = config_for(dir.path());
         let build = |filesystem_now_ms| {
             build_workspace_state::<FrozenClock>(
                 dir.path(),
@@ -2055,7 +2061,7 @@ mod build_workspace_state_tests {
         let project_manifests: Vec<(PathBuf, &PackageManifest)> =
             manifests.iter().map(|(p, m)| (p.clone(), m)).collect();
 
-        let config = Config::new();
+        let config = config_for(dir.path());
         let state = build_workspace_state::<FrozenClock>(
             dir.path(),
             &config,
@@ -2088,12 +2094,12 @@ mod build_workspace_state_tests {
     /// stale, and reinstalls on every `pnpm run` / `pnpm node`.
     #[test]
     fn records_config_dependencies_from_config() {
-        let mut config = Config::new();
+        let dir = tempdir().unwrap();
+        let mut config = config_for(dir.path());
         config.config_dependencies = Some(BTreeMap::from([(
             "@pnpm/pacquet".to_string(),
             ConfigDependency::VersionWithIntegrity("0.2.2-14".to_string()),
         )]));
-        let dir = tempdir().unwrap();
         let state = build_workspace_state::<FrozenClock>(
             dir.path(),
             &config,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -24,8 +24,8 @@
 //! invalidates the fast path; plugin pnpmfiles from config dependencies
 //! are covered by the `config_dependencies` comparison instead of the
 //! mtime check), and the local-file-dependency bail: mutable directory
-//! dependencies always take the full install path. Local tarballs take it
-//! only when their mtime is missing or newer than the last validation.
+//! dependencies always take the full install path. Local tarballs stay on the
+//! fast path only when their bytes match the integrity in the lockfile.
 //! Local specs introduced through `pnpm.overrides` or package extensions
 //! remain on the full path because their resolution base is graph-dependent.
 //! The local-file-dependency freshness branch of linked-package
@@ -211,15 +211,14 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
         };
     }
 
-    if has_local_file_dep_requiring_install(
-        project_manifests,
-        included,
-        catalogs,
-        state.last_validated_timestamp,
-    ) {
-        return Decision::Skipped {
-            reason: "a dependency is a local file dependency and its contents may have changed",
-        };
+    match has_local_file_dep_requiring_install(check) {
+        Ok(true) => {
+            return Decision::Skipped {
+                reason: "a dependency is a local file dependency and its contents may have changed",
+            };
+        }
+        Ok(false) => {}
+        Err(reason) => return Decision::Skipped { reason },
     }
     match has_local_file_override(config, catalogs) {
         Ok(true) => {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -23,14 +23,15 @@
 //! the pnpmfile branch (an added, removed, or edited workspace pnpmfile
 //! invalidates the fast path; plugin pnpmfiles from config dependencies
 //! are covered by the `config_dependencies` comparison instead of the
-//! mtime check), and the local-file-dependency bail: no tracked mtime
-//! covers the *contents* of a local file dependency (a `file:` specifier
-//! or a bare local path/tarball spec, declared directly or through a
-//! `pnpm.overrides` entry), so projects declaring one always take the
-//! full install path, which refetches those dependencies. The
-//! local-file-dependency freshness branch of linked-package verification
-//! is NOT ported here. When this function returns `Decision::Skipped` the
-//! caller proceeds with the full install path, which still has its own
+//! mtime check), and the local-file-dependency bail: mutable directory
+//! dependencies always take the full install path. Local tarballs take it
+//! only when their mtime is missing or newer than the last validation.
+//! Local specs introduced through `pnpm.overrides` or package extensions
+//! remain on the full path because their resolution base is graph-dependent.
+//! The local-file-dependency freshness branch of linked-package
+//! verification is NOT ported here. When this function returns
+//! `Decision::Skipped` the caller proceeds with the full install path,
+//! which has its own
 //! freshness guards (`check_lockfile_freshness`, the no-op
 //! short-circuit).
 //!
@@ -56,7 +57,7 @@ pub(crate) use conflict_markers::{
 };
 pub use deps_status::{RunDepsStatus, check_deps_status_before_run};
 pub(crate) use local_file_deps::{
-    has_local_file_dep, has_local_file_override, has_local_file_package_extension,
+    has_local_file_dep_requiring_install, has_local_file_override, has_local_file_package_extension,
 };
 pub(crate) use manifest_agreement::{
     LinkedPackagesContext, ManifestStat, modified_manifests_match_lockfile, stat_manifests,
@@ -210,9 +211,12 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
         };
     }
 
-    // Unconditional here because the only caller is the install
-    // command, which always treats local file deps as outdated.
-    if has_local_file_dep(project_manifests, included, catalogs) {
+    if has_local_file_dep_requiring_install(
+        project_manifests,
+        included,
+        catalogs,
+        state.last_validated_timestamp,
+    ) {
         return Decision::Skipped {
             reason: "a dependency is a local file dependency and its contents may have changed",
         };

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
@@ -1,86 +1,153 @@
 //! Detecting dependency specs that point at the local filesystem.
 
 use super::{
-    CatalogResolutionResult, Catalogs, Config, IncludedDependencies, PackageManifest, Path,
-    PathBuf, WantedDependency, file_mtime, modified_at_or_after, resolve_from_catalog,
+    CatalogResolutionResult, Catalogs, Config, DependencyGroup, IncludedDependencies, Lockfile,
+    OptimisticRepeatInstallCheck, Path, PathBuf, WantedDependency, resolve_from_catalog,
 };
+use pnpm_lockfile::{LockfileResolution, PkgName};
 use pnpm_resolving_local_resolver::local_tarball_path;
+use pnpm_workspace::importer_id_from_root_dir;
+use ssri::{Integrity, IntegrityChecker};
+use std::{borrow::Cow, fs, io::Read};
+
+struct LocalTarballDependency {
+    project_dir: PathBuf,
+    alias: String,
+    group: DependencyGroup,
+    path: PathBuf,
+}
 
 /// Whether any project declares a mutable local directory dependency or a
-/// local tarball that may have changed since the last successful install.
-/// Groups excluded from the current install are skipped. `catalog:` specs are
-/// dereferenced through the workspace catalogs.
+/// local tarball whose current bytes do not match the integrity recorded by
+/// the previous install. Groups excluded from the current install are skipped.
+/// `catalog:` specs are dereferenced through the workspace catalogs.
 pub(crate) fn has_local_file_dep_requiring_install(
-    project_manifests: &[(PathBuf, &PackageManifest)],
-    included: IncludedDependencies,
-    catalogs: &Catalogs,
-    last_validated_timestamp: i64,
-) -> bool {
-    let fields: [(&str, bool); 3] = [
-        ("dependencies", included.dependencies),
-        ("devDependencies", included.dev_dependencies),
-        ("optionalDependencies", included.optional_dependencies),
+    check: &OptimisticRepeatInstallCheck<'_>,
+) -> Result<bool, &'static str> {
+    let fields: [(&str, DependencyGroup, bool); 3] = [
+        ("dependencies", DependencyGroup::Prod, check.included.dependencies),
+        ("devDependencies", DependencyGroup::Dev, check.included.dev_dependencies),
+        ("optionalDependencies", DependencyGroup::Optional, check.included.optional_dependencies),
     ];
-    project_manifests.iter().any(|(project_dir, manifest)| {
-        fields.iter().any(|(field, group_included)| {
-            *group_included
-                && manifest.value().get(*field).and_then(|value| value.as_object()).is_some_and(
-                    |deps| {
-                        deps.iter().any(|(alias, spec)| {
-                            spec.as_str().is_some_and(|spec| {
-                                local_file_dep_requires_install(
-                                    project_dir,
-                                    spec,
-                                    last_validated_timestamp,
-                                ) || catalog_local_file_dep_requires_install(
-                                    project_dir,
-                                    catalogs,
-                                    alias,
-                                    spec,
-                                    last_validated_timestamp,
-                                )
-                            })
-                        })
-                    },
-                )
-        })
-    })
-}
-
-fn local_file_dep_requires_install(
-    project_dir: &Path,
-    spec: &str,
-    last_validated_timestamp: i64,
-) -> bool {
-    if !is_local_file_spec(spec) {
-        return false;
+    let mut tarballs = Vec::new();
+    for (project_dir, manifest) in check.project_manifests {
+        for (field, group, group_included) in fields {
+            if !group_included {
+                continue;
+            }
+            let Some(deps) = manifest.value().get(field).and_then(|value| value.as_object()) else {
+                continue;
+            };
+            for (alias, spec) in deps {
+                let Some(spec) = spec.as_str() else { continue };
+                let resolved_spec = resolve_catalog_spec(check.catalogs, alias, spec);
+                let Some(spec) = resolved_spec.as_deref() else { continue };
+                if !is_local_file_spec(spec) {
+                    continue;
+                }
+                let Some(path) = local_tarball_path(spec, project_dir) else {
+                    return Ok(true);
+                };
+                tarballs.push(LocalTarballDependency {
+                    project_dir: project_dir.clone(),
+                    alias: alias.clone(),
+                    group,
+                    path,
+                });
+            }
+        }
     }
-    let Some(path) = local_tarball_path(spec, project_dir) else {
-        return true;
+    if tarballs.is_empty() {
+        return Ok(false);
+    }
+
+    let current_lockfile;
+    let lockfile = if let Some(lockfile) = check
+        .lockfile
+        .get()
+        .map_err(|_| "the wanted lockfile cannot be loaded to verify local tarballs")?
+    {
+        lockfile
+    } else {
+        current_lockfile =
+            Lockfile::load_current_from_virtual_store_dir(&check.config.virtual_store_dir)
+                .map_err(|_| "the current lockfile cannot be loaded to verify local tarballs")?;
+        let Some(lockfile) = current_lockfile.as_ref() else { return Ok(true) };
+        lockfile
     };
-    file_mtime(&path).is_none_or(|mtime| modified_at_or_after(mtime, last_validated_timestamp))
+
+    Ok(tarballs.iter().any(|dependency| {
+        !local_tarball_matches_lockfile(check.workspace_root, lockfile, dependency)
+    }))
 }
 
-fn catalog_local_file_dep_requires_install(
-    project_dir: &Path,
+fn resolve_catalog_spec<'a>(
     catalogs: &Catalogs,
     alias: &str,
-    spec: &str,
-    last_validated_timestamp: i64,
-) -> bool {
+    spec: &'a str,
+) -> Option<Cow<'a, str>> {
     if !spec.starts_with("catalog:") {
-        return false;
+        return Some(Cow::Borrowed(spec));
     }
     match resolve_from_catalog(
         catalogs,
         &WantedDependency { alias: alias.to_string(), bare_specifier: spec.to_string() },
     ) {
-        CatalogResolutionResult::Found(found) => local_file_dep_requires_install(
-            project_dir,
-            &found.resolution.specifier,
-            last_validated_timestamp,
-        ),
-        _ => false,
+        CatalogResolutionResult::Found(found) => Some(Cow::Owned(found.resolution.specifier)),
+        _ => None,
+    }
+}
+
+fn local_tarball_matches_lockfile(
+    workspace_root: &Path,
+    lockfile: &Lockfile,
+    dependency: &LocalTarballDependency,
+) -> bool {
+    let importer_id = importer_id_from_root_dir(workspace_root, &dependency.project_dir);
+    let Some(importer) = lockfile.importers.get(&importer_id) else { return false };
+    let Ok(alias) = PkgName::parse(&dependency.alias) else { return false };
+    let Some(resolved) = importer
+        .get_map_by_group(dependency.group)
+        .and_then(|dependencies| dependencies.get(&alias))
+    else {
+        return false;
+    };
+    let Some(package_key) = resolved.version.resolved_key(&alias).map(|key| key.without_peer())
+    else {
+        return false;
+    };
+    let Some(LockfileResolution::Tarball(resolution)) = lockfile
+        .packages
+        .as_ref()
+        .and_then(|packages| packages.get(&package_key))
+        .map(|metadata| &metadata.resolution)
+    else {
+        return false;
+    };
+    let Some(integrity) = resolution.integrity.as_ref().filter(|value| !value.hashes.is_empty())
+    else {
+        return false;
+    };
+    let Some(recorded_path) = local_tarball_path(&resolution.tarball, workspace_root) else {
+        return false;
+    };
+    recorded_path == dependency.path && file_matches_integrity(&dependency.path, integrity)
+}
+
+fn file_matches_integrity(path: &Path, integrity: &Integrity) -> bool {
+    let Ok(mut file) = fs::File::open(path) else { return false };
+    let Ok(metadata) = file.metadata() else { return false };
+    if !metadata.is_file() {
+        return false;
+    }
+    let mut checker = IntegrityChecker::new(integrity.clone());
+    let mut buffer = vec![0_u8; 64 * 1024].into_boxed_slice();
+    loop {
+        match file.read(&mut buffer) {
+            Ok(0) => return checker.result().is_ok(),
+            Ok(read) => checker.input(&buffer[..read]),
+            Err(_) => return false,
+        }
     }
 }
 
@@ -155,9 +222,9 @@ pub(crate) fn has_local_file_package_extension(
 
 /// Whether the specifier resolves to a local directory or tarball whose
 /// contents can change without any manifest or lockfile mtime moving:
-/// the `file:` protocol, path-prefixed specs (`./`, `../`, `~/`,
+/// the `file:` protocol and path-prefixed specs (`./`, `../`, `~/`,
 /// absolute POSIX paths, and Windows drive paths including
-/// drive-relative ones like `c:dir`), and bare tarball file names.
+/// drive-relative ones like `c:dir`).
 ///
 /// Deliberately narrower than the local resolver's bare-path matching:
 /// a bare path like `user/repo` is statically indistinguishable from a
@@ -179,23 +246,7 @@ pub(crate) fn is_local_file_spec(spec: &str) -> bool {
     {
         return true;
     }
-    if spec.contains(':') {
-        return false;
-    }
-    if spec.contains('#') {
-        return false;
-    }
-    ends_with_ignore_ascii_case(spec, ".tgz")
-        || ends_with_ignore_ascii_case(spec, ".tar.gz")
-        || ends_with_ignore_ascii_case(spec, ".tar")
-}
-
-/// Case-insensitive (ASCII) suffix check that, unlike
-/// `spec.to_ascii_lowercase().ends_with(suffix)`, does not allocate.
-pub(crate) fn ends_with_ignore_ascii_case(spec: &str, suffix: &str) -> bool {
-    let spec = spec.as_bytes();
-    let suffix = suffix.as_bytes();
-    spec.len() >= suffix.len() && spec[spec.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
+    false
 }
 
 /// `c:/...`, `c:\...`, or drive-relative `c:foo` — a Windows drive

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
@@ -1,40 +1,87 @@
 //! Detecting dependency specs that point at the local filesystem.
 
 use super::{
-    CatalogResolutionResult, Catalogs, Config, IncludedDependencies, PackageManifest, PathBuf,
-    WantedDependency, resolve_from_catalog,
+    CatalogResolutionResult, Catalogs, Config, IncludedDependencies, PackageManifest, Path,
+    PathBuf, WantedDependency, file_mtime, modified_at_or_after, resolve_from_catalog,
 };
+use pnpm_resolving_local_resolver::local_tarball_path;
 
-/// Whether any project declares a dependency with a local file
-/// specifier in `dependencies`, `devDependencies`, or
-/// `optionalDependencies`. Groups excluded from the current install
-/// (per `included`) are skipped. `catalog:` specs are dereferenced
-/// through the workspace catalogs.
-pub(crate) fn has_local_file_dep(
+/// Whether any project declares a mutable local directory dependency or a
+/// local tarball that may have changed since the last successful install.
+/// Groups excluded from the current install are skipped. `catalog:` specs are
+/// dereferenced through the workspace catalogs.
+pub(crate) fn has_local_file_dep_requiring_install(
     project_manifests: &[(PathBuf, &PackageManifest)],
     included: IncludedDependencies,
     catalogs: &Catalogs,
+    last_validated_timestamp: i64,
 ) -> bool {
     let fields: [(&str, bool); 3] = [
         ("dependencies", included.dependencies),
         ("devDependencies", included.dev_dependencies),
         ("optionalDependencies", included.optional_dependencies),
     ];
-    project_manifests.iter().any(|(_, manifest)| {
+    project_manifests.iter().any(|(project_dir, manifest)| {
         fields.iter().any(|(field, group_included)| {
             *group_included
                 && manifest.value().get(*field).and_then(|value| value.as_object()).is_some_and(
                     |deps| {
                         deps.iter().any(|(alias, spec)| {
                             spec.as_str().is_some_and(|spec| {
-                                is_local_file_spec(spec)
-                                    || catalog_resolves_to_local_file(catalogs, alias, spec)
+                                local_file_dep_requires_install(
+                                    project_dir,
+                                    spec,
+                                    last_validated_timestamp,
+                                ) || catalog_local_file_dep_requires_install(
+                                    project_dir,
+                                    catalogs,
+                                    alias,
+                                    spec,
+                                    last_validated_timestamp,
+                                )
                             })
                         })
                     },
                 )
         })
     })
+}
+
+fn local_file_dep_requires_install(
+    project_dir: &Path,
+    spec: &str,
+    last_validated_timestamp: i64,
+) -> bool {
+    if !is_local_file_spec(spec) {
+        return false;
+    }
+    let Some(path) = local_tarball_path(spec, project_dir) else {
+        return true;
+    };
+    file_mtime(&path).is_none_or(|mtime| modified_at_or_after(mtime, last_validated_timestamp))
+}
+
+fn catalog_local_file_dep_requires_install(
+    project_dir: &Path,
+    catalogs: &Catalogs,
+    alias: &str,
+    spec: &str,
+    last_validated_timestamp: i64,
+) -> bool {
+    if !spec.starts_with("catalog:") {
+        return false;
+    }
+    match resolve_from_catalog(
+        catalogs,
+        &WantedDependency { alias: alias.to_string(), bare_specifier: spec.to_string() },
+    ) {
+        CatalogResolutionResult::Found(found) => local_file_dep_requires_install(
+            project_dir,
+            &found.resolution.specifier,
+            last_validated_timestamp,
+        ),
+        _ => false,
+    }
 }
 
 /// Whether a `catalog:` spec dereferences (through the workspace

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
@@ -14,7 +14,8 @@ struct LocalTarballDependency {
     project_dir: PathBuf,
     alias: String,
     group: DependencyGroup,
-    path: PathBuf,
+    path: Option<PathBuf>,
+    must_be_local: bool,
 }
 
 /// Whether any project declares a mutable local directory dependency or a
@@ -45,14 +46,17 @@ pub(crate) fn has_local_file_dep_requiring_install(
                 if !is_local_file_spec(spec) {
                     continue;
                 }
-                let Some(path) = local_tarball_path(spec, project_dir) else {
+                let must_be_local = is_unambiguous_local_file_spec(spec);
+                let path = local_tarball_path(spec, project_dir);
+                if must_be_local && path.is_none() {
                     return Ok(true);
-                };
+                }
                 tarballs.push(LocalTarballDependency {
                     project_dir: project_dir.clone(),
                     alias: alias.clone(),
                     group,
                     path,
+                    must_be_local,
                 });
             }
         }
@@ -77,7 +81,7 @@ pub(crate) fn has_local_file_dep_requiring_install(
     };
 
     Ok(tarballs.iter().any(|dependency| {
-        !local_tarball_matches_lockfile(check.workspace_root, lockfile, dependency)
+        local_tarball_requires_install(check.workspace_root, lockfile, dependency)
     }))
 }
 
@@ -98,40 +102,45 @@ fn resolve_catalog_spec<'a>(
     }
 }
 
-fn local_tarball_matches_lockfile(
+fn local_tarball_requires_install(
     workspace_root: &Path,
     lockfile: &Lockfile,
     dependency: &LocalTarballDependency,
 ) -> bool {
     let importer_id = importer_id_from_root_dir(workspace_root, &dependency.project_dir);
-    let Some(importer) = lockfile.importers.get(&importer_id) else { return false };
-    let Ok(alias) = PkgName::parse(&dependency.alias) else { return false };
+    let Some(importer) = lockfile.importers.get(&importer_id) else { return true };
+    let Ok(alias) = PkgName::parse(&dependency.alias) else { return true };
     let Some(resolved) = importer
         .get_map_by_group(dependency.group)
         .and_then(|dependencies| dependencies.get(&alias))
     else {
-        return false;
+        return true;
     };
     let Some(package_key) = resolved.version.resolved_key(&alias).map(|key| key.without_peer())
     else {
-        return false;
+        return dependency.must_be_local;
     };
-    let Some(LockfileResolution::Tarball(resolution)) = lockfile
-        .packages
-        .as_ref()
-        .and_then(|packages| packages.get(&package_key))
-        .map(|metadata| &metadata.resolution)
+    let Some(metadata) = lockfile.packages.as_ref().and_then(|packages| packages.get(&package_key))
     else {
-        return false;
+        return true;
     };
+    let LockfileResolution::Tarball(resolution) = &metadata.resolution else {
+        return dependency.must_be_local;
+    };
+    if !resolution.tarball.starts_with("file:") {
+        return dependency.must_be_local;
+    }
+    let Some(recorded_path) = local_tarball_path(&resolution.tarball, workspace_root) else {
+        return true;
+    };
+    if dependency.path.as_ref().is_some_and(|path| path != &recorded_path) {
+        return true;
+    }
     let Some(integrity) = resolution.integrity.as_ref().filter(|value| !value.hashes.is_empty())
     else {
-        return false;
+        return true;
     };
-    let Some(recorded_path) = local_tarball_path(&resolution.tarball, workspace_root) else {
-        return false;
-    };
-    recorded_path == dependency.path && file_matches_integrity(&dependency.path, integrity)
+    !file_matches_integrity(&recorded_path, integrity)
 }
 
 fn file_matches_integrity(path: &Path, integrity: &Integrity) -> bool {
@@ -236,6 +245,18 @@ pub(crate) fn has_local_file_package_extension(
 /// catalog entry may hold a bare local path (the catalog resolver only
 /// bans the `workspace:`, `link:`, and `file:` protocols).
 pub(crate) fn is_local_file_spec(spec: &str) -> bool {
+    if is_unambiguous_local_file_spec(spec) {
+        return true;
+    }
+    if spec.contains([':', '#']) {
+        return false;
+    }
+    ends_with_ignore_ascii_case(spec, ".tgz")
+        || ends_with_ignore_ascii_case(spec, ".tar.gz")
+        || ends_with_ignore_ascii_case(spec, ".tar")
+}
+
+fn is_unambiguous_local_file_spec(spec: &str) -> bool {
     if spec.starts_with("file:") {
         return true;
     }
@@ -247,6 +268,12 @@ pub(crate) fn is_local_file_spec(spec: &str) -> bool {
         return true;
     }
     false
+}
+
+fn ends_with_ignore_ascii_case(spec: &str, suffix: &str) -> bool {
+    let spec = spec.as_bytes();
+    let suffix = suffix.as_bytes();
+    spec.len() >= suffix.len() && spec[spec.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
 }
 
 /// `c:/...`, `c:\...`, or drive-relative `c:foo` — a Windows drive

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -128,6 +128,50 @@ fn write_local_tarball_lockfile(
     lockfile
 }
 
+fn write_bare_tarball_lockfile(
+    workspace_root: &std::path::Path,
+    virtual_store_dir: &std::path::Path,
+    tarball: &[u8],
+) -> Lockfile {
+    let integrity = IntegrityOpts::new().algorithm(Algorithm::Sha512).chain(tarball).result();
+    fs::write(
+        workspace_root.join(Lockfile::FILE_NAME),
+        format!(
+            "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      tar:\n        specifier: dependency.tgz\n        version: file:dependency.tgz\npackages:\n  tar@file:dependency.tgz:\n    resolution: {{integrity: {integrity}, tarball: file:dependency.tgz}}\nsnapshots:\n  tar@file:dependency.tgz: {{}}\n",
+        ),
+    )
+    .expect("write bare tarball lockfile");
+    let lockfile = Lockfile::load_wanted_from_dir(workspace_root)
+        .expect("load bare tarball lockfile")
+        .expect("bare tarball lockfile on disk");
+    lockfile
+        .save_current_to_virtual_store_dir(virtual_store_dir)
+        .expect("write current bare tarball lockfile");
+    lockfile
+}
+
+fn write_registry_lockfile(
+    workspace_root: &std::path::Path,
+    virtual_store_dir: &std::path::Path,
+    specifier: &str,
+) -> Lockfile {
+    let integrity = IntegrityOpts::new().algorithm(Algorithm::Sha512).chain(b"registry").result();
+    fs::write(
+        workspace_root.join(Lockfile::FILE_NAME),
+        format!(
+            "lockfileVersion: '9.0'\nimporters:\n  .:\n    dependencies:\n      tar:\n        specifier: {specifier}\n        version: 1.0.0\npackages:\n  tar@1.0.0:\n    resolution: {{integrity: {integrity}}}\nsnapshots:\n  tar@1.0.0: {{}}\n",
+        ),
+    )
+    .expect("write registry lockfile");
+    let lockfile = Lockfile::load_wanted_from_dir(workspace_root)
+        .expect("load registry lockfile")
+        .expect("registry lockfile on disk");
+    lockfile
+        .save_current_to_virtual_store_dir(virtual_store_dir)
+        .expect("write current registry lockfile");
+    lockfile
+}
+
 fn write_state(
     workspace_root: &std::path::Path,
     timestamp: i64,
@@ -484,16 +528,53 @@ fn returns_up_to_date_when_bare_tarball_specs_are_ambiguous() {
         let path = dir.path().join(spec);
         fs::create_dir_all(path.parent().expect("tarball parent")).expect("create parent");
         fs::write(path, b"local file with an ambiguous specifier").expect("write local file");
+        let lockfile = write_registry_lockfile(dir.path(), &config.virtual_store_dir, spec);
         validate_existing_files(dir.path());
 
-        let decision = check(
+        let decision = check_with_lockfile(
             dir.path(),
             config,
             pnpm_config::NodeLinker::Isolated,
             &[(dir.path().to_path_buf(), &manifest)],
+            &lockfile,
         );
         assert_eq!(decision, Decision::UpToDate, "specifier {spec:?}");
     }
+}
+
+#[test]
+fn verifies_a_bare_tarball_when_the_lockfile_records_a_local_resolution() {
+    let (dir, config, manifest) = setup_fresh_install(
+        pnpm_config::NodeLinker::Isolated,
+        "root",
+        "1.0.0",
+        r#""dependencies":{"tar":"dependency.tgz"}"#,
+    );
+    let tarball = dir.path().join("dependency.tgz");
+    fs::write(&tarball, b"original").expect("write bare tarball");
+    let lockfile = write_bare_tarball_lockfile(dir.path(), &config.virtual_store_dir, b"original");
+    validate_existing_files(dir.path());
+
+    let unchanged = check_with_lockfile(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+        &lockfile,
+    );
+    assert_eq!(unchanged, Decision::UpToDate);
+
+    fs::write(&tarball, b"repacked").expect("repack bare tarball");
+    let changed = check_with_lockfile(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+        &lockfile,
+    );
+    assert!(
+        matches!(changed, Decision::Skipped { reason } if reason.contains("local file dependency")),
+    );
 }
 
 /// Bare local paths resolve to local directory dependencies and stay on the

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -19,6 +19,7 @@ use pnpm_workspace_state::{
     ProjectEntry, WorkspaceState, WorkspaceStateSettings, load_workspace_state,
     update_workspace_state,
 };
+use ssri::{Algorithm, IntegrityOpts};
 use std::{collections::BTreeMap, fs};
 use tempfile::tempdir;
 
@@ -66,6 +67,26 @@ fn check_with_catalogs(
     })
 }
 
+fn check_with_lockfile(
+    workspace_root: &std::path::Path,
+    config: &Config,
+    node_linker: pnpm_config::NodeLinker,
+    project_manifests: &[(std::path::PathBuf, &PackageManifest)],
+    lockfile: &Lockfile,
+) -> Decision {
+    check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
+        workspace_root,
+        config,
+        node_linker,
+        included: isolated_included(),
+        supported_architectures: None,
+        project_manifests,
+        is_workspace_install: false,
+        lockfile: MaybeLazyLockfile::Loaded(Some(lockfile)),
+        catalogs: &BTreeMap::default(),
+    })
+}
+
 fn check_workspace(
     workspace_root: &std::path::Path,
     config: &Config,
@@ -82,6 +103,29 @@ fn check_workspace(
 fn write_empty_lockfile(workspace_root: &std::path::Path) {
     fs::write(workspace_root.join(Lockfile::FILE_NAME), "lockfileVersion: '9.0'\n")
         .expect("write pnpm-lock.yaml");
+}
+
+fn write_local_tarball_lockfile(
+    workspace_root: &std::path::Path,
+    virtual_store_dir: &std::path::Path,
+    dependency_group: &str,
+    tarball: &[u8],
+) -> Lockfile {
+    let integrity = IntegrityOpts::new().algorithm(Algorithm::Sha512).chain(tarball).result();
+    fs::write(
+        workspace_root.join(Lockfile::FILE_NAME),
+        format!(
+            "lockfileVersion: '9.0'\nimporters:\n  .:\n    {dependency_group}:\n      tar:\n        specifier: file:./vendor/tar.tgz\n        version: file:vendor/tar.tgz\npackages:\n  tar@file:vendor/tar.tgz:\n    resolution: {{integrity: {integrity}, tarball: file:vendor/tar.tgz}}\nsnapshots:\n  tar@file:vendor/tar.tgz: {{}}\n",
+        ),
+    )
+    .expect("write local tarball lockfile");
+    let lockfile = Lockfile::load_wanted_from_dir(workspace_root)
+        .expect("load local tarball lockfile")
+        .expect("local tarball lockfile on disk");
+    lockfile
+        .save_current_to_virtual_store_dir(virtual_store_dir)
+        .expect("write current local tarball lockfile");
+    lockfile
 }
 
 fn write_state(
@@ -203,6 +247,7 @@ fn setup_fresh_install_with_config(
 
     let mut config = Config::new();
     config.modules_dir = workspace_root.join("node_modules");
+    config.virtual_store_dir = config.modules_dir.join(".pnpm");
     configure(&mut config);
     let config = Box::leak(Box::new(config));
     // Pre-create the modules dir so the "missing node_modules" guard
@@ -315,14 +360,22 @@ fn returns_up_to_date_when_a_project_has_an_unchanged_file_tarball_dependency() 
         r#""devDependencies":{"tar":"file:./vendor/tar.tgz"}"#,
     );
     fs::create_dir_all(dir.path().join("vendor")).expect("create vendor dir");
-    fs::write(dir.path().join("vendor/tar.tgz"), b"unchanged").expect("write tarball");
+    let tarball = b"unchanged";
+    fs::write(dir.path().join("vendor/tar.tgz"), tarball).expect("write tarball");
+    let lockfile = write_local_tarball_lockfile(
+        dir.path(),
+        &config.virtual_store_dir,
+        "devDependencies",
+        tarball,
+    );
     validate_existing_files(dir.path());
 
-    let decision = check(
+    let decision = check_with_lockfile(
         dir.path(),
         config,
         pnpm_config::NodeLinker::Isolated,
         &[(dir.path().to_path_buf(), &manifest)],
+        &lockfile,
     );
 
     assert_eq!(decision, Decision::UpToDate);
@@ -339,8 +392,73 @@ fn returns_skipped_when_a_project_file_tarball_changed_after_validation() {
     fs::create_dir_all(dir.path().join("vendor")).expect("create vendor dir");
     let tarball = dir.path().join("vendor/tar.tgz");
     fs::write(&tarball, b"original").expect("write tarball");
+    let lockfile = write_local_tarball_lockfile(
+        dir.path(),
+        &config.virtual_store_dir,
+        "dependencies",
+        b"original",
+    );
     validate_existing_files(dir.path());
     fs::write(&tarball, b"repacked").expect("repack tarball");
+
+    let decision = check_with_lockfile(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+        &lockfile,
+    );
+
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("local file dependency")),
+    );
+}
+
+#[test]
+fn returns_skipped_when_a_project_file_tarball_changes_without_an_mtime_change() {
+    let (dir, config, manifest) = setup_fresh_install(
+        pnpm_config::NodeLinker::Isolated,
+        "root",
+        "1.0.0",
+        r#""dependencies":{"tar":"file:./vendor/tar.tgz"}"#,
+    );
+    fs::create_dir_all(dir.path().join("vendor")).expect("create vendor dir");
+    let tarball = dir.path().join("vendor/tar.tgz");
+    fs::write(&tarball, b"original").expect("write tarball");
+    let modified = fs::metadata(&tarball).expect("stat tarball").modified().expect("tarball mtime");
+    let lockfile = write_local_tarball_lockfile(
+        dir.path(),
+        &config.virtual_store_dir,
+        "dependencies",
+        b"original",
+    );
+    validate_existing_files(dir.path());
+    fs::write(&tarball, b"repacked").expect("repack tarball");
+    set_mtime(&tarball, modified);
+
+    let decision = check_with_lockfile(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+        &lockfile,
+    );
+
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("local file dependency")),
+    );
+}
+
+#[test]
+fn returns_skipped_when_a_file_tarball_spec_points_to_a_directory() {
+    let (dir, config, manifest) = setup_fresh_install(
+        pnpm_config::NodeLinker::Isolated,
+        "root",
+        "1.0.0",
+        r#""dependencies":{"tar":"file:./vendor/tar.tgz"}"#,
+    );
+    fs::create_dir_all(dir.path().join("vendor/tar.tgz")).expect("create tarball-shaped dir");
+    validate_existing_files(dir.path());
 
     let decision = check(
         dir.path(),
@@ -352,6 +470,30 @@ fn returns_skipped_when_a_project_file_tarball_changed_after_validation() {
     assert!(
         matches!(decision, Decision::Skipped { reason } if reason.contains("local file dependency")),
     );
+}
+
+#[test]
+fn returns_up_to_date_when_bare_tarball_specs_are_ambiguous() {
+    for spec in ["dependency.tgz", "user/repo.tgz"] {
+        let (dir, config, manifest) = setup_fresh_install(
+            pnpm_config::NodeLinker::Isolated,
+            "root",
+            "1.0.0",
+            &format!(r#""dependencies":{{"tar":"{spec}"}}"#),
+        );
+        let path = dir.path().join(spec);
+        fs::create_dir_all(path.parent().expect("tarball parent")).expect("create parent");
+        fs::write(path, b"local file with an ambiguous specifier").expect("write local file");
+        validate_existing_files(dir.path());
+
+        let decision = check(
+            dir.path(),
+            config,
+            pnpm_config::NodeLinker::Isolated,
+            &[(dir.path().to_path_buf(), &manifest)],
+        );
+        assert_eq!(decision, Decision::UpToDate, "specifier {spec:?}");
+    }
 }
 
 /// Bare local paths resolve to local directory dependencies and stay on the

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/tests.rs
@@ -111,6 +111,15 @@ fn write_state_with_pnpmfiles(
     update_workspace_state(workspace_root, &state).expect("write workspace state");
 }
 
+fn validate_existing_files(workspace_root: &std::path::Path) {
+    let timestamp = backdate_existing_files(workspace_root);
+    let mut state = load_workspace_state(workspace_root)
+        .expect("read workspace state")
+        .expect("workspace state on disk");
+    state.last_validated_timestamp = timestamp;
+    update_workspace_state(workspace_root, &state).expect("refresh workspace state");
+}
+
 #[test]
 fn returns_skipped_when_a_pnpmfile_is_modified() {
     let (dir, config, manifest) =
@@ -275,10 +284,10 @@ fn returns_skipped_when_a_project_has_a_file_dependency() {
     );
 }
 
-/// Same bail for a `file:` *tarball* in any dependency group — a
-/// repacked `.tgz` bumps no manifest mtime either.
+/// A missing local tarball must reach the full install path so it can report
+/// the resolver's contextual error.
 #[test]
-fn returns_skipped_when_a_project_has_a_file_tarball_dev_dependency() {
+fn returns_skipped_when_a_project_has_a_missing_file_tarball_dependency() {
     let (dir, config, manifest) = setup_fresh_install(
         pnpm_config::NodeLinker::Isolated,
         "root",
@@ -297,13 +306,59 @@ fn returns_skipped_when_a_project_has_a_file_tarball_dev_dependency() {
     );
 }
 
-/// Bare local path and tarball specs resolve to local file dependencies
-/// too — same bail as `file:`, for the same reason.
+#[test]
+fn returns_up_to_date_when_a_project_has_an_unchanged_file_tarball_dependency() {
+    let (dir, config, manifest) = setup_fresh_install(
+        pnpm_config::NodeLinker::Isolated,
+        "root",
+        "1.0.0",
+        r#""devDependencies":{"tar":"file:./vendor/tar.tgz"}"#,
+    );
+    fs::create_dir_all(dir.path().join("vendor")).expect("create vendor dir");
+    fs::write(dir.path().join("vendor/tar.tgz"), b"unchanged").expect("write tarball");
+    validate_existing_files(dir.path());
+
+    let decision = check(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+    );
+
+    assert_eq!(decision, Decision::UpToDate);
+}
+
+#[test]
+fn returns_skipped_when_a_project_file_tarball_changed_after_validation() {
+    let (dir, config, manifest) = setup_fresh_install(
+        pnpm_config::NodeLinker::Isolated,
+        "root",
+        "1.0.0",
+        r#""dependencies":{"tar":"file:./vendor/tar.tgz"}"#,
+    );
+    fs::create_dir_all(dir.path().join("vendor")).expect("create vendor dir");
+    let tarball = dir.path().join("vendor/tar.tgz");
+    fs::write(&tarball, b"original").expect("write tarball");
+    validate_existing_files(dir.path());
+    fs::write(&tarball, b"repacked").expect("repack tarball");
+
+    let decision = check(
+        dir.path(),
+        config,
+        pnpm_config::NodeLinker::Isolated,
+        &[(dir.path().to_path_buf(), &manifest)],
+    );
+
+    assert!(
+        matches!(decision, Decision::Skipped { reason } if reason.contains("local file dependency")),
+    );
+}
+
+/// Bare local paths resolve to local directory dependencies and stay on the
+/// full install path.
 #[test]
 fn returns_skipped_when_a_project_has_a_bare_local_path_dependency() {
-    for spec in
-        ["vendor/pkg.tgz", "../sibling-dir", "~/pkgs/foo", "/abs/path/foo", "c:/pkgs/foo", "c:pkgs"]
-    {
+    for spec in ["../sibling-dir", "~/pkgs/foo", "/abs/path/foo", "c:/pkgs/foo", "c:pkgs"] {
         let (dir, config, manifest) = setup_fresh_install(
             pnpm_config::NodeLinker::Isolated,
             "root",

--- a/pnpm/crates/resolving-local-resolver/src/lib.rs
+++ b/pnpm/crates/resolving-local-resolver/src/lib.rs
@@ -34,5 +34,5 @@ pub use local_resolver::{
 };
 pub use parse_bare_specifier::{
     PathProtocolNotSupportedError, WantedLocalDependency, is_local_filesystem_specifier,
-    is_tarball_filename,
+    is_tarball_filename, local_tarball_path,
 };

--- a/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
@@ -356,6 +356,24 @@ pub fn is_tarball_filename(bare: &str) -> bool {
     lower.ends_with(".tgz") || lower.ends_with(".tar.gz") || lower.ends_with(".tar")
 }
 
+/// Resolve a local tarball specifier to the file inspected by the local
+/// resolver. Returns `None` for directories and non-local tarball URLs.
+#[must_use]
+pub fn local_tarball_path(bare: &str, project_dir: &Path) -> Option<PathBuf> {
+    if !is_local_filesystem_specifier(bare) || !is_tarball_filename(bare) {
+        return None;
+    }
+    let wanted = WantedLocalDependency { bare_specifier: bare.to_string(), injected: false };
+    let spec = if bare.starts_with("file:") || bare.starts_with("link:") {
+        parse_local_scheme(&wanted, project_dir, project_dir, ParseOptions::default())
+            .ok()
+            .flatten()
+    } else {
+        parse_local_path(&wanted, project_dir, project_dir, ParseOptions::default())
+    }?;
+    matches!(spec.kind, LocalSpecKind::File).then_some(spec.fetch_spec)
+}
+
 fn contains_path_sep(bare: &str) -> bool {
     bare.contains(std::path::MAIN_SEPARATOR) || bare.contains('/')
 }

--- a/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
+++ b/pnpm/crates/resolving-local-resolver/src/parse_bare_specifier.rs
@@ -356,22 +356,24 @@ pub fn is_tarball_filename(bare: &str) -> bool {
     lower.ends_with(".tgz") || lower.ends_with(".tar.gz") || lower.ends_with(".tar")
 }
 
-/// Resolve a local tarball specifier to the file inspected by the local
-/// resolver. Returns `None` for directories and non-local tarball URLs.
+/// Resolve an unambiguous local tarball specifier to the regular file
+/// inspected by the local resolver. Returns `None` for directories,
+/// ambiguous bare specifiers, and non-local tarball URLs.
 #[must_use]
 pub fn local_tarball_path(bare: &str, project_dir: &Path) -> Option<PathBuf> {
-    if !is_local_filesystem_specifier(bare) || !is_tarball_filename(bare) {
+    if !(bare.starts_with("file:") || is_filespec(bare)) || !is_tarball_filename(bare) {
         return None;
     }
     let wanted = WantedLocalDependency { bare_specifier: bare.to_string(), injected: false };
-    let spec = if bare.starts_with("file:") || bare.starts_with("link:") {
+    let spec = if bare.starts_with("file:") {
         parse_local_scheme(&wanted, project_dir, project_dir, ParseOptions::default())
             .ok()
             .flatten()
     } else {
         parse_local_path(&wanted, project_dir, project_dir, ParseOptions::default())
     }?;
-    matches!(spec.kind, LocalSpecKind::File).then_some(spec.fetch_spec)
+    (matches!(spec.kind, LocalSpecKind::File) && spec.fetch_spec.is_file())
+        .then_some(spec.fetch_spec)
 }
 
 fn contains_path_sep(bare: &str) -> bool {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

- Keep direct local tarball dependencies on the optimistic repeat-install path when their bytes match the integrity recorded by the previous install.
- Fall back to a full install for missing, changed, non-regular, or unverifiable archives. Use each lockfile resolution to distinguish bare local tarballs from registry, Git, remote, and custom dependencies.
- Add unit coverage for unchanged archives, preserved mtimes, directory-shaped `.tgz` paths, and ambiguous specs, plus an end-to-end regression test for the reported hoisted workspace.

This is a pacquet-only fix because pnpm 12 uses the Rust CLI and the reported hoisted rematerialization occurs there. The TypeScript pnpm 11 CLI is frozen and does not have this repeat-install implementation.

Fixes pnpm/pnpm#14495.

## Squash Commit Body

```text
Direct local filesystem dependencies disabled the optimistic repeat-install
path because directory contents can change without touching the declaring
manifest. Applying that rule to local tarball files made every repeat install
run the full resolution and materialization pipeline, even when the archive
was unchanged.

Resolve each unambiguous direct local tarball with the local resolver and
stream its bytes through the integrity recorded by the previous install.
Matching archives can use the fast path. Missing, changed, non-regular, or
unverifiable archives and all local directories still use the authoritative
full install path. The lockfile resolution distinguishes bare local tarballs
from registry, Git, remote, and custom dependencies.

Fixes pnpm/pnpm#14495.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repeated installs now correctly report “Already up to date” when unchanged local tarball dependencies match their lockfile integrity.
  * Local tarballs are reinstalled when their contents change, are missing, or cannot be verified.
  * Improved handling of local tarball paths and ambiguous archive specifications.
* **Tests**
  * Added coverage for unchanged, repacked, missing, and directory-based local tarball dependencies.
* **Documentation**
  * Documented integrity-based verification for local tarballs during repeat installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->