### PR TITLE
feat: add linux-riscv64 build

### DIFF
--- a/.changeset/add-linux-riscv64-build.md
+++ b/.changeset/add-linux-riscv64-build.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+pnpm now runs on Linux systems with RISC-V (riscv64) CPUs [#7582](https://github.com/pnpm/pnpm/issues/7582).

--- a/.changeset/add-linux-riscv64-build.md
+++ b/.changeset/add-linux-riscv64-build.md
@@ -2,4 +2,4 @@
 "pacquet": minor
 ---
 
-pnpm now runs on Linux systems with RISC-V (riscv64) CPUs [#7582](https://github.com/pnpm/pnpm/issues/7582).
+pnpm now runs on Linux systems with RISC-V (riscv64) CPUs that use glibc [#7582](https://github.com/pnpm/pnpm/issues/7582).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,6 +715,10 @@ jobs:
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
 
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: riscv64gc-unknown-linux-gnu
+            code-target: linux-riscv64
+
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -595,6 +595,10 @@ jobs:
             target: aarch64-unknown-linux-musl
             code-target: linux-arm64-musl
 
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: riscv64gc-unknown-linux-gnu
+            code-target: linux-riscv64
+
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -107,7 +107,8 @@ The addon ships as prebuilt per-platform packages, the same model as the
   `optionalDependencies`.
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
-`linux-x64`, `linux-arm64`, `linux-x64-musl`, `linux-arm64-musl`.
+`linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-x64-musl`,
+`linux-arm64-musl`.
 
 ## Local development
 

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -41,6 +41,7 @@ const TARGETS = [
   { platform: 'darwin', arch: 'arm64', codeTarget: 'darwin-arm64', packageTarget: 'darwin-arm64' },
   { platform: 'linux', arch: 'x64', libc: 'glibc', codeTarget: 'linux-x64', packageTarget: 'linux-x64' },
   { platform: 'linux', arch: 'arm64', libc: 'glibc', codeTarget: 'linux-arm64', packageTarget: 'linux-arm64' },
+  { platform: 'linux', arch: 'riscv64', libc: 'glibc', codeTarget: 'linux-riscv64', packageTarget: 'linux-riscv64' },
   { platform: 'linux', arch: 'x64', libc: 'musl', codeTarget: 'linux-x64-musl', packageTarget: 'linux-x64-musl' },
   { platform: 'linux', arch: 'arm64', libc: 'musl', codeTarget: 'linux-arm64-musl', packageTarget: 'linux-arm64-musl' },
 ]

--- a/pnpm/npm/pnpm/install.js
+++ b/pnpm/npm/pnpm/install.js
@@ -23,6 +23,7 @@ import path from 'node:path'
 import process from 'node:process'
 import {
   getBinCandidates,
+  hostTarget,
   readWrapperManifest,
   resolveInstalledBinary,
   splitBinSpecifier,
@@ -47,7 +48,7 @@ function setup () {
 
   const candidates = getBinCandidates()
   if (candidates.length === 0) {
-    fail(`pnpm does not ship a prebuilt binary for ${process.platform}-${process.arch}.`)
+    fail(`pnpm does not ship a prebuilt binary for ${hostTarget()}.`)
   }
 
   const nativeBinary = resolveInstalledBinary()

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -29,6 +29,11 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-arm64/pnpm',
       musl: '@pnpm/exe.linux-arm64-musl/pnpm',
     },
+    // Only a glibc build is released for this architecture, so the specifier
+    // is a plain string rather than a libc pair: the libc ordering below maps
+    // over the pair's keys, and a missing one would yield an `undefined`
+    // specifier.
+    riscv64: '@pnpm/exe.linux-riscv64/pnpm',
   },
 }
 

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -29,11 +29,12 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-arm64/pnpm',
       musl: '@pnpm/exe.linux-arm64-musl/pnpm',
     },
-    // Only a glibc build is released for this architecture, so the specifier
-    // is a plain string rather than a libc pair: the libc ordering below maps
-    // over the pair's keys, and a missing one would yield an `undefined`
-    // specifier.
-    riscv64: '@pnpm/exe.linux-riscv64/pnpm',
+    // No musl build is released for this architecture. The pair is therefore
+    // glibc-only, and a musl host resolves no candidate at all rather than a
+    // binary it cannot run.
+    riscv64: {
+      glibc: '@pnpm/exe.linux-riscv64/pnpm',
+    },
   },
 }
 
@@ -54,8 +55,17 @@ export function getBinCandidates () {
     return [platformEntry]
   }
 
-  const order = detectLinuxLibc() === 'musl' ? ['musl', 'glibc'] : ['glibc', 'musl']
-  return order.map((libc) => platformEntry[libc])
+  // `detectLinuxLibc` returns null when `process.report` is unavailable; that
+  // falls back to glibc, which is what the ordering defaulted to before.
+  const detected = detectLinuxLibc() === 'musl' ? 'musl' : 'glibc'
+  const preferred = platformEntry[detected]
+  // An architecture released for only one libc has no entry for the other, and
+  // the binary it does ship cannot run there, so it offers no candidate.
+  if (preferred == null) {
+    return []
+  }
+  const alternate = platformEntry[detected === 'musl' ? 'glibc' : 'musl']
+  return alternate == null ? [preferred] : [preferred, alternate]
 }
 
 /**

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -29,9 +29,7 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-arm64/pnpm',
       musl: '@pnpm/exe.linux-arm64-musl/pnpm',
     },
-    // No musl build is released for this architecture. The pair is therefore
-    // glibc-only, and a musl host resolves no candidate at all rather than a
-    // binary it cannot run.
+    // Only a glibc build is released for riscv64.
     riscv64: {
       glibc: '@pnpm/exe.linux-riscv64/pnpm',
     },
@@ -39,9 +37,10 @@ const PLATFORMS = {
 }
 
 /**
- * Native binary specifiers to try, most-preferred first; empty when the host is
- * unsupported. The linux glibc/musl pair is ordered by detected libc, which
- * only decides the winner when both are installed (e.g. `npm install --force`).
+ * Native binary specifiers to try, most-preferred first; empty when no released
+ * binary runs on the host. The linux glibc/musl pair is ordered by detected
+ * libc, which only decides the winner when both are installed (e.g.
+ * `npm install --force`).
  *
  * @returns {string[]}
  */
@@ -55,17 +54,26 @@ export function getBinCandidates () {
     return [platformEntry]
   }
 
-  // `detectLinuxLibc` returns null when `process.report` is unavailable; that
-  // falls back to glibc, which is what the ordering defaulted to before.
+  // An unprobeable libc (`detectLinuxLibc` returns null) counts as glibc.
   const detected = detectLinuxLibc() === 'musl' ? 'musl' : 'glibc'
   const preferred = platformEntry[detected]
-  // An architecture released for only one libc has no entry for the other, and
+  // An architecture released for one libc only has no entry for the other, and
   // the binary it does ship cannot run there, so it offers no candidate.
   if (preferred == null) {
     return []
   }
   const alternate = platformEntry[detected === 'musl' ? 'glibc' : 'musl']
   return alternate == null ? [preferred] : [preferred, alternate]
+}
+
+/**
+ * How the host names itself in messages, spelled like the targets pnpm releases
+ * binaries for: `linux-x64-musl`, `darwin-arm64`.
+ *
+ * @returns {string}
+ */
+export function hostTarget () {
+  return `${platform}-${arch}${detectLinuxLibc() === 'musl' ? '-musl' : ''}`
 }
 
 /**

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -187,6 +187,7 @@ const TARGETS = [
   { platform: "darwin", arch: "arm64", codeTarget: "darwin-arm64", packageTarget: "darwin-arm64" },
   { platform: "linux", arch: "x64", libc: "glibc", codeTarget: "linux-x64", packageTarget: "linux-x64" },
   { platform: "linux", arch: "arm64", libc: "glibc", codeTarget: "linux-arm64", packageTarget: "linux-arm64" },
+  { platform: "linux", arch: "riscv64", libc: "glibc", codeTarget: "linux-riscv64", packageTarget: "linux-riscv64" },
   { platform: "linux", arch: "x64", libc: "musl", codeTarget: "linux-x64-musl", packageTarget: "linux-x64-musl" },
   { platform: "linux", arch: "arm64", libc: "musl", codeTarget: "linux-arm64-musl", packageTarget: "linux-arm64-musl" },
 ];

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -203,6 +203,60 @@ function runNpm (args, cwd) {
   }
 }
 
+test('linux riscv64 resolves the glibc package, and nothing under musl', async (t) => {
+  const restore = fakeHost(t, 'riscv64')
+
+  // `native-binary.mjs` reads process.platform and process.arch at module
+  // scope, so it has to be imported again once they are faked. The libc is
+  // read per call, so one import covers both cases.
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?riscv64')
+
+  restore.setLibc('glibc')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-riscv64/pnpm'])
+
+  // No musl binary is released for riscv64, and the glibc one cannot run
+  // there, so the installer reports an unsupported platform instead.
+  restore.setLibc('musl')
+  assert.deepEqual(candidates(), [])
+})
+
+test('an architecture released for both libcs still offers the other as a fallback', async (t) => {
+  const restore = fakeHost(t, 'x64')
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?x64')
+
+  restore.setLibc('glibc')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'])
+
+  restore.setLibc('musl')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64-musl/pnpm', '@pnpm/exe.linux-x64/pnpm'])
+})
+
+/**
+ * Present the running process as a Linux host of `arch`, restoring the real
+ * descriptors when the test ends. `setLibc` drives `detectLinuxLibc`, which
+ * reads `process.report`, so the cases do not depend on the host's own libc.
+ */
+function fakeHost (t, arch) {
+  const saved = ['platform', 'arch', 'report']
+    .map(key => [key, Object.getOwnPropertyDescriptor(process, key)])
+  t.after(() => {
+    for (const [key, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(process, key, descriptor)
+    }
+  })
+  Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+  Object.defineProperty(process, 'arch', { value: arch, configurable: true })
+  return {
+    setLibc (libc) {
+      const header = libc === 'glibc' ? { glibcVersionRuntime: '2.39' } : {}
+      Object.defineProperty(process, 'report', {
+        value: { getReport: () => ({ header }) },
+        configurable: true,
+      })
+    },
+  }
+}
+
 function writeNativeFixture (destPath) {
   if (process.platform === 'win32') {
     try {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -73,6 +73,34 @@ test('pnpm links a symlink that runs the placeholder when executables are symlin
   assert.equal(runThroughShell(bin, ['works']), 'fixture:works\n')
 })
 
+test('linux riscv64 resolves the glibc package, and nothing under musl', async (t) => {
+  const { setLibc } = fakeHost(t, 'riscv64')
+
+  // `native-binary.mjs` reads process.platform and process.arch at module
+  // scope, so it has to be imported again once they are faked. The libc is
+  // read per call, so one import covers both cases.
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?riscv64')
+
+  setLibc('glibc')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-riscv64/pnpm'])
+
+  // No musl binary is released for riscv64, and the glibc one cannot run
+  // there, so the installer reports an unsupported platform instead.
+  setLibc('musl')
+  assert.deepEqual(candidates(), [])
+})
+
+test('an architecture released for both libcs still offers the other as a fallback', async (t) => {
+  const { setLibc } = fakeHost(t, 'x64')
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?x64')
+
+  setLibc('glibc')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'])
+
+  setLibc('musl')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64-musl/pnpm', '@pnpm/exe.linux-x64/pnpm'])
+})
+
 /**
  * Install the wrapper fixture globally with npm into a prefix of its own.
  * Throws when npm fails; the temp tree is removed when `t` ends.
@@ -203,38 +231,15 @@ function runNpm (args, cwd) {
   }
 }
 
-test('linux riscv64 resolves the glibc package, and nothing under musl', async (t) => {
-  const restore = fakeHost(t, 'riscv64')
-
-  // `native-binary.mjs` reads process.platform and process.arch at module
-  // scope, so it has to be imported again once they are faked. The libc is
-  // read per call, so one import covers both cases.
-  const { getBinCandidates: candidates } = await import('../native-binary.mjs?riscv64')
-
-  restore.setLibc('glibc')
-  assert.deepEqual(candidates(), ['@pnpm/exe.linux-riscv64/pnpm'])
-
-  // No musl binary is released for riscv64, and the glibc one cannot run
-  // there, so the installer reports an unsupported platform instead.
-  restore.setLibc('musl')
-  assert.deepEqual(candidates(), [])
-})
-
-test('an architecture released for both libcs still offers the other as a fallback', async (t) => {
-  const restore = fakeHost(t, 'x64')
-  const { getBinCandidates: candidates } = await import('../native-binary.mjs?x64')
-
-  restore.setLibc('glibc')
-  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64/pnpm', '@pnpm/exe.linux-x64-musl/pnpm'])
-
-  restore.setLibc('musl')
-  assert.deepEqual(candidates(), ['@pnpm/exe.linux-x64-musl/pnpm', '@pnpm/exe.linux-x64/pnpm'])
-})
-
 /**
  * Present the running process as a Linux host of `arch`, restoring the real
- * descriptors when the test ends. `setLibc` drives `detectLinuxLibc`, which
- * reads `process.report`, so the cases do not depend on the host's own libc.
+ * descriptors when the test ends.
+ *
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {string} arch The `process.arch` to present.
+ * @returns {{ setLibc: (libc: 'glibc' | 'musl') => void }} `setLibc` fakes the
+ *   `process.report` that `detectLinuxLibc` reads, so a case does not depend on
+ *   the host's own libc.
  */
 function fakeHost (t, arch) {
   const saved = ['platform', 'arch', 'report']


### PR DESCRIPTION
Adds `linux-riscv64` to the Rust CLI's release targets, so pnpm 12 has a native binary on RISC-V. Closes pnpm/pnpm#7582.

Three places name a target, and this adds the same one to each:

- `release.yml` builds `riscv64gc-unknown-linux-gnu` with `cross`, on the existing `ubuntu-2404` runner that already produces both aarch64 targets. No new runner and no riscv64 hardware.
- `generate-packages.mjs` emits `@pnpm/exe.linux-riscv64` and lists it in the wrapper's `optionalDependencies`.
- `native-binary.mjs` resolves that package at install time.

No Rust or CLI logic changes.

### Relation to #8779

pnpm/pnpm#8779 added riscv64 in November 2024 and was reverted the next day in cebe493 (no PR, no stated reason). That version depended on Vercel `pkg` fetching a prebuilt `node20-linux-riscv64`, which `pkg-fetch` does not publish, so the target could only fail once a release actually ran. Since `release.yml` runs on tags and `workflow_dispatch` only, nothing in that PR could have failed in review.

The Rust CLI has no such dependency: `cross` supports `riscv64gc-unknown-linux-gnu` (`cpp`, `dylib`, `std`, `run`) and the binary is compiled rather than bundled around a prebuilt Node.

`pack_app.rs` still lists targets for `pnpm pack-app`, which embeds a Node binary via Node SEA. That constraint is unchanged, so this PR deliberately leaves it alone.

### Verification

The release workflow does not run on pull requests, so CI here will not build this target. Verified locally instead, against this branch. `cross` needs Docker, which was not available on the machine I tested on, so this is the same Cargo invocation `cross-build.sh` wraps, run against a native `riscv64-linux-gnu` toolchain. The sysroot and glibc therefore differ from what `cross` would use:

```
cargo build --locked -p pnpm-cli --bin pnpm --release --target riscv64gc-unknown-linux-gnu
  -> Finished `release` profile [optimized] in 9m 34s
  -> ELF 64-bit LSB pie executable, UCB RISC-V, RVC, double-float ABI
```

Under `qemu-riscv64`:

```
pnpm --version            -> 12.3.2
pnpm view is-odd version  -> 3.0.1     (live HTTPS to the registry)
```

The registry query matters because it exercises rustls and `aws-lc-rs` on riscv64. aws-lc-rs lists `riscv64gc-unknown-linux-gnu` as Build and Tests supported, and non-FIPS `aws-lc-sys` needs no CMake, bindgen, or Go.

Also checked `generate-packages.mjs` end to end in an isolated tree with the real binary staged. It produces `{"os":["linux"],"cpu":["riscv64"],"libc":["glibc"]}`, matching `@pnpm/exe.linux-arm64`'s shape, and `cpu: ["riscv64"]` matches what `@pnpm/linux-riscv64@9.14.0` published. Running `install.js` with `process.arch` forced to `riscv64` replaces the placeholder bin with the native binary at mode 755, which then runs.

A `workflow_dispatch` run on this branch before merge would confirm it in your CI rather than at tag time, which is where the 2024 attempt came apart.

## Squash Commit Body

```text
Build the Rust CLI for riscv64gc-unknown-linux-gnu and publish it as
@pnpm/exe.linux-riscv64, so installing pnpm on a riscv64 host resolves a
native binary instead of finding no prebuilt binary for the platform.

The release matrix builds the target with cross on the existing x86_64 Linux
runner, the same way it already builds both aarch64 targets, so no riscv64
hardware is involved.

PLATFORMS.linux gets a plain string specifier rather than a glibc/musl pair.
Only a glibc build is released, and the libc ordering maps over the pair's
keys, so a pair with a missing musl entry would yield an undefined specifier.

```
## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791100711&installation_model_id=426870&pr_number=14529&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14529&signature=a9191ab909653dc65938ff46bf6fd7dc8b61820593567d647d1722a48cdfea8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for running pnpm on glibc-based Linux systems with RISC-V 64-bit processors.
  - Added dedicated Linux RISC-V 64-bit native packages for improved platform compatibility.
  - Release builds now include the Linux RISC-V 64-bit target.
  - Added platform detection to select compatible native binaries and avoid unsupported libc combinations.
  - Improved fallback ordering on systems supporting multiple libc variants.
  - Updated supported-platform documentation to include Linux RISC-V 64-bit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->