### PR TITLE
fix: relink workspace packages when linkDirectory changes

### DIFF
--- a/.changeset/relink-publish-directories.md
+++ b/.changeset/relink-publish-directories.md
@@ -1,0 +1,11 @@
+---
+"@pnpm/installing.deps-installer": patch
+"@pnpm/installing.deps-resolver": patch
+"@pnpm/lockfile.fs": patch
+"@pnpm/lockfile.types": patch
+"@pnpm/lockfile.verification": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm install` now relinks workspace packages when `publishConfig.linkDirectory` changes. Frozen installs report an outdated lockfile until it is regenerated [pnpm/pnpm#14488](https://github.com/pnpm/pnpm/issues/14488).

--- a/pnpm/crates/cli/tests/suite/multiple_importers.rs
+++ b/pnpm/crates/cli/tests/suite/multiple_importers.rs
@@ -492,8 +492,7 @@ fn custom_virtual_store_directory_in_a_workspace_with_shared_lockfile() {
     assert_recorded_virtual_store("frozen");
 }
 
-/// TS: `symlink local package from the location described in its
-/// publishConfig.directory when linkDirectory is true`
+/// TS: `relink local package when publishConfig.linkDirectory changes`
 /// (`multipleImporters.ts:1766`).
 #[test]
 fn symlink_local_package_from_publish_config_directory() {
@@ -529,11 +528,28 @@ fn symlink_local_package_from_publish_config_directory() {
         fixture.wanted().importers["packages/project-1"].publish_directory.as_deref(),
         Some("dist"),
     );
+    assert_eq!(fixture.wanted().importers["packages/project-1"].link_directory, None);
 
     fs::remove_dir_all(fixture.workspace.join("node_modules")).expect("remove root node_modules");
     fs::remove_dir_all(project_2.join("node_modules")).expect("remove project-2 node_modules");
     fixture.run(["install", "--frozen-lockfile"]);
     assert_publish_dir_is_linked();
+
+    project_1_manifest["publishConfig"]["linkDirectory"] = json!(false);
+    write_manifest_value(&project_1, &project_1_manifest);
+
+    let output = fixture.command_at(&fixture.workspace, ["install", "--frozen-lockfile"]);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "frozen install accepted linkDirectory drift\nstderr:\n{stderr}",
+    );
+    assert!(stderr.contains("ERR_PNPM_OUTDATED_LOCKFILE"), "got:\n{stderr}");
+
+    fixture.run(["install"]);
+    let linked = read_manifest(&project_2.join("node_modules/project-1"));
+    assert_eq!(linked["name"], "project-1");
+    assert_eq!(fixture.wanted().importers["packages/project-1"].link_directory, Some(false));
 }
 
 /// TS: `recursive install with shared-workspace-lockfile builds

--- a/pnpm/crates/deps-restorer/src/build_graph/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_graph/tests.rs
@@ -58,6 +58,7 @@ fn importer(deps: &[(&str, &str)]) -> ProjectSnapshot {
         dev_dependencies: None,
         dependencies_meta: None,
         publish_directory: None,
+        link_directory: None,
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -426,6 +426,7 @@ fn root_importers(deps: &[(&str, &str)]) -> HashMap<String, ProjectSnapshot> {
             dev_dependencies: None,
             dependencies_meta: None,
             publish_directory: None,
+            link_directory: None,
         },
     )])
 }

--- a/pnpm/crates/lockfile/src/filter_by_importers.rs
+++ b/pnpm/crates/lockfile/src/filter_by_importers.rs
@@ -110,7 +110,7 @@ impl Lockfile {
 }
 
 /// Empty the dependency groups `include` excludes. The other fields of the
-/// importer entry (`dependenciesMeta`, `publishDirectory`) are dropped the
+/// importer entry (`dependenciesMeta`, `publishDirectory`, `linkDirectory`) are dropped the
 /// same way the TypeScript `filterImporter` drops them: the filtered
 /// lockfile describes a dependency closure, not a publishable project.
 fn filter_importer(importer: &ProjectSnapshot, include: IncludedDependencies) -> ProjectSnapshot {
@@ -127,6 +127,7 @@ fn filter_importer(importer: &ProjectSnapshot, include: IncludedDependencies) ->
         )),
         dependencies_meta: None,
         publish_directory: None,
+        link_directory: None,
     }
 }
 

--- a/pnpm/crates/lockfile/src/freshness.rs
+++ b/pnpm/crates/lockfile/src/freshness.rs
@@ -95,6 +95,13 @@ pub enum StalenessReason {
     )]
     PublishDirectoryMismatch { lockfile: Option<String>, manifest: Option<String> },
 
+    /// Whether workspace links use `publishDirectory` differs from the
+    /// manifest's effective `publishConfig.linkDirectory` value.
+    #[display(
+        r#""linkDirectory" in the lockfile ({lockfile}) doesn't match "publishConfig.linkDirectory" in package.json ({manifest})"#
+    )]
+    LinkDirectoryMismatch { lockfile: bool, manifest: bool },
+
     /// `dependenciesMeta` on the importer doesn't match
     /// `dependenciesMeta` on the manifest.
     #[display(
@@ -267,6 +274,7 @@ impl StalenessReason {
             | StalenessReason::RemovedImporter { .. }
             | StalenessReason::SpecifiersDiffer(_)
             | StalenessReason::PublishDirectoryMismatch { .. }
+            | StalenessReason::LinkDirectoryMismatch { .. }
             | StalenessReason::DependenciesMetaMismatch { .. }
             | StalenessReason::DepSpecifierMismatch { .. }
             | StalenessReason::ResolutionDoesNotSatisfy { .. } => None,
@@ -571,7 +579,7 @@ fn all_catalogs_are_up_to_date(
 ///    dependencies ∪ optionalDependencies` (∪ the auto-installed
 ///    peers below). Catches added / removed / modified deps in one
 ///    bucket.
-/// 2. `publishDirectory` vs `publishConfig.directory`.
+/// 2. `publishDirectory` / `linkDirectory` vs `publishConfig`.
 /// 3. `dependenciesMeta` equality.
 /// 4. Per-field name-set, per-dep specifier, and resolved-version
 ///    checks. Catches
@@ -610,12 +618,9 @@ pub fn satisfies_package_manifest(
         return Err(StalenessReason::SpecifiersDiffer(diff));
     }
 
-    // Phase 2: `publishDirectory` parity. Compares the importer's
-    // `publishDirectory` to the manifest's `publishConfig.directory`
-    // verbatim; pacquet's `ProjectSnapshot.publish_directory` is
-    // `Option<String>` and the manifest exposes the field via the
-    // raw `value()`. Two `None`s match; anything else mismatched
-    // fails the check.
+    // Phase 2: publish-directory parity. The directory is compared verbatim;
+    // `linkDirectory` is compared by its effective value because omitted and
+    // explicit `true` have the same behavior and only `false` is recorded.
     let manifest_publish_dir = manifest
         .value()
         .get("publishConfig")
@@ -626,6 +631,21 @@ pub fn satisfies_package_manifest(
         return Err(StalenessReason::PublishDirectoryMismatch {
             lockfile: importer.publish_directory.clone(),
             manifest: manifest_publish_dir,
+        });
+    }
+    let lockfile_links_publish_directory =
+        importer.publish_directory.is_some() && importer.link_directory != Some(false);
+    let manifest_links_publish_directory = manifest_publish_dir.is_some()
+        && manifest
+            .value()
+            .get("publishConfig")
+            .and_then(|publish_config| publish_config.get("linkDirectory"))
+            .and_then(serde_json::Value::as_bool)
+            != Some(false);
+    if lockfile_links_publish_directory != manifest_links_publish_directory {
+        return Err(StalenessReason::LinkDirectoryMismatch {
+            lockfile: lockfile_links_publish_directory,
+            manifest: manifest_links_publish_directory,
         });
     }
 

--- a/pnpm/crates/lockfile/src/freshness/tests.rs
+++ b/pnpm/crates/lockfile/src/freshness/tests.rs
@@ -387,6 +387,31 @@ fn publish_directory_mismatch_returns_publish_directory_mismatch() {
 }
 
 #[test]
+fn link_directory_mismatch_returns_link_directory_mismatch() {
+    let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
+        "lockfileVersion: '9.0'"
+        "importers:"
+        "  .:"
+        "    publishDirectory: ./dist"
+    })
+    .expect("parse fixture lockfile");
+    let importer = lockfile.root_project().expect("root importer present");
+    let (_dir, manifest) = manifest_from_json(
+        r#"{
+        "name": "x",
+        "version": "1.0.0",
+        "publishConfig": { "directory": "./dist", "linkDirectory": false }
+    }"#,
+    );
+    let err = satisfies_package_manifest(importer, &manifest, true, &|_: &str| false)
+        .expect_err("should be stale");
+    assert!(
+        matches!(err, StalenessReason::LinkDirectoryMismatch { .. }),
+        "expected LinkDirectoryMismatch, got {err:?}",
+    );
+}
+
+#[test]
 fn dependencies_meta_mismatch_returns_dependencies_meta_mismatch() {
     let lockfile: Lockfile = serde_saphyr::from_str(text_block! {
         "lockfileVersion: '9.0'"

--- a/pnpm/crates/lockfile/src/merge_lockfile_changes.rs
+++ b/pnpm/crates/lockfile/src/merge_lockfile_changes.rs
@@ -164,6 +164,7 @@ fn merge_importers(
                 optional_dependencies: group(|importer| importer.optional_dependencies.as_ref()),
                 dependencies_meta: None,
                 publish_directory: None,
+                link_directory: None,
             },
         );
     }

--- a/pnpm/crates/lockfile/src/project_snapshot.rs
+++ b/pnpm/crates/lockfile/src/project_snapshot.rs
@@ -37,6 +37,9 @@ pub struct ProjectSnapshot {
     pub dependencies_meta: Option<serde_json::Value>, // TODO: DependenciesMeta
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publish_directory: Option<String>,
+    /// `Some(false)` when workspace links must ignore [`Self::publish_directory`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_directory: Option<bool>,
 }
 
 impl ProjectSnapshot {

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -492,12 +492,7 @@ fn build_importer(
         .get("dependenciesMeta")
         .filter(|value| value.as_object().is_some_and(|meta| !meta.is_empty()))
         .cloned();
-    let publish_directory = manifest
-        .value()
-        .get("publishConfig")
-        .and_then(|publish_config| publish_config.get("directory"))
-        .and_then(Value::as_str)
-        .map(str::to_string);
+    let (publish_directory, link_directory) = manifest_publish_config(manifest);
 
     Ok(ProjectSnapshot {
         specifiers: (!specifiers.is_empty()).then_some(specifiers),
@@ -506,7 +501,25 @@ fn build_importer(
         optional_dependencies: (!optional_dependencies.is_empty()).then_some(optional_dependencies),
         dependencies_meta,
         publish_directory,
+        link_directory,
     })
+}
+
+pub(crate) fn manifest_publish_config(
+    manifest: &PackageManifest,
+) -> (Option<String>, Option<bool>) {
+    let publish_config = manifest.value().get("publishConfig");
+    let publish_directory = publish_config
+        .and_then(|publish_config| publish_config.get("directory"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let link_directory = publish_directory.as_ref().and_then(|_| {
+        publish_config
+            .and_then(|publish_config| publish_config.get("linkDirectory"))
+            .and_then(Value::as_bool)
+            .filter(|link_directory| !link_directory)
+    });
+    (publish_directory, link_directory)
 }
 
 /// Map each direct-dep alias to the manifest group it appears in.

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile/tests.rs
@@ -433,7 +433,7 @@ fn fresh_install_records_importer_manifest_metadata() {
         "name": "fixture",
         "version": "1.0.0",
         "dependenciesMeta": { "pkg-a": { "injected": true } },
-        "publishConfig": { "directory": "dist" },
+        "publishConfig": { "directory": "dist", "linkDirectory": false },
     }));
     let graph = DependenciesGraph::default();
 
@@ -450,6 +450,7 @@ fn fresh_install_records_importer_manifest_metadata() {
 
     assert_eq!(importer.dependencies_meta, Some(json!({ "pkg-a": { "injected": true } })));
     assert_eq!(importer.publish_directory.as_deref(), Some("dist"));
+    assert_eq!(importer.link_directory, Some(false));
 }
 
 #[test]

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -1,4 +1,5 @@
 use crate::{
+    dependencies_graph_to_lockfile::manifest_publish_config,
     fast_update_compose::Drift,
     fast_update_lockfile::GraphEdits,
     fast_update_settings::{is_directory_dependency, workspace_package_names},
@@ -266,12 +267,7 @@ fn importer_from_locked_versions(
     }
     importer.specifiers = Some(specifiers);
     importer.dependencies_meta = manifest.value().get("dependenciesMeta").cloned();
-    importer.publish_directory = manifest
-        .value()
-        .get("publishConfig")
-        .and_then(|publish_config| publish_config.get("directory"))
-        .and_then(serde_json::Value::as_str)
-        .map(ToString::to_string);
+    (importer.publish_directory, importer.link_directory) = manifest_publish_config(manifest);
     Some(importer)
 }
 

--- a/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
+++ b/pnpm11/installing/deps-installer/src/install/tryFastUpdateImporters.ts
@@ -191,6 +191,9 @@ function writeImporterFromLockedVersions (
   }
   if (project.manifest.publishConfig?.directory != null) {
     importer.publishDirectory = project.manifest.publishConfig.directory
+    if (project.manifest.publishConfig.linkDirectory === false) {
+      importer.linkDirectory = false
+    }
   }
   lockfile.importers[project.id] = importer
   return true

--- a/pnpm11/installing/deps-installer/test/install/multipleImporters.ts
+++ b/pnpm11/installing/deps-installer/test/install/multipleImporters.ts
@@ -1763,7 +1763,7 @@ test('do not update dependency that has the same name as a dependency in the wor
   ])
 })
 
-test('symlink local package from the location described in its publishConfig.directory when linkDirectory is true', async () => {
+test('relink local package when publishConfig.linkDirectory changes', async () => {
   preparePackages([
     {
       location: 'project-1',
@@ -1827,6 +1827,7 @@ test('symlink local package from the location described in its publishConfig.dir
   const project = assertProject(process.cwd())
   const lockfile = project.readLockfile()
   expect(lockfile.importers['project-1'].publishDirectory).toBe('dist')
+  expect(lockfile.importers['project-1'].linkDirectory).toBeUndefined()
 
   rimrafSync('node_modules')
   await mutateModules(importers, testDefaults({ allProjects, frozenLockfile: true }))
@@ -1835,6 +1836,22 @@ test('symlink local package from the location described in its publishConfig.dir
     const linkedManifest = loadJsonFileSync<{ name: string }>('project-2/node_modules/project-1/package.json')
     expect(linkedManifest.name).toBe('project-1-dist')
   }
+
+  project1Manifest.publishConfig.linkDirectory = false
+  await expect(
+    mutateModules(importers, testDefaults({ allProjects, frozenLockfile: true }))
+  ).rejects.toMatchObject({ code: 'ERR_PNPM_OUTDATED_LOCKFILE' })
+
+  await mutateModules(importers, testDefaults({ allProjects }))
+
+  {
+    const linkedManifest = loadJsonFileSync<{ name: string }>('project-2/node_modules/project-1/package.json')
+    expect(linkedManifest.name).toBe('project-1')
+  }
+
+  const updatedLockfile = project.readLockfile()
+  expect(updatedLockfile.importers['project-1'].linkDirectory).toBe(false)
+  expect(updatedLockfile.importers['project-2'].dependencies?.['project-1'].version).toBe('link:../project-1')
 })
 
 test('do not symlink local package from the location described in its publishConfig.directory', async () => {

--- a/pnpm11/installing/deps-resolver/src/index.ts
+++ b/pnpm11/installing/deps-resolver/src/index.ts
@@ -531,6 +531,9 @@ function addDirectDependenciesToLockfile (
 
   if (newManifest.publishConfig?.directory) {
     newProjectSnapshot.publishDirectory = newManifest.publishConfig.directory
+    if (newManifest.publishConfig.linkDirectory === false) {
+      newProjectSnapshot.linkDirectory = false
+    }
   }
 
   for (const linkedPkg of linkedPackages) {

--- a/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
+++ b/pnpm11/lockfile/fs/src/lockfileFormatConverters.ts
@@ -77,6 +77,9 @@ function normalizeLockfile (lockfile: LockfileFile): LockfileFile {
       if (importer.publishDirectory) {
         normalizedImporter.publishDirectory = importer.publishDirectory
       }
+      if (importer.linkDirectory === false) {
+        normalizedImporter.linkDirectory = false
+      }
       return normalizedImporter as LockfileFileProjectSnapshot
     }, lockfile.importers ?? {}),
   }

--- a/pnpm11/lockfile/fs/test/normalizeLockfile.test.ts
+++ b/pnpm11/lockfile/fs/test/normalizeLockfile.test.ts
@@ -35,6 +35,27 @@ test('empty overrides are removed during lockfile normalization', () => {
   })
 })
 
+test('linkDirectory false is preserved during lockfile normalization', () => {
+  expect(convertToLockfileFile({
+    lockfileVersion: LOCKFILE_VERSION,
+    importers: {
+      ['foo' as ProjectId]: {
+        linkDirectory: false,
+        publishDirectory: 'dist',
+        specifiers: {},
+      },
+    },
+  })).toStrictEqual({
+    lockfileVersion: LOCKFILE_VERSION,
+    importers: {
+      foo: {
+        publishDirectory: 'dist',
+        linkDirectory: false,
+      },
+    },
+  })
+})
+
 test('redundant fields are removed from "time"', () => {
   expect(convertToLockfileFile({
     lockfileVersion: LOCKFILE_VERSION,

--- a/pnpm11/lockfile/types/src/index.ts
+++ b/pnpm11/lockfile/types/src/index.ts
@@ -68,6 +68,8 @@ export interface LockfilePackageInfo {
 export interface ProjectSnapshotBase {
   dependenciesMeta?: DependenciesMeta
   publishDirectory?: string
+  /** Present only when workspace links must ignore `publishDirectory`. */
+  linkDirectory?: false
 }
 
 export interface ProjectSnapshot extends ProjectSnapshotBase {

--- a/pnpm11/lockfile/verification/src/satisfiesPackageManifest.ts
+++ b/pnpm11/lockfile/verification/src/satisfiesPackageManifest.ts
@@ -63,6 +63,14 @@ export function satisfiesPackageManifest (
       detailedReason: `"publishDirectory" in the lockfile (${importer.publishDirectory ?? 'undefined'}) doesn't match "publishConfig.directory" in package.json (${pkg.publishConfig?.directory ?? 'undefined'})`,
     }
   }
+  const lockfileLinksPublishDirectory = importer.publishDirectory != null && importer.linkDirectory !== false
+  const manifestLinksPublishDirectory = pkg.publishConfig?.directory != null && pkg.publishConfig.linkDirectory !== false
+  if (lockfileLinksPublishDirectory !== manifestLinksPublishDirectory) {
+    return {
+      satisfies: false,
+      detailedReason: `"linkDirectory" in the lockfile (${lockfileLinksPublishDirectory}) doesn't match "publishConfig.linkDirectory" in package.json (${manifestLinksPublishDirectory})`,
+    }
+  }
   if (!equals(pkg.dependenciesMeta ?? {}, importer.dependenciesMeta ?? {})) {
     return {
       satisfies: false,

--- a/pnpm11/lockfile/verification/test/satisfiesPackageManifest.ts
+++ b/pnpm11/lockfile/verification/test/satisfiesPackageManifest.ts
@@ -360,6 +360,42 @@ test('satisfiesPackageManifest()', () => {
   })
 
   expect(satisfiesPackageManifest(
+    {},
+    {
+      specifiers: {},
+      publishDirectory: 'dist',
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      publishConfig: {
+        directory: 'dist',
+        linkDirectory: false,
+      },
+    }
+  )).toStrictEqual({
+    satisfies: false,
+    detailedReason: '"linkDirectory" in the lockfile (true) doesn\'t match "publishConfig.linkDirectory" in package.json (false)',
+  })
+
+  expect(satisfiesPackageManifest(
+    {},
+    {
+      specifiers: {},
+      publishDirectory: 'dist',
+      linkDirectory: false,
+    },
+    {
+      ...DEFAULT_PKG_FIELDS,
+      publishConfig: {
+        directory: 'dist',
+      },
+    }
+  )).toStrictEqual({
+    satisfies: false,
+    detailedReason: '"linkDirectory" in the lockfile (false) doesn\'t match "publishConfig.linkDirectory" in package.json (true)',
+  })
+
+  expect(satisfiesPackageManifest(
     {
       excludeLinksFromLockfile: true,
     },


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Track whether workspace packages with `publishConfig.directory` link from the publish directory or the package root in importer lockfile snapshots. Changing `publishConfig.linkDirectory` now invalidates the snapshot, so a mutable install resolves and relinks dependents to the correct location. A frozen install reports the lockfile as outdated.

The TypeScript CLI and the Rust `pnpm/` port implement the same lockfile field, freshness check, and regression coverage.

Fixes pnpm/pnpm#14488.

## Squash Commit Body

```text
Record `publishConfig.linkDirectory: false` in importer snapshots so lockfile freshness can distinguish links to a publish directory from links to the package root. Omit the field for the default and explicit `true` values to avoid unnecessary lockfile churn.

Treat changes to the effective setting as manifest drift. Mutable installs then re-resolve workspace links, while frozen installs report an outdated lockfile.

Implement the same lockfile contract and behavior in the TypeScript CLI and the Rust port.

Fixes pnpm/pnpm#14488.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14517"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791057819&installation_model_id=426870&pr_number=14517&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14517&signature=9cc978bf2565dc2e4224f30dbb8b4082d8a8f5fdf9c7d30872ce67226dc56c4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace packages are now relinked when `publishConfig.linkDirectory` changes.
  - Lockfile validation detects mismatches in workspace linking behavior, including the default behavior when the setting is omitted.
  - Frozen installs now report an outdated lockfile when linking configuration has changed.
  - Lockfile normalization preserves `linkDirectory: false` settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->