### PR TITLE
perf(deps-restorer): trust existing global-virtual-store slots when restoring node_modules

### DIFF
--- a/.changeset/warm-gvs-restore.md
+++ b/.changeset/warm-gvs-restore.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up installs that restore a deleted `node_modules` from a warm global virtual store. pnpm now trusts an existing package directory in the global virtual store and only recreates the project links, so a restore no longer re-links every package in the store [#14510](https://github.com/pnpm/pnpm/issues/14510).
+Sped up installs that restore a deleted `node_modules` from a warm global virtual store. pnpm no longer re-links packages that are already fully present in the global virtual store [#14510](https://github.com/pnpm/pnpm/issues/14510).

--- a/.changeset/warm-gvs-restore.md
+++ b/.changeset/warm-gvs-restore.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up installs that restore a deleted `node_modules` from a warm global virtual store. pnpm now trusts an existing package directory in the global virtual store and only recreates the project links, so a restore no longer re-links every package in the store [#14510](https://github.com/pnpm/pnpm/issues/14510).

--- a/pnpm/crates/cli/tests/suite/global_virtual_store.rs
+++ b/pnpm/crates/cli/tests/suite/global_virtual_store.rs
@@ -237,7 +237,22 @@ fn reinstall_from_warm_global_virtual_store_after_deleting_node_modules() {
     assert!(gvs_root(&store_dir).is_dir(), "the GVS must survive the node_modules wipe");
 
     eprintln!("Frozen reinstall — must reattach from the warm GVS...");
-    pacquet(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    let output = pacquet(&workspace)
+        .with_args(["install", "--frozen-lockfile", "--reporter=ndjson"])
+        .output()
+        .expect("run the frozen reinstall");
+    assert_success(&output);
+    let added: Vec<u64> = ndjson_records(&output)
+        .iter()
+        .filter(|record| record["name"] == "pnpm:stats")
+        .filter_map(|record| record["added"].as_u64())
+        .collect();
+    assert_eq!(
+        added,
+        vec![0],
+        "a wiped node_modules loses the current lockfile, but the content-addressed \
+         GVS slots are still authoritative, so nothing may be re-materialized",
+    );
 
     assert_eq!(
         hash_dirs(&version_dir),

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -375,6 +375,14 @@ pub enum CreateVirtualStoreError {
         #[error(source)]
         error: std::io::Error,
     },
+
+    #[display("Failed to inspect the virtual store slot at {path:?}: {error}")]
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_INSPECT_VIRTUAL_STORE_SLOT))]
+    InspectVirtualStoreSlot {
+        path: PathBuf,
+        #[error(source)]
+        error: std::io::Error,
+    },
 }
 
 impl CreateVirtualStore<'_> {

--- a/pnpm/crates/deps-restorer/src/create_virtual_store.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store.rs
@@ -512,6 +512,7 @@ impl CreateVirtualStore<'_> {
             allow_build_policy,
             skipped,
             link_dependencies: !is_hoisted && config.symlink,
+            force: config.force,
             is_hoisted,
             include_optional_dependencies,
             cache_keys: &mut snapshot_cache_keys,

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -308,18 +308,40 @@ fn regular_children_match(
         else {
             return Ok(false);
         };
-        match std::fs::symlink_metadata(&child_path) {
-            Ok(_) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
-            Err(error) => {
-                return Err(CreateVirtualStoreError::InspectVirtualStoreSlot {
-                    path: child_path,
-                    error,
-                });
-            }
+        if !child_link_present(&child_path)? {
+            return Ok(false);
         }
     }
     Ok(true)
+}
+
+/// Whether `child_path` holds the directory link the symlink layout
+/// writes. A plain file or directory in its place is a corrupted slot,
+/// not a link, so it does not count.
+fn child_link_present(child_path: &Path) -> Result<bool, CreateVirtualStoreError> {
+    match std::fs::symlink_metadata(child_path) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() {
+                return Ok(true);
+            }
+            // On Windows `symlink_dir` may have fallen back to a
+            // junction, which `is_symlink` does not report.
+            #[cfg(windows)]
+            return pnpm_fs::is_symlink_or_junction(child_path).map_err(|error| {
+                CreateVirtualStoreError::InspectVirtualStoreSlot {
+                    path: child_path.to_path_buf(),
+                    error,
+                }
+            });
+            #[cfg(not(windows))]
+            Ok(false)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(CreateVirtualStoreError::InspectVirtualStoreSlot {
+            path: child_path.to_path_buf(),
+            error,
+        }),
+    }
 }
 
 /// Kind of dirent a slot probe expects.

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -31,9 +31,9 @@ pub(super) struct SnapshotPlanInputs<'a, 'b> {
     pub skipped: &'b SkippedSnapshots,
     pub link_dependencies: bool,
     /// `--force` re-materializes every slot, so both skip paths — the
-    /// current-lockfile comparison (whose `current_snapshots` the
-    /// callers already null out under force) and the global-virtual-
-    /// store existence probe — are disabled.
+    /// current-lockfile comparison and the global-virtual-store
+    /// existence probe — are disabled here, whether or not the caller
+    /// also nulled out `current_snapshots`.
     pub force: bool,
     pub is_hoisted: bool,
     pub include_optional_dependencies: bool,
@@ -118,15 +118,17 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 ) {
                     return Ok(false);
                 }
-                let current_entry_unchanged = current_snapshots
-                    .and_then(|current_snapshots| current_snapshots.get(snapshot_key))
-                    .is_some_and(|current_snapshot| {
-                        snapshot_deps_equal(current_snapshot, snapshot)
-                            && integrity_equal(
-                                current_packages.and_then(|p| p.get(&snapshot_key.without_peer())),
-                                wanted_metadata,
-                            )
-                    });
+                let current_entry_unchanged = !force
+                    && current_snapshots
+                        .and_then(|current_snapshots| current_snapshots.get(snapshot_key))
+                        .is_some_and(|current_snapshot| {
+                            snapshot_deps_equal(current_snapshot, snapshot)
+                                && integrity_equal(
+                                    current_packages
+                                        .and_then(|p| p.get(&snapshot_key.without_peer())),
+                                    wanted_metadata,
+                                )
+                        });
                 // A global-virtual-store slot path is content-addressed:
                 // the graph hash covers the snapshot's wiring, integrity,
                 // and engine, so an existing slot is current even when no
@@ -143,7 +145,7 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                     .slot_dir(snapshot_key)
                     .join("node_modules")
                     .join(snapshot_key.name.to_string());
-                if !dir.is_dir() {
+                if !probe_slot_entry(&dir, EntryKind::Dir)? {
                     // Only a slot the current lockfile vouches for is
                     // "broken" when missing; a mere GVS-existence miss is
                     // a fresh materialization.
@@ -169,7 +171,9 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 // which the import places last. A rare package whose file
                 // map lacks `package.json` merely re-materializes, and
                 // the import then short-circuits on its actual marker.
-                if !current_entry_unchanged && !dir.join("package.json").is_file() {
+                if !current_entry_unchanged
+                    && !probe_slot_entry(&dir.join("package.json"), EntryKind::File)?
+                {
                     return Ok(false);
                 }
                 if !optional_children_match(
@@ -240,6 +244,38 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         marker_rebuilds,
         has_git_hosted_survivor,
     })
+}
+
+/// Kind of dirent a slot probe expects.
+#[derive(Clone, Copy)]
+enum EntryKind {
+    Dir,
+    File,
+}
+
+/// Whether `path` exists as the expected kind. `NotFound` — and
+/// `NotADirectory`, a file sitting where a parent directory is
+/// expected — mean the slot is not there; any other inspection error
+/// aborts the install, per the warm-slot fold's contract.
+fn probe_slot_entry(path: &Path, kind: EntryKind) -> Result<bool, CreateVirtualStoreError> {
+    match std::fs::metadata(path) {
+        Ok(metadata) => Ok(match kind {
+            EntryKind::Dir => metadata.is_dir(),
+            EntryKind::File => metadata.is_file(),
+        }),
+        Err(error)
+            if matches!(
+                error.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+            ) =>
+        {
+            Ok(false)
+        }
+        Err(error) => Err(CreateVirtualStoreError::InspectVirtualStoreSlot {
+            path: path.to_path_buf(),
+            error,
+        }),
+    }
 }
 
 fn optional_children_match(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -14,25 +14,33 @@ use std::{
     path::Path,
 };
 
-pub(super) struct SnapshotPlanInputs<'a> {
+/// `'a` is the lifetime of the lockfile maps the resulting
+/// [`SnapshotPlan`] borrows from; `'b` covers the inputs the plan pass
+/// only reads while running.
+pub(super) struct SnapshotPlanInputs<'a, 'b> {
     pub snapshots: &'a HashMap<PackageKey, SnapshotEntry>,
     pub packages: &'a HashMap<PackageKey, PackageMetadata>,
     /// What the previous install materialized. `None` on a first
     /// install; when present, a snapshot whose wiring and integrity are
     /// unchanged *and* whose slot is still on disk is left alone.
-    pub current_snapshots: Option<&'a HashMap<PackageKey, SnapshotEntry>>,
-    pub current_packages: Option<&'a HashMap<PackageKey, PackageMetadata>>,
-    pub layout: &'a VirtualStoreLayout,
-    pub allow_build_policy: &'a crate::AllowBuildPolicy,
+    pub current_snapshots: Option<&'b HashMap<PackageKey, SnapshotEntry>>,
+    pub current_packages: Option<&'b HashMap<PackageKey, PackageMetadata>>,
+    pub layout: &'b VirtualStoreLayout,
+    pub allow_build_policy: &'b crate::AllowBuildPolicy,
     /// Snapshots the installability pass ruled out on this host.
-    pub skipped: &'a SkippedSnapshots,
+    pub skipped: &'b SkippedSnapshots,
     pub link_dependencies: bool,
+    /// `--force` re-materializes every slot, so both skip paths — the
+    /// current-lockfile comparison (whose `current_snapshots` the
+    /// callers already null out under force) and the global-virtual-
+    /// store existence probe — are disabled.
+    pub force: bool,
     pub is_hoisted: bool,
     pub include_optional_dependencies: bool,
     /// One derivation `Result` per lockfile snapshot, taken by the
     /// entry that keeps it. See [`super::CasPrefetch::start`], which
     /// guarantees the every-snapshot coverage.
-    pub cache_keys: &'a mut HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
+    pub cache_keys: &'b mut HashMap<PackageKey, Result<SnapshotCacheKey, CreateVirtualStoreError>>,
 }
 
 /// The snapshots to install, the ones deliberately left alone, and the
@@ -40,10 +48,10 @@ pub(super) struct SnapshotPlanInputs<'a> {
 pub(super) struct SnapshotPlan<'a> {
     /// Snapshots this install materializes.
     pub survivors: Vec<SnapshotWithCacheKey<'a>>,
-    /// Snapshots the current-lockfile check skipped. They contribute no
-    /// link work, but their store-index rows still feed the build
-    /// phase's `is_built` gate, so a warm reinstall does not re-run
-    /// approved build scripts.
+    /// Snapshots the current-lockfile check or the global-virtual-store
+    /// existence probe skipped. They contribute no link work, but their
+    /// store-index rows still feed the build phase's `is_built` gate,
+    /// so a warm reinstall does not re-run approved build scripts.
     pub skipped_entries: Vec<SnapshotWithCacheKey<'a>>,
     pub marker_rebuilds: HashSet<PackageKey>,
     pub has_git_hosted_survivor: bool,
@@ -58,9 +66,9 @@ pub(super) struct SnapshotPlan<'a> {
 /// warm batch starts rather than several seconds into it. Skipped
 /// snapshots get a lenient pass — they are not being installed, and
 /// swallowing a per-snapshot error there costs only a prefetch row.
-pub(super) fn plan_snapshots<Reporter: self::Reporter>(
-    inputs: SnapshotPlanInputs<'_>,
-) -> Result<SnapshotPlan<'_>, CreateVirtualStoreError> {
+pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
+    inputs: SnapshotPlanInputs<'a, '_>,
+) -> Result<SnapshotPlan<'a>, CreateVirtualStoreError> {
     let SnapshotPlanInputs {
         snapshots,
         packages,
@@ -70,6 +78,7 @@ pub(super) fn plan_snapshots<Reporter: self::Reporter>(
         allow_build_policy,
         skipped,
         link_dependencies,
+        force,
         is_hoisted,
         include_optional_dependencies,
         cache_keys,
@@ -87,10 +96,11 @@ pub(super) fn plan_snapshots<Reporter: self::Reporter>(
         .iter()
         // Reason 1: installability skip. Drop entirely.
         .filter(|(snapshot_key, _)| !skipped.contains(snapshot_key))
-        // Reason 2: current-lockfile skip. Drop survivors that already
-        // match the previous install. This is a fallible fold because a
-        // warm-slot lstat error must abort the install rather than quietly
-        // converting the slot into a rebuild on every run.
+        // Reason 2: warm-slot skip. Drop survivors that already match
+        // the previous install, or whose content-addressed global-
+        // virtual-store slot already exists. This is a fallible fold
+        // because a warm-slot lstat error must abort the install rather
+        // than quietly converting the slot into a rebuild on every run.
         .try_fold(Vec::new(), |mut entries, (snapshot_key, snapshot)| {
             let current_slot_matches = (|| -> Result<bool, CreateVirtualStoreError> {
                 // The hoisted linker writes no virtual-store slot, so
@@ -98,25 +108,35 @@ pub(super) fn plan_snapshots<Reporter: self::Reporter>(
                 if is_hoisted {
                     return Ok(false);
                 }
-                let Some(current_snapshots) = current_snapshots else { return Ok(false) };
-                let Some(current_snapshot) = current_snapshots.get(snapshot_key) else {
-                    return Ok(false);
-                };
                 let wanted_metadata = packages.get(&snapshot_key.without_peer());
-                // A `file:` dependency's source is mutable, so an
-                // unchanged lockfile is no evidence its slot is current.
+                // A `file:` dependency's source is mutable, so neither
+                // an unchanged lockfile nor an existing slot is
+                // evidence its copy is current.
                 if matches!(
                     wanted_metadata.map(|meta| &meta.resolution),
                     Some(LockfileResolution::Directory(_)),
                 ) {
                     return Ok(false);
                 }
-                if !snapshot_deps_equal(current_snapshot, snapshot) {
-                    return Ok(false);
-                }
-                let current_metadata =
-                    current_packages.and_then(|p| p.get(&snapshot_key.without_peer()));
-                if !integrity_equal(current_metadata, wanted_metadata) {
+                let current_entry_unchanged = current_snapshots
+                    .and_then(|current_snapshots| current_snapshots.get(snapshot_key))
+                    .is_some_and(|current_snapshot| {
+                        snapshot_deps_equal(current_snapshot, snapshot)
+                            && integrity_equal(
+                                current_packages.and_then(|p| p.get(&snapshot_key.without_peer())),
+                                wanted_metadata,
+                            )
+                    });
+                // A global-virtual-store slot path is content-addressed:
+                // the graph hash covers the snapshot's wiring, integrity,
+                // and engine, so an existing slot is current even when no
+                // current lockfile survives — a wiped `node_modules`
+                // takes `<virtual_store_dir>/lock.yaml` with it, and
+                // without this probe such a restore re-links every slot
+                // the store already holds (pnpm/pnpm#14510). Mirrors the
+                // GVS fast path in pnpm's `lockfileToDepGraph`.
+                let gvs_slot_is_authoritative = layout.enable_global_virtual_store() && !force;
+                if !current_entry_unchanged && !gvs_slot_is_authoritative {
                     return Ok(false);
                 }
                 let dir = layout
@@ -124,10 +144,15 @@ pub(super) fn plan_snapshots<Reporter: self::Reporter>(
                     .join("node_modules")
                     .join(snapshot_key.name.to_string());
                 if !dir.is_dir() {
-                    Reporter::emit(&LogEvent::BrokenModules(BrokenModulesLog {
-                        level: LogLevel::Debug,
-                        missing: dir.to_string_lossy().into_owned(),
-                    }));
+                    // Only a slot the current lockfile vouches for is
+                    // "broken" when missing; a mere GVS-existence miss is
+                    // a fresh materialization.
+                    if current_entry_unchanged {
+                        Reporter::emit(&LogEvent::BrokenModules(BrokenModulesLog {
+                            level: LogLevel::Debug,
+                            missing: dir.to_string_lossy().into_owned(),
+                        }));
+                    }
                     return Ok(false);
                 }
                 if !optional_children_match(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -266,7 +266,7 @@ fn probe_slot_entry(path: &Path, kind: EntryKind) -> Result<bool, CreateVirtualS
         Err(error)
             if matches!(
                 error.kind(),
-                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory,
             ) =>
         {
             Ok(false)

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -153,6 +153,23 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                             missing: dir.to_string_lossy().into_owned(),
                         }));
                     }
+                    // A missing slot has no build marker either, so the
+                    // survivor marker rescan after this fold need not
+                    // stat under it again.
+                    marker_probe_keys.insert(snapshot_key.clone());
+                    return Ok(false);
+                }
+                // The importer populates shared GVS slots in place, so an
+                // existing directory may be an import another install is
+                // still filling or died halfway through (see
+                // `import_into_shared_dir`). Without a current-lockfile
+                // record vouching that a previous install completed the
+                // slot, require the importer's own completion invariant —
+                // pnpm's `pkgExistsAtTargetDir` probes `package.json`,
+                // which the import places last. A rare package whose file
+                // map lacks `package.json` merely re-materializes, and
+                // the import then short-circuits on its actual marker.
+                if !current_entry_unchanged && !dir.join("package.json").is_file() {
                     return Ok(false);
                 }
                 if !optional_children_match(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan.rs
@@ -186,6 +186,25 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
                 )? {
                     return Ok(false);
                 }
+                // The completion marker only covers the file import: the
+                // slot's child symlinks are written concurrently with it
+                // (`rayon::join` in `CreateVirtualDirBySnapshot::run`),
+                // so a crash can leave a marker-complete slot with links
+                // missing. A current-lockfile record is only written by
+                // a completed install and so vouches for the links too;
+                // without one, probe every child the symlink layout
+                // would have created.
+                if !current_entry_unchanged
+                    && !regular_children_match(
+                        snapshot_key,
+                        snapshot,
+                        layout,
+                        skipped,
+                        link_dependencies,
+                    )?
+                {
+                    return Ok(false);
+                }
                 let needs_rebuild =
                     gvs_slot_needs_rebuild(layout, allow_build_policy, snapshot_key);
                 marker_probe_keys.insert(snapshot_key.clone());
@@ -244,6 +263,63 @@ pub(super) fn plan_snapshots<'a, Reporter: self::Reporter>(
         marker_rebuilds,
         has_git_hosted_survivor,
     })
+}
+
+/// Whether every child link the symlink layout would create for the
+/// snapshot's regular `dependencies` is present in the slot. Mirrors
+/// [`crate::create_symlink_layout()`]'s predicate: the slot's own name
+/// never gets a link, a `link:` child is linked only when the layout
+/// knows the lockfile dir, and a skipped target gets no link. Children
+/// the layout would not create are not required to be absent — a
+/// shared slot may carry links written by an install with a different
+/// skip set, and re-importing would not remove them, so requiring
+/// absence would re-materialize the slot on every install.
+///
+/// Presence is an lstat: the layout creates each symlink regardless of
+/// whether its target slot is materialized yet.
+fn regular_children_match(
+    snapshot_key: &PackageKey,
+    snapshot: &SnapshotEntry,
+    layout: &VirtualStoreLayout,
+    skipped: &SkippedSnapshots,
+    link_dependencies: bool,
+) -> Result<bool, CreateVirtualStoreError> {
+    if !link_dependencies {
+        return Ok(true);
+    }
+    let Some(dependencies) = snapshot.dependencies.as_ref() else {
+        return Ok(true);
+    };
+    let modules_dir = layout.slot_dir(snapshot_key).join("node_modules");
+    for (alias, dep_ref) in dependencies {
+        if alias == &snapshot_key.name {
+            continue;
+        }
+        let expected = if let Some(target) = dep_ref.resolve(alias) {
+            !skipped.contains(&target)
+        } else {
+            dep_ref.as_link_target().is_some() && layout.lockfile_dir().is_some()
+        };
+        if !expected {
+            continue;
+        }
+        let Ok(child_path) =
+            crate::safe_join_modules_dir::safe_join_modules_dir(&modules_dir, &alias.to_string())
+        else {
+            return Ok(false);
+        };
+        match std::fs::symlink_metadata(&child_path) {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(CreateVirtualStoreError::InspectVirtualStoreSlot {
+                    path: child_path,
+                    error,
+                });
+            }
+        }
+    }
+    Ok(true)
 }
 
 /// Kind of dirent a slot probe expects.

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
@@ -302,11 +302,21 @@ fn gvs_slot_missing_a_regular_child_link_survives() {
         "a marker-complete slot missing a child link is a partial import and must be repaired",
     );
 
+    let child_link = parent_dir.parent().expect("modules dir").join("bar");
+    fs::create_dir(&child_link).expect("plant a plain directory where the child link belongs");
+    let plan = fixture.plan(false);
+    let survivor_keys: HashSet<String> =
+        plan.survivors.iter().map(|(key, _, _)| key.to_string()).collect();
+    assert!(
+        survivor_keys.contains("foo@1.0.0"),
+        "a plain directory where the child link belongs is a corrupted slot and must be repaired",
+    );
+    fs::remove_dir(&child_link).expect("remove the plain directory");
+
     let child_dir = fixture.layout.slot_dir(&child_key).join("node_modules").join("bar");
     fs::create_dir_all(&child_dir).expect("materialize the child slot");
     fs::write(child_dir.join("package.json"), "{}").expect("place the child completion marker");
-    pnpm_fs::symlink_dir(&child_dir, &parent_dir.parent().expect("modules dir").join("bar"))
-        .expect("link the child into the parent slot");
+    pnpm_fs::symlink_dir(&child_dir, &child_link).expect("link the child into the parent slot");
 
     let plan = fixture.plan(false);
     assert!(

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
@@ -1,7 +1,21 @@
-use super::{optional_children_match, optional_children_match_with};
-use crate::{CreateVirtualStoreError, SkippedSnapshots, VirtualStoreLayout};
-use pnpm_lockfile::{PackageKey, PkgName, SnapshotDepRef, SnapshotEntry};
-use std::{collections::HashMap, fs, io};
+use super::{
+    SnapshotPlan, SnapshotPlanInputs, optional_children_match, optional_children_match_with,
+    plan_snapshots,
+};
+use crate::{
+    AllowBuildPolicy, CreateVirtualStoreError, SkippedSnapshots, VirtualStoreLayout,
+    create_virtual_store::SnapshotCacheKey,
+};
+use pnpm_lockfile::{
+    DirectoryResolution, LockfileResolution, PackageKey, PackageMetadata, PkgName,
+    RegistryResolution, SnapshotDepRef, SnapshotEntry,
+};
+use pnpm_reporter::SilentReporter;
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io,
+    path::Path,
+};
 
 #[test]
 fn optional_child_probe_propagates_io_errors() {
@@ -99,5 +113,179 @@ fn invalid_optional_child_entries_do_not_match() {
             true,
         )
         .expect("inspect non-directory optional child"),
+    );
+}
+
+const DUMMY_SHA512: &str = "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==";
+
+fn registry_metadata() -> PackageMetadata {
+    PackageMetadata {
+        resolution: LockfileResolution::Registry(RegistryResolution {
+            integrity: DUMMY_SHA512.parse().expect("parse integrity"),
+            revision: None,
+        }),
+        version: None,
+        engines: None,
+        cpu: None,
+        os: None,
+        libc: None,
+        deprecated: None,
+        has_bin: None,
+        prepare: None,
+        bundled_dependencies: None,
+        peer_dependencies: None,
+        peer_dependencies_meta: None,
+    }
+}
+
+struct PlanFixture {
+    snapshots: HashMap<PackageKey, SnapshotEntry>,
+    packages: HashMap<PackageKey, PackageMetadata>,
+    layout: VirtualStoreLayout,
+}
+
+impl PlanFixture {
+    fn gvs(store_root: &Path, metadata: PackageMetadata) -> Self {
+        let snapshot_key: PackageKey = "foo@1.0.0".parse().expect("parse snapshot key");
+        let snapshots = HashMap::from([(snapshot_key.clone(), SnapshotEntry::default())]);
+        let packages = HashMap::from([(snapshot_key, metadata)]);
+        let layout = VirtualStoreLayout::global(
+            store_root.join("links"),
+            120,
+            None,
+            Some(&snapshots),
+            Some(&packages),
+            None,
+            None,
+        );
+        PlanFixture { snapshots, packages, layout }
+    }
+
+    fn snapshot_key(&self) -> &PackageKey {
+        self.snapshots.keys().next().expect("fixture holds one snapshot")
+    }
+
+    fn materialize_slot(&self) {
+        let dir = self
+            .layout
+            .slot_dir(self.snapshot_key())
+            .join("node_modules")
+            .join(self.snapshot_key().name.to_string());
+        fs::create_dir_all(dir).expect("materialize the slot's package dir");
+    }
+
+    fn plan(&self, force: bool) -> SnapshotPlan<'_> {
+        let allow_build_policy = AllowBuildPolicy::new(HashSet::new(), HashSet::new(), false);
+        let mut cache_keys = self
+            .snapshots
+            .keys()
+            .map(|snapshot_key| {
+                (
+                    snapshot_key.clone(),
+                    Ok(SnapshotCacheKey {
+                        value: Some(format!("cache-key:{snapshot_key}")),
+                        is_git_hosted: false,
+                    }),
+                )
+            })
+            .collect();
+        plan_snapshots::<SilentReporter>(SnapshotPlanInputs {
+            snapshots: &self.snapshots,
+            packages: &self.packages,
+            current_snapshots: None,
+            current_packages: None,
+            layout: &self.layout,
+            allow_build_policy: &allow_build_policy,
+            skipped: &SkippedSnapshots::default(),
+            link_dependencies: true,
+            force,
+            is_hoisted: false,
+            include_optional_dependencies: true,
+            cache_keys: &mut cache_keys,
+        })
+        .expect("plan snapshots")
+    }
+}
+
+#[test]
+fn gvs_existing_slot_is_skipped_without_a_current_lockfile() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+    fixture.materialize_slot();
+
+    let plan = fixture.plan(false);
+
+    assert!(
+        plan.survivors.is_empty(),
+        "an existing content-addressed slot needs no re-materialization",
+    );
+    assert_eq!(plan.skipped_entries.len(), 1);
+    let (snapshot_key, _, cache_key) = &plan.skipped_entries[0];
+    assert_eq!(*snapshot_key, fixture.snapshot_key());
+    assert!(
+        cache_key.is_some(),
+        "the skipped entry must keep its cache key so its store-index rows still feed the build phase",
+    );
+}
+
+#[test]
+fn gvs_missing_slot_survives_without_a_current_lockfile() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+
+    let plan = fixture.plan(false);
+
+    assert_eq!(plan.survivors.len(), 1, "a missing slot must be materialized");
+    assert!(plan.skipped_entries.is_empty());
+}
+
+#[test]
+fn force_defeats_the_gvs_existing_slot_skip() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+    fixture.materialize_slot();
+
+    let plan = fixture.plan(true);
+
+    assert_eq!(plan.survivors.len(), 1, "--force must re-materialize an existing slot");
+}
+
+#[test]
+fn gvs_directory_resolution_is_never_skipped_by_slot_existence() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let metadata = PackageMetadata {
+        resolution: LockfileResolution::Directory(DirectoryResolution {
+            directory: "local-foo".to_string(),
+        }),
+        ..registry_metadata()
+    };
+    let fixture = PlanFixture::gvs(temp_dir.path(), metadata);
+    fixture.materialize_slot();
+
+    let plan = fixture.plan(false);
+
+    assert_eq!(
+        plan.survivors.len(),
+        1,
+        "a directory resolution's source is mutable, so its slot must be re-imported",
+    );
+}
+
+#[test]
+fn existing_slot_without_gvs_still_survives_without_a_current_lockfile() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let gvs_fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+    let fixture = PlanFixture {
+        layout: VirtualStoreLayout::legacy(temp_dir.path().join("virtual-store"), 120),
+        ..gvs_fixture
+    };
+    fixture.materialize_slot();
+
+    let plan = fixture.plan(false);
+
+    assert_eq!(
+        plan.survivors.len(),
+        1,
+        "a project-local slot is not content-addressed, so existence alone must not skip it",
     );
 }

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
@@ -165,13 +165,19 @@ impl PlanFixture {
         self.snapshots.keys().next().expect("fixture holds one snapshot")
     }
 
-    fn materialize_slot(&self) {
-        let dir = self
-            .layout
+    fn slot_package_dir(&self) -> std::path::PathBuf {
+        self.layout
             .slot_dir(self.snapshot_key())
             .join("node_modules")
-            .join(self.snapshot_key().name.to_string());
-        fs::create_dir_all(dir).expect("materialize the slot's package dir");
+            .join(self.snapshot_key().name.to_string())
+    }
+
+    fn materialize_slot(&self) {
+        let dir = self.slot_package_dir();
+        fs::create_dir_all(&dir).expect("materialize the slot's package dir");
+        // The import places the completion marker (`package.json`) last;
+        // a slot without it is a partial import.
+        fs::write(dir.join("package.json"), "{}").expect("place the completion marker");
     }
 
     fn plan(&self, force: bool) -> SnapshotPlan<'_> {
@@ -225,6 +231,22 @@ fn gvs_existing_slot_is_skipped_without_a_current_lockfile() {
     assert!(
         cache_key.is_some(),
         "the skipped entry must keep its cache key so its store-index rows still feed the build phase",
+    );
+}
+
+#[test]
+fn gvs_partial_slot_without_completion_marker_survives() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+    fs::create_dir_all(fixture.slot_package_dir())
+        .expect("materialize the slot's package dir without its completion marker");
+
+    let plan = fixture.plan(false);
+
+    assert_eq!(
+        plan.survivors.len(),
+        1,
+        "a slot directory without its completion marker is a partial import and must be repaired",
     );
 }
 

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
@@ -181,6 +181,16 @@ impl PlanFixture {
     }
 
     fn plan(&self, force: bool) -> SnapshotPlan<'_> {
+        self.plan_inner(false, force)
+    }
+
+    /// Plan with a current lockfile that matches the wanted one, as a
+    /// completed previous install would have recorded it.
+    fn plan_with_matching_current(&self, force: bool) -> SnapshotPlan<'_> {
+        self.plan_inner(true, force)
+    }
+
+    fn plan_inner(&self, current_matches_wanted: bool, force: bool) -> SnapshotPlan<'_> {
         let allow_build_policy = AllowBuildPolicy::new(HashSet::new(), HashSet::new(), false);
         let mut cache_keys = self
             .snapshots
@@ -198,8 +208,8 @@ impl PlanFixture {
         plan_snapshots::<SilentReporter>(SnapshotPlanInputs {
             snapshots: &self.snapshots,
             packages: &self.packages,
-            current_snapshots: None,
-            current_packages: None,
+            current_snapshots: current_matches_wanted.then_some(&self.snapshots),
+            current_packages: current_matches_wanted.then_some(&self.packages),
             layout: &self.layout,
             allow_build_policy: &allow_build_policy,
             skipped: &SkippedSnapshots::default(),
@@ -270,6 +280,25 @@ fn force_defeats_the_gvs_existing_slot_skip() {
     let plan = fixture.plan(true);
 
     assert_eq!(plan.survivors.len(), 1, "--force must re-materialize an existing slot");
+}
+
+#[test]
+fn force_defeats_the_current_lockfile_skip() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let gvs_fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());
+    let fixture = PlanFixture {
+        layout: VirtualStoreLayout::legacy(temp_dir.path().join("virtual-store"), 120),
+        ..gvs_fixture
+    };
+    fixture.materialize_slot();
+
+    let plan = fixture.plan_with_matching_current(true);
+
+    assert_eq!(
+        plan.survivors.len(),
+        1,
+        "--force must re-materialize even a slot the current lockfile vouches for",
+    );
 }
 
 #[test]

--- a/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
+++ b/pnpm/crates/deps-restorer/src/create_virtual_store/snapshot_plan/tests.rs
@@ -261,6 +261,61 @@ fn gvs_partial_slot_without_completion_marker_survives() {
 }
 
 #[test]
+fn gvs_slot_missing_a_regular_child_link_survives() {
+    let temp_dir = tempfile::tempdir().expect("create temp directory");
+    let parent_key: PackageKey = "foo@1.0.0".parse().expect("parse snapshot key");
+    let child_key: PackageKey = "bar@1.0.0".parse().expect("parse snapshot key");
+    let parent_snapshot = SnapshotEntry {
+        dependencies: Some(HashMap::from([(
+            PkgName::parse("bar").expect("parse alias"),
+            SnapshotDepRef::Plain("1.0.0".parse().expect("parse version")),
+        )])),
+        ..SnapshotEntry::default()
+    };
+    let snapshots = HashMap::from([
+        (parent_key.clone(), parent_snapshot),
+        (child_key.clone(), SnapshotEntry::default()),
+    ]);
+    let packages = HashMap::from([
+        (parent_key.clone(), registry_metadata()),
+        (child_key.clone(), registry_metadata()),
+    ]);
+    let layout = VirtualStoreLayout::global(
+        temp_dir.path().join("links"),
+        120,
+        None,
+        Some(&snapshots),
+        Some(&packages),
+        None,
+        None,
+    );
+    let fixture = PlanFixture { snapshots, packages, layout };
+    let parent_dir = fixture.layout.slot_dir(&parent_key).join("node_modules").join("foo");
+    fs::create_dir_all(&parent_dir).expect("materialize the parent slot");
+    fs::write(parent_dir.join("package.json"), "{}").expect("place the completion marker");
+
+    let plan = fixture.plan(false);
+    let survivor_keys: HashSet<String> =
+        plan.survivors.iter().map(|(key, _, _)| key.to_string()).collect();
+    assert!(
+        survivor_keys.contains("foo@1.0.0"),
+        "a marker-complete slot missing a child link is a partial import and must be repaired",
+    );
+
+    let child_dir = fixture.layout.slot_dir(&child_key).join("node_modules").join("bar");
+    fs::create_dir_all(&child_dir).expect("materialize the child slot");
+    fs::write(child_dir.join("package.json"), "{}").expect("place the child completion marker");
+    pnpm_fs::symlink_dir(&child_dir, &parent_dir.parent().expect("modules dir").join("bar"))
+        .expect("link the child into the parent slot");
+
+    let plan = fixture.plan(false);
+    assert!(
+        plan.survivors.is_empty(),
+        "with the marker and every child link present both slots are complete",
+    );
+}
+
+#[test]
 fn gvs_missing_slot_survives_without_a_current_lockfile() {
     let temp_dir = tempfile::tempdir().expect("create temp directory");
     let fixture = PlanFixture::gvs(temp_dir.path(), registry_metadata());

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -246,13 +246,24 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
         // the `-exec` suffix (idempotent, a no-op for non-exec entries)
         // before adopting the dirent.
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link).map_err(
-                |error| LinkFileError::Import {
+            match pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link) {
+                Ok(()) => Ok(()),
+                // Nothing serializes shared-slot imports across
+                // processes: the writer that owns the target may
+                // replace it again before this chmod lands. Whoever
+                // unlinked the path writes an equivalent
+                // content-addressed file and restores its exec bit in
+                // turn, so `NotFound` means another writer finished
+                // the job — the same tolerance the bin-shim chmod
+                // applies (`chmod_tolerating_removal` in
+                // `pnpm-cmd-shim`, pnpm/pnpm#14353).
+                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(LinkFileError::Import {
                     from: source_file.to_path_buf(),
                     to: target_link.to_path_buf(),
                     error,
-                },
-            )
+                }),
+            }
         }
         Err(error) => Err(LinkFileError::Import {
             from: source_file.to_path_buf(),

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -253,11 +253,24 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
                 // replace it again before this chmod lands. Whoever
                 // unlinked the path writes an equivalent
                 // content-addressed file and restores its exec bit in
-                // turn, so `NotFound` means another writer finished
-                // the job — the same tolerance the bin-shim chmod
-                // applies (`chmod_tolerating_removal` in
-                // `pnpm-cmd-shim`, pnpm/pnpm#14353).
-                Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+                // turn, so `NotFound` with the dirent actually gone
+                // means another writer finished the job — the same
+                // tolerance the bin-shim chmod applies
+                // (`chmod_tolerating_removal` in `pnpm-cmd-shim`,
+                // pnpm/pnpm#14353). The dirent check keeps the
+                // dangling-symlink detection this recovery is
+                // responsible for: a symlink squatting at the path
+                // also opens as `NotFound`, but its dirent is still
+                // there and no concurrent writer will heal it.
+                Err(error)
+                    if error.kind() == io::ErrorKind::NotFound
+                        && matches!(
+                            fs::symlink_metadata(target_link),
+                            Err(ref stat_error) if stat_error.kind() == io::ErrorKind::NotFound,
+                        ) =>
+                {
+                    Ok(())
+                }
                 Err(error) => Err(LinkFileError::Import {
                     from: source_file.to_path_buf(),
                     to: target_link.to_path_buf(),

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -141,6 +141,31 @@ fn eexist_does_not_widen_non_exec_mode() {
     assert_eq!(dst_mode, 0o600, "non-exec EEXIST target must not gain exec bits");
 }
 
+/// A dangling symlink squatting at an executable entry's path must
+/// keep failing the import: the syscall reports EEXIST for the dirent,
+/// the exec-bit re-assertion opens through the symlink and gets
+/// `NotFound`, and no concurrent writer will ever heal it — unlike a
+/// target that truly vanished, whose remover writes an equivalent file.
+#[test]
+#[cfg(unix)]
+fn eexist_recovery_rejects_a_dangling_symlink_target() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    let dst = tmp.path().join("dst");
+    std::os::unix::fs::symlink(tmp.path().join("missing-target"), &dst).unwrap();
+
+    import_into_fresh_target::<SilentReporter>(
+        &AtomicU8::new(0),
+        PackageImportMethod::Hardlink,
+        &src,
+        &dst,
+    )
+    .expect_err("a dangling symlink at the target is corruption, not a concurrent writer");
+}
+
 /// Hardlinking in the same directory on the same filesystem works on
 /// every mainstream OS the project supports.
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes [pnpm/pnpm#14510](https://github.com/pnpm/pnpm/issues/14510).

Restoring a deleted `node_modules` from a warm global virtual store was several times slower in pnpm 12 than in pnpm 11, with the profile showing a storm of `symlink`/`open`/`stat` syscalls and heavy kernel contention.

Root cause: pacquet's per-snapshot skip decision (`plan_snapshots` in `pnpm-deps-restorer`) only skipped a snapshot when the previous install's current lockfile (`<virtual_store_dir>/lock.yaml`) vouched for it. That file lives inside the project's `node_modules/.pnpm`, so wiping `node_modules` wiped the baseline too, and every install re-linked every slot the global virtual store already held — re-probing completion markers and recreating every internal child symlink, which APFS serializes volume-wide.

The TypeScript CLI does not need the current lockfile for this: its `lockfileToDepGraph` has a GVS fast path that trusts an existing slot directory outright, because a global-virtual-store slot path is content-addressed (the graph hash covers the snapshot's wiring, integrity, and engine), so existence implies currency. This PR ports that fast path to pacquet: under the global virtual store, a snapshot whose slot's package directory exists is skipped even without a current-lockfile entry. All the existing guards keep their behavior:

- directory (`file:`) resolutions are never skipped (mutable source),
- `--force` disables the probe,
- missing slots and mismatched optional children still re-materialize,
- slots carrying a `.pnpm-needs-build` marker still force a rebuild.

On the Material UI repro from the issue (M4 Pro, APFS, five alternating warm restores per binary):

| Binary | Warm restore (median) |
|---|---:|
| pnpm 11.25.0 | 2.33 s |
| pnpm 12.3.1 | 1.90 s |
| this PR | 1.17 s |

With the fix, 1955 of 1959 snapshots are skipped (the remaining 4 are the repo's `allowBuilds: true` packages whose slots carry `.pnpm-needs-build` markers under `--ignore-scripts`, matching the TypeScript CLI's marker semantics), the warm link phase drops to ~100 ms, and the resulting tree is identical (2034 symlinks, same directory counts).

The TypeScript CLI already behaves this way (pnpm 11 is the fast baseline in the issue), so no TS-side change is needed.

## Squash Commit Body

```text
A wiped node_modules takes <virtual_store_dir>/lock.yaml with it, so the
per-snapshot skip decision in plan_snapshots lost its current-lockfile
baseline and every install re-linked every slot the global virtual store
already held. On APFS the resulting symlink storm serializes volume-wide,
making a warm restore several times slower than pnpm 11.

A global-virtual-store slot path is content-addressed: the graph hash
covers the snapshot's wiring, integrity, and engine, so an existing slot
is current evidence on its own. The plan pass now skips a snapshot whose
slot directory exists even without a current-lockfile entry, mirroring
the GVS fast path in the TypeScript CLI's lockfileToDepGraph. Directory
resolutions (mutable sources), --force, missing slots, mismatched
optional children, and slots carrying a .pnpm-needs-build marker keep
re-materializing exactly as before.

On the Material UI repro from the issue, a warm global-virtual-store
restore drops from about 1.9 s to about 1.1 s locally, with 1955 of 1959
snapshots skipped and an identical resulting tree.

The TypeScript CLI already behaves this way, so no TS-side change is
needed.

Closes pnpm/pnpm#14510.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (The
  TypeScript CLI already has this fast path; this PR ports it to pacquet.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058676&installation_model_id=426870&pr_number=14518&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14518&signature=62acf5065cda104a5b1f398fb59ca3c1869b5d737222d543b2ce392b0fe19b23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Warm reinstalls after deleting `node_modules` are faster by avoiding unnecessary package relinking when packages are already available.

- **Reliability**
  - Improved handling of complete and partial global virtual store entries during reinstalls.
  - Forced reinstalls continue to refresh existing package entries when requested.
  - Corrupted or incomplete package links are detected and repaired automatically.
  - Concurrent package restoration is handled more reliably, including dangling-link conflicts.

- **Bug Fixes**
  - Missing or incomplete package entries are now correctly repaired, while directory-based dependencies continue to be materialized as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->