### PR TITLE
fix(package-manager): scope GVS build marker checks

### DIFF
--- a/.changeset/calm-slots-rest.md
+++ b/.changeset/calm-slots-rest.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer reruns root lifecycle scripts when the global virtual store contains an unfinished-build marker in a package slot that the current lockfile does not use [pnpm/pnpm#14485](https://github.com/pnpm/pnpm/issues/14485).

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -802,7 +802,7 @@ fn needs_build_marker_triggers_reimport_on_next_install() {
         &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
     );
     let workspace_settings = format!(
-        "{}sideEffectsCache: false\n",
+        "{}nodeVersion: 20.0.0\nsideEffectsCache: false\n",
         allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
     );
     set_gvs_workspace_yaml(&workspace, &workspace_settings);

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -793,68 +793,92 @@ fn gvs_rebuilds_successfully_after_simulated_build_failure_cleanup() {
 /// (`globalVirtualStore.ts:411`).
 #[test]
 fn needs_build_marker_triggers_reimport_on_next_install() {
-    let CommandTempCwd { root, workspace, npmrc_info, .. } =
-        CommandTempCwd::init().add_mocked_registry();
-    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+    for with_installability_constraint in [false, true] {
+        let CommandTempCwd { root, workspace, npmrc_info, .. } =
+            CommandTempCwd::init().add_mocked_registry();
+        let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
 
-    write_manifest(
-        &workspace,
-        &serde_json::json!({ "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" }),
-    );
-    let workspace_settings = format!(
-        "{}nodeVersion: 20.0.0\nsideEffectsCache: false\n",
-        allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
-    );
-    set_gvs_workspace_yaml(&workspace, &workspace_settings);
+        let dependencies = if with_installability_constraint {
+            let constraint = workspace.join("constraint");
+            fs::create_dir(&constraint).expect("create constrained dependency");
+            fs::write(
+                constraint.join("package.json"),
+                serde_json::json!({
+                    "name": "constraint",
+                    "version": "1.0.0",
+                    "engines": { "node": ">=18" },
+                })
+                .to_string(),
+            )
+            .expect("write constrained dependency manifest");
+            serde_json::json!({
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+                "constraint": "file:./constraint",
+            })
+        } else {
+            serde_json::json!({
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            })
+        };
+        write_manifest(&workspace, &dependencies);
+        let workspace_settings = format!(
+            "{}nodeVersion: 20.0.0\nsideEffectsCache: false\n",
+            allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
+        );
+        set_gvs_workspace_yaml(&workspace, &workspace_settings);
 
-    eprintln!("First install, with the build approved...");
-    pacquet(&workspace).with_arg("install").assert().success();
+        eprintln!("First install, with the build approved...");
+        pacquet(&workspace).with_arg("install").assert().success();
 
-    let version_dir =
-        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
-    let pkg =
-        pkg_in_slot(&sole_hash_dir(&version_dir), "@pnpm.e2e/pre-and-postinstall-scripts-example");
-    let marker = pkg.join(".pnpm-needs-build");
-    let postinstall_artifact = pkg.join("generated-by-postinstall.js");
-    let package_manifest = pkg.join("package.json");
-    let pristine_manifest = fs::read_to_string(&package_manifest).expect("read package manifest");
-    assert!(postinstall_artifact.exists());
-    assert!(!marker.exists());
+        let version_dir =
+            pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+        let pkg = pkg_in_slot(
+            &sole_hash_dir(&version_dir),
+            "@pnpm.e2e/pre-and-postinstall-scripts-example",
+        );
+        let marker = pkg.join(".pnpm-needs-build");
+        let postinstall_artifact = pkg.join("generated-by-postinstall.js");
+        let package_manifest = pkg.join("package.json");
+        let pristine_manifest =
+            fs::read_to_string(&package_manifest).expect("read package manifest");
+        assert!(postinstall_artifact.exists());
+        assert!(!marker.exists());
 
-    eprintln!("Simulating a crash after import but before the build...");
-    fs::write(&marker, "").expect("write the incomplete-build marker");
-    fs::remove_file(&postinstall_artifact).expect("remove the build artifact");
-    corrupt_pristine_file(&package_manifest);
+        eprintln!("Simulating a crash after import but before the build...");
+        fs::write(&marker, "").expect("write the incomplete-build marker");
+        fs::remove_file(&postinstall_artifact).expect("remove the build artifact");
+        corrupt_pristine_file(&package_manifest);
 
-    eprintln!("Frozen reinstall with intact project links must rebuild the marked slot...");
-    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+        eprintln!("Frozen reinstall with intact project links must rebuild the marked slot...");
+        pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
 
-    assert!(!marker.exists(), "the successful retry must remove the marker");
-    assert!(postinstall_artifact.exists(), "the successful retry must recreate build output");
-    assert_eq!(
-        fs::read_to_string(&package_manifest).expect("read the restored manifest"),
-        pristine_manifest,
-        "the retry must re-import pristine package files before rebuilding",
-    );
+        assert!(!marker.exists(), "the successful retry must remove the marker");
+        assert!(postinstall_artifact.exists(), "the successful retry must recreate build output");
+        assert_eq!(
+            fs::read_to_string(&package_manifest).expect("read the restored manifest"),
+            pristine_manifest,
+            "the retry must re-import pristine package files before rebuilding",
+        );
 
-    eprintln!("Marking the slot again to exercise the optimistic repeat-install paths...");
-    fs::write(&marker, "").expect("write the second incomplete-build marker");
-    fs::remove_file(&postinstall_artifact).expect("remove the rebuilt artifact");
-    fs::write(&package_manifest, "{}").expect("corrupt the pristine file again");
-    pacquet(&workspace).with_arg("install").assert().success();
+        eprintln!("Marking the slot again to exercise the optimistic repeat-install paths...");
+        fs::write(&marker, "").expect("write the second incomplete-build marker");
+        fs::remove_file(&postinstall_artifact).expect("remove the rebuilt artifact");
+        fs::write(&package_manifest, "{}").expect("corrupt the pristine file again");
+        pacquet(&workspace).with_arg("install").assert().success();
 
-    assert!(!marker.exists(), "the ordinary reinstall must remove the marker");
-    assert!(
-        postinstall_artifact.exists(),
-        "the ordinary reinstall must not report up to date before rebuilding",
-    );
-    assert_eq!(
-        fs::read_to_string(&package_manifest).expect("read the twice-restored manifest"),
-        pristine_manifest,
-        "the ordinary reinstall must re-import the package before rebuilding",
-    );
+        assert!(!marker.exists(), "the ordinary reinstall must remove the marker");
+        assert!(
+            postinstall_artifact.exists(),
+            "the ordinary reinstall must not report up to date before rebuilding",
+        );
+        assert_eq!(
+            fs::read_to_string(&package_manifest).expect("read the twice-restored manifest"),
+            pristine_manifest,
+            "the ordinary reinstall must re-import the package before rebuilding",
+        );
 
-    drop((root, mock_instance));
+        drop((root, mock_instance));
+    }
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -857,6 +857,52 @@ fn needs_build_marker_triggers_reimport_on_next_install() {
     drop((root, mock_instance));
 }
 
+#[test]
+fn orphan_needs_build_marker_does_not_invalidate_repeat_install() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { store_dir, mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0",
+            },
+            "scripts": {
+                "postinstall": r#"node -e "require('fs').appendFileSync('root-postinstall.txt', 'run\n')""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+    set_gvs_workspace_yaml(
+        &workspace,
+        &allow_builds_yaml(&[("@pnpm.e2e/pre-and-postinstall-scripts-example", true)]),
+    );
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    let version_dir =
+        pkg_version_dir(&store_dir, "@pnpm.e2e/pre-and-postinstall-scripts-example", "1.0.0");
+    let orphan_pkg = pkg_in_slot(
+        &version_dir.join("0000000000000000000000000000000000000000000000000000000000000000"),
+        "@pnpm.e2e/pre-and-postinstall-scripts-example",
+    );
+    fs::create_dir_all(&orphan_pkg).expect("create orphan GVS slot");
+    fs::write(orphan_pkg.join(".pnpm-needs-build"), "").expect("write orphan build marker");
+
+    pacquet(&workspace).with_arg("install").assert().success();
+
+    assert_eq!(
+        fs::read_to_string(workspace.join("root-postinstall.txt")).expect("read script output"),
+        "run\n",
+        "an unrelated GVS slot must not cause the root lifecycle scripts to run again",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// TS: `local directory dependency works with global virtual store`
 /// (`globalVirtualStore.ts`).
 ///

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -404,6 +404,27 @@ pub fn virtual_store_layout_for_lockfile(
     )
 }
 
+/// Return the GVS directory containing every graph-hash slot for one snapshot.
+/// This derives only the `<scope>/<name>/<version>` prefix and does not build or
+/// hash the dependency graph.
+#[must_use]
+pub fn global_virtual_store_version_dir(
+    package_store_dir: &Path,
+    snapshot_key: &PackageKey,
+    metadata: Option<&PackageMetadata>,
+) -> Option<PathBuf> {
+    let name = snapshot_key.name.to_string();
+    let version = gvs_version_segment(metadata, &snapshot_key.suffix);
+    let candidate_slot = join_global_virtual_store_path(
+        package_store_dir,
+        &format_global_virtual_store_path(&name, &version, "candidate"),
+    );
+    if !pnpm_fs::is_subdir(package_store_dir, &candidate_slot) {
+        return None;
+    }
+    candidate_slot.parent().map(Path::to_path_buf)
+}
+
 /// Map each injected `file:` project to the virtual-store package
 /// directories its copies were materialized at.
 ///

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout.rs
@@ -406,7 +406,8 @@ pub fn virtual_store_layout_for_lockfile(
 
 /// Return the GVS directory containing every graph-hash slot for one snapshot.
 /// This derives only the `<scope>/<name>/<version>` prefix and does not build or
-/// hash the dependency graph.
+/// hash the dependency graph. Returns `None` when lockfile data cannot form the
+/// exact package-name and version components in that prefix.
 #[must_use]
 pub fn global_virtual_store_version_dir(
     package_store_dir: &Path,
@@ -415,6 +416,11 @@ pub fn global_virtual_store_version_dir(
 ) -> Option<PathBuf> {
     let name = snapshot_key.name.to_string();
     let version = gvs_version_segment(metadata, &snapshot_key.suffix);
+    if !pnpm_resolving_deps_resolver::is_valid_dependency_alias(&name)
+        || !is_single_gvs_path_component(&version)
+    {
+        return None;
+    }
     let candidate_slot = join_global_virtual_store_path(
         package_store_dir,
         &format_global_virtual_store_path(&name, &version, "candidate"),
@@ -532,6 +538,13 @@ fn gvs_version_segment(metadata: Option<&PackageMetadata>, suffix: &PkgVerPeer) 
         Some(version) => version.to_string(),
         None => suffix.version().to_string(),
     }
+}
+
+fn is_single_gvs_path_component(value: &str) -> bool {
+    let mut components = Path::new(value).components();
+    !value.contains(['/', '\\'])
+        && matches!(components.next(), Some(std::path::Component::Normal(_)))
+        && components.next().is_none()
 }
 
 /// Stands in for the version of a snapshot resolved from a local

--- a/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
+++ b/pnpm/crates/deps-restorer/src/virtual_store_layout/tests.rs
@@ -1,4 +1,4 @@
-use super::VirtualStoreLayout;
+use super::{VirtualStoreLayout, global_virtual_store_version_dir};
 use pnpm_config::Config;
 use pnpm_lockfile::{
     DirectoryResolution, LockfileResolution, PackageKey, PackageMetadata, PkgName,
@@ -157,6 +157,38 @@ fn slot_dir_prefixes_unscoped_with_at_slash_under_gvs() {
     let _ = slot
         .strip_prefix("/tmp/store/links/@/foo/1.0.0/")
         .expect("unscoped GVS slots live under <root>/@/<name>/<version>/<hash>");
+}
+
+#[test]
+fn gvs_version_dir_requires_exact_name_and_version_components() {
+    let root = PathBuf::from("store").join("links");
+    let scoped: PackageKey = "@scope/foo@1.2.3".parse().expect("parse scoped key");
+    let unscoped: PackageKey = "foo@1.2.3".parse().expect("parse unscoped key");
+    assert_eq!(
+        global_virtual_store_version_dir(&root, &scoped, None),
+        Some(root.join("@scope").join("foo").join("1.2.3")),
+    );
+    assert_eq!(
+        global_virtual_store_version_dir(&root, &unscoped, None),
+        Some(root.join("@").join("foo").join("1.2.3")),
+    );
+
+    for key in ["../other@1.2.3", "@scope/../other@1.2.3", r"@scope\evil/foo@1.2.3"] {
+        let key: PackageKey = key.parse().expect("parse unsafe package name");
+        assert_eq!(global_virtual_store_version_dir(&root, &key, None), None);
+    }
+
+    let registry = RegistryResolution {
+        integrity: "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+            .parse()
+            .expect("parse integrity"),
+        revision: None,
+    };
+    for version in ["../@/other/1.2.3", r"..\@\other\1.2.3"] {
+        let metadata =
+            package_metadata(LockfileResolution::Registry(registry.clone()), Some(version));
+        assert_eq!(global_virtual_store_version_dir(&root, &unscoped, Some(&metadata)), None);
+    }
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/install/modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/modules_state.rs
@@ -172,6 +172,66 @@ pub(super) fn gvs_build_marker_present(
     let Ok(policy) = crate::AllowBuildPolicy::from_config(config) else {
         return true;
     };
+    let Some(snapshots) = wanted.snapshots.as_ref() else {
+        return false;
+    };
+    let eligible_snapshots = snapshots
+        .keys()
+        .filter(|snapshot_key| {
+            crate::snapshot_has_patch(snapshot_key)
+                || policy.check(&snapshot_key.without_peer().to_string()) == Some(true)
+        })
+        .collect::<Vec<_>>();
+    let mut marker_candidate = false;
+    let mut visited_version_dirs = HashSet::new();
+    for &snapshot_key in &eligible_snapshots {
+        let metadata = wanted
+            .packages
+            .as_ref()
+            .and_then(|packages| packages.get(&snapshot_key.without_peer()));
+        let Some(version_dir) = crate::global_virtual_store_version_dir(
+            &config.global_virtual_store_dir,
+            snapshot_key,
+            metadata,
+        ) else {
+            return true;
+        };
+        if !visited_version_dirs.insert(version_dir.clone()) {
+            continue;
+        }
+        let hash_dirs = match std::fs::read_dir(version_dir) {
+            Ok(hash_dirs) => hash_dirs,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(_) => return true,
+        };
+        for hash_dir in hash_dirs {
+            let Ok(hash_dir) = hash_dir else {
+                return true;
+            };
+            let Ok(file_type) = hash_dir.file_type() else {
+                return true;
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let Ok(pkg_dir) = crate::safe_join_modules_dir::safe_join_modules_dir(
+                &hash_dir.path().join("node_modules"),
+                &snapshot_key.name.to_string(),
+            ) else {
+                return true;
+            };
+            if pkg_dir.join(crate::NEEDS_BUILD_MARKER).is_file() {
+                marker_candidate = true;
+                break;
+            }
+        }
+        if marker_candidate {
+            break;
+        }
+    }
+    if !marker_candidate {
+        return false;
+    }
     let effective_node_version = match (&wanted.snapshots, &wanted.packages) {
         (Some(snapshots), Some(packages))
             if !config.force
@@ -193,16 +253,8 @@ pub(super) fn gvs_build_marker_present(
     if crate::validate_virtual_store_slot_containment(wanted.snapshots.as_ref(), &layout).is_err() {
         return true;
     }
-    let Some(snapshots) = wanted.snapshots.as_ref() else {
-        return false;
-    };
 
-    for snapshot_key in snapshots.keys() {
-        let can_recover = crate::snapshot_has_patch(snapshot_key)
-            || policy.check(&snapshot_key.without_peer().to_string()) == Some(true);
-        if !can_recover {
-            continue;
-        }
+    for snapshot_key in eligible_snapshots {
         let Ok(pkg_dir) = crate::safe_join_modules_dir::safe_join_modules_dir(
             &layout.slot_dir(snapshot_key).join("node_modules"),
             &snapshot_key.name.to_string(),

--- a/pnpm/crates/package-manager/src/install/modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/modules_state.rs
@@ -155,14 +155,14 @@ pub(super) fn gvs_build_markers_may_require_recovery(config: &Config) -> bool {
             || config.patched_dependencies.as_ref().is_some_and(|patches| !patches.is_empty()))
 }
 
-/// Probe the GVS name/version directories that can contain an actionable
-/// marker for this lockfile. Hash directories are enumerated rather than
-/// recomputed because buildable slots include the runtime engine in their
-/// graph hash, which the pre-runtime fast path deliberately has not resolved.
+/// Probe the buildable or patched GVS slots this lockfile resolves to.
+/// Markers in sibling hash directories belong to other dependency graphs and
+/// cannot be recovered by materializing this one.
 pub(super) fn gvs_build_marker_present(
     wanted: &Lockfile,
     config: &Config,
     lockfile_dir: &Path,
+    effective_node_version: Option<&str>,
 ) -> bool {
     if !gvs_build_markers_may_require_recovery(config) {
         return false;
@@ -170,9 +170,9 @@ pub(super) fn gvs_build_marker_present(
     let Ok(policy) = crate::AllowBuildPolicy::from_config(config) else {
         return true;
     };
-    let layout = crate::VirtualStoreLayout::new(
+    let layout = crate::virtual_store_layout_for_lockfile(
         config,
-        None,
+        effective_node_version,
         wanted.snapshots.as_ref(),
         wanted.packages.as_ref(),
         Some(&policy),
@@ -185,44 +185,20 @@ pub(super) fn gvs_build_marker_present(
         return false;
     };
 
-    let mut visited_version_dirs = HashSet::new();
     for snapshot_key in snapshots.keys() {
         let can_recover = crate::snapshot_has_patch(snapshot_key)
             || policy.check(&snapshot_key.without_peer().to_string()) == Some(true);
         if !can_recover {
             continue;
         }
-        let Some(version_dir) = layout.slot_dir(snapshot_key).parent().map(Path::to_path_buf)
-        else {
+        let Ok(pkg_dir) = crate::safe_join_modules_dir::safe_join_modules_dir(
+            &layout.slot_dir(snapshot_key).join("node_modules"),
+            &snapshot_key.name.to_string(),
+        ) else {
             return true;
         };
-        if !visited_version_dirs.insert(version_dir.clone()) {
-            continue;
-        }
-        let hash_dirs = match std::fs::read_dir(&version_dir) {
-            Ok(hash_dirs) => hash_dirs,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(_) => return true,
-        };
-        for hash_dir in hash_dirs {
-            let Ok(hash_dir) = hash_dir else {
-                return true;
-            };
-            let Ok(file_type) = hash_dir.file_type() else {
-                return true;
-            };
-            if !file_type.is_dir() {
-                continue;
-            }
-            let Ok(pkg_dir) = crate::safe_join_modules_dir::safe_join_modules_dir(
-                &hash_dir.path().join("node_modules"),
-                &snapshot_key.name.to_string(),
-            ) else {
-                return true;
-            };
-            if pkg_dir.join(crate::NEEDS_BUILD_MARKER).is_file() {
-                return true;
-            }
+        if pkg_dir.join(crate::NEEDS_BUILD_MARKER).is_file() {
+            return true;
         }
     }
     false

--- a/pnpm/crates/package-manager/src/install/modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/modules_state.rs
@@ -157,7 +157,9 @@ pub(super) fn gvs_build_markers_may_require_recovery(config: &Config) -> bool {
 
 /// Probe the buildable or patched GVS slots this lockfile resolves to.
 /// Markers in sibling hash directories belong to other dependency graphs and
-/// cannot be recovered by materializing this one.
+/// cannot be recovered by materializing this one. The effective Node version
+/// participates only when materialization would run installability checks;
+/// constraint-free materialization keys the layout to the detected host Node.
 pub(super) fn gvs_build_marker_present(
     wanted: &Lockfile,
     config: &Config,
@@ -169,6 +171,16 @@ pub(super) fn gvs_build_marker_present(
     }
     let Ok(policy) = crate::AllowBuildPolicy::from_config(config) else {
         return true;
+    };
+    let effective_node_version = match (&wanted.snapshots, &wanted.packages) {
+        (Some(snapshots), Some(packages))
+            if !config.force
+                && !snapshots.is_empty()
+                && crate::any_installability_constraint(snapshots, packages) =>
+        {
+            effective_node_version
+        }
+        _ => None,
     };
     let layout = crate::virtual_store_layout_for_lockfile(
         config,

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -34,6 +34,7 @@ pub(super) struct PrepareModulesStateInputs<'a, 'install> {
     pub(super) save_lockfile: bool,
     pub(super) catalogs: &'a Catalogs,
     pub(super) project_manifests: &'a [(PathBuf, &'a PackageManifest)],
+    pub(super) effective_node_version: Option<&'a str>,
     pub(super) prefix: &'a str,
 }
 
@@ -73,6 +74,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
         save_lockfile,
         catalogs,
         project_manifests,
+        effective_node_version,
         prefix,
     } = inputs;
     // A no-op still refreshes workspace state so `verifyDepsBeforeRun`
@@ -321,7 +323,12 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
             // project-state input checked above. Let materialization inspect
             // buildable and patched GVS slots instead of declaring the local
             // tree complete from importer links alone.
-            && !gvs_build_marker_present(wanted_lockfile, config, workspace_root)
+            && !gvs_build_marker_present(
+                wanted_lockfile,
+                config,
+                workspace_root,
+                effective_node_version,
+            )
             // An explicit `pacquet rebuild` always re-runs the build phase,
             // so it never short-circuits here.
             && rebuild.is_none()

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -111,6 +111,7 @@ where
             pnpmfile_hook_override,
             workspace_projects_override,
         } = self;
+        let effective_node_version = super::effective_node_version(config, manifest);
         http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
         let can_prompt = prompt_eligibility_override
@@ -396,7 +397,12 @@ where
             // swallowed read error.
             let marker_safe = if gvs_build_markers_may_require_recovery(config) {
                 match lockfile.get() {
-                    Ok(Some(wanted)) => !gvs_build_marker_present(wanted, config, &workspace_root),
+                    Ok(Some(wanted)) => !gvs_build_marker_present(
+                        wanted,
+                        config,
+                        &workspace_root,
+                        effective_node_version.as_deref(),
+                    ),
                     Ok(None) => true,
                     Err(_) => false,
                 }
@@ -1119,6 +1125,7 @@ where
             save_lockfile,
             catalogs: &catalogs,
             project_manifests: &project_manifests,
+            effective_node_version: effective_node_version.as_deref(),
             prefix: &prefix,
         })
         .await?

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -118,7 +118,13 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
     }
     if gvs_build_markers_may_require_recovery(config) {
         let wanted = lockfile.get().ok().flatten()?;
-        if gvs_build_marker_present(wanted, config, &lockfile_root) {
+        let effective_node_version = super::effective_node_version(config, manifest);
+        if gvs_build_marker_present(
+            wanted,
+            config,
+            &lockfile_root,
+            effective_node_version.as_deref(),
+        ) {
             return None;
         }
     }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Scope `.pnpm-needs-build` recovery checks to the global virtual store slots resolved by the current lockfile. Orphan markers in sibling dependency-graph hashes no longer disable the optimistic repeat-install path and rerun root lifecycle scripts.

The probe now computes the exact slot layout with the same Node engine selection as frozen materialization. Markers in active buildable or patched slots still trigger recovery, including when a configured Node version differs from the host.

Marker-free repeat installs first scan eligible name/version directories and return without hashing the dependency graph or detecting the host Node. Exact slot calculation runs only when a marker needs to be classified as active or orphaned.

The prefix scan validates lockfile-derived package names and version components before reading candidate directories.

This is specific to the Rust pnpm 12 implementation. The TypeScript pnpm 11 stack has no equivalent global-virtual-store optimistic fast path.

Validation:

- Added a regression test that plants an orphan marker and verifies that a repeat install does not rerun the root lifecycle script.
- Extended the active-slot marker test to cover constrained and constraint-free lockfiles when the configured Node version differs from the host.
- Added focused path-shape tests for valid scoped and unscoped slots plus slash and backslash traversal attempts.
- `just ready`: 9,900 tests passed, with formatting, workspace checks, and clippy green.
- Full pre-push checks: TypeScript compile and lint, Rust formatting, clippy, rustdoc, dylint, spelling, and TOML formatting green.

Closes pnpm/pnpm#14485

## Squash Commit Body

```text
Compute the exact global virtual store slots for the current lockfile before
checking incomplete-build markers. This keeps recovery for active slots while
ignoring markers left in sibling dependency-graph hashes.

Match the marker probe's Node engine selection to frozen materialization. Use
the effective Node version when installability constraints require it and the
detected host Node for constraint-free lockfiles.

Avoid graph hashing and host Node discovery on marker-free repeat installs by
checking eligible name and version directories before calculating exact slots.

Validate lockfile-derived name and version components before scanning global
virtual store directories.

Closes pnpm/pnpm#14485
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).
