### PR TITLE
fix(deps-restorer): preserve modules across exdev moves

### DIFF
--- a/.changeset/fix-pacquet-exdev-preserve.md
+++ b/.changeset/fix-pacquet-exdev-preserve.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pacquet` now preserves `node_modules` when a forced reinstall has to move a package directory across an `EXDEV` filesystem boundary.

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir.rs
@@ -1,5 +1,5 @@
 use crate::{
-    LinkFileError, import_into_fresh_target,
+    LinkFileError, import_into_fresh_target, link_file::is_cross_device,
     remove_quarantine::remove_quarantine_from_native_binaries,
 };
 use derive_more::{Display, Error};
@@ -724,7 +724,7 @@ fn preserve_modules_dir(
     destination: &Path,
     backup: &Path,
 ) -> Result<PreservedModules, PreserveModulesFailure> {
-    match fs::rename(source, destination) {
+    match move_dirent_or_copy_across_device(source, destination) {
         Ok(()) => return Ok(PreservedModules::Directory),
         Err(error) if is_modules_dir_collision(&error) => {}
         Err(error) => {
@@ -732,7 +732,7 @@ fn preserve_modules_dir(
         }
     }
 
-    fs::rename(source, backup)
+    move_dirent_or_copy_across_device(source, backup)
         .map_err(|error| PreserveModulesFailure { error, preserved: PreservedModules::None })?;
 
     let destination_entries = fs::read_dir(destination)
@@ -766,18 +766,83 @@ fn preserve_modules_dir(
         if destination_entries.contains(&name) {
             continue;
         }
-        fs::rename(entry.path(), destination.join(&name)).map_err(|error| {
-            PreserveModulesFailure {
+        move_dirent_or_copy_across_device(&entry.path(), &destination.join(&name)).map_err(
+            |error| PreserveModulesFailure {
                 error,
                 preserved: PreservedModules::Merged {
                     backup: backup.to_path_buf(),
                     moved_entries: moved_entries.clone(),
                 },
-            }
-        })?;
+            },
+        )?;
         moved_entries.push(name);
     }
     Ok(PreservedModules::Merged { backup: backup.to_path_buf(), moved_entries })
+}
+
+fn move_dirent_or_copy_across_device(source: &Path, destination: &Path) -> io::Result<()> {
+    match fs::rename(source, destination) {
+        Ok(()) => Ok(()),
+        Err(error) => copy_dirent_after_cross_device_rename_error(error, source, destination),
+    }
+}
+
+fn copy_dirent_after_cross_device_rename_error(
+    rename_error: io::Error,
+    source: &Path,
+    destination: &Path,
+) -> io::Result<()> {
+    if !is_cross_device(&rename_error) {
+        return Err(rename_error);
+    }
+
+    let file_type = fs::symlink_metadata(source)?.file_type();
+    copy_dirent(source, destination, file_type)?;
+    if file_type.is_dir() {
+        pnpm_fs::remove_dir_all_with_retry(source)
+    } else {
+        remove_non_dir_dirent(source, file_type)
+    }
+}
+
+fn copy_dirent(source: &Path, destination: &Path, file_type: fs::FileType) -> io::Result<()> {
+    if file_type.is_symlink() {
+        copy_symlink(source, destination)
+    } else if file_type.is_dir() {
+        copy_dir(source, destination)
+    } else if file_type.is_file() {
+        fs::copy(source, destination).map(|_| ())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "cannot copy unsupported node_modules entry",
+        ))
+    }
+}
+
+fn copy_dir(source: &Path, destination: &Path) -> io::Result<()> {
+    let permissions = fs::symlink_metadata(source)?.permissions();
+    fs::create_dir(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        copy_dirent(&entry.path(), &destination.join(entry.file_name()), file_type)?;
+    }
+    fs::set_permissions(destination, permissions)
+}
+
+fn copy_symlink(source: &Path, destination: &Path) -> io::Result<()> {
+    let target = fs::read_link(source)?;
+    #[cfg(unix)]
+    return std::os::unix::fs::symlink(target, destination);
+    #[cfg(windows)]
+    {
+        if matches!(fs::metadata(source), Ok(meta) if meta.is_dir()) {
+            std::os::windows::fs::symlink_dir(target, destination)
+        } else {
+            std::os::windows::fs::symlink_file(target, destination)
+        }
+    }
 }
 
 fn is_modules_dir_collision(error: &io::Error) -> bool {

--- a/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
+++ b/pnpm/crates/deps-restorer/src/import_indexed_dir/tests.rs
@@ -1,10 +1,13 @@
-use super::{ImportIndexedDirError, ImportIndexedDirOpts, claim_dir, import_indexed_dir};
+use super::{
+    ImportIndexedDirError, ImportIndexedDirOpts, claim_dir,
+    copy_dirent_after_cross_device_rename_error, import_indexed_dir,
+};
 use pnpm_config::PackageImportMethod;
 use pnpm_reporter::SilentReporter;
 use pretty_assertions::assert_eq;
 use std::{
     collections::HashMap,
-    fs,
+    fs, io,
     path::{Path, PathBuf},
     sync::atomic::AtomicU8,
 };
@@ -329,6 +332,42 @@ fn node_modules_collision_in_file_map_merges() {
     assert!(!target.join("node_modules/foo/stale.js").exists());
 }
 
+#[test]
+fn cross_device_preserve_fallback_copies_then_removes_source() {
+    let tmp = tempdir().unwrap();
+    let source = tmp.path().join("node_modules");
+    fs::create_dir_all(source.join("existing")).unwrap();
+    fs::write(source.join("existing/keep.js"), b"survivor").unwrap();
+
+    let destination = tmp.path().join("stage/node_modules");
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+
+    let exdev = cross_device_error();
+    copy_dirent_after_cross_device_rename_error(exdev, &source, &destination)
+        .expect("EXDEV should copy the tree and remove the source");
+
+    assert!(!source.exists(), "the old tree should be removed after copy fallback");
+    assert_eq!(fs::read(destination.join("existing/keep.js")).unwrap(), b"survivor");
+}
+
+#[cfg(unix)]
+#[test]
+fn cross_device_preserve_fallback_copies_symlinks_without_following() {
+    let tmp = tempdir().unwrap();
+    let source = tmp.path().join("node_modules");
+    fs::create_dir_all(&source).unwrap();
+    std::os::unix::fs::symlink("../real-target", source.join("pkg")).unwrap();
+
+    let destination = tmp.path().join("stage/node_modules");
+    fs::create_dir_all(destination.parent().unwrap()).unwrap();
+
+    let exdev = cross_device_error();
+    copy_dirent_after_cross_device_rename_error(exdev, &source, &destination)
+        .expect("EXDEV should preserve symlink entries");
+
+    assert_eq!(fs::read_link(destination.join("pkg")).unwrap(), PathBuf::from("../real-target"));
+}
+
 /// On Unix, when `Hardlink` is available we want force re-imports to
 /// share inodes with the freshly-staged source so re-installs benefit
 /// from the same store-sharing as fresh installs. Doubles as proof
@@ -360,6 +399,15 @@ fn hardlink_method_survives_staging_swap() {
     let src_ino = fs::metadata(&src).unwrap().ino();
     let dst_ino = fs::metadata(target.join("package.json")).unwrap().ino();
     assert_eq!(src_ino, dst_ino, "hardlinked re-import must share inode with the store source");
+}
+
+fn cross_device_error() -> io::Error {
+    #[cfg(unix)]
+    return io::Error::from_raw_os_error(18);
+    #[cfg(windows)]
+    return io::Error::from_raw_os_error(17);
+    #[cfg(not(any(unix, windows)))]
+    return io::Error::from(io::ErrorKind::Other);
 }
 
 /// Data-loss regression: if `remove_dir_all(dir_path)` fails *after*

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -359,7 +359,7 @@ fn clone_file(source_file: &Path, target_link: &Path) -> io::Result<()> {
 /// short-circuit and the link / reflink call. Falling back to
 /// `fs::copy` on that signal would overwrite the other process's
 /// freshly-installed file.
-fn is_cross_device(err: &io::Error) -> bool {
+pub(crate) fn is_cross_device(err: &io::Error) -> bool {
     #[cfg(unix)]
     return err.raw_os_error() == Some(18);
     #[cfg(windows)]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#14504.

`preserve_modules_dir` now falls back to copy-and-remove when moving a preserved `node_modules` entry fails with `EXDEV`. The fallback is shared by the direct preserve move, the merge backup move, and non-conflicting entry moves, and it preserves symlink entries without following them.

This is pacquet-only. The issue triage notes that the TypeScript CLI already goes through `renameEvenAcrossDevices` for the equivalent path.

## Squash Commit Body

```text
preserve_modules_dir moved an existing node_modules tree with fs::rename
before swapping in the newly imported package directory. On overlayfs,
renaming a directory that still lives in a lower image layer can fail
with EXDEV, which made global virtual store installs stop even though
only a preserve move was needed.

Reuse the existing cross-device errno classifier and fall back to
copying the dirent tree, then removing the source, when the preserve
move hits EXDEV. Apply the same move helper to the merge backup and
non-conflicting entry moves so bundled node_modules merges handle the
same filesystem boundary. The copy path preserves symlink entries
without following them.

Add regression coverage for the EXDEV fallback and symlink preservation.

Closes pnpm/pnpm#14504.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-only; the TypeScript CLI already uses `renameEvenAcrossDevices` here.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791096901&installation_model_id=426870&pr_number=14528&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14528&signature=38dd811e9c426747b556945afecd762747ca3a7766bc818d5ed5f89e107024ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->