### PR TITLE
ci(release): retry cross builds on transient failures

### DIFF
--- a/.github/scripts/cross-build.sh
+++ b/.github/scripts/cross-build.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Runs `cross build` with the given arguments, retrying when it fails.
+#
+# The release runners occasionally hit transient failures that a plain rerun
+# clears: the Apple linker has segfaulted mid-build, and tool downloads can
+# time out. Cargo keeps every crate a failed attempt did finish, so a retry
+# only redoes the crate that died. This wrapper saves the maintainer from
+# waiting on the whole run, then clicking "re-run failed jobs".
+
+set -euo pipefail
+
+attempts=3
+delay_seconds=15
+
+for attempt in $(seq 1 "$attempts"); do
+  if cross build "$@"; then
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    echo "::warning::cross build failed (attempt $attempt of $attempts), retrying in ${delay_seconds}s" >&2
+    sleep "$delay_seconds"
+  fi
+done
+
+echo "::error::cross build failed after $attempts attempts" >&2
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -617,7 +617,10 @@ jobs:
           version: ${{ needs.plan.outputs.rust_version }}
 
       - name: Build with cross
-        run: cross build --locked -p pnpm-cli --bin pnpm --release --target=${{ matrix.target }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: .github/scripts/cross-build.sh --locked -p pnpm-cli --bin pnpm --release --target="$TARGET"
 
       - name: Download node-gyp payload
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -747,7 +750,7 @@ jobs:
           if [[ "$TARGET" == *musl* ]]; then
             export RUSTFLAGS="-C target-feature=-crt-static"
           fi
-          cross build --locked -p pnpm-napi --profile napi-release --target="$TARGET"
+          .github/scripts/cross-build.sh --locked -p pnpm-napi --profile napi-release --target="$TARGET"
 
       - name: Prepare NAPI addon
         shell: bash
@@ -1202,7 +1205,10 @@ jobs:
         run: grep -E "^version\s*=\s*\"$VERSION\"" pnpr/crates/pnpr/Cargo.toml
 
       - name: Build with cross
-        run: cross build --locked -p pnpr --bin pnpr --release --target=${{ matrix.target }}
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: .github/scripts/cross-build.sh --locked -p pnpr --bin pnpr --release --target="$TARGET"
 
       # The binary is zipped to fix permission loss https://github.com/actions/upload-artifact#permission-loss
       # Rename the binary to include the target triple so the archive


### PR DESCRIPTION
## Summary

The v12.3.2 release run ([33818388735](https://github.com/pnpm/pnpm/actions/runs/33818388735/job/100855674397)) failed in `Package @pnpm/napi darwin-x64`: Apple clang segfaulted while linking the `httparse` build script. Nothing in the tree caused it. The same Blacksmith macOS image built v12.3.1 the day before, and every other Rust packaging job in the same run, including both darwin CLI builds, passed. The failure cancelled all sibling napi jobs, and the release had to wait for the whole run to finish before "re-run failed jobs" became available.

This PR routes the three release cross builds (Rust CLI, NAPI addon, pnpr) through `.github/scripts/cross-build.sh`, which retries `cross build` up to three times with a 15s pause. Cargo keeps every crate a failed attempt finished, so a retry only rebuilds the crate that died. Each retry emits a `::warning::` annotation so flakes stay visible in the run summary.

The Windows legs of `build-rust` and `build-pnpr` now run their build step under `bash` instead of the default `pwsh`. The napi packaging job already did this on both Windows targets, and the win32-arm64 clang-cl environment is exported through `GITHUB_ENV` and `GITHUB_PATH`, so it reaches bash the same way.

## Squash Commit Body

```text
The v12.3.2 release run died in "Package pnpm-napi darwin-x64" because
Apple clang segfaulted while linking the httparse build script. Nothing
in the tree changed; the same Blacksmith image built v12.3.1 fine the
day before. Every other packaging job was cancelled and the release had
to wait for the run to finish before "re-run failed jobs" was possible.

Route the three release cross builds through a wrapper script that
retries up to three times. Cargo keeps the crates a failed attempt
finished, so a retry only redoes the crate that died.

The Windows legs of build-rust and build-pnpr now run the build step
under bash instead of the default pwsh, as the napi packaging job
already did on both Windows targets. The clang-cl environment for
win32-arm64 is exported through GITHUB_ENV and GITHUB_PATH, so it
reaches bash the same way.
```

## Checklist

- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting. (CI only, no product code.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. (No published package changes.)
- [x] Added or updated tests. (The wrapper was exercised locally against a fake `cross` that fails once and then succeeds, and one that always fails.)
- [x] Updated the documentation if needed. (None needed.)

---
Written by an agent (Claude Code, claude-fable-5-1).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791072817&installation_model_id=426870&pr_number=14522&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14522&signature=c62a6ca1c4a5c5c1864c89e5b548111d39b0d9c4a5ae9327b9ba53e4367dd365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release build reliability by automatically retrying failed cross-platform builds up to three times.
  * Added a short delay and CI warnings between retry attempts.
  * Release builds now report a clear failure after all retry attempts are exhausted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->