### PR TITLE
perf(cli): index deploy workspace projects

### DIFF
--- a/.changeset/deploy-project-index.md
+++ b/.changeset/deploy-project-index.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up `pnpm deploy` in workspaces with many projects [#14539](https://github.com/pnpm/pnpm/issues/14539).

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -113,7 +113,6 @@ enum DeployError {
 
 #[derive(Clone)]
 struct ProjectInfo {
-    root_dir: PathBuf,
     name: Option<String>,
     peer_dependencies: Vec<PkgName>,
     /// Names the project declares as prod or optional dependencies. A peer it
@@ -124,7 +123,7 @@ struct ProjectInfo {
 
 struct SelectedProject {
     project: Project,
-    all_projects: Vec<ProjectInfo>,
+    projects_by_path: HashMap<Vec<String>, ProjectInfo>,
 }
 
 struct DeployWorkspaceConfig {
@@ -145,7 +144,7 @@ enum DeployInstallMode {
 }
 
 struct ConvertCtx<'a> {
-    all_projects: &'a [ProjectInfo],
+    projects_by_path: &'a HashMap<Vec<String>, ProjectInfo>,
     deploy_dir: &'a Path,
     lockfile_dir: &'a Path,
     deployed_project_root: &'a Path,
@@ -459,20 +458,33 @@ fn select_project(
     dir: &Path,
 ) -> miette::Result<SelectedProject> {
     let (projects, _patterns) = discover_workspace_projects(workspace_dir, config)?;
-    let all_projects = projects
+    let projects_by_path = projects
         .iter()
-        .map(|project| ProjectInfo {
-            root_dir: lexical_normalize(&project.root_dir),
-            name: project.manifest.value().get("name").and_then(Value::as_str).map(str::to_string),
-            peer_dependencies: manifest_dependency_names(&project.manifest, &["peerDependencies"]),
-            declared_dependencies: manifest_dependency_names(
-                &project.manifest,
-                &["dependencies", "optionalDependencies"],
+        .map(|project| {
+            let root_dir = lexical_normalize(&project.root_dir);
+            (
+                comparable_path_components(&root_dir),
+                ProjectInfo {
+                    name: project
+                        .manifest
+                        .value()
+                        .get("name")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    peer_dependencies: manifest_dependency_names(
+                        &project.manifest,
+                        &["peerDependencies"],
+                    ),
+                    declared_dependencies: manifest_dependency_names(
+                        &project.manifest,
+                        &["dependencies", "optionalDependencies"],
+                    )
+                    .into_iter()
+                    .collect(),
+                },
             )
-            .into_iter()
-            .collect(),
         })
-        .collect::<Vec<_>>();
+        .collect::<HashMap<_, _>>();
 
     let selected_root = {
         let selection =
@@ -488,7 +500,7 @@ fn select_project(
         .into_iter()
         .find(|project| lexical_normalize(&project.root_dir) == selected_root)
         .ok_or(DeployError::NothingToDeploy)?;
-    Ok(SelectedProject { project, all_projects })
+    Ok(SelectedProject { project, projects_by_path })
 }
 
 fn resolve_target_dir(dir: &Path, target: &Path) -> PathBuf {
@@ -757,7 +769,7 @@ fn create_deploy_files(
     let deployed_project_root =
         validate_lockfile_local_path(&lockfile_dir.join(project_id), lockfile_dir)?;
     let ctx = ConvertCtx {
-        all_projects: &selected.all_projects,
+        projects_by_path: &selected.projects_by_path,
         deploy_dir,
         lockfile_dir,
         deployed_project_root: &deployed_project_root,
@@ -834,7 +846,7 @@ fn create_deploy_files(
         }
         let project_root =
             validate_lockfile_local_path(&lockfile_dir.join(importer_path), lockfile_dir)?;
-        let package_key = create_file_url_key(&project_root, "", &selected.all_projects, None)?;
+        let package_key = create_file_url_key(&project_root, "", &selected.projects_by_path, None)?;
         packages.insert(
             package_key,
             PackageMetadata {
@@ -863,14 +875,6 @@ fn create_deploy_files(
             snapshots.insert(output_key, convert_snapshot(snapshot, &ctx, lockfile_dir)?);
         }
     }
-    // Indexed on the same components `same_path` compares, so the importer loop
-    // below costs one lookup per importer rather than a scan of every project.
-    let peer_bearing_projects = selected
-        .all_projects
-        .iter()
-        .filter(|project| !project.peer_dependencies.is_empty())
-        .map(|project| (comparable_path_components(&project.root_dir), project))
-        .collect::<HashMap<_, _>>();
     let mut linked_workspace_projects = HashMap::new();
     for (importer_path, project_snapshot) in &lockfile.importers {
         if importer_path == project_id {
@@ -879,10 +883,12 @@ fn create_deploy_files(
         let project_root =
             validate_lockfile_local_path(&lockfile_dir.join(importer_path), lockfile_dir)?;
         let bases = ResolveBases { file_base: lockfile_dir, link_base: &project_root };
-        let package_key = create_file_url_key(&project_root, "", &selected.all_projects, None)?;
-        if let Some(project) = peer_bearing_projects.get(&comparable_path_components(&project_root))
+        let package_key = create_file_url_key(&project_root, "", &selected.projects_by_path, None)?;
+        if let Some(project) =
+            selected.projects_by_path.get(&comparable_path_components(&project_root))
+            && !project.peer_dependencies.is_empty()
         {
-            linked_workspace_projects.insert(package_key.clone(), (*project).clone());
+            linked_workspace_projects.insert(package_key.clone(), project.clone());
         }
         snapshots.insert(
             package_key,
@@ -1427,7 +1433,8 @@ fn local_to_importer_dep_version(
     if same_path(&resolved_path, ctx.deployed_project_root) {
         return Ok(ImporterDepVersion::Link(".".to_string()));
     }
-    let key = create_file_url_key(&resolved_path, &local.suffix, ctx.all_projects, Some(alias))?;
+    let key =
+        create_file_url_key(&resolved_path, &local.suffix, ctx.projects_by_path, Some(alias))?;
     Ok(ImporterDepVersion::Alias(key))
 }
 
@@ -1443,7 +1450,7 @@ fn local_to_snapshot_dep_ref(
     Ok(SnapshotDepRef::Alias(create_file_url_key(
         &resolved_path,
         &local.suffix,
-        ctx.all_projects,
+        ctx.projects_by_path,
         Some(alias),
     )?))
 }
@@ -1451,7 +1458,7 @@ fn local_to_snapshot_dep_ref(
 fn convert_package_key(key: &PackageKey, ctx: &ConvertCtx) -> miette::Result<PackageKey> {
     let VersionPart::File(path) = key.suffix.version() else { return Ok(key.clone()) };
     let resolved = validate_lockfile_local_path(&ctx.lockfile_dir.join(path), ctx.lockfile_dir)?;
-    create_file_url_key(&resolved, key.suffix.peer(), ctx.all_projects, Some(&key.name))
+    create_file_url_key(&resolved, key.suffix.peer(), ctx.projects_by_path, Some(&key.name))
 }
 
 fn validate_lockfile_local_path(path: &Path, lockfile_dir: &Path) -> miette::Result<PathBuf> {
@@ -1466,7 +1473,7 @@ fn validate_lockfile_local_path(path: &Path, lockfile_dir: &Path) -> miette::Res
 fn create_file_url_key(
     resolved_path: &Path,
     suffix: &str,
-    all_projects: &[ProjectInfo],
+    projects_by_path: &HashMap<Vec<String>, ProjectInfo>,
     package_name: Option<&PkgName>,
 ) -> miette::Result<PkgNameVerPeer> {
     let normalized = lexical_normalize(resolved_path);
@@ -1474,9 +1481,8 @@ fn create_file_url_key(
     let dep_file_url = url::Url::from_file_path(&normalized)
         .map_err(|()| miette::miette!("could not convert {} to a file URL", normalized_display))?
         .to_string();
-    let name = all_projects
-        .iter()
-        .find(|project| same_path(&project.root_dir, &normalized))
+    let name = projects_by_path
+        .get(&comparable_path_components(&normalized))
         .and_then(|project| project.name.as_deref())
         .map(str::to_string)
         .or_else(|| package_name.map(PkgName::to_string))

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -123,10 +123,7 @@ struct ProjectInfo {
 
 struct SelectedProject {
     project: Project,
-    /// Keyed by [`comparable_path_components`] of each normalized project root,
-    /// the components [`same_path`] compares, so a lockfile local path finds its
-    /// project with one lookup. The first project discovered under a key wins.
-    projects_by_path: HashMap<Vec<String>, ProjectInfo>,
+    projects_by_path: HashMap<ProjectPathKey, ProjectInfo>,
 }
 
 struct DeployWorkspaceConfig {
@@ -147,7 +144,7 @@ enum DeployInstallMode {
 }
 
 struct ConvertCtx<'a> {
-    projects_by_path: &'a HashMap<Vec<String>, ProjectInfo>,
+    projects_by_path: &'a HashMap<ProjectPathKey, ProjectInfo>,
     deploy_dir: &'a Path,
     lockfile_dir: &'a Path,
     deployed_project_root: &'a Path,
@@ -461,10 +458,31 @@ fn select_project(
     dir: &Path,
 ) -> miette::Result<SelectedProject> {
     let (projects, _patterns) = discover_workspace_projects(workspace_dir, config)?;
+    let projects_by_path = index_projects(&projects);
+
+    let selected_root = {
+        let selection =
+            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
+        let mut selected = selection.selected.keys();
+        match (selected.next(), selected.next()) {
+            (None, _) => return Err(DeployError::NothingToDeploy.into()),
+            (Some(root), None) => lexical_normalize(root),
+            (Some(_), Some(_)) => return Err(DeployError::CannotDeployMany.into()),
+        }
+    };
+    let project = projects
+        .into_iter()
+        .find(|project| lexical_normalize(&project.root_dir) == selected_root)
+        .ok_or(DeployError::NothingToDeploy)?;
+    Ok(SelectedProject { project, projects_by_path })
+}
+
+/// Index the workspace projects by [`ProjectPathKey`]. When two roots compare
+/// equal, the first discovered project wins.
+fn index_projects(projects: &[Project]) -> HashMap<ProjectPathKey, ProjectInfo> {
     let mut projects_by_path = HashMap::with_capacity(projects.len());
-    for project in &projects {
-        let root_dir = lexical_normalize(&project.root_dir);
-        projects_by_path.entry(comparable_path_components(&root_dir)).or_insert_with(|| {
+    for project in projects {
+        projects_by_path.entry(ProjectPathKey::new(&project.root_dir)).or_insert_with(|| {
             ProjectInfo {
                 name: project
                     .manifest
@@ -485,22 +503,7 @@ fn select_project(
             }
         });
     }
-
-    let selected_root = {
-        let selection =
-            select_recursive_projects(&projects, config, dir, AutoExcludeRoot::Disabled)?;
-        let mut selected = selection.selected.keys();
-        match (selected.next(), selected.next()) {
-            (None, _) => return Err(DeployError::NothingToDeploy.into()),
-            (Some(root), None) => lexical_normalize(root),
-            (Some(_), Some(_)) => return Err(DeployError::CannotDeployMany.into()),
-        }
-    };
-    let project = projects
-        .into_iter()
-        .find(|project| lexical_normalize(&project.root_dir) == selected_root)
-        .ok_or(DeployError::NothingToDeploy)?;
-    Ok(SelectedProject { project, projects_by_path })
+    projects_by_path
 }
 
 fn resolve_target_dir(dir: &Path, target: &Path) -> PathBuf {
@@ -884,8 +887,7 @@ fn create_deploy_files(
             validate_lockfile_local_path(&lockfile_dir.join(importer_path), lockfile_dir)?;
         let bases = ResolveBases { file_base: lockfile_dir, link_base: &project_root };
         let package_key = create_file_url_key(&project_root, "", &selected.projects_by_path, None)?;
-        if let Some(project) =
-            selected.projects_by_path.get(&comparable_path_components(&project_root))
+        if let Some(project) = selected.projects_by_path.get(&ProjectPathKey::new(&project_root))
             && !project.peer_dependencies.is_empty()
         {
             linked_workspace_projects.insert(package_key.clone(), project.clone());
@@ -1473,7 +1475,7 @@ fn validate_lockfile_local_path(path: &Path, lockfile_dir: &Path) -> miette::Res
 fn create_file_url_key(
     resolved_path: &Path,
     suffix: &str,
-    projects_by_path: &HashMap<Vec<String>, ProjectInfo>,
+    projects_by_path: &HashMap<ProjectPathKey, ProjectInfo>,
     package_name: Option<&PkgName>,
 ) -> miette::Result<PkgNameVerPeer> {
     let normalized = lexical_normalize(resolved_path);
@@ -1482,7 +1484,7 @@ fn create_file_url_key(
         .map_err(|()| miette::miette!("could not convert {} to a file URL", normalized_display))?
         .to_string();
     let name = projects_by_path
-        .get(&comparable_path_components(&normalized))
+        .get(&ProjectPathKey::new(&normalized))
         .and_then(|project| project.name.as_deref())
         .map(str::to_string)
         .or_else(|| package_name.map(PkgName::to_string))
@@ -1498,6 +1500,17 @@ fn same_path(left: &Path, right: &Path) -> bool {
     let left = lexical_normalize(left);
     let right = lexical_normalize(right);
     path_components_match(&left, &right)
+}
+
+/// Hash key under which two paths collide exactly when [`same_path`] equates
+/// them.
+#[derive(PartialEq, Eq, Hash)]
+struct ProjectPathKey(Vec<String>);
+
+impl ProjectPathKey {
+    fn new(path: &Path) -> Self {
+        Self(comparable_path_components(&lexical_normalize(path)))
+    }
 }
 
 fn has_path_prefix(child: &Path, parent: &Path) -> bool {

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -123,6 +123,9 @@ struct ProjectInfo {
 
 struct SelectedProject {
     project: Project,
+    /// Keyed by [`comparable_path_components`] of each normalized project root,
+    /// the components [`same_path`] compares, so a lockfile local path finds its
+    /// project with one lookup. The first project discovered under a key wins.
     projects_by_path: HashMap<Vec<String>, ProjectInfo>,
 }
 

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -458,33 +458,30 @@ fn select_project(
     dir: &Path,
 ) -> miette::Result<SelectedProject> {
     let (projects, _patterns) = discover_workspace_projects(workspace_dir, config)?;
-    let projects_by_path = projects
-        .iter()
-        .map(|project| {
-            let root_dir = lexical_normalize(&project.root_dir);
-            (
-                comparable_path_components(&root_dir),
-                ProjectInfo {
-                    name: project
-                        .manifest
-                        .value()
-                        .get("name")
-                        .and_then(Value::as_str)
-                        .map(str::to_string),
-                    peer_dependencies: manifest_dependency_names(
-                        &project.manifest,
-                        &["peerDependencies"],
-                    ),
-                    declared_dependencies: manifest_dependency_names(
-                        &project.manifest,
-                        &["dependencies", "optionalDependencies"],
-                    )
-                    .into_iter()
-                    .collect(),
-                },
-            )
-        })
-        .collect::<HashMap<_, _>>();
+    let mut projects_by_path = HashMap::with_capacity(projects.len());
+    for project in &projects {
+        let root_dir = lexical_normalize(&project.root_dir);
+        projects_by_path.entry(comparable_path_components(&root_dir)).or_insert_with(|| {
+            ProjectInfo {
+                name: project
+                    .manifest
+                    .value()
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                peer_dependencies: manifest_dependency_names(
+                    &project.manifest,
+                    &["peerDependencies"],
+                ),
+                declared_dependencies: manifest_dependency_names(
+                    &project.manifest,
+                    &["dependencies", "optionalDependencies"],
+                )
+                .into_iter()
+                .collect(),
+            }
+        });
+    }
 
     let selected_root = {
         let selection =

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -1,30 +1,26 @@
 use super::{
     ConvertCtx, ProjectInfo, ProjectPathKey, convert_package_key, convert_package_metadata,
-    create_deploy_install_config, create_file_url_key, split_local_payload,
+    create_deploy_install_config, create_file_url_key, index_projects, split_local_payload,
     validate_lockfile_local_path,
 };
 use pnpm_config::{Config, NodeLinker};
 use pnpm_lockfile::{LockfileResolution, PackageKey, PackageMetadata, TarballResolution};
+use pnpm_package_manifest::PackageManifest;
+use pnpm_workspace::Project;
+use serde_json::json;
 use std::{
     collections::{HashMap, HashSet},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 #[cfg(unix)]
-use super::{DeployFiles, DeployWorkspaceConfig, index_projects, write_deploy_files};
+use super::{DeployFiles, DeployWorkspaceConfig, write_deploy_files};
 #[cfg(unix)]
 use pnpm_lockfile::Lockfile;
-#[cfg(unix)]
-use pnpm_package_manifest::PackageManifest;
-#[cfg(unix)]
-use pnpm_workspace::Project;
-#[cfg(unix)]
-use serde_json::json;
 #[cfg(unix)]
 use std::{
     ffi::OsStr,
     os::unix::{ffi::OsStrExt, fs::symlink},
-    path::PathBuf,
 };
 
 #[cfg(windows)]
@@ -171,21 +167,35 @@ fn create_file_url_key_prefers_workspace_project_name() {
 
 #[cfg(unix)]
 #[test]
-fn index_projects_keeps_the_first_project_per_comparison_key() {
-    let project = |name: &str, root_dir: &[u8]| {
-        let root_dir = PathBuf::from(OsStr::from_bytes(root_dir));
-        let manifest =
-            PackageManifest::from_value(root_dir.join("package.json"), json!({ "name": name }));
-        Project { root_dir, manifest, dependency_manifest: None }
-    };
+fn index_projects_keeps_the_first_project_per_lossy_root() {
     // Both roots print as `a\u{FFFD}`, so they share a comparison key while
-    // staying distinct paths, as case variants do on Windows.
-    let projects = [
-        project("first", b"/workspace/packages/a\xff"),
-        project("second", b"/workspace/packages/a\xfe"),
-    ];
+    // staying distinct paths.
+    assert_first_project_wins(&[
+        workspace_project("first", PathBuf::from(OsStr::from_bytes(b"/workspace/packages/a\xff"))),
+        workspace_project("second", PathBuf::from(OsStr::from_bytes(b"/workspace/packages/a\xfe"))),
+    ]);
+}
 
-    let index = index_projects(&projects);
+#[cfg(windows)]
+#[test]
+fn index_projects_keeps_the_first_project_per_case_variant_root() {
+    assert_first_project_wins(&[
+        workspace_project("first", PathBuf::from(r"C:\Workspace\Packages\Lib")),
+        workspace_project("second", PathBuf::from(r"c:\workspace\packages\lib")),
+    ]);
+}
+
+fn workspace_project(name: &str, root_dir: PathBuf) -> Project {
+    let manifest =
+        PackageManifest::from_value(root_dir.join("package.json"), json!({ "name": name }));
+    Project { root_dir, manifest, dependency_manifest: None }
+}
+
+/// The two projects must have distinct roots that share one comparison key.
+fn assert_first_project_wins(projects: &[Project; 2]) {
+    assert_ne!(projects[0].root_dir, projects[1].root_dir, "the roots must be distinct paths");
+
+    let index = index_projects(projects);
 
     assert_eq!(index.len(), 1, "comparison-equal roots share one entry");
     let project = index.get(&ProjectPathKey::new(&projects[1].root_dir)).expect("indexed project");

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use pnpm_config::{Config, NodeLinker};
 use pnpm_lockfile::{LockfileResolution, PackageKey, PackageMetadata, TarballResolution};
-use std::path::Path;
+use std::{collections::HashMap, path::Path};
 
 #[cfg(unix)]
 use super::{DeployFiles, DeployWorkspaceConfig, write_deploy_files};
@@ -68,7 +68,7 @@ fn convert_package_metadata_rebases_file_tarball_resolution_to_deploy_dir() {
     let lockfile_dir = tmp.path().join("workspace");
     let deploy_dir = lockfile_dir.join("deploy");
     let deployed_project_root = lockfile_dir.join("packages/app");
-    let all_projects = Vec::new();
+    let projects_by_path = HashMap::new();
     let metadata = PackageMetadata {
         resolution: LockfileResolution::Tarball(TarballResolution {
             tarball: "file:vendor/pkg.tgz".to_string(),
@@ -94,7 +94,7 @@ fn convert_package_metadata_rebases_file_tarball_resolution_to_deploy_dir() {
         peer_dependencies_meta: None,
     };
     let ctx = ConvertCtx {
-        all_projects: &all_projects,
+        projects_by_path: &projects_by_path,
         deploy_dir: &deploy_dir,
         lockfile_dir: &lockfile_dir,
         deployed_project_root: &deployed_project_root,
@@ -116,9 +116,9 @@ fn convert_package_key_preserves_local_tarball_name() {
     let lockfile_dir = tmp.path().join("workspace");
     let deploy_dir = lockfile_dir.join("deploy");
     let deployed_project_root = lockfile_dir.join("packages/app");
-    let all_projects = Vec::new();
+    let projects_by_path = HashMap::new();
     let ctx = ConvertCtx {
-        all_projects: &all_projects,
+        projects_by_path: &projects_by_path,
         deploy_dir: &deploy_dir,
         lockfile_dir: &lockfile_dir,
         deployed_project_root: &deployed_project_root,

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    ConvertCtx, ProjectInfo, comparable_path_components, convert_package_key,
-    convert_package_metadata, create_deploy_install_config, create_file_url_key,
-    split_local_payload, validate_lockfile_local_path,
+    ConvertCtx, ProjectInfo, ProjectPathKey, convert_package_key, convert_package_metadata,
+    create_deploy_install_config, create_file_url_key, split_local_payload,
+    validate_lockfile_local_path,
 };
 use pnpm_config::{Config, NodeLinker};
 use pnpm_lockfile::{LockfileResolution, PackageKey, PackageMetadata, TarballResolution};
@@ -11,13 +11,21 @@ use std::{
 };
 
 #[cfg(unix)]
-use super::{DeployFiles, DeployWorkspaceConfig, write_deploy_files};
+use super::{DeployFiles, DeployWorkspaceConfig, index_projects, write_deploy_files};
 #[cfg(unix)]
 use pnpm_lockfile::Lockfile;
 #[cfg(unix)]
+use pnpm_package_manifest::PackageManifest;
+#[cfg(unix)]
+use pnpm_workspace::Project;
+#[cfg(unix)]
 use serde_json::json;
 #[cfg(unix)]
-use std::os::unix::fs::symlink;
+use std::{
+    ffi::OsStr,
+    os::unix::{ffi::OsStrExt, fs::symlink},
+    path::PathBuf,
+};
 
 #[cfg(windows)]
 use super::{is_ancestor_path, is_child_path, same_path, validate_deploy_target};
@@ -146,7 +154,7 @@ fn create_file_url_key_prefers_workspace_project_name() {
     let resolved_path = project_root.join("../local-pkg");
     let mut projects_by_path = HashMap::new();
     projects_by_path.insert(
-        comparable_path_components(&project_root),
+        ProjectPathKey::new(&project_root),
         ProjectInfo {
             name: Some("workspace-name".to_string()),
             peer_dependencies: Vec::new(),
@@ -159,6 +167,29 @@ fn create_file_url_key_prefers_workspace_project_name() {
         .expect("create file URL key");
 
     assert_eq!(key.name.to_string(), "workspace-name");
+}
+
+#[cfg(unix)]
+#[test]
+fn index_projects_keeps_the_first_project_per_comparison_key() {
+    let project = |name: &str, root_dir: &[u8]| {
+        let root_dir = PathBuf::from(OsStr::from_bytes(root_dir));
+        let manifest =
+            PackageManifest::from_value(root_dir.join("package.json"), json!({ "name": name }));
+        Project { root_dir, manifest, dependency_manifest: None }
+    };
+    // Both roots print as `a\u{FFFD}`, so they share a comparison key while
+    // staying distinct paths, as case variants do on Windows.
+    let projects = [
+        project("first", b"/workspace/packages/a\xff"),
+        project("second", b"/workspace/packages/a\xfe"),
+    ];
+
+    let index = index_projects(&projects);
+
+    assert_eq!(index.len(), 1, "comparison-equal roots share one entry");
+    let project = index.get(&ProjectPathKey::new(&projects[1].root_dir)).expect("indexed project");
+    assert_eq!(project.name.as_deref(), Some("first"), "the first discovered project wins");
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/cli_args/deploy/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy/tests.rs
@@ -1,10 +1,14 @@
 use super::{
-    ConvertCtx, convert_package_key, convert_package_metadata, create_deploy_install_config,
+    ConvertCtx, ProjectInfo, comparable_path_components, convert_package_key,
+    convert_package_metadata, create_deploy_install_config, create_file_url_key,
     split_local_payload, validate_lockfile_local_path,
 };
 use pnpm_config::{Config, NodeLinker};
 use pnpm_lockfile::{LockfileResolution, PackageKey, PackageMetadata, TarballResolution};
-use std::{collections::HashMap, path::Path};
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
 
 #[cfg(unix)]
 use super::{DeployFiles, DeployWorkspaceConfig, write_deploy_files};
@@ -133,6 +137,28 @@ fn convert_package_key_preserves_local_tarball_name() {
         "tar-pkg",
         "the tarball's package name must be kept, not the tarball filename",
     );
+}
+
+#[test]
+fn create_file_url_key_prefers_workspace_project_name() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project_root = tmp.path().join("workspace/packages/local-pkg");
+    let resolved_path = project_root.join("../local-pkg");
+    let mut projects_by_path = HashMap::new();
+    projects_by_path.insert(
+        comparable_path_components(&project_root),
+        ProjectInfo {
+            name: Some("workspace-name".to_string()),
+            peer_dependencies: Vec::new(),
+            declared_dependencies: HashSet::default(),
+        },
+    );
+    let lockfile_name = "lockfile-name".parse().expect("parse package name");
+
+    let key = create_file_url_key(&resolved_path, "", &projects_by_path, Some(&lockfile_name))
+        .expect("create file URL key");
+
+    assert_eq!(key.name.to_string(), "workspace-name");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

- Build one normalized-path index for Rust deploy workspace metadata.
- Reuse the index for local package-key conversion and peer-bearing workspace lookup.
- Preserve the existing cross-platform path comparison and generated output.
- Reduce the median time for a 1,001-project deploy fixture from 1,599 ms to 680 ms across 10 alternating release runs, a 57.5% improvement.
- Keep this as a Rust-only performance change. It does not change CLI behavior and needs no TypeScript equivalent. It carries a `pacquet` patch changeset, as every Rust perf change does.

Closes pnpm/pnpm#14539.

Validation: `just ready` passed, including 9,947 tests. The baseline and optimized builds produced byte-identical lockfiles and semantically identical manifests.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Build one normalized-path index for workspace metadata and reuse it while
converting local deploy lockfile entries.

This removes repeated project scans and the separate peer-only index. On a
1,001-project local workspace, alternating release runs reduced median deploy
time from 1,599 ms to 680 ms.

Closes pnpm/pnpm#14539.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that do not apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791117481&installation_model_id=426870&pr_number=14542&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14542&signature=8ba6c4ae98f167ba68e1ab5a7001a2af125b8ca5638d2443126b66c2e6e0bb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved deployment performance for workspaces containing many projects.
  * Deployment now handles duplicate or normalized project paths more reliably while preserving the first matching project.
* **Bug Fixes**
  * Improved project identification during deployment, including platform-specific path comparisons.
* **Tests**
  * Expanded coverage for project-path indexing, invalid path data, and duplicate paths with differing case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
