### PR TITLE
feat(pnpr): support browser registry discovery

### DIFF
--- a/.changeset/fuzzy-geckos-search.md
+++ b/.changeset/fuzzy-geckos-search.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+pnpr can now serve browser registry UIs through an origin allowlist. Search supports pagination and maintainer filters, authenticated publishers are recorded for discovery, organization package listings are available, and upstream discovery can be enabled per registry.

--- a/.changeset/fuzzy-geckos-search.md
+++ b/.changeset/fuzzy-geckos-search.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr can now serve browser registry UIs through an origin allowlist. Search supports pagination and maintainer filters, authenticated publishers are recorded for discovery, organization package listings are available, and upstream discovery can be enabled per registry.
+pnpr can now serve browser registry UIs through an origin allowlist. Search supports pagination and maintainer filters. Authenticated publishers are recorded for discovery. Organization package listings are available. Upstream discovery can be enabled per registry.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ tabled             = { version = "0.21", features = ["ansi"] }
 tar                = { version = "0.4.46" }
 text-block-macros  = { version = "0.2.0" }
 tower              = { version = "0.5.3" }
-tower-http         = { version = "0.7.0", features = ["compression-gzip", "trace"] }
+tower-http         = { version = "0.7.0", features = ["compression-gzip", "cors", "trace"] }
 tracing            = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -766,7 +766,8 @@ fn is_loopback_host(host: &str) -> bool {
 #[must_use]
 pub fn is_url_secure_for_credentials(url: &str) -> bool {
     ParsedUrl::parse(url).is_some_and(|parsed| {
-        parsed.scheme.eq_ignore_ascii_case("https") || is_loopback_host(parsed.host)
+        parsed.scheme.eq_ignore_ascii_case("https")
+            || (parsed.scheme.eq_ignore_ascii_case("http") && is_loopback_host(parsed.host))
     })
 }
 

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -401,8 +401,7 @@ impl AuthHeaders {
     /// Package-aware counterpart to [`Self::for_secure_url`].
     #[must_use]
     pub fn for_secure_url_with_package(&self, url: &str, pkg_name: Option<&str>) -> Option<String> {
-        let parsed = ParsedUrl::parse(url)?;
-        if !parsed.scheme.eq_ignore_ascii_case("https") && !is_loopback_host(parsed.host) {
+        if !is_url_secure_for_credentials(url) {
             return None;
         }
         self.for_url_with_package(url, pkg_name)
@@ -760,6 +759,15 @@ fn is_loopback_host(host: &str) -> bool {
             .trim_matches(['[', ']'])
             .parse::<std::net::IpAddr>()
             .is_ok_and(|address| address.is_loopback())
+}
+
+/// Whether credentials may be sent to `url` without crossing a cleartext
+/// network link. HTTPS and loopback HTTP endpoints are accepted.
+#[must_use]
+pub fn is_url_secure_for_credentials(url: &str) -> bool {
+    ParsedUrl::parse(url).is_some_and(|parsed| {
+        parsed.scheme.eq_ignore_ascii_case("https") || is_loopback_host(parsed.host)
+    })
 }
 
 /// Local base64 encode so this crate doesn't pull in `base64` just for

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -574,6 +574,8 @@ fn classifies_urls_that_are_secure_for_credentials() {
     assert!(super::is_url_secure_for_credentials("http://localhost:4873/pkg"));
     assert!(super::is_url_secure_for_credentials("http://127.0.0.1/pkg"));
     assert!(!super::is_url_secure_for_credentials("http://reg.example/pkg"));
+    assert!(!super::is_url_secure_for_credentials("ftp://localhost/pkg"));
+    assert!(!super::is_url_secure_for_credentials("ws://127.0.0.1/pkg"));
     assert!(!super::is_url_secure_for_credentials("not a url"));
 }
 

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -568,6 +568,15 @@ fn secure_lookup_rejects_plain_http_but_allows_loopback() {
     assert_eq!(ipv6_local.as_deref(), Some("Bearer ipv6-local"));
 }
 
+#[test]
+fn classifies_urls_that_are_secure_for_credentials() {
+    assert!(super::is_url_secure_for_credentials("https://reg.example/pkg"));
+    assert!(super::is_url_secure_for_credentials("http://localhost:4873/pkg"));
+    assert!(super::is_url_secure_for_credentials("http://127.0.0.1/pkg"));
+    assert!(!super::is_url_secure_for_credentials("http://reg.example/pkg"));
+    assert!(!super::is_url_secure_for_credentials("not a url"));
+}
+
 /// Specifically exercises the trailing-slash-append branch in
 /// [`AuthHeaders::for_url`]: the URL ends without a `/` *and*
 /// names a path segment (`/scope`). Without the append,

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -10,9 +10,9 @@ mod token_helper;
 
 pub use auth::{
     AuthHeaders, AuthHeadersByScope, DEFAULT_REGISTRY_SCOPE, MetadataCacheScope, UpstreamRouteHook,
-    base64_encode, base64_encode_bytes, hide_auth_information, nerf_dart, normalize_auth_key,
-    redact_and_sanitize, redact_and_sanitize_multiline, redact_url_credentials,
-    redact_url_for_display,
+    base64_encode, base64_encode_bytes, hide_auth_information, is_url_secure_for_credentials,
+    nerf_dart, normalize_auth_key, redact_and_sanitize, redact_and_sanitize_multiline,
+    redact_url_credentials, redact_url_for_display,
 };
 pub use limited_body::{LimitedBody, read_limited_body};
 pub use token_helper::{TokenHelperOutput, TokenHelperRunner};

--- a/pnpm/crates/pnpr-client/tests/integration.rs
+++ b/pnpm/crates/pnpr-client/tests/integration.rs
@@ -131,6 +131,7 @@ fn registry_upstream(registry_url: &str, token: &str) -> (String, pnpr::Upstream
             max_fails: pnpr::UpstreamConfig::DEFAULT_MAX_FAILS,
             fail_timeout: pnpr::UpstreamConfig::DEFAULT_FAIL_TIMEOUT,
             cache: true,
+            search: false,
             access: Some(pnpr::AccessList::from_tokens(["$authenticated"])),
             rules: pnpr::PackageRules::default(),
         },

--- a/pnpr/crates/config/config.yaml
+++ b/pnpr/crates/config/config.yaml
@@ -7,6 +7,13 @@ storage: ./storage
 # to a `.pnpr-cache` subdirectory of `storage`; point it at a separate,
 # ephemeral volume to keep cached upstream content off the durable disk.
 #cache: ./cache
+# Cross-origin browser access is disabled unless exact origins are listed.
+# This is enough to let a separately hosted registry UI read metadata, search,
+# organization listings, and tarballs without opening pnpr to every website.
+#cors:
+#  allowedOrigins:
+#    - https://npmx.dev
+#    - http://localhost:3000
 # Store the hosted (published) packages and enabled shared artifacts in an
 # S3-compatible object store instead of local directories. Works with AWS S3 (omit
 # `endpoint`), Cloudflare R2 (`region: auto` + the account endpoint),
@@ -185,6 +192,9 @@ registries:
     type: upstream
     url: https://registry.npmjs.org/
     public: true
+    # Opt in to upstream search and organization discovery for browser UIs.
+    # Omit this to retain pnpr's local-only search behavior.
+    #search: true
   # One URL routing each package to the first listed source whose declared
   # packages claim it. The fixture names are authoritative-local; everything
   # else is npm. A router refuses to start on an unreachable source, so the

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -67,6 +67,9 @@ pub struct Config {
     /// `dist.tarball` URLs in served packuments so tarball requests
     /// flow through this server.
     pub public_url: String,
+    /// Cross-origin browser access. Empty by default, so pnpr emits no CORS
+    /// response headers unless an operator explicitly names trusted origins.
+    pub cors: CorsConfig,
     /// Directory under which authoritative packuments and tarballs
     /// live: packages published to this server and the content served
     /// in static mode. This is the source of truth — it is never
@@ -170,6 +173,32 @@ pub struct HostedConfig {
     /// list them. Membership is config-declared: the API serves reads only,
     /// and team mutations are rejected.
     pub teams: Teams,
+}
+
+/// Exact browser origins allowed to call pnpr across origins.
+#[derive(Debug, Default, Clone)]
+pub struct CorsConfig {
+    allowed_origins: Vec<String>,
+}
+
+impl CorsConfig {
+    pub fn from_allowed_origins(
+        origins: impl IntoIterator<Item = impl AsRef<str>>,
+    ) -> Result<Self, RegistryError> {
+        let mut allowed_origins = Vec::new();
+        for origin in origins {
+            let origin = normalize_cors_origin(origin.as_ref())?;
+            if !allowed_origins.contains(&origin) {
+                allowed_origins.push(origin);
+            }
+        }
+        Ok(Self { allowed_origins })
+    }
+
+    #[must_use]
+    pub fn allowed_origins(&self) -> &[String] {
+        &self.allowed_origins
+    }
 }
 
 /// Which fetch routes the resolution cache treats as public. The official
@@ -918,6 +947,9 @@ struct UpstreamFile {
     fail_timeout: Option<Interval>,
     #[serde(default)]
     cache: Option<bool>,
+    /// Opt an upstream into browser-facing search and organization discovery.
+    #[serde(default)]
+    search: bool,
     /// Which pnpr callers may reach this registry at `/~<name>/`. Required for a
     /// non-`public` upstream (otherwise no one could be authorized to use it).
     #[serde(default)]
@@ -959,6 +991,10 @@ struct ConfigFile {
     /// it defaults to a `.pnpr-cache` subdirectory of `storage`.
     #[serde(default)]
     cache: Option<String>,
+    /// pnpr-only browser access policy. Cross-origin access stays disabled
+    /// when this block is absent or its allowlist is empty.
+    #[serde(default)]
+    cors: CorsFile,
     /// pnpr-only block: store the hosted (published) packages in an
     /// S3-compatible object store instead of `storage`. Absent on a
     /// stock verdaccio config (silently ignored there).
@@ -1026,6 +1062,13 @@ struct ConfigFile {
     /// intentionally not accepted.
     #[serde(default)]
     log: Option<LogEntryFile>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CorsFile {
+    #[serde(default)]
+    allowed_origins: Vec<String>,
 }
 
 /// Marker for a present top-level `packages:` key, whatever its value.
@@ -1265,6 +1308,7 @@ impl Config {
         Self {
             listen,
             public_url: format!("http://{listen}"),
+            cors: CorsConfig::default(),
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams,
@@ -1314,6 +1358,7 @@ impl Config {
         Self {
             listen,
             public_url: format!("http://{listen}"),
+            cors: CorsConfig::default(),
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams: IndexMap::new(),
@@ -1531,6 +1576,7 @@ impl Config {
         };
         let backend = build_backend_config(file.backend, base_dir)?;
         let public_url = public_url.unwrap_or_else(|| format!("http://{listen}"));
+        let cors = build_cors_config(file.cors)?;
         let auth = build_auth_config(&file.auth, base_dir);
         let logs = build_log_config(file.log.as_ref());
         // The global ACL and group blocks are gone, not ignorable: they used
@@ -1588,6 +1634,7 @@ impl Config {
         let config = Self {
             listen,
             public_url,
+            cors,
             storage,
             cache_storage,
             upstreams,
@@ -1727,6 +1774,30 @@ impl Config {
         }
         self.registries.validate().map_err(|err| registry_err(&err))
     }
+}
+
+fn build_cors_config(file: CorsFile) -> Result<CorsConfig, RegistryError> {
+    CorsConfig::from_allowed_origins(file.allowed_origins)
+}
+
+fn normalize_cors_origin(raw: &str) -> Result<String, RegistryError> {
+    let parsed = url::Url::parse(raw).map_err(|_| RegistryError::InvalidConfig {
+        reason: format!("CORS allowed origin {raw:?} is not an absolute URL"),
+    })?;
+    if !matches!(parsed.scheme(), "http" | "https")
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+        || parsed.path() != "/"
+    {
+        return Err(RegistryError::InvalidConfig {
+            reason: format!(
+                "CORS allowed origin {raw:?} must contain only an http(s) scheme, host, and optional port",
+            ),
+        });
+    }
+    Ok(parsed.origin().ascii_serialization())
 }
 
 /// Build the runtime [`AuthConfig`] from the YAML `auth:` block.
@@ -2031,6 +2102,7 @@ fn resolve_upstream_registry<Sys: EnvVar>(
         max_fails: file.max_fails,
         fail_timeout: file.fail_timeout,
         cache: file.cache,
+        search: file.search,
         access,
     };
     resolve_upstream_config::<Sys>(name, upstream_config_file, teams)

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -47,6 +47,7 @@ fn upstream_config_file(
         max_fails: None,
         fail_timeout: None,
         cache: None,
+        search: false,
         access: None,
     }
 }
@@ -386,6 +387,40 @@ registries:
     let upstream = &config.upstreams["npmjs"];
     assert_eq!(upstream.maxage, Some(Duration::from_mins(10)));
     assert_eq!(upstream.timeout, Duration::from_secs(45));
+}
+
+#[test]
+fn parses_cors_origins_and_upstream_search() {
+    let yaml = r"
+cors:
+  allowedOrigins:
+    - https://npmx.dev
+    - http://localhost:3000/
+registries:
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+    search: true
+";
+    let config = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None).unwrap();
+    assert_eq!(
+        config.cors.allowed_origins(),
+        ["https://npmx.dev".to_string(), "http://localhost:3000".to_string()],
+    );
+    assert!(config.upstreams["npmjs"].search);
+}
+
+#[test]
+fn rejects_non_origin_cors_urls() {
+    for origin in ["*", "null", "ftp://example.test", "https://example.test/path"] {
+        let yaml = format!("cors:\n  allowedOrigins: [{origin:?}]\n");
+        let err = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap_err();
+        assert!(
+            matches!(err, RegistryError::InvalidConfig { reason } if reason.contains("CORS allowed origin")),
+            "expected an InvalidConfig for {origin:?}",
+        );
+    }
 }
 
 #[test]
@@ -2225,6 +2260,7 @@ fn resolve_upstream_config_defaults_knobs_to_verdaccio_values() {
     assert_eq!(upstream.max_fails, UpstreamConfig::DEFAULT_MAX_FAILS);
     assert_eq!(upstream.fail_timeout, UpstreamConfig::DEFAULT_FAIL_TIMEOUT);
     assert!(upstream.cache);
+    assert!(!upstream.search);
 }
 
 #[test]
@@ -2236,12 +2272,14 @@ fn resolve_upstream_config_parses_explicit_knobs() {
     file.max_fails = Some(5);
     file.fail_timeout = Some(Interval("1m".to_string()));
     file.cache = Some(false);
+    file.search = true;
     let upstream = resolve_upstream("npmjs", file).unwrap();
     assert_eq!(upstream.maxage, Some(Duration::from_mins(10)));
     assert_eq!(upstream.timeout, Duration::from_secs(45));
     assert_eq!(upstream.max_fails, 5);
     assert_eq!(upstream.fail_timeout, Duration::from_mins(1));
     assert!(!upstream.cache);
+    assert!(upstream.search);
 }
 
 #[test]

--- a/pnpr/crates/config/src/upstream.rs
+++ b/pnpr/crates/config/src/upstream.rs
@@ -47,6 +47,9 @@ pub struct UpstreamConfig {
     /// mirror (verdaccio's `cache`). `false` streams them through
     /// uncached. Defaults to `true`.
     pub cache: bool,
+    /// Whether browser-facing discovery endpoints may query this upstream.
+    /// Disabled by default to preserve local-only search behavior.
+    pub search: bool,
     /// Which pnpr callers may select this upstream as a proxied private-route
     /// credential, and reach it through its `/~<name>/` registry endpoint.
     /// `None` means the upstream is registry-proxy only and is never offered as
@@ -82,6 +85,7 @@ impl UpstreamConfig {
             max_fails: Self::DEFAULT_MAX_FAILS,
             fail_timeout: Self::DEFAULT_FAIL_TIMEOUT,
             cache: true,
+            search: false,
             access: None,
             rules: PackageRules::default(),
         }
@@ -98,6 +102,7 @@ impl fmt::Debug for UpstreamConfig {
             .field("max_fails", &self.max_fails)
             .field("fail_timeout", &self.fail_timeout)
             .field("cache", &self.cache)
+            .field("search", &self.search)
             .field("access", &self.access)
             .field("rules", &self.rules)
             .finish()
@@ -142,6 +147,8 @@ pub(super) struct UpstreamConfigFile {
     pub(super) fail_timeout: Option<Interval>,
     #[serde(default)]
     pub(super) cache: Option<bool>,
+    #[serde(default)]
+    pub(super) search: bool,
     /// Which pnpr callers may select this upstream as a proxied private-route
     /// credential. Its presence is what promotes a plain proxy upstream into a
     /// resolver private-route credential exposed at `/~<name>/`.
@@ -311,6 +318,7 @@ pub(super) fn resolve_upstream_config<Sys: EnvVar>(
         max_fails: file.max_fails.unwrap_or(UpstreamConfig::DEFAULT_MAX_FAILS),
         fail_timeout,
         cache: file.cache.unwrap_or(true),
+        search: file.search,
         access,
         // The `packages:` rules are attached by the caller
         // (`build_registries`) — this resolver only handles the serving

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -22,6 +22,14 @@ pub enum RegistryError {
         body: String,
     },
 
+    #[display("Invalid response from upstream {url}: {reason}")]
+    #[from(skip)]
+    UpstreamResponse {
+        #[error(not(source))]
+        url: String,
+        reason: String,
+    },
+
     /// The upstream's circuit breaker is open: it reached `max_fails`
     /// consecutive failures and is still inside its `fail_timeout`
     /// cooldown, so pnpr short-circuits the request instead of hammering
@@ -286,6 +294,7 @@ impl RegistryError {
         match self {
             RegistryError::Upstream { .. } => "upstream",
             RegistryError::UpstreamStatus { .. } => "upstream_status",
+            RegistryError::UpstreamResponse { .. } => "upstream_response",
             RegistryError::UpstreamUnavailable { .. } => "upstream_unavailable",
             RegistryError::TarballIntegrity { .. } => "tarball_integrity",
             RegistryError::InvalidPackageName { .. } => "invalid_package_name",
@@ -368,9 +377,9 @@ impl RegistryError {
                     StatusCode::BAD_GATEWAY
                 }
             }
-            RegistryError::UpstreamStatus { .. } | RegistryError::TarballIntegrity { .. } => {
-                StatusCode::BAD_GATEWAY
-            }
+            RegistryError::UpstreamStatus { .. }
+            | RegistryError::UpstreamResponse { .. }
+            | RegistryError::TarballIntegrity { .. } => StatusCode::BAD_GATEWAY,
             RegistryError::UpstreamUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             RegistryError::InvalidPackageName { .. }
             | RegistryError::InvalidTarballName { .. }

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -37,10 +37,13 @@ Origins must contain only an `http` or `https` scheme, host, and optional port.
 The `search` setting also enables `/-/org/{scope}/package` discovery for that
 upstream. pnpr applies registry routing and access rules to returned entries and
 uses only the upstream credentials from its configuration, never a browser
-caller's authorization header. Search totals count only visible, deduplicated
-results. When an upstream has more results than pnpr needs for the current page,
-the total is a visible lower bound through the next page rather than the
-upstream's unfiltered count. It becomes exact when every source is exhausted.
+caller's authorization header. Discovery refuses redirects and sends configured
+upstream headers only over HTTPS or loopback HTTP. Search totals count only
+visible, deduplicated results and are exact across every participating source.
+To bound work from a single browser request, pnpr rejects upstream searches
+that would scan more than 2,000 upstream results or eight upstream pages.
+Offsets that would require a larger upstream scan are also rejected. Refine the
+search term when a query reaches that limit.
 
 ## License
 

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -37,8 +37,10 @@ Origins must contain only an `http` or `https` scheme, host, and optional port.
 The `search` setting also enables `/-/org/{scope}/package` discovery for that
 upstream. pnpr applies registry routing and access rules to returned entries and
 uses only the upstream credentials from its configuration, never a browser
-caller's authorization header. Hosted totals are counted after filtering;
-upstream totals are the values reported by each eligible upstream.
+caller's authorization header. Search totals count only visible, deduplicated
+results. When an upstream has more results than pnpr needs for the current page,
+the total is a visible lower bound through the next page rather than the
+upstream's unfiltered count. It becomes exact when every source is exhausted.
 
 ## License
 

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -4,6 +4,42 @@ A pnpm-compatible npm registry server, written in Rust.
 
 Lives in the [pnpm monorepo](https://github.com/pnpm/pnpm) under `registry/`.
 
+## Browser registry UIs
+
+Cross-origin browser access and upstream discovery are disabled by default. To
+run a registry UI on a separate origin, list that exact origin and opt the
+needed upstreams into search and organization discovery:
+
+```yaml
+cors:
+  allowedOrigins:
+    - https://registry-ui.example.com
+
+registries:
+  local:
+    type: hosted
+    access: $all
+    packages:
+      '@example/*': {}
+  npmjs:
+    type: upstream
+    url: https://registry.npmjs.org/
+    public: true
+    search: true
+  main:
+    type: router
+    sources: [local, npmjs]
+
+defaultRegistry: main
+```
+
+Origins must contain only an `http` or `https` scheme, host, and optional port.
+The `search` setting also enables `/-/org/{scope}/package` discovery for that
+upstream. pnpr applies registry routing and access rules to returned entries and
+uses only the upstream credentials from its configuration, never a browser
+caller's authorization header. Hosted totals are counted after filtering;
+upstream totals are the values reported by each eligible upstream.
+
 ## License
 
 Source-available under the [PolyForm Shield License 1.0.0](../../LICENSE.md) —

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -15,7 +15,7 @@ pub use pnpr_auth::{
     identify,
 };
 pub use pnpr_config::{
-    AccessSpec, ArtifactsFeature, AuthConfig, BackendConfig, Config, ConfigSource,
+    AccessSpec, ArtifactsFeature, AuthConfig, BackendConfig, Config, ConfigSource, CorsConfig,
     DEFAULT_CONFIG_YAML, FeatureOverrides, HostedConfig, HostedStoreConfig, HtpasswdConfig,
     LibsqlSettings, LogConfig, LogFormat, LogLevel, MaxUsers, OsvConfig, PackageAccess,
     PublicRoute, RegistryFeature, ResolverFeature, RoutePolicy, S3Settings, SqlBackendSettings,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -54,7 +54,7 @@ use pnpr_upstream::{
     rewrite_upstream_tarball_urls, tarball_basename,
 };
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use ssri::Integrity;
 use std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration};
 
@@ -1508,6 +1508,51 @@ enum RegistrySource {
     NotFound,
 }
 
+enum DiscoverySource {
+    Hosted(String),
+    Upstream(String),
+}
+
+struct SearchPage {
+    objects: Vec<Value>,
+    names: HashSet<String>,
+    from: usize,
+    size: usize,
+}
+
+impl SearchPage {
+    fn new(from: usize, size: usize) -> Self {
+        Self { objects: Vec::new(), names: HashSet::new(), from, size }
+    }
+
+    fn append_source(&mut self, source_objects: Vec<Value>, source_start: usize) {
+        let skip = self.from.saturating_sub(source_start);
+        for object in source_objects.into_iter().skip(skip) {
+            if self.is_full() {
+                break;
+            }
+            self.push(object);
+        }
+    }
+
+    fn push(&mut self, object: Value) {
+        let Some(name) = search_object_name(&object) else {
+            return;
+        };
+        if self.names.insert(name.to_string()) {
+            self.objects.push(object);
+        }
+    }
+
+    fn is_full(&self) -> bool {
+        self.objects.len() >= self.size
+    }
+
+    fn remaining(&self) -> usize {
+        self.size.saturating_sub(self.objects.len())
+    }
+}
+
 /// The registry the path-less base (`https://<pnpr>/`) aliases, owned so it can be
 /// held across an `await`. `None` disables the path-less base entirely — the
 /// bare host has no registry and every request is a not-found, so clients must
@@ -2234,42 +2279,17 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
     }
 }
 
-/// `GET /-/v1/search?text=...&size=...` — npm search v1 endpoint.
-///
-/// Local-only: scans the on-disk storage and matches package names
-/// as a case-insensitive substring on `text`. Matches verdaccio's
-/// default behavior. We deliberately do NOT proxy to upstream npm
-/// even in proxy mode — the tests rely on the local-search semantics
-/// (`releasing/commands/test/search.ts` asserts that a guaranteed-not
-/// -to-exist query returns "No packages found", which an upstream
-/// proxy can't deliver because npm's search is fuzzy and returns
-/// dozens of unrelated matches for almost anything).
-///
-/// Results are served through the registry graph and gated exactly like the
-/// packument and tarball GETs:
-///
-/// * Only the hosted registries the addressed registry serves are scanned (see
-///   [`hosted_search_sources`]), each gated by its **registry access list** — a
-///   caller a registry denies gets nothing from it, the same existence mask the
-///   read paths apply. Without this, search would enumerate a private registry's
-///   packages by name/version/description while the packument GET correctly
-///   404s.
-/// * Under a router, a name is kept only when the router actually **routes it
-///   to the scanned source**, so a hosted package shadowed by an earlier route
-///   is as invisible to search as it is to a packument GET.
-/// * The **per-package access policy** drops any package the caller can't
-///   read (e.g. anonymous + `@private/*` with the default rules).
-///
-/// `total` counts the returned (post-filter, size-capped) objects so clients
-/// can't infer the existence of hidden packages from a mismatched total.
+/// `GET /-/v1/search?text=...&from=...&size=...` — npm search v1 endpoint.
+/// Hosted results are counted after routing and access filters, then optional
+/// upstream results are appended in registry-source order. An upstream only
+/// participates when its `search` setting is enabled.
 async fn serve_search(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
     query_string: &str,
 ) -> Response {
-    let result = |objects: Vec<Value>| {
-        let total = objects.len();
+    let result = |objects: Vec<Value>, total: usize| {
         let body = json!({ "objects": objects, "total": total, "time": now_iso() });
         let bytes = serde_json::to_vec(&body).expect("search response serializes");
         Response::builder()
@@ -2278,68 +2298,221 @@ async fn serve_search(
             .body(Body::from(bytes))
             .expect("static-shape response always builds")
     };
-    let Some(text) = pnpr_search::parse_query(query_string) else {
-        return result(Vec::new());
+    let Some(params) = pnpr_search::parse_params(query_string, 20) else {
+        return result(Vec::new(), 0);
     };
     let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
     else {
-        return result(Vec::new());
+        return result(Vec::new(), 0);
     };
-    let size = pnpr_search::parse_size(query_string, 20);
-    let mut objects: Vec<Value> = Vec::new();
-    for source in hosted_search_sources(state, &registry) {
-        if objects.len() >= size {
-            break;
-        }
-        let Some(hosted) = state.inner.config.hosted.get(&source) else {
-            continue;
-        };
-        // Fast path: a caller no rule of this registry could ever admit
-        // gets the empty result without a storage scan — the blanket mask
-        // must not become an enumeration (or scan-timing) primitive.
-        if !hosted.rules.any_access_admits(identity) {
-            continue;
-        }
-        let org = hosted.org.clone();
-        let storage = hosted_storage(state, Some(&org));
-        // The caller was resolved once by the middleware; both filters run
-        // synchronously against it inside the scan. Visibility is
-        // per-package: each hit is gated by this hosted registry's effective
-        // access for that name, so a per-package rule can open (or close) a
-        // name regardless of the registry-level default.
-        let keep = |name: &str| {
-            matches!(
-                resolve_registry_source(state, &registry, name),
-                RegistrySource::Hosted(resolved) if resolved == source,
-            ) && matches!(hosted_gate(state, identity, &source, name), HostedGate::Allowed(_))
-        };
-        match pnpr_search::run_local_search(&storage, &text, size - objects.len(), keep).await {
-            Ok(mut entries) => objects.append(&mut entries),
-            Err(err) => return err.into_response(),
+    let mut page = SearchPage::new(params.from, params.size);
+    let mut total = 0usize;
+    for source in discovery_sources(state, &registry) {
+        match source {
+            DiscoverySource::Hosted(source) => {
+                let Some(hosted) = state.inner.config.hosted.get(&source) else {
+                    continue;
+                };
+                if !hosted.rules.any_access_admits(identity) {
+                    continue;
+                }
+                let storage = hosted_storage(state, Some(&hosted.org));
+                let keep = |name: &str| {
+                    matches!(
+                        resolve_registry_source(state, &registry, name),
+                        RegistrySource::Hosted(resolved) if resolved == source,
+                    ) && matches!(
+                        hosted_gate(state, identity, &source, name),
+                        HostedGate::Allowed(_),
+                    )
+                };
+                let entries =
+                    match pnpr_search::run_local_search(&storage, &params.text, keep).await {
+                        Ok(entries) => entries,
+                        Err(err) => return err.into_response(),
+                    };
+                let source_total = entries.len();
+                page.append_source(entries, total);
+                total = total.saturating_add(source_total);
+            }
+            DiscoverySource::Upstream(source) => {
+                let Some(config) = state.inner.config.upstreams.get(&source) else {
+                    continue;
+                };
+                if !config.search
+                    || config.access.as_ref().is_some_and(|access| !access.allows(identity))
+                    || !config.rules.all_access_admit(identity)
+                {
+                    continue;
+                }
+                let Some(upstream) = state.inner.upstreams.get(&source) else {
+                    continue;
+                };
+                let source_from = params.from.saturating_sub(total);
+                let request_size = page.remaining().max(1);
+                let query = upstream_search_query(query_string, source_from, request_size);
+                let response = match upstream.fetch_search(&query).await {
+                    Ok(FetchOutcome::Ok(response)) => response,
+                    Ok(FetchOutcome::NotFound) => continue,
+                    Err(err) => return err.into_response(),
+                };
+                let source_total = response.total;
+                for object in response.objects {
+                    if page.is_full() {
+                        break;
+                    }
+                    let Some(name) = search_object_name(&object) else {
+                        continue;
+                    };
+                    let resolved = RegistrySource::Upstream(source.clone());
+                    if !matches!(
+                        resolve_registry_source(state, &registry, name),
+                        RegistrySource::Upstream(candidate) if candidate == source,
+                    ) || authorize(state, identity, &resolved, name, Action::Access).is_err()
+                    {
+                        continue;
+                    }
+                    page.push(object);
+                }
+                total = total.saturating_add(source_total);
+            }
         }
     }
-    result(objects)
+    result(page.objects, total)
 }
 
-/// The hosted registries a search addressed to `registry` scans, in source order.
-/// A hosted registry scans itself; a router scans each of its hosted sources; an
-/// upstream registry scans nothing — search is local-only, never proxied (an
-/// upstream is reached only through its own registry, by exact package name;
-/// there is no cross-origin search merge).
-fn hosted_search_sources(state: &AppState, registry: &str) -> Vec<String> {
+fn discovery_sources(state: &AppState, registry: &str) -> Vec<DiscoverySource> {
     match state.inner.config.registries.get(registry) {
-        Some(Registry::Hosted { .. }) => vec![registry.to_string()],
+        Some(Registry::Hosted { .. }) => vec![DiscoverySource::Hosted(registry.to_string())],
+        Some(Registry::Upstream { .. }) => vec![DiscoverySource::Upstream(registry.to_string())],
         Some(Registry::Router { sources }) => sources
             .iter()
-            .filter(|source| {
-                matches!(
-                    state.inner.config.registries.get(source.as_str()),
-                    Some(Registry::Hosted { .. }),
-                )
+            .filter_map(|source| match state.inner.config.registries.get(source.as_str()) {
+                Some(Registry::Hosted { .. }) => Some(DiscoverySource::Hosted(source.clone())),
+                Some(Registry::Upstream { .. }) => Some(DiscoverySource::Upstream(source.clone())),
+                Some(Registry::Router { .. }) | None => None,
             })
-            .cloned()
             .collect(),
-        Some(Registry::Upstream { .. }) | None => Vec::new(),
+        None => Vec::new(),
+    }
+}
+
+fn search_object_name(object: &Value) -> Option<&str> {
+    object.get("package")?.get("name")?.as_str()
+}
+
+fn upstream_search_query(query_string: &str, from: usize, size: usize) -> String {
+    let mut query = url::form_urlencoded::Serializer::new(String::new());
+    for (key, value) in url::form_urlencoded::parse(query_string.as_bytes()) {
+        if key != "from" && key != "size" {
+            query.append_pair(&key, &value);
+        }
+    }
+    query.append_pair("from", &from.to_string());
+    query.append_pair("size", &size.clamp(1, 250).to_string());
+    query.finish()
+}
+
+/// `GET /-/org/{scope}/package` — the npm-compatible package-permission map.
+/// Values are useful to npm's account UI; registry UIs such as npmX consume
+/// the keys as the authoritative package list.
+async fn serve_org_packages(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    raw_scope: &str,
+) -> Response {
+    let scope = raw_scope.strip_prefix('@').unwrap_or(raw_scope);
+    if PackageName::parse(&format!("@{scope}/package")).is_err() {
+        return not_found();
+    }
+    let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
+    else {
+        return not_found();
+    };
+    let prefix = format!("@{scope}/");
+    let mut packages = Map::new();
+    for source in discovery_sources(state, &registry) {
+        match source {
+            DiscoverySource::Hosted(source) => {
+                let Some(hosted) = state.inner.config.hosted.get(&source) else {
+                    continue;
+                };
+                if !hosted.rules.any_access_admits(identity) {
+                    continue;
+                }
+                let storage = hosted_storage(state, Some(&hosted.org));
+                let mut names = match storage.hosted_package_names().await {
+                    Ok(names) => names,
+                    Err(err) => return err.into_response(),
+                };
+                names.sort();
+                for name in names {
+                    if !name.starts_with(&prefix)
+                        || !matches!(
+                            resolve_registry_source(state, &registry, &name),
+                            RegistrySource::Hosted(candidate) if candidate == source,
+                        )
+                        || !matches!(
+                            hosted_gate(state, identity, &source, &name),
+                            HostedGate::Allowed(_),
+                        )
+                    {
+                        continue;
+                    }
+                    let resolved = RegistrySource::Hosted(source.clone());
+                    let permission =
+                        if authorize(state, identity, &resolved, &name, Action::Publish).is_ok() {
+                            "write"
+                        } else {
+                            "read"
+                        };
+                    packages.insert(name, Value::String(permission.to_string()));
+                }
+            }
+            DiscoverySource::Upstream(source) => {
+                let Some(config) = state.inner.config.upstreams.get(&source) else {
+                    continue;
+                };
+                if !config.search
+                    || config.access.as_ref().is_some_and(|access| !access.allows(identity))
+                {
+                    continue;
+                }
+                let Some(upstream) = state.inner.upstreams.get(&source) else {
+                    continue;
+                };
+                let upstream_packages = match upstream.fetch_org_packages(scope).await {
+                    Ok(FetchOutcome::Ok(packages)) => packages,
+                    Ok(FetchOutcome::NotFound) => continue,
+                    Err(err) => return err.into_response(),
+                };
+                for (name, permission) in upstream_packages {
+                    let resolved = RegistrySource::Upstream(source.clone());
+                    if !name.starts_with(&prefix)
+                        || !matches!(
+                            resolve_registry_source(state, &registry, &name),
+                            RegistrySource::Upstream(candidate) if candidate == source,
+                        )
+                        || authorize(state, identity, &resolved, &name, Action::Access).is_err()
+                    {
+                        continue;
+                    }
+                    packages.entry(name).or_insert(permission);
+                }
+            }
+        }
+    }
+    if packages.is_empty() {
+        return not_found();
+    }
+    match serde_json::to_vec(&packages) {
+        Ok(body) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(body))
+            .expect("static-shape response always builds"),
+        Err(err) => RegistryError::Json(err).into_response(),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1545,12 +1545,32 @@ impl SearchPage {
         false
     }
 
-    fn needs_lookahead(&self) -> bool {
-        self.names.len() <= self.from.saturating_add(self.size)
-    }
-
     fn total(&self) -> usize {
         self.names.len()
+    }
+}
+
+const MAX_UPSTREAM_SEARCH_RESULTS: usize = 2_000;
+const MAX_UPSTREAM_SEARCH_PAGES: usize = 8;
+
+#[derive(Default)]
+struct UpstreamSearchBudget {
+    pages: usize,
+    results: usize,
+}
+
+struct UpstreamSearchContext<'a> {
+    state: &'a AppState,
+    identity: &'a Identity,
+    registry: &'a str,
+    source: &'a str,
+    upstream: &'a Upstream,
+    query_string: &'a str,
+}
+
+impl UpstreamSearchBudget {
+    fn remaining_results(&self) -> usize {
+        MAX_UPSTREAM_SEARCH_RESULTS.saturating_sub(self.results)
     }
 }
 
@@ -2282,10 +2302,10 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
 
 /// `GET /-/v1/search?text=...&from=...&size=...` — npm search v1 endpoint.
 /// Hosted results are counted after routing and access filters, then optional
-/// upstream results are appended in registry-source order. Upstream scans stop
-/// after one visible result beyond the requested page, so `total` is a safe
-/// visible lower bound until every source has been exhausted. An upstream only
-/// participates when its `search` setting is enabled.
+/// upstream results are appended in registry-source order. Every participating
+/// upstream is exhausted so `total` describes the complete visible,
+/// deduplicated result set. An upstream only participates when its `search`
+/// setting is enabled.
 async fn serve_search(
     state: &AppState,
     identity: &Identity,
@@ -2309,6 +2329,7 @@ async fn serve_search(
         return result(Vec::new(), 0);
     };
     let mut page = SearchPage::new(params.from, params.size);
+    let mut upstream_budget = UpstreamSearchBudget::default();
     for source in discovery_sources(state, &registry) {
         match source {
             DiscoverySource::Hosted(source) => {
@@ -2352,20 +2373,23 @@ async fn serve_search(
                 let Some(upstream) = state.inner.upstreams.get(&source) else {
                     continue;
                 };
-                if !page.needs_lookahead() {
-                    continue;
+                if params.from > page.total().saturating_add(upstream_budget.remaining_results()) {
+                    return RegistryError::BadRequest {
+                        reason: format!(
+                            "search `from` would require scanning more than {MAX_UPSTREAM_SEARCH_RESULTS} upstream results",
+                        ),
+                    }
+                    .into_response();
                 }
-                match append_upstream_search(
+                let context = UpstreamSearchContext {
                     state,
                     identity,
-                    &registry,
-                    &source,
+                    registry: &registry,
+                    source: &source,
                     upstream,
                     query_string,
-                    &mut page,
-                )
-                .await
-                {
+                };
+                match append_upstream_search(context, &mut page, &mut upstream_budget).await {
                     Ok(()) => {}
                     Err(err) => return err.into_response(),
                 }
@@ -2377,33 +2401,47 @@ async fn serve_search(
 }
 
 async fn append_upstream_search(
-    state: &AppState,
-    identity: &Identity,
-    registry: &str,
-    source: &str,
-    upstream: &Upstream,
-    query_string: &str,
+    context: UpstreamSearchContext<'_>,
     page: &mut SearchPage,
+    budget: &mut UpstreamSearchBudget,
 ) -> Result<(), RegistryError> {
     const FETCH_SIZE: usize = 250;
 
-    let resolved = RegistrySource::Upstream(source.to_string());
+    let resolved = RegistrySource::Upstream(context.source.to_string());
+    let source_result_budget = budget.remaining_results();
     let mut from = 0usize;
-    while page.needs_lookahead() {
-        let query = upstream_search_query(query_string, from, FETCH_SIZE);
-        let response = match upstream.fetch_search(&query).await? {
+    loop {
+        if budget.pages == MAX_UPSTREAM_SEARCH_PAGES {
+            return Err(RegistryError::BadRequest {
+                reason: format!(
+                    "upstream search is limited to {MAX_UPSTREAM_SEARCH_PAGES} pages; refine the query",
+                ),
+            });
+        }
+        budget.pages += 1;
+        let query = upstream_search_query(context.query_string, from, FETCH_SIZE);
+        let response = match context.upstream.fetch_search(&query).await? {
             FetchOutcome::Ok(response) => response,
             FetchOutcome::NotFound => return Ok(()),
         };
         let object_count = response.objects.len();
+        if response.total > source_result_budget || object_count > budget.remaining_results() {
+            return Err(RegistryError::BadRequest {
+                reason: format!(
+                    "upstream search is limited to {MAX_UPSTREAM_SEARCH_RESULTS} results; refine the query",
+                ),
+            });
+        }
+        budget.results += object_count;
         for object in response.objects {
             let Some(name) = search_object_name(&object) else {
                 continue;
             };
             if !matches!(
-                resolve_registry_source(state, registry, name),
-                RegistrySource::Upstream(candidate) if candidate == source,
-            ) || authorize(state, identity, &resolved, name, Action::Access).is_err()
+                resolve_registry_source(context.state, context.registry, name),
+                RegistrySource::Upstream(candidate) if candidate == context.source,
+            ) || authorize(context.state, context.identity, &resolved, name, Action::Access)
+                .is_err()
             {
                 continue;
             }
@@ -2415,12 +2453,11 @@ async fn append_upstream_search(
         }
         if object_count == 0 {
             return Err(RegistryError::UpstreamResponse {
-                url: format!("{source}/-/v1/search"),
+                url: format!("{}/-/v1/search", context.source),
                 reason: format!("reported {} results but returned an empty page", response.total),
             });
         }
     }
-    Ok(())
 }
 
 fn discovery_sources(state: &AppState, registry: &str) -> Vec<DiscoverySource> {

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1525,31 +1525,32 @@ impl SearchPage {
         Self { objects: Vec::new(), names: HashSet::new(), from, size }
     }
 
-    fn append_source(&mut self, source_objects: Vec<Value>, source_start: usize) {
-        let skip = self.from.saturating_sub(source_start);
-        for object in source_objects.into_iter().skip(skip) {
-            if self.is_full() {
-                break;
-            }
-            self.push(object);
-        }
-    }
-
     fn push(&mut self, object: Value) {
         let Some(name) = search_object_name(&object) else {
             return;
         };
-        if self.names.insert(name.to_string()) {
+        if self.push_name(name) {
             self.objects.push(object);
         }
     }
 
-    fn is_full(&self) -> bool {
-        self.objects.len() >= self.size
+    fn push_name(&mut self, name: &str) -> bool {
+        let position = self.names.len();
+        if self.names.insert(name.to_string())
+            && position >= self.from
+            && position < self.from.saturating_add(self.size)
+        {
+            return true;
+        }
+        false
     }
 
-    fn remaining(&self) -> usize {
-        self.size.saturating_sub(self.objects.len())
+    fn needs_lookahead(&self) -> bool {
+        self.names.len() <= self.from.saturating_add(self.size)
+    }
+
+    fn total(&self) -> usize {
+        self.names.len()
     }
 }
 
@@ -2281,7 +2282,9 @@ fn hosted_storage(state: &AppState, org: Option<&str>) -> Storage {
 
 /// `GET /-/v1/search?text=...&from=...&size=...` — npm search v1 endpoint.
 /// Hosted results are counted after routing and access filters, then optional
-/// upstream results are appended in registry-source order. An upstream only
+/// upstream results are appended in registry-source order. Upstream scans stop
+/// after one visible result beyond the requested page, so `total` is a safe
+/// visible lower bound until every source has been exhausted. An upstream only
 /// participates when its `search` setting is enabled.
 async fn serve_search(
     state: &AppState,
@@ -2306,7 +2309,6 @@ async fn serve_search(
         return result(Vec::new(), 0);
     };
     let mut page = SearchPage::new(params.from, params.size);
-    let mut total = 0usize;
     for source in discovery_sources(state, &registry) {
         match source {
             DiscoverySource::Hosted(source) => {
@@ -2326,14 +2328,16 @@ async fn serve_search(
                         HostedGate::Allowed(_),
                     )
                 };
-                let entries =
-                    match pnpr_search::run_local_search(&storage, &params.text, keep).await {
-                        Ok(entries) => entries,
+                let names =
+                    match pnpr_search::local_search_names(&storage, &params.text, keep).await {
+                        Ok(names) => names,
                         Err(err) => return err.into_response(),
                     };
-                let source_total = entries.len();
-                page.append_source(entries, total);
-                total = total.saturating_add(source_total);
+                for name in names {
+                    if page.push_name(&name) {
+                        page.objects.push(pnpr_search::local_search_entry(&storage, &name).await);
+                    }
+                }
             }
             DiscoverySource::Upstream(source) => {
                 let Some(config) = state.inner.config.upstreams.get(&source) else {
@@ -2348,37 +2352,75 @@ async fn serve_search(
                 let Some(upstream) = state.inner.upstreams.get(&source) else {
                     continue;
                 };
-                let source_from = params.from.saturating_sub(total);
-                let request_size = page.remaining().max(1);
-                let query = upstream_search_query(query_string, source_from, request_size);
-                let response = match upstream.fetch_search(&query).await {
-                    Ok(FetchOutcome::Ok(response)) => response,
-                    Ok(FetchOutcome::NotFound) => continue,
-                    Err(err) => return err.into_response(),
-                };
-                let source_total = response.total;
-                for object in response.objects {
-                    if page.is_full() {
-                        break;
-                    }
-                    let Some(name) = search_object_name(&object) else {
-                        continue;
-                    };
-                    let resolved = RegistrySource::Upstream(source.clone());
-                    if !matches!(
-                        resolve_registry_source(state, &registry, name),
-                        RegistrySource::Upstream(candidate) if candidate == source,
-                    ) || authorize(state, identity, &resolved, name, Action::Access).is_err()
-                    {
-                        continue;
-                    }
-                    page.push(object);
+                if !page.needs_lookahead() {
+                    continue;
                 }
-                total = total.saturating_add(source_total);
+                match append_upstream_search(
+                    state,
+                    identity,
+                    &registry,
+                    &source,
+                    upstream,
+                    query_string,
+                    &mut page,
+                )
+                .await
+                {
+                    Ok(()) => {}
+                    Err(err) => return err.into_response(),
+                }
             }
         }
     }
+    let total = page.total();
     result(page.objects, total)
+}
+
+async fn append_upstream_search(
+    state: &AppState,
+    identity: &Identity,
+    registry: &str,
+    source: &str,
+    upstream: &Upstream,
+    query_string: &str,
+    page: &mut SearchPage,
+) -> Result<(), RegistryError> {
+    const FETCH_SIZE: usize = 250;
+
+    let resolved = RegistrySource::Upstream(source.to_string());
+    let mut from = 0usize;
+    while page.needs_lookahead() {
+        let query = upstream_search_query(query_string, from, FETCH_SIZE);
+        let response = match upstream.fetch_search(&query).await? {
+            FetchOutcome::Ok(response) => response,
+            FetchOutcome::NotFound => return Ok(()),
+        };
+        let object_count = response.objects.len();
+        for object in response.objects {
+            let Some(name) = search_object_name(&object) else {
+                continue;
+            };
+            if !matches!(
+                resolve_registry_source(state, registry, name),
+                RegistrySource::Upstream(candidate) if candidate == source,
+            ) || authorize(state, identity, &resolved, name, Action::Access).is_err()
+            {
+                continue;
+            }
+            page.push(object);
+        }
+        from = from.saturating_add(object_count);
+        if from >= response.total {
+            return Ok(());
+        }
+        if object_count == 0 {
+            return Err(RegistryError::UpstreamResponse {
+                url: format!("{source}/-/v1/search"),
+                reason: format!("reported {} results but returned an empty page", response.total),
+            });
+        }
+    }
+    Ok(())
 }
 
 fn discovery_sources(state: &AppState, registry: &str) -> Vec<DiscoverySource> {
@@ -2487,7 +2529,7 @@ async fn serve_org_packages(
                     Ok(FetchOutcome::NotFound) => continue,
                     Err(err) => return err.into_response(),
                 };
-                for (name, permission) in upstream_packages {
+                for (name, _) in upstream_packages {
                     let resolved = RegistrySource::Upstream(source.clone());
                     if !name.starts_with(&prefix)
                         || !matches!(
@@ -2498,7 +2540,7 @@ async fn serve_org_packages(
                     {
                         continue;
                     }
-                    packages.entry(name).or_insert(permission);
+                    packages.entry(name).or_insert_with(|| Value::String("read".to_string()));
                 }
             }
         }

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -370,14 +370,18 @@ pub(super) async fn validate_publish_doc(
 }
 
 fn record_publisher(incoming: &mut Value, identity: &Identity) {
-    let Identity::User { username } = identity else {
-        return;
-    };
     let Some(versions) = incoming.get_mut("versions").and_then(Value::as_object_mut) else {
         return;
     };
     for manifest in versions.values_mut().filter_map(Value::as_object_mut) {
-        manifest.insert("_npmUser".to_string(), json!({ "name": username }));
+        match identity {
+            Identity::User { username } => {
+                manifest.insert("_npmUser".to_string(), json!({ "name": username }));
+            }
+            Identity::Anonymous => {
+                manifest.remove("_npmUser");
+            }
+        }
     }
 }
 
@@ -691,3 +695,6 @@ async fn cleanup_tmp_slots(slots: Vec<pnpr_storage::TarballSlot>) {
         let _ = tokio::fs::remove_file(&slot.tmp_path).await;
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -377,7 +377,7 @@ fn record_publisher(incoming: &mut Value, identity: &Identity) {
         return;
     };
     for manifest in versions.values_mut().filter_map(Value::as_object_mut) {
-        manifest.entry("_npmUser").or_insert_with(|| json!({ "name": username }));
+        manifest.insert("_npmUser".to_string(), json!({ "name": username }));
     }
 }
 

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -345,6 +345,7 @@ pub(super) async fn validate_publish_doc(
     )?;
 
     let attachments = extract_attachments(&mut incoming)?;
+    record_publisher(&mut incoming, identity);
 
     // Resolve each attachment's canonical disk filename + matching
     // `versions[v].dist` block. Attachment names that don't match the
@@ -366,6 +367,18 @@ pub(super) async fn validate_publish_doc(
         prepared.push(PreparedAttachment { attachment, canonical, version, dist });
     }
     Ok((ValidatedPublish { name, incoming, prepared }, target))
+}
+
+fn record_publisher(incoming: &mut Value, identity: &Identity) {
+    let Identity::User { username } = identity else {
+        return;
+    };
+    let Some(versions) = incoming.get_mut("versions").and_then(Value::as_object_mut) else {
+        return;
+    };
+    for manifest in versions.values_mut().filter_map(Value::as_object_mut) {
+        manifest.entry("_npmUser").or_insert_with(|| json!({ "name": username }));
+    }
 }
 
 /// A publish whose packument is merged and whose tarballs are fully

--- a/pnpr/crates/pnpr/src/server/publishing/tests.rs
+++ b/pnpr/crates/pnpr/src/server/publishing/tests.rs
@@ -1,0 +1,18 @@
+use super::record_publisher;
+use pnpr_policy::Identity;
+use serde_json::json;
+
+#[test]
+fn publisher_attribution_comes_only_from_an_authenticated_identity() {
+    let mut authenticated = json!({
+        "versions": { "1.0.0": { "_npmUser": { "name": "mallory" } } },
+    });
+    record_publisher(&mut authenticated, &Identity::user("alice"));
+    assert_eq!(authenticated["versions"]["1.0.0"]["_npmUser"]["name"], "alice");
+
+    let mut anonymous = json!({
+        "versions": { "1.0.0": { "_npmUser": { "name": "mallory" } } },
+    });
+    record_publisher(&mut anonymous, &Identity::Anonymous);
+    assert!(anonymous["versions"]["1.0.0"].get("_npmUser").is_none());
+}

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -4,7 +4,7 @@ use axum::{
     Router,
     body::Body,
     extract::{DefaultBodyLimit, OriginalUri, Path, Request, State},
-    http::HeaderMap,
+    http::{HeaderMap, HeaderValue, Method, header},
     middleware,
     response::Response,
     routing::{any, delete, get, post, put},
@@ -15,6 +15,7 @@ use tower_http::{
         CompressionLayer,
         predicate::{DefaultPredicate, NotForContentType, Predicate as _},
     },
+    cors::{AllowOrigin, CorsLayer},
     trace::TraceLayer,
 };
 use tracing::Span;
@@ -33,11 +34,12 @@ use super::{
     get_token_list, get_whoami, loggable_uri, not_found, pnpr_protocols_disabled,
     private_if_caller_gated, private_no_cache, publish_package, put_login, reject_team_mutation,
     remove_dist_tag, require_artifact_caller, require_resolver_caller, serve_artifact_blob,
-    serve_batch_publish, serve_packument, serve_ping, serve_pnpr_handshake, serve_publish_artifact,
-    serve_registry_packument, serve_registry_tarball, serve_registry_version_manifest,
-    serve_resolve, serve_resolve_artifacts, serve_revision_tarball, serve_search, serve_tarball,
-    serve_verify_lockfile, serve_version_manifest, set_dist_tag, staged, tilde_registry,
-    update_packument, upstream_tarball_base,
+    serve_batch_publish, serve_org_packages, serve_packument, serve_ping, serve_pnpr_handshake,
+    serve_publish_artifact, serve_registry_packument, serve_registry_tarball,
+    serve_registry_version_manifest, serve_resolve, serve_resolve_artifacts,
+    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
+    serve_version_manifest, set_dist_tag, staged, tilde_registry, update_packument,
+    upstream_tarball_base,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -45,6 +47,16 @@ pub(super) fn router_with_auth_and_osv(
     auth: AuthState,
     osv_index: Option<Arc<pnpr_osv::OsvIndex>>,
 ) -> pnpr_error::Result<Router> {
+    let cors_origins = config
+        .cors
+        .allowed_origins()
+        .iter()
+        .map(|origin| {
+            HeaderValue::from_str(origin).map_err(|_| pnpr_error::RegistryError::InvalidConfig {
+                reason: format!("CORS allowed origin {origin:?} is not a valid HTTP header value"),
+            })
+        })
+        .collect::<pnpr_error::Result<Vec<_>>>()?;
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
     let registry_enabled = config.registry.enabled;
@@ -239,14 +251,23 @@ pub(super) fn router_with_auth_and_osv(
             // `DELETE /~<name>/@scope/name/-/<file>/-rev/<rev>`
             .route("/{a}/{b}/{c}/{d}/{e}/{f}/{g}", delete(delete_seven_segments));
     }
-    Ok(router
+    let mut router = router
         .layer(DefaultBodyLimit::max(MAX_PUBLISH_BODY_BYTES))
         // Authenticate once, ahead of every handler: resolve the caller,
         // enforce bearer-token read-only / CIDR restrictions (so a
         // restricted token is rejected before a write handler buffers its
         // up-to-100-MiB body), and stash the identity for handlers to read.
         // Inside the trace layer below, so a rejection is still one record.
-        .layer(axum::middleware::from_fn_with_state(state.clone(), authenticate))
+        .layer(axum::middleware::from_fn_with_state(state.clone(), authenticate));
+    if !cors_origins.is_empty() {
+        router = router.layer(
+            CorsLayer::new()
+                .allow_origin(AllowOrigin::list(cors_origins))
+                .allow_methods([Method::GET, Method::HEAD, Method::OPTIONS])
+                .allow_headers([header::AUTHORIZATION, header::ACCEPT, header::CONTENT_TYPE]),
+        );
+    }
+    let router = router
         // gzip metadata responses for clients that send `Accept-Encoding:
         // gzip`, matching how a real (CDN-fronted) registry serves
         // packuments — pnpr is commonly hit directly with no proxy in
@@ -297,8 +318,8 @@ pub(super) fn router_with_auth_and_osv(
                     );
                 })
                 .on_failure(()),
-        )
-        .with_state(state))
+        );
+    Ok(router.with_state(state))
 }
 
 // --------------------------------------------------------------------
@@ -441,6 +462,9 @@ async fn get_four_segments(
     if a == "-" && b == "org" && d == "team" {
         return private_no_cache(get_org_teams(&state, &identity, None, &c));
     }
+    if a == "-" && b == "org" && d == "package" {
+        return private_no_cache(serve_org_packages(&state, &identity, None, &c).await);
+    }
     if let Some(registry) = tilde_registry(&a) {
         if b == "-" && c == "v1" && d == "search" {
             let query = uri.query().unwrap_or("");
@@ -492,6 +516,11 @@ async fn get_five_segments(
         }
         if b == "-" && c == "org" && e == "team" {
             return private_no_cache(get_org_teams(&state, &identity, Some(registry), &d));
+        }
+        if b == "-" && c == "org" && e == "package" {
+            return private_no_cache(
+                serve_org_packages(&state, &identity, Some(registry), &d).await,
+            );
         }
     }
     not_found()

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3175,6 +3175,14 @@ fn seed_hosted(storage: &Path, pkg: &str) {
     std::fs::write(storage.join(pkg).join("package.json"), packument.to_string()).unwrap();
 }
 
+fn seed_hosted_with_maintainer(storage: &Path, pkg: &str, maintainer: &str) {
+    seed_hosted(storage, pkg);
+    let path = storage.join(pkg).join("package.json");
+    let mut packument: Value = serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+    packument["maintainers"] = json!([{ "username": maintainer }]);
+    std::fs::write(path, serde_json::to_vec(&packument).unwrap()).unwrap();
+}
+
 #[tokio::test]
 async fn hosted_registry_serves_only_what_it_hosts() {
     let tmp = TempDir::new().unwrap();
@@ -3390,6 +3398,22 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     assert_eq!(read.status(), StatusCode::OK);
     let doc = body_json(read.into_body()).await;
     assert!(doc["versions"]["1.0.0"].is_object());
+    assert_eq!(doc["versions"]["1.0.0"]["_npmUser"]["name"], json!("alice"));
+
+    let search = app
+        .clone()
+        .oneshot(
+            Request::get("/~acme/-/v1/search?text=maintainer%3Aalice")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(search.status(), StatusCode::OK);
+    let search = body_json(search.into_body()).await;
+    assert_eq!(search["total"], json!(1));
+    assert_eq!(search["objects"][0]["package"]["name"], json!("@acme/widget"));
 
     // ...and its tarball serves from the org namespace.
     let tar = app
@@ -3995,6 +4019,278 @@ async fn search_does_not_enumerate_a_private_flat_root_registry() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = body_json(response.into_body()).await;
     assert_eq!(body["objects"][0]["package"]["name"], json!("@corp/secret-tool"));
+}
+
+#[tokio::test]
+async fn search_paginates_visible_results_and_filters_by_maintainer() {
+    let tmp = TempDir::new().unwrap();
+    seed_hosted_with_maintainer(tmp.path(), "tool-a", "alice");
+    seed_hosted_with_maintainer(tmp.path(), "tool-b", "bob");
+    seed_hosted_with_maintainer(tmp.path(), "tool-c", "alice");
+    let app = router(Config::static_serve(
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
+        tmp.path().to_path_buf(),
+    ));
+
+    let page = app
+        .clone()
+        .oneshot(Request::get("/-/v1/search?text=tool&from=1&size=1").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let page = body_json(page.into_body()).await;
+    assert_eq!(page["total"], json!(3));
+    assert_eq!(page["objects"][0]["package"]["name"], json!("tool-b"));
+
+    let maintained = app
+        .oneshot(
+            Request::get("/-/v1/search?text=maintainer%3Aalice&from=1&size=1")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let maintained = body_json(maintained.into_body()).await;
+    assert_eq!(maintained["total"], json!(2));
+    assert_eq!(maintained["objects"][0]["package"]["name"], json!("tool-c"));
+}
+
+#[tokio::test]
+async fn organization_packages_are_available_on_both_registry_routes() {
+    let tmp = TempDir::new().unwrap();
+    seed_hosted(tmp.path(), "@acme/alpha");
+    seed_hosted(tmp.path(), "@acme/beta");
+    seed_hosted(tmp.path(), "@other/ignored");
+    let app = router(Config::static_serve(
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
+        tmp.path().to_path_buf(),
+    ));
+
+    for route in ["/-/org/acme/package", "/~main/-/org/acme/package"] {
+        let response =
+            app.clone().oneshot(Request::get(route).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let packages = body_json(response.into_body()).await;
+        assert_eq!(packages["@acme/alpha"], json!("read"));
+        assert_eq!(packages["@acme/beta"], json!("read"));
+        assert!(packages.get("@other/ignored").is_none());
+    }
+}
+
+#[tokio::test]
+async fn cors_allows_only_configured_origins_and_handles_preflight() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = Config::static_serve(
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 0)),
+        tmp.path().to_path_buf(),
+    );
+    config.cors = pnpr::CorsConfig::from_allowed_origins(["https://npmx.example"]).unwrap();
+    let app = router(config);
+
+    let allowed = app
+        .clone()
+        .oneshot(
+            Request::get("/-/ping")
+                .header(header::ORIGIN, "https://npmx.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        allowed.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://npmx.example")),
+    );
+    assert!(allowed.headers().get(header::VARY).is_some_and(|value| {
+        value.to_str().is_ok_and(|value| {
+            value.split(',').any(|header| header.trim().eq_ignore_ascii_case("origin"))
+        })
+    }));
+
+    let missing = app
+        .clone()
+        .oneshot(
+            Request::get("/missing")
+                .header(header::ORIGIN, "https://npmx.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        missing.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://npmx.example")),
+    );
+
+    let denied = app
+        .clone()
+        .oneshot(
+            Request::get("/-/ping")
+                .header(header::ORIGIN, "https://other.example")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(denied.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN).is_none());
+
+    let preflight = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/-/v1/search?text=tool")
+                .header(header::ORIGIN, "https://npmx.example")
+                .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+                .header(header::ACCESS_CONTROL_REQUEST_HEADERS, "authorization")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(preflight.status(), StatusCode::OK);
+    assert_eq!(
+        preflight.headers().get(header::ACCESS_CONTROL_ALLOW_ORIGIN),
+        Some(&HeaderValue::from_static("https://npmx.example")),
+    );
+    assert!(preflight.headers().get(header::ACCESS_CONTROL_ALLOW_HEADERS).is_some_and(|value| {
+        value.to_str().is_ok_and(|value| {
+            value.split(',').any(|header| header.trim().eq_ignore_ascii_case("authorization"))
+        })
+    }),);
+}
+
+#[tokio::test]
+async fn opt_in_upstream_discovery_serves_search_and_organization_packages() {
+    let mut upstream = mockito::Server::new_async().await;
+    let search = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query("text=remote&from=0&size=5")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [{
+                    "package": { "name": "remote-package", "version": "1.0.0" },
+                    "score": { "final": 1.0 },
+                    "searchScore": 1.0,
+                }],
+                "total": 1,
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let org = upstream
+        .mock("GET", "/-/org/acme/package")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "@acme/remote": "write" }).to_string())
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/-/v1/search?text=remote&size=5")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let response = body_json(response.into_body()).await;
+    assert_eq!(response["total"], json!(1));
+    assert_eq!(response["objects"][0]["package"]["name"], json!("remote-package"));
+
+    let response = app
+        .oneshot(
+            Request::get("/-/org/acme/package")
+                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_json(response.into_body()).await["@acme/remote"], json!("write"));
+    search.assert_async().await;
+    org.assert_async().await;
+}
+
+#[tokio::test]
+async fn search_paginates_across_hosted_and_upstream_sources() {
+    let mut upstream = mockito::Server::new_async().await;
+    let first = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("text".into(), "ajv".into()),
+            mockito::Matcher::UrlEncoded("from".into(), "0".into()),
+            mockito::Matcher::UrlEncoded("size".into(), "1".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [{ "package": { "name": "ajv-remote-a" } }],
+                "total": 2,
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let second = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("text".into(), "ajv".into()),
+            mockito::Matcher::UrlEncoded("from".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("size".into(), "1".into()),
+        ]))
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [{ "package": { "name": "ajv-remote-b" } }],
+                "total": 2,
+            })
+            .to_string(),
+        )
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    seed_hosted(tmp.path(), "ajv");
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let app = router(config);
+
+    let first_page = app
+        .clone()
+        .oneshot(Request::get("/-/v1/search?text=ajv&size=2").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(first_page.status(), StatusCode::OK);
+    let first_page = body_json(first_page.into_body()).await;
+    assert_eq!(first_page["total"], json!(3));
+    assert_eq!(first_page["objects"][0]["package"]["name"], json!("ajv"));
+    assert_eq!(first_page["objects"][1]["package"]["name"], json!("ajv-remote-a"));
+
+    let second_page = app
+        .oneshot(Request::get("/-/v1/search?text=ajv&from=2&size=1").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(second_page.status(), StatusCode::OK);
+    let second_page = body_json(second_page.into_body()).await;
+    assert_eq!(second_page["total"], json!(3));
+    assert_eq!(second_page["objects"][0]["package"]["name"], json!("ajv-remote-b"));
+    first.assert_async().await;
+    second.assert_async().await;
 }
 
 /// Every registry operation routes through the registry graph when addressed as

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -3349,10 +3349,15 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     let body = json!({
         "name": "@acme/widget",
         "dist-tags": { "latest": "1.0.0" },
-        "versions": { "1.0.0": { "name": "@acme/widget", "version": "1.0.0", "dist": {
-            "tarball": "http://example.test/@acme/widget/-/widget-1.0.0.tgz",
-            "integrity": sha512_integrity(tarball),
-        } } },
+        "versions": { "1.0.0": {
+            "name": "@acme/widget",
+            "version": "1.0.0",
+            "_npmUser": { "name": "mallory" },
+            "dist": {
+                "tarball": "http://example.test/@acme/widget/-/widget-1.0.0.tgz",
+                "integrity": sha512_integrity(tarball),
+            },
+        } },
         "_attachments": { "@acme/widget-1.0.0.tgz": {
             "content_type": "application/octet-stream",
             "data": BASE64.encode(tarball),
@@ -3398,7 +3403,11 @@ async fn publish_to_hosted_round_trips_in_its_own_namespace() {
     assert_eq!(read.status(), StatusCode::OK);
     let doc = body_json(read.into_body()).await;
     assert!(doc["versions"]["1.0.0"].is_object());
-    assert_eq!(doc["versions"]["1.0.0"]["_npmUser"]["name"], json!("alice"));
+    assert_eq!(
+        doc["versions"]["1.0.0"]["_npmUser"]["name"],
+        json!("alice"),
+        "the authenticated publisher must replace client-supplied attribution",
+    );
 
     let search = app
         .clone()
@@ -4164,7 +4173,7 @@ async fn opt_in_upstream_discovery_serves_search_and_organization_packages() {
     let mut upstream = mockito::Server::new_async().await;
     let search = upstream
         .mock("GET", "/-/v1/search")
-        .match_query("text=remote&from=0&size=5")
+        .match_query("text=remote&from=0&size=250")
         .match_header("authorization", mockito::Matcher::Missing)
         .with_status(200)
         .with_header("content-type", "application/json")
@@ -4220,7 +4229,7 @@ async fn opt_in_upstream_discovery_serves_search_and_organization_packages() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    assert_eq!(body_json(response.into_body()).await["@acme/remote"], json!("write"));
+    assert_eq!(body_json(response.into_body()).await["@acme/remote"], json!("read"));
     search.assert_async().await;
     org.assert_async().await;
 }
@@ -4228,40 +4237,48 @@ async fn opt_in_upstream_discovery_serves_search_and_organization_packages() {
 #[tokio::test]
 async fn search_paginates_across_hosted_and_upstream_sources() {
     let mut upstream = mockito::Server::new_async().await;
-    let first = upstream
+    let shadowed = upstream
         .mock("GET", "/-/v1/search")
         .match_query(mockito::Matcher::AllOf(vec![
             mockito::Matcher::UrlEncoded("text".into(), "ajv".into()),
             mockito::Matcher::UrlEncoded("from".into(), "0".into()),
-            mockito::Matcher::UrlEncoded("size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("size".into(), "250".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "objects": [{ "package": { "name": "ajv-remote-a" } }],
-                "total": 2,
+                "objects": [
+                    { "package": { "name": "ajv" } },
+                    { "package": { "name": "ajv-keywords" } },
+                ],
+                "total": 4,
             })
             .to_string(),
         )
+        .expect(2)
         .create_async()
         .await;
-    let second = upstream
+    let visible = upstream
         .mock("GET", "/-/v1/search")
         .match_query(mockito::Matcher::AllOf(vec![
             mockito::Matcher::UrlEncoded("text".into(), "ajv".into()),
-            mockito::Matcher::UrlEncoded("from".into(), "1".into()),
-            mockito::Matcher::UrlEncoded("size".into(), "1".into()),
+            mockito::Matcher::UrlEncoded("from".into(), "2".into()),
+            mockito::Matcher::UrlEncoded("size".into(), "250".into()),
         ]))
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(
             json!({
-                "objects": [{ "package": { "name": "ajv-remote-b" } }],
-                "total": 2,
+                "objects": [
+                    { "package": { "name": "ajv-remote-a" } },
+                    { "package": { "name": "ajv-remote-b" } },
+                ],
+                "total": 4,
             })
             .to_string(),
         )
+        .expect(2)
         .create_async()
         .await;
     let tmp = TempDir::new().unwrap();
@@ -4289,8 +4306,8 @@ async fn search_paginates_across_hosted_and_upstream_sources() {
     let second_page = body_json(second_page.into_body()).await;
     assert_eq!(second_page["total"], json!(3));
     assert_eq!(second_page["objects"][0]["package"]["name"], json!("ajv-remote-b"));
-    first.assert_async().await;
-    second.assert_async().await;
+    shadowed.assert_async().await;
+    visible.assert_async().await;
 }
 
 /// Every registry operation routes through the registry graph when addressed as

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4310,6 +4310,124 @@ async fn search_paginates_across_hosted_and_upstream_sources() {
     visible.assert_async().await;
 }
 
+#[tokio::test]
+async fn upstream_search_exhausts_results_to_return_an_exact_total() {
+    let mut upstream = mockito::Server::new_async().await;
+    let first = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query("text=remote&from=0&size=250")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [
+                    { "package": { "name": "remote-a" } },
+                    { "package": { "name": "remote-b" } },
+                ],
+                "total": 3,
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let last = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query("text=remote&from=2&size=250")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [{ "package": { "name": "remote-c" } }],
+                "total": 3,
+            })
+            .to_string(),
+        )
+        .expect(1)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let app = router(config);
+
+    let response = app
+        .oneshot(Request::get("/-/v1/search?text=remote&size=1").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response = body_json(response.into_body()).await;
+    assert_eq!(response["total"], json!(3));
+    assert_eq!(response["objects"][0]["package"]["name"], json!("remote-a"));
+    first.assert_async().await;
+    last.assert_async().await;
+}
+
+#[tokio::test]
+async fn upstream_search_rejects_unbounded_offsets_and_result_sets() {
+    let mut upstream = mockito::Server::new_async().await;
+    let oversized = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query("text=remote&from=0&size=250")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(json!({ "objects": [], "total": 2_001 }).to_string())
+        .expect(1)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let app = router(config);
+
+    let offset = app
+        .clone()
+        .oneshot(Request::get("/-/v1/search?text=remote&from=2001").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(offset.status(), StatusCode::BAD_REQUEST);
+
+    let result_set = app
+        .oneshot(Request::get("/-/v1/search?text=remote").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(result_set.status(), StatusCode::BAD_REQUEST);
+    oversized.assert_async().await;
+}
+
+#[tokio::test]
+async fn upstream_search_rejects_more_than_eight_short_pages() {
+    let mut upstream = mockito::Server::new_async().await;
+    let short_page = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query(mockito::Matcher::Any)
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(
+            json!({
+                "objects": [{ "package": { "name": "repeated" } }],
+                "total": 9,
+            })
+            .to_string(),
+        )
+        .expect(8)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let app = router(config);
+
+    let response = app
+        .oneshot(Request::get("/-/v1/search?text=remote").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    short_page.assert_async().await;
+}
+
 /// Every registry operation routes through the registry graph when addressed as
 /// `/~<name>/...` (RFC "registries", implementation point 7): dist-tag
 /// read/add/remove, whoami, search, the version manifest, and the whole

--- a/pnpr/crates/policy/src/lib.rs
+++ b/pnpr/crates/policy/src/lib.rs
@@ -341,6 +341,17 @@ impl PackageRules {
                 .iter()
                 .any(|rule| rule.access.as_ref().is_some_and(|access| access.allows(identity)))
     }
+
+    /// Whether every package-specific access refinement and the registry
+    /// default admit `identity`.
+    #[must_use]
+    pub fn all_access_admit(&self, identity: &Identity) -> bool {
+        self.default_access.allows(identity)
+            && self
+                .rules
+                .iter()
+                .all(|rule| rule.access.as_ref().is_none_or(|access| access.allows(identity)))
+    }
 }
 
 #[cfg(test)]

--- a/pnpr/crates/policy/src/tests.rs
+++ b/pnpr/crates/policy/src/tests.rs
@@ -212,6 +212,21 @@ fn unclaimed_name_still_answers_with_defaults() {
 }
 
 #[test]
+fn all_access_admit_requires_the_default_and_every_refinement() {
+    let public = PackageRules::default();
+    assert!(public.all_access_admit(&Identity::Anonymous));
+
+    let private_default = PackageRules::new(Vec::new(), Some(list("$authenticated")));
+    assert!(!private_default.all_access_admit(&Identity::Anonymous));
+    assert!(private_default.all_access_admit(&user("alice")));
+
+    let private_refinement =
+        PackageRules::new(vec![rule("@private/*", Some("$authenticated"))], None);
+    assert!(!private_refinement.all_access_admit(&Identity::Anonymous));
+    assert!(private_refinement.all_access_admit(&user("alice")));
+}
+
+#[test]
 fn falls_back_to_safe_defaults_when_no_rules_match() {
     let policies = PackageRules::default();
     let effective = policies.for_package("anything");

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -7,11 +7,6 @@
 //! query for a guaranteed-not-to-exist string returns "No packages
 //! found", which an upstream proxy can't guarantee because npm's
 //! search returns dozens of fuzzy matches for almost anything.
-//!
-//! Package-name searches count matching storage names without loading every
-//! packument, then load metadata only for the requested page. Maintainer
-//! searches inspect packuments because pnpr does not maintain a separate
-//! ownership index.
 
 use pnpr_error::Result;
 use pnpr_package_name::PackageName;
@@ -113,9 +108,6 @@ pub fn parse_from(query_string: &str) -> usize {
     0
 }
 
-/// Return the sorted package names that match one hosted search source. A
-/// package-name query needs only the storage listing. A maintainer query reads
-/// candidate packuments because that metadata is not indexed separately.
 pub async fn local_search_names(
     storage: &Storage,
     query: &SearchText,
@@ -148,9 +140,6 @@ pub async fn local_search_names(
     Ok(matches)
 }
 
-/// Build the npm search object for one already-selected hosted package. A
-/// package can disappear or become malformed between listing and reading; the
-/// minimal object preserves stable pagination without inventing metadata.
 pub async fn local_search_entry(storage: &Storage, name: &str) -> Value {
     let entry = async {
         let parsed = PackageName::parse(name).ok()?;

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -10,15 +10,43 @@
 //!
 //! Implementation is intentionally simple: a one-shot scan of
 //! `<storage>/<pkg>/package.json` files at request time, filtered
-//! by a case-insensitive substring match on `name`. Sufficient for
-//! the `@pnpm/registry-mock` fixture (a few dozen packages) and the
-//! test queries that exercise it.
+//! by a case-insensitive package-name or maintainer match. The caller
+//! receives every visible match and applies pagination after combining
+//! hosted registries, which keeps `total` accurate for the local view.
 
 use pnpr_error::Result;
 use pnpr_package_name::PackageName;
 use pnpr_storage::Storage;
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SearchText {
+    Package(String),
+    Maintainer(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchParams {
+    pub text: SearchText,
+    pub from: usize,
+    pub size: usize,
+}
+
+#[must_use]
+pub fn parse_params(query_string: &str, default_size: usize) -> Option<SearchParams> {
+    let query = parse_query(query_string)?;
+    let text =
+        query.strip_prefix("maintainer:").filter(|maintainer| !maintainer.is_empty()).map_or_else(
+            || SearchText::Package(query.clone()),
+            |maintainer| SearchText::Maintainer(maintainer.to_string()),
+        );
+    Some(SearchParams {
+        text,
+        from: parse_from(query_string),
+        size: parse_size(query_string, default_size),
+    })
+}
 
 /// Parse the `text` query parameter out of a `/-/v1/search?...`
 /// query string. npm clients always send `text=...`; we accept
@@ -72,34 +100,50 @@ pub fn parse_size(query_string: &str, default_size: usize) -> usize {
     default_size
 }
 
-/// Scan one hosted store for packuments whose name contains `query`
-/// (case-insensitive) and passes `keep` — the server's routing and access
-/// filter, applied before any packument is read so a filtered name costs
-/// no I/O. Returns at most `limit` entries in npm search v1 `objects`
-/// shape (`{ package: {...}, score: {...}, searchScore }`); the server
-/// aggregates entries across the namespaces a registry serves and builds the
-/// response body. Errors reading individual packuments are tolerated — a
-/// malformed packument just doesn't match anything. Works against both
-/// the local-directory and the S3-backed hosted store.
+/// `from=` URL param. Invalid values start at the first result.
+#[must_use]
+pub fn parse_from(query_string: &str) -> usize {
+    for pair in query_string.split('&') {
+        if let Some((key, value)) = pair.split_once('=')
+            && key == "from"
+            && let Ok(parsed) = value.parse::<usize>()
+        {
+            return parsed;
+        }
+    }
+    0
+}
+
+/// Scan one hosted store for packuments that match `query` and pass `keep`.
+/// The server applies pagination only after it combines every eligible source,
+/// so this returns the complete visible result set. Errors reading individual
+/// packuments are tolerated. A malformed packument simply does not match.
 pub async fn run_local_search(
     storage: &Storage,
-    query: &str,
-    limit: usize,
+    query: &SearchText,
     keep: impl Fn(&str) -> bool,
 ) -> Result<Vec<Value>> {
-    let needle = query.to_lowercase();
+    let needle = match query {
+        SearchText::Package(query) | SearchText::Maintainer(query) => query.to_lowercase(),
+    };
     let mut matches: Vec<Value> = Vec::new();
+    let mut names = storage.hosted_package_names().await?;
+    names.sort();
 
-    for name in storage.hosted_package_names().await? {
-        if matches.len() >= limit {
-            break;
-        }
-        if !name.to_lowercase().contains(&needle) || !keep(&name) {
+    for name in names {
+        if !keep(&name)
+            || matches!(query, SearchText::Package(_)) && !name.to_lowercase().contains(&needle)
+        {
             continue;
         }
         let Ok(parsed) = PackageName::parse(&name) else { continue };
         let Ok(Some(bytes)) = storage.read_hosted_packument(&parsed).await else { continue };
         let Ok(packument) = serde_json::from_slice::<Value>(&bytes) else { continue };
+        if matches!(query, SearchText::Maintainer(_))
+            && !packument_has_maintainer(&packument, &needle)
+        {
+            continue;
+        }
         if let Some(entry) = build_search_entry(&name, &packument) {
             matches.push(entry);
         }
@@ -134,11 +178,17 @@ fn build_search_package(name: &str, packument: &Value) -> Option<Value> {
     pkg.insert("name".to_string(), Value::String(name.to_string()));
     pkg.insert("version".to_string(), Value::String(version_id.to_string()));
     if let Some(version_obj) = version_obj {
-        for field in ["description", "keywords", "author", "maintainers", "homepage"] {
+        for field in ["description", "keywords", "author", "homepage"] {
             if let Some(value) = version_obj.get(field) {
                 pkg.insert(field.to_string(), value.clone());
             }
         }
+    }
+    if let Some(maintainers) = obj
+        .get("maintainers")
+        .or_else(|| version_obj.and_then(|version| version.get("maintainers")))
+    {
+        pkg.insert("maintainers".to_string(), maintainers.clone());
     }
     // `time.<version>` if present, else `time.modified` as a fallback.
     if let Some(time) = obj.get("time").and_then(Value::as_object) {
@@ -158,6 +208,34 @@ fn build_search_package(name: &str, packument: &Value) -> Option<Value> {
     links.insert("npm".to_string(), Value::String(format!("https://npmx.dev/package/{name}")));
     pkg.insert("links".to_string(), serde_json::to_value(links).ok()?);
     Some(Value::Object(pkg))
+}
+
+fn packument_has_maintainer(packument: &Value, needle: &str) -> bool {
+    if maintainer_value_matches(packument.get("maintainers"), needle) {
+        return true;
+    }
+    let versions = packument.get("versions").and_then(Value::as_object);
+    versions.is_some_and(|versions| {
+        versions.values().any(|version| {
+            maintainer_value_matches(version.get("maintainers"), needle)
+                || maintainer_value_matches(version.get("_npmUser"), needle)
+                || maintainer_value_matches(version.get("publisher"), needle)
+        })
+    })
+}
+
+fn maintainer_value_matches(value: Option<&Value>, needle: &str) -> bool {
+    match value {
+        Some(Value::String(value)) => value.to_lowercase().contains(needle),
+        Some(Value::Array(values)) => {
+            values.iter().any(|value| maintainer_value_matches(Some(value), needle))
+        }
+        Some(Value::Object(value)) => ["username", "name", "email"]
+            .iter()
+            .filter_map(|field| value.get(*field).and_then(Value::as_str))
+            .any(|value| value.to_lowercase().contains(needle)),
+        _ => false,
+    }
 }
 
 /// Decode a percent-encoded query value. ASCII-oriented: multi-byte UTF-8

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -8,11 +8,10 @@
 //! found", which an upstream proxy can't guarantee because npm's
 //! search returns dozens of fuzzy matches for almost anything.
 //!
-//! Implementation is intentionally simple: a one-shot scan of
-//! `<storage>/<pkg>/package.json` files at request time, filtered
-//! by a case-insensitive package-name or maintainer match. The caller
-//! receives every visible match and applies pagination after combining
-//! hosted registries, which keeps `total` accurate for the local view.
+//! Package-name searches count matching storage names without loading every
+//! packument, then load metadata only for the requested page. Maintainer
+//! searches inspect packuments because pnpr does not maintain a separate
+//! ownership index.
 
 use pnpr_error::Result;
 use pnpr_package_name::PackageName;
@@ -114,19 +113,18 @@ pub fn parse_from(query_string: &str) -> usize {
     0
 }
 
-/// Scan one hosted store for packuments that match `query` and pass `keep`.
-/// The server applies pagination only after it combines every eligible source,
-/// so this returns the complete visible result set. Errors reading individual
-/// packuments are tolerated. A malformed packument simply does not match.
-pub async fn run_local_search(
+/// Return the sorted package names that match one hosted search source. A
+/// package-name query needs only the storage listing. A maintainer query reads
+/// candidate packuments because that metadata is not indexed separately.
+pub async fn local_search_names(
     storage: &Storage,
     query: &SearchText,
     keep: impl Fn(&str) -> bool,
-) -> Result<Vec<Value>> {
+) -> Result<Vec<String>> {
     let needle = match query {
         SearchText::Package(query) | SearchText::Maintainer(query) => query.to_lowercase(),
     };
-    let mut matches: Vec<Value> = Vec::new();
+    let mut matches = Vec::new();
     let mut names = storage.hosted_package_names().await?;
     names.sort();
 
@@ -136,20 +134,40 @@ pub async fn run_local_search(
         {
             continue;
         }
-        let Ok(parsed) = PackageName::parse(&name) else { continue };
-        let Ok(Some(bytes)) = storage.read_hosted_packument(&parsed).await else { continue };
-        let Ok(packument) = serde_json::from_slice::<Value>(&bytes) else { continue };
-        if matches!(query, SearchText::Maintainer(_))
-            && !packument_has_maintainer(&packument, &needle)
-        {
-            continue;
+        if matches!(query, SearchText::Maintainer(_)) {
+            let Ok(parsed) = PackageName::parse(&name) else { continue };
+            let Ok(Some(bytes)) = storage.read_hosted_packument(&parsed).await else { continue };
+            let Ok(packument) = serde_json::from_slice::<Value>(&bytes) else { continue };
+            if !packument_has_maintainer(&packument, &needle) {
+                continue;
+            }
         }
-        if let Some(entry) = build_search_entry(&name, &packument) {
-            matches.push(entry);
-        }
+        matches.push(name);
     }
 
     Ok(matches)
+}
+
+/// Build the npm search object for one already-selected hosted package. A
+/// package can disappear or become malformed between listing and reading; the
+/// minimal object preserves stable pagination without inventing metadata.
+pub async fn local_search_entry(storage: &Storage, name: &str) -> Value {
+    let entry = async {
+        let parsed = PackageName::parse(name).ok()?;
+        let bytes = storage.read_hosted_packument(&parsed).await.ok()??;
+        let packument = serde_json::from_slice::<Value>(&bytes).ok()?;
+        build_search_entry(name, &packument)
+    }
+    .await;
+    entry.unwrap_or_else(|| build_minimal_search_entry(name))
+}
+
+fn build_minimal_search_entry(name: &str) -> Value {
+    json!({
+        "package": { "name": name },
+        "score": { "final": 1.0 },
+        "searchScore": 1.0,
+    })
 }
 
 /// Construct one entry for the `objects` array.

--- a/pnpr/crates/search/src/tests.rs
+++ b/pnpr/crates/search/src/tests.rs
@@ -1,4 +1,4 @@
-use super::{parse_query, parse_size};
+use super::{SearchParams, SearchText, parse_from, parse_params, parse_query, parse_size};
 
 #[test]
 fn parses_text_query() {
@@ -51,4 +51,27 @@ fn size_clamps() {
     assert_eq!(parse_size("size=9999", 20), 250);
     assert_eq!(parse_size("size=garbage", 20), 20);
     assert_eq!(parse_size("", 20), 20);
+}
+
+#[test]
+fn parses_pagination() {
+    assert_eq!(parse_from("text=foo&from=25&size=10"), 25);
+    assert_eq!(parse_from("text=foo&from=invalid"), 0);
+    assert_eq!(parse_from("text=foo"), 0);
+}
+
+#[test]
+fn parses_package_search_params() {
+    assert_eq!(
+        parse_params("text=foo&from=20&size=10", 20),
+        Some(SearchParams { text: SearchText::Package("foo".to_string()), from: 20, size: 10 }),
+    );
+}
+
+#[test]
+fn parses_maintainer_search_params() {
+    assert_eq!(
+        parse_params("text=maintainer%3Aalice&size=1", 20),
+        Some(SearchParams { text: SearchText::Maintainer("alice".to_string()), from: 0, size: 1 }),
+    );
 }

--- a/pnpr/crates/upstream/src/lib.rs
+++ b/pnpr/crates/upstream/src/lib.rs
@@ -3,7 +3,9 @@ use pnpm_lockfile::{
     MAX_TARBALL_REVISION, TarballRevision, integrity_addressed_registry_tarball_url,
     is_integrity_addressed_registry_tarball_url,
 };
-use pnpm_network::{ThrottledClient, read_limited_body};
+use pnpm_network::{
+    ThrottledClient, UNPRIORITIZED, is_url_secure_for_credentials, read_limited_body,
+};
 use pnpr_config::{RedactedHeaders, UpstreamConfig};
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::PackageName;
@@ -357,8 +359,9 @@ impl Upstream {
     ) -> Result<FetchOutcome<Payload>> {
         self.ensure_available()?;
         let url = format!("{}{path_and_query}", self.base.trim_end_matches('/'));
-        let client = self.client.acquire_for_url(&url).await;
-        let request = client.get(&url).timeout(self.timeout).headers(self.headers.clone());
+        let client =
+            self.client.acquire_for_url_without_redirects_with_priority(&url, UNPRIORITIZED).await;
+        let request = client.get(&url).timeout(self.timeout).headers(self.discovery_headers(&url));
         let response = self.run(request, &url).await?;
         if response.status() == StatusCode::NOT_FOUND {
             self.breaker.record_success();
@@ -367,6 +370,7 @@ impl Upstream {
         let response = self.checked(response, &url).await?;
         let body =
             read_limited_body(response, UPSTREAM_DISCOVERY_BODY_LIMIT).await.map_err(|err| {
+                self.breaker.record_failure();
                 RegistryError::UpstreamResponse { url: url.clone(), reason: err.to_string() }
             })?;
         if body.truncated {
@@ -384,6 +388,13 @@ impl Upstream {
         })?;
         self.breaker.record_success();
         Ok(FetchOutcome::Ok(parsed))
+    }
+
+    fn discovery_headers(&self, url: &str) -> HeaderMap {
+        if is_url_secure_for_credentials(url) {
+            return self.headers.clone();
+        }
+        HeaderMap::new()
     }
 
     /// Fail fast with [`RegistryError::UpstreamUnavailable`] when the

--- a/pnpr/crates/upstream/src/lib.rs
+++ b/pnpr/crates/upstream/src/lib.rs
@@ -11,8 +11,8 @@ use reqwest::{
     StatusCode,
     header::{self, HeaderMap, HeaderValue},
 };
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_json::{Map, Value};
 use ssri::Integrity;
 use std::{
     fmt,
@@ -21,6 +21,13 @@ use std::{
 };
 
 const UPSTREAM_ERROR_BODY_LIMIT: usize = 64 * 1024;
+const UPSTREAM_DISCOVERY_BODY_LIMIT: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Deserialize)]
+pub struct SearchResponse {
+    pub objects: Vec<Value>,
+    pub total: usize,
+}
 
 /// Wraps a shared [`ThrottledClient`] (so the registry inherits pnpm's
 /// tuned reqwest defaults: `User-Agent: pnpm`, HTTP/1.1, capped native DNS,
@@ -327,6 +334,56 @@ impl Upstream {
         let response = self.checked(response, &url).await?;
         self.breaker.record_success();
         Ok(FetchOutcome::Ok(response))
+    }
+
+    /// Query an upstream npm search endpoint with the caller's already-encoded
+    /// query string. The upstream client contributes only configured headers,
+    /// never headers supplied by the browser caller.
+    pub async fn fetch_search(&self, query_string: &str) -> Result<FetchOutcome<SearchResponse>> {
+        self.fetch_discovery_json(&format!("/-/v1/search?{query_string}")).await
+    }
+
+    /// Fetch the npm organization package map for one validated scope.
+    pub async fn fetch_org_packages(
+        &self,
+        scope: &str,
+    ) -> Result<FetchOutcome<Map<String, Value>>> {
+        self.fetch_discovery_json(&format!("/-/org/{scope}/package")).await
+    }
+
+    async fn fetch_discovery_json<Payload: DeserializeOwned>(
+        &self,
+        path_and_query: &str,
+    ) -> Result<FetchOutcome<Payload>> {
+        self.ensure_available()?;
+        let url = format!("{}{path_and_query}", self.base.trim_end_matches('/'));
+        let client = self.client.acquire_for_url(&url).await;
+        let request = client.get(&url).timeout(self.timeout).headers(self.headers.clone());
+        let response = self.run(request, &url).await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            self.breaker.record_success();
+            return Ok(FetchOutcome::NotFound);
+        }
+        let response = self.checked(response, &url).await?;
+        let body =
+            read_limited_body(response, UPSTREAM_DISCOVERY_BODY_LIMIT).await.map_err(|err| {
+                RegistryError::UpstreamResponse { url: url.clone(), reason: err.to_string() }
+            })?;
+        if body.truncated {
+            self.breaker.record_failure();
+            return Err(RegistryError::UpstreamResponse {
+                url,
+                reason: format!(
+                    "response body exceeds the {UPSTREAM_DISCOVERY_BODY_LIMIT}-byte limit",
+                ),
+            });
+        }
+        let parsed = serde_json::from_slice(&body.bytes).map_err(|err| {
+            self.breaker.record_failure();
+            RegistryError::UpstreamResponse { url, reason: err.to_string() }
+        })?;
+        self.breaker.record_success();
+        Ok(FetchOutcome::Ok(parsed))
     }
 
     /// Fail fast with [`RegistryError::UpstreamUnavailable`] when the

--- a/pnpr/crates/upstream/src/tests.rs
+++ b/pnpr/crates/upstream/src/tests.rs
@@ -663,6 +663,7 @@ fn breaking_upstream(url: String, max_fails: u32) -> Upstream {
             max_fails,
             fail_timeout: Duration::from_mins(5),
             cache: true,
+            search: false,
             access: None,
             rules: pnpr_policy::PackageRules::default(),
         },

--- a/pnpr/crates/upstream/src/tests.rs
+++ b/pnpr/crates/upstream/src/tests.rs
@@ -10,6 +10,10 @@ use pnpr_package_name::PackageName;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::json;
 use std::time::Duration;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
 
 /// Build an [`Upstream`] pointing at `url` with `headers`, all per-upstream
 /// tuning knobs at their verdaccio defaults.
@@ -102,6 +106,77 @@ async fn fetch_revision_tarball_rejects_redirects_and_forwards_headers() {
     ));
     redirect.assert_async().await;
     redirected.assert_async().await;
+}
+
+#[tokio::test]
+async fn discovery_rejects_redirects_before_configured_headers_reach_the_target() {
+    let mut target = mockito::Server::new_async().await;
+    let redirected = target
+        .mock("GET", "/-/v1/search")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .expect(0)
+        .create_async()
+        .await;
+    let mut source = mockito::Server::new_async().await;
+    let redirect = source
+        .mock("GET", "/-/v1/search")
+        .match_query("text=foo")
+        .match_header("authorization", "Bearer secret-token")
+        .with_status(302)
+        .with_header("location", &format!("{}/-/v1/search", target.url()))
+        .expect(1)
+        .create_async()
+        .await;
+
+    let upstream = upstream(source.url(), auth_and_custom_headers());
+    let result = upstream.fetch_search("text=foo").await;
+
+    assert!(
+        matches!(result, Err(RegistryError::UpstreamStatus { status: 302, .. })),
+        "expected the first redirect response, got {result:?}",
+    );
+    redirect.assert_async().await;
+    redirected.assert_async().await;
+}
+
+#[test]
+fn discovery_omits_configured_headers_on_insecure_remote_urls() {
+    let upstream = upstream("http://registry.example".to_string(), auth_and_custom_headers());
+
+    assert!(upstream.discovery_headers("http://registry.example/-/v1/search").is_empty());
+    assert!(!upstream.discovery_headers("https://registry.example/-/v1/search").is_empty());
+    assert!(!upstream.discovery_headers("http://127.0.0.1/-/v1/search").is_empty());
+}
+
+#[tokio::test]
+async fn discovery_body_read_failure_opens_the_circuit() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let server = tokio::spawn(async move {
+        let (mut socket, _) = listener.accept().await.unwrap();
+        let mut request = [0u8; 4096];
+        let _ = socket.read(&mut request).await;
+        socket
+            .write_all(
+                b"HTTP/1.1 200 OK\r\n\
+                  Content-Length: 1024\r\n\
+                  Content-Type: application/json\r\n\
+                  Connection: close\r\n\
+                  \r\n\
+                  {}",
+            )
+            .await
+            .unwrap();
+    });
+    let upstream = breaking_upstream(url, 1);
+
+    let first = upstream.fetch_search("text=foo").await;
+    server.await.unwrap();
+    assert!(matches!(first, Err(RegistryError::UpstreamResponse { .. })));
+    assert!(matches!(
+        upstream.fetch_search("text=foo").await,
+        Err(RegistryError::UpstreamUnavailable { .. }),
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#14543.

- Add a global `cors.allowedOrigins` exact-origin allowlist. CORS remains off
  when the list is absent or empty, and allowed origins receive read preflight
  support across success and error responses.
- Complete hosted discovery with `from` and `size` pagination, accurate
  post-authorization totals, `maintainer:<term>` queries, authenticated
  publisher recording, and pathless plus registry-addressed organization
  package listings.
- Add an opt-in `search: true` setting to upstream registries. Eligible hosted
  and upstream search results are combined in registry-source order and
  deduplicated by package name. Upstream organization listings use the same
  opt-in.
- Apply registry routing and read policy before returning discovery entries.
  Upstream discovery uses only configured upstream headers and never forwards
  the browser caller's authorization header. An upstream with package-specific
  access restrictions is omitted from search when its reported total could
  reveal entries the caller cannot read.

Search never exposes an upstream-reported total after routing filters. pnpr
exhausts each accepted upstream result set to compute an exact visible,
deduplicated total. One request may scan at most 2,000 upstream results across
eight pages; broader searches and offsets are rejected. Discovery requests do
not follow redirects, withhold configured headers from insecure remote HTTP,
and count body-read failures against the circuit breaker.

Validated with `just ready`, the repository pre-push checks, and a live npmX
development server pointed at pnpr. npmX rendered a proxied package, a locally
hosted package, combined search results, and an organization page; browser
preflight returned the configured origin and read headers.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Add an exact-origin CORS allowlist for separately hosted browser registry UIs.

Complete hosted search pagination and maintainer discovery, record authenticated publishers,
and serve npm-compatible organization package maps. Apply registry routing and access rules
before counting or returning local packages.

Add opt-in upstream search and organization discovery. Use only configured upstream credentials.
Treat upstream pages as a visible, deduplicated sequence so filtered entries neither underfill pages
nor leak through provider-reported totals. Derive publisher and organization permission metadata
from pnpr authorization rather than client or upstream service-account values.

Closes pnpm/pnpm#14543
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] This is a pnpr-only feature, so no TypeScript CLI or Rust `pnpm/` port is
  needed.
- [x] Added a changeset (`pnpm changeset`) for `@pnpm/pnpr`.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791121403&installation_model_id=426870&pr_number=14544&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14544&signature=9ee73f1461142948667c3b726c4bbe7e935bd737713946bafa8fa454d850249e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added browser registry UI support with configurable CORS origins.
  * Added paginated, deduplicated package search with maintainer filtering and exact result totals.
  * Added optional upstream search and organization package discovery.
  * Added organization package listings with normalized access information.
  * Published package versions now record authenticated publisher information.
* **Bug Fixes**
  * Improved upstream discovery security by blocking redirects and protecting credentials.
  * Improved invalid upstream response handling and reporting.
  * Added safeguards for overly broad upstream searches.
* **Documentation**
  * Added configuration examples and guidance for browser UIs, CORS, and discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->