### PR TITLE
fix(import): honor lockfileDir when replacing lockfiles

### DIFF
--- a/.changeset/import-lockfile-directory.md
+++ b/.changeset/import-lockfile-directory.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm import` now leaves the project-local lockfile unchanged when `lockfileDir` points to another directory [#14563](https://github.com/pnpm/pnpm/issues/14563).
+`pnpm import` now leaves the project-local lockfile unchanged when `lockfileDir` points to another directory. Failed imports restore the destination lockfile. Imports that use a branch lockfile leave the shared lockfile unchanged [#14563](https://github.com/pnpm/pnpm/issues/14563).

--- a/.changeset/import-lockfile-directory.md
+++ b/.changeset/import-lockfile-directory.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/installing.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm import` now leaves the project-local lockfile unchanged when `lockfileDir` points to another directory [#14563](https://github.com/pnpm/pnpm/issues/14563).

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -24,8 +24,9 @@ impl ImportArgs {
         let State { tarball_mem_cache, http_client, config, manifest, resolved_packages, .. } =
             &state;
         let dir = manifest.path().parent().expect("manifest path always has a parent dir");
-        let lockfile_path = dir.join("pnpm-lock.yaml");
-        let env_lockfile = EnvLockfile::read(dir)
+        let lockfile_dir = state.lockfile_dir();
+        let lockfile_path = lockfile_dir.join("pnpm-lock.yaml");
+        let env_lockfile = EnvLockfile::read(lockfile_dir)
             .into_diagnostic()
             .wrap_err("reading the env lockfile before import")?;
 
@@ -94,7 +95,7 @@ impl ImportArgs {
         let import_result = install_result.and_then(|()| {
             if let Some(env_lockfile) = env_lockfile {
                 env_lockfile
-                    .write(dir)
+                    .write(lockfile_dir)
                     .into_diagnostic()
                     .wrap_err("preserving the env lockfile after import")?;
             }

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -1,7 +1,7 @@
 use crate::State;
 use clap::Args;
 use miette::{Context, IntoDiagnostic};
-use pnpm_lockfile::EnvLockfile;
+use pnpm_lockfile::{EnvLockfile, Lockfile};
 use pnpm_lockfile_import::{read_foreign_lockfile_versions, to_preferred_versions};
 use pnpm_network::redact_url_for_display;
 use pnpm_package_manager::{Install, ProjectMutation};
@@ -25,10 +25,14 @@ impl ImportArgs {
             &state;
         let dir = manifest.path().parent().expect("manifest path always has a parent dir");
         let lockfile_dir = state.lockfile_dir();
-        let lockfile_path = lockfile_dir.join("pnpm-lock.yaml");
-        let env_lockfile = EnvLockfile::read(lockfile_dir)
-            .into_diagnostic()
-            .wrap_err("reading the env lockfile before import")?;
+        let lockfile_path = state.lockfile_path();
+        let env_lockfile = if config.wanted_lockfile_name() == Lockfile::FILE_NAME {
+            EnvLockfile::read(lockfile_dir)
+                .into_diagnostic()
+                .wrap_err("reading the env lockfile before import")?
+        } else {
+            None
+        };
 
         if let Some(pnpr_server) = self.pnpr_server.as_deref().or(config.pnpr_server.as_deref()) {
             let pnpr_server = redact_url_for_display(pnpr_server);

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -43,7 +43,10 @@ impl ImportArgs {
 
         let preferred_versions = to_preferred_versions(&read_foreign_lockfile_versions(dir)?);
 
-        let lockfile_backup = lockfile_path.with_extension("yaml.import.bak");
+        // A backup of its own keeps overlapping imports from restoring each
+        // other's copy.
+        let lockfile_backup =
+            lockfile_path.with_extension(format!("yaml.{}.import.bak", std::process::id()));
         let lockfile_existed = lockfile_path.exists();
         if lockfile_existed {
             std::fs::rename(&lockfile_path, &lockfile_backup)
@@ -116,27 +119,36 @@ impl ImportArgs {
                 Ok(())
             }
             Err(error) => {
-                if lockfile_existed {
-                    restore_lockfile(&lockfile_path, &lockfile_backup).wrap_err_with(|| {
-                        format!("restoring pnpm-lock.yaml after import failed: {error}")
-                    })?;
-                }
+                discard_failed_import(
+                    &lockfile_path,
+                    lockfile_existed.then_some(lockfile_backup.as_path()),
+                )
+                .wrap_err_with(|| {
+                    format!(
+                        "restoring {} after the failed import: {error}",
+                        lockfile_path.display(),
+                    )
+                })?;
                 Err(error)
             }
         }
     }
 }
 
-fn restore_lockfile(
+/// Takes back what an import wrote: whatever it left at `lockfile_path`
+/// goes, and the backup, when the import had a lockfile to back up, moves
+/// into its place. An import that started without one leaves none behind.
+fn discard_failed_import(
     lockfile_path: &std::path::Path,
-    backup_path: &std::path::Path,
+    backup_path: Option<&std::path::Path>,
 ) -> miette::Result<()> {
     if let Err(error) = std::fs::remove_file(lockfile_path)
         && error.kind() != std::io::ErrorKind::NotFound
     {
         return Err(error).into_diagnostic().wrap_err("removing the failed imported lockfile");
     }
+    let Some(backup_path) = backup_path else { return Ok(()) };
     std::fs::rename(backup_path, lockfile_path)
         .into_diagnostic()
-        .wrap_err("restoring the original pnpm-lock.yaml")
+        .wrap_err("restoring the original lockfile")
 }

--- a/pnpm/crates/cli/src/cli_args/import.rs
+++ b/pnpm/crates/cli/src/cli_args/import.rs
@@ -135,9 +135,8 @@ impl ImportArgs {
     }
 }
 
-/// Takes back what an import wrote: whatever it left at `lockfile_path`
-/// goes, and the backup, when the import had a lockfile to back up, moves
-/// into its place. An import that started without one leaves none behind.
+/// Restores the destination an import replaced. An import that started
+/// without a lockfile there leaves none behind.
 fn discard_failed_import(
     lockfile_path: &std::path::Path,
     backup_path: Option<&std::path::Path>,

--- a/pnpm/crates/cli/tests/suite/import.rs
+++ b/pnpm/crates/cli/tests/suite/import.rs
@@ -492,6 +492,116 @@ fn import_replaces_existing_lockfile() {
 }
 
 #[test]
+fn import_preserves_project_lockfile_with_external_lockfile_dir() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_own_storage();
+    npmrc_info.set_dist_tag(DEP_OF_PKG_WITH_1_DEP, "100.1.0", "latest");
+
+    write_file(&workspace, "package.json", NPM_FIXTURE_MANIFEST);
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    let project_lockfile = "# project lockfile must stay unchanged\n";
+    write_file(&workspace, "pnpm-lock.yaml", project_lockfile);
+
+    pacquet.with_arg("import").assert().success();
+
+    assert_pins(
+        root.path(),
+        &["@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"],
+        &["@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"],
+    );
+    let lockfile = pnpm_lockfile::Lockfile::load_wanted_from_dir(root.path())
+        .expect("load imported lockfile")
+        .expect("imported lockfile exists");
+    assert_eq!(lockfile.importers.into_keys().collect::<Vec<_>>(), ["workspace"]);
+    assert_eq!(
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read project lockfile"),
+        project_lockfile,
+    );
+    assert!(!workspace.join("node_modules").exists(), "import must not create node_modules");
+
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn import_replaces_external_lockfile_and_preserves_its_env_document() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_own_storage();
+    npmrc_info.set_dist_tag(DEP_OF_PKG_WITH_1_DEP, "100.1.0", "latest");
+
+    write_file(&workspace, "package.json", NPM_FIXTURE_MANIFEST);
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    write_file(root.path(), "pnpm-lock.yaml", "# stale placeholder lockfile\n");
+    let mut env_lockfile = pnpm_lockfile::EnvLockfile::create();
+    env_lockfile.root_importer_mut().config_dependencies.insert(
+        "@pnpm.e2e/foo".to_string(),
+        pnpm_lockfile::SpecifierAndResolution {
+            specifier: "1.0.0".to_string(),
+            version: "1.0.0".to_string(),
+        },
+    );
+    env_lockfile.write(root.path()).expect("write external env document");
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+
+    pacquet.with_arg("import").assert().success();
+
+    let lockfile = pnpm_lockfile::Lockfile::load_wanted_from_dir(root.path())
+        .expect("load imported lockfile")
+        .expect("imported lockfile exists");
+    let packages: Vec<_> = lockfile
+        .packages
+        .expect("imported packages exist")
+        .keys()
+        .map(ToString::to_string)
+        .collect();
+    assert!(
+        packages.contains(&"@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0".to_string()),
+        "imported packages: {packages:?}",
+    );
+    assert!(
+        !packages.contains(&"@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0".to_string()),
+        "imported packages: {packages:?}",
+    );
+    assert_eq!(
+        pnpm_lockfile::EnvLockfile::read(root.path()).expect("read external env document"),
+        Some(env_lockfile),
+    );
+    assert!(!workspace.join("pnpm-lock.yaml").exists(), "no lockfile in the project directory");
+    assert!(!root.path().join("pnpm-lock.yaml.import.bak").exists(), "no import backup remains");
+
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn failed_import_restores_external_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_file(
+        &workspace,
+        "package.json",
+        r#"{"dependencies":{"@pnpm.e2e/hello-world-js-bin-parent":"99.99.99"}}"#,
+    );
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    let original_lockfile = "# existing external lockfile\n";
+    write_file(root.path(), "pnpm-lock.yaml", original_lockfile);
+
+    let output = pacquet.with_arg("import").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_NO_MATCHING_VERSION"), "stderr:\n{stderr}");
+    assert_eq!(
+        fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read restored lockfile"),
+        original_lockfile,
+    );
+    assert!(!root.path().join("pnpm-lock.yaml.import.bak").exists(), "no import backup remains");
+    assert!(!workspace.join("pnpm-lock.yaml").exists(), "no lockfile in the project directory");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn import_from_shared_yarn_lock_of_monorepo() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/import.rs
+++ b/pnpm/crates/cli/tests/suite/import.rs
@@ -573,6 +573,98 @@ fn import_replaces_external_lockfile_and_preserves_its_env_document() {
 }
 
 #[test]
+fn import_preserves_shared_lockfile_when_writing_a_branch_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_own_storage();
+    npmrc_info.set_dist_tag(DEP_OF_PKG_WITH_1_DEP, "100.1.0", "latest");
+
+    write_file(&workspace, "package.json", NPM_FIXTURE_MANIFEST);
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    write_file(&workspace, ".git/HEAD", "ref: refs/heads/feature/import\n");
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    append_workspace_yaml_key(&workspace, "gitBranchLockfile", true);
+    let shared_lockfile = "# shared lockfile must stay unchanged\n";
+    write_file(root.path(), "pnpm-lock.yaml", shared_lockfile);
+    let mut env_lockfile = pnpm_lockfile::EnvLockfile::create();
+    env_lockfile.root_importer_mut().config_dependencies.insert(
+        "@pnpm.e2e/foo".to_string(),
+        pnpm_lockfile::SpecifierAndResolution {
+            specifier: "1.0.0".to_string(),
+            version: "1.0.0".to_string(),
+        },
+    );
+    env_lockfile.write(root.path()).expect("write shared env document");
+    let shared_lockfile =
+        fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read shared lockfile");
+    write_file(root.path(), "pnpm-lock.feature!import.yaml", "# stale branch lockfile\n");
+
+    pacquet.with_arg("import").assert().success();
+
+    let lockfile =
+        pnpm_lockfile::Lockfile::load_from_path(&root.path().join("pnpm-lock.feature!import.yaml"))
+            .expect("load branch lockfile")
+            .expect("branch lockfile exists");
+    assert_eq!(lockfile.importers.into_keys().collect::<Vec<_>>(), ["workspace"]);
+    let packages = lockfile.packages.expect("imported packages exist");
+    assert!(
+        packages.keys().any(|key| key.to_string() == "@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0"),
+    );
+    assert!(
+        !packages.keys().any(|key| key.to_string() == "@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0"),
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read shared lockfile"),
+        shared_lockfile,
+    );
+    assert!(
+        !root.path().join("pnpm-lock.feature!import.yaml.import.bak").exists(),
+        "no branch lockfile backup remains",
+    );
+
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn failed_import_restores_branch_lockfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_file(
+        &workspace,
+        "package.json",
+        r#"{"dependencies":{"@pnpm.e2e/hello-world-js-bin-parent":"99.99.99"}}"#,
+    );
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    write_file(&workspace, ".git/HEAD", "ref: refs/heads/feature/import\n");
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    append_workspace_yaml_key(&workspace, "gitBranchLockfile", true);
+    let shared_lockfile = "# shared lockfile\n";
+    let branch_lockfile = "# branch lockfile\n";
+    write_file(root.path(), "pnpm-lock.yaml", shared_lockfile);
+    write_file(root.path(), "pnpm-lock.feature!import.yaml", branch_lockfile);
+
+    let output = pacquet.with_arg("import").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_NO_MATCHING_VERSION"), "stderr:\n{stderr}");
+    assert_eq!(
+        fs::read_to_string(root.path().join("pnpm-lock.feature!import.yaml"))
+            .expect("read restored branch lockfile"),
+        branch_lockfile,
+    );
+    assert_eq!(
+        fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read shared lockfile"),
+        shared_lockfile,
+    );
+    assert!(
+        !root.path().join("pnpm-lock.feature!import.yaml.import.bak").exists(),
+        "no branch lockfile backup remains",
+    );
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn failed_import_restores_external_lockfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/cli/tests/suite/import.rs
+++ b/pnpm/crates/cli/tests/suite/import.rs
@@ -19,6 +19,16 @@ use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path};
 
+/// A finished import leaves no backup behind, whatever it named one.
+fn assert_no_import_backups(lockfile_dir: &Path) {
+    let leftovers: Vec<_> = fs::read_dir(lockfile_dir)
+        .expect("read the lockfile directory")
+        .map(|entry| entry.expect("read a lockfile directory entry").file_name())
+        .filter(|name| name.to_string_lossy().ends_with(".import.bak"))
+        .collect();
+    assert!(leftovers.is_empty(), "import backups left behind: {leftovers:?}");
+}
+
 const DEP_OF_PKG_WITH_1_DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 
 /// The manifest shared by pnpm's `has-package-lock-json`,
@@ -567,7 +577,7 @@ fn import_replaces_external_lockfile_and_preserves_its_env_document() {
         Some(env_lockfile),
     );
     assert!(!workspace.join("pnpm-lock.yaml").exists(), "no lockfile in the project directory");
-    assert!(!root.path().join("pnpm-lock.yaml.import.bak").exists(), "no import backup remains");
+    assert_no_import_backups(root.path());
 
     drop((root, npmrc_info));
 }
@@ -616,10 +626,7 @@ fn import_preserves_shared_lockfile_when_writing_a_branch_lockfile() {
         fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read shared lockfile"),
         shared_lockfile,
     );
-    assert!(
-        !root.path().join("pnpm-lock.feature!import.yaml.import.bak").exists(),
-        "no branch lockfile backup remains",
-    );
+    assert_no_import_backups(root.path());
 
     drop((root, npmrc_info));
 }
@@ -656,10 +663,7 @@ fn failed_import_restores_branch_lockfile() {
         fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read shared lockfile"),
         shared_lockfile,
     );
-    assert!(
-        !root.path().join("pnpm-lock.feature!import.yaml.import.bak").exists(),
-        "no branch lockfile backup remains",
-    );
+    assert_no_import_backups(root.path());
 
     drop((root, mock_instance));
 }
@@ -687,7 +691,34 @@ fn failed_import_restores_external_lockfile() {
         fs::read_to_string(root.path().join("pnpm-lock.yaml")).expect("read restored lockfile"),
         original_lockfile,
     );
-    assert!(!root.path().join("pnpm-lock.yaml.import.bak").exists(), "no import backup remains");
+    assert_no_import_backups(root.path());
+    assert!(!workspace.join("pnpm-lock.yaml").exists(), "no lockfile in the project directory");
+
+    drop((root, mock_instance));
+}
+
+#[test]
+fn failed_import_writes_no_lockfile_where_there_was_none() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    write_file(
+        &workspace,
+        "package.json",
+        r#"{"dependencies":{"@pnpm.e2e/hello-world-js-bin-parent":"99.99.99"}}"#,
+    );
+    write_file(&workspace, "package-lock.json", NPM_LOCKFILE_V1);
+    append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+
+    let output = pacquet.with_arg("import").assert().failure();
+    let stderr = String::from_utf8_lossy(&output.get_output().stderr);
+    assert!(stderr.contains("ERR_PNPM_NO_MATCHING_VERSION"), "stderr:\n{stderr}");
+    assert!(
+        !root.path().join("pnpm-lock.yaml").exists(),
+        "no lockfile in the external lockfile directory",
+    );
+    assert_no_import_backups(root.path());
     assert!(!workspace.join("pnpm-lock.yaml").exists(), "no lockfile in the project directory");
 
     drop((root, mock_instance));

--- a/pnpm/crates/cli/tests/suite/import.rs
+++ b/pnpm/crates/cli/tests/suite/import.rs
@@ -19,7 +19,6 @@ use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
 use std::{fs, path::Path};
 
-/// A finished import leaves no backup behind, whatever it named one.
 fn assert_no_import_backups(lockfile_dir: &Path) {
     let leftovers: Vec<_> = fs::read_dir(lockfile_dir)
         .expect("read the lockfile directory")

--- a/pnpm11/installing/commands/src/import/index.ts
+++ b/pnpm11/installing/commands/src/import/index.ts
@@ -7,6 +7,7 @@ import { WANTED_LOCKFILE } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
 import gfs from '@pnpm/fs.graceful-fs'
 import { install, type InstallOptions } from '@pnpm/installing.deps-installer'
+import { readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { logger } from '@pnpm/logger'
 import {
   createStoreController,
@@ -117,9 +118,14 @@ export async function handler (
   opts: ImportCommandOptions,
   params: string[]
 ): Promise<void> {
+  const lockfileDir = opts.lockfileDir ?? opts.dir
+  const envLockfile = await readEnvLockfile(lockfileDir)
   // Removing existing pnpm lockfile
   // it should not influence the new one
-  await rimraf(path.join(opts.dir, WANTED_LOCKFILE))
+  await rimraf(path.join(lockfileDir, WANTED_LOCKFILE))
+  if (envLockfile) {
+    await writeEnvLockfile(lockfileDir, envLockfile)
+  }
   const versionsByPackageNames = {}
   let preferredVersions = {}
   if (fs.existsSync(path.join(opts.dir, 'yarn.lock'))) {

--- a/pnpm11/installing/commands/src/import/index.ts
+++ b/pnpm11/installing/commands/src/import/index.ts
@@ -1,14 +1,17 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
 import { docsUrl } from '@pnpm/cli.utils'
 import type { Config, ConfigContext } from '@pnpm/config.reader'
-import { WANTED_LOCKFILE } from '@pnpm/constants'
+import { LOCKFILE_VERSION, WANTED_LOCKFILE } from '@pnpm/constants'
 import { PnpmError } from '@pnpm/error'
 import gfs from '@pnpm/fs.graceful-fs'
 import { install, type InstallOptions } from '@pnpm/installing.deps-installer'
-import { readEnvLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
+import { getWantedLockfileName, readEnvLockfile, writeEnvLockfile, writeWantedLockfile } from '@pnpm/lockfile.fs'
 import { logger } from '@pnpm/logger'
+import type { PreferredVersions } from '@pnpm/resolving.resolver-base'
 import {
   createStoreController,
   type CreateStoreControllerOptions,
@@ -19,7 +22,6 @@ import { findWorkspaceProjects } from '@pnpm/workspace.projects-reader'
 import { sequenceGraph } from '@pnpm/workspace.projects-sorter'
 import * as structUtils from '@yarnpkg/core/structUtils'
 import { type LockFileObject, parse as parseYarnLockfile } from '@yarnpkg/lockfile'
-import { rimraf } from '@zkochan/rimraf'
 import yaml from 'js-yaml'
 import { loadJsonFile } from 'load-json-file'
 import { map as mapValues } from 'ramda'
@@ -118,16 +120,7 @@ export async function handler (
   opts: ImportCommandOptions,
   params: string[]
 ): Promise<void> {
-  const lockfileDir = opts.lockfileDir ?? opts.dir
-  const envLockfile = await readEnvLockfile(lockfileDir)
-  // Removing existing pnpm lockfile
-  // it should not influence the new one
-  await rimraf(path.join(lockfileDir, WANTED_LOCKFILE))
-  if (envLockfile) {
-    await writeEnvLockfile(lockfileDir, envLockfile)
-  }
   const versionsByPackageNames = {}
-  let preferredVersions = {}
   if (fs.existsSync(path.join(opts.dir, 'yarn.lock'))) {
     const yarnPackageLockFile = await readYarnLockFile(opts.dir)
     getAllVersionsFromYarnLockFile(yarnPackageLockFile, versionsByPackageNames)
@@ -144,8 +137,47 @@ export async function handler (
   } else {
     throw new PnpmError('LOCKFILE_NOT_FOUND', 'No lockfile found')
   }
-  preferredVersions = getPreferredVersions(versionsByPackageNames)
+  const preferredVersions = getPreferredVersions(versionsByPackageNames)
+  const lockfileDir = opts.lockfileDir ?? opts.dir
+  const lockfileName = await getWantedLockfileName(opts)
+  const lockfilePath = path.join(lockfileDir, lockfileName)
+  const envLockfile = lockfileName === WANTED_LOCKFILE ? await readEnvLockfile(lockfileDir) : undefined
+  const backupPath = `${lockfilePath}.${randomUUID()}.import.bak`
+  let lockfileExisted = true
+  // The existing pnpm lockfile must not influence the imported versions.
+  try {
+    await fs.promises.rename(lockfilePath, backupPath)
+  } catch (err: unknown) {
+    if (!util.types.isNativeError(err) || !('code' in err) || err.code !== 'ENOENT') throw err
+    lockfileExisted = false
+  }
+  try {
+    if (lockfileName !== WANTED_LOCKFILE) {
+      // An absent branch lockfile would fall back to the shared lockfile.
+      await fs.promises.mkdir(lockfileDir, { recursive: true })
+      await writeWantedLockfile(lockfileDir, { lockfileVersion: LOCKFILE_VERSION, importers: {} }, { lockfileName })
+    }
+    if (envLockfile) {
+      await writeEnvLockfile(lockfileDir, envLockfile)
+    }
+    await installImportedLockfile(opts, params, preferredVersions)
+  } catch (err: unknown) {
+    await fs.promises.rm(lockfilePath, { force: true })
+    if (lockfileExisted) {
+      await fs.promises.rename(backupPath, lockfilePath)
+    }
+    throw err
+  }
+  if (lockfileExisted) {
+    await fs.promises.unlink(backupPath)
+  }
+}
 
+async function installImportedLockfile (
+  opts: ImportCommandOptions,
+  params: string[],
+  preferredVersions: PreferredVersions
+): Promise<void> {
   // For a workspace with shared lockfile
   if (opts.workspaceDir) {
     const allProjects = opts.allProjects ?? await findWorkspaceProjects(opts.workspaceDir, {
@@ -272,9 +304,9 @@ async function readNpmLockfile (dir: string): Promise<LockedPackage> {
   throw new PnpmError('NPM_LOCKFILE_NOT_FOUND', 'No package-lock.json or npm-shrinkwrap.json found')
 }
 
-function getPreferredVersions (versionsByPackageNames: VersionsByPackageNames): Record<string, Record<string, string>> {
+function getPreferredVersions (versionsByPackageNames: VersionsByPackageNames): PreferredVersions {
   const preferredVersions = mapValues(
-    (versions) => Object.fromEntries(Array.from(versions).map((version) => [version, 'version'])),
+    (versions) => Object.fromEntries(Array.from(versions).map((version) => [version, 'version' as const])),
     versionsByPackageNames
   )
   return preferredVersions

--- a/pnpm11/installing/commands/src/import/index.ts
+++ b/pnpm11/installing/commands/src/import/index.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
@@ -147,7 +148,8 @@ export async function handler (
   const lockfilePath = path.join(lockfileDir, lockfileName)
   // The env document leads pnpm-lock.yaml, so a branch import has none to carry over.
   const envLockfile = lockfileName === WANTED_LOCKFILE ? await readEnvLockfile(lockfileDir) : undefined
-  const backupPath = `${lockfilePath}.import.bak`
+  // A backup of its own keeps overlapping imports from restoring each other's copy.
+  const backupPath = `${lockfilePath}.${randomUUID()}.import.bak`
   let lockfileExisted = true
   // The existing pnpm lockfile must not influence the imported versions.
   try {

--- a/pnpm11/installing/commands/src/import/index.ts
+++ b/pnpm11/installing/commands/src/import/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto'
 import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
@@ -139,10 +138,16 @@ export async function handler (
   }
   const preferredVersions = getPreferredVersions(versionsByPackageNames)
   const lockfileDir = opts.lockfileDir ?? opts.dir
-  const lockfileName = await getWantedLockfileName(opts)
+  // Resolved the way the installer resolves it, so the backed up file and the
+  // file the import writes back are the same one.
+  const lockfileName = await getWantedLockfileName({
+    useGitBranchLockfile: opts.useGitBranchLockfile,
+    mergeGitBranchLockfiles: opts.mergeGitBranchLockfiles,
+  })
   const lockfilePath = path.join(lockfileDir, lockfileName)
+  // The env document leads pnpm-lock.yaml, so a branch import has none to carry over.
   const envLockfile = lockfileName === WANTED_LOCKFILE ? await readEnvLockfile(lockfileDir) : undefined
-  const backupPath = `${lockfilePath}.${randomUUID()}.import.bak`
+  const backupPath = `${lockfilePath}.import.bak`
   let lockfileExisted = true
   // The existing pnpm lockfile must not influence the imported versions.
   try {

--- a/pnpm11/installing/commands/test/import.ts
+++ b/pnpm11/installing/commands/test/import.ts
@@ -111,6 +111,80 @@ test('import preserves the env document in an external lockfile', async () => {
   expect(await readEnvLockfile(lockfileDir)).toEqual(envLockfile)
 })
 
+test.each(['missing', 'malformed', 'unresolvable'])('failed import preserves the external lockfile with %s input', async (input) => {
+  f.prepare('has-package-lock-json')
+  const dir = process.cwd()
+  const lockfileDir = path.join(dir, 'lockfile')
+  await fs.mkdir(lockfileDir)
+  const lockfilePath = path.join(lockfileDir, 'pnpm-lock.yaml')
+  await fs.writeFile(lockfilePath, "lockfileVersion: '9.0'\nimporters: {}\n")
+  const envLockfile = createEnvLockfile()
+  envLockfile.importers['.'].configDependencies['@pnpm.e2e/foo'] = { specifier: '1.0.0', version: '1.0.0' }
+  await writeEnvLockfile(lockfileDir, envLockfile)
+  const originalLockfile = await fs.readFile(lockfilePath, 'utf8')
+  if (input === 'missing') {
+    await fs.unlink(path.join(dir, 'package-lock.json'))
+  } else if (input === 'malformed') {
+    await fs.writeFile(path.join(dir, 'package-lock.json'), '{')
+  } else {
+    await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify({
+      dependencies: { '@pnpm.e2e/hello-world-js-bin-parent': '99.99.99' },
+    }))
+  }
+
+  await expect(importCommand.handler({ ...DEFAULT_OPTS, dir, lockfileDir }, [])).rejects.toThrow()
+
+  expect(await fs.readFile(lockfilePath, 'utf8')).toBe(originalLockfile)
+  expect(await fs.readdir(lockfileDir)).toEqual(['pnpm-lock.yaml'])
+})
+
+test.each([
+  { failure: false, existingBranch: true },
+  { failure: true, existingBranch: true },
+  { failure: true, existingBranch: false },
+])('import preserves the shared lockfile with branch lockfiles ($failure, $existingBranch)', async ({ failure, existingBranch }) => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  f.prepare('has-package-lock-json')
+  const dir = process.cwd()
+  const lockfileDir = path.join(dir, 'lockfile')
+  await fs.mkdir(lockfileDir)
+  await fs.mkdir(path.join(dir, '.git'))
+  await fs.writeFile(path.join(dir, '.git/HEAD'), 'ref: refs/heads/feature/import\n')
+  const sharedLockfilePath = path.join(lockfileDir, 'pnpm-lock.yaml')
+  await fs.writeFile(sharedLockfilePath, "lockfileVersion: '9.0'\nimporters: {}\n")
+  const envLockfile = createEnvLockfile()
+  envLockfile.importers['.'].configDependencies['@pnpm.e2e/foo'] = { specifier: '1.0.0', version: '1.0.0' }
+  await writeEnvLockfile(lockfileDir, envLockfile)
+  const sharedLockfile = await fs.readFile(sharedLockfilePath, 'utf8')
+  const branchLockfilePath = path.join(lockfileDir, 'pnpm-lock.feature!import.yaml')
+  const branchLockfile = '# existing branch lockfile\n'
+  if (existingBranch) {
+    await fs.writeFile(branchLockfilePath, branchLockfile)
+  }
+  if (failure) {
+    await fs.writeFile(path.join(dir, 'package.json'), JSON.stringify({
+      dependencies: { '@pnpm.e2e/hello-world-js-bin-parent': '99.99.99' },
+    }))
+  }
+
+  const result = importCommand.handler({ ...DEFAULT_OPTS, dir, lockfileDir, useGitBranchLockfile: true }, [])
+  if (failure) {
+    await expect(result).rejects.toThrow()
+    if (existingBranch) {
+      expect(await fs.readFile(branchLockfilePath, 'utf8')).toBe(branchLockfile)
+    }
+  } else {
+    await result
+    const lockfile = await readWantedLockfile(lockfileDir, { ignoreIncompatible: false, useGitBranchLockfile: true })
+    expect(lockfile?.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+    expect(lockfile?.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  }
+  expect(await fs.readFile(sharedLockfilePath, 'utf8')).toBe(sharedLockfile)
+  expect((await fs.readdir(lockfileDir)).sort()).toEqual(existingBranch
+    ? ['pnpm-lock.feature!import.yaml', 'pnpm-lock.yaml']
+    : ['pnpm-lock.yaml'])
+})
+
 test('import from yarn.lock', async () => {
   await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
 

--- a/pnpm11/installing/commands/test/import.ts
+++ b/pnpm11/installing/commands/test/import.ts
@@ -1,10 +1,12 @@
 /// <reference path="../../../__typings__/index.d.ts" />
+import fs from 'node:fs/promises'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
 import { assertProject } from '@pnpm/assert-project'
 import { PnpmError } from '@pnpm/error'
 import { importCommand } from '@pnpm/installing.commands'
+import { createEnvLockfile, readEnvLockfile, readWantedLockfile, writeEnvLockfile } from '@pnpm/lockfile.fs'
 import { prepare } from '@pnpm/prepare'
 import { fixtures } from '@pnpm/test-fixtures'
 import { addDistTag, REGISTRY_MOCK_PORT } from '@pnpm/testing.registry-mock'
@@ -64,6 +66,49 @@ test('import from package-lock.json', async () => {
   // node_modules is not created
   project.hasNot('@pnpm.e2e/dep-of-pkg-with-1-dep')
   project.hasNot('@pnpm.e2e/pkg-with-1-dep')
+})
+
+test('import preserves the project lockfile when lockfileDir points elsewhere', async () => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  f.prepare('has-package-lock-json')
+  const dir = process.cwd()
+  const lockfileDir = path.join(dir, 'lockfile')
+  await fs.mkdir(lockfileDir)
+  const projectLockfile = '# project lockfile must stay unchanged\n'
+  await fs.writeFile(path.join(dir, 'pnpm-lock.yaml'), projectLockfile)
+
+  await importCommand.handler({
+    ...DEFAULT_OPTS,
+    dir,
+    lockfileDir,
+  }, [])
+
+  const lockfile = assertProject(lockfileDir).readLockfile()
+  expect(lockfile.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+  expect(lockfile.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(await fs.readFile(path.join(dir, 'pnpm-lock.yaml'), 'utf8')).toBe(projectLockfile)
+})
+
+test('import preserves the env document in an external lockfile', async () => {
+  await addDistTag({ package: '@pnpm.e2e/dep-of-pkg-with-1-dep', version: '100.1.0', distTag: 'latest' })
+  f.prepare('has-package-lock-json')
+  const dir = process.cwd()
+  const lockfileDir = path.join(dir, 'lockfile')
+  await fs.mkdir(lockfileDir)
+  const envLockfile = createEnvLockfile()
+  envLockfile.importers['.'].configDependencies['@pnpm.e2e/foo'] = { specifier: '1.0.0', version: '1.0.0' }
+  await writeEnvLockfile(lockfileDir, envLockfile)
+
+  await importCommand.handler({
+    ...DEFAULT_OPTS,
+    dir,
+    lockfileDir,
+  }, [])
+
+  const lockfile = await readWantedLockfile(lockfileDir, { ignoreIncompatible: false })
+  expect(lockfile?.packages).toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.0.0'])
+  expect(lockfile?.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
+  expect(await readEnvLockfile(lockfileDir)).toEqual(envLockfile)
 })
 
 test('import from yarn.lock', async () => {

--- a/pnpm11/installing/commands/test/import.ts
+++ b/pnpm11/installing/commands/test/import.ts
@@ -140,6 +140,7 @@ test.each(['missing', 'malformed', 'unresolvable'])('failed import preserves the
 
 test.each([
   { failure: false, existingBranch: true },
+  { failure: false, existingBranch: false },
   { failure: true, existingBranch: true },
   { failure: true, existingBranch: false },
 ])('import preserves the shared lockfile with branch lockfiles ($failure, $existingBranch)', async ({ failure, existingBranch }) => {
@@ -195,7 +196,7 @@ test.each([
     expect(lockfile?.packages).not.toHaveProperty(['@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0'])
   }
   expect(await fs.readFile(sharedLockfilePath, 'utf8')).toBe(sharedLockfile)
-  expect((await fs.readdir(lockfileDir)).sort()).toEqual(existingBranch
+  expect((await fs.readdir(lockfileDir)).sort()).toEqual(existingBranch || !failure
     ? ['pnpm-lock.feature!import.yaml', 'pnpm-lock.yaml']
     : ['pnpm-lock.yaml'])
 })

--- a/pnpm11/installing/commands/test/import.ts
+++ b/pnpm11/installing/commands/test/import.ts
@@ -148,14 +148,29 @@ test.each([
   const dir = process.cwd()
   const lockfileDir = path.join(dir, 'lockfile')
   await fs.mkdir(lockfileDir)
+  const npmLockfilePath = path.join(dir, 'package-lock.json')
+  const npmLockfile = await fs.readFile(npmLockfilePath, 'utf8')
+  // The shared lockfile resolves the transitive dependency to a version the
+  // package-lock.json does not, so a branch import reading it gets caught.
+  await fs.writeFile(npmLockfilePath, JSON.stringify({
+    lockfileVersion: 1,
+    dependencies: {
+      '@pnpm.e2e/pkg-with-1-dep': {
+        version: '100.0.0',
+        dependencies: { '@pnpm.e2e/dep-of-pkg-with-1-dep': { version: '100.1.0' } },
+      },
+    },
+  }))
+  await importCommand.handler({ ...DEFAULT_OPTS, dir, lockfileDir }, [])
+  await fs.writeFile(npmLockfilePath, npmLockfile)
   await fs.mkdir(path.join(dir, '.git'))
   await fs.writeFile(path.join(dir, '.git/HEAD'), 'ref: refs/heads/feature/import\n')
   const sharedLockfilePath = path.join(lockfileDir, 'pnpm-lock.yaml')
-  await fs.writeFile(sharedLockfilePath, "lockfileVersion: '9.0'\nimporters: {}\n")
   const envLockfile = createEnvLockfile()
   envLockfile.importers['.'].configDependencies['@pnpm.e2e/foo'] = { specifier: '1.0.0', version: '1.0.0' }
   await writeEnvLockfile(lockfileDir, envLockfile)
   const sharedLockfile = await fs.readFile(sharedLockfilePath, 'utf8')
+  expect(sharedLockfile).toContain('@pnpm.e2e/dep-of-pkg-with-1-dep@100.1.0')
   const branchLockfilePath = path.join(lockfileDir, 'pnpm-lock.feature!import.yaml')
   const branchLockfile = '# existing branch lockfile\n'
   if (existingBranch) {


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Fixes pnpm/pnpm#14563.

`pnpm import` already writes to `lockfileDir`, but its cleanup targets the project-local lockfile. This can delete a file that is not the import destination.

- Apply `lockfileDir` to import cleanup in both the Rust v12 CLI and the TypeScript v11 CLI. Keep reading the foreign lockfile from the project directory.
- Preserve the env document in the destination lockfile. Parse the foreign lockfile before changing the destination, and restore the destination if an import fails.
- Use the configured branch-lockfile name in both versions. Leave the shared lockfile and its env document unchanged when importing into a branch lockfile.
- Add separate regression tests for project-local file preservation, external env document preservation, failed-import recovery, and branch lockfiles. Existing tests are unchanged.

Validation:

- The new project-local file test failed on unmodified `main` in both versions with `ENOENT`.
- The env document tests caught data loss when only the cleanup path was changed.
- Review regressions reproduced v11 destination data loss and Rust shared-lockfile deletion before the fixes.
- Rust import suite: 15 passed.
- TypeScript import suites: 17 passed.
- `just ready`: 10,026 Rust tests passed, plus formatting, type checking, spelling, and Clippy.
- Pre-push checks passed, including the TypeScript build and lint, rustdoc, and Dylint.

The first full run stopped because a global-update test's child process was interrupted with no stderr. That test passed in isolation and in the full rerun without code or test-setting changes.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Import writes its output to the configured lockfile directory, but cleanup
still removed the lockfile beside the project manifest. Use lockfileDir for
cleanup in both CLI versions while keeping foreign-lockfile reads in the
project directory.

Preserve the destination's env document when replacing its dependency graph.
Parse the foreign lockfile before changing the destination. Back up the
destination and restore it on failure in both versions.

Use the configured wanted-lockfile name for backup, replacement, and recovery.
Branch imports must not change the shared lockfile. In v11, seed an empty
branch lockfile to prevent the reader from falling back to the shared graph.

Add new regression tests for preserving the project-local lockfile and the
external env document, failed-import recovery, and branch lockfiles in both
versions.

Closes pnpm/pnpm#14563.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791162307&installation_model_id=426870&pr_number=14564&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14564&signature=03815e70a6a98f3863b9168de5e7dc58a9039dbdc74e3bda7fe48ce87ebfcd96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm import` so lockfiles are written to the configured external directory while existing project lockfiles remain unchanged.
  * Preserved configuration details in existing external lockfiles during imports.
  * Improved recovery after failed imports by restoring destination lockfiles, removing temporary backups, and avoiding creation of lockfiles when none existed.
  * Preserved shared lockfiles when importing with branch-specific lockfiles, writing changes to the appropriate branch lockfile instead.

* **Tests**
  * Added coverage for external directories, branch lockfiles, preservation behavior, and failed-import recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
