### PR TITLE
docs: make pnpm v12 the feature development target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,8 +26,8 @@ Explain what changed and why. Reference issues here too (Closes pnpm/pnpm#123).
 
 - [ ] I checked the referenced issue and verified that none of the PRs
   already linked to it solves it.
-- [ ] The change is implemented in both the TypeScript CLI and the Rust
-  `pnpm/` port, or the description notes what still needs porting.
+- [ ] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
+  are implemented in every affected version.
 - [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
   package. Keep it short and written for pnpm users — it becomes a release note.
 - [ ] Added or updated tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,65 +4,63 @@ This document provides context and instructions for AI agents working on the pnp
 
 The repository contains three products:
 
-- The **TypeScript pnpm CLI** — the main TypeScript workspaces outside `pnpm/` and `pnpr/`.
-- The **Rust pacquet port** — `pnpm/`. See [`pnpm/AGENTS.md`](./pnpm/AGENTS.md) for pacquet-specific rules; it adds to (and never contradicts) the conventions below.
+- The **TypeScript pnpm v11 CLI** — `pnpm11/`.
+- The **Rust pnpm v12 CLI (pacquet)** — `pnpm/`. pnpm v12 is the latest stable release. See [`pnpm/AGENTS.md`](./pnpm/AGENTS.md) for pacquet-specific rules; it adds to (and never contradicts) the conventions below.
 - The **Rust pnpr registry server** — `pnpr/`. See [`pnpr/AGENTS.md`](./pnpr/AGENTS.md) for pnpr-specific rules; it adds to (and never contradicts) the conventions below.
 
 Sections below marked "(TypeScript only)" apply to TypeScript code only; they do not apply to Rust code in `pnpm/` or `pnpr/`. Everything else applies repo-wide unless a nested `AGENTS.md` specializes it.
 
-## Keep pnpm and pacquet in sync
+## pnpm v12 and v11 development policy
 
-The two stacks are parallel implementations of the same CLI, kept behaviorally identical — the same flags, defaults, error codes, file formats, and lockfile shape. They are now at near-complete feature parity and are developed together, so **any user-visible change has to land in both at the same time.** Neither stack is downstream of the other: pacquet is a source of truth in its own right, not a port that trails the TypeScript CLI.
+pnpm v12, implemented in Rust under `pnpm/`, is the latest stable release and the target for new development. pnpm v11, implemented in TypeScript under `pnpm11/`, is maintained for bug fixes.
 
-When you change one side, do the equivalent change on the other in the same PR if you can. If you can't (different expertise, scope too large, or pacquet hasn't ported the surrounding feature yet), open the PR with just your side — call out in the description what still needs porting, and someone else will push the matching commits to the same PR before it lands.
+**Implement new features only in pnpm v12. Do not add them to pnpm v11.** A feature that intentionally exists only in v12 is not a parity gap.
 
-"User-visible" means anything that affects the CLI surface or the on-disk contract: command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file format, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, hook semantics. Pure internal refactors, perf wins, and TS-only test cleanups don't need mirroring.
+For bug fixes, first determine which versions contain the bug. If the bug is present in both v11 and v12, implement and test the fix in both stacks. Keep their observable behavior aligned for the affected functionality, including command-line flags and defaults, environment-variable handling, lockfile/manifest/state-file formats, error codes and messages, log emissions parsed by `@pnpm/cli.default-reporter`, store layout, and hook semantics. If the bug exists in only one version, fix only that version.
 
-**Any user-visible change to either stack must be replicated in the other.**
+When a shared bug fix cannot be completed in both stacks in the same PR, call out the missing implementation in the PR description so it can be added before the PR lands.
 
-The pacquet-side conventions for keeping the two stacks aligned are in [`pnpm/AGENTS.md`](./pnpm/AGENTS.md#the-cardinal-rule).
+The pacquet-side version policy is in [`pnpm/AGENTS.md`](./pnpm/AGENTS.md#version-policy).
 
 ## Repository Structure
 
 The pnpm codebase is a monorepo managed by pnpm itself. The root contains functional directories organized by domain:
 
-### Core Directories
+### TypeScript pnpm v11 Core Directories
 
--   `pnpm/`: The CLI entry point and main package.
--   `pkg-manager/`: Core package management logic (installation, linking, etc.).
--   `resolving/`: Dependency resolution logic (resolvers for npm, tarballs, git, etc.).
--   `fetching/`: Package fetching logic.
--   `store/`: Store management logic (content-addressable storage).
--   `lockfile/`: Lockfile handling, parsing, and utilities.
+-   `pnpm11/pnpm/`: The CLI entry point and main package.
+-   `pnpm11/pkg-manager/`: Core package management logic (installation, linking, etc.).
+-   `pnpm11/resolving/`: Dependency resolution logic (resolvers for npm, tarballs, git, etc.).
+-   `pnpm11/fetching/`: Package fetching logic.
+-   `pnpm11/store/`: Store management logic (content-addressable storage).
+-   `pnpm11/lockfile/`: Lockfile handling, parsing, and utilities.
 
 ### CLI & Configuration
 
--   `cli/`: CLI command implementations and infrastructure.
--   `config/`: Configuration management and parsing.
--   `hooks/`: pnpm hooks (readPackage, etc.).
--   `completion/`: Shell completion support.
+-   `pnpm11/cli/`: CLI command implementations and infrastructure.
+-   `pnpm11/config/`: Configuration management and parsing.
+-   `pnpm11/hooks/`: pnpm hooks (readPackage, etc.).
+-   `pnpm11/cli/commands/src/completion/`: Shell completion support.
 
 ### Other Functional Directories
 
--   `network/`: Network-related utilities (proxy, fetch, auth).
--   `workspace/`: Workspace-related utilities.
--   `exec/`: Execution-related commands (run, exec, dlx).
--   `env/`: Node.js environment management.
--   `cache/`: Cache-related commands and utilities.
--   `patching/`: Package patching functionality.
--   `reviewing/`: License and dependency review tools.
--   `releasing/`: Release and publishing utilities.
+-   `pnpm11/network/`: Network-related utilities (proxy, fetch, auth).
+-   `pnpm11/workspace/`: Workspace-related utilities.
+-   `pnpm11/exec/`: Execution-related commands (run, exec, dlx).
+-   `pnpm11/engine/runtime/commands/`: Node.js environment management.
+-   `pnpm11/cache/`: Cache-related commands and utilities.
+-   `pnpm11/patching/`: Package patching functionality.
+-   `pnpm11/releasing/`: Release and publishing utilities.
 
 ### Shared Utilities
 
--   `packages/`: Shared utility packages (constants, error handling, logger, types, etc.).
--   `fs/`: Filesystem utilities.
--   `crypto/`: Cryptographic utilities.
--   `text/`: Text processing utilities.
+-   `pnpm11/fs/`: Filesystem utilities.
+-   `pnpm11/crypto/`: Cryptographic utilities.
+-   `pnpm11/text/`: Text processing utilities.
 
 ### Rust Projects
 
--   `pnpm/`: The pnpm CLI ported to Rust. Self-contained sub-project with its own crates, tests, and tooling — see [`pnpm/AGENTS.md`](./pnpm/AGENTS.md).
+-   `pnpm/`: The Rust pnpm v12 CLI. Self-contained sub-project with its own crates, tests, and tooling — see [`pnpm/AGENTS.md`](./pnpm/AGENTS.md).
 -   `pnpr/`: The pnpm-compatible npm registry server. Self-contained sub-project with its own crates, tests, and tooling — see [`pnpr/AGENTS.md`](./pnpr/AGENTS.md).
 
 ## Setup & Build (TypeScript only)
@@ -80,13 +78,13 @@ To compile a specific package:
 pnpm --filter <package_name> run compile
 ```
 
-**Important:** The pnpm CLI e2e tests (in `pnpm/test/`) use the **bundled** `pnpm/dist/pnpm.mjs`, not the individual package `lib/` outputs. After changing any package, you must rebuild the bundle before running e2e tests:
+**Important:** The TypeScript pnpm v11 CLI e2e tests (in `pnpm11/pnpm/test/`) use the **bundled** `pnpm11/pnpm/dist/pnpm.mjs`, not the individual package `lib/` outputs. After changing any TypeScript package, you must rebuild the bundle before running e2e tests:
 
 ```bash
 pnpm --filter pnpm run compile
 ```
 
-This runs `tsgo --build`, linting, and `pnpm run bundle` (which bundles all packages into `pnpm/dist/pnpm.mjs`). Without this step, e2e tests will use a stale bundle and your changes won't be tested.
+This runs `tsgo --build`, linting, and `pnpm run bundle` (which bundles all TypeScript packages into `pnpm11/pnpm/dist/pnpm.mjs`). Without this step, e2e tests will use a stale bundle and your changes won't be tested.
 
 ## Testing (TypeScript only)
 
@@ -128,7 +126,7 @@ Do not dismiss a failing test as a "pre-existing" failure that is unrelated to y
 
 ## AI Review Guidance
 
-The repository's review framework lives in **[REVIEW_GUIDE.md](./REVIEW_GUIDE.md)** — how changes are accepted or rejected, the security-first / performance-second priorities, the security checklist and advisory regression themes, and the test/changeset/parity expectations. Apply it when reviewing pull requests. (TypeScript-specific code style and engineering conventions for the CLI are documented in the "Code Style" section of this file; pacquet and pnpr follow their own `AGENTS.md` and style guides.)
+The repository's review framework lives in **[REVIEW_GUIDE.md](./REVIEW_GUIDE.md)** — how changes are accepted or rejected, the security-first / performance-second priorities, the security checklist and advisory regression themes, and the test/changeset/version-coverage expectations. Apply it when reviewing pull requests. (TypeScript-specific code style and engineering conventions for the CLI are documented in the "Code Style" section of this file; pacquet and pnpr follow their own `AGENTS.md` and style guides.)
 
 Security is the first review priority and performance the second. Surface only issues tied to the changed code, and explain the exploit path, impact, or hot path affected. See the guide's Security and Performance review sections for the full checklist.
 
@@ -194,23 +192,21 @@ GitHub turns any `@name` into a mention of that user/org/team, which is wrong ei
 
 If your changes affect published packages, you MUST create a changeset file in the `.changeset` directory (`pnpm change` records one interactively; `pnpm change status` shows the pending release plan). The file describes the change and specifies the affected packages with their pending version bump types: patch, minor, or major. Write the description for pnpm users and keep it concise — it becomes a release note. Implementation rationale belongs in the commit message, not the changeset. The bare `pnpm version -r` consumes the pending changesets at release time; there is no separate `@changesets/cli` dependency.
 
-**IMPORTANT: Always explicitly include `"pnpm"` in the changeset** with the appropriate version bump (patch, minor, or major). The pnpm CLI will only receive automatic patch bumps from its dependencies, so if your change warrants a minor or major version bump for the CLI, you must specify it explicitly. The changeset description will appear on the release notes page.
+**IMPORTANT: For changes to the TypeScript pnpm v11 CLI, always explicitly include `"pnpm"` in the changeset with a patch bump.** The changeset description will appear on the release notes page. For pnpm v12 changes, follow the Rust-product rules below and target `pacquet` instead.
 
 Example:
 
 ```
 ---
-"@pnpm/installing.deps-installer": minor
-"pnpm": minor
+"@pnpm/installing.deps-installer": patch
+"pnpm": patch
+"pacquet": patch
 ---
 
-Added a new setting `blockExoticSubdeps` that prevents the resolution of exotic protocols in transitive dependencies [#10352](https://github.com/pnpm/pnpm/issues/10352).
+Fixed a `pnpm install` bug that affected both pnpm v11 and v12.
 ```
 
-**Versioning Guidelines for pnpm CLI:**
-- **patch**: Bug fixes, internal refactors, and changes that don't require documentation updates
-- **minor**: New features, settings, or commands that should be documented (anything users should know about)
-- **major**: Breaking changes
+The TypeScript pnpm v11 CLI is maintenance-only. Its changesets use patch bumps for bug fixes and internal maintenance. Do not implement new features or breaking changes in v11.
 
 ### Changeset style
 
@@ -253,13 +249,13 @@ After:
 
 The Rust products are released through the same native flow. Their npm wrapper packages are workspace packages with committed versions, so a user-visible change to a Rust product needs a changeset too, targeting:
 
-- `pacquet` — the Rust pnpm CLI (published to npm as `pnpm` and `@pnpm/exe` under its `next-<major>` dist-tag; named `pacquet` in-repo so its name can't collide with the TypeScript CLI). `@pnpm/napi` is a `versioning.fixed` group with it and bumps with it automatically.
+- `pacquet` — the Rust pnpm v12 CLI (published to npm as `pnpm` and `@pnpm/exe`; named `pacquet` in-repo so its name can't collide with the TypeScript CLI). `@pnpm/napi` is a `versioning.fixed` group with it and bumps with it automatically.
 - `@pnpm/napi` — the Node.js addon bindings for the Rust engine.
 - `@pnpm/pnpr` — the pnpr registry server (published as `@pnpm/pnpr` and its platform packages, plus the `ghcr.io/pnpm/pnpr` Docker image).
 
-The Rust products release on prerelease lanes (`versioning.lanes` in `pnpm-workspace.yaml`): each run of `pnpm version -r` that consumes an intent for one of them cuts an `X.Y.Z-<lane>.N` prerelease — `rc` for the Rust CLI and its NAPI addon, `alpha` for pnpr — while the TypeScript CLI keeps releasing stable versions on the main lane. `pnpm lane main --filter …` graduates a product to a stable version.
+pnpm v12 and its NAPI addon release as stable versions on the main lane. pnpr releases on the `alpha` prerelease lane configured in `pnpm-workspace.yaml`; `pnpm lane main --filter …` graduates it to a stable version.
 
-Do not add `"pnpm"` to a Rust-only changeset: in changesets, `pnpm` always means the TypeScript CLI package. A changeset whose implementation is Rust-only and targets `pacquet` must omit `"pnpm"`. A parity change that lands in both stacks carries one changeset naming both the affected TypeScript packages (plus `"pnpm"`) and the Rust wrapper(s).
+Do not add `"pnpm"` to a Rust-only changeset: in changesets, `pnpm` always means the TypeScript v11 CLI package. A changeset for a pnpm v12 feature or v12-only bug fix targets `pacquet` and omits `"pnpm"`. A shared bug fix that lands in both versions carries one changeset naming both the affected TypeScript packages (plus `"pnpm"`) and the Rust wrapper(s).
 
 Use `pacquet` as the changeset package name, but use `pnpm` in its release-note prose and command examples (`pnpm add`, not `pacquet add`). The published Rust CLI's executable is `pnpm`; `pacquet` is only its in-repo package identifier.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ If your changes affect published packages, you MUST create a changeset file in t
 
 Example:
 
-```
+```text
 ---
 "@pnpm/installing.deps-installer": patch
 "pnpm": patch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,14 @@ This document provides context and instructions for AI agents working on the pnp
 The repository contains three products:
 
 - The **TypeScript pnpm v11 CLI** — `pnpm11/`.
-- The **Rust pnpm v12 CLI (pacquet)** — `pnpm/`. pnpm v12 is the latest stable release. See [`pnpm/AGENTS.md`](./pnpm/AGENTS.md) for pacquet-specific rules; it adds to (and never contradicts) the conventions below.
+- The **Rust pnpm v12 CLI (pacquet)** — `pnpm/`. pnpm v12 is the target for new feature development. See [`pnpm/AGENTS.md`](./pnpm/AGENTS.md) for pacquet-specific rules; it adds to (and never contradicts) the conventions below.
 - The **Rust pnpr registry server** — `pnpr/`. See [`pnpr/AGENTS.md`](./pnpr/AGENTS.md) for pnpr-specific rules; it adds to (and never contradicts) the conventions below.
 
 Sections below marked "(TypeScript only)" apply to TypeScript code only; they do not apply to Rust code in `pnpm/` or `pnpr/`. Everything else applies repo-wide unless a nested `AGENTS.md` specializes it.
 
 ## pnpm v12 and v11 development policy
 
-pnpm v12, implemented in Rust under `pnpm/`, is the latest stable release and the target for new development. pnpm v11, implemented in TypeScript under `pnpm11/`, is maintained for bug fixes.
+pnpm v12, implemented in Rust under `pnpm/`, is the target for new development. pnpm v11, implemented in TypeScript under `pnpm11/`, is maintained for bug fixes.
 
 **Implement new features only in pnpm v12. Do not add them to pnpm v11.** A feature that intentionally exists only in v12 is not a parity gap.
 

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -329,12 +329,12 @@ For each PR, in order:
 6. **Product/contract.** npm-recognized semantics; defaults preserved or properly gated;
    no log noise. (§5)
 7. **Tests.** Right level, meaningful, regression-proving, cross-platform where relevant. (§7)
-8. **Changeset.** Present iff user-visible; `"pnpm"` included; one per change; accurate; styled
-   per `AGENTS.md`. (§8)
+8. **Changeset.** Present iff user-visible; targets every affected package (`pacquet` for v12,
+   `"pnpm"` for v11); one per change; accurate; styled per `AGENTS.md`. (§8)
 9. **Version coverage.** New features target v12 only; bug fixes cover every affected version. (§9)
 10. **Conventions.** `PnpmError`, no swallowed errors, good names, reused libraries, correct
     dependency placement, config through options. (`AGENTS.md` → Conventions)
 
 A change is mergeable when it is the **smallest correct, secure, in-scope version of a thing
 pnpm should do**, in the right layer, proven by a meaningful test, documented if user-visible,
-and mirrored in pacquet.
+and implemented in every affected pnpm version.

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -262,6 +262,9 @@ Tests must prove the changed behavior, not just execute nearby code.
 
 ## 9. pnpm v12 and v11 coverage
 
+This section applies to the pnpm CLI implementations under `pnpm/` and `pnpm11/`, not to the
+pnpr registry server.
+
 pnpm v12 is the target for new features. It is implemented in Rust under `pnpm/`. pnpm v11 is
 the TypeScript implementation under `pnpm11/` and receives bug fixes only. **Reject new-feature
 implementations in v11; a v12-only feature is an intentional version difference, not a parity
@@ -331,10 +334,11 @@ For each PR, in order:
 7. **Tests.** Right level, meaningful, regression-proving, cross-platform where relevant. (§7)
 8. **Changeset.** Present iff user-visible; targets every affected package (`pacquet` for v12,
    `"pnpm"` for v11); one per change; accurate; styled per `AGENTS.md`. (§8)
-9. **Version coverage.** New features target v12 only; bug fixes cover every affected version. (§9)
+9. **CLI version coverage.** New pnpm CLI features target v12 only; CLI bug fixes cover every
+   affected version. This rule does not apply to pnpr. (§9)
 10. **Conventions.** `PnpmError`, no swallowed errors, good names, reused libraries, correct
     dependency placement, config through options. (`AGENTS.md` → Conventions)
 
 A change is mergeable when it is the **smallest correct, secure, in-scope version of a thing
 pnpm should do**, in the right layer, proven by a meaningful test, documented if user-visible,
-and implemented in every affected pnpm version.
+and implemented in every affected pnpm CLI version when the change is to the CLI.

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -262,10 +262,10 @@ Tests must prove the changed behavior, not just execute nearby code.
 
 ## 9. pnpm v12 and v11 coverage
 
-pnpm v12 is the latest stable release and the target for new features. It is implemented in
-Rust under `pnpm/`. pnpm v11 is the TypeScript implementation under `pnpm11/` and receives bug
-fixes only. **Reject new-feature implementations in v11; a v12-only feature is an intentional
-version difference, not a parity failure.**
+pnpm v12 is the target for new features. It is implemented in Rust under `pnpm/`. pnpm v11 is
+the TypeScript implementation under `pnpm11/` and receives bug fixes only. **Reject new-feature
+implementations in v11; a v12-only feature is an intentional version difference, not a parity
+failure.**
 
 - For a bug fix, establish whether the bug is present in v11, v12, or both.
 - If both versions are affected, fix and test both implementations. Do both sides in one PR

--- a/REVIEW_GUIDE.md
+++ b/REVIEW_GUIDE.md
@@ -39,7 +39,7 @@ security advice untethered from the diff. Security fixes themselves need precise
   env var, or path influence a **trust decision**?
 - Does the bug expose end users, or only dev dependencies/tests in the repo?
 - Is the fix in the right layer, or does it only patch one call site?
-- Does it keep pnpm/pacquet parity where behavior is shared?
+- Does the fix cover every affected pnpm version?
 
 Treat as attacker-controlled: package metadata, tarball contents, lockfiles, workspace
 manifests, `.npmrc`/environment config, registry responses, git URLs, filesystem paths, and
@@ -66,7 +66,7 @@ Advisory regression themes — recurring classes from past pnpm advisories:
   registry scope and trust boundary are explicit;
 - lifecycle/build-script approval gates must cover all dependency sources and phases — git
   dependencies, fetch/prepare/prepack/prepublish paths, `allowBuilds`, ignored-build reporting,
-  explicit denials, and pacquet parity;
+  explicit denials, and every affected pnpm version;
 - opaque dependency identities (git, URL, tarball, file, directory, patch, alias locators) stay
   byte-for-byte exact where used for trust; don't normalize away attacker-controlled suffixes or
   confuse them with registry peer suffixes;
@@ -116,8 +116,7 @@ before it ships as a default.
 
 pnpm is performance-sensitive; be skeptical of extra work in common flows.
 
-- **Never trade correctness for a micro-optimization.** This is pacquet's cardinal rule — match
-  pnpm exactly even when that's slower. Declining an optimization that risks order-dependent
+- **Never trade correctness for a micro-optimization.** Declining an optimization that risks order-dependent
   output, breaks an invariant, or couples concerns is correct.
 - **A performance change must be measured.** If it's pitched as perf, there must be a number.
 
@@ -250,28 +249,30 @@ Tests must prove the changed behavior, not just execute nearby code.
 - **User-visible change to a published package → changeset required.**
 - **Test-only or internal change (not visible to CLI users) → none.**
 - **Behavior/setting users should know about → changeset and usually docs.**
-- **Always include `"pnpm"` explicitly** with the right bump: `patch` (bug fix / internal),
-  `minor` (feature / setting), `major` (breaking).
+- **For a pnpm v11 fix, include `"pnpm"` explicitly with a patch bump.**
+- **For a pnpm v12 change, target `pacquet`.** A shared bug fix targets both CLI packages and
+  any affected supporting packages.
 - **One changeset per logical change.** The text is a user-facing release note — accurate and
   concise, no implementation rationale — and it must match what the code actually does.
 - **The text follows the changeset style rules** (`AGENTS.md` → Changeset style): the user-visible
   effect first, no list of internals, no em dashes, no "instead of" tail on every sentence.
-- **pacquet-only PRs don't get changesets.**
+- **A user-visible pacquet change needs a changeset.** Test-only and internal changes do not.
 
 ---
 
-## 9. pnpm ↔ pacquet parity
+## 9. pnpm v12 and v11 coverage
 
-pnpm is the source of truth; pacquet is the Rust port that matches it exactly. **Every command
-should have a pacquet equivalent, and every user-visible change must land in both products** —
-flags, defaults, env handling, error codes/messages, lockfile shape, store layout, build
-policy, lifecycle behavior, config handling, output. A change without its pacquet counterpart
-is incomplete.
+pnpm v12 is the latest stable release and the target for new features. It is implemented in
+Rust under `pnpm/`. pnpm v11 is the TypeScript implementation under `pnpm11/` and receives bug
+fixes only. **Reject new-feature implementations in v11; a v12-only feature is an intentional
+version difference, not a parity failure.**
 
-- Do both sides in one PR when practical; otherwise open with one side and state in the
-  description what still needs porting.
-- Don't make pacquet "better" than pnpm independently — land the behavior in pnpm first, then
-  mirror.
+- For a bug fix, establish whether the bug is present in v11, v12, or both.
+- If both versions are affected, fix and test both implementations. Do both sides in one PR
+  when practical; otherwise state in the description what is still missing.
+- If only one version is affected, change only that version and make the scope clear in the PR.
+- Compare flags, defaults, env handling, error codes/messages, lockfile shape, store layout,
+  build policy, lifecycle behavior, config handling, and output when reviewing shared bug fixes.
 - When a bot says a symbol is "not referenced," it may be searching only one major's branch;
   check the other branch.
 
@@ -330,7 +331,7 @@ For each PR, in order:
 7. **Tests.** Right level, meaningful, regression-proving, cross-platform where relevant. (§7)
 8. **Changeset.** Present iff user-visible; `"pnpm"` included; one per change; accurate; styled
    per `AGENTS.md`. (§8)
-9. **Parity.** pacquet equivalent handled or explicitly deferred. (§9)
+9. **Version coverage.** New features target v12 only; bug fixes cover every affected version. (§9)
 10. **Conventions.** `PnpmError`, no swallowed errors, good names, reused libraries, correct
     dependency placement, config through options. (`AGENTS.md` → Conventions)
 

--- a/pnpm/AGENTS.md
+++ b/pnpm/AGENTS.md
@@ -6,57 +6,47 @@ Guidance for AI coding agents working in `pnpm/`.
 
 ## What this project is
 
-`pacquet` is the [pnpm](https://pnpm.io) CLI implemented in Rust. It is one of
-two parallel implementations of the same package manager — the other is the
-TypeScript pnpm CLI (the workspaces outside `pnpm/`). The two are kept
-behaviorally identical: the same commands, flags, defaults, error codes, file
-formats, lockfile shape, and directory layout. pacquet is not a downstream port
-that trails the TypeScript CLI; it is a source of truth in its own right, at
-near-complete feature parity, and the two stacks are developed together.
+`pacquet` is pnpm v12, the latest stable [pnpm](https://pnpm.io) CLI,
+implemented in Rust. The TypeScript CLI under `../pnpm11/` is pnpm v11, which
+is maintained for bug fixes. New features are developed only in pacquet.
 
-## The cardinal rule
+## Version policy
 
-**pacquet and the TypeScript pnpm CLI must stay behaviorally identical.**
-They are parallel implementations of one package manager, developed together at
-near-complete feature parity. Any user-visible change — a command, flag,
-default, error code or message, lockfile/manifest/state-file format, log
-emission parsed by `@pnpm/cli.default-reporter`, store layout, or hook
-semantic — must land in both stacks at the same time. The repo-wide statement
-of this obligation lives in
-[`../AGENTS.md`](../AGENTS.md#keep-pnpm-and-pacquet-in-sync); this section is the
-pacquet-side detail.
+**Implement new features only in pnpm v12. Do not add them to pnpm v11.** A
+new command, flag, behavior, or format introduced in pacquet does not need a
+TypeScript implementation.
 
-Neither stack is downstream of the other. You are not "porting from" the
-TypeScript code: when you implement or change behavior in pacquet, make the
-equivalent change in the TypeScript workspaces in the same PR, and vice versa.
-If you genuinely can't (different expertise, scope too large, or the other
-stack hasn't grown the surrounding feature yet), ship your side and say so in
-the PR description so the matching commits can follow before it lands.
+Bug fixes follow the affected versions. If a bug is present in both pnpm v11
+and v12, fix and test it in both implementations. If it is present in only one
+version, fix only that version. The repo-wide policy lives in
+[`../AGENTS.md`](../AGENTS.md#pnpm-v12-and-v11-development-policy); this section
+is the pacquet-side detail.
 
 Working rules:
 
-1. **Keep the two implementations in agreement.** When you touch behavior in
-   pacquet, find the counterpart in the TypeScript workspaces — they live at
-   the repo root (`pnpm/` for the CLI entry, `pkg-manager/`, `resolving/`,
-   `lockfile/`, `store/`, `fetching/`, `config/`, `hooks/`, and so on; see the
-   [repo-structure section](../AGENTS.md#repository-structure)) — and change it
-   there too. The two must agree on logic, edge cases, config resolution, error
-   messages, and file/lockfile formats.
-2. **Match observable behavior, not structure.** Structural similarity (similar
+1. **Classify the change before editing v11.** New features and v12-only bug
+   fixes stay in pacquet. Only edit `../pnpm11/` when fixing a bug that is also
+   present in v11 or when doing work explicitly requested for v11.
+2. **Fix shared bugs in both versions.** For a bug present in both releases,
+   find the counterpart under `../pnpm11/` and make both implementations agree
+   on logic, edge cases, config resolution, error messages, and file/lockfile
+   formats affected by the fix.
+3. **Match observable behavior, not structure.** Structural similarity (similar
    function decomposition and names) is a convenience for cross-referencing, not
    a requirement. What must match is what a user or a downstream tool can
-   observe.
-3. **Don't diverge unilaterally.** Do not add a feature, flag, or quirk to one
-   stack without the other, and do not "fix" a behavior in only one. A genuine
-   bug present in both is fixed in both.
-4. **Log emissions are part of behavioral identity.** A function that fires
-   `pnpm:<channel>` events through the reporter must use the same call site,
-   payload, and ordering in both stacks so `@pnpm/cli.default-reporter` parses
-   pacquet's NDJSON the same way it parses the TypeScript CLI's. See
+   observe for the shared bug fix.
+4. **Keep version-specific behavior deliberate.** A new v12 feature is an
+   intentional difference, not something to backport to v11. Do not introduce
+   unrelated differences while implementing a shared bug fix.
+5. **Log emissions are part of shared bug-fix behavior.** When a shared fix
+   changes a function that fires `pnpm:<channel>` events through the reporter,
+   keep the call site, payload, and ordering consistent in both stacks so
+   `@pnpm/cli.default-reporter` parses pacquet's NDJSON the same way it parses
+   the TypeScript CLI's. See
    [Reporter / log events](./CODE_STYLE_GUIDE.md#reporter--log-events)
    in the style guide for the convention (channel mapping, threading
    `R: Reporter`, emit-site placement, recording-fake tests).
-5. **Prefer real fixtures; reach for the dependency-injection seam
+6. **Prefer real fixtures; reach for the dependency-injection seam
    only when they can't cover the branch.** Most happy paths and
    error paths should be tested with a `tempfile::TempDir`, the
    mocked registry, or an integration test that spawns the actual
@@ -206,10 +196,10 @@ Warnings are errors (`--deny warnings` in lint). Do not silence them with
 - Tests that need the mocked registry start `pnpr` through
   `pnpm-testing-utils`; `cargo test` / `cargo nextest run` should not
   require a separate `just registry-mock launch` step.
-- When a behavior change spans both stacks, keep their tests in sync — give
+- When a bug fix spans both versions, keep their tests in sync — give
   pacquet a Rust test for the same scenario the TypeScript stack covers (and
   vice versa) whenever it translates. Matching test coverage is the easiest
-  way to prove behavioral parity.
+  way to prove the shared bug is fixed consistently.
 - The active test-porting plan lives in
   [`plans/TEST_PORTING.md`](./plans/TEST_PORTING.md). It enumerates the
   upstream TypeScript tests scheduled to be ported (with file paths and line
@@ -402,9 +392,9 @@ are part of the public contract, not implementation detail. See
 
 - Keep commits focused. A bug fix commit should not also refactor or
   reformat unrelated code.
-- When a change has a counterpart in the TypeScript pnpm CLI, land both
-  together; if they must be split, cross-reference the matching PR so a
-  reviewer can confirm the two stacks stay in sync.
+- When a bug fix also applies to pnpm v11, land both implementations together;
+  if they must be split, cross-reference the matching PR so a reviewer can
+  confirm both versions are fixed.
 - Run `just ready` before pushing.
 - The repo-wide husky `pre-push` hook runs `pnpm/scripts/pre-push-rust.sh`,
   which checks `rustfmt`, `taplo`, `cargo clippy` (with `--all-targets -D
@@ -433,11 +423,10 @@ perf(store-dir): share one read-only StoreIndex across cache lookups
 
 ## Things not to do
 
-- Do not add a feature, flag, or behavior to one stack without making the
-  same change to the other. The two move together.
-- Do not change lockfile format, store layout, `.npmrc` semantics, or CLI
-  surface in only one stack — those are the shared contract and must change
-  in both at once.
+- Do not implement new features, flags, or behaviors in pnpm v11. New features
+  belong only in pnpm v12.
+- Do not fix a bug in only one implementation when the same bug is present in
+  both pnpm v11 and v12.
 - A dependency that is already declared in `[workspace.dependencies]` in the
   root `Cargo.toml` may be added to any crate that needs it.
 - Do not add a dependency that is not already declared in the workspace

--- a/pnpm/AGENTS.md
+++ b/pnpm/AGENTS.md
@@ -6,9 +6,9 @@ Guidance for AI coding agents working in `pnpm/`.
 
 ## What this project is
 
-`pacquet` is pnpm v12, the latest stable [pnpm](https://pnpm.io) CLI,
-implemented in Rust. The TypeScript CLI under `../pnpm11/` is pnpm v11, which
-is maintained for bug fixes. New features are developed only in pacquet.
+`pacquet` is pnpm v12, implemented in Rust and the target for new feature
+development. The TypeScript CLI under `../pnpm11/` is pnpm v11, which is
+maintained for bug fixes. New features are developed only in pacquet.
 
 ## Version policy
 

--- a/pnpm/CONTRIBUTING.md
+++ b/pnpm/CONTRIBUTING.md
@@ -4,7 +4,7 @@ See also [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md) for the code style guide
 
 ## Scope and Version Policy
 
-pacquet is pnpm v12, the latest stable release and the target for new feature development. New commands, settings, and other user-visible features are implemented here and are not backported to the TypeScript pnpm v11 CLI under `../pnpm11/`.
+pacquet is pnpm v12 and the target for new feature development. New commands, settings, and other user-visible features are implemented here and are not backported to the TypeScript pnpm v11 CLI under `../pnpm11/`.
 
 For bug fixes, determine which supported versions contain the bug. A bug present in both v11 and v12 must be fixed and tested in both implementations. A bug present in only one version is fixed only in that version. See [`AGENTS.md`](./AGENTS.md) for the full version policy.
 

--- a/pnpm/CONTRIBUTING.md
+++ b/pnpm/CONTRIBUTING.md
@@ -2,21 +2,15 @@
 
 See also [`CODE_STYLE_GUIDE.md`](./CODE_STYLE_GUIDE.md) for the code style guide.
 
-## Scope and Roadmap
+## Scope and Version Policy
 
-pacquet's scope is defined by the roadmap in [#299](https://github.com/pnpm/pacquet/issues/299). The current focus is **Stage 1 — Headless installer**: making `pacquet install --frozen-lockfile` feature-complete with `pnpm install --frozen-lockfile`.
+pacquet is pnpm v12, the latest stable release and the target for new feature development. New commands, settings, and other user-visible features are implemented here and are not backported to the TypeScript pnpm v11 CLI under `../pnpm11/`.
 
-Stage 1 focuses on `pacquet install` and the settings and behavior needed to match `pnpm install --frozen-lockfile`. Other top-level commands exist in the CLI today, but they are not part of Stage 1 and are not receiving feature work, and new top-level commands are out of scope. pacquet is intended to be executed by the pnpm CLI under the hood, so configuration arrives through pnpm settings (such as `.npmrc` and `pnpm-workspace.yaml`) rather than through new command-line flags.
+For bug fixes, determine which supported versions contain the bug. A bug present in both v11 and v12 must be fixed and tested in both implementations. A bug present in only one version is fixed only in that version. See [`AGENTS.md`](./AGENTS.md) for the full version policy.
 
-Before opening a pull request that adds a new setting or user-visible feature, **confirm the feature is listed under Stage 1 of the roadmap**. Work that does not appear under Stage 1 will not be reviewed or merged at this time, regardless of implementation quality. Stage 2 and later items are deferred until Stage 1 is complete.
+Opening an issue first is optional for a clearly scoped change. Open one when the intended user-visible behavior or design is not obvious, or when coordination is needed for work already in progress.
 
-Opening an issue first is optional when the change is in Stage 1 *and* the implementation exactly mirrors how the pnpm CLI works: same behavior, same defaults, same error codes, same file formats. See [`AGENTS.md`](./AGENTS.md) for the parity rule. Open an issue first when the right approach is not obvious from upstream code, or to coordinate on in-flight work.
-
-Deviating from pnpm's behavior is not an option in pacquet. If you believe pnpm itself should change, raise it in the [pnpm repository](https://github.com/pnpm/pnpm) first. Once the change has landed in pnpm and shipped, the corresponding port can be made here.
-
-Bug fixes, performance improvements, tests, and documentation for behavior that already exists do not need a roadmap entry and may be sent directly as pull requests.
-
-Pull requests for new top-level commands, or for features outside the current Stage 1 scope, will be closed with a pointer to the roadmap.
+Bug fixes, performance improvements, tests, and documentation may be sent directly as pull requests. New features must follow the repository's normal design, documentation, testing, and changeset requirements.
 
 ## Commit Message Convention
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -5,8 +5,8 @@ in-repository package name; the published CLI and executable are named `pnpm`.
 
 pnpm v12 is the target for new feature development. The TypeScript pnpm v11
 CLI under `../pnpm11/` is maintained for bug fixes. Bugs present in both
-versions are fixed in both implementations, while new features are not
-backported to v11.
+versions are fixed in both implementations. Bugs present in only one version
+are fixed only there. New features are not backported to v11.
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for development setup, debugging, testing, and benchmarking.
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -1,12 +1,12 @@
 # pnpm v12 (pacquet)
 
-The [pnpm](https://pnpm.io) v12 CLI, implemented in Rust. `pacquet` is its
+The [pnpm](https://pnpm.io) v12 CLI is implemented in Rust. `pacquet` is its
 in-repository package name; the published CLI and executable are named `pnpm`.
 
 pnpm v12 is the target for new feature development. The TypeScript pnpm v11
 CLI under `../pnpm11/` is maintained for bug fixes. Bugs present in both
 versions are fixed in both implementations. Bugs present in only one version
-are fixed only there. New features are not backported to v11.
+are fixed in that version. New features are not backported to v11.
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for development setup, debugging, testing, and benchmarking.
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -1,23 +1,13 @@
-# pacquet
+# pnpm v12 (pacquet)
 
-> [!WARNING]
-> **pacquet is under active development and not yet ready for production use.**
+The latest stable [pnpm](https://pnpm.io) CLI, implemented in Rust. `pacquet` is
+its in-repository package name; the published CLI and executable are named
+`pnpm`.
 
-The official pnpm rewrite in Rust.
-
-pacquet is the [pnpm](https://pnpm.io) CLI implemented in Rust — one of two parallel implementations of the same package manager, kept behaviorally identical (the same commands, flags, defaults, error codes, file formats, and directory layout). It is developed alongside the TypeScript pnpm CLI at near-complete feature parity, not as a downstream port that trails it.
-
-## Roadmap
-
-pacquet will become the installation engine of pnpm. The transition will happen in two phases.
-
-### Phase 1: fetching and linking
-
-pacquet replaces fetching and linking only. pnpm continues to create the lockfile, and pacquet does the rest. We expect this alone to make pnpm at least twice as fast in most scenarios. Shipping this phase is the current focus.
-
-### Phase 2: resolution
-
-pacquet also takes over dependency resolution.
+pnpm v12 is the target for new feature development. The TypeScript pnpm v11
+CLI under `../pnpm11/` is maintained for bug fixes. Bugs present in both
+versions are fixed in both implementations, while new features are not
+backported to v11.
 
 See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for development setup, debugging, testing, and benchmarking.
 

--- a/pnpm/README.md
+++ b/pnpm/README.md
@@ -1,8 +1,7 @@
 # pnpm v12 (pacquet)
 
-The latest stable [pnpm](https://pnpm.io) CLI, implemented in Rust. `pacquet` is
-its in-repository package name; the published CLI and executable are named
-`pnpm`.
+The [pnpm](https://pnpm.io) v12 CLI, implemented in Rust. `pacquet` is its
+in-repository package name; the published CLI and executable are named `pnpm`.
 
 pnpm v12 is the target for new feature development. The TypeScript pnpm v11
 CLI under `../pnpm11/` is maintained for bug fixes. Bugs present in both

--- a/pnpr/AGENTS.md
+++ b/pnpr/AGENTS.md
@@ -19,15 +19,16 @@ the `Cargo.lock` stays unified.
 
 ## Relationship to pacquet
 
-- **`pnpm/`** is a *port* of the pnpm CLI. Its cardinal rule is
-  "match pnpm exactly" — see [`../pnpm/AGENTS.md`](../pnpm/AGENTS.md).
+- **`pnpm/`** is pnpm v12, the latest stable CLI and the target for new
+  feature development. See [`../pnpm/AGENTS.md`](../pnpm/AGENTS.md) for its
+  version policy.
 - **`pnpr/`** has no pnpm-CLI counterpart to mirror. It is a new
   server. Behavior here is designed, not ported.
 
-That means the "match upstream pnpm" discipline that governs `pnpm/`
-does **not** apply here. The registry can pick its own architecture,
-flags, and config format. It must still be compatible with the npm
-registry protocol that pnpm (and npm, yarn, etc.) clients speak.
+The pnpm v12 and v11 coverage policy governs the CLI implementations, not
+pnpr. The registry can pick its own architecture, flags, and config format. It
+must still be compatible with the npm registry protocol that pnpm (and npm,
+yarn, etc.) clients speak.
 
 ## Layout
 
@@ -82,7 +83,7 @@ drive-by during feature work.
 ### New registry-only crates
 
 When the registry needs its own crate (logic that isn't shared with the
-pnpm port and doesn't fit in `pnpm/`), put it under
+pnpm CLI and doesn't fit in `pnpm/`), put it under
 `pnpr/crates/<short-name>/` and name the package
 `pnpr-<short-name>` in its `Cargo.toml`. The
 `pnpr/crates/*` glob in the root workspace `members` picks it up

--- a/pnpr/AGENTS.md
+++ b/pnpr/AGENTS.md
@@ -19,9 +19,8 @@ the `Cargo.lock` stays unified.
 
 ## Relationship to pacquet
 
-- **`pnpm/`** is pnpm v12, the latest stable CLI and the target for new
-  feature development. See [`../pnpm/AGENTS.md`](../pnpm/AGENTS.md) for its
-  version policy.
+- **`pnpm/`** is pnpm v12 and the target for new feature development. See
+  [`../pnpm/AGENTS.md`](../pnpm/AGENTS.md) for its version policy.
 - **`pnpr/`** has no pnpm-CLI counterpart to mirror. It is a new
   server. Behavior here is designed, not ported.
 


### PR DESCRIPTION
## Summary

Updates contributor and agent guidance to make pnpm v12 the target for new feature development.

- Directs new feature development exclusively to the Rust pnpm v12 CLI.
- Limits the TypeScript pnpm v11 CLI to maintenance and bug fixes.
- Requires bug fixes to cover both versions only when both are affected.
- Aligns the agent guides, contributor guide, Rust CLI README, review checklist, PR template, changeset guidance, release guidance, and TypeScript workspace paths with this policy.

## Squash Commit Body

```text
pnpm v12 is the target for new feature development. The TypeScript pnpm v11 implementation is maintenance-only.

Update the repository guidance so shared bugs are fixed and tested in both versions, while v12-only features and fixes do not create v11 parity work. Align the contributor, review, changeset, release, README, and PR checklist instructions with the same policy.
```

## Checklist

- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contribution, review, and development guidance to distinguish pnpm v11 maintenance from pnpm v12 feature development.
  * Clarified version-specific expectations for bug fixes, security fixes, testing, performance, changesets, and implementation coverage.
  * Updated project documentation and repository layout references, including pnpr’s independent registry-server scope.

* **User Impact**
  * No end-user functionality or public APIs changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->