### PR TITLE
perf(install): parallel importer manifest transforms and one-pass link rendering

### DIFF
--- a/.changeset/parallel-manifest-transforms.md
+++ b/.changeset/parallel-manifest-transforms.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up dependency resolution in large workspaces. pnpm now prepares project manifests for resolution in parallel and renders workspace link paths in a single pass [#14352](https://github.com/pnpm/pnpm/issues/14352).
+Sped up dependency resolution in large workspaces [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/.changeset/parallel-manifest-transforms.md
+++ b/.changeset/parallel-manifest-transforms.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up dependency resolution in large workspaces. pnpm now prepares project manifests for resolution in parallel and renders workspace link paths in a single pass [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
@@ -76,23 +76,31 @@ pub(super) fn build_manifest_transforms(
         || versions_overrider.as_ref().is_some_and(|overrider| !overrider.is_empty())
         || deploy_manifest_hook
     {
-        for (id, manifest) in importer_manifests {
-            let mut cloned = (*manifest).clone();
-            if let Some(extender) = compat_package_extender {
-                extender.apply(cloned.value_mut());
-            }
-            if let Some(extender) = package_extender.as_ref() {
-                extender.apply(cloned.value_mut());
-            }
-            if deploy_manifest_hook {
-                apply_deploy_manifest_hook(cloned.value_mut());
-            }
-            if let Some(overrider) = versions_overrider.as_ref() {
-                let manifest_dir = cloned.path().parent().map(Path::to_path_buf);
-                overrider.apply(&mut cloned, manifest_dir.as_deref());
-            }
-            effective_importer_manifests.insert(id.clone(), cloned);
-        }
+        // Every importer's transform is independent — a clone of its own
+        // manifest plus in-place rewrites — so a workspace-scale set fans
+        // out across rayon. The rebuilt `BTreeMap` restores the ordering
+        // regardless of completion order.
+        use rayon::prelude::*;
+        effective_importer_manifests = importer_manifests
+            .par_iter()
+            .map(|(id, manifest)| {
+                let mut cloned = (*manifest).clone();
+                if let Some(extender) = compat_package_extender {
+                    extender.apply(cloned.value_mut());
+                }
+                if let Some(extender) = package_extender.as_ref() {
+                    extender.apply(cloned.value_mut());
+                }
+                if deploy_manifest_hook {
+                    apply_deploy_manifest_hook(cloned.value_mut());
+                }
+                if let Some(overrider) = versions_overrider.as_ref() {
+                    let manifest_dir = cloned.path().parent().map(Path::to_path_buf);
+                    overrider.apply(&mut cloned, manifest_dir.as_deref());
+                }
+                (id.clone(), cloned)
+            })
+            .collect();
     }
 
     let compat_package_extensions_hook: Option<ManifestHook> = compat_package_extender

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -58,23 +58,78 @@ impl ImporterAnchor {
     /// target, or one that carries `..` components.
     pub(crate) fn target_relative_to_importer(&self, target: &str) -> Option<String> {
         let rel = self.rel_components.as_deref()?;
-        let segments = relative_segments(target)?;
+        if target.starts_with(SEPARATORS) {
+            return None;
+        }
+        // One pass over the target's bytes: classify each raw segment,
+        // grow the shared prefix, and remember where the kept tail
+        // starts. The kept tail is almost always verbatim — no
+        // collapsed separators, no `.` segments, no trailing separator
+        // — and then the rendering is one `String` build from two
+        // slices instead of a second segment split.
         let mut shared = 0;
         let mut still_shared = true;
-        for segment in segments.clone() {
-            if segment == ".." {
+        let mut tail_start: Option<usize> = None;
+        let mut tail_verbatim = true;
+        let mut pos = 0;
+        loop {
+            let end = target[pos..].find(SEPARATORS).map_or(target.len(), |offset| pos + offset);
+            let segment = &target[pos..end];
+            if segment.is_empty() || segment == "." {
+                if tail_start.is_some() {
+                    tail_verbatim = false;
+                }
+            } else if segment == ".." {
                 return None;
-            }
-            if still_shared && rel.get(shared).is_some_and(|name| name == segment) {
-                shared += 1;
             } else {
-                still_shared = false;
+                #[cfg(windows)]
+                if pos == 0 && segment.contains(':') {
+                    return None;
+                }
+                if still_shared && rel.get(shared).is_some_and(|name| name == segment) {
+                    shared += 1;
+                } else {
+                    still_shared = false;
+                    if tail_start.is_none() {
+                        tail_start = Some(pos);
+                    }
+                }
             }
+            if end == target.len() {
+                break;
+            }
+            pos = end + 1;
         }
-        Some(render(
-            std::iter::repeat_n("..", rel.len() - shared).chain(segments.skip(shared)),
-            3 * (rel.len() - shared) + target.len(),
-        ))
+        let climb = rel.len() - shared;
+        let tail = match tail_start {
+            Some(tail_start) if tail_verbatim => &target[tail_start..],
+            None => "",
+            // A tail that dropped or collapsed segments re-renders
+            // through the general segment join.
+            Some(_) => {
+                return Some(render(
+                    std::iter::repeat_n("..", climb).chain(relative_segments(target)?.skip(shared)),
+                    3 * climb + target.len(),
+                ));
+            }
+        };
+        let mut rendered = String::with_capacity(3 * climb + tail.len());
+        for _ in 0..climb {
+            if !rendered.is_empty() {
+                rendered.push('/');
+            }
+            rendered.push_str("..");
+        }
+        if !tail.is_empty() {
+            if !rendered.is_empty() {
+                rendered.push('/');
+            }
+            rendered.push_str(tail);
+        }
+        if rendered.contains('\\') {
+            rendered = rendered.replace('\\', "/");
+        }
+        Some(rendered)
     }
 
     /// Express an importer-relative `target` (which typically climbs

--- a/pnpm/crates/resolving-deps-resolver/src/link_target.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target.rs
@@ -61,12 +61,9 @@ impl ImporterAnchor {
         if target.starts_with(SEPARATORS) {
             return None;
         }
-        // One pass over the target's bytes: classify each raw segment,
-        // grow the shared prefix, and remember where the kept tail
-        // starts. The kept tail is almost always verbatim — no
-        // collapsed separators, no `.` segments, no trailing separator
-        // — and then the rendering is one `String` build from two
-        // slices instead of a second segment split.
+        // Avoid splitting the target a second time for the rendering:
+        // when the kept tail is verbatim — nothing collapsed or
+        // dropped — it copies over as one slice.
         let mut shared = 0;
         let mut still_shared = true;
         let mut tail_start: Option<usize> = None;

--- a/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/link_target/tests.rs
@@ -64,6 +64,31 @@ fn guards_send_unclean_inputs_to_the_fallback() {
     assert_eq!(disarmed.target_relative_to_lockfile_root("packages/lib"), None);
 }
 
+/// Targets whose kept tail is not verbatim — collapsed separators, `.`
+/// segments, a trailing separator — re-render through the segment join
+/// and agree with the clean spelling of the same target.
+#[test]
+fn filtered_segments_render_like_their_clean_spelling() {
+    let anchor = ImporterAnchor::new(&abs_root().join("packages/app"), abs_root());
+    for messy in ["packages//lib", "packages/./lib", "packages/lib/", "./packages/lib"] {
+        assert_eq!(
+            anchor.target_relative_to_importer(messy),
+            Some("../lib".to_string()),
+            "target {messy:?}",
+        );
+    }
+    assert_eq!(
+        anchor.target_relative_to_importer("packages/app"),
+        Some(String::new()),
+        "a target that is the importer itself renders empty",
+    );
+    assert_eq!(
+        anchor.target_relative_to_importer("packages"),
+        Some("..".to_string()),
+        "a target that is a prefix of the importer only climbs",
+    );
+}
+
 #[test]
 fn root_importer_uses_the_empty_suffix() {
     let rel = importer_rel_dir(abs_root(), abs_root()).expect("same dir");


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to [pnpm/pnpm#14352](https://github.com/pnpm/pnpm/issues/14352) (continuing the large-workspace performance effort).

Re-profiling the warm lockfile-only update on the 6,833-project repro (current `main`, ~1.07 s median locally) surfaced two per-importer costs still paid serially:

1. **`build_manifest_transforms` transformed every importer manifest on the main thread.** The compatibility-DB package extender is active by default, so a workspace-scale install always clones and rewrites all 6,833 importer manifests in a serial loop before resolution starts. Each importer's transform is independent, so the loop now fans out across rayon; the rebuilt `BTreeMap` restores ordering regardless of completion order. Profile: 16 → 2 samples.

2. **`ImporterAnchor::target_relative_to_importer` split the target string twice per edge** — once to find the shared prefix with the importer suffix, and again to render the kept tail (`str::split` was the single largest self-time entry in the profile). One pass over the target's bytes now classifies raw segments, grows the shared prefix, and remembers where the kept tail starts; when the tail is verbatim (no collapsed separators, `.` segments, or trailing separator — the overwhelmingly common case) the rendering is a single `String` build from the climb count and the raw tail slice. A non-verbatim tail falls back to the segment join. New unit tests pin that messy spellings (`packages//lib`, `packages/./lib`, `packages/lib/`, `./packages/lib`) render identically to their clean form, alongside the existing `diff_paths` parity test. Profile: peers pass 56 → 42 samples inclusive.

Benchmark (protocol from the prior PRs in this effort: restore `package.json` + `pnpm-lock.yaml`, flip one root dep `workspace:*` → `workspace:^`, `pnpm install --lockfile-only --trust-lockfile --offline --ignore-scripts`, medians of 10 runs):

| | median | min |
|---|---:|---:|
| main | 1067 ms | 1035 ms |
| this PR | 969 ms | 941 ms |

The produced lockfile is byte-identical: diffing against the committed lockfile shows exactly the one flipped specifier line.

This is pacquet-internal performance work with no user-visible behavior change, so no TypeScript-side change is needed.

## Squash Commit Body

```text
Two costs the warm lockfile-only update profile on the 6,833-project
workspace repro still charged per importer:

- build_manifest_transforms cloned and transformed every importer
  manifest serially; the compatibility-DB extender is active by
  default, so a workspace-scale install always paid the whole loop on
  the main thread. Each importer's transform is independent, so the
  loop now fans out across rayon and the rebuilt BTreeMap restores the
  ordering (16 -> 2 profile samples).

- ImporterAnchor::target_relative_to_importer split the target string
  twice per edge: once to find the shared prefix, and again to render
  the kept tail. One pass over the target's bytes now classifies the
  raw segments, grows the shared prefix, and remembers where the kept
  tail starts; when the tail is verbatim (no collapsed separators, dot
  segments, or trailing separator - the overwhelmingly common case)
  the rendering is a single String build from the climb and the raw
  tail slice. A non-verbatim tail falls back to the segment join, with
  new unit tests pinning that both spellings render identically.

Warm lockfile-only update on the repro: median 1067 ms -> 969 ms, with
the produced lockfile byte-identical (only the flipped specifier
changes). Part of the pnpm/pnpm#14352 performance effort.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-internal performance work; no behavior change to mirror.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791078476&installation_model_id=426870&pr_number=14523&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14523&signature=f5bb905a3a185bc0a43313f2a1327117fd43502d36da98b36a865772d50d1366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Dependency resolution now prepares project manifests in parallel, improving installation efficiency while preserving deterministic results.

- **Bug Fixes**
  - Workspace link paths are rendered more reliably, including paths with repeated separators, relative segments, trailing separators, and platform-specific formats.
  - Invalid anchored or drive-prefixed paths are handled safely.

- **Tests**
  - Added coverage for normalized workspace link rendering and edge cases involving equivalent or parent paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->