### PR TITLE
fix(store): keep CAS blobs on verification failure instead of unlinking them

### DIFF
--- a/.changeset/keep-cas-blobs-on-verify-failure.md
+++ b/.changeset/keep-cas-blobs-on-verify-failure.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-Fixed concurrent installs that share a store occasionally failing with an ENOENT error while importing a package file. Store integrity verification no longer deletes a mismatched or unreadable file, because another install may be importing from it at that moment. The re-fetch replaces the file atomically instead [#14353](https://github.com/pnpm/pnpm/issues/14353).
+Fixed concurrent installs sharing a store occasionally failing with an ENOENT error while importing a package file [#14353](https://github.com/pnpm/pnpm/issues/14353).

--- a/.changeset/keep-cas-blobs-on-verify-failure.md
+++ b/.changeset/keep-cas-blobs-on-verify-failure.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/store.cafs": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed concurrent installs that share a store occasionally failing with an ENOENT error while importing a package file. Store integrity verification no longer deletes a mismatched or unreadable file, because another install may be importing from it at that moment. The re-fetch replaces the file atomically instead [#14353](https://github.com/pnpm/pnpm/issues/14353).

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -431,40 +431,33 @@ fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> 
     passed
 }
 
-/// Remove a *directory* squatting at a CAFS blob path (stray
-/// `mkdir -p`, interrupted write, filesystem hiccup), so the store
-/// self-heals: the re-fetch's `rename` cannot replace a directory, and
-/// without this the next install's verification would fail again and
-/// again.
+/// Remove a *directory* squatting at a CAFS blob path so the
+/// re-fetch's `rename` can land. Every other dirent stays: the
+/// re-fetch replaces a mismatched file atomically, and unlinking here
+/// would race installs in other processes importing from this very
+/// path (pnpm/pnpm#14353's error class) — the verifier's lock is
+/// process-local, and [`verify_file_integrity`] reports a transient
+/// read failure the same way as a real mismatch.
 ///
-/// Any other dirent — a corrupt or truncated blob, a symlink — is
-/// deliberately left in place. The re-fetch replaces it atomically
-/// (`write_cas_file` byte-verifies an existing file and rename-swaps
-/// anything that doesn't match), so unlinking here buys nothing and
-/// races every other install sharing the store: nothing serializes
-/// installs across processes, and a concurrent install may hold this
-/// path in its `cas_paths` and be mid-import from it — the unlink
-/// surfaces there as an ENOENT that fails that whole install
-/// (pnpm/pnpm#14353's error class). This matters doubly because
-/// [`verify_file_integrity`] reports a *transient read failure* the
-/// same way as a mismatch, so an unlink here could remove a perfectly
-/// healthy blob.
-///
-/// Best-effort: errors are logged at `debug` and dropped — worst case
-/// the next install notices the same dirent and retries. We use
-/// `symlink_metadata` so a symlink is not followed into whatever it
-/// points at.
+/// `remove_dir_all` itself refuses a non-directory (a file or a
+/// symlink at the path errors without deleting anything), so the
+/// dirent-type decision and the removal are one call with no window
+/// between them. Best-effort: a failure is logged at `debug` and the
+/// next install retries.
 fn scrub_directory_at_cafs_path(path: &Path) {
-    if !fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir()) {
-        return;
-    }
     if let Err(error) = fs::remove_dir_all(path) {
-        tracing::debug!(
-            target: "pacquet::store_index",
-            ?path,
-            ?error,
-            "failed to scrub a directory at a CAFS path; next install will retry",
-        );
+        // A non-directory dirent (or nothing at all) at the path makes
+        // `remove_dir_all` fail without deleting anything — exactly the
+        // leave-it-alone outcome — so only a directory that could not
+        // be removed is worth a log line.
+        if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir()) {
+            tracing::debug!(
+                target: "pacquet::store_index",
+                ?path,
+                ?error,
+                "failed to scrub a directory at a CAFS path; next install will retry",
+            );
+        }
     }
 }
 

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -345,20 +345,18 @@ fn is_safe_overlay_path(filename: &str) -> bool {
 ///
 /// **Locking discipline.** The fast path (`is_modified == false`, i.e.
 /// the file's mtime is within 100 ms of the recorded `checked_at`)
-/// runs lock-free — it never touches the file's bytes and never
-/// considers a delete, so it cannot race with an in-flight writer.
-/// The slow path (where verification could lead to a
-/// [`remove_stale_cafs_entry`] call) acquires
+/// runs lock-free — it never touches the file's bytes, so it cannot
+/// race with an in-flight writer. The slow path acquires
 /// [`pnpm_fs::cas_write_lock`] for `path` before re-stating the
 /// file. This is the same per-path mutex
 /// [`pnpm_fs::ensure_file`] holds across `O_CREAT|O_EXCL` +
-/// `write_all`, so a concurrent writer's full sequence completes
-/// before the verifier evaluates the file. Without this gate, the
-/// verifier observes the writer's intermediate (partial) state,
-/// `unlink`s the file out from under the writer's open fd, and the
-/// install ends up with `cas_paths` referencing a path whose dirent
-/// has been removed — which surfaces later as ENOENT in
-/// `link_file`.
+/// `write_all`, so a concurrent same-process writer's full sequence
+/// completes before the verifier evaluates the file — without the
+/// gate the verifier would read the writer's intermediate (partial)
+/// state and report a spurious miss. The lock is process-local, which
+/// is exactly why a failed verification must never unlink a file:
+/// another *process* sharing the store may be importing from it — see
+/// [`scrub_directory_at_cafs_path`].
 fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> bool {
     // Lock-free fast path. `check_file` is read-only and only touches
     // the file's metadata; no risk of clobbering a writer's state.
@@ -406,18 +404,18 @@ fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> 
         return true;
     }
     if size != info.size {
-        // Wrong size → content definitely changed. Remove so the next
-        // caller fetches a clean copy. See `remove_stale_cafs_entry`
-        // for why this has to cover dirs too.
+        // Wrong size → content definitely changed. Report the miss so
+        // the caller re-fetches; see `scrub_directory_at_cafs_path` for
+        // why nothing but a directory is removed here.
         tracing::debug!(
             target: "pacquet::store_index",
             ?filename,
             ?path,
             expected_size = info.size,
             actual_size = size,
-            "CAFS file size mismatch; scrubbing and re-fetching",
+            "CAFS file size mismatch; re-fetching",
         );
-        remove_stale_cafs_entry(path);
+        scrub_directory_at_cafs_path(path);
         return false;
     }
     let passed = verify_file_integrity(path, &info.digest, algo);
@@ -426,37 +424,46 @@ fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> 
             target: "pacquet::store_index",
             ?filename,
             ?path,
-            "CAFS file digest mismatch or unknown algo; scrubbing and re-fetching",
+            "CAFS file digest mismatch, read failure, or unknown algo; re-fetching",
         );
-        remove_stale_cafs_entry(path);
+        scrub_directory_at_cafs_path(path);
     }
     passed
 }
 
-/// Remove a CAFS dirent that failed verification, with recursive
-/// (`rimraf`-style) semantics that also handle a directory.
+/// Remove a *directory* squatting at a CAFS blob path (stray
+/// `mkdir -p`, interrupted write, filesystem hiccup), so the store
+/// self-heals: the re-fetch's `rename` cannot replace a directory, and
+/// without this the next install's verification would fail again and
+/// again.
 ///
-/// `fs::remove_file` on a directory returns `EISDIR` / `EPERM`, and a
-/// corrupted store that has a directory sitting where a CAFS blob
-/// belongs (stray `mkdir -p`, interrupted write, filesystem hiccup)
-/// would stay there forever if we only tried `remove_file`. Next
-/// install's verification would fail again and again — the store
-/// wouldn't self-heal.
+/// Any other dirent — a corrupt or truncated blob, a symlink — is
+/// deliberately left in place. The re-fetch replaces it atomically
+/// (`write_cas_file` byte-verifies an existing file and rename-swaps
+/// anything that doesn't match), so unlinking here buys nothing and
+/// races every other install sharing the store: nothing serializes
+/// installs across processes, and a concurrent install may hold this
+/// path in its `cas_paths` and be mid-import from it — the unlink
+/// surfaces there as an ENOENT that fails that whole install
+/// (pnpm/pnpm#14353's error class). This matters doubly because
+/// [`verify_file_integrity`] reports a *transient read failure* the
+/// same way as a mismatch, so an unlink here could remove a perfectly
+/// healthy blob.
 ///
-/// Best-effort for both: try `remove_file`, fall back to
-/// `remove_dir_all` if the dirent is a directory. Errors are logged at
-/// `debug` and dropped — worst case the next install notices the same
-/// stale dirent and retries. We use `symlink_metadata` so we identify
-/// the dirent type without following a symlink.
-fn remove_stale_cafs_entry(path: &Path) {
-    let is_dir = fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir());
-    let result = if is_dir { fs::remove_dir_all(path) } else { fs::remove_file(path) };
-    if let Err(error) = result {
+/// Best-effort: errors are logged at `debug` and dropped — worst case
+/// the next install notices the same dirent and retries. We use
+/// `symlink_metadata` so a symlink is not followed into whatever it
+/// points at.
+fn scrub_directory_at_cafs_path(path: &Path) {
+    if !fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir()) {
+        return;
+    }
+    if let Err(error) = fs::remove_dir_all(path) {
         tracing::debug!(
             target: "pacquet::store_index",
             ?path,
             ?error,
-            "failed to scrub stale CAFS entry; next install will retry",
+            "failed to scrub a directory at a CAFS path; next install will retry",
         );
     }
 }

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -439,25 +439,57 @@ fn verify_file(path: &Path, filename: &str, info: &CafsFileInfo, algo: &str) -> 
 /// process-local, and [`verify_file_integrity`] reports a transient
 /// read failure the same way as a real mismatch.
 ///
-/// `remove_dir_all` itself refuses a non-directory (a file or a
-/// symlink at the path errors without deleting anything), so the
-/// dirent-type decision and the removal are one call with no window
-/// between them. Best-effort: a failure is logged at `debug` and the
-/// next install retries.
+/// A check-then-delete on the live path could delete whatever a
+/// concurrent process put there in between, so the dirent is renamed
+/// aside first and only then inspected: a directory is removed at its
+/// scrub name, and anything else — including a blob a concurrent
+/// re-fetch landed after the failed verification — is renamed back
+/// where it was. `remove_dir_all` is never pointed at the live path
+/// (it would unlink a terminal symlink there, not just a directory).
+///
+/// Best-effort throughout: a failure is logged at `debug` and the next
+/// install retries. A crash between the two renames leaves an inert
+/// `*.pacquet-scrub-*` entry in the shard directory, which nothing
+/// ever resolves.
 fn scrub_directory_at_cafs_path(path: &Path) {
-    if let Err(error) = fs::remove_dir_all(path) {
-        // A non-directory dirent (or nothing at all) at the path makes
-        // `remove_dir_all` fail without deleting anything — exactly the
-        // leave-it-alone outcome — so only a directory that could not
-        // be removed is worth a log line.
-        if fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir()) {
-            tracing::debug!(
-                target: "pacquet::store_index",
-                ?path,
-                ?error,
-                "failed to scrub a directory at a CAFS path; next install will retry",
-            );
-        }
+    // Cheap gate only — the rename + inspect below re-decides
+    // authoritatively, so a dirent swapped after this stat is still
+    // handled correctly. Without the gate every mismatched *file*
+    // would pay the rename round-trip and briefly vanish from its
+    // path.
+    if !fs::symlink_metadata(path).is_ok_and(|meta| meta.file_type().is_dir()) {
+        return;
+    }
+    static SCRUB_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let mut scrub_path = path.as_os_str().to_owned();
+    scrub_path.push(format!(
+        ".pacquet-scrub-{}-{}",
+        std::process::id(),
+        SCRUB_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    ));
+    let scrub_path = Path::new(&scrub_path);
+    if fs::rename(path, scrub_path).is_err() {
+        // Nothing left at the path (a concurrent scrubber won), or the
+        // rename is not possible; either way the next install retries.
+        return;
+    }
+    let is_dir = fs::symlink_metadata(scrub_path).is_ok_and(|meta| meta.file_type().is_dir());
+    let result = if is_dir {
+        fs::remove_dir_all(scrub_path)
+    } else {
+        // The dirent changed between the failed verification and the
+        // rename — a concurrent process replaced the squatter. Put the
+        // newcomer back where every reader expects it.
+        fs::rename(scrub_path, path)
+    };
+    if let Err(error) = result {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            ?path,
+            ?scrub_path,
+            ?error,
+            "failed to scrub a directory at a CAFS path; next install will retry",
+        );
     }
 }
 

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -253,6 +253,31 @@ fn careful_path_fails_unknown_algo_as_verification_failure() {
     );
 }
 
+/// A blob the verifier cannot open reports a miss like a mismatch
+/// would, and the failure may be transient — so the file must survive
+/// for the concurrent installs that may be importing from it.
+#[test]
+#[cfg(unix)]
+fn careful_path_fails_but_keeps_unreadable_file() {
+    use std::os::unix::fs::PermissionsExt;
+    let tmp = tempdir().unwrap();
+    let store_dir = StoreDir::new(tmp.path());
+    let content = b"guarded content";
+    let digest = sha512_hex(content);
+    let path = plant_cafs_file(&store_dir, &digest, 0o644, content);
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o000)).unwrap();
+    let entry =
+        index_with("sha512", vec![("x", info(&digest, content.len() as u64, 0o644, Some(0)))]);
+    let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+    dbg!(&result);
+    assert!(!result.passed, "an unreadable blob is a verification miss");
+    assert!(
+        path.exists(),
+        "a read failure is no evidence of corruption; the blob must survive for concurrent readers",
+    );
+}
+
 /// The tally is process-wide, so a test measuring a delta across it has
 /// to be the only one hashing at the time. Every test that hashes holds
 /// this for its duration; without it, a sibling's re-hash lands between

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -253,6 +253,32 @@ fn careful_path_fails_unknown_algo_as_verification_failure() {
     );
 }
 
+/// A symlink at a blob path fails verification (its target's bytes are
+/// not the store's), but only a *directory* may be scrubbed — the
+/// symlink itself must survive, like every other non-directory dirent.
+#[test]
+#[cfg(unix)]
+fn careful_path_fails_but_keeps_symlink_at_cafs_path() {
+    let tmp = tempdir().unwrap();
+    let store_dir = StoreDir::new(tmp.path());
+    let content = b"claimed content";
+    let digest = sha512_hex(content);
+    let target = tmp.path().join("elsewhere");
+    fs::write(&target, b"other bytes!!!!").unwrap();
+    let link = store_dir.cas_file_path_by_mode(&digest, 0o644).unwrap();
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    let entry =
+        index_with("sha512", vec![("x", info(&digest, content.len() as u64, 0o644, Some(0)))]);
+    let result = check_pkg_files_integrity(&store_dir, entry, &VerifiedFilesCache::new());
+    dbg!(&result);
+    assert!(!result.passed);
+    assert!(
+        fs::symlink_metadata(&link).is_ok(),
+        "a symlink at the blob path is not a directory and must not be scrubbed",
+    );
+}
+
 /// A blob the verifier cannot open reports a miss like a mismatch
 /// would, and the failure may be transient — so the file must survive
 /// for the concurrent installs that may be importing from it.

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -100,7 +100,7 @@ fn careful_path_fails_on_missing_cafs_file() {
 /// `checked_at = 0` makes the mtime-slack delta "definitely > 100 ms",
 /// forcing a re-hash.
 #[test]
-fn careful_path_removes_file_whose_content_hash_mismatches() {
+fn careful_path_fails_but_keeps_file_whose_content_hash_mismatches() {
     let _guard = TALLY.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let tmp = tempdir().unwrap();
     let store_dir = StoreDir::new(tmp.path());
@@ -115,13 +115,17 @@ fn careful_path_removes_file_whose_content_hash_mismatches() {
     dbg!(&result);
     assert!(!result.passed, "bad hash → fail");
     eprintln!("path={path:?} exists={}", path.exists());
-    assert!(!path.exists(), "mismatched file is removed so the next call re-fetches");
+    assert!(
+        path.exists(),
+        "the mismatched file stays: the re-fetch replaces it atomically, and a concurrent \
+         install sharing the store may be importing from this path right now",
+    );
 }
 
 /// `checked_at = 0` puts us firmly in the "modified" branch (mtime now
 /// > 100 ms past 0), so the size check runs.
 #[test]
-fn careful_path_removes_file_whose_size_mismatches_after_touch() {
+fn careful_path_fails_but_keeps_file_whose_size_mismatches_after_touch() {
     let tmp = tempdir().unwrap();
     let store_dir = StoreDir::new(tmp.path());
     let content = b"actual content";
@@ -132,7 +136,11 @@ fn careful_path_removes_file_whose_size_mismatches_after_touch() {
     dbg!(&result);
     assert!(!result.passed);
     eprintln!("path={path:?} exists={}", path.exists());
-    assert!(!path.exists(), "size mismatch removes the file so a re-fetch starts clean");
+    assert!(
+        path.exists(),
+        "the mismatched file stays: the re-fetch replaces it atomically, and a concurrent \
+         install sharing the store may be importing from this path right now",
+    );
 }
 
 #[test]
@@ -239,7 +247,10 @@ fn careful_path_fails_unknown_algo_as_verification_failure() {
     dbg!(&result);
     assert!(!result.passed);
     eprintln!("path={path:?} exists={}", path.exists());
-    assert!(!path.exists(), "unknown algo → treated as corrupt → removed");
+    assert!(
+        path.exists(),
+        "an unverifiable file is no evidence of corruption; it stays for the re-fetch to replace",
+    );
 }
 
 /// The tally is process-wide, so a test measuring a delta across it has
@@ -316,8 +327,9 @@ fn the_tally_covers_hashing_only() {
 }
 
 /// Plants a directory where a CAFS blob belongs (store corruption —
-/// stray `mkdir -p` or interrupted write) to exercise the dirent-type
-/// fallback in `remove_stale_cafs_entry`.
+/// stray `mkdir -p` or interrupted write) to exercise
+/// `scrub_directory_at_cafs_path`: a directory is the one dirent the
+/// re-fetch's rename cannot replace, so the verifier removes it.
 #[test]
 fn careful_path_removes_directory_at_cafs_path() {
     let tmp = tempdir().unwrap();

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -220,26 +220,22 @@ function verifyFile (
 }
 
 /**
- * A mismatched or unreadable file is left in place: the re-fetch replaces it
- * atomically (writeBufferToCafs verifies an existing file and swaps in a fresh
- * copy via temp+rename), while unlinking it here races every other install
- * sharing the store. Nothing serializes installs across processes, so a
- * concurrent install may hold this path in its files map and be importing from
- * it right now — the unlink surfaces there as ENOENT and fails that whole
- * install. Verification also reports a transient read failure the same way as
- * a mismatch, so an unlink could remove a perfectly healthy blob. Only a
- * directory squatting at the blob's path is removed: a rename cannot replace
- * it, so it would otherwise wedge the path forever.
+ * Removes a directory squatting at a CAFS blob path, so the re-fetch's rename
+ * can land. Every other dirent stays: the re-fetch replaces a mismatched file
+ * atomically (writeBufferToCafs), and unlinking here would race installs in
+ * other processes importing from this very path (the pnpm/pnpm#14353 error
+ * class) — verification also reports a transient read failure the same way as
+ * a real mismatch. The non-recursive rmdir refuses a non-directory without
+ * deleting anything; only its ENOTEMPTY (a directory, observed as such by the
+ * removal itself) falls back to the recursive removal.
  */
 function scrubDirectoryAtCafsPath (filename: string): void {
-  let stats
   try {
-    stats = fs.lstatSync(filename)
-  } catch {
-    return
-  }
-  if (stats.isDirectory()) {
-    rimrafSync(filename)
+    fs.rmdirSync(filename)
+  } catch (err: unknown) {
+    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOTEMPTY') {
+      rimrafSync(filename)
+    }
   }
 }
 

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -225,17 +225,48 @@ function verifyFile (
  * atomically (writeBufferToCafs), and unlinking here would race installs in
  * other processes importing from this very path (the pnpm/pnpm#14353 error
  * class) — verification also reports a transient read failure the same way as
- * a real mismatch. The non-recursive rmdir refuses a non-directory without
- * deleting anything; only its ENOTEMPTY (a directory, observed as such by the
- * removal itself) falls back to the recursive removal.
+ * a real mismatch.
+ *
+ * A check-then-delete on the live path could delete whatever a concurrent
+ * process put there in between, so the dirent is renamed aside first and only
+ * then inspected: a directory is removed at its scrub name, and anything
+ * else — including a blob a concurrent re-fetch landed after the failed
+ * verification — is renamed back where it was. Best-effort throughout; a
+ * crash between the two renames leaves an inert `*.pnpm-scrub-*` entry in the
+ * shard directory, which nothing ever resolves.
  */
+let scrubCounter = 0
 function scrubDirectoryAtCafsPath (filename: string): void {
+  let stats
   try {
-    fs.rmdirSync(filename)
-  } catch (err: unknown) {
-    if (util.types.isNativeError(err) && 'code' in err && err.code === 'ENOTEMPTY') {
-      rimrafSync(filename)
+    stats = fs.lstatSync(filename)
+  } catch {
+    return
+  }
+  // Cheap gate only — the rename + inspect below re-decides
+  // authoritatively, so a dirent swapped after this stat is still handled
+  // correctly. Without the gate every mismatched *file* would pay the
+  // rename round-trip and briefly vanish from its path.
+  if (!stats.isDirectory()) return
+  const scrubName = `${filename}.pnpm-scrub-${process.pid}-${scrubCounter++}`
+  try {
+    fs.renameSync(filename, scrubName)
+  } catch {
+    // Nothing left at the path (a concurrent scrubber won), or the rename
+    // is not possible; either way the next install retries.
+    return
+  }
+  try {
+    if (fs.lstatSync(scrubName).isDirectory()) {
+      rimrafSync(scrubName)
+    } else {
+      // The dirent changed between the failed verification and the
+      // rename — a concurrent process replaced the squatter. Put the
+      // newcomer back where every reader expects it.
+      fs.renameSync(scrubName, filename)
     }
+  } catch {
+    // Best-effort; the next install retries.
   }
 }
 

--- a/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
+++ b/pnpm11/store/cafs/src/checkPkgFilesIntegrity.ts
@@ -204,12 +204,12 @@ function verifyFile (
   if (currentFile == null) return false
   if (currentFile.isModified) {
     if (currentFile.size !== fstat.size) {
-      rimrafSync(filename)
+      scrubDirectoryAtCafsPath(filename)
       return false
     }
     const passed = tallyVerifyFileIntegrity(filename, { digest: fstat.digest, algorithm })
     if (!passed) {
-      gfs.unlinkSync(filename)
+      scrubDirectoryAtCafsPath(filename)
     }
     return passed
   }
@@ -217,6 +217,30 @@ function verifyFile (
   // digest read. Store integrity verification detects corruption; it does not make
   // a store writable by untrusted users safe.
   return true
+}
+
+/**
+ * A mismatched or unreadable file is left in place: the re-fetch replaces it
+ * atomically (writeBufferToCafs verifies an existing file and swaps in a fresh
+ * copy via temp+rename), while unlinking it here races every other install
+ * sharing the store. Nothing serializes installs across processes, so a
+ * concurrent install may hold this path in its files map and be importing from
+ * it right now — the unlink surfaces there as ENOENT and fails that whole
+ * install. Verification also reports a transient read failure the same way as
+ * a mismatch, so an unlink could remove a perfectly healthy blob. Only a
+ * directory squatting at the blob's path is removed: a rename cannot replace
+ * it, so it would otherwise wedge the path forever.
+ */
+function scrubDirectoryAtCafsPath (filename: string): void {
+  let stats
+  try {
+    stats = fs.lstatSync(filename)
+  } catch {
+    return
+  }
+  if (stats.isDirectory()) {
+    rimrafSync(filename)
+  }
 }
 
 /**

--- a/pnpm11/store/cafs/test/index.ts
+++ b/pnpm11/store/cafs/test/index.ts
@@ -1,3 +1,4 @@
+import crypto from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 
@@ -185,6 +186,38 @@ describe('checkPkgFilesIntegrity()', () => {
         }],
       ]),
     }).passed).toBeFalsy()
+  })
+
+  it('leaves a mismatched file in place for the re-fetch to replace atomically', () => {
+    const storeDir = temporaryDirectory()
+    const actual = Buffer.from('actual bytes!!!')
+    const claimedDigest = crypto.createHash('sha512').update('claimed content').digest('hex')
+    const filename = getFilePathByModeInCafs(storeDir, claimedDigest, 420)
+    fs.mkdirSync(path.dirname(filename), { recursive: true })
+    fs.writeFileSync(filename, actual)
+    expect(checkPkgFilesIntegrity(storeDir, {
+      algo: 'sha512',
+      files: new Map([
+        ['foo', { digest: claimedDigest, mode: 420, size: actual.length }],
+      ]),
+    }).passed).toBeFalsy()
+    // A concurrent install sharing the store may be importing from this
+    // path right now; the re-fetch replaces it via temp+rename instead.
+    expect(fs.existsSync(filename)).toBeTruthy()
+  })
+
+  it('removes a directory squatting at a blob path so the re-fetch can land', () => {
+    const storeDir = temporaryDirectory()
+    const claimedDigest = crypto.createHash('sha512').update('some content').digest('hex')
+    const filename = getFilePathByModeInCafs(storeDir, claimedDigest, 420)
+    fs.mkdirSync(filename, { recursive: true })
+    expect(checkPkgFilesIntegrity(storeDir, {
+      algo: 'sha512',
+      files: new Map([
+        ['foo', { digest: claimedDigest, mode: 420, size: 1_000_000 }],
+      ]),
+    }).passed).toBeFalsy()
+    expect(fs.existsSync(filename)).toBeFalsy()
   })
 })
 

--- a/pnpm11/store/cafs/test/index.ts
+++ b/pnpm11/store/cafs/test/index.ts
@@ -206,6 +206,29 @@ describe('checkPkgFilesIntegrity()', () => {
     expect(fs.existsSync(filename)).toBeTruthy()
   })
 
+  // Windows ignores the 0o000 mode, so the open cannot be made to fail there.
+  const itOnPosix = process.platform === 'win32' ? it.skip : it
+  itOnPosix('leaves an unreadable file in place', () => {
+    const storeDir = temporaryDirectory()
+    const content = Buffer.from('guarded content')
+    const digest = crypto.createHash('sha512').update(content).digest('hex')
+    const filename = getFilePathByModeInCafs(storeDir, digest, 420)
+    fs.mkdirSync(path.dirname(filename), { recursive: true })
+    fs.writeFileSync(filename, content)
+    fs.chmodSync(filename, 0)
+    // A non-ENOENT read failure surfaces as an error (graceful-fs already
+    // absorbs transient EMFILE pressure); what matters here is that the
+    // blob is not deleted on the way out.
+    expect(() => checkPkgFilesIntegrity(storeDir, {
+      algo: 'sha512',
+      files: new Map([
+        ['foo', { digest, mode: 420, size: content.length }],
+      ]),
+    })).toThrow()
+    fs.chmodSync(filename, 0o644)
+    expect(fs.existsSync(filename)).toBeTruthy()
+  })
+
   it('removes a directory squatting at a blob path so the re-fetch can land', () => {
     const storeDir = temporaryDirectory()
     const claimedDigest = crypto.createHash('sha512').update('some content').digest('hex')

--- a/pnpm11/store/cafs/test/index.ts
+++ b/pnpm11/store/cafs/test/index.ts
@@ -206,8 +206,9 @@ describe('checkPkgFilesIntegrity()', () => {
     expect(fs.existsSync(filename)).toBeTruthy()
   })
 
-  // Windows ignores the 0o000 mode, so the open cannot be made to fail there.
-  const itOnPosix = process.platform === 'win32' ? it.skip : it
+  // Windows ignores the 0o000 mode, and root reads through it, so the open
+  // cannot be made to fail in either case.
+  const itOnPosix = process.platform === 'win32' || process.getuid?.() === 0 ? it.skip : it
   itOnPosix('leaves an unreadable file in place', () => {
     const storeDir = temporaryDirectory()
     const content = Buffer.from('guarded content')


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to [pnpm/pnpm#14353](https://github.com/pnpm/pnpm/issues/14353) (the same error class), and fixes the intermittent macOS CI failure of `global_virtual_store::concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins` (seen on [pnpm/pnpm#14518](https://github.com/pnpm/pnpm/pull/14518) and [pnpm/pnpm#14523](https://github.com/pnpm/pnpm/pull/14523): `failed to import <store blob> to <slot file>: No such file or directory`).

Store integrity verification deleted a CAS blob whose size or digest check failed. That deletion is both unsafe and unnecessary:

- **Unsafe across processes.** The `cas_write_lock` guarding the verifier is process-local. Nothing serializes installs across processes, so a concurrent install sharing the store can hold the blob's path in its `cas_paths` and be mid-import from it — the unlink surfaces there as an ENOENT that fails that whole install. Verification also reports a *transient* open/read failure the same way as a real mismatch, so the unlink could remove a perfectly healthy blob.
- **Unnecessary.** On a verification miss the caller re-fetches, and both stacks' CAS writers already byte-verify an existing file and replace a mismatched one atomically via temp+rename (`write_cas_file` in pacquet, `writeBufferToCafs` in the TypeScript CLI). The store self-heals without any deletion.

The verifier now leaves every non-directory dirent in place and removes only a *directory* squatting at a blob path — the one dirent a rename cannot replace, which would otherwise wedge the path forever.

Applied to both stacks in this PR:

- pacquet: `check_pkg_files_integrity.rs` (`remove_stale_cafs_entry` becomes `scrub_directory_at_cafs_path`), with the three removal-asserting unit tests flipped to pin that mismatched/unverifiable files stay, and the directory-squat test retained.
- TypeScript CLI: `@pnpm/store.cafs` `checkPkgFilesIntegrity.ts` (`rimrafSync`/`unlinkSync` become `scrubDirectoryAtCafsPath`), with two new tests pinning the same contract.

The concurrent-GVS stress suite (30 tests, including the 20-repetition 8-worker test) passes locally with the fix; the race itself only reproduces at CI speeds, which is why it surfaced as a rare flake there.

## Squash Commit Body

```text
Store integrity verification deleted a blob whose size or digest check
failed. Both failure signals are unreliable for that decision: a
transient open or read error reports the same way as a real mismatch,
so a perfectly healthy blob could be unlinked. Worse, the deletion
races every other install sharing the store. The per-path
cas_write_lock that guards the verifier is process-local, so a
concurrent install in another process can hold the path in its
cas_paths and be mid-import from it; the unlink surfaces there as
'failed to import ... No such file or directory' and fails that whole
install. This is the intermittent failure the concurrent-GVS stress
test kept catching on macOS CI, and the same error class as
pnpm/pnpm#14353.

Deleting the file is also unnecessary: on a verification miss the
caller re-fetches, and both stacks' CAS writers already byte-verify an
existing file and replace a mismatched one atomically via temp+rename.
The verifier now leaves every non-directory dirent in place and only
removes a directory squatting at a blob path, which a rename cannot
replace and which would otherwise wedge the path forever.

Applied to both stacks: pacquet's check_pkg_files_integrity and the
TypeScript CLI's @pnpm/store.cafs checkPkgFilesIntegrity, with tests
updated on both sides to pin that mismatched files stay and squatting
directories are removed.

Related to pnpm/pnpm#14353.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791080737&installation_model_id=426870&pr_number=14526&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14526&signature=48f7e1d60494378e43c1af12458ce5cbfeaa2bdeb859af2e9d2368f758e9d564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent installs sharing a store by preserving mismatched, unreadable, or otherwise invalid package files during integrity checks.
  * Re-fetched package files can now replace existing files safely, reducing intermittent installation failures.
  * Directories occupying expected package file paths are removed so packages can be restored correctly, while non-directory entries such as symlinks remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->