### PR TITLE
fix(pacquet): accept the boolean settings as bare flags on every command

### DIFF
--- a/.changeset/remove-unsafe-perm-flag.md
+++ b/.changeset/remove-unsafe-perm-flag.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+---
+
+`pnpm remove` now accepts `--unsafe-perm` and `--no-unsafe-perm`, the same flag `pnpm install`, `pnpm add`, and `pnpm update` take.

--- a/.changeset/remove-unsafe-perm-flag.md
+++ b/.changeset/remove-unsafe-perm-flag.md
@@ -1,6 +1,0 @@
----
-"@pnpm/installing.commands": patch
-"pnpm": patch
----
-
-`pnpm remove` now accepts `--unsafe-perm` and `--no-unsafe-perm`, the same flag `pnpm install`, `pnpm add`, and `pnpm update` take.

--- a/.changeset/unsafe-perm-flag.md
+++ b/.changeset/unsafe-perm-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install --unsafe-perm` and the `--unsafe-perm` flag on every other command now work. pnpm 12 rejected the flag with `unexpected argument '--unsafe-perm' found`, which failed every install on Vercel, whose build runs pnpm with that flag [#14346](https://github.com/pnpm/pnpm/issues/14346).

--- a/.changeset/unsafe-perm-flag.md
+++ b/.changeset/unsafe-perm-flag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install --unsafe-perm` and the `--unsafe-perm` flag on every other command now work. pnpm 12 rejected the flag with `unexpected argument '--unsafe-perm' found`, which failed every install on Vercel, whose build runs pnpm with that flag [#14346](https://github.com/pnpm/pnpm/issues/14346).
+`pnpm install --unsafe-perm` and the `--unsafe-perm` flag on every other command now work. pnpm 12 rejected the flag with `unexpected argument '--unsafe-perm' found`, which failed every install on Vercel [#14346](https://github.com/pnpm/pnpm/issues/14346).

--- a/.changeset/unsafe-perm-flag.md
+++ b/.changeset/unsafe-perm-flag.md
@@ -1,5 +1,9 @@
 ---
+"@pnpm/installing.commands": patch
+"pnpm": patch
 "pacquet": patch
 ---
 
-`pnpm install --unsafe-perm` and the `--unsafe-perm` flag on every other command now work. pnpm 12 rejected the flag with `unexpected argument '--unsafe-perm' found`, which failed every install on Vercel [#14346](https://github.com/pnpm/pnpm/issues/14346).
+pnpm 12 now accepts the boolean settings as command-line flags on every command that takes them in pnpm 11, for example `pnpm install --unsafe-perm`, `pnpm add foo --offline`, and `pnpm install --dangerously-allow-all-builds`. pnpm 12 rejected them with `unexpected argument`, which failed every install on Vercel, whose build runs `pnpm install --unsafe-perm` [#14346](https://github.com/pnpm/pnpm/issues/14346).
+
+`pnpm remove` now accepts `--unsafe-perm`, the same flag `pnpm install`, `pnpm add`, and `pnpm update` take.

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1,7 +1,8 @@
 use pnpm_config::{
     ColorMode, Config, EnvVar, GLOBAL_LAYOUT_VERSION, GetCurrentDir, GetHomeDir, LinkProbe,
-    NodeLinker, PackageImportMethod, PmOnFail, RuntimeOnFail, TrustPolicy, VerifyDepsBeforeRun,
-    default_state_dir, resolve_child_concurrency,
+    LinkWorkspacePackages, NodeLinker, PackageImportMethod, PmOnFail, RuntimeOnFail,
+    SaveWorkspaceProtocol, TrustPolicy, VerifyDepsBeforeRun, default_state_dir,
+    resolve_child_concurrency,
 };
 use pnpm_fs::lexical_normalize;
 use pnpm_store_dir::StoreDir;
@@ -121,13 +122,19 @@ pub struct ConfigOverrides {
     scope: Option<String>,
     registries: BTreeMap<String, String>,
     child_concurrency: Option<i32>,
+    dangerously_allow_all_builds: Option<bool>,
     deploy_all_files: Option<bool>,
+    engine_strict: Option<bool>,
     force_legacy_deploy: Option<bool>,
+    frozen_store: Option<bool>,
     global_dir: Option<String>,
     hoist: Option<bool>,
     hoist_pattern: Option<Vec<String>>,
+    ignore_pnpmfile: Option<bool>,
     ignore_scripts: Option<bool>,
     inject_workspace_packages: Option<bool>,
+    link_workspace_packages: Option<LinkWorkspacePackages>,
+    lockfile_include_tarball_url: Option<bool>,
     /// `maxsockets`, npm's spelling of [`Self::max_sockets`]. Kept apart
     /// so the canonical spelling can win when one command line carries
     /// both.
@@ -137,6 +144,11 @@ pub struct ConfigOverrides {
     minimum_release_age_exclude: Option<Vec<String>>,
     minimum_release_age_ignore_missing_time: Option<bool>,
     minimum_release_age_strict: Option<bool>,
+    merge_git_branch_lockfiles: Option<bool>,
+    node_experimental_package_map: Option<bool>,
+    offline: Option<bool>,
+    prefer_frozen_lockfile: Option<bool>,
+    prefer_offline: Option<bool>,
     /// The raw `modulesDir` / `virtualStoreDir` spellings, kept unresolved
     /// so [`Config::anchor_lockfile_paths`] can re-resolve them against
     /// whichever directory ends up anchoring the install.
@@ -148,6 +160,7 @@ pub struct ConfigOverrides {
     pm_on_fail: Option<PmOnFail>,
     public_hoist_pattern: Option<Vec<String>>,
     runtime_on_fail: Option<RuntimeOnFail>,
+    save_workspace_protocol: Option<SaveWorkspaceProtocol>,
     shared_workspace_lockfile: Option<bool>,
     strict_peer_dependencies: Option<bool>,
     trust_lockfile: Option<bool>,
@@ -156,6 +169,8 @@ pub struct ConfigOverrides {
     trust_policy_ignore_after: Option<u64>,
     unsafe_perm: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
+    verify_store_integrity: Option<bool>,
+    virtual_store_only: Option<bool>,
     https_proxy: Option<String>,
     http_proxy: Option<String>,
     no_proxy: Option<String>,
@@ -227,23 +242,47 @@ impl ConfigOverrides {
             "allow-unused-patches" => self.allow_unused_patches = parse_bool(value),
             "bail" => self.bail = parse_bool(value),
             "ci" => self.ci = parse_bool(value),
+            "dangerously-allow-all-builds" => {
+                self.dangerously_allow_all_builds = parse_bool(value);
+            }
             "color" => {
                 self.color = parse_bool(value)
                     .map(|enabled| if enabled { ColorMode::Always } else { ColorMode::Never })
                     .or_else(|| parse_enum(value));
             }
             "embed-readme" => self.embed_readme = parse_bool(value),
+            "engine-strict" => self.engine_strict = parse_bool(value),
+            "frozen-store" => self.frozen_store = parse_bool(value),
             "ignore-workspace-root-check" => {
                 self.ignore_workspace_root_check = parse_bool(value);
             }
             "hoist" => self.hoist = parse_bool(value),
+            "ignore-pnpmfile" => self.ignore_pnpmfile = parse_bool(value),
+            "link-workspace-packages" => {
+                self.link_workspace_packages = parse_bool_or_enum(value);
+            }
             "lockfile" => self.lockfile = parse_bool(value),
+            "lockfile-include-tarball-url" => {
+                self.lockfile_include_tarball_url = parse_bool(value);
+            }
+            "merge-git-branch-lockfiles" => {
+                self.merge_git_branch_lockfiles = parse_bool(value);
+            }
+            "node-experimental-package-map" => {
+                self.node_experimental_package_map = parse_bool(value);
+            }
+            "offline" => self.offline = parse_bool(value),
             "optimistic-repeat-install" => self.optimistic_repeat_install = parse_bool(value),
             "optional" => self.optional = parse_bool(value),
             "package-lock" => self.package_lock = parse_bool(value),
             "pending" => self.pending = parse_bool(value),
+            "prefer-frozen-lockfile" => self.prefer_frozen_lockfile = parse_bool(value),
+            "prefer-offline" => self.prefer_offline = parse_bool(value),
             "recursive-install" => self.recursive_install = parse_bool(value),
             "reverse" => self.reverse = parse_bool(value),
+            "save-workspace-protocol" => {
+                self.save_workspace_protocol = parse_bool_or_enum(value);
+            }
             "shamefully-hoist" => self.shamefully_hoist = parse_bool(value),
             "shell-emulator" => self.shell_emulator = parse_bool(value),
             "side-effects-cache" => self.side_effects_cache = parse_bool(value),
@@ -258,6 +297,8 @@ impl ConfigOverrides {
             "trust-lockfile" => self.trust_lockfile = parse_bool(value),
             "unsafe-perm" => self.unsafe_perm = parse_bool(value),
             "use-beta-cli" => self.use_beta_cli = parse_bool(value),
+            "verify-store-integrity" => self.verify_store_integrity = parse_bool(value),
+            "virtual-store-only" => self.virtual_store_only = parse_bool(value),
             _ => {}
         }
         if key == "registry" {
@@ -558,6 +599,7 @@ impl ConfigOverrides {
         }
         if let Some(value) = self.shared_workspace_lockfile {
             config.shared_workspace_lockfile = value;
+            config.explicit_settings.insert("sharedWorkspaceLockfile".to_string(), value.into());
         }
         // The `pnpm_config_verify_deps_before_run` env var outranks even
         // the CLI for this one key (pnpm's config reader applies it after
@@ -622,6 +664,67 @@ impl ConfigOverrides {
         if let Some(value) = self.unsafe_perm {
             config.unsafe_perm = value;
             config.explicit_settings.insert("unsafePerm".to_string(), value.into());
+        }
+        if let Some(value) = self.dangerously_allow_all_builds {
+            config.dangerously_allow_all_builds = value;
+            config.explicit_settings.insert("dangerouslyAllowAllBuilds".to_string(), value.into());
+        }
+        if let Some(value) = self.engine_strict {
+            config.engine_strict = value;
+            config.explicit_settings.insert("engineStrict".to_string(), value.into());
+        }
+        if let Some(value) = self.frozen_store {
+            config.frozen_store = value;
+            config.explicit_settings.insert("frozenStore".to_string(), value.into());
+        }
+        if let Some(value) = self.ignore_pnpmfile {
+            config.ignore_pnpmfile = value;
+            config.explicit_settings.insert("ignorePnpmfile".to_string(), value.into());
+        }
+        if let Some(value) = self.link_workspace_packages {
+            config.link_workspace_packages = value;
+            config
+                .explicit_settings
+                .insert("linkWorkspacePackages".to_string(), setting_value(value));
+        }
+        if let Some(value) = self.lockfile_include_tarball_url {
+            config.lockfile_include_tarball_url = value;
+            config.explicit_settings.insert("lockfileIncludeTarballUrl".to_string(), value.into());
+        }
+        if let Some(value) = self.merge_git_branch_lockfiles {
+            config.merge_git_branch_lockfiles = value;
+            config.explicit_settings.insert("mergeGitBranchLockfiles".to_string(), value.into());
+        }
+        if let Some(value) = self.node_experimental_package_map {
+            config.node_experimental_package_map = value;
+            config.explicit_settings.insert("nodeExperimentalPackageMap".to_string(), value.into());
+        }
+        if let Some(value) = self.offline {
+            config.offline = value;
+            config.explicit_settings.insert("offline".to_string(), value.into());
+        }
+        if let Some(value) = self.prefer_frozen_lockfile {
+            config.prefer_frozen_lockfile = value;
+            config.explicit_settings.insert("preferFrozenLockfile".to_string(), value.into());
+        }
+        if let Some(value) = self.prefer_offline {
+            config.prefer_offline = value;
+            config.explicit_settings.insert("preferOffline".to_string(), value.into());
+        }
+        if let Some(value) = self.save_workspace_protocol {
+            config.save_workspace_protocol = value;
+            config
+                .explicit_settings
+                .insert("saveWorkspaceProtocol".to_string(), setting_value(value));
+        }
+        if let Some(value) = self.verify_store_integrity {
+            config.verify_store_integrity = value;
+            config.explicit_settings.insert("verifyStoreIntegrity".to_string(), value.into());
+        }
+        if let Some(value) = self.virtual_store_only {
+            config.virtual_store_only = value;
+            config.explicit_settings.insert("virtualStoreOnly".to_string(), value.into());
+            config.apply_virtual_store_only_derivation();
         }
         if let Some(value) = self.global_dir.as_deref().filter(|value| !value.is_empty()) {
             let global_dir = lexical_normalize(&dir.join(value));
@@ -734,13 +837,15 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
         return ConfigToken::NotOurs;
     };
     if let Some(negated) = flag.strip_prefix("no-")
-        && let Some((key, SettingArity::Boolean)) = setting(negated)
+        && let Some((key, SettingArity::Boolean | SettingArity::BooleanOr(_))) = setting(negated)
     {
         return ConfigToken::WellFormed { key, value: "false" };
     }
     let Some((key, value)) = flag.split_once('=') else {
         return match setting(flag) {
-            Some((key, SettingArity::Boolean)) => ConfigToken::BooleanFollows(key),
+            Some((key, SettingArity::Boolean | SettingArity::BooleanOr(_))) => {
+                ConfigToken::BooleanFollows(key)
+            }
             Some((key, _)) => ConfigToken::ValueFollows(key),
             None => ConfigToken::NotOurs,
         };
@@ -760,6 +865,13 @@ enum SettingArity {
     /// `--<setting>`, `--no-<setting>`, `--<setting>=<bool>`, and
     /// `--<setting> <bool>`.
     Boolean,
+    /// Every [`Boolean`] spelling, plus `--<setting>=<value>` for a value
+    /// the carried predicate accepts: the settings whose type is a
+    /// boolean or a keyword, like `linkWorkspacePackages: deep`. Only a
+    /// boolean is claimed from the token after the flag.
+    ///
+    /// [`Boolean`]: Self::Boolean
+    BooleanOr(fn(&str) -> bool),
     /// A path, a glob pattern, or another free-form value: every spelling
     /// is one the setting takes, so the token after the flag is claimed
     /// only when it cannot be anything else — see [`claims_as_value`].
@@ -779,20 +891,35 @@ enum SettingArity {
 /// setting the invoked command declares as its own option is left for
 /// clap; a setting that collides with a *global* option would be claimed
 /// on every command line and so must not appear here at all.
-const BARE_SETTING_FLAGS: [(&str, SettingArity); 22] = [
+const BARE_SETTING_FLAGS: [(&str, SettingArity); 39] = [
     ("allow-unused-patches", SettingArity::Boolean),
     ("child-concurrency", SettingArity::Parsed(is_i32)),
+    ("dangerously-allow-all-builds", SettingArity::Boolean),
+    ("engine-strict", SettingArity::Boolean),
+    ("force-legacy-deploy", SettingArity::Boolean),
+    ("frozen-store", SettingArity::Boolean),
     ("global-dir", SettingArity::Text),
     ("hoist", SettingArity::Boolean),
     ("hoist-pattern", SettingArity::Text),
+    ("ignore-pnpmfile", SettingArity::Boolean),
+    ("ignore-scripts", SettingArity::Boolean),
+    ("link-workspace-packages", SettingArity::BooleanOr(is_enum::<LinkWorkspacePackages>)),
     ("lockfile", SettingArity::Boolean),
+    ("lockfile-include-tarball-url", SettingArity::Boolean),
+    ("merge-git-branch-lockfiles", SettingArity::Boolean),
     ("modules-dir", SettingArity::Text),
+    ("node-experimental-package-map", SettingArity::Boolean),
+    ("offline", SettingArity::Boolean),
     ("optimistic-repeat-install", SettingArity::Boolean),
     ("package-import-method", SettingArity::Parsed(is_enum::<PackageImportMethod>)),
     ("pm-on-fail", SettingArity::Parsed(is_enum::<PmOnFail>)),
+    ("prefer-frozen-lockfile", SettingArity::Boolean),
+    ("prefer-offline", SettingArity::Boolean),
     ("public-hoist-pattern", SettingArity::Text),
     ("runtime-on-fail", SettingArity::Parsed(is_enum::<RuntimeOnFail>)),
+    ("save-workspace-protocol", SettingArity::BooleanOr(is_enum::<SaveWorkspaceProtocol>)),
     ("shamefully-hoist", SettingArity::Boolean),
+    ("shared-workspace-lockfile", SettingArity::Boolean),
     ("side-effects-cache", SettingArity::Boolean),
     ("side-effects-cache-readonly", SettingArity::Boolean),
     ("strict-peer-dependencies", SettingArity::Boolean),
@@ -801,7 +928,9 @@ const BARE_SETTING_FLAGS: [(&str, SettingArity); 22] = [
     ("trust-policy-exclude", SettingArity::Text),
     ("trust-policy-ignore-after", SettingArity::Parsed(is_u64)),
     ("unsafe-perm", SettingArity::Boolean),
+    ("verify-store-integrity", SettingArity::Boolean),
     ("virtual-store-dir", SettingArity::Text),
+    ("virtual-store-only", SettingArity::Boolean),
 ];
 
 fn is_i32(value: &str) -> bool {
@@ -826,6 +955,7 @@ fn named_bare_setting_flag(key: &str) -> Option<(&'static str, SettingArity)> {
 fn setting_takes(key: &str, value: &str) -> bool {
     match named_bare_setting_flag(key) {
         Some((_, SettingArity::Boolean)) => parse_bool(value).is_some(),
+        Some((_, SettingArity::BooleanOr(takes))) => parse_bool(value).is_some() || takes(value),
         Some((_, SettingArity::Text)) => true,
         Some((_, SettingArity::Parsed(takes))) => takes(value),
         None => true,
@@ -842,7 +972,7 @@ fn setting_takes(key: &str, value: &str) -> bool {
 /// `--child-concurrency -1` mean "every core but one".
 fn claims_as_value(key: &str, token: &str) -> bool {
     match named_bare_setting_flag(key) {
-        Some((_, SettingArity::Boolean)) => is_boolean_value(token),
+        Some((_, SettingArity::Boolean | SettingArity::BooleanOr(_))) => is_boolean_value(token),
         Some((_, SettingArity::Text)) => !token.starts_with('-'),
         Some((_, SettingArity::Parsed(takes))) => takes(token),
         None => false,
@@ -867,8 +997,10 @@ fn is_boolean_value(token: &str) -> bool {
 /// that is both, and `pnpm --lockfile true --config.registry=… install`
 /// loses everything past the boolean to the script fallback.
 pub(crate) fn bare_boolean_setting_claims(flag: &str, next: Option<&str>) -> bool {
-    matches!(named_bare_setting_flag(flag), Some((_, SettingArity::Boolean)))
-        && next.is_some_and(is_boolean_value)
+    matches!(
+        named_bare_setting_flag(flag),
+        Some((_, SettingArity::Boolean | SettingArity::BooleanOr(_))),
+    ) && next.is_some_and(is_boolean_value)
 }
 
 /// How many argv slots a bare `--<setting>` flag occupies, given the
@@ -905,6 +1037,14 @@ fn normalize_registry_url(registry: &str) -> String {
 
 fn parse_enum<Value: serde::de::DeserializeOwned>(value: &str) -> Option<Value> {
     serde_json::from_value(serde_json::Value::String(value.to_string())).ok()
+}
+
+/// A setting whose type is a boolean or a keyword, from either spelling.
+fn parse_bool_or_enum<Value: serde::de::DeserializeOwned>(value: &str) -> Option<Value> {
+    match parse_bool(value) {
+        Some(boolean) => serde_json::from_value(serde_json::Value::Bool(boolean)).ok(),
+        None => parse_enum(value),
+    }
 }
 
 /// An enum setting's kebab-case spelling, for [`Config::explicit_settings`]

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -481,6 +481,18 @@ impl ConfigOverrides {
         if let Some(value) = self.reverse {
             config.reverse = value;
         }
+        // Ahead of the hoist settings below: a `--no-virtual-store-only`
+        // gets the lower layers' patterns back first, and a pattern on the
+        // same command line then replaces them.
+        if let Some(value) = self.virtual_store_only {
+            config.virtual_store_only = value;
+            config.explicit_settings.insert("virtualStoreOnly".to_string(), value.into());
+            if value {
+                config.apply_virtual_store_only_derivation();
+            } else {
+                config.restore_hoist_patterns_after_virtual_store_only();
+            }
+        }
         if let Some(value) = self.shamefully_hoist {
             config.shamefully_hoist = value;
             config.explicit_settings.insert("shamefullyHoist".to_string(), value.into());
@@ -720,15 +732,6 @@ impl ConfigOverrides {
         if let Some(value) = self.verify_store_integrity {
             config.verify_store_integrity = value;
             config.explicit_settings.insert("verifyStoreIntegrity".to_string(), value.into());
-        }
-        if let Some(value) = self.virtual_store_only {
-            config.virtual_store_only = value;
-            config.explicit_settings.insert("virtualStoreOnly".to_string(), value.into());
-            if value {
-                config.apply_virtual_store_only_derivation();
-            } else {
-                config.restore_hoist_patterns_after_virtual_store_only();
-            }
         }
         if let Some(value) = self.global_dir.as_deref().filter(|value| !value.is_empty()) {
             let global_dir = lexical_normalize(&dir.join(value));

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -837,13 +837,14 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
         return ConfigToken::NotOurs;
     };
     if let Some(negated) = flag.strip_prefix("no-")
-        && let Some((key, SettingArity::Boolean | SettingArity::BooleanOr(_))) = setting(negated)
+        && let Some((key, SettingArity::Boolean | SettingArity::BooleanOr { .. })) =
+            setting(negated)
     {
         return ConfigToken::WellFormed { key, value: "false" };
     }
     let Some((key, value)) = flag.split_once('=') else {
         return match setting(flag) {
-            Some((key, SettingArity::Boolean | SettingArity::BooleanOr(_))) => {
+            Some((key, SettingArity::Boolean | SettingArity::BooleanOr { .. })) => {
                 ConfigToken::BooleanFollows(key)
             }
             Some((key, _)) => ConfigToken::ValueFollows(key),
@@ -851,6 +852,11 @@ fn classify<'a>(arg: &'a OsStr, claimed_by_command: &HashSet<&str>) -> ConfigTok
         };
     };
     match setting(key) {
+        Some((_, SettingArity::BooleanOr { bare_keyword: false, .. }))
+            if parse_bool(value).is_none() =>
+        {
+            ConfigToken::NotOurs
+        }
         Some(_) if !setting_takes(key, value) => ConfigToken::NotOurs,
         Some((key, _)) => ConfigToken::WellFormed { key, value },
         None => ConfigToken::NotOurs,
@@ -865,13 +871,19 @@ enum SettingArity {
     /// `--<setting>`, `--no-<setting>`, `--<setting>=<bool>`, and
     /// `--<setting> <bool>`.
     Boolean,
-    /// Every [`Boolean`] spelling, plus `--<setting>=<value>` for a value
-    /// the carried predicate accepts: the settings whose type is a
-    /// boolean or a keyword, like `linkWorkspacePackages: deep`. Only a
-    /// boolean is claimed from the token after the flag.
+    /// Every [`Boolean`] spelling, plus a keyword `takes` accepts, for a
+    /// setting whose type is a boolean or a keyword. Only a boolean is
+    /// claimed from the token after the flag.
+    ///
+    /// `bare_keyword` says whether the keyword is spellable as
+    /// `--<setting>=<keyword>`, which follows the `nopt` type pnpm gives
+    /// the setting: `linkWorkspacePackages` is `[Boolean, 'deep']`, so
+    /// `--link-workspace-packages=deep` parses; `saveWorkspaceProtocol` is
+    /// `Boolean` alone, so `rolling` reaches it only through the untyped
+    /// `--config.` form.
     ///
     /// [`Boolean`]: Self::Boolean
-    BooleanOr(fn(&str) -> bool),
+    BooleanOr { takes: fn(&str) -> bool, bare_keyword: bool },
     /// A path, a glob pattern, or another free-form value: every spelling
     /// is one the setting takes, so the token after the flag is claimed
     /// only when it cannot be anything else — see [`claims_as_value`].
@@ -903,7 +915,10 @@ const BARE_SETTING_FLAGS: [(&str, SettingArity); 39] = [
     ("hoist-pattern", SettingArity::Text),
     ("ignore-pnpmfile", SettingArity::Boolean),
     ("ignore-scripts", SettingArity::Boolean),
-    ("link-workspace-packages", SettingArity::BooleanOr(is_enum::<LinkWorkspacePackages>)),
+    (
+        "link-workspace-packages",
+        SettingArity::BooleanOr { takes: is_enum::<LinkWorkspacePackages>, bare_keyword: true },
+    ),
     ("lockfile", SettingArity::Boolean),
     ("lockfile-include-tarball-url", SettingArity::Boolean),
     ("merge-git-branch-lockfiles", SettingArity::Boolean),
@@ -917,7 +932,10 @@ const BARE_SETTING_FLAGS: [(&str, SettingArity); 39] = [
     ("prefer-offline", SettingArity::Boolean),
     ("public-hoist-pattern", SettingArity::Text),
     ("runtime-on-fail", SettingArity::Parsed(is_enum::<RuntimeOnFail>)),
-    ("save-workspace-protocol", SettingArity::BooleanOr(is_enum::<SaveWorkspaceProtocol>)),
+    (
+        "save-workspace-protocol",
+        SettingArity::BooleanOr { takes: is_enum::<SaveWorkspaceProtocol>, bare_keyword: false },
+    ),
     ("shamefully-hoist", SettingArity::Boolean),
     ("shared-workspace-lockfile", SettingArity::Boolean),
     ("side-effects-cache", SettingArity::Boolean),
@@ -955,7 +973,9 @@ fn named_bare_setting_flag(key: &str) -> Option<(&'static str, SettingArity)> {
 fn setting_takes(key: &str, value: &str) -> bool {
     match named_bare_setting_flag(key) {
         Some((_, SettingArity::Boolean)) => parse_bool(value).is_some(),
-        Some((_, SettingArity::BooleanOr(takes))) => parse_bool(value).is_some() || takes(value),
+        Some((_, SettingArity::BooleanOr { takes, .. })) => {
+            parse_bool(value).is_some() || takes(value)
+        }
         Some((_, SettingArity::Text)) => true,
         Some((_, SettingArity::Parsed(takes))) => takes(value),
         None => true,
@@ -972,7 +992,9 @@ fn setting_takes(key: &str, value: &str) -> bool {
 /// `--child-concurrency -1` mean "every core but one".
 fn claims_as_value(key: &str, token: &str) -> bool {
     match named_bare_setting_flag(key) {
-        Some((_, SettingArity::Boolean | SettingArity::BooleanOr(_))) => is_boolean_value(token),
+        Some((_, SettingArity::Boolean | SettingArity::BooleanOr { .. })) => {
+            is_boolean_value(token)
+        }
         Some((_, SettingArity::Text)) => !token.starts_with('-'),
         Some((_, SettingArity::Parsed(takes))) => takes(token),
         None => false,
@@ -999,7 +1021,7 @@ fn is_boolean_value(token: &str) -> bool {
 pub(crate) fn bare_boolean_setting_claims(flag: &str, next: Option<&str>) -> bool {
     matches!(
         named_bare_setting_flag(flag),
-        Some((_, SettingArity::Boolean | SettingArity::BooleanOr(_))),
+        Some((_, SettingArity::Boolean | SettingArity::BooleanOr { .. })),
     ) && next.is_some_and(is_boolean_value)
 }
 

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -724,7 +724,11 @@ impl ConfigOverrides {
         if let Some(value) = self.virtual_store_only {
             config.virtual_store_only = value;
             config.explicit_settings.insert("virtualStoreOnly".to_string(), value.into());
-            config.apply_virtual_store_only_derivation();
+            if value {
+                config.apply_virtual_store_only_derivation();
+            } else {
+                config.restore_hoist_patterns_after_virtual_store_only();
+            }
         }
         if let Some(value) = self.global_dir.as_deref().filter(|value| !value.is_empty()) {
             let global_dir = lexical_normalize(&dir.join(value));

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -154,6 +154,7 @@ pub struct ConfigOverrides {
     trust_policy: Option<TrustPolicy>,
     trust_policy_exclude: Option<Vec<String>>,
     trust_policy_ignore_after: Option<u64>,
+    unsafe_perm: Option<bool>,
     verify_deps_before_run: Option<VerifyDepsBeforeRun>,
     https_proxy: Option<String>,
     http_proxy: Option<String>,
@@ -255,6 +256,7 @@ impl ConfigOverrides {
             "sort" => self.sort = parse_bool(value),
             "strict-peer-dependencies" => self.strict_peer_dependencies = parse_bool(value),
             "trust-lockfile" => self.trust_lockfile = parse_bool(value),
+            "unsafe-perm" => self.unsafe_perm = parse_bool(value),
             "use-beta-cli" => self.use_beta_cli = parse_bool(value),
             _ => {}
         }
@@ -617,6 +619,10 @@ impl ConfigOverrides {
             config.trust_policy_ignore_after = Some(value);
             config.explicit_settings.insert("trustPolicyIgnoreAfter".to_string(), value.into());
         }
+        if let Some(value) = self.unsafe_perm {
+            config.unsafe_perm = value;
+            config.explicit_settings.insert("unsafePerm".to_string(), value.into());
+        }
         if let Some(value) = self.global_dir.as_deref().filter(|value| !value.is_empty()) {
             let global_dir = lexical_normalize(&dir.join(value));
             config.global_pkg_dir = Some(global_dir.join(GLOBAL_LAYOUT_VERSION));
@@ -773,7 +779,7 @@ enum SettingArity {
 /// setting the invoked command declares as its own option is left for
 /// clap; a setting that collides with a *global* option would be claimed
 /// on every command line and so must not appear here at all.
-const BARE_SETTING_FLAGS: [(&str, SettingArity); 21] = [
+const BARE_SETTING_FLAGS: [(&str, SettingArity); 22] = [
     ("allow-unused-patches", SettingArity::Boolean),
     ("child-concurrency", SettingArity::Parsed(is_i32)),
     ("global-dir", SettingArity::Text),
@@ -794,6 +800,7 @@ const BARE_SETTING_FLAGS: [(&str, SettingArity); 21] = [
     ("trust-policy", SettingArity::Parsed(is_enum::<TrustPolicy>)),
     ("trust-policy-exclude", SettingArity::Text),
     ("trust-policy-ignore-after", SettingArity::Parsed(is_u64)),
+    ("unsafe-perm", SettingArity::Boolean),
     ("virtual-store-dir", SettingArity::Text),
 ];
 

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -2,8 +2,9 @@ use super::{
     ConfigOverrides, apply_registry_override, apply_state_dir_override, apply_store_dir_override,
 };
 use pnpm_config::{
-    ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, NodeLinker,
-    PackageImportMethod, PmOnFail, RemoteSideEffectsCacheSettings, RuntimeOnFail, TrustPolicy,
+    ColorMode, Config, EnvVar, GetCurrentDir, GetHomeDir, LinkProbe, LinkWorkspacePackages,
+    NodeLinker, PackageImportMethod, PmOnFail, RemoteSideEffectsCacheSettings, RuntimeOnFail,
+    SaveWorkspaceProtocol, TrustPolicy,
 };
 use pnpm_store_dir::STORE_VERSION;
 use pretty_assertions::assert_eq;
@@ -814,6 +815,136 @@ fn unsafe_perm_is_a_bare_flag_on_every_command() {
     assert_eq!(config.explicit_settings.get("unsafePerm"), Some(&serde_json::Value::Bool(false)));
 }
 
+/// The boolean settings pnpm's `nopt` types make spellable on every
+/// command that lists them, which clap rejected as unexpected arguments.
+#[test]
+fn the_boolean_settings_are_bare_flags_where_no_command_declares_them() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "add",
+        "foo",
+        "--dangerously-allow-all-builds",
+        "--engine-strict",
+        "--frozen-store",
+        "--lockfile-include-tarball-url",
+        "--merge-git-branch-lockfiles",
+        "--node-experimental-package-map",
+        "--offline",
+        "--prefer-frozen-lockfile",
+        "--prefer-offline",
+        "--no-shared-workspace-lockfile",
+        "--no-verify-store-integrity",
+        "--force-legacy-deploy",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "foo"]));
+
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.dangerously_allow_all_builds);
+    assert!(config.engine_strict);
+    assert!(config.frozen_store);
+    assert!(config.lockfile_include_tarball_url);
+    assert!(config.merge_git_branch_lockfiles);
+    assert!(config.node_experimental_package_map);
+    assert!(config.offline);
+    assert!(config.prefer_frozen_lockfile);
+    assert!(config.prefer_offline);
+    assert!(!config.shared_workspace_lockfile);
+    assert!(!config.verify_store_integrity);
+    assert!(config.force_legacy_deploy);
+    assert_eq!(config.explicit_settings.get("offline"), Some(&serde_json::Value::Bool(true)));
+    assert_eq!(
+        config.explicit_settings.get("sharedWorkspaceLockfile"),
+        Some(&serde_json::Value::Bool(false)),
+    );
+
+    // `audit` declares neither, unlike `install` and `add`.
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "audit",
+        "--ignore-scripts",
+        "--ignore-pnpmfile",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "audit"]));
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.ignore_scripts);
+    assert!(config.ignore_pnpmfile);
+}
+
+/// `virtualStoreOnly` empties the hoist patterns the way the yaml layer
+/// does, so a later install does not read a pattern this one never applied.
+#[test]
+fn virtual_store_only_flag_empties_the_hoist_patterns() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--virtual-store-only"]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+    let mut config = Config {
+        hoist_pattern: Some(vec!["*".to_string()]),
+        public_hoist_pattern: Some(vec!["*eslint*".to_string()]),
+        ..Config::default()
+    };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.virtual_store_only);
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
+    assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
+}
+
+/// `linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a
+/// keyword, so they take every boolean spelling plus the keyword in the
+/// `=` form.
+#[test]
+fn a_boolean_or_keyword_setting_takes_both_spellings() {
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "add",
+        "foo",
+        "--link-workspace-packages",
+        "--save-workspace-protocol=rolling",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "foo"]));
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.link_workspace_packages, LinkWorkspacePackages::DirectOnly);
+    assert_eq!(config.save_workspace_protocol, SaveWorkspaceProtocol::Rolling);
+    assert_eq!(
+        config.explicit_settings.get("linkWorkspacePackages"),
+        Some(&serde_json::Value::Bool(true)),
+    );
+    assert_eq!(
+        config.explicit_settings.get("saveWorkspaceProtocol"),
+        Some(&serde_json::Value::String("rolling".to_string())),
+    );
+
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "add",
+        "foo",
+        "--link-workspace-packages=deep",
+        "--no-save-workspace-protocol",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "foo"]));
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.link_workspace_packages, LinkWorkspacePackages::Deep);
+    assert_eq!(config.save_workspace_protocol, SaveWorkspaceProtocol::Off);
+
+    // The keyword is only taken in the `=` form; a following token is
+    // claimed only when it spells a boolean.
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "add",
+        "--link-workspace-packages",
+        "false",
+        "foo",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "foo"]));
+    let mut config =
+        Config { link_workspace_packages: LinkWorkspacePackages::Deep, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.link_workspace_packages, LinkWorkspacePackages::Off);
+}
+
 #[test]
 fn install_keeps_the_trust_lockfile_pair_for_clap() {
     for flag in ["--trust-lockfile", "--no-trust-lockfile"] {
@@ -1032,6 +1163,9 @@ fn extract_leaves_invalid_setting_values_for_clap() {
         &["--child-concurrency=lots"],
         &["--child-concurrency", "lots"],
         &["--trust-policy-ignore-after=soon"],
+        &["--link-workspace-packages=shallow"],
+        &["--save-workspace-protocol=sometimes"],
+        &["--offline=maybe"],
     ] {
         let command_line = ["pacquet", "install"]
             .into_iter()

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -813,6 +813,20 @@ fn unsafe_perm_is_a_bare_flag_on_every_command() {
     overrides.apply(&mut config, Path::new("/workspace"));
     assert!(!config.unsafe_perm);
     assert_eq!(config.explicit_settings.get("unsafePerm"), Some(&serde_json::Value::Bool(false)));
+
+    for (flag, expected) in [
+        ("--unsafe-perm", true),
+        ("--unsafe-perm=true", true),
+        ("--no-unsafe-perm", false),
+        ("--unsafe-perm=false", false),
+    ] {
+        let (overrides, remaining) =
+            ConfigOverrides::extract(argv(["pacquet", "remove", "foo", flag]));
+        assert_eq!(remaining, argv(["pacquet", "remove", "foo"]), "{flag}");
+        let mut config = Config { unsafe_perm: !expected, ..Config::default() };
+        overrides.apply(&mut config, Path::new("/workspace"));
+        assert_eq!(config.unsafe_perm, expected, "{flag}");
+    }
 }
 
 /// The boolean settings pnpm's `nopt` types make spellable on every
@@ -892,7 +906,7 @@ fn virtual_store_only_flag_empties_the_hoist_patterns() {
 
 /// A lower layer's `virtualStoreOnly: true` empties the patterns when the
 /// config is built; `--no-virtual-store-only` outranks it and gets them
-/// back, from the layer that set them or from the defaults.
+/// back exactly, an explicitly disabled pattern included.
 #[test]
 fn no_virtual_store_only_restores_the_hoist_patterns() {
     let (overrides, remaining) =
@@ -901,26 +915,17 @@ fn no_virtual_store_only_restores_the_hoist_patterns() {
 
     let mut config = Config {
         virtual_store_only: true,
-        hoist_pattern: Some(Vec::new()),
-        public_hoist_pattern: Some(Vec::new()),
+        hoist_pattern: Some(vec!["*eslint*".to_string()]),
+        public_hoist_pattern: None,
         ..Config::default()
     };
+    config.apply_virtual_store_only_derivation();
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
     overrides.apply(&mut config, Path::new("/workspace"));
     assert!(!config.virtual_store_only);
-    assert_eq!(config.hoist_pattern, Config::default().hoist_pattern);
-    assert_eq!(config.public_hoist_pattern, Config::default().public_hoist_pattern);
-
-    let mut config = Config {
-        virtual_store_only: true,
-        hoist_pattern: Some(Vec::new()),
-        public_hoist_pattern: Some(Vec::new()),
-        ..Config::default()
-    };
-    config.explicit_settings.insert("hoistPattern".to_string(), vec!["*eslint*"].into());
-    config.explicit_settings.insert("publicHoistPattern".to_string(), serde_json::Value::Null);
-    overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.hoist_pattern, Some(vec!["*eslint*".to_string()]));
     assert_eq!(config.public_hoist_pattern, None);
+    assert_eq!(config.hoist_patterns_before_virtual_store_only, None);
 
     // A pattern given on the same command line is what comes back.
     let (overrides, _) = ConfigOverrides::extract(argv([
@@ -929,15 +934,24 @@ fn no_virtual_store_only_restores_the_hoist_patterns() {
         "--hoist-pattern=foo",
         "--no-virtual-store-only",
     ]));
-    let mut config = Config {
-        virtual_store_only: true,
-        hoist_pattern: Some(Vec::new()),
-        public_hoist_pattern: Some(Vec::new()),
-        ..Config::default()
-    };
+    let mut config = Config { virtual_store_only: true, ..Config::default() };
+    config.apply_virtual_store_only_derivation();
     overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.hoist_pattern, Some(vec!["foo".to_string()]));
     assert_eq!(config.public_hoist_pattern, Config::default().public_hoist_pattern);
+
+    // Turning the mode on from the command line keeps the patterns
+    // empty whatever else the command line says about them.
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--virtual-store-only",
+        "--hoist-pattern=foo",
+    ]));
+    let mut config = Config::default();
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
+    assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
 }
 
 /// `linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a
@@ -1231,6 +1245,7 @@ fn extract_leaves_invalid_setting_values_for_clap() {
         &["--link-workspace-packages=shallow"],
         &["--save-workspace-protocol=sometimes"],
         &["--offline=maybe"],
+        &["--unsafe-perm=maybe"],
     ] {
         let command_line = ["pacquet", "install"]
             .into_iter()

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -793,6 +793,27 @@ fn trust_lockfile_is_a_bare_flag_where_no_command_declares_it() {
     assert!(config.trust_lockfile);
 }
 
+/// Vercel runs every pnpm install as `pnpm install --unsafe-perm`
+/// ([pnpm/pnpm#14346](https://github.com/pnpm/pnpm/issues/14346)).
+#[test]
+fn unsafe_perm_is_a_bare_flag_on_every_command() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--unsafe-perm"]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+    let mut config = Config { unsafe_perm: false, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(config.unsafe_perm);
+    assert_eq!(config.explicit_settings.get("unsafePerm"), Some(&serde_json::Value::Bool(true)));
+
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "rebuild", "--no-unsafe-perm"]));
+    assert_eq!(remaining, argv(["pacquet", "rebuild"]));
+    let mut config = Config { unsafe_perm: true, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(!config.unsafe_perm);
+    assert_eq!(config.explicit_settings.get("unsafePerm"), Some(&serde_json::Value::Bool(false)));
+}
+
 #[test]
 fn install_keeps_the_trust_lockfile_pair_for_clap() {
     for flag in ["--trust-lockfile", "--no-trust-lockfile"] {

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -891,8 +891,9 @@ fn virtual_store_only_flag_empties_the_hoist_patterns() {
 }
 
 /// `linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a
-/// keyword, so they take every boolean spelling plus the keyword in the
-/// `=` form.
+/// keyword, so they take every boolean spelling plus the keyword. pnpm
+/// types the first `[Boolean, 'deep']` and the second `Boolean`, so only
+/// `deep` is spellable bare; `rolling` needs the `--config.` form.
 #[test]
 fn a_boolean_or_keyword_setting_takes_both_spellings() {
     let (overrides, remaining) = ConfigOverrides::extract(argv([
@@ -900,7 +901,7 @@ fn a_boolean_or_keyword_setting_takes_both_spellings() {
         "add",
         "foo",
         "--link-workspace-packages",
-        "--save-workspace-protocol=rolling",
+        "--config.save-workspace-protocol=rolling",
     ]));
     assert_eq!(remaining, argv(["pacquet", "add", "foo"]));
     let mut config = Config::default();
@@ -943,6 +944,20 @@ fn a_boolean_or_keyword_setting_takes_both_spellings() {
         Config { link_workspace_packages: LinkWorkspacePackages::Deep, ..Config::default() };
     overrides.apply(&mut config, Path::new("/workspace"));
     assert_eq!(config.link_workspace_packages, LinkWorkspacePackages::Off);
+
+    // pnpm's `nopt` type for `saveWorkspaceProtocol` is `Boolean`, so the
+    // bare spelling of the keyword is left for clap to report.
+    let (overrides, remaining) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "add",
+        "foo",
+        "--save-workspace-protocol=rolling",
+    ]));
+    assert_eq!(remaining, argv(["pacquet", "add", "foo", "--save-workspace-protocol=rolling"]));
+    let mut config =
+        Config { save_workspace_protocol: SaveWorkspaceProtocol::On, ..Config::default() };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.save_workspace_protocol, SaveWorkspaceProtocol::On);
 }
 
 #[test]

--- a/pnpm/crates/cli/src/config_overrides/tests.rs
+++ b/pnpm/crates/cli/src/config_overrides/tests.rs
@@ -890,6 +890,56 @@ fn virtual_store_only_flag_empties_the_hoist_patterns() {
     assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
 }
 
+/// A lower layer's `virtualStoreOnly: true` empties the patterns when the
+/// config is built; `--no-virtual-store-only` outranks it and gets them
+/// back, from the layer that set them or from the defaults.
+#[test]
+fn no_virtual_store_only_restores_the_hoist_patterns() {
+    let (overrides, remaining) =
+        ConfigOverrides::extract(argv(["pacquet", "install", "--no-virtual-store-only"]));
+    assert_eq!(remaining, argv(["pacquet", "install"]));
+
+    let mut config = Config {
+        virtual_store_only: true,
+        hoist_pattern: Some(Vec::new()),
+        public_hoist_pattern: Some(Vec::new()),
+        ..Config::default()
+    };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert!(!config.virtual_store_only);
+    assert_eq!(config.hoist_pattern, Config::default().hoist_pattern);
+    assert_eq!(config.public_hoist_pattern, Config::default().public_hoist_pattern);
+
+    let mut config = Config {
+        virtual_store_only: true,
+        hoist_pattern: Some(Vec::new()),
+        public_hoist_pattern: Some(Vec::new()),
+        ..Config::default()
+    };
+    config.explicit_settings.insert("hoistPattern".to_string(), vec!["*eslint*"].into());
+    config.explicit_settings.insert("publicHoistPattern".to_string(), serde_json::Value::Null);
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.hoist_pattern, Some(vec!["*eslint*".to_string()]));
+    assert_eq!(config.public_hoist_pattern, None);
+
+    // A pattern given on the same command line is what comes back.
+    let (overrides, _) = ConfigOverrides::extract(argv([
+        "pacquet",
+        "install",
+        "--hoist-pattern=foo",
+        "--no-virtual-store-only",
+    ]));
+    let mut config = Config {
+        virtual_store_only: true,
+        hoist_pattern: Some(Vec::new()),
+        public_hoist_pattern: Some(Vec::new()),
+        ..Config::default()
+    };
+    overrides.apply(&mut config, Path::new("/workspace"));
+    assert_eq!(config.hoist_pattern, Some(vec!["foo".to_string()]));
+    assert_eq!(config.public_hoist_pattern, Config::default().public_hoist_pattern);
+}
+
 /// `linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a
 /// keyword, so they take every boolean spelling plus the keyword. pnpm
 /// types the first `[Boolean, 'deep']` and the second `Boolean`, so only

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -914,14 +914,6 @@ pub enum PackageImportMethod {
     CloneOrCopy,
 }
 
-/// Resolved runtime config built from defaults, the auth subset of
-/// `.npmrc`, and `pnpm-workspace.yaml` (see [`Config::current`]).
-///
-/// The type carries the merged result — it is never deserialized from a
-/// file directly. Yaml is parsed into [`WorkspaceSettings`] and applied
-/// onto `Config` field-by-field, following pnpm 11's split between
-/// `.npmrc` (auth/registry/network) and `pnpm-workspace.yaml`
-/// (project-structural settings).
 /// The two hoist patterns as one value, for
 /// [`Config::hoist_patterns_before_virtual_store_only`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -930,6 +922,14 @@ pub struct HoistPatterns {
     pub public_hoist_pattern: Option<Vec<String>>,
 }
 
+/// Resolved runtime config built from defaults, the auth subset of
+/// `.npmrc`, and `pnpm-workspace.yaml` (see [`Config::current`]).
+///
+/// The type carries the merged result — it is never deserialized from a
+/// file directly. Yaml is parsed into [`WorkspaceSettings`] and applied
+/// onto `Config` field-by-field, following pnpm 11's split between
+/// `.npmrc` (auth/registry/network) and `pnpm-workspace.yaml`
+/// (project-structural settings).
 #[derive(Debug, Clone, SmartDefault)]
 pub struct Config {
     /// Whether recursive commands stop after the first failure.

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -922,6 +922,14 @@ pub enum PackageImportMethod {
 /// onto `Config` field-by-field, following pnpm 11's split between
 /// `.npmrc` (auth/registry/network) and `pnpm-workspace.yaml`
 /// (project-structural settings).
+/// The two hoist patterns as one value, for
+/// [`Config::hoist_patterns_before_virtual_store_only`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HoistPatterns {
+    pub hoist_pattern: Option<Vec<String>>,
+    pub public_hoist_pattern: Option<Vec<String>>,
+}
+
 #[derive(Debug, Clone, SmartDefault)]
 pub struct Config {
     /// Whether recursive commands stop after the first failure.
@@ -1060,6 +1068,14 @@ pub struct Config {
     /// ([pnpm/pnpm#11750](https://github.com/pnpm/pnpm/issues/11750)).
     #[default(_code = "Some(default_public_hoist_pattern())")]
     pub public_hoist_pattern: Option<Vec<String>>,
+
+    /// The patterns [`apply_virtual_store_only_derivation`] emptied, so
+    /// a command-line `--no-virtual-store-only` that outranks a lower
+    /// layer's `virtualStoreOnly: true` can bring them back exactly.
+    /// `None` until that derivation empties them.
+    ///
+    /// [`apply_virtual_store_only_derivation`]: Self::apply_virtual_store_only_derivation
+    pub hoist_patterns_before_virtual_store_only: Option<HoistPatterns>,
 
     /// `extendNodePath`: when `true` (the default) and the isolated
     /// `nodeLinker` runs with a hoist pattern, command shims set
@@ -2997,6 +3013,12 @@ impl Config {
         if !self.virtual_store_only {
             return;
         }
+        if self.hoist_patterns_before_virtual_store_only.is_none() {
+            self.hoist_patterns_before_virtual_store_only = Some(HoistPatterns {
+                hoist_pattern: self.hoist_pattern.take(),
+                public_hoist_pattern: self.public_hoist_pattern.take(),
+            });
+        }
         self.hoist_pattern = Some(Vec::new());
         self.public_hoist_pattern = Some(Vec::new());
     }
@@ -3004,34 +3026,17 @@ impl Config {
     /// Undo [`apply_virtual_store_only_derivation`] after a command-line
     /// `--no-virtual-store-only` outranks a lower layer's
     /// `virtualStoreOnly: true`, which emptied both patterns when the
-    /// config was built. Each pattern comes back from the setting that
-    /// supplied it, or from its default, and the derivations that run
-    /// over the patterns run again. pnpm merges the command line before
-    /// it derives, so it never empties them in the first place.
+    /// config was built. pnpm merges the command line before it derives,
+    /// so it never empties them in the first place.
     ///
     /// [`apply_virtual_store_only_derivation`]: Self::apply_virtual_store_only_derivation
     pub fn restore_hoist_patterns_after_virtual_store_only(&mut self) {
         if self.virtual_store_only {
             return;
         }
-        self.hoist_pattern = self.explicit_pattern("hoistPattern", default_hoist_pattern);
-        self.public_hoist_pattern =
-            self.explicit_pattern("publicHoistPattern", default_public_hoist_pattern);
-        if !self.hoist {
-            self.hoist_pattern = None;
-        }
-        self.apply_shamefully_hoist_derivation();
-    }
-
-    /// A pattern list from [`explicit_settings`], or `default` when no
-    /// layer set it. An explicit `null` keeps the pattern off.
-    ///
-    /// [`explicit_settings`]: Self::explicit_settings
-    fn explicit_pattern(&self, key: &str, default: fn() -> Vec<String>) -> Option<Vec<String>> {
-        match self.explicit_settings.get(key) {
-            None => Some(default()),
-            Some(serde_json::Value::Null) => None,
-            Some(value) => serde_json::from_value(value.clone()).ok().or_else(|| Some(default())),
+        if let Some(patterns) = self.hoist_patterns_before_virtual_store_only.take() {
+            self.hoist_pattern = patterns.hoist_pattern;
+            self.public_hoist_pattern = patterns.public_hoist_pattern;
         }
     }
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3001,6 +3001,40 @@ impl Config {
         self.public_hoist_pattern = Some(Vec::new());
     }
 
+    /// Undo [`apply_virtual_store_only_derivation`] after a command-line
+    /// `--no-virtual-store-only` outranks a lower layer's
+    /// `virtualStoreOnly: true`, which emptied both patterns when the
+    /// config was built. Each pattern comes back from the setting that
+    /// supplied it, or from its default, and the derivations that run
+    /// over the patterns run again. pnpm merges the command line before
+    /// it derives, so it never empties them in the first place.
+    ///
+    /// [`apply_virtual_store_only_derivation`]: Self::apply_virtual_store_only_derivation
+    pub fn restore_hoist_patterns_after_virtual_store_only(&mut self) {
+        if self.virtual_store_only {
+            return;
+        }
+        self.hoist_pattern = self.explicit_pattern("hoistPattern", default_hoist_pattern);
+        self.public_hoist_pattern =
+            self.explicit_pattern("publicHoistPattern", default_public_hoist_pattern);
+        if !self.hoist {
+            self.hoist_pattern = None;
+        }
+        self.apply_shamefully_hoist_derivation();
+    }
+
+    /// A pattern list from [`explicit_settings`], or `default` when no
+    /// layer set it. An explicit `null` keeps the pattern off.
+    ///
+    /// [`explicit_settings`]: Self::explicit_settings
+    fn explicit_pattern(&self, key: &str, default: fn() -> Vec<String>) -> Option<Vec<String>> {
+        match self.explicit_settings.get(key) {
+            None => Some(default()),
+            Some(serde_json::Value::Null) => None,
+            Some(value) => serde_json::from_value(value.clone()).ok().or_else(|| Some(default())),
+        }
+    }
+
     /// The lockfile file name this install reads first and writes back:
     /// the branch lockfile under `gitBranchLockfile`, `pnpm-lock.yaml`
     /// otherwise.

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -57,6 +57,7 @@ fn create_config(
         hoist: false,
         hoist_pattern: None,
         public_hoist_pattern: None,
+        hoist_patterns_before_virtual_store_only: None,
         extend_node_path: true,
         prefer_symlinked_executables: None,
         shamefully_hoist: false,

--- a/pnpm11/installing/commands/src/remove.ts
+++ b/pnpm11/installing/commands/src/remove.ts
@@ -71,6 +71,7 @@ export function rcOptionsTypes (): Record<string, unknown> {
     'trust-policy',
     'trust-policy-exclude',
     'trust-policy-ignore-after',
+    'unsafe-perm',
     'virtual-store-dir',
   ], allTypes)
 }

--- a/pnpm11/installing/commands/test/remove/remove.ts
+++ b/pnpm11/installing/commands/test/remove/remove.ts
@@ -173,3 +173,7 @@ test('cliOptionsTypes registers the supply-chain policy options', () => {
   expect(optionTypes).toHaveProperty('trust-policy-exclude')
   expect(optionTypes).toHaveProperty('trust-policy-ignore-after')
 })
+
+test('cliOptionsTypes registers unsafe-perm', () => {
+  expect(remove.cliOptionsTypes()).toHaveProperty('unsafe-perm')
+})

--- a/pnpm11/pnpm/test/parseCliArgs.test.ts
+++ b/pnpm11/pnpm/test/parseCliArgs.test.ts
@@ -22,3 +22,27 @@ test('a bare --fix does not consume the flag that follows it', async () => {
   expect(options.fix).toBe('')
   expect(options.json).toBe(true)
 })
+
+test('remove takes --unsafe-perm in every spelling, before and after the command', async () => {
+  const enabled = await Promise.all([
+    ['remove', 'foo', '--unsafe-perm'],
+    ['--unsafe-perm', 'remove', 'foo'],
+    ['remove', 'foo', '--unsafe-perm=true'],
+  ].map((argv) => parseCliArgs(argv)))
+  for (const { cmd, params, options, unknownOptions } of enabled) {
+    expect(cmd).toBe('remove')
+    expect(params).toStrictEqual(['foo'])
+    expect(options['unsafe-perm']).toBe(true)
+    expect(unknownOptions.size).toBe(0)
+  }
+
+  const disabled = await Promise.all([
+    ['remove', 'foo', '--no-unsafe-perm'],
+    ['remove', 'foo', '--unsafe-perm=false'],
+  ].map((argv) => parseCliArgs(argv)))
+  for (const { params, options, unknownOptions } of disabled) {
+    expect(params).toStrictEqual(['foo'])
+    expect(options['unsafe-perm']).toBe(false)
+    expect(unknownOptions.size).toBe(0)
+  }
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Related to pnpm/pnpm#14346. After pnpm/pnpm#14527 shipped in 12.3.3, a Vercel build with `packageManager: pnpm@12.3.3` gets past the placeholder bin and then fails on the next layer ([report](https://x.com/ruchernchong/status/2095836132517023882)):

```
Detected `pnpm-lock.yaml` version 9 generated by pnpm@10.x with package.json#packageManager pnpm@12.3.3
Installing dependencies...
error: unexpected argument '--unsafe-perm' found

  tip: a similar argument exists: '--resume-from'

Usage: pnpm install [OPTIONS]
Error: Command "pnpm install" exited with 2
```

Vercel's build-utils runs every pnpm install as `pnpm install --unsafe-perm` ([run-user-scripts.ts](https://github.com/vercel/vercel/blob/main/packages/build-utils/src/fs/run-user-scripts.ts), the `case 'pnpm'` branch). pnpm declares a `nopt` type for every setting, so any command that lists a setting in its option types takes it as a bare `--<setting>` flag. pacquet only knew the flags each command declared to clap plus the `BARE_SETTING_FLAGS` table (pnpm/pnpm#14283), and rejected the rest.

**What this PR does.** Probing every boolean option of every TypeScript command against the binary (`<cmd> --<flag> --help`, so clap reports the unknown flag before anything runs) found seventeen settings with a `Config` field and no table row. They are all rows now:

`dangerously-allow-all-builds`, `engine-strict`, `force-legacy-deploy`, `frozen-store`, `ignore-pnpmfile`, `ignore-scripts`, `link-workspace-packages`, `lockfile-include-tarball-url`, `merge-git-branch-lockfiles`, `node-experimental-package-map`, `offline`, `prefer-frozen-lockfile`, `prefer-offline`, `save-workspace-protocol`, `shared-workspace-lockfile`, `unsafe-perm`, `verify-store-integrity`, `virtual-store-only`.

A command that declares one of them to clap (`install --offline`, `add --ignore-scripts`) keeps its own flag; the rest take the setting from the table. `linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a keyword (`deep`, `rolling`), so the table gains a `BooleanOr` arity: every boolean spelling, plus the keyword. Whether the keyword is spellable bare follows the `nopt` type pnpm gives the setting: `[Boolean, 'deep']` makes `--link-workspace-packages=deep` parse, while `saveWorkspaceProtocol` is `Boolean` alone, so `rolling` reaches it only through `--config.save-workspace-protocol=rolling`, as in pnpm 11. `--virtual-store-only` re-runs the hoist-pattern derivation the yaml layer applies, and `--no-virtual-store-only` puts back the patterns a lower layer's `virtualStoreOnly: true` emptied, verbatim: the derivation keeps them on `Config` when it empties them. `sharedWorkspaceLockfile` now records itself in `explicit_settings` like the other overrides.

The TypeScript `remove` command registers `unsafe-perm` as well, as pnpm/pnpm#14432 did for `trust-lockfile`; it was the only command where the two stacks disagreed on that flag (`fetch` and `dedupe` reuse `install`'s option list).

**Still rejected**, deliberately out of scope: command options with no setting behind them, which need clap arguments and command logic on those commands: `update --force`, `remove --force`, `add --workspace`, `install --no-save`, `install --global`, `init --bare`, `licenses list --compatible` / `--table`, `--resolution-only`, and `--parseable` outside the list family.

## Squash Commit Body

```text
pnpm declares a `nopt` type for every setting, so any command that lists
a setting in its option types takes it as a bare `--<setting>` flag.
pacquet only knew the flags each command declared to clap plus the
`BARE_SETTING_FLAGS` table, and rejected the rest as unexpected
arguments. Vercel runs every install as `pnpm install --unsafe-perm`, so
every pnpm 12 install there failed; it was masked until 12.3.3 by the
placeholder bin failing first (pnpm/pnpm#14527). `pnpm install
--dangerously-allow-all-builds`, `pnpm add foo --offline`, and `pnpm
install --engine-strict` failed the same way.

Probing every boolean option of every TypeScript command against the
binary found seventeen settings with a `Config` field and no table row.
Add them: dangerously-allow-all-builds, engine-strict,
force-legacy-deploy, frozen-store, ignore-pnpmfile, ignore-scripts,
link-workspace-packages, lockfile-include-tarball-url,
merge-git-branch-lockfiles, node-experimental-package-map, offline,
prefer-frozen-lockfile, prefer-offline, save-workspace-protocol,
shared-workspace-lockfile, unsafe-perm, verify-store-integrity, and
virtual-store-only. A command that declares one of them to clap keeps
its own flag; the rest take the setting from the table.

`linkWorkspacePackages` and `saveWorkspaceProtocol` are a boolean or a
keyword (`deep`, `rolling`), so the table gains a `BooleanOr` arity:
every boolean spelling, plus the keyword. Whether the keyword is
spellable bare follows the `nopt` type pnpm gives the setting:
`[Boolean, 'deep']` makes `--link-workspace-packages=deep` parse, while
`saveWorkspaceProtocol` is `Boolean` alone, so `rolling` reaches it only
through the `--config.` form, as in pnpm 11.
`--virtual-store-only` re-runs the hoist-pattern derivation the yaml
layer applies, and `--no-virtual-store-only` puts back the patterns a
lower layer's `virtualStoreOnly: true` emptied, verbatim: the derivation
keeps them on `Config` when it empties them, since pnpm merges the
command line before it derives and never empties them at all. `sharedWorkspaceLockfile` now records itself in
`explicit_settings` like the other overrides.

The TypeScript `remove` command registers `unsafe-perm` as well, as
pnpm/pnpm#14432 did for `trust-lockfile`; it was the only command where
the two stacks disagreed.

The flags still rejected are command options with no setting behind
them (`update --force`, `add --workspace`, `install --no-save`,
`init --bare`, `licenses list --compatible`, `--parseable` outside the
list family) and need clap arguments on those commands.

Related to pnpm/pnpm#14346.
```

## Verification

Every boolean option of every TypeScript command, probed against the pacquet binary before and after:

| | before | after |
| --- | --- | --- |
| setting-backed flags rejected somewhere | 17 | 0 |
| regressions (newly rejected) | | 0 |

Spot checks with the rebuilt binary in a project with an up-to-date lockfile: `pnpm install --unsafe-perm`, `--no-unsafe-perm`, `--unsafe-perm=false`, `pnpm --unsafe-perm install`, and `pnpm config get unsafe-perm --unsafe-perm` (prints `true`) all work; every one exited 2 on 12.3.3.

`cargo test -p pnpm-cli --lib config_overrides`: 60 passed. `pnpm-config`: 623 passed. `parse_boundary`: 8 passed. `pnpm/scripts/pre-push-rust.sh` green. TypeScript: `pnpm11/pnpm` `test/parseCliArgs.test.ts` drives `pnpm remove foo --unsafe-perm` through the real argv parser in all five spellings, and fails with the `remove` registration removed.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TZKLVoKNha58YRmNKQfoG1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored support for boolean CLI flags, including `--unsafe-perm`, `--offline`, and `--dangerously-allow-all-builds`.
  * Added `--unsafe-perm` support to `pnpm remove`.
  * Expanded CLI configuration overrides for installation, lockfile, workspace, store, and package resolution settings.
  * Added support for settings that accept either a boolean value or a keyword.

* **Bug Fixes**
  * Hoist patterns are now correctly restored when `virtual-store-only` is disabled and remain suppressed when it is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->