### PR TITLE
perf(resolver): hash-cache the wanted keys and fan out the importers drift check

### DIFF
--- a/.changeset/hashed-wanted-keys.md
+++ b/.changeset/hashed-wanted-keys.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up dependency resolution in large workspaces [#14352](https://github.com/pnpm/pnpm/issues/14352).

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -54,7 +54,7 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     resolution_picks_lowest: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
     // Each importer's map builds from its own manifest alone, so a
-    // workspace-scale set fans out across rayon; an unparseable alias
+    // workspace-scale set fans out across rayon; an unparsable alias
     // anywhere still sends the whole compose to the resolver.
     let manifest_dependencies: Result<
         Vec<(&String, &PackageManifest, ManifestDependencies<'_>)>,

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -10,6 +10,8 @@ use pnpm_lockfile::{
     ResolvedDependencySpec,
 };
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
+use rayon::prelude::*;
+use rustc_hash::FxHashMap;
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     path::PathBuf,
@@ -22,7 +24,7 @@ type LockedPackages = HashMap<PackageKey, pnpm_lockfile::PackageMetadata>;
 /// Each manifest alias with its specifier and the group it is
 /// effectively declared under. Keyed by [`PkgName`] so membership tests
 /// against importer records need no per-dependency conversions.
-type ManifestDependencies<'manifest> = HashMap<PkgName, (&'manifest str, DependencyGroup)>;
+type ManifestDependencies<'manifest> = FxHashMap<PkgName, (&'manifest str, DependencyGroup)>;
 
 /// The prepared inputs [`apply_importers_update`] replays: each
 /// importer's manifest map, built once so detection and application share
@@ -51,23 +53,33 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     prune_stale_importers: bool,
     resolution_picks_lowest: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
-    let mut manifest_dependencies: Vec<(&String, &PackageManifest, ManifestDependencies<'_>)> =
-        Vec::new();
-    for (importer_id, manifest) in manifests {
-        // Later groups overwrite, so each alias ends at the group
-        // `satisfies_package_manifest` expects it recorded under when it
-        // appears in several: optional wins over prod, prod over dev.
-        let mut dependencies = HashMap::new();
-        for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
-            for (name, specifier) in manifest.dependencies([group]) {
-                let Ok(name) = PkgName::parse(name) else {
-                    return Drift::Resolve;
-                };
-                dependencies.insert(name, (specifier, group));
+    // Each importer's map builds from its own manifest alone, so a
+    // workspace-scale set fans out across rayon; an unparseable alias
+    // anywhere still sends the whole compose to the resolver.
+    let manifest_dependencies: Result<
+        Vec<(&String, &PackageManifest, ManifestDependencies<'_>)>,
+        (),
+    > = manifests
+        .par_iter()
+        .map(|(importer_id, manifest)| {
+            // Later groups overwrite, so each alias ends at the group
+            // `satisfies_package_manifest` expects it recorded under when it
+            // appears in several: optional wins over prod, prod over dev.
+            let mut dependencies = ManifestDependencies::default();
+            for group in [DependencyGroup::Dev, DependencyGroup::Prod, DependencyGroup::Optional] {
+                for (name, specifier) in manifest.dependencies([group]) {
+                    let Ok(name) = PkgName::parse(name) else {
+                        return Err(());
+                    };
+                    dependencies.insert(name, (specifier, group));
+                }
             }
-        }
-        manifest_dependencies.push((importer_id, *manifest, dependencies));
-    }
+            Ok((importer_id, *manifest, dependencies))
+        })
+        .collect();
+    let Ok(manifest_dependencies) = manifest_dependencies else {
+        return Drift::Resolve;
+    };
     let stale: Vec<String> = if prune_stale_importers {
         let manifest_ids: HashSet<&str> =
             manifests.iter().map(|(importer_id, _)| importer_id.as_str()).collect();
@@ -80,9 +92,18 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     } else {
         Vec::new()
     };
+    // Divergence checks only read the lockfile and each importer's own
+    // map, so they fan out too. `Resolve` must win over `Absorbable`
+    // regardless of which importer reports it, which the fold preserves.
     let mut any_diverged = false;
-    for (importer_id, _, dependencies) in &manifest_dependencies {
-        match importer_divergence(lockfile, importer_id, dependencies) {
+    for divergence in manifest_dependencies
+        .par_iter()
+        .map(|(importer_id, _, dependencies)| {
+            importer_divergence(lockfile, importer_id, dependencies)
+        })
+        .collect::<Vec<_>>()
+    {
+        match divergence {
             ImporterDivergence::Clean => {}
             ImporterDivergence::Absorbable => any_diverged = true,
             // Bail before the compose clones the whole lockfile: the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -53,9 +53,8 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     prune_stale_importers: bool,
     resolution_picks_lowest: bool,
 ) -> Drift<ImportersPlan<'a, 'manifest>> {
-    // Each importer's map builds from its own manifest alone, so a
-    // workspace-scale set fans out across rayon; an unparsable alias
-    // anywhere still sends the whole compose to the resolver.
+    // Each importer's map builds from its own manifest alone; an
+    // unparsable alias anywhere still sends the compose to the resolver.
     let manifest_dependencies: Result<
         Vec<(&String, &PackageManifest, ManifestDependencies<'_>)>,
         (),
@@ -92,9 +91,8 @@ pub(crate) fn detect_importers_drift<'a, 'manifest>(
     } else {
         Vec::new()
     };
-    // Divergence checks only read the lockfile and each importer's own
-    // map, so they fan out too. `Resolve` must win over `Absorbable`
-    // regardless of which importer reports it, which the fold preserves.
+    // `Resolve` must win over `Absorbable` regardless of which importer
+    // reports it, which the fold preserves.
     let mut any_diverged = false;
     for divergence in manifest_dependencies
         .par_iter()

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1500,3 +1500,63 @@ fn rejects_adding_a_dependency_to_a_lockfile_that_records_publish_dates() {
         "only a resolution can record the publish date of a new direct dependency",
     );
 }
+
+const TWO_IMPORTERS: &str = r"
+lockfileVersion: '9.0'
+importers:
+  a:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+  b:
+    dependencies:
+      foo:
+        specifier: ^1.0.0
+        version: 1.1.0
+packages:
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-deadbeef
+snapshots:
+  foo@1.1.0: {}
+";
+
+/// One importer needing the resolver must veto the compose no matter
+/// where it sits relative to importers whose drift is absorbable.
+#[test]
+fn a_resolve_needing_importer_vetoes_absorbable_siblings_in_either_order() {
+    let lockfile = parsed_lockfile(TWO_IMPORTERS);
+    let absorbable = manifest(">=1 <2");
+    let needs_resolve = manifest("^2");
+    assert!(
+        try_fast_update_importers(
+            &lockfile,
+            &[("a".to_string(), &absorbable), ("b".to_string(), &needs_resolve)],
+        )
+        .is_none(),
+        "needs-resolve after absorbable must veto",
+    );
+    assert!(
+        try_fast_update_importers(
+            &lockfile,
+            &[("a".to_string(), &needs_resolve), ("b".to_string(), &absorbable)],
+        )
+        .is_none(),
+        "needs-resolve before absorbable must veto",
+    );
+
+    // Control: with both importers absorbable the compose applies.
+    let clean = manifest("^1.0.0");
+    let updated = try_fast_update_importers(
+        &lockfile,
+        &[("a".to_string(), &absorbable), ("b".to_string(), &clean)],
+    )
+    .expect("absorbable + clean should compose");
+    assert_eq!(
+        updated.importers["a"].dependencies.as_ref().expect("dependencies")
+            [&"foo".parse().expect("package name")]
+            .specifier,
+        ">=1 <2",
+    );
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1522,8 +1522,6 @@ snapshots:
   foo@1.1.0: {}
 ";
 
-/// One importer needing the resolver must veto the compose no matter
-/// where it sits relative to importers whose drift is absorbable.
 #[test]
 fn a_resolve_needing_importer_vetoes_absorbable_siblings_in_either_order() {
     let lockfile = parsed_lockfile(TWO_IMPORTERS);

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk.rs
@@ -350,7 +350,7 @@ where
         prior_key.as_ref().and_then(|key| key.suffix.version_semver()),
         depth,
     );
-    let cache_key: WantedKey = (
+    let cache_key = WantedKey::new((
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
         wanted.optional,
@@ -359,10 +359,10 @@ where
         opts.published_by,
         project_scope,
         prior_key.clone(),
-        overlay_versions.clone(),
+        overlay_versions,
         ctx.update_cache_scope(),
         update_target,
-    );
+    ));
     let result =
         match resolve_wanted_cached(ctx, resolver, &wanted, opts, pick_overlay.as_ref(), cache_key)
             .await
@@ -1256,25 +1256,12 @@ fn shared_workspace_key(
             "the importer-wide workspace-resolution key must describe every edge's options",
         );
     }
-    // The consumer scope is exactly what the shared key drops. Every
-    // `workspace:` selector carries one, so its absence means this edge is not
-    // the shape assumed here.
-    cache_key.6.as_ref()?;
-    let wanted_key = (
-        cache_key.0.clone(),
-        cache_key.1.clone(),
-        cache_key.2,
-        cache_key.3,
-        cache_key.4,
-        cache_key.5,
-        None,
-        cache_key.7.clone(),
-        cache_key.8.clone(),
-        cache_key.9.clone(),
-        cache_key.10,
-    );
+    // The consumer scope is exactly what the shared key's hash and
+    // equality drop. Every `workspace:` selector carries one, so its
+    // absence means this edge is not the shape assumed here.
+    cache_key.fields().6.as_ref()?;
     Some(SharedWorkspaceWantedKey::new(
-        wanted_key,
+        cache_key.clone(),
         wanted.prev_specifier.clone(),
         &ctx.workspace_resolution_options_key,
     ))
@@ -1312,8 +1299,8 @@ where
     // npm-aliases, folded from the jsr specifier for jsr deps) is in the
     // update target list — so the picker's held-back-update warning fires
     // only for the packages the user actually asked to update.
-    let needs_overlay = !cache_key.8.is_empty();
-    let update_target = cache_key.10;
+    let needs_overlay = !cache_key.fields().8.is_empty();
+    let update_target = cache_key.fields().10;
     let needs_update = update_target != opts.update_requested;
     let owned_opts;
     let opts = if needs_overlay || needs_update {
@@ -1605,7 +1592,7 @@ async fn warm_result_children<Chain>(
                 // into its own bucket and re-picks from the warm
                 // metadata caches.
                 let project_scope = project_relative_cache_scope(&wanted, opts);
-                let cache_key: WantedKey = (
+                let cache_key = WantedKey::new((
                     wanted.alias.clone(),
                     wanted.bare_specifier.clone(),
                     wanted.optional,
@@ -1619,7 +1606,7 @@ async fn warm_result_children<Chain>(
                     Vec::new(),
                     ctx.update_cache_scope(),
                     is_update_target(ctx.update_scope(), &wanted, None, depth + 1),
-                );
+                ));
                 let Ok(child) =
                     resolve_wanted_cached(ctx, resolver, &wanted, opts, None, cache_key).await
                 else {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/walk/tests/shared_workspace_resolution_cache.rs
@@ -20,7 +20,7 @@ fn wanted(specifier: &str) -> WantedDependency {
 }
 
 fn key(wanted: &WantedDependency, project_dir: &str) -> WantedKey {
-    (
+    WantedKey::new((
         wanted.alias.clone(),
         wanted.bare_specifier.clone(),
         wanted.optional,
@@ -32,7 +32,7 @@ fn key(wanted: &WantedDependency, project_dir: &str) -> WantedKey {
         Vec::new(),
         None,
         false,
-    )
+    ))
 }
 
 fn opts(project_dir: &str) -> ResolveOptions {

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -101,12 +101,10 @@ pub(super) type WantedKeyFields = (
     bool,
 );
 
-/// A [`WantedKeyFields`] tuple behind an `Arc`, with its hashes
-/// precomputed at construction: one over every field, and one that
-/// skips the consumer-scope slot for [`SharedWorkspaceWantedKey`]. An
-/// edge builds its key once; the maps and derived keys that carry it
-/// afterwards bump the `Arc` and write the cached hash instead of
-/// re-cloning and re-hashing the strings inside.
+/// A [`WantedKeyFields`] tuple with its hashes fixed at construction —
+/// the full one, and a consumer-scope-less one for
+/// [`SharedWorkspaceWantedKey`] — so an edge's key is hashed once
+/// however many maps and derived keys carry it. Cloning is cheap.
 #[derive(Debug, Clone)]
 pub(super) struct WantedKey(Arc<WantedKeyInner>);
 
@@ -200,10 +198,8 @@ impl Hash for PathKey {
 /// A wanted dependency key without its consumer directory, plus the resolver
 /// inputs that may vary between importers.
 ///
-/// Holds the edge's full [`WantedKey`] (an `Arc` bump, not a field
-/// clone); the consumer directory is dropped by `Hash`/`Eq` instead —
-/// they use the key's scope-less hash and field comparison, so keys
-/// built by different importers still match by value.
+/// Holds the edge's full [`WantedKey`]; `Hash`/`Eq` drop the consumer
+/// directory, so keys built by different importers match by value.
 #[derive(Debug, Clone)]
 pub(super) struct SharedWorkspaceWantedKey {
     wanted: WantedKey,

--- a/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
+++ b/pnpm/crates/resolving-deps-resolver/src/resolve_dependency_tree/workspace_ctx.rs
@@ -87,7 +87,7 @@ use super::{
 /// [`WantedDependency`]: pnpm_resolving_resolver_base::WantedDependency
 /// [`extend_tree`]: super::extend_tree
 /// [`fn@resolve_node`]: super::walk::resolve_node
-pub(super) type WantedKey = (
+pub(super) type WantedKeyFields = (
     Option<String>,
     Option<String>,
     Option<bool>,
@@ -100,6 +100,75 @@ pub(super) type WantedKey = (
     Option<String>,
     bool,
 );
+
+/// A [`WantedKeyFields`] tuple behind an `Arc`, with its hashes
+/// precomputed at construction: one over every field, and one that
+/// skips the consumer-scope slot for [`SharedWorkspaceWantedKey`]. An
+/// edge builds its key once; the maps and derived keys that carry it
+/// afterwards bump the `Arc` and write the cached hash instead of
+/// re-cloning and re-hashing the strings inside.
+#[derive(Debug, Clone)]
+pub(super) struct WantedKey(Arc<WantedKeyInner>);
+
+#[derive(Debug)]
+struct WantedKeyInner {
+    full_hash: u64,
+    scopeless_hash: u64,
+    fields: WantedKeyFields,
+}
+
+impl WantedKey {
+    pub(super) fn new(fields: WantedKeyFields) -> Self {
+        // One pass over the fields serves both hashes: everything but
+        // the consumer scope feeds a hasher whose intermediate state is
+        // snapshotted for the scope-less hash before the scope joins.
+        let mut hasher = rustc_hash::FxHasher::default();
+        (
+            &fields.0, &fields.1, &fields.2, &fields.3, &fields.4, &fields.5, &fields.7, &fields.8,
+            &fields.9, &fields.10,
+        )
+            .hash(&mut hasher);
+        let scopeless_hash = hasher.clone().finish();
+        fields.6.hash(&mut hasher);
+        WantedKey(Arc::new(WantedKeyInner { full_hash: hasher.finish(), scopeless_hash, fields }))
+    }
+
+    pub(super) fn fields(&self) -> &WantedKeyFields {
+        &self.0.fields
+    }
+
+    /// Field-wise equality without the consumer-scope slot — the
+    /// equality [`SharedWorkspaceWantedKey`] shares between importers.
+    fn scopeless_eq(&self, other: &Self) -> bool {
+        let left = &self.0.fields;
+        let right = &other.0.fields;
+        left.0 == right.0
+            && left.1 == right.1
+            && left.2 == right.2
+            && left.3 == right.3
+            && left.4 == right.4
+            && left.5 == right.5
+            && left.7 == right.7
+            && left.8 == right.8
+            && left.9 == right.9
+            && left.10 == right.10
+    }
+}
+
+impl PartialEq for WantedKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+            || (self.0.full_hash == other.0.full_hash && self.0.fields == other.0.fields)
+    }
+}
+
+impl Eq for WantedKey {}
+
+impl Hash for WantedKey {
+    fn hash<State: Hasher>(&self, state: &mut State) {
+        state.write_u64(self.0.full_hash);
+    }
+}
 
 /// A path slot of a resolver cache key.
 ///
@@ -130,14 +199,19 @@ impl Hash for PathKey {
 
 /// A wanted dependency key without its consumer directory, plus the resolver
 /// inputs that may vary between importers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+///
+/// Holds the edge's full [`WantedKey`] (an `Arc` bump, not a field
+/// clone); the consumer directory is dropped by `Hash`/`Eq` instead —
+/// they use the key's scope-less hash and field comparison, so keys
+/// built by different importers still match by value.
+#[derive(Debug, Clone)]
 pub(super) struct SharedWorkspaceWantedKey {
     wanted: WantedKey,
     previous_specifier: Option<String>,
     // Behind an `Arc` because the fields are invariant per importer
     // (see [`WorkspaceResolutionOptionsKey`]) while a key is built per
-    // dependency edge; the derived `Hash`/`Eq` see through the `Arc`,
-    // so keys built by different importers still match by value.
+    // dependency edge; `Hash`/`Eq` see through the `Arc`, so keys
+    // built by different importers still match by value.
     resolve_options: Arc<WorkspaceResolutionOptionsKey>,
 }
 
@@ -148,6 +222,24 @@ impl SharedWorkspaceWantedKey {
         resolve_options: &Arc<WorkspaceResolutionOptionsKey>,
     ) -> Self {
         Self { wanted, previous_specifier, resolve_options: Arc::clone(resolve_options) }
+    }
+}
+
+impl PartialEq for SharedWorkspaceWantedKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.wanted.scopeless_eq(&other.wanted)
+            && self.previous_specifier == other.previous_specifier
+            && self.resolve_options == other.resolve_options
+    }
+}
+
+impl Eq for SharedWorkspaceWantedKey {}
+
+impl Hash for SharedWorkspaceWantedKey {
+    fn hash<State: Hasher>(&self, state: &mut State) {
+        state.write_u64(self.wanted.0.scopeless_hash);
+        self.previous_specifier.hash(state);
+        self.resolve_options.hash(state);
     }
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to [pnpm/pnpm#14352](https://github.com/pnpm/pnpm/issues/14352) (continuing the large-workspace performance effort).

A fresh profile of the warm lockfile-only update on the 6,833-project repro after [pnpm/pnpm#14530](https://github.com/pnpm/pnpm/pull/14530) shows the resolver walk dominating (286 of 595 samples), with two coherent slices attackable without structural change:

1. **Wanted-key traffic (~30 samples).** The per-wanted dedup key was a large tuple of owned strings: every map probe re-hashed all of them, and every workspace-edge miss re-cloned the tuple field by field into `SharedWorkspaceWantedKey` (the "full-WantedKey clone" noted in `resolve_workspace.rs`), then hashed it again for the shared and final maps. `WantedKey` is now the same tuple behind an `Arc` with two hashes precomputed at construction — one over every field, one skipping the consumer-scope slot. Maps write the cached hash; `SharedWorkspaceWantedKey` holds the same `Arc` and drops the consumer directory in its own `Hash`/`Eq` instead of rebuilding the tuple (semantics pinned by the existing `shared_workspace_resolution_cache` tests); downstream clones become refcount bumps; the overlay view moves into the key instead of being cloned.

2. **Importers drift check (~15 samples).** `detect_importers_drift` built each importer's manifest map serially (a `PkgName` parse per dependency into a SipHash-keyed map, dropped right after) and ran each importer's divergence check serially. Both loops fan out across rayon now, the map is FxHash-keyed, and the error precedence is unchanged: an unparsable alias or a `NeedsResolve` divergence anywhere still sends the compose to the resolver regardless of other importers' outcomes.

Benchmark (interleaved A/B against a main-built baseline binary, 12 pairs, same protocol as the prior PRs):

| | median | min |
|---|---:|---:|
| main | 917 ms | 895 ms |
| this PR | 887 ms | 865 ms |

The candidate's spread also tightens noticeably (865–911 ms vs 895–1099 ms). The produced lockfile is unchanged byte for byte (diff against the committed lockfile is exactly the one flipped specifier line).

pacquet-internal performance work with no user-visible behavior change, so no TypeScript-side change is needed.

## Squash Commit Body

```text
Two per-edge and per-importer costs on the 6,833-project warm-update
repro:

- The resolver's per-wanted dedup key was a large tuple of owned
  strings, re-hashed on every map probe and re-cloned field by field
  into the shared workspace key on every workspace-edge miss. WantedKey
  is now that tuple behind an Arc with two hashes precomputed at
  construction: one over every field, and one that skips the
  consumer-scope slot. Maps write the cached hash instead of re-hashing
  the strings, SharedWorkspaceWantedKey bumps the Arc and drops the
  consumer directory through its own Hash/Eq rather than rebuilding the
  tuple, and every downstream clone is a refcount. The overlay view
  also moves into the key instead of being cloned.

- The fast-update importers drift check built each importer's manifest
  map (with a PkgName parse per dependency, into a SipHash map) and ran
  each importer's divergence check serially. Both loops now fan out
  across rayon, the map is FxHash-keyed, and an unparsable alias or a
  divergence that needs the resolver still wins over any absorbable
  outcome.

Warm lockfile-only update on the repro, interleaved A/B of 12 runs:
median 917 ms to 887 ms, minimum 895 ms to 865 ms, lockfile unchanged
byte for byte. Part of the pnpm/pnpm#14352 performance effort.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
  (pacquet-internal performance work; no behavior change to mirror.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113148&installation_model_id=426870&pr_number=14534&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14534&signature=9314da77ccc4dc3e584086bd52f9406ec8940dac76eeff89d0bda715b1c71241"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved dependency resolution speed, especially in large workspaces.
  - Workspace dependency checks are processed more efficiently across multiple projects.

- **Reliability**
  - Improved consistency when resolving dependencies across shared workspace contexts.
  - Ensured dependency changes requiring resolution are handled correctly in mixed workspace scenarios.

- **Release**
  - Included a patch release update for pacquet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->