### PR TITLE
refactor(cli): decouple ecosystem install coordination

### DIFF
--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,3 +1,4 @@
+use crate::ecosystem_install::InstallContext;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::Config;
@@ -38,6 +39,12 @@ pub(crate) enum CargoLockfilePolicy {
     Resolve,
 }
 
+pub(crate) struct CargoInstallOptions<'a> {
+    pub(crate) root_dir: &'a Path,
+    pub(crate) discover_projects: bool,
+    pub(crate) lockfile_policy: CargoLockfilePolicy,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LockedCrate {
     name: String,
@@ -65,14 +72,11 @@ struct ManagedDirectory {
 }
 
 pub async fn install<Reporter: self::Reporter + 'static>(
-    config: &'static Config,
-    root_dir: &Path,
-    discover_projects: bool,
-    lockfile_only: bool,
-    frozen_lockfile: bool,
-    lockfile_policy: CargoLockfilePolicy,
-    http_client: Arc<ThrottledClient>,
+    context: InstallContext,
+    options: CargoInstallOptions<'_>,
 ) -> Result<()> {
+    let InstallContext { config, http_client, lockfile_only, frozen_lockfile } = context;
+    let CargoInstallOptions { root_dir, discover_projects, lockfile_policy } = options;
     if !config.cargo.enabled {
         return Ok(());
     }

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -427,6 +427,18 @@ impl InstallPipeline {
         let http_client = State::new_http_client(cfg).wrap_err("initialize the install network")?;
         let cfg: &'static Config = cfg;
         let lockfile_only = args.lockfile_only;
+        if !ecosystem_install::is_enabled(cfg) {
+            return run_node_install::<Reporter>(
+                plan,
+                args,
+                cfg,
+                manifest_path,
+                require_lockfile,
+                lockfile,
+                http_client,
+            )
+            .await;
+        }
         let node_install = run_node_install::<Reporter>(
             plan,
             args,
@@ -436,17 +448,23 @@ impl InstallPipeline {
             lockfile,
             Arc::clone(&http_client),
         );
-        ecosystem_install::EcosystemInstallCoordinator {
-            config: cfg,
-            root_dir: &config_root,
-            discover_cargo_projects: true,
-            http_client,
-            lockfile_only,
-            frozen_lockfile,
-            cargo_lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::UseExisting,
-        }
-        .run::<Reporter, _>(node_install)
-        .await
+        let cargo_install = crate::cargo_deps::install::<Reporter>(
+            ecosystem_install::InstallContext {
+                config: cfg,
+                http_client,
+                lockfile_only,
+                frozen_lockfile,
+            },
+            crate::cargo_deps::CargoInstallOptions {
+                root_dir: &config_root,
+                discover_projects: true,
+                lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::UseExisting,
+            },
+        );
+        ecosystem_install::EcosystemInstallCoordinator::new(node_install)
+            .with_install(cargo_install)
+            .run()
+            .await
     }
 }
 
@@ -682,17 +700,23 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
         let state = init_shared_state(manifest_path, cfg, false, None, node_http_client)?;
         Box::pin(node_args.run::<Reporter>(state, None)).await
     };
-    ecosystem_install::EcosystemInstallCoordinator {
-        config: cfg,
-        root_dir: &cargo_root,
-        discover_cargo_projects: false,
-        http_client,
-        lockfile_only,
-        frozen_lockfile: false,
-        cargo_lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
-    }
-    .run::<Reporter, _>(node_install)
-    .await
+    let cargo_install = crate::cargo_deps::install::<Reporter>(
+        ecosystem_install::InstallContext {
+            config: cfg,
+            http_client,
+            lockfile_only,
+            frozen_lockfile: false,
+        },
+        crate::cargo_deps::CargoInstallOptions {
+            root_dir: &cargo_root,
+            discover_projects: false,
+            lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
+        },
+    );
+    ecosystem_install::EcosystemInstallCoordinator::new(node_install)
+        .with_install(cargo_install)
+        .run()
+        .await
 }
 
 pub(crate) struct UpdatePipeline {

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -9,7 +9,6 @@ pub(crate) fn is_enabled(config: &Config) -> bool {
     config.cargo.enabled
 }
 
-/// Resources and command policy shared by every ecosystem in one install.
 pub(crate) struct InstallContext {
     pub(crate) config: &'static Config,
     pub(crate) http_client: Arc<ThrottledClient>,
@@ -38,7 +37,6 @@ impl<'a> EcosystemInstallCoordinator<'a> {
         self
     }
 
-    /// Install every configured ecosystem under the shared resource budgets.
     pub(crate) async fn run(self) -> miette::Result<()> {
         futures_util::future::try_join_all(self.installers).await?;
         Ok(())

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -1,7 +1,6 @@
-use crate::cargo_deps::{self, CargoLockfilePolicy};
 use pnpm_config::Config;
 use pnpm_network::ThrottledClient;
-use std::{future::Future, path::Path, pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 type Installer<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
 
@@ -10,43 +9,40 @@ pub(crate) fn is_enabled(config: &Config) -> bool {
     config.cargo.enabled
 }
 
-/// Coordinates dependency installation across every configured ecosystem.
-pub(crate) struct EcosystemInstallCoordinator<'a> {
+/// Resources and command policy shared by every ecosystem in one install.
+pub(crate) struct InstallContext {
     pub(crate) config: &'static Config,
-    pub(crate) root_dir: &'a Path,
-    pub(crate) discover_cargo_projects: bool,
     pub(crate) http_client: Arc<ThrottledClient>,
     pub(crate) lockfile_only: bool,
     pub(crate) frozen_lockfile: bool,
-    pub(crate) cargo_lockfile_policy: CargoLockfilePolicy,
+}
+
+/// Coordinates dependency installation across every configured ecosystem.
+pub(crate) struct EcosystemInstallCoordinator<'a> {
+    installers: Vec<Installer<'a>>,
 }
 
 impl<'a> EcosystemInstallCoordinator<'a> {
-    /// Install every configured ecosystem under the shared network budget.
-    pub(crate) async fn run<Reporter, NodeInstall>(
-        self,
-        node_install: NodeInstall,
-    ) -> miette::Result<()>
+    pub(crate) fn new<Install>(install: Install) -> Self
     where
-        Reporter: pnpm_reporter::Reporter + 'static,
-        NodeInstall: Future<Output = miette::Result<()>> + Send + 'a,
+        Install: Future<Output = miette::Result<()>> + Send + 'a,
     {
-        let cargo_install = cargo_deps::install::<Reporter>(
-            self.config,
-            self.root_dir,
-            self.discover_cargo_projects,
-            self.lockfile_only,
-            self.frozen_lockfile,
-            self.cargo_lockfile_policy,
-            Arc::clone(&self.http_client),
-        );
-        run_installers(vec![Box::pin(node_install), Box::pin(cargo_install)]).await
+        Self { installers: vec![Box::pin(install)] }
     }
-}
 
-async fn run_installers(installers: Vec<Installer<'_>>) -> miette::Result<()> {
-    futures_util::future::try_join_all(installers).await?;
-    Ok(())
+    pub(crate) fn with_install<Install>(mut self, install: Install) -> Self
+    where
+        Install: Future<Output = miette::Result<()>> + Send + 'a,
+    {
+        self.installers.push(Box::pin(install));
+        self
+    }
+
+    /// Install every configured ecosystem under the shared resource budgets.
+    pub(crate) async fn run(self) -> miette::Result<()> {
+        futures_util::future::try_join_all(self.installers).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/ecosystem_install/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/tests.rs
@@ -1,4 +1,4 @@
-use super::run_installers;
+use super::EcosystemInstallCoordinator;
 use std::{
     future::poll_fn,
     sync::{
@@ -27,11 +27,10 @@ async fn polls_ecosystem_installers_concurrently() {
 
     tokio::time::timeout(
         Duration::from_secs(1),
-        run_installers(vec![
-            Box::pin(installer(0b001)),
-            Box::pin(installer(0b010)),
-            Box::pin(installer(0b100)),
-        ]),
+        EcosystemInstallCoordinator::new(installer(0b001))
+            .with_install(installer(0b010))
+            .with_install(installer(0b100))
+            .run(),
     )
     .await
     .expect("every installer must start without waiting for another to finish")


### PR DESCRIPTION
## Summary

Related to #14566 and pnpm/rfcs#34.

Decouple multi-ecosystem install coordination from the Cargo implementation:

- make `EcosystemInstallCoordinator` coordinate externally constructed install futures instead of owning Cargo-specific inputs
- split shared install state into `InstallContext` and Cargo-only state into `CargoInstallOptions`
- keep the npm-only install path direct when Cargo support is disabled, avoiding coordinator allocation and dispatch overhead
- preserve concurrent npm and Cargo installs when Cargo support is enabled

This is an internal-only refactor. It does not change published behavior, so no changeset is needed.

Validation:

- `just ready`: 10,011 tests passed, 5 skipped; formatting, checks, and Clippy passed
- full pre-push gate, including rustdoc and dylint, passed
- integrated npm-only benchmark, `isolated-linker.fresh-restore.cold-cache.cold-store`, compared with merge commit `5a18bfc6609ec860138ad431cd6d560ef6359aad`
  - run 1: HEAD 1.458s, baseline 1.426s (`1.02 ± 0.05x` baseline advantage)
  - run 2: HEAD 1.401s, baseline 1.457s (`1.04 ± 0.06x` HEAD advantage)
  - the reversal and overlapping ranges show no reproducible regression

## Squash Commit Body

```text
Separate ecosystem-neutral install coordination from Cargo-specific setup.

The coordinator now accepts install futures constructed by each ecosystem integration, while InstallContext carries only state shared across integrations and CargoInstallOptions carries Cargo-specific policy. This creates a narrow seam for future ecosystems without prematurely imposing a universal resolver or lockfile abstraction.

Keep Cargo-disabled npm installs on the existing direct path so the abstraction adds no allocation, discovery, or dispatch work to the common case. Cargo-enabled mixed workspaces continue to resolve and fetch npm and Cargo dependencies concurrently.

Related to #14566 and pnpm/rfcs#34.
```

## Checklist

- [x] Added or updated tests.
- [x] Updated the architecture documentation in pnpm/rfcs#34.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14565"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791162998&installation_model_id=426870&pr_number=14565&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14565&signature=4d266cc824f7ab469d4351b4c91d97d0ce0e2341aa5535dd8eeeae2bcb068674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation flow when Cargo installation is disabled by skipping unnecessary processing.
  * Installers now run concurrently, improving efficiency for projects using multiple ecosystems.

* **Refactor**
  * Streamlined installation configuration and coordination across installation workflows.
  * Improved consistency when installing dependencies across supported ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
