### PR TITLE
fix(deps-restorer): adopt a slot file that clonefile misreports as missing

### DIFF
--- a/.changeset/gvs-concurrent-import-not-found.md
+++ b/.changeset/gvs-concurrent-import-not-found.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed concurrent installs that share a global virtual store on macOS failing with "failed to import ... No such file or directory" while another install was populating the same package [#14560](https://github.com/pnpm/pnpm/issues/14560).

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -217,17 +217,10 @@ pub fn link_file<Reporter: self::Reporter>(
 /// runs against a directory it just created — that protection is
 /// unneeded.
 ///
-/// EEXIST from the import syscall means a concurrent install (or a
-/// sibling rayon worker writing the same CAFS path) raced past the
-/// freshness guarantee. The content is content-addressed so the
-/// existing dirent is equivalent — but a reflink the winner used
-/// drops the exec bit, so we re-assert it from the `-exec` suffix
-/// instead of adopting a possibly-`0o644` binary. That re-assertion
-/// also heals a target an earlier failed restore left non-executable,
-/// which is why the clone tier no longer deletes on restore failure.
-/// A `NotFound` whose target dirent turns out to exist is the same
-/// race reported under the wrong code; see
-/// `recover_from_concurrent_import`.
+/// A concurrent install (or a sibling rayon worker writing the same
+/// CAFS path) can race past the freshness guarantee;
+/// `recover_from_concurrent_import` decides which import failures mean
+/// that and adopts the file it placed.
 pub fn import_into_fresh_target<Reporter: self::Reporter>(
     logged: &AtomicU8,
     method: PackageImportMethod,
@@ -252,14 +245,17 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
 /// returns here without touching disk, but pnpm's clone preserves the
 /// mode and pacquet's reflink does not — so re-assert the exec bit from
 /// the `-exec` suffix (idempotent, a no-op for non-exec entries) before
-/// adopting the dirent.
+/// adopting the dirent. That re-assertion also heals a target an earlier
+/// failed restore left non-executable, which is why the clone tier no
+/// longer deletes on restore failure.
 ///
-/// `NotFound` is the same race when the target dirent exists: APFS
-/// `clonefile` intermittently reports a destination that another process
-/// renamed into place moments earlier as missing instead of existing
-/// (pnpm/pnpm#14560). The source check keeps a store blob that really is
-/// gone an error, and a target that is absent too means the parent
-/// directory vanished, which no concurrent importer of this slot does.
+/// `NotFound` is the same race when a regular file now sits at the
+/// target: APFS `clonefile` intermittently reports a destination that
+/// another process renamed into place moments earlier as missing instead
+/// of existing (pnpm/pnpm#14560). Both checks follow symlinks, so a
+/// dangling link squatting at either path is not mistaken for the race:
+/// a store blob that really is gone stays an error, and so does a target
+/// the copy tier could not open through.
 ///
 /// Every other error is the caller's to surface.
 fn recover_from_concurrent_import(
@@ -275,7 +271,8 @@ fn recover_from_concurrent_import(
     let placed_concurrently = match error.kind() {
         io::ErrorKind::AlreadyExists => true,
         io::ErrorKind::NotFound => {
-            fs::symlink_metadata(target_link).is_ok() && fs::symlink_metadata(source_file).is_ok()
+            fs::metadata(target_link).is_ok_and(|meta| meta.is_file())
+                && fs::metadata(source_file).is_ok()
         }
         _ => false,
     };

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -225,6 +225,9 @@ pub fn link_file<Reporter: self::Reporter>(
 /// instead of adopting a possibly-`0o644` binary. That re-assertion
 /// also heals a target an earlier failed restore left non-executable,
 /// which is why the clone tier no longer deletes on restore failure.
+/// A `NotFound` whose target dirent turns out to exist is the same
+/// race reported under the wrong code; see
+/// `recover_from_concurrent_import`.
 pub fn import_into_fresh_target<Reporter: self::Reporter>(
     logged: &AtomicU8,
     method: PackageImportMethod,
@@ -237,52 +240,74 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
     // Current pnpm's indexed-pkg-importer does not guard against this
     // either — postinstall handling lives in the script runner, not the
     // import layer — so there's nothing to gate on here.
-    match try_import::<Reporter>(method, logged, source_file, target_link) {
-        Ok(()) => Ok(()),
-        // A concurrent writer beat us to the target; its content is
-        // content-addressed and equivalent. pnpm's `linkOrCopy` returns
-        // here without touching disk, but pnpm's clone preserves the mode
-        // and pacquet's reflink does not — so re-assert the exec bit from
-        // the `-exec` suffix (idempotent, a no-op for non-exec entries)
-        // before adopting the dirent.
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            match pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link) {
-                Ok(()) => Ok(()),
-                // Nothing serializes shared-slot imports across
-                // processes: the writer that owns the target may
-                // replace it again before this chmod lands. Whoever
-                // unlinked the path writes an equivalent
-                // content-addressed file and restores its exec bit in
-                // turn, so `NotFound` with the dirent actually gone
-                // means another writer finished the job — the same
-                // tolerance the bin-shim chmod applies
-                // (`chmod_tolerating_removal` in `pnpm-cmd-shim`,
-                // pnpm/pnpm#14353). The dirent check keeps the
-                // dangling-symlink detection this recovery is
-                // responsible for: a symlink squatting at the path
-                // also opens as `NotFound`, but its dirent is still
-                // there and no concurrent writer will heal it.
-                Err(error)
-                    if error.kind() == io::ErrorKind::NotFound
-                        && matches!(
-                            fs::symlink_metadata(target_link),
-                            Err(ref stat_error) if stat_error.kind() == io::ErrorKind::NotFound,
-                        ) =>
-                {
-                    Ok(())
-                }
-                Err(error) => Err(LinkFileError::Import {
-                    from: source_file.to_path_buf(),
-                    to: target_link.to_path_buf(),
-                    error,
-                }),
-            }
+    try_import::<Reporter>(method, logged, source_file, target_link)
+        .or_else(|error| recover_from_concurrent_import(error, source_file, target_link))
+}
+
+/// Resolve an import syscall failure against a target the caller
+/// believed fresh.
+///
+/// `AlreadyExists` means a concurrent writer beat us to the target; its
+/// content is content-addressed and equivalent. pnpm's `linkOrCopy`
+/// returns here without touching disk, but pnpm's clone preserves the
+/// mode and pacquet's reflink does not — so re-assert the exec bit from
+/// the `-exec` suffix (idempotent, a no-op for non-exec entries) before
+/// adopting the dirent.
+///
+/// `NotFound` is the same race when the target dirent exists: APFS
+/// `clonefile` intermittently reports a destination that another process
+/// renamed into place moments earlier as missing instead of existing
+/// (pnpm/pnpm#14560). The source check keeps a store blob that really is
+/// gone an error, and a target that is absent too means the parent
+/// directory vanished, which no concurrent importer of this slot does.
+///
+/// Every other error is the caller's to surface.
+fn recover_from_concurrent_import(
+    error: io::Error,
+    source_file: &Path,
+    target_link: &Path,
+) -> Result<(), LinkFileError> {
+    let import_error = |error| LinkFileError::Import {
+        from: source_file.to_path_buf(),
+        to: target_link.to_path_buf(),
+        error,
+    };
+    let placed_concurrently = match error.kind() {
+        io::ErrorKind::AlreadyExists => true,
+        io::ErrorKind::NotFound => {
+            fs::symlink_metadata(target_link).is_ok() && fs::symlink_metadata(source_file).is_ok()
         }
-        Err(error) => Err(LinkFileError::Import {
-            from: source_file.to_path_buf(),
-            to: target_link.to_path_buf(),
-            error,
-        }),
+        _ => false,
+    };
+    if !placed_concurrently {
+        return Err(import_error(error));
+    }
+    match pnpm_fs::file_mode::restore_exec_bit_from_cas_suffix(source_file, target_link) {
+        Ok(()) => Ok(()),
+        // Nothing serializes shared-slot imports across
+        // processes: the writer that owns the target may
+        // replace it again before this chmod lands. Whoever
+        // unlinked the path writes an equivalent
+        // content-addressed file and restores its exec bit in
+        // turn, so `NotFound` with the dirent actually gone
+        // means another writer finished the job — the same
+        // tolerance the bin-shim chmod applies
+        // (`chmod_tolerating_removal` in `pnpm-cmd-shim`,
+        // pnpm/pnpm#14353). The dirent check keeps the
+        // dangling-symlink detection this recovery is
+        // responsible for: a symlink squatting at the path
+        // also opens as `NotFound`, but its dirent is still
+        // there and no concurrent writer will heal it.
+        Err(error)
+            if error.kind() == io::ErrorKind::NotFound
+                && matches!(
+                    fs::symlink_metadata(target_link),
+                    Err(ref stat_error) if stat_error.kind() == io::ErrorKind::NotFound,
+                ) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(import_error(error)),
     }
 }
 

--- a/pnpm/crates/deps-restorer/src/link_file.rs
+++ b/pnpm/crates/deps-restorer/src/link_file.rs
@@ -245,9 +245,9 @@ pub fn import_into_fresh_target<Reporter: self::Reporter>(
 /// returns here without touching disk, but pnpm's clone preserves the
 /// mode and pacquet's reflink does not — so re-assert the exec bit from
 /// the `-exec` suffix (idempotent, a no-op for non-exec entries) before
-/// adopting the dirent. That re-assertion also heals a target an earlier
-/// failed restore left non-executable, which is why the clone tier no
-/// longer deletes on restore failure.
+/// adopting the dirent. That re-assertion also heals a target that an
+/// earlier failed restore left non-executable; the clone tier relies on
+/// it and keeps such a target in place.
 ///
 /// `NotFound` is the same race when a regular file now sits at the
 /// target: APFS `clonefile` intermittently reports a destination that

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -166,6 +166,20 @@ fn eexist_recovery_rejects_a_dangling_symlink_target() {
     .expect_err("a dangling symlink at the target is corruption, not a concurrent writer");
 }
 
+/// The writer that owns a shared slot may replace the target again
+/// before the exec-bit re-assertion opens it; it restores the bit itself,
+/// so an EEXIST whose dirent is gone by then is finished work, not a loss.
+#[test]
+#[cfg(unix)]
+fn eexist_recovery_tolerates_a_target_its_writer_replaced() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    let dst = tmp.path().join("dst");
+
+    recover_from_concurrent_import(io::Error::from(io::ErrorKind::AlreadyExists), &src, &dst)
+        .expect("a target unlinked after EEXIST belongs to a writer that finishes it");
+}
+
 /// APFS `clonefile` can report a destination another importer renamed
 /// into place as `NotFound` (pnpm/pnpm#14560). With the dirent and the
 /// source both present that is the concurrent-writer case, and the

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     AUTO_FIRST_TIER, LINK_STATE_CLONE, LINK_STATE_HARDLINK, LinkFileError, auto_link,
     clone_or_copy_link, downgrade_auto_tier, is_call_error, is_cross_device, link_file,
-    next_auto_tier,
+    next_auto_tier, recover_from_concurrent_import,
 };
 #[cfg(unix)]
 use super::{LINK_STATE_COPY, import_into_fresh_target};
@@ -164,6 +164,77 @@ fn eexist_recovery_rejects_a_dangling_symlink_target() {
         &dst,
     )
     .expect_err("a dangling symlink at the target is corruption, not a concurrent writer");
+}
+
+/// APFS `clonefile` can report a destination another importer renamed
+/// into place as `NotFound` (pnpm/pnpm#14560). With the dirent and the
+/// source both present that is the concurrent-writer case, and the
+/// adopted target gets its exec bit re-asserted like an EEXIST one.
+#[test]
+#[cfg(unix)]
+fn spurious_not_found_with_an_existing_target_is_adopted() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9-exec", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    let dst = write_source(tmp.path(), "dst", b"#!/usr/bin/env node\n");
+    fs::set_permissions(&dst, fs::Permissions::from_mode(0o644)).unwrap();
+
+    recover_from_concurrent_import(io::Error::from(io::ErrorKind::NotFound), &src, &dst)
+        .expect("a NotFound against an existing target is a concurrent import");
+
+    let dst_mode = fs::metadata(&dst).unwrap().permissions().mode() & 0o777;
+    assert_eq!(dst_mode, 0o755, "the adopted target must be restored to 0o755");
+}
+
+/// A `NotFound` with nothing at the target is a missing parent
+/// directory or source, not a race, and must surface.
+#[test]
+fn not_found_without_a_target_propagates() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9", b"data\n");
+    let dst = tmp.path().join("dst");
+
+    let error =
+        recover_from_concurrent_import(io::Error::from(io::ErrorKind::NotFound), &src, &dst)
+            .expect_err("a NotFound with no target dirent is a real failure");
+    let LinkFileError::Import { from, to, error } = error;
+    assert_eq!((from, to), (src, dst));
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+}
+
+/// A store blob that is really gone stays an error even when something
+/// occupies the target.
+#[test]
+fn not_found_without_a_source_propagates() {
+    let tmp = tempdir().unwrap();
+    let src = tmp.path().join("missing-blob");
+    let dst = write_source(tmp.path(), "dst", b"data\n");
+
+    let error =
+        recover_from_concurrent_import(io::Error::from(io::ErrorKind::NotFound), &src, &dst)
+            .expect_err("a NotFound for a missing source is a real failure");
+    let LinkFileError::Import { error, .. } = error;
+    assert_eq!(error.kind(), io::ErrorKind::NotFound);
+}
+
+/// Only the two race codes are recovered; anything else surfaces even
+/// with both files present.
+#[test]
+fn other_import_errors_propagate() {
+    let tmp = tempdir().unwrap();
+    let src = write_source(tmp.path(), "1b59d9", b"data\n");
+    let dst = write_source(tmp.path(), "dst", b"data\n");
+
+    let error = recover_from_concurrent_import(
+        io::Error::from(io::ErrorKind::PermissionDenied),
+        &src,
+        &dst,
+    )
+    .expect_err("PermissionDenied is not a concurrent import");
+    let LinkFileError::Import { error, .. } = error;
+    assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
 }
 
 /// Hardlinking in the same directory on the same filesystem works on

--- a/pnpm/crates/deps-restorer/src/link_file/tests.rs
+++ b/pnpm/crates/deps-restorer/src/link_file/tests.rs
@@ -188,8 +188,6 @@ fn spurious_not_found_with_an_existing_target_is_adopted() {
     assert_eq!(dst_mode, 0o755, "the adopted target must be restored to 0o755");
 }
 
-/// A `NotFound` with nothing at the target is a missing parent
-/// directory or source, not a race, and must surface.
 #[test]
 fn not_found_without_a_target_propagates() {
     let tmp = tempdir().unwrap();
@@ -204,8 +202,6 @@ fn not_found_without_a_target_propagates() {
     assert_eq!(error.kind(), io::ErrorKind::NotFound);
 }
 
-/// A store blob that is really gone stays an error even when something
-/// occupies the target.
 #[test]
 fn not_found_without_a_source_propagates() {
     let tmp = tempdir().unwrap();
@@ -219,8 +215,29 @@ fn not_found_without_a_source_propagates() {
     assert_eq!(error.kind(), io::ErrorKind::NotFound);
 }
 
-/// Only the two race codes are recovered; anything else surfaces even
-/// with both files present.
+/// A dangling symlink at either path also opens as `NotFound` for the
+/// copy tier, and no concurrent importer will ever heal it.
+#[test]
+#[cfg(unix)]
+fn not_found_with_a_dangling_symlink_at_either_path_propagates() {
+    let tmp = tempdir().unwrap();
+    let dangling = |name: &str| {
+        let link = tmp.path().join(name);
+        std::os::unix::fs::symlink(tmp.path().join("missing-target"), &link).unwrap();
+        link
+    };
+    let src = write_source(tmp.path(), "1b59d9", b"data\n");
+    let dst = write_source(tmp.path(), "dst", b"data\n");
+
+    for (src, dst) in [(src, dangling("dangling-dst")), (dangling("dangling-src"), dst)] {
+        let error =
+            recover_from_concurrent_import(io::Error::from(io::ErrorKind::NotFound), &src, &dst)
+                .expect_err("a dangling symlink is corruption, not a concurrent writer");
+        let LinkFileError::Import { error, .. } = error;
+        assert_eq!(error.kind(), io::ErrorKind::NotFound);
+    }
+}
+
 #[test]
 fn other_import_errors_propagate() {
     let tmp = tempdir().unwrap();


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fixes pnpm/pnpm#14560.

The macOS Rust CI job intermittently failed `global_virtual_store::concurrent_installs_sharing_a_gvs_do_not_fail_while_linking_bins` with `failed to import <blob> to <slot>/<file>: No such file or directory`, even though nothing had deleted the source blob or the slot directory.

**Root cause.** I traced every `unlink`, `rmdir`, `rename`, `mkdir`, and `clonefile` the eight workers issue (a `DYLD_INSERT_LIBRARIES` interposer logging into one file). All four captured failures have the identical shape: a *repairing* importer had just renamed its staged copy of the file into the shared slot (`rename(LICENSE_pacquet-stage_…, LICENSE)`), and 0.1 to 3 ms later the importer that *owned* the slot called `clonefile(<blob>, <slot>/LICENSE)` on that now-existing destination and got **ENOENT instead of EEXIST**. A standalone two-process C stress program that mimics the claimer/repairer sequence reproduces the misreport on APFS (source, destination directory, and destination file all exist at the time of the failure); the same program with `link()` in place of `clonefile()` never does. So this is `clonefile` behaviour, not a pacquet race removing files.

**Fix.** `import_into_fresh_target` already treats `AlreadyExists` as "a concurrent importer placed an equivalent content-addressed file" and re-asserts the exec bit before adopting it. It now handles `NotFound` the same way when the target dirent and the source both still exist. A missing source or a missing target still surfaces as an error. The decision lives in a small `recover_from_concurrent_import` helper with unit tests for the adopt, missing-target, missing-source, and other-error cases.

**Why it never reproduced locally.** macOS serializes concurrent execs of the same binary file at roughly 300 ms each, so the eight workers never overlapped in the linking phase on a developer machine (each finished its whole install before the next one started). Giving each worker its own copy of the `pnpm` binary removed the serialization; with that, the unchanged test failed in 3 of 4 runs of 60 repetitions before this change and passed 8 of 8 runs after it. I did not bake the per-worker copies into the test because copying a 250 MB debug binary eight times per run is not acceptable, and CI already overlaps the workers on its slower runners.

**pnpm v11.** Not changed. Its `importIntoSharedDir` falls through to the in-place repair whenever the exclusive importer's write fails, so the same kernel misreport is absorbed there without surfacing.

## Squash Commit Body

```text
Concurrent installs sharing a global virtual store intermittently failed
on macOS with `failed to import <blob> to <slot>/<file>: No such file or
directory`. Tracing every unlink, rename, and clonefile of the 8-worker
concurrency suite showed the same shape in every failure: a repairing
importer had just renamed its staged copy of the file into the slot, and
the importer that owned the slot then called clonefile onto that existing
destination and got ENOENT instead of EEXIST. Nothing had removed the
source blob or the directory. A standalone two-process stress program
reproduces the misreport with clonefile and not with link, so it is APFS
behaviour rather than a pacquet race.

`import_into_fresh_target` now treats `NotFound` the same as
`AlreadyExists` when the target dirent and the source both still exist,
re-asserting the exec bit and adopting the concurrently placed file. A
missing source or a missing target keeps surfacing as an error.

pnpm v11 is not affected in the same way: its `importIntoSharedDir`
falls through to the in-place repair when the exclusive importer's write
fails, so the misreport is absorbed there.

The suite rarely overlaps its workers on a local macOS machine because
the kernel serializes concurrent execs of one binary at roughly 300 ms
each. Running each worker from its own copy of the binary made the
failure reproduce in 3 of 4 runs before this change and in 0 of 8 after.

Fixes pnpm/pnpm#14560
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5-1).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791163481&installation_model_id=426870&pr_number=14568&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14568&signature=6069362d57b1757bd7f4a9a67166794ca79ccf4b7a1e1a22fa2558151e1b46c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed concurrent package installations on macOS that could fail with a “No such file or directory” error when sharing a global virtual store.
  * Improved recovery when package files are imported simultaneously, while preserving accurate reporting for missing files, broken links, and permission errors.

* **Tests**
  * Added coverage for concurrent import recovery, executable permissions, missing files, broken links, and unrelated import failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->