### PR TITLE
fix(cli): register pn alias in completions

### DIFF
--- a/.changeset/pn-completion-alias.md
+++ b/.changeset/pn-completion-alias.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm completion` registers the `pn` short alias in bash, fish, pwsh, and zsh scripts. Tab-completing `pn` now lists the same commands and flags as `pnpm` [#11955](https://github.com/pnpm/pnpm/issues/11955).

--- a/.changeset/pn-completion-alias.md
+++ b/.changeset/pn-completion-alias.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm completion` registers the `pn` short alias in bash, fish, pwsh, and zsh scripts. Tab-completing `pn` now lists the same commands and flags as `pnpm` [#11955](https://github.com/pnpm/pnpm/issues/11955).
+Tab-completing `pn` now lists the same commands and flags as `pnpm`. The scripts printed by `pnpm completion` register the `pn` alias for bash, fish, pwsh, and zsh [#11955](https://github.com/pnpm/pnpm/issues/11955).

--- a/pnpm/crates/cli/src/cli_args/completion.rs
+++ b/pnpm/crates/cli/src/cli_args/completion.rs
@@ -188,7 +188,7 @@ fn words_without_binary(words: &[String]) -> Vec<String> {
     if Path::new(first)
         .file_stem()
         .and_then(|name| name.to_str())
-        .is_some_and(|name| name == "pnpm" || name == "pacquet")
+        .is_some_and(|name| matches!(name, "pnpm" | "pn" | "pacquet"))
     {
         rest.to_vec()
     } else {
@@ -333,7 +333,7 @@ _pnpm_completion() {
   local IFS=$'\n'
   COMPREPLY=($(COMP_LINE="$COMP_LINE" COMP_POINT="$COMP_POINT" SHELL=bash pnpm completion-server -- "${COMP_WORDS[@]}"))
 }
-complete -F _pnpm_completion pnpm
+complete -F _pnpm_completion pnpm pn
 ###-end-pnpm-completion-###
 "#;
 
@@ -352,11 +352,12 @@ function __pnpm_completion
   pnpm completion-server -- $tokens
 end
 complete -c pnpm -f -a "(__pnpm_completion)"
+complete -c pn -f -a "(__pnpm_completion)"
 ###-end-pnpm-completion-###
 "#;
 
 const PWSH_COMPLETION: &str = r#"###-begin-pnpm-completion-###
-Register-ArgumentCompleter -Native -CommandName pnpm -ScriptBlock {
+Register-ArgumentCompleter -Native -CommandName pnpm,pn -ScriptBlock {
   param($wordToComplete, $commandAst, $cursorPosition)
   $env:SHELL = "pwsh"
   $env:COMP_LINE = $commandAst.ToString()
@@ -370,14 +371,14 @@ Register-ArgumentCompleter -Native -CommandName pnpm -ScriptBlock {
 ###-end-pnpm-completion-###
 "#;
 
-const ZSH_COMPLETION: &str = r#"#compdef pnpm
+const ZSH_COMPLETION: &str = r#"#compdef pnpm pn
 ###-begin-pnpm-completion-###
 _pnpm_completion() {
   local reply
   reply=("${(@f)$(COMP_CWORD=$((CURRENT-1)) COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" SHELL=zsh pnpm completion-server -- "${words[@]}")}")
   _describe 'values' reply
 }
-compdef _pnpm_completion pnpm
+compdef _pnpm_completion pnpm pn
 ###-end-pnpm-completion-###
 "#;
 

--- a/pnpm/crates/cli/src/cli_args/completion/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/completion/tests.rs
@@ -73,6 +73,46 @@ fn generated_scripts_call_completion_server() {
 }
 
 #[test]
+fn generated_scripts_register_pn_alias() {
+    let cases = [
+        (CompletionShell::Bash, &["complete -F _pnpm_completion pnpm pn"][..]),
+        (
+            CompletionShell::Fish,
+            &[
+                r#"complete -c pnpm -f -a "(__pnpm_completion)""#,
+                r#"complete -c pn -f -a "(__pnpm_completion)""#,
+            ],
+        ),
+        (
+            CompletionShell::Pwsh,
+            &["Register-ArgumentCompleter -Native -CommandName pnpm,pn -ScriptBlock"],
+        ),
+        (CompletionShell::Zsh, &["#compdef pnpm pn", "compdef _pnpm_completion pnpm pn"]),
+    ];
+
+    for (shell, snippets) in cases {
+        let mut output = Vec::new();
+        super::generate_completion(shell, &mut output).expect("generate completion");
+        let script = String::from_utf8(output).expect("script is utf8");
+        for snippet in snippets {
+            assert!(
+                script.contains(snippet),
+                "{shell:?} script should contain {snippet:?}: {script}",
+            );
+        }
+    }
+}
+
+#[test]
+fn completion_server_treats_pn_as_the_pnpm_binary() {
+    let pnpm = super::complete_words(&strings(&["pnpm", ""]));
+    let pn = super::complete_words(&strings(&["pn", ""]));
+
+    assert_eq!(pnpm, pn);
+    assert!(pn.iter().any(|completion| completion == "install"), "{pn:?}");
+}
+
+#[test]
 fn completion_can_run_before_async_runtime_setup() {
     let args = CliArgs::parse_from(["pnpm", "completion-server", "--", "pnpm", "completion", ""]);
 

--- a/pnpm/crates/cli/src/cli_args/completion/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/completion/tests.rs
@@ -104,6 +104,19 @@ fn generated_scripts_register_pn_alias() {
 }
 
 #[test]
+fn pn_is_stripped_like_the_other_pnpm_binary_names() {
+    for binary in ["pnpm", "pn", "pacquet", "/usr/local/bin/pn", "pn.exe"] {
+        assert_eq!(
+            super::words_without_binary(&strings(&[binary, "add", ""])),
+            strings(&["add", ""]),
+            "{binary} should be dropped",
+        );
+    }
+
+    assert_eq!(super::words_without_binary(&strings(&["npm", ""])), strings(&["npm", ""]));
+}
+
+#[test]
 fn completion_server_treats_pn_as_the_pnpm_binary() {
     let pnpm = super::complete_words(&strings(&["pnpm", ""]));
     let pn = super::complete_words(&strings(&["pn", ""]));

--- a/pnpm/crates/cli/tests/suite/completion.rs
+++ b/pnpm/crates/cli/tests/suite/completion.rs
@@ -22,7 +22,7 @@ fn completion_scripts_are_lightweight_shims_for_pnpm_supported_shells() {
         ("bash", "_pnpm_completion"),
         ("fish", "complete -c pnpm"),
         ("pwsh", "Register-ArgumentCompleter -Native -CommandName pnpm"),
-        ("zsh", "#compdef pnpm"),
+        ("zsh", "#compdef pnpm pn"),
     ];
 
     for (shell, marker) in cases {
@@ -72,6 +72,19 @@ fn completion_scripts_preserve_current_token_for_fish_and_pwsh() {
 fn completion_server_lists_top_level_commands() {
     let output = pacquet()
         .args(["completion-server", "--", "pnpm", ""])
+        .output()
+        .expect("run pnpm completion-server");
+    let reply = stdout(output);
+
+    assert!(reply.lines().any(|line| line == "install"), "{reply}");
+    assert!(reply.lines().any(|line| line == "completion"), "{reply}");
+    assert!(reply.lines().any(|line| line == "add"), "{reply}");
+}
+
+#[test]
+fn completion_server_lists_top_level_commands_for_pn_alias() {
+    let output = pacquet()
+        .args(["completion-server", "--", "pn", ""])
         .output()
         .expect("run pnpm completion-server");
     let reply = stdout(output);

--- a/pnpm/crates/cli/tests/suite/completion.rs
+++ b/pnpm/crates/cli/tests/suite/completion.rs
@@ -82,16 +82,18 @@ fn completion_server_lists_top_level_commands() {
 }
 
 #[test]
-fn completion_server_lists_top_level_commands_for_pn_alias() {
-    let output = pacquet()
-        .args(["completion-server", "--", "pn", ""])
-        .output()
-        .expect("run pnpm completion-server");
-    let reply = stdout(output);
+fn completion_server_answers_the_pn_alias_like_pnpm() {
+    let reply = |binary: &str| {
+        let output = pacquet()
+            .args(["completion-server", "--", binary, ""])
+            .output()
+            .expect("run pnpm completion-server");
+        stdout(output)
+    };
 
-    assert!(reply.lines().any(|line| line == "install"), "{reply}");
-    assert!(reply.lines().any(|line| line == "completion"), "{reply}");
-    assert!(reply.lines().any(|line| line == "add"), "{reply}");
+    let pn = reply("pn");
+    assert_eq!(pn, reply("pnpm"));
+    assert!(pn.lines().any(|line| line == "install"), "{pn}");
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/completion.rs
+++ b/pnpm/crates/cli/tests/suite/completion.rs
@@ -22,7 +22,7 @@ fn completion_scripts_are_lightweight_shims_for_pnpm_supported_shells() {
         ("bash", "_pnpm_completion"),
         ("fish", "complete -c pnpm"),
         ("pwsh", "Register-ArgumentCompleter -Native -CommandName pnpm"),
-        ("zsh", "#compdef pnpm pn"),
+        ("zsh", "#compdef pnpm"),
     ];
 
     for (shell, marker) in cases {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

adds `pn` autocompletion to the various shell completion scripts

the typescript cli already had this addressed here pnpm/pnpm#12861
this change ports to rust/pnpm 12

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
adds `pn` autocompletion to the various shell completion scripts

the typescript cli already had this addressed here pnpm/pnpm#12861
this change ports to rust/pnpm 12

the rust completion server strips the binary name before matching
subcommands, and it only recognized `pnpm` and `pacquet`. without
treating `pn` the same way, registering the alias in the scripts
still leaves `pn <tab>` empty. both sides of that are in this patch.

related to pnpm/pnpm#11955
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791132307&installation_model_id=426870&pr_number=14552&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14552&signature=8735447b30f183bae2ef4eccce721004b875fd3d2c065b5889de07aba2897c87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tab-completion support for the `pn` alias across Bash, Fish, PowerShell, and Zsh.
  * `pn` now provides the same command and flag completions as `pnpm`, including top-level commands such as `install`, `completion`, and `add`.
  * Completion results are consistent whether commands are entered using `pn` or `pnpm`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->