### PR TITLE
fix(pacquet): make the placeholder bin runnable without a shebang

### DIFF
--- a/.changeset/sh-placeholder-bin.md
+++ b/.changeset/sh-placeholder-bin.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install` failing with `syntax error near unexpected token ')'` when pnpm was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts` [#14346](https://github.com/pnpm/pnpm/issues/14346). pnpm now runs through Node.js in those installs until the native binary is in place. On Windows such an install still cannot run pnpm.

--- a/.changeset/sh-placeholder-bin.md
+++ b/.changeset/sh-placeholder-bin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm install` failing with `syntax error near unexpected token ')'` when pnpm was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts` [#14346](https://github.com/pnpm/pnpm/issues/14346). pnpm now runs through Node.js in those installs until the native binary is in place. On Windows such an install still cannot run pnpm.
+pnpm now runs through Node.js when it was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts`. Those installs previously failed with `syntax error near unexpected token ')'`. On Windows they still cannot run pnpm [#14346](https://github.com/pnpm/pnpm/issues/14346).

--- a/.changeset/sh-placeholder-bin.md
+++ b/.changeset/sh-placeholder-bin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-pnpm now runs through Node.js when it was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts`. Those installs previously failed with `syntax error near unexpected token ')'`. On Windows they still cannot run pnpm [#14346](https://github.com/pnpm/pnpm/issues/14346).
+pnpm now runs through Node.js when it was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts`. Those installs previously failed with `syntax error near unexpected token ')'`. They still cannot run pnpm on Windows, and on macOS only a shell can start it [#14346](https://github.com/pnpm/pnpm/issues/14346).

--- a/.changeset/sh-placeholder-bin.md
+++ b/.changeset/sh-placeholder-bin.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-pnpm now runs through Node.js when it was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts`. Those installs previously failed with `syntax error near unexpected token ')'`. They still cannot run pnpm on Windows, and on macOS only a shell can start it [#14346](https://github.com/pnpm/pnpm/issues/14346).
+pnpm now runs through Node.js when it was installed by a tool that skips build scripts, such as Vercel's `packageManager` provisioning, Bun, Deno, or `npm install --ignore-scripts`. Those installs previously failed with `syntax error near unexpected token ')'`. They still cannot run pnpm on Windows. On macOS only a shell can start it [#14346](https://github.com/pnpm/pnpm/issues/14346).

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -289,11 +289,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Both, because the wrapper places and spawns a native executable and
-          # those are where Windows differs. The tests that need to spawn one
-          # skip themselves there; the download half runs everywhere.
+          # All three, because the wrapper places and spawns a native executable
+          # and runs a shebang-less bin, and those are where the platforms
+          # differ. Windows runs neither, so those tests skip themselves there;
+          # macOS reaches them through a BSD `sh`, `readlink`, and `dirname`.
           - os: blacksmith-4vcpu-ubuntu-2404
             os_label: ubuntu
+          - os: blacksmith-12vcpu-macos-latest
+            os_label: macos
           - os: blacksmith-8vcpu-windows-2025
             os_label: windows
     runs-on: ${{ matrix.os }}

--- a/pnpm/npm/pnpm/bin/pnpm.mjs
+++ b/pnpm/npm/pnpm/bin/pnpm.mjs
@@ -3,14 +3,17 @@
 // `./bin/pnpx.mjs` for every pnpm >=11 (see its `config.json`) and loads them
 // into its own Node.js process, which a native executable cannot be loaded into.
 //
-// Only Corepack reaches this file: `package.json#bin` still points at the native
-// binary, so an ordinary `npm install -g pnpm` never pays for a Node.js startup.
+// The `pnpm` placeholder bin runs it too, on Unix, when the install script that
+// replaces it with the native binary did not (build scripts blocked). An
+// ordinary `npm install -g pnpm` never pays for a Node.js startup:
+// `package.json#bin` points at the native binary.
 //
 // Corepack installs no dependencies and runs no lifecycle scripts, so the
 // `@pnpm/exe.<target>` package that carries the binary is absent and
 // `install.js` never ran. The binary is therefore downloaded on first use and
 // kept next to this wrapper — where the native binary also finds the `dist/`
-// payload it ships node-gyp in.
+// payload it ships node-gyp in. The placeholder's installs usually do carry
+// that package, and the binary is taken from there.
 //
 // The download itself is `get-pnpm`, the package behind https://get.pnpm.io,
 // which already knows how to verify one; it travels in that same `dist/`

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -7,7 +7,7 @@
 // the extensionless path after the `bin` rewrite, so postinstall asks npm to
 // regenerate them against `pnpm.exe`. When lifecycle scripts are blocked
 // (`--ignore-scripts`, pnpm/Bun default), the placeholder remains and runs pnpm
-// through Node.js on Unix (see the `pnpm` file); Windows cannot run it at all.
+// through Node.js wherever a shell reaches it (see the `pnpm` file).
 //
 // `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts on Unix (so only `pnpm` is
 // relinked); on Windows the native binary is hardlinked onto each and

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -6,8 +6,8 @@
 // the native binary at the same path. npm's global Windows shims still target
 // the extensionless path after the `bin` rewrite, so postinstall asks npm to
 // regenerate them against `pnpm.exe`. When lifecycle scripts are blocked
-// (`--ignore-scripts`, pnpm/Bun default), the placeholder remains and pnpm
-// cannot run.
+// (`--ignore-scripts`, pnpm/Bun default), the placeholder remains and runs pnpm
+// through Node.js on Unix (see the `pnpm` file); Windows cannot run it at all.
 //
 // `pn`/`pnpx`/`pnx` are committed `#!/bin/sh` scripts on Unix (so only `pnpm` is
 // relinked); on Windows the native binary is hardlinked onto each and

--- a/pnpm/npm/pnpm/pnpm
+++ b/pnpm/npm/pnpm/pnpm
@@ -4,8 +4,12 @@
 #
 # Shebang-less on purpose, and therefore an `sh` script: a bin shim generated
 # from a shebang records that interpreter, and pnpm 11 generates the shim before
-# it puts the native binary at this path. Windows cannot run an extension-less
-# file at all, so there a script-blocked install leaves pnpm unrunnable.
+# it puts the native binary at this path.
+#
+# Something has to retry this file under a shell, because the kernel answers
+# ENOEXEC for it. A bin shim and a shell both do, and so does glibc's `execvp`.
+# Apple's libc does not, so on macOS a program that spawns this path itself gets
+# ENOEXEC; Windows has neither and cannot reach it at all.
 if ! command -v node > /dev/null 2>&1; then
   echo "pnpm's native binary was not installed, and there is no Node.js to run pnpm without it." >&2
   echo "Reinstall pnpm with build scripts enabled (allow-list pnpm's build under pnpm or Bun, or drop --ignore-scripts)." >&2

--- a/pnpm/npm/pnpm/pnpm
+++ b/pnpm/npm/pnpm/pnpm
@@ -1,4 +1,34 @@
-This is a placeholder. pnpm's native binary replaces this file during
-installation (see ./install.js). If you are reading this, the install/build
-script did not run — reinstall with build scripts enabled (e.g. allow-list
-pnpm's build under pnpm or Bun, or drop --ignore-scripts).
+# pnpm's native binary replaces this file during installation (see
+# ./install.js). Until then this hands over to ./bin/pnpm.mjs, which finds the
+# installed binary or downloads one and spawns it.
+#
+# Shebang-less on purpose, and therefore an `sh` script: a bin shim generated
+# from a shebang records that interpreter, and pnpm 11 generates the shim before
+# it puts the native binary at this path. Windows cannot run an extension-less
+# file at all, so there a script-blocked install leaves pnpm unrunnable.
+if ! command -v node > /dev/null 2>&1; then
+  echo "pnpm's native binary was not installed, and there is no Node.js to run pnpm without it." >&2
+  echo "Reinstall pnpm with build scripts enabled (allow-list pnpm's build under pnpm or Bun, or drop --ignore-scripts)." >&2
+  exit 1
+fi
+
+if [ -t 2 ]; then
+  echo "pnpm is running through Node.js because the script that installs its native binary was skipped." >&2
+  echo "Reinstall pnpm with its build scripts allowed to run the binary directly." >&2
+fi
+
+# $0 is whatever shim or symlink pnpm was launched through; ./bin/pnpm.mjs is
+# found relative to this file. The hop cap matches the kernel's ELOOP limit, so
+# a cycle cannot hang the script.
+self=$0
+hops=0
+while [ -L "$self" ] && [ "$hops" -lt 40 ]; do
+  hops=$((hops + 1))
+  link=$(readlink "$self")
+  case $link in
+    /*) self=$link ;;
+    *) self=$(dirname "$self")/$link ;;
+  esac
+done
+
+exec node "$(dirname "$self")/bin/pnpm.mjs" "$@"

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -186,7 +186,7 @@ function writeFixture (t) {
  * @returns {string} Its stdout, decoded as UTF-8.
  */
 function runThroughShell (bin, args) {
-  return execFileSync('sh', ['-c', 'exec "$0" "$@"', bin, ...args], { encoding: 'utf8' })
+  return execFileSync('sh', [bin, ...args], { encoding: 'utf8' })
 }
 
 function runNpm (args, cwd) {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -15,6 +15,48 @@ const wrapperManifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'packag
 test('npm installs a shim that runs the native pnpm binary', (t) => {
   assert.equal(wrapperManifest.bin.pnpm, 'pnpm')
 
+  const { prefix } = installFixtureWithNpm(t, ['--dangerously-allow-all-scripts'])
+
+  if (process.platform === 'win32') {
+    const cmdShim = path.join(prefix, 'pnpm.cmd')
+    assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+
+    const powershellShim = path.join(prefix, 'pnpm.ps1')
+    assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)
+    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
+  } else {
+    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  }
+})
+
+// npm's shim execs the placeholder rather than naming an interpreter for it,
+// which is what keeps it working once the native binary takes the same path.
+// Windows has no such fallback: its shims can only run what the shell can.
+test('the shim runs pnpm through Node.js when npm skipped the install scripts', {
+  skip: process.platform === 'win32' && 'Windows cannot run an extension-less file',
+}, (t) => {
+  const { prefix, fixtureDir } = installFixtureWithNpm(t, ['--ignore-scripts'])
+  const placeholder = fs.readFileSync(path.join(fixtureDir, 'pnpm'), 'utf8')
+  const installedPlaceholder = path.join(prefix, 'lib', 'node_modules', 'pnpm-install-fixture', 'pnpm')
+  assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
+
+  assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  // The binary never arrived, so the placeholder is still what the shim runs.
+  assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
+})
+
+/**
+ * Install the wrapper fixture globally with npm into a prefix of its own, with
+ * the host's platform package as a `file:` optional dependency. Throws when npm
+ * fails; the temp tree is removed when `t` ends.
+ *
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {string[]} npmFlags Extra `npm install` flags, e.g. `--ignore-scripts`.
+ * @returns {{ prefix: string, fixtureDir: string }} The npm prefix the shims
+ *   landed in, and the fixture wrapper it was installed from.
+ */
+function installFixtureWithNpm (t, npmFlags) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm wrapper install-'))
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
 
@@ -30,8 +72,8 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
   writeNativeFixture(path.join(nativePackageDir, binFile))
 
   const fixtureDir = path.join(tempDir, 'wrapper')
-  fs.mkdirSync(fixtureDir)
-  for (const file of ['install.js', 'native-binary.mjs', wrapperManifest.bin.pnpm]) {
+  fs.mkdirSync(path.join(fixtureDir, 'bin'), { recursive: true })
+  for (const file of ['install.js', 'native-binary.mjs', 'bin/pnpm.mjs', wrapperManifest.bin.pnpm]) {
     fs.copyFileSync(path.join(wrapperDir, file), path.join(fixtureDir, file))
   }
   fs.writeFileSync(path.join(fixtureDir, 'package.json'), JSON.stringify({
@@ -51,24 +93,13 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
     'install',
     '--global',
     '--install-links=true',
-    '--dangerously-allow-all-scripts',
+    ...npmFlags,
     '--prefix',
     prefix,
     fixtureDir,
   ], tempDir)
-
-  if (process.platform === 'win32') {
-    const cmdShim = path.join(prefix, 'pnpm.cmd')
-    assert.match(fs.readFileSync(cmdShim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('cmd.exe', ['/d', '/s', '/c', 'call', cmdShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
-
-    const powershellShim = path.join(prefix, 'pnpm.ps1')
-    assert.match(fs.readFileSync(powershellShim, 'utf8'), /pnpm\.exe/)
-    assert.match(execFileSync('pwsh', ['-NoProfile', '-File', powershellShim, '--version'], { encoding: 'utf8' }), /^v\d+/)
-  } else {
-    assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
-  }
-})
+  return { prefix, fixtureDir }
+}
 
 function runNpm (args, cwd) {
   if (process.platform === 'win32') {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -11,6 +11,7 @@ import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
 
 const wrapperDir = path.resolve(fileURLToPath(import.meta.url), '../..')
 const wrapperManifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'package.json'), 'utf8'))
+const HAS_A_SHELL = process.platform === 'win32' && 'Windows has no sh'
 
 test('npm installs a shim that runs the native pnpm binary', (t) => {
   assert.equal(wrapperManifest.bin.pnpm, 'pnpm')
@@ -30,18 +31,18 @@ test('npm installs a shim that runs the native pnpm binary', (t) => {
   }
 })
 
-// npm's shim execs the placeholder rather than naming an interpreter for it,
-// which is what keeps it working once the native binary takes the same path.
-// Windows has no such fallback: its shims can only run what the shell can.
+// npm's bin points straight at the placeholder rather than naming an
+// interpreter for it, which is what keeps it working once the native binary
+// takes the same path. Windows has no shell that could run it instead.
 test('the shim runs pnpm through Node.js when npm skipped the install scripts', {
-  skip: process.platform === 'win32' && 'Windows cannot run an extension-less file',
+  skip: HAS_A_SHELL,
 }, (t) => {
   const { prefix, fixtureDir } = installFixtureWithNpm(t, ['--ignore-scripts'])
   const placeholder = fs.readFileSync(path.join(fixtureDir, 'pnpm'), 'utf8')
   const installedPlaceholder = path.join(prefix, 'lib', 'node_modules', 'pnpm-install-fixture', 'pnpm')
   assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
 
-  assert.equal(execFileSync(path.join(prefix, 'bin', 'pnpm'), ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  assert.equal(runThroughShell(path.join(prefix, 'bin', 'pnpm'), ['works']), 'fixture:works\n')
   // The binary never arrived, so the placeholder is still what the shim runs.
   assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
 })
@@ -50,11 +51,8 @@ test('the shim runs pnpm through Node.js when npm skipped the install scripts', 
 // pnpm leaves behind when a `packageManager` pin sends it to fetch a newer one.
 // Its two bin-link shapes are covered separately: a shim that execs the target,
 // and a symlink to it.
-const PNPM_SKIPS_THE_PLACEHOLDER = process.platform === 'win32' &&
-  'Windows cannot run an extension-less file'
-
 test('pnpm links a shim that runs the placeholder when it skipped the build scripts', {
-  skip: PNPM_SKIPS_THE_PLACEHOLDER,
+  skip: HAS_A_SHELL,
 }, (t) => {
   const { projectDir } = installFixtureWithPnpm(t, [])
   const bin = path.join(projectDir, 'node_modules', '.bin', 'pnpm')
@@ -66,13 +64,13 @@ test('pnpm links a shim that runs the placeholder when it skipped the build scri
 // The shape `installPnpmToTools` produces for the version store a
 // `packageManager` pin is delegated to.
 test('pnpm links a symlink that runs the placeholder when executables are symlinked', {
-  skip: PNPM_SKIPS_THE_PLACEHOLDER,
+  skip: HAS_A_SHELL,
 }, (t) => {
   const { projectDir } = installFixtureWithPnpm(t, ['--config.node-linker=hoisted'])
   const bin = path.join(projectDir, 'node_modules', '.bin', 'pnpm')
   assert.equal(fs.lstatSync(bin).isSymbolicLink(), true)
 
-  assert.equal(execFileSync(bin, ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+  assert.equal(runThroughShell(bin, ['works']), 'fixture:works\n')
 })
 
 /**
@@ -176,6 +174,19 @@ function writeFixture (t) {
   }))
 
   return { tempDir, fixtureDir }
+}
+
+/**
+ * Run `bin` from a shell, as a user's `pnpm` is run. A shebang-less bin is
+ * reached only that way outside Linux, whose libc retries ENOEXEC under `/bin/sh`
+ * itself. Throws when it exits non-zero.
+ *
+ * @param {string} bin Absolute path to the bin to run.
+ * @param {string[]} args Arguments to pass to it.
+ * @returns {string} Its stdout, decoded as UTF-8.
+ */
+function runThroughShell (bin, args) {
+  return execFileSync('sh', ['-c', 'exec "$0" "$@"', bin, ...args], { encoding: 'utf8' })
 }
 
 function runNpm (args, cwd) {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -46,10 +46,38 @@ test('the shim runs pnpm through Node.js when npm skipped the install scripts', 
   assert.equal(fs.readFileSync(installedPlaceholder, 'utf8'), placeholder)
 })
 
+// pnpm blocks a dependency's build scripts by default, so this is what an older
+// pnpm leaves behind when a `packageManager` pin sends it to fetch a newer one.
+// Its two bin-link shapes are covered separately: a shim that execs the target,
+// and a symlink to it.
+const PNPM_SKIPS_THE_PLACEHOLDER = process.platform === 'win32' &&
+  'Windows cannot run an extension-less file'
+
+test('pnpm links a shim that runs the placeholder when it skipped the build scripts', {
+  skip: PNPM_SKIPS_THE_PLACEHOLDER,
+}, (t) => {
+  const { projectDir } = installFixtureWithPnpm(t, [])
+  const bin = path.join(projectDir, 'node_modules', '.bin', 'pnpm')
+  assert.equal(fs.lstatSync(bin).isSymbolicLink(), false)
+
+  assert.equal(execFileSync(bin, ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+})
+
+// The shape `installPnpmToTools` produces for the version store a
+// `packageManager` pin is delegated to.
+test('pnpm links a symlink that runs the placeholder when executables are symlinked', {
+  skip: PNPM_SKIPS_THE_PLACEHOLDER,
+}, (t) => {
+  const { projectDir } = installFixtureWithPnpm(t, ['--config.node-linker=hoisted'])
+  const bin = path.join(projectDir, 'node_modules', '.bin', 'pnpm')
+  assert.equal(fs.lstatSync(bin).isSymbolicLink(), true)
+
+  assert.equal(execFileSync(bin, ['works'], { encoding: 'utf8' }), 'fixture:works\n')
+})
+
 /**
- * Install the wrapper fixture globally with npm into a prefix of its own, with
- * the host's platform package as a `file:` optional dependency. Throws when npm
- * fails; the temp tree is removed when `t` ends.
+ * Install the wrapper fixture globally with npm into a prefix of its own.
+ * Throws when npm fails; the temp tree is removed when `t` ends.
  *
  * @param {import('node:test').TestContext} t The test, for cleanup.
  * @param {string[]} npmFlags Extra `npm install` flags, e.g. `--ignore-scripts`.
@@ -57,6 +85,65 @@ test('the shim runs pnpm through Node.js when npm skipped the install scripts', 
  *   landed in, and the fixture wrapper it was installed from.
  */
 function installFixtureWithNpm (t, npmFlags) {
+  const { tempDir, fixtureDir } = writeFixture(t)
+
+  const prefix = path.join(tempDir, 'prefix')
+  runNpm([
+    'install',
+    '--global',
+    '--install-links=true',
+    ...npmFlags,
+    '--prefix',
+    prefix,
+    fixtureDir,
+  ], tempDir)
+  return { prefix, fixtureDir }
+}
+
+/**
+ * Install the wrapper fixture into a project of its own with the `pnpm` on
+ * PATH, from a tarball so it is unpacked rather than linked, and with its build
+ * scripts skipped. Throws when pnpm fails; the temp tree is removed when `t`
+ * ends.
+ *
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {string[]} pnpmFlags Extra `pnpm add` flags, e.g. a node linker.
+ * @returns {{ projectDir: string, fixtureDir: string }} The project the bin was
+ *   linked into, and the fixture wrapper it was installed from.
+ */
+function installFixtureWithPnpm (t, pnpmFlags) {
+  const { tempDir, fixtureDir } = writeFixture(t)
+  runNpm(['pack', fixtureDir, '--pack-destination', tempDir], tempDir)
+  const tarball = path.join(tempDir, 'pnpm-install-fixture-1.0.0.tgz')
+
+  const projectDir = path.join(tempDir, 'project')
+  fs.mkdirSync(projectDir)
+  fs.writeFileSync(path.join(projectDir, 'package.json'), JSON.stringify({ name: 'project', private: true }))
+  execFileSync('pnpm', [
+    'add',
+    tarball,
+    // The fixture lives under the OS temp dir, so nothing above it should be
+    // read as a workspace, and nothing should reach the caller's store.
+    '--ignore-workspace',
+    '--store-dir',
+    path.join(tempDir, 'store'),
+    '--ignore-scripts',
+    ...pnpmFlags,
+  ], { cwd: projectDir, stdio: 'pipe' })
+  return { projectDir, fixtureDir }
+}
+
+/**
+ * The wrapper as a package manager receives it: the files a script-less install
+ * leaves behind, and the host's platform package as a `file:` optional
+ * dependency. Filesystem errors propagate; the temp tree is removed when `t`
+ * ends.
+ *
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @returns {{ tempDir: string, fixtureDir: string }} The temp root, and the
+ *   wrapper directory inside it.
+ */
+function writeFixture (t) {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm wrapper install-'))
   t.after(() => fs.rmSync(tempDir, { recursive: true, force: true }))
 
@@ -88,17 +175,7 @@ function installFixtureWithNpm (t, npmFlags) {
     optionalDependencies: { [packageName]: `file:${nativePackageDir}` },
   }))
 
-  const prefix = path.join(tempDir, 'prefix')
-  runNpm([
-    'install',
-    '--global',
-    '--install-links=true',
-    ...npmFlags,
-    '--prefix',
-    prefix,
-    fixtureDir,
-  ], tempDir)
-  return { prefix, fixtureDir }
+  return { tempDir, fixtureDir }
 }
 
 function runNpm (args, cwd) {

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -62,7 +62,7 @@ describe('placeholder bin', () => {
     const link = path.join(binDir, 'pnpm')
     fs.symlinkSync(path.relative(binDir, fixture.placeholder), link)
 
-    const result = await run('sh', ['-c', 'exec "$0" "$@"', link, '--version'])
+    const result = await run('sh', [link, '--version'])
     assert.equal(result.status, 0, result.stderr)
     assert.match(result.stdout, FAKE_BINARY_OUTPUT)
   })
@@ -85,7 +85,7 @@ describe('placeholder bin', () => {
   it('hands over to the entry point when no platform package is installed', { skip: HAS_A_SHELL }, async () => {
     const fixture = createFixture({ installPlatformPackage: false })
 
-    const result = await run('sh', ['-c', 'exec "$0" "$@"', fixture.placeholder, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    const result = await run('sh', [fixture.placeholder, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /Network access is disabled/)
   })

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -17,9 +17,14 @@ const WRAPPER_FILES = ['pnpm', 'native-binary.mjs', 'bin/pnpm.mjs']
 const FAKE_BINARY_OUTPUT = /^installed: --version\n$/
 
 const IS_UNIX = process.platform !== 'win32'
-// Windows runs neither the placeholder nor the stand-in for the native binary:
-// it has no ENOEXEC fallback for an extension-less file, and no `sh`.
-const RUNS_THE_PLACEHOLDER = !IS_UNIX && 'Windows cannot run an extension-less file'
+// A shebang-less file runs only where something retries it under a shell after
+// the kernel answers ENOEXEC. Every shell does, and so does glibc's `execvp` —
+// but Apple's libc does not, and Windows has neither. So a shim or a shell
+// reaches the placeholder wherever `sh` exists, while a bare `spawn` of it
+// reaches it on Linux alone.
+const HAS_A_SHELL = !IS_UNIX && 'Windows has no sh'
+const SPAWNS_A_SHEBANGLESS_FILE = process.platform !== 'linux' &&
+  `${process.platform} does not retry a shebang-less file under a shell`
 
 describe('placeholder bin', () => {
   // The constraint the whole file exists under: a bin shim generated from a
@@ -29,12 +34,13 @@ describe('placeholder bin', () => {
     assert.doesNotMatch(fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'), /^#!/)
   })
 
-  it('parses as an sh script', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  it('parses as an sh script', { skip: HAS_A_SHELL }, async () => {
     const result = await run('sh', ['-n', path.join(WRAPPER_DIR, 'pnpm')])
     assert.equal(result.status, 0, result.stderr)
   })
 
-  it('runs the installed native binary', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  // Spawned with no shell in between, which only Linux resolves.
+  it('runs the installed native binary', { skip: SPAWNS_A_SHEBANGLESS_FILE }, async () => {
     const fixture = createFixture()
 
     const result = await run(fixture.placeholder, ['--version'])
@@ -46,15 +52,17 @@ describe('placeholder bin', () => {
   })
 
   // How pnpm links a bin when it symlinks executables, which is what pnpm 10
-  // does for the version store it delegates a `packageManager` pin to.
-  it('runs from a symlink to itself', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  // does for the version store it delegates a `packageManager` pin to. Started
+  // from a shell, as a user's `pnpm` is, so the symlink chain `$0` walks is
+  // exercised on macOS too.
+  it('runs from a symlink to itself', { skip: HAS_A_SHELL }, async () => {
     const fixture = createFixture()
     const binDir = path.join(fixture.dir, 'node_modules', '.bin')
     fs.mkdirSync(binDir, { recursive: true })
     const link = path.join(binDir, 'pnpm')
     fs.symlinkSync(path.relative(binDir, fixture.placeholder), link)
 
-    const result = await run(link, ['--version'])
+    const result = await run('sh', ['-c', 'exec "$0" "$@"', link, '--version'])
     assert.equal(result.status, 0, result.stderr)
     assert.match(result.stdout, FAKE_BINARY_OUTPUT)
   })
@@ -62,7 +70,7 @@ describe('placeholder bin', () => {
   // What a bin linker writes for a target with no shebang, and the shape pnpm 11
   // leaves behind: an `exec` of the file itself, so the same shim keeps working
   // once the native binary takes its place.
-  it('runs from a bin shim that execs it', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  it('runs from a bin shim that execs it', { skip: HAS_A_SHELL }, async () => {
     const fixture = createFixture()
     const binDir = path.join(fixture.dir, 'node_modules', '.bin')
     fs.mkdirSync(binDir, { recursive: true })
@@ -74,10 +82,10 @@ describe('placeholder bin', () => {
     assert.match(result.stdout, FAKE_BINARY_OUTPUT)
   })
 
-  it('hands over to the entry point when no platform package is installed', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  it('hands over to the entry point when no platform package is installed', { skip: HAS_A_SHELL }, async () => {
     const fixture = createFixture({ installPlatformPackage: false })
 
-    const result = await run(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    const result = await run('sh', ['-c', 'exec "$0" "$@"', fixture.placeholder, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /Network access is disabled/)
   })

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -84,11 +84,13 @@ describe('placeholder bin', () => {
 
   // A project the wrapper sits under can hold anything under the platform
   // package's name; only what was installed with the wrapper is its binary.
-  it('does not run a platform package from an ancestor node_modules', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+  // Launched through the entry point, whose rule this is, so Windows is covered
+  // too — the placeholder cannot run there.
+  it('does not run a platform package from an ancestor node_modules', async () => {
     const fixture = createFixture({ installPlatformPackage: false, nestedUnder: ['node_modules', 'tool', 'node_modules'] })
     writePlatformPackage(path.join(fixture.dir, 'node_modules'))
 
-    const result = await run(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    const result = await run(process.execPath, [fixture.entryPoint, '--version'], { COREPACK_ENABLE_NETWORK: '0' })
     assert.notEqual(result.status, 0)
     assert.match(result.stderr, /Network access is disabled/)
     assert.doesNotMatch(result.stdout, FAKE_BINARY_OUTPUT)
@@ -100,7 +102,12 @@ describe('placeholder bin', () => {
  * Resolves once the child has exited, with its exit status and decoded output;
  * rejects only if it could not be spawned.
  *
+ * @param {string} command Executable to spawn, as an absolute path or a name on `PATH`.
+ * @param {string[]} args Arguments to pass to it.
+ * @param {Record<string, string>} [env] Variables layered over `process.env`; the
+ *   environment is inherited unchanged when omitted.
  * @returns {Promise<{status: number | null, stdout: string, stderr: string}>}
+ *   `status` is null when a signal ended the child.
  */
 function run (command, args, env) {
   const child = spawn(command, args, { env: { ...process.env, ...env } })
@@ -139,18 +146,22 @@ function createFixture ({ installPlatformPackage = true, nestedUnder = [] } = {}
     writePlatformPackage(path.join(wrapperDir, 'node_modules'))
   }
 
-  return { dir, placeholder: path.join(wrapperDir, 'pnpm') }
+  return { dir, placeholder: path.join(wrapperDir, 'pnpm'), entryPoint: path.join(wrapperDir, 'bin', 'pnpm.mjs') }
 }
 
 /**
  * Create the host's `@pnpm/exe.<target>` package under `modulesDir` (created if
- * missing): a manifest and the stand-in binary, an executable `sh` script.
- * Filesystem errors propagate.
+ * missing): a manifest and the stand-in binary — an executable `sh` script on
+ * Unix, a copy of the running node on Windows. Filesystem errors propagate.
  */
 function writePlatformPackage (modulesDir) {
   const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
   const packageDir = path.join(modulesDir, packageName)
   fs.mkdirSync(packageDir, { recursive: true })
   fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
-  fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
+  if (IS_UNIX) {
+    fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
+  } else {
+    fs.copyFileSync(process.execPath, path.join(packageDir, binFile))
+  }
 }

--- a/pnpm/npm/pnpm/test/placeholder.test.mjs
+++ b/pnpm/npm/pnpm/test/placeholder.test.mjs
@@ -1,11 +1,156 @@
+// Exercises the `pnpm` placeholder bin the way a script-less install leaves it:
+// the install script never replaced it with the native binary, so it is what
+// runs — as an `sh` script, since it carries no shebang for the kernel to read.
 import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
-import { test } from 'node:test'
+import process from 'node:process'
+import { after, describe, it } from 'node:test'
 import { fileURLToPath } from 'node:url'
 
-const wrapperDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
 
-test('the placeholder is not a Node.js script', () => {
-  assert.doesNotMatch(fs.readFileSync(path.join(wrapperDir, 'pnpm'), 'utf8'), /^#!/)
+const WRAPPER_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const WRAPPER_FILES = ['pnpm', 'native-binary.mjs', 'bin/pnpm.mjs']
+const FAKE_BINARY_OUTPUT = /^installed: --version\n$/
+
+const IS_UNIX = process.platform !== 'win32'
+// Windows runs neither the placeholder nor the stand-in for the native binary:
+// it has no ENOEXEC fallback for an extension-less file, and no `sh`.
+const RUNS_THE_PLACEHOLDER = !IS_UNIX && 'Windows cannot run an extension-less file'
+
+describe('placeholder bin', () => {
+  // The constraint the whole file exists under: a bin shim generated from a
+  // shebang records that interpreter, and pnpm 11 generates the shim before it
+  // puts the native binary at this path.
+  it('carries no shebang', () => {
+    assert.doesNotMatch(fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'), /^#!/)
+  })
+
+  it('parses as an sh script', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const result = await run('sh', ['-n', path.join(WRAPPER_DIR, 'pnpm')])
+    assert.equal(result.status, 0, result.stderr)
+  })
+
+  it('runs the installed native binary', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const fixture = createFixture()
+
+    const result = await run(fixture.placeholder, ['--version'])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, FAKE_BINARY_OUTPUT)
+    // Not a terminal, so no notice.
+    assert.equal(result.stderr, '')
+    assert.equal(fs.readFileSync(fixture.placeholder, 'utf8'), fs.readFileSync(path.join(WRAPPER_DIR, 'pnpm'), 'utf8'))
+  })
+
+  // How pnpm links a bin when it symlinks executables, which is what pnpm 10
+  // does for the version store it delegates a `packageManager` pin to.
+  it('runs from a symlink to itself', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const fixture = createFixture()
+    const binDir = path.join(fixture.dir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    const link = path.join(binDir, 'pnpm')
+    fs.symlinkSync(path.relative(binDir, fixture.placeholder), link)
+
+    const result = await run(link, ['--version'])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, FAKE_BINARY_OUTPUT)
+  })
+
+  // What a bin linker writes for a target with no shebang, and the shape pnpm 11
+  // leaves behind: an `exec` of the file itself, so the same shim keeps working
+  // once the native binary takes its place.
+  it('runs from a bin shim that execs it', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const fixture = createFixture()
+    const binDir = path.join(fixture.dir, 'node_modules', '.bin')
+    fs.mkdirSync(binDir, { recursive: true })
+    const shim = path.join(binDir, 'pnpm')
+    fs.writeFileSync(shim, `#!/bin/sh\nbasedir=$(dirname "$0")\nexec "$basedir/${path.relative(binDir, fixture.placeholder)}" "$@"\n`, { mode: 0o755 })
+
+    const result = await run(shim, ['--version'])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, FAKE_BINARY_OUTPUT)
+  })
+
+  it('hands over to the entry point when no platform package is installed', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const fixture = createFixture({ installPlatformPackage: false })
+
+    const result = await run(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Network access is disabled/)
+  })
+
+  // A project the wrapper sits under can hold anything under the platform
+  // package's name; only what was installed with the wrapper is its binary.
+  it('does not run a platform package from an ancestor node_modules', { skip: RUNS_THE_PLACEHOLDER }, async () => {
+    const fixture = createFixture({ installPlatformPackage: false, nestedUnder: ['node_modules', 'tool', 'node_modules'] })
+    writePlatformPackage(path.join(fixture.dir, 'node_modules'))
+
+    const result = await run(fixture.placeholder, ['--version'], { COREPACK_ENABLE_NETWORK: '0' })
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, /Network access is disabled/)
+    assert.doesNotMatch(result.stdout, FAKE_BINARY_OUTPUT)
+  })
 })
+
+/**
+ * Spawn `command` with `args`, `env` overriding the inherited environment.
+ * Resolves once the child has exited, with its exit status and decoded output;
+ * rejects only if it could not be spawned.
+ *
+ * @returns {Promise<{status: number | null, stdout: string, stderr: string}>}
+ */
+function run (command, args, env) {
+  const child = spawn(command, args, { env: { ...process.env, ...env } })
+
+  let stdout = ''
+  let stderr = ''
+  child.stdout.setEncoding('utf8').on('data', (chunk) => { stdout += chunk })
+  child.stderr.setEncoding('utf8').on('data', (chunk) => { stderr += chunk })
+
+  return new Promise((resolve, reject) => {
+    child.on('error', reject)
+    child.on('close', (status) => { resolve({ status, stdout, stderr }) })
+  })
+}
+
+/**
+ * A wrapper directory as a script-less install leaves it: the placeholder still
+ * in place, and — unless told otherwise — the platform package that carries the
+ * binary installed in the wrapper's own `node_modules`, since only the scripts
+ * were skipped. `nestedUnder` places the wrapper that many directories below
+ * the fixture root, which then stands for a project the wrapper sits under.
+ */
+function createFixture ({ installPlatformPackage = true, nestedUnder = [] } = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-placeholder-'))
+  after(() => fs.rmSync(dir, { force: true, recursive: true }))
+  const wrapperDir = path.join(dir, ...nestedUnder, nestedUnder.length > 0 ? 'pnpm' : '')
+
+  for (const file of WRAPPER_FILES) {
+    fs.mkdirSync(path.dirname(path.join(wrapperDir, file)), { recursive: true })
+    fs.copyFileSync(path.join(WRAPPER_DIR, file), path.join(wrapperDir, file))
+  }
+  fs.chmodSync(path.join(wrapperDir, 'pnpm'), 0o755)
+  fs.writeFileSync(path.join(wrapperDir, 'package.json'), JSON.stringify({ name: 'pnpm', version: '99.0.0' }))
+
+  if (installPlatformPackage) {
+    writePlatformPackage(path.join(wrapperDir, 'node_modules'))
+  }
+
+  return { dir, placeholder: path.join(wrapperDir, 'pnpm') }
+}
+
+/**
+ * Create the host's `@pnpm/exe.<target>` package under `modulesDir` (created if
+ * missing): a manifest and the stand-in binary, an executable `sh` script.
+ * Filesystem errors propagate.
+ */
+function writePlatformPackage (modulesDir) {
+  const { packageName, binFile } = splitBinSpecifier(getBinCandidates()[0])
+  const packageDir = path.join(modulesDir, packageName)
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.writeFileSync(path.join(packageDir, 'package.json'), JSON.stringify({ name: packageName, version: '99.0.0' }))
+  fs.writeFileSync(path.join(packageDir, binFile), '#!/bin/sh\necho "installed: $*"\n', { mode: 0o755 })
+}


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14346, reported again against 12.3.2 on Vercel:

```
Detected `pnpm-lock.yaml` version 9 generated by pnpm@10.x with package.json#packageManager pnpm@12.3.2
/vercel/.local/share/pnpm/.tools/pnpm/12.3.2/bin/pnpm: line 4: syntax error near unexpected token `)'
/vercel/.local/share/pnpm/.tools/pnpm/12.3.2/bin/pnpm: line 4: `pnpm's build under pnpm or Bun, or drop --ignore-scripts).'
```

The `pnpm` bin is a placeholder the preinstall script replaces with the native
binary. It has to stay shebang-less: a bin shim generated from a shebang records
that interpreter, and pnpm 11 generates the shim before it puts the binary at
that path (pnpm/pnpm#14502). An installer that skips build scripts never replaces
the file, and prose is not a shell script, so every command failed to parse.

This makes the placeholder a **valid `sh` script with no shebang**. On ENOEXEC
both the shell and glibc's `execvp` retry the file under `/bin/sh`, so it runs
from a symlinked bin, from a shim that execs it, and from a direct `spawn`. It
resolves `$0` through the symlink chain and hands over to `bin/pnpm.mjs`, which
finds the installed `@pnpm/exe.<target>` binary or downloads one. The old prose
survives as the branch taken when there is no Node.js.

Nothing changes for an ordinary install: `install.js` still replaces the file, so
no Node.js startup is paid per call.

**Why Vercel and not just pnpm 10.** `installPnpmToTools` only learned to run
`linkExePlatformBinary` for major >= 12 in 47ef6f04ed, released in 10.34.5 alone.
Vercel's build image is older, so it runs `pnpm add pnpm@<v12> --ignore-scripts`
and stops. That is unreachable retroactively, as are Bun, Deno, and
`npm install --ignore-scripts`.

**Where it does not reach.** Something has to retry the file under a shell after
the kernel answers ENOEXEC. A bin shim does, a shell does, and so does glibc's
`execvp` — but Apple's libc runs `execve` and returns the error, and Windows has
neither (cmd.exe cannot run an extension-less file, and `@zkochan/cmd-shim` falls
to `prog = quotedPathToTarget` with no shebang). So:

| | Linux | macOS | Windows |
| --- | --- | --- | --- |
| bin shim / shell (a user's `pnpm`) | ✓ | ✓ | ✗ |
| a program spawning the bin's path | ✓ | ✗ | ✗ |

The reported case is Vercel, which is Linux and goes through a shell. On macOS an
older pnpm's `switchCliVersion` spawns the path directly, so that delegation stays
broken there — as it is on 12.3.2 today, so no regression, but not a fix either.
The macOS runner added in 20cd69d3e7 is what surfaced this.

No single `bin/pnpm` can do better: any shebang, `#!/bin/sh` included, is recorded
by the shim and then breaks when the binary takes the path, and a file with no
shebang is not executable by `execve` at all.

## Squash Commit Body

```text
The npm package's `pnpm` bin is a placeholder that the preinstall script
replaces with the native binary. It has to stay shebang-less, because a bin
shim generated from a shebang records that interpreter and pnpm 11 generates
the shim before it puts the binary at that path. Installers that skip build
scripts never replace it, and a prose placeholder is not a shell script, so
every command failed with `syntax error near unexpected token ')'`.

Make the placeholder a valid `sh` script with no shebang. On ENOEXEC the shell
and glibc's `execvp` both retry the file under `/bin/sh`, so it runs from a
symlinked bin, from a shim that execs it, and from a direct spawn; it hands
over to `bin/pnpm.mjs`, which finds the installed binary or downloads one.
A shim generated from it still execs the file itself, so pnpm 11 delegation
keeps working once the binary takes the same path.

Windows has no ENOEXEC fallback and cannot run an extension-less file, so a
script-blocked install there still cannot run pnpm.

Closes pnpm/pnpm#14346.
```

## Verification

End-to-end against the bootstrapper that produced the report — pnpm 10.34.4 with
`packageManager: pnpm@12.3.2`, the same `.tools` tree, only the placeholder
swapped:

```
BEFORE  .tools/pnpm/12.3.2/bin/pnpm: line 4: syntax error near unexpected token `)'
AFTER   12.3.2
```

Each of the three placeholder variants was put in place to check the tests
discriminate in both directions:

| placeholder | wrapper suite | pnpm 11 delegation test |
| --- | --- | --- |
| prose (12.3.2) | 6 fail | pass |
| node shebang (12.3.0-1) | 2 fail | fail (pnpm/pnpm#14502) |
| this PR | 19 pass | pass |

That pnpm 11 test is `selfUpdate.test.ts`'s `linkExePlatformBinary` case, which
copies the real file and drives `linkBins` -> `linkExePlatformBinary` ->
`linkBins`. Full `selfUpdate.test.ts`: 75 passed, 1 skipped.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  <!-- The v12 npm wrapper is Rust-side only; pnpm 11's `@pnpm/exe` declares no
  `bin`, so it has no counterpart placeholder. -->
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791096858&installation_model_id=426870&pr_number=14527&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14527&signature=463f4422c41a1f27c8b56f76f605a715829feadf0614d58d83ef009c375da4e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pnpm fallback behavior when installation tools skip lifecycle scripts.
  * pnpm can now run through Node.js on Unix systems when the native binary is unavailable.
  * Improved support for placeholder scripts and symlinked installations.
  * Windows installations still cannot run pnpm when required installation scripts are blocked.

* **Tests**
  * Expanded coverage for fallback execution, symlinks, skipped install scripts, and platform-specific behavior on Linux and macOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
