### PR TITLE
fix(cli): roll back failed multi-ecosystem adds

### DIFF
--- a/.changeset/mixed-add-rollback.md
+++ b/.changeset/mixed-add-rollback.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Failed `pnpm add` operations that include crates now restore the Node.js and Cargo manifests and lockfiles instead of leaving one ecosystem partially updated.
+Failed `pnpm add` operations that include crates now restore the Node.js and Cargo manifests and lockfiles. These operations previously could leave one ecosystem partially updated.

--- a/.changeset/mixed-add-rollback.md
+++ b/.changeset/mixed-add-rollback.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Failed `pnpm add` operations that include crates now restore the Node.js and Cargo manifests and lockfiles instead of leaving one ecosystem partially updated.

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,3 +1,4 @@
+use crate::ecosystem_install::InstallContext;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::Config;
@@ -38,6 +39,12 @@ pub(crate) enum CargoLockfilePolicy {
     Resolve,
 }
 
+pub(crate) struct CargoInstallOptions<'a> {
+    pub(crate) root_dir: &'a Path,
+    pub(crate) discover_projects: bool,
+    pub(crate) lockfile_policy: CargoLockfilePolicy,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct LockedCrate {
     name: String,
@@ -65,14 +72,11 @@ struct ManagedDirectory {
 }
 
 pub async fn install<Reporter: self::Reporter + 'static>(
-    config: &'static Config,
-    root_dir: &Path,
-    discover_projects: bool,
-    lockfile_only: bool,
-    frozen_lockfile: bool,
-    lockfile_policy: CargoLockfilePolicy,
-    http_client: Arc<ThrottledClient>,
+    context: InstallContext,
+    options: CargoInstallOptions<'_>,
 ) -> Result<()> {
+    let InstallContext { config, http_client, lockfile_only, frozen_lockfile } = context;
+    let CargoInstallOptions { root_dir, discover_projects, lockfile_policy } = options;
     if !config.cargo.enabled {
         return Ok(());
     }

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -427,6 +427,18 @@ impl InstallPipeline {
         let http_client = State::new_http_client(cfg).wrap_err("initialize the install network")?;
         let cfg: &'static Config = cfg;
         let lockfile_only = args.lockfile_only;
+        if !ecosystem_install::is_enabled(cfg) {
+            return run_node_install::<Reporter>(
+                plan,
+                args,
+                cfg,
+                manifest_path,
+                require_lockfile,
+                lockfile,
+                http_client,
+            )
+            .await;
+        }
         let node_install = run_node_install::<Reporter>(
             plan,
             args,
@@ -436,17 +448,23 @@ impl InstallPipeline {
             lockfile,
             Arc::clone(&http_client),
         );
-        ecosystem_install::EcosystemInstallCoordinator {
-            config: cfg,
-            root_dir: &config_root,
-            discover_cargo_projects: true,
-            http_client,
-            lockfile_only,
-            frozen_lockfile,
-            cargo_lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::UseExisting,
-        }
-        .run::<Reporter, _>(node_install)
-        .await
+        let cargo_install = crate::cargo_deps::install::<Reporter>(
+            ecosystem_install::InstallContext {
+                config: cfg,
+                http_client,
+                lockfile_only,
+                frozen_lockfile,
+            },
+            crate::cargo_deps::CargoInstallOptions {
+                root_dir: &config_root,
+                discover_projects: true,
+                lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::UseExisting,
+            },
+        );
+        ecosystem_install::EcosystemInstallCoordinator::new(node_install)
+            .with_install(cargo_install)
+            .run()
+            .await
     }
 }
 
@@ -682,17 +700,23 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
         let state = init_shared_state(manifest_path, cfg, false, None, node_http_client)?;
         Box::pin(node_args.run::<Reporter>(state, None)).await
     };
-    ecosystem_install::EcosystemInstallCoordinator {
-        config: cfg,
-        root_dir: &cargo_root,
-        discover_cargo_projects: false,
-        http_client,
-        lockfile_only,
-        frozen_lockfile: false,
-        cargo_lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
-    }
-    .run::<Reporter, _>(node_install)
-    .await
+    let cargo_install = crate::cargo_deps::install::<Reporter>(
+        ecosystem_install::InstallContext {
+            config: cfg,
+            http_client,
+            lockfile_only,
+            frozen_lockfile: false,
+        },
+        crate::cargo_deps::CargoInstallOptions {
+            root_dir: &cargo_root,
+            discover_projects: false,
+            lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
+        },
+    );
+    ecosystem_install::EcosystemInstallCoordinator::new(node_install)
+        .with_install(cargo_install)
+        .run()
+        .await
 }
 
 pub(crate) struct UpdatePipeline {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -676,47 +676,85 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
     }
     let http_client = State::new_http_client(cfg).wrap_err("initialize the add network")?;
     let cargo_manifest_path = prefix.join("Cargo.toml");
-    ecosystem_add::prepare(
-        cfg,
-        &cargo_manifest_path,
-        &package_specifier_plan.ecosystem_packages,
-        cargo_dependency_kind,
-        args.save_exact,
-        args.save_prefix.as_deref(),
-        Arc::clone(&http_client),
-    )
-    .await?;
-
     let cargo_root = crate::cargo_deps::workspace_root(&cargo_manifest_path).await?;
+    let metadata_mutation = ecosystem_install::MetadataMutation::capture(add_metadata_paths(
+        cfg,
+        &manifest_path,
+        &cargo_manifest_path,
+        &cargo_root,
+        has_node_packages,
+    ))?;
     let lockfile_only = args.lockfile_only;
-    let mut node_args = args;
-    node_args.package_names = package_specifier_plan.node_packages;
-    let cfg: &'static Config = cfg;
-    let node_http_client = Arc::clone(&http_client);
-    let node_install = async move {
-        if node_args.package_names.is_empty() {
-            return Ok(());
+    let outcome = async {
+        ecosystem_add::prepare(
+            cfg,
+            &cargo_manifest_path,
+            &package_specifier_plan.ecosystem_packages,
+            cargo_dependency_kind,
+            args.save_exact,
+            args.save_prefix.as_deref(),
+            Arc::clone(&http_client),
+        )
+        .await?;
+
+        let mut node_args = args;
+        node_args.package_names = package_specifier_plan.node_packages;
+        let cfg: &'static Config = cfg;
+        let node_http_client = Arc::clone(&http_client);
+        let node_install = async move {
+            if node_args.package_names.is_empty() {
+                return Ok(());
+            }
+            let state = init_shared_state(manifest_path, cfg, false, None, node_http_client)?;
+            Box::pin(node_args.run::<Reporter>(state, None)).await
+        };
+        let cargo_install = crate::cargo_deps::install::<Reporter>(
+            ecosystem_install::InstallContext {
+                config: cfg,
+                http_client,
+                lockfile_only,
+                frozen_lockfile: false,
+            },
+            crate::cargo_deps::CargoInstallOptions {
+                root_dir: &cargo_root,
+                discover_projects: false,
+                lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
+            },
+        );
+        ecosystem_install::EcosystemInstallCoordinator::new(node_install)
+            .with_install(cargo_install)
+            .run()
+            .await
+    }
+    .await;
+    metadata_mutation.finish(outcome)
+}
+
+fn add_metadata_paths(
+    config: &Config,
+    node_manifest_path: &Path,
+    cargo_manifest_path: &Path,
+    cargo_root: &Path,
+    has_node_packages: bool,
+) -> Vec<PathBuf> {
+    let mut paths = vec![
+        cargo_manifest_path.to_path_buf(),
+        cargo_root.join("Cargo.lock"),
+        cargo_root.join(".cargo/config.toml"),
+    ];
+    if has_node_packages {
+        let node_project_dir =
+            node_manifest_path.parent().expect("manifest path always has a parent dir");
+        paths.extend([
+            node_manifest_path.to_path_buf(),
+            config.lockfile_dir_for(node_project_dir).join(config.wanted_lockfile_name()),
+            config.virtual_store_dir.join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
+        ]);
+        if let Some(workspace_dir) = config.workspace_dir.as_deref() {
+            paths.push(workspace_dir.join("pnpm-workspace.yaml"));
         }
-        let state = init_shared_state(manifest_path, cfg, false, None, node_http_client)?;
-        Box::pin(node_args.run::<Reporter>(state, None)).await
-    };
-    let cargo_install = crate::cargo_deps::install::<Reporter>(
-        ecosystem_install::InstallContext {
-            config: cfg,
-            http_client,
-            lockfile_only,
-            frozen_lockfile: false,
-        },
-        crate::cargo_deps::CargoInstallOptions {
-            root_dir: &cargo_root,
-            discover_projects: false,
-            lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
-        },
-    );
-    ecosystem_install::EcosystemInstallCoordinator::new(node_install)
-        .with_install(cargo_install)
-        .run()
-        .await
+    }
+    paths
 }
 
 pub(crate) struct UpdatePipeline {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -752,7 +752,9 @@ fn add_metadata_paths(
         paths.extend([
             node_manifest_path.to_path_buf(),
             config.lockfile_dir_for(node_project_dir).join(config.wanted_lockfile_name()),
-            config.effective_virtual_store_dir().join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
+            // The current lockfile remains project-local even when package
+            // materialization uses the global virtual store.
+            config.virtual_store_dir.join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
             config.modules_dir.join(pnpm_modules_yaml::MODULES_FILENAME),
         ]);
         if let Some(workspace_dir) = config.workspace_dir.as_deref() {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -678,7 +678,6 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
     let cargo_manifest_path = prefix.join("Cargo.toml");
     let cargo_root = crate::cargo_deps::workspace_root(&cargo_manifest_path).await?;
     let metadata_mutation = ecosystem_install::MetadataMutation::capture(
-        cfg.store_dir.tmp().join("metadata-mutation-locks"),
         cargo_root.clone(),
         add_metadata_paths(
             cfg,

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -752,8 +752,8 @@ fn add_metadata_paths(
         paths.extend([
             node_manifest_path.to_path_buf(),
             config.lockfile_dir_for(node_project_dir).join(config.wanted_lockfile_name()),
-            config.virtual_store_dir.join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
-            node_project_dir.join("node_modules/.modules.yaml"),
+            config.effective_virtual_store_dir().join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
+            config.modules_dir.join(pnpm_modules_yaml::MODULES_FILENAME),
         ]);
         if let Some(workspace_dir) = config.workspace_dir.as_deref() {
             paths.push(workspace_dir.join("pnpm-workspace.yaml"));
@@ -761,6 +761,9 @@ fn add_metadata_paths(
     }
     paths
 }
+
+#[cfg(test)]
+mod add_metadata_paths_tests;
 
 pub(crate) struct UpdatePipeline {
     pub(crate) args: UpdateArgs,

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -754,6 +754,7 @@ fn add_metadata_paths(
             node_manifest_path.to_path_buf(),
             config.lockfile_dir_for(node_project_dir).join(config.wanted_lockfile_name()),
             config.virtual_store_dir.join(pnpm_lockfile::Lockfile::CURRENT_FILE_NAME),
+            node_project_dir.join("node_modules/.modules.yaml"),
         ]);
         if let Some(workspace_dir) = config.workspace_dir.as_deref() {
             paths.push(workspace_dir.join("pnpm-workspace.yaml"));

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -677,13 +677,18 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
     let http_client = State::new_http_client(cfg).wrap_err("initialize the add network")?;
     let cargo_manifest_path = prefix.join("Cargo.toml");
     let cargo_root = crate::cargo_deps::workspace_root(&cargo_manifest_path).await?;
-    let metadata_mutation = ecosystem_install::MetadataMutation::capture(add_metadata_paths(
-        cfg,
-        &manifest_path,
-        &cargo_manifest_path,
-        &cargo_root,
-        has_node_packages,
-    ))?;
+    let metadata_mutation = ecosystem_install::MetadataMutation::capture(
+        cfg.store_dir.tmp().join("metadata-mutation-locks"),
+        cargo_root.clone(),
+        add_metadata_paths(
+            cfg,
+            &manifest_path,
+            &cargo_manifest_path,
+            &cargo_root,
+            has_node_packages,
+        ),
+    )
+    .await?;
     let lockfile_only = args.lockfile_only;
     let outcome = async {
         ecosystem_add::prepare(
@@ -723,7 +728,7 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
         );
         ecosystem_install::EcosystemInstallCoordinator::new(node_install)
             .with_install(cargo_install)
-            .run()
+            .run_to_settlement()
             .await
     }
     .await;

--- a/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
@@ -16,8 +16,11 @@ fn uses_configured_node_metadata_locations() {
         ..Config::default()
     };
 
+    let metadata_paths = add_metadata_paths(&config, &node_manifest, &cargo_manifest, &root, true);
+    eprintln!("metadata paths: {metadata_paths:#?}");
+
     assert_eq!(
-        add_metadata_paths(&config, &node_manifest, &cargo_manifest, &root, true),
+        metadata_paths,
         vec![
             cargo_manifest,
             root.join("Cargo.lock"),

--- a/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
@@ -1,0 +1,31 @@
+use super::add_metadata_paths;
+use pnpm_config::Config;
+use std::path::PathBuf;
+
+#[test]
+fn uses_configured_node_metadata_locations() {
+    let root = PathBuf::from("workspace");
+    let node_manifest = root.join("package.json");
+    let cargo_manifest = root.join("Cargo.toml");
+    let config = Config {
+        lockfile_dir: Some(root.clone()),
+        modules_dir: root.join("custom_modules"),
+        virtual_store_dir: root.join("project-store"),
+        global_virtual_store_dir: root.join("global-store"),
+        enable_global_virtual_store: true,
+        ..Config::default()
+    };
+
+    assert_eq!(
+        add_metadata_paths(&config, &node_manifest, &cargo_manifest, &root, true),
+        vec![
+            cargo_manifest,
+            root.join("Cargo.lock"),
+            root.join(".cargo/config.toml"),
+            node_manifest,
+            root.join("pnpm-lock.yaml"),
+            root.join("global-store/lock.yaml"),
+            root.join("custom_modules/.modules.yaml"),
+        ],
+    );
+}

--- a/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines/add_metadata_paths_tests.rs
@@ -24,7 +24,7 @@ fn uses_configured_node_metadata_locations() {
             root.join(".cargo/config.toml"),
             node_manifest,
             root.join("pnpm-lock.yaml"),
-            root.join("global-store/lock.yaml"),
+            root.join("project-store/lock.yaml"),
             root.join("custom_modules/.modules.yaml"),
         ],
     );

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -2,6 +2,7 @@ use pnpm_config::Config;
 use pnpm_network::ThrottledClient;
 use std::{future::Future, pin::Pin, sync::Arc};
 
+mod metadata_file;
 mod mutation;
 
 pub(crate) use mutation::MetadataMutation;
@@ -42,6 +43,11 @@ impl<'a> EcosystemInstallCoordinator<'a> {
     }
 
     pub(crate) async fn run(self) -> miette::Result<()> {
+        futures_util::future::try_join_all(self.installers).await?;
+        Ok(())
+    }
+
+    pub(crate) async fn run_to_settlement(self) -> miette::Result<()> {
         futures_util::future::join_all(self.installers).await.into_iter().collect()
     }
 }

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -9,7 +9,6 @@ pub(crate) fn is_enabled(config: &Config) -> bool {
     config.cargo.enabled
 }
 
-/// Resources and command policy shared by every ecosystem in one install.
 pub(crate) struct InstallContext {
     pub(crate) config: &'static Config,
     pub(crate) http_client: Arc<ThrottledClient>,
@@ -38,7 +37,6 @@ impl<'a> EcosystemInstallCoordinator<'a> {
         self
     }
 
-    /// Install every configured ecosystem under the shared resource budgets.
     pub(crate) async fn run(self) -> miette::Result<()> {
         futures_util::future::try_join_all(self.installers).await?;
         Ok(())

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -2,6 +2,10 @@ use pnpm_config::Config;
 use pnpm_network::ThrottledClient;
 use std::{future::Future, pin::Pin, sync::Arc};
 
+mod mutation;
+
+pub(crate) use mutation::MetadataMutation;
+
 type Installer<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
 
 /// Report whether a non-Node.js ecosystem participates in this install.
@@ -38,8 +42,7 @@ impl<'a> EcosystemInstallCoordinator<'a> {
     }
 
     pub(crate) async fn run(self) -> miette::Result<()> {
-        futures_util::future::try_join_all(self.installers).await?;
-        Ok(())
+        futures_util::future::join_all(self.installers).await.into_iter().collect()
     }
 }
 

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -1,7 +1,6 @@
-use crate::cargo_deps::{self, CargoLockfilePolicy};
 use pnpm_config::Config;
 use pnpm_network::ThrottledClient;
-use std::{future::Future, path::Path, pin::Pin, sync::Arc};
+use std::{future::Future, pin::Pin, sync::Arc};
 
 type Installer<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
 
@@ -10,43 +9,40 @@ pub(crate) fn is_enabled(config: &Config) -> bool {
     config.cargo.enabled
 }
 
-/// Coordinates dependency installation across every configured ecosystem.
-pub(crate) struct EcosystemInstallCoordinator<'a> {
+/// Resources and command policy shared by every ecosystem in one install.
+pub(crate) struct InstallContext {
     pub(crate) config: &'static Config,
-    pub(crate) root_dir: &'a Path,
-    pub(crate) discover_cargo_projects: bool,
     pub(crate) http_client: Arc<ThrottledClient>,
     pub(crate) lockfile_only: bool,
     pub(crate) frozen_lockfile: bool,
-    pub(crate) cargo_lockfile_policy: CargoLockfilePolicy,
+}
+
+/// Coordinates dependency installation across every configured ecosystem.
+pub(crate) struct EcosystemInstallCoordinator<'a> {
+    installers: Vec<Installer<'a>>,
 }
 
 impl<'a> EcosystemInstallCoordinator<'a> {
-    /// Install every configured ecosystem under the shared network budget.
-    pub(crate) async fn run<Reporter, NodeInstall>(
-        self,
-        node_install: NodeInstall,
-    ) -> miette::Result<()>
+    pub(crate) fn new<Install>(install: Install) -> Self
     where
-        Reporter: pnpm_reporter::Reporter + 'static,
-        NodeInstall: Future<Output = miette::Result<()>> + Send + 'a,
+        Install: Future<Output = miette::Result<()>> + Send + 'a,
     {
-        let cargo_install = cargo_deps::install::<Reporter>(
-            self.config,
-            self.root_dir,
-            self.discover_cargo_projects,
-            self.lockfile_only,
-            self.frozen_lockfile,
-            self.cargo_lockfile_policy,
-            Arc::clone(&self.http_client),
-        );
-        run_installers(vec![Box::pin(node_install), Box::pin(cargo_install)]).await
+        Self { installers: vec![Box::pin(install)] }
     }
-}
 
-async fn run_installers(installers: Vec<Installer<'_>>) -> miette::Result<()> {
-    futures_util::future::try_join_all(installers).await?;
-    Ok(())
+    pub(crate) fn with_install<Install>(mut self, install: Install) -> Self
+    where
+        Install: Future<Output = miette::Result<()>> + Send + 'a,
+    {
+        self.installers.push(Box::pin(install));
+        self
+    }
+
+    /// Install every configured ecosystem under the shared resource budgets.
+    pub(crate) async fn run(self) -> miette::Result<()> {
+        futures_util::future::try_join_all(self.installers).await?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
@@ -34,13 +34,14 @@ pub(super) struct MetadataFile {
 impl MetadataFile {
     pub(super) fn capture(path: PathBuf) -> Result<Self> {
         let path = absolute_path(path)?;
+        let path_display = path.display().to_string();
         let name = path
             .file_name()
-            .ok_or_else(|| miette::miette!("metadata path has no file name: {}", path.display()))?
+            .ok_or_else(|| miette::miette!("metadata path has no file name: {path_display}"))?
             .to_os_string();
         let parent_path = path
             .parent()
-            .ok_or_else(|| miette::miette!("metadata path has no parent: {}", path.display()))?;
+            .ok_or_else(|| miette::miette!("metadata path has no parent: {path_display}"))?;
         let (parent, remaining_parent) = PinnedDirectory::nearest_existing(parent_path)
             .wrap_err_with(|| format!("pin parent of {}", path.display()))?;
         let state = read_from(&parent, &remaining_parent, &name)
@@ -85,16 +86,14 @@ fn absolute_path(path: PathBuf) -> Result<PathBuf> {
     } else {
         std::env::current_dir().into_diagnostic()?.join(path)
     };
+    let path_display = path.display().to_string();
     let mut normalized = PathBuf::new();
     for component in path.components() {
         match component {
             Component::CurDir => {}
             Component::ParentDir => {
                 if !normalized.pop() {
-                    return Err(miette::miette!(
-                        "metadata path escapes its root: {}",
-                        path.display()
-                    ));
+                    return Err(miette::miette!("metadata path escapes its root: {path_display}"));
                 }
             }
             component => normalized.push(component.as_os_str()),
@@ -113,6 +112,7 @@ struct PinnedDirectory {
 
 impl PinnedDirectory {
     fn nearest_existing(path: &Path) -> Result<(Self, Vec<OsString>)> {
+        let path_display = path.display().to_string();
         let mut existing = path;
         let mut remaining = Vec::new();
         loop {
@@ -120,11 +120,11 @@ impl PinnedDirectory {
                 Ok(_) => break,
                 Err(error) if error.kind() == io::ErrorKind::NotFound => {
                     let name = existing.file_name().ok_or_else(|| {
-                        miette::miette!("no existing ancestor for {}", path.display())
+                        miette::miette!("no existing ancestor for {path_display}")
                     })?;
                     remaining.push(name.to_os_string());
                     existing = existing.parent().ok_or_else(|| {
-                        miette::miette!("no existing ancestor for {}", path.display())
+                        miette::miette!("no existing ancestor for {path_display}")
                     })?;
                 }
                 Err(error) => {

--- a/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
@@ -534,6 +534,9 @@ fn open_windows_directory(path: &Path) -> io::Result<fs::File> {
         FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
     };
 
+    // Deliberately omit FILE_SHARE_DELETE. Every component handle remains
+    // alive in `PinnedDirectory`, so Windows cannot rename or replace a
+    // validated parent before the later pathname-based child operation.
     fs::OpenOptions::new()
         .read(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)

--- a/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
@@ -6,10 +6,10 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 use std::sync::atomic::{AtomicU64, Ordering};
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 static TEMPORARY_FILE_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, PartialEq, Eq)]
@@ -332,13 +332,56 @@ fn write_symlink(parent: &PinnedDirectory, name: &OsStr, target: &Path) -> io::R
 
 #[cfg(windows)]
 fn write_symlink(parent: &PinnedDirectory, name: &OsStr, target: &Path) -> io::Result<()> {
-    let path = parent.path.join(name);
-    match fs::remove_file(&path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-        Err(error) => return Err(error),
+    let destination = parent.path.join(name);
+    let temporary = loop {
+        let temporary = windows_temporary_path(parent, name);
+        match std::os::windows::fs::symlink_file(target, &temporary) {
+            Ok(()) => break temporary,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    };
+    let result = replace_windows_path(&temporary, &destination);
+    if result.is_err() {
+        let _ = fs::remove_file(&temporary);
     }
-    std::os::windows::fs::symlink_file(target, path)
+    result
+}
+
+#[cfg(windows)]
+fn windows_temporary_path(parent: &PinnedDirectory, name: &OsStr) -> PathBuf {
+    let mut temporary = OsString::from(".");
+    temporary.push(name);
+    temporary.push(format!(
+        ".pnpm-{}-{}",
+        std::process::id(),
+        TEMPORARY_FILE_ID.fetch_add(1, Ordering::Relaxed),
+    ));
+    parent.path.join(temporary)
+}
+
+#[cfg(windows)]
+fn replace_windows_path(source: &Path, destination: &Path) -> io::Result<()> {
+    use std::os::windows::ffi::OsStrExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        MOVEFILE_REPLACE_EXISTING, MOVEFILE_WRITE_THROUGH, MoveFileExW,
+    };
+
+    let source = source.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    let destination = destination.as_os_str().encode_wide().chain(Some(0)).collect::<Vec<_>>();
+    // SAFETY: both paths are NUL-terminated and remain alive for the call.
+    if unsafe {
+        MoveFileExW(
+            source.as_ptr(),
+            destination.as_ptr(),
+            MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH,
+        )
+    } != 0
+    {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/metadata_file.rs
@@ -1,0 +1,527 @@
+use miette::{IntoDiagnostic, Result, WrapErr};
+use std::{
+    ffi::{OsStr, OsString},
+    fs,
+    io::{self, Read as _},
+    path::{Component, Path, PathBuf},
+};
+
+#[cfg(unix)]
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[cfg(unix)]
+static TEMPORARY_FILE_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, PartialEq, Eq)]
+enum FileState {
+    Missing,
+    Regular {
+        contents: Vec<u8>,
+        #[cfg(unix)]
+        mode: u32,
+    },
+    Symlink(PathBuf),
+}
+
+pub(super) struct MetadataFile {
+    path: PathBuf,
+    parent: PinnedDirectory,
+    remaining_parent: Vec<OsString>,
+    name: OsString,
+    state: FileState,
+}
+
+impl MetadataFile {
+    pub(super) fn capture(path: PathBuf) -> Result<Self> {
+        let path = absolute_path(path)?;
+        let name = path
+            .file_name()
+            .ok_or_else(|| miette::miette!("metadata path has no file name: {}", path.display()))?
+            .to_os_string();
+        let parent_path = path
+            .parent()
+            .ok_or_else(|| miette::miette!("metadata path has no parent: {}", path.display()))?;
+        let (parent, remaining_parent) = PinnedDirectory::nearest_existing(parent_path)
+            .wrap_err_with(|| format!("pin parent of {}", path.display()))?;
+        let state = read_from(&parent, &remaining_parent, &name)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("snapshot {}", path.display()))?;
+        Ok(Self { path, parent, remaining_parent, name, state })
+    }
+
+    pub(super) fn restore(self) -> Result<()> {
+        let current = read_from(&self.parent, &self.remaining_parent, &self.name)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("inspect {} before restoration", self.path.display()))?;
+        if current == self.state {
+            return Ok(());
+        }
+        let parent =
+            self.parent.open_descendant(&self.remaining_parent).into_diagnostic().wrap_err_with(
+                || format!("open parent of {} for restoration", self.path.display()),
+            )?;
+        let outcome = match self.state {
+            FileState::Missing => remove_file(&parent, &self.name),
+            FileState::Regular {
+                contents,
+                #[cfg(unix)]
+                mode,
+            } => write_file(
+                &parent,
+                &self.name,
+                &contents,
+                #[cfg(unix)]
+                mode,
+            ),
+            FileState::Symlink(target) => write_symlink(&parent, &self.name, &target),
+        };
+        outcome.into_diagnostic().wrap_err_with(|| format!("restore {}", self.path.display()))
+    }
+}
+
+fn absolute_path(path: PathBuf) -> Result<PathBuf> {
+    let path = if path.is_absolute() {
+        path
+    } else {
+        std::env::current_dir().into_diagnostic()?.join(path)
+    };
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return Err(miette::miette!(
+                        "metadata path escapes its root: {}",
+                        path.display()
+                    ));
+                }
+            }
+            component => normalized.push(component.as_os_str()),
+        }
+    }
+    Ok(normalized)
+}
+
+struct PinnedDirectory {
+    path: PathBuf,
+    #[cfg(unix)]
+    handle: fs::File,
+    #[cfg(windows)]
+    handles: Vec<fs::File>,
+}
+
+impl PinnedDirectory {
+    fn nearest_existing(path: &Path) -> Result<(Self, Vec<OsString>)> {
+        let mut existing = path;
+        let mut remaining = Vec::new();
+        loop {
+            match fs::symlink_metadata(existing) {
+                Ok(_) => break,
+                Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                    let name = existing.file_name().ok_or_else(|| {
+                        miette::miette!("no existing ancestor for {}", path.display())
+                    })?;
+                    remaining.push(name.to_os_string());
+                    existing = existing.parent().ok_or_else(|| {
+                        miette::miette!("no existing ancestor for {}", path.display())
+                    })?;
+                }
+                Err(error) => {
+                    return Err(error)
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("inspect directory {}", existing.display()));
+                }
+            }
+        }
+        remaining.reverse();
+        let canonical = fs::canonicalize(existing)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("resolve directory {}", existing.display()))?;
+        let directory = Self::open(canonical)?;
+        Ok((directory, remaining))
+    }
+
+    #[cfg(unix)]
+    fn open(path: PathBuf) -> Result<Self> {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        let mut options = fs::OpenOptions::new();
+        options.read(true).custom_flags(libc::O_CLOEXEC | libc::O_DIRECTORY);
+        let handle = options
+            .open(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("open directory {}", path.display()))?;
+        Ok(Self { path, handle })
+    }
+
+    #[cfg(windows)]
+    fn open(path: PathBuf) -> Result<Self> {
+        let handle = open_windows_directory(&path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("open directory {}", path.display()))?;
+        ensure_real_windows_directory(&handle, &path)?;
+        Ok(Self { path, handles: vec![handle] })
+    }
+
+    fn open_descendant(&self, components: &[OsString]) -> io::Result<Self> {
+        #[cfg(unix)]
+        let mut directory = Self { path: self.path.clone(), handle: self.handle.try_clone()? };
+        #[cfg(windows)]
+        let mut directory = Self {
+            path: self.path.clone(),
+            handles: self.handles.iter().map(fs::File::try_clone).collect::<io::Result<_>>()?,
+        };
+        for component in components {
+            directory = directory.open_child(component)?;
+        }
+        Ok(directory)
+    }
+
+    #[cfg(unix)]
+    fn open_child(&self, name: &OsStr) -> io::Result<Self> {
+        use std::os::{fd::AsRawFd as _, unix::ffi::OsStrExt as _};
+
+        let name = std::ffi::CString::new(name.as_bytes())?;
+        // SAFETY: `name` is NUL-terminated, the parent descriptor remains
+        // valid for the call, and the returned descriptor is owned on success.
+        let descriptor = unsafe {
+            libc::openat(
+                self.handle.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_DIRECTORY | libc::O_NOFOLLOW,
+            )
+        };
+        let handle = file_from_descriptor(descriptor)?;
+        Ok(Self { path: self.path.join(OsStr::from_bytes(name.as_bytes())), handle })
+    }
+
+    #[cfg(windows)]
+    fn open_child(&self, name: &OsStr) -> io::Result<Self> {
+        let path = self.path.join(name);
+        let handle = open_windows_directory(&path)?;
+        ensure_real_windows_directory_io(&handle, &path)?;
+        let mut handles =
+            self.handles.iter().map(fs::File::try_clone).collect::<io::Result<Vec<_>>>()?;
+        handles.push(handle);
+        Ok(Self { path, handles })
+    }
+}
+
+fn read_from(
+    base: &PinnedDirectory,
+    parent_components: &[OsString],
+    name: &OsStr,
+) -> io::Result<FileState> {
+    let parent = match base.open_descendant(parent_components) {
+        Ok(parent) => parent,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(FileState::Missing),
+        Err(error) => return Err(error),
+    };
+    read_file(&parent, name)
+}
+
+#[cfg(unix)]
+fn read_file(parent: &PinnedDirectory, name: &OsStr) -> io::Result<FileState> {
+    use std::os::{
+        fd::AsRawFd as _,
+        unix::{ffi::OsStrExt as _, fs::PermissionsExt as _},
+    };
+
+    let name = std::ffi::CString::new(name.as_bytes())?;
+    match read_link_at(&parent.handle, &name) {
+        Ok(target) => return Ok(FileState::Symlink(target)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(FileState::Missing),
+        Err(error) if error.raw_os_error() == Some(libc::EINVAL) => {}
+        Err(error) => return Err(error),
+    }
+    // SAFETY: `name` is NUL-terminated and the pinned parent remains valid.
+    let descriptor = unsafe {
+        libc::openat(
+            parent.handle.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+        )
+    };
+    let mut file = match file_from_descriptor(descriptor) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(FileState::Missing),
+        Err(error) => return Err(error),
+    };
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(io::Error::other("project metadata path is not a regular file or symlink"));
+    }
+    let mode = metadata.permissions().mode();
+    let mut contents = Vec::new();
+    #[expect(
+        clippy::verbose_file_reads,
+        reason = "the descriptor-relative open is what prevents a symlink race"
+    )]
+    file.read_to_end(&mut contents)?;
+    Ok(FileState::Regular { contents, mode })
+}
+
+#[cfg(windows)]
+fn read_file(parent: &PinnedDirectory, name: &OsStr) -> io::Result<FileState> {
+    let path = parent.path.join(name);
+    let metadata = match fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(FileState::Missing),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() {
+        return fs::read_link(path).map(FileState::Symlink);
+    }
+    if !metadata.is_file() || is_windows_reparse_point(&metadata) {
+        return Err(io::Error::other("project metadata path is not a regular file or symlink"));
+    }
+    fs::read(path).map(|contents| FileState::Regular { contents })
+}
+
+#[cfg(unix)]
+fn write_file(
+    parent: &PinnedDirectory,
+    name: &OsStr,
+    contents: &[u8],
+    mode: u32,
+) -> io::Result<()> {
+    use std::io::Write as _;
+    use std::os::{unix::ffi::OsStrExt as _, unix::fs::PermissionsExt as _};
+
+    let destination = std::ffi::CString::new(name.as_bytes())?;
+    let (temporary, mut file) = create_temporary_file(parent, name)?;
+    let result = (|| {
+        file.write_all(contents)?;
+        file.set_permissions(fs::Permissions::from_mode(mode))?;
+        file.sync_all()?;
+        rename_at(parent, &temporary, &destination)
+    })();
+    drop(file);
+    if result.is_err() {
+        let _ = unlink_at(parent, &temporary);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn write_file(parent: &PinnedDirectory, name: &OsStr, contents: &[u8]) -> io::Result<()> {
+    pnpm_fs::write_atomic(&parent.path.join(name), contents)
+}
+
+#[cfg(unix)]
+fn write_symlink(parent: &PinnedDirectory, name: &OsStr, target: &Path) -> io::Result<()> {
+    use std::os::{fd::AsRawFd as _, unix::ffi::OsStrExt as _};
+
+    let destination = std::ffi::CString::new(name.as_bytes())?;
+    let target = std::ffi::CString::new(target.as_os_str().as_bytes())?;
+    let temporary = temporary_name(name)?;
+    // SAFETY: the target and temporary name are NUL-terminated, and the
+    // directory descriptor remains valid.
+    if unsafe { libc::symlinkat(target.as_ptr(), parent.handle.as_raw_fd(), temporary.as_ptr()) }
+        != 0
+    {
+        return Err(io::Error::last_os_error());
+    }
+    let result = rename_at(parent, &temporary, &destination);
+    if result.is_err() {
+        let _ = unlink_at(parent, &temporary);
+    }
+    result
+}
+
+#[cfg(windows)]
+fn write_symlink(parent: &PinnedDirectory, name: &OsStr, target: &Path) -> io::Result<()> {
+    let path = parent.path.join(name);
+    match fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    std::os::windows::fs::symlink_file(target, path)
+}
+
+#[cfg(unix)]
+fn remove_file(parent: &PinnedDirectory, name: &OsStr) -> io::Result<()> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let name = std::ffi::CString::new(name.as_bytes())?;
+    match unlink_at(parent, &name) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(windows)]
+fn remove_file(parent: &PinnedDirectory, name: &OsStr) -> io::Result<()> {
+    match fs::remove_file(parent.path.join(name)) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(unix)]
+fn create_temporary_file(
+    parent: &PinnedDirectory,
+    name: &OsStr,
+) -> io::Result<(std::ffi::CString, fs::File)> {
+    use std::os::fd::AsRawFd as _;
+
+    loop {
+        let temporary = temporary_name(name)?;
+        // SAFETY: the name is NUL-terminated, the directory descriptor remains
+        // valid, and a successful descriptor is immediately owned.
+        let descriptor = unsafe {
+            libc::openat(
+                parent.handle.as_raw_fd(),
+                temporary.as_ptr(),
+                libc::O_WRONLY | libc::O_CLOEXEC | libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW,
+                0o600,
+            )
+        };
+        match file_from_descriptor(descriptor) {
+            Ok(file) => return Ok((temporary, file)),
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn temporary_name(name: &OsStr) -> io::Result<std::ffi::CString> {
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut temporary = OsString::from(".");
+    temporary.push(name);
+    temporary.push(format!(
+        ".pnpm-{}-{}",
+        std::process::id(),
+        TEMPORARY_FILE_ID.fetch_add(1, Ordering::Relaxed),
+    ));
+    Ok(std::ffi::CString::new(temporary.as_bytes())?)
+}
+
+#[cfg(unix)]
+fn rename_at(
+    parent: &PinnedDirectory,
+    source: &std::ffi::CStr,
+    destination: &std::ffi::CStr,
+) -> io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+
+    // SAFETY: both names and the pinned directory descriptor remain valid.
+    if unsafe {
+        libc::renameat(
+            parent.handle.as_raw_fd(),
+            source.as_ptr(),
+            parent.handle.as_raw_fd(),
+            destination.as_ptr(),
+        )
+    } == 0
+    {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn unlink_at(parent: &PinnedDirectory, name: &std::ffi::CStr) -> io::Result<()> {
+    use std::os::fd::AsRawFd as _;
+
+    // SAFETY: the name and pinned directory descriptor remain valid.
+    if unsafe { libc::unlinkat(parent.handle.as_raw_fd(), name.as_ptr(), 0) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(unix)]
+fn read_link_at(directory: &fs::File, name: &std::ffi::CStr) -> io::Result<PathBuf> {
+    use std::os::{fd::AsRawFd as _, unix::ffi::OsStringExt as _};
+
+    let mut capacity = 256;
+    loop {
+        let mut contents = Vec::<u8>::with_capacity(capacity);
+        // SAFETY: the name and directory descriptor are valid, and the buffer
+        // exposes `capacity` writable bytes to `readlinkat`.
+        let length = unsafe {
+            libc::readlinkat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                contents.as_mut_ptr().cast(),
+                contents.capacity(),
+            )
+        };
+        if length == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        let length = usize::try_from(length).expect("readlinkat returned a nonnegative length");
+        if length < contents.capacity() {
+            // SAFETY: `readlinkat` initialized exactly `length` bytes.
+            unsafe {
+                contents.set_len(length);
+            }
+            return Ok(OsString::from_vec(contents).into());
+        }
+        capacity *= 2;
+    }
+}
+
+#[cfg(unix)]
+fn file_from_descriptor(descriptor: libc::c_int) -> io::Result<fs::File> {
+    use std::os::fd::{FromRawFd as _, OwnedFd};
+
+    if descriptor == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        // SAFETY: a successful `openat` returned a new owned descriptor.
+        let descriptor = unsafe { OwnedFd::from_raw_fd(descriptor) };
+        Ok(fs::File::from(descriptor))
+    }
+}
+
+#[cfg(windows)]
+fn open_windows_directory(path: &Path) -> io::Result<fs::File> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    fs::OpenOptions::new()
+        .read(true)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+}
+
+#[cfg(windows)]
+fn ensure_real_windows_directory(handle: &fs::File, path: &Path) -> Result<()> {
+    ensure_real_windows_directory_io(handle, path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("inspect directory {}", path.display()))
+}
+
+#[cfg(windows)]
+fn ensure_real_windows_directory_io(handle: &fs::File, path: &Path) -> io::Result<()> {
+    let metadata = handle.metadata()?;
+    if metadata.is_dir() && !is_windows_reparse_point(&metadata) {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "managed metadata directory {} must be a real directory",
+            path.display(),
+        )))
+    }
+}
+
+#[cfg(windows)]
+fn is_windows_reparse_point(metadata: &fs::Metadata) -> bool {
+    use std::os::windows::fs::MetadataExt as _;
+    use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_REPARSE_POINT;
+
+    metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+}

--- a/pnpm/crates/cli/src/ecosystem_install/mutation.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation.rs
@@ -53,7 +53,7 @@ impl MetadataMutation {
         };
         self.restore().map_err(|restore_error| {
             restore_error.wrap_err(format!(
-                "restore project metadata after dependency operation failed: {operation_error}"
+                "restore project metadata after dependency operation failed: {operation_error}",
             ))
         })?;
         Err(operation_error)

--- a/pnpm/crates/cli/src/ecosystem_install/mutation.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation.rs
@@ -1,50 +1,64 @@
+use super::metadata_file::MetadataFile;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use std::{collections::BTreeSet, fs, path::PathBuf};
 
-struct FileSnapshot {
-    path: PathBuf,
-    contents: Option<Vec<u8>>,
-}
-
-impl FileSnapshot {
-    fn restore(self) -> Result<()> {
-        let Self { path, contents } = self;
-        let outcome = match contents {
-            Some(contents) => pnpm_fs::write_atomic(&path, &contents),
-            None => match fs::remove_file(&path) {
-                Ok(()) => Ok(()),
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-                Err(error) => Err(error),
-            },
-        };
-        outcome.into_diagnostic().wrap_err_with(|| format!("restore {}", path.display()))
-    }
-}
-
 pub(crate) struct MetadataMutation {
-    snapshots: Vec<FileSnapshot>,
+    snapshots: Vec<MetadataFile>,
+    // Every mixed add using this store and Cargo workspace takes the same
+    // advisory lock from before capture through either commit or rollback.
+    // Keeping it here makes the transaction lifetime structural.
+    _lock: fs::File,
 }
 
 impl MetadataMutation {
-    pub(crate) fn capture(paths: impl IntoIterator<Item = PathBuf>) -> Result<Self> {
+    pub(crate) async fn capture(
+        lock_directory: PathBuf,
+        transaction_key: PathBuf,
+        paths: impl IntoIterator<Item = PathBuf>,
+    ) -> Result<Self> {
+        let paths = paths.into_iter().collect::<Vec<_>>();
+        tokio::task::spawn_blocking(move || {
+            Self::capture_blocking(&lock_directory, &transaction_key, paths)
+        })
+        .await
+        .into_diagnostic()
+        .wrap_err("join metadata snapshot task")?
+    }
+
+    fn capture_blocking(
+        lock_directory: &std::path::Path,
+        transaction_key: &std::path::Path,
+        paths: Vec<PathBuf>,
+    ) -> Result<Self> {
+        fs::create_dir_all(lock_directory).into_diagnostic().wrap_err_with(|| {
+            format!("create metadata lock directory {}", lock_directory.display())
+        })?;
+        let transaction_key =
+            fs::canonicalize(transaction_key).into_diagnostic().wrap_err_with(|| {
+                format!("resolve metadata transaction key {}", transaction_key.display())
+            })?;
+        let lock_path = lock_directory.join(format!(
+            "{}.lock",
+            pnpm_crypto_hash::create_hex_hash(&transaction_key.to_string_lossy()),
+        ));
+        let lock = fs::OpenOptions::new()
+            .create(true)
+            .truncate(false)
+            .read(true)
+            .write(true)
+            .open(&lock_path)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("open metadata transaction lock {}", lock_path.display()))?;
+        lock.lock().into_diagnostic().wrap_err_with(|| {
+            format!("acquire metadata transaction lock {}", lock_path.display())
+        })?;
         let snapshots = paths
             .into_iter()
             .collect::<BTreeSet<_>>()
             .into_iter()
-            .map(|path| {
-                let contents = match fs::read(&path) {
-                    Ok(contents) => Some(contents),
-                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-                    Err(error) => {
-                        return Err(error)
-                            .into_diagnostic()
-                            .wrap_err_with(|| format!("snapshot {}", path.display()));
-                    }
-                };
-                Ok(FileSnapshot { path, contents })
-            })
+            .map(MetadataFile::capture)
             .collect::<Result<Vec<_>>>()?;
-        Ok(Self { snapshots })
+        Ok(Self { snapshots, _lock: lock })
     }
 
     pub(crate) fn finish(self, outcome: Result<()>) -> Result<()> {

--- a/pnpm/crates/cli/src/ecosystem_install/mutation.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation.rs
@@ -1,0 +1,76 @@
+use miette::{IntoDiagnostic, Result, WrapErr};
+use std::{collections::BTreeSet, fs, path::PathBuf};
+
+struct FileSnapshot {
+    path: PathBuf,
+    contents: Option<Vec<u8>>,
+}
+
+impl FileSnapshot {
+    fn restore(self) -> Result<()> {
+        let Self { path, contents } = self;
+        let outcome = match contents {
+            Some(contents) => pnpm_fs::write_atomic(&path, &contents),
+            None => match fs::remove_file(&path) {
+                Ok(()) => Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            },
+        };
+        outcome.into_diagnostic().wrap_err_with(|| format!("restore {}", path.display()))
+    }
+}
+
+pub(crate) struct MetadataMutation {
+    snapshots: Vec<FileSnapshot>,
+}
+
+impl MetadataMutation {
+    pub(crate) fn capture(paths: impl IntoIterator<Item = PathBuf>) -> Result<Self> {
+        let snapshots = paths
+            .into_iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|path| {
+                let contents = match fs::read(&path) {
+                    Ok(contents) => Some(contents),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                    Err(error) => {
+                        return Err(error)
+                            .into_diagnostic()
+                            .wrap_err_with(|| format!("snapshot {}", path.display()));
+                    }
+                };
+                Ok(FileSnapshot { path, contents })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self { snapshots })
+    }
+
+    pub(crate) fn finish(self, outcome: Result<()>) -> Result<()> {
+        let Err(operation_error) = outcome else {
+            return Ok(());
+        };
+        self.restore().map_err(|restore_error| {
+            restore_error.wrap_err(format!(
+                "restore project metadata after dependency operation failed: {operation_error}"
+            ))
+        })?;
+        Err(operation_error)
+    }
+
+    fn restore(self) -> Result<()> {
+        let mut first_error = None;
+        for snapshot in self.snapshots.into_iter().rev() {
+            if let Err(error) = snapshot.restore()
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/ecosystem_install/mutation.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation.rs
@@ -4,35 +4,27 @@ use std::{collections::BTreeSet, fs, path::PathBuf};
 
 pub(crate) struct MetadataMutation {
     snapshots: Vec<MetadataFile>,
-    // Every mixed add using this store and Cargo workspace takes the same
-    // advisory lock from before capture through either commit or rollback.
+    // Every mixed add targeting this Cargo workspace takes the same advisory
+    // lock from before capture through either commit or rollback.
     // Keeping it here makes the transaction lifetime structural.
     _lock: fs::File,
 }
 
 impl MetadataMutation {
     pub(crate) async fn capture(
-        lock_directory: PathBuf,
         transaction_key: PathBuf,
         paths: impl IntoIterator<Item = PathBuf>,
     ) -> Result<Self> {
         let paths = paths.into_iter().collect::<Vec<_>>();
-        tokio::task::spawn_blocking(move || {
-            Self::capture_blocking(&lock_directory, &transaction_key, paths)
-        })
-        .await
-        .into_diagnostic()
-        .wrap_err("join metadata snapshot task")?
+        tokio::task::spawn_blocking(move || Self::capture_blocking(&transaction_key, paths))
+            .await
+            .into_diagnostic()
+            .wrap_err("join metadata snapshot task")?
     }
 
-    fn capture_blocking(
-        lock_directory: &std::path::Path,
-        transaction_key: &std::path::Path,
-        paths: Vec<PathBuf>,
-    ) -> Result<Self> {
-        fs::create_dir_all(lock_directory).into_diagnostic().wrap_err_with(|| {
-            format!("create metadata lock directory {}", lock_directory.display())
-        })?;
+    fn capture_blocking(transaction_key: &std::path::Path, paths: Vec<PathBuf>) -> Result<Self> {
+        let lock_directory = metadata_lock_directory();
+        prepare_metadata_lock_directory(&lock_directory)?;
         let transaction_key =
             fs::canonicalize(transaction_key).into_diagnostic().wrap_err_with(|| {
                 format!("resolve metadata transaction key {}", transaction_key.display())
@@ -41,14 +33,7 @@ impl MetadataMutation {
             "{}.lock",
             pnpm_crypto_hash::create_hex_hash(&transaction_key.to_string_lossy()),
         ));
-        let lock = fs::OpenOptions::new()
-            .create(true)
-            .truncate(false)
-            .read(true)
-            .write(true)
-            .open(&lock_path)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("open metadata transaction lock {}", lock_path.display()))?;
+        let lock = open_metadata_lock(&lock_path)?;
         lock.lock().into_diagnostic().wrap_err_with(|| {
             format!("acquire metadata transaction lock {}", lock_path.display())
         })?;
@@ -84,6 +69,80 @@ impl MetadataMutation {
         }
         first_error.map_or(Ok(()), Err)
     }
+}
+
+fn metadata_lock_directory() -> PathBuf {
+    let mut directory = std::env::temp_dir();
+    #[cfg(unix)]
+    directory.push(format!(
+        "pnpm-metadata-mutation-locks-{}",
+        // SAFETY: `geteuid` has no preconditions and does not mutate memory.
+        unsafe { libc::geteuid() },
+    ));
+    #[cfg(not(unix))]
+    directory.push("pnpm-metadata-mutation-locks");
+    directory
+}
+
+fn prepare_metadata_lock_directory(directory: &std::path::Path) -> Result<()> {
+    fs::create_dir_all(directory)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("create metadata lock directory {}", directory.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+
+        let metadata = fs::symlink_metadata(directory)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("inspect metadata lock directory {}", directory.display()))?;
+        // SAFETY: `geteuid` has no preconditions and does not mutate memory.
+        let effective_user = unsafe { libc::geteuid() };
+        if !metadata.is_dir() || metadata.uid() != effective_user {
+            let directory = directory.display();
+            return Err(miette::miette!(
+                "metadata lock directory must be a real directory owned by the current user: {}",
+                directory,
+            ));
+        }
+        fs::set_permissions(directory, fs::Permissions::from_mode(0o700))
+            .into_diagnostic()
+            .wrap_err_with(|| format!("secure metadata lock directory {}", directory.display()))?;
+    }
+    Ok(())
+}
+
+fn open_metadata_lock(path: &std::path::Path) -> Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.create(true).truncate(false).read(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+
+        options.mode(0o600).custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW);
+    }
+    let lock = options
+        .open(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("open metadata transaction lock {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+
+        let metadata = lock
+            .metadata()
+            .into_diagnostic()
+            .wrap_err_with(|| format!("inspect metadata transaction lock {}", path.display()))?;
+        // SAFETY: `geteuid` has no preconditions and does not mutate memory.
+        let effective_user = unsafe { libc::geteuid() };
+        if !metadata.is_file() || metadata.uid() != effective_user || metadata.nlink() != 1 {
+            let path = path.display();
+            return Err(miette::miette!(
+                "metadata transaction lock must be a regular file owned by the current user: {}",
+                path,
+            ));
+        }
+    }
+    Ok(lock)
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
@@ -1,0 +1,48 @@
+use super::MetadataMutation;
+use std::fs;
+
+#[test]
+fn restores_changed_and_new_files_after_an_error() {
+    let directory = tempfile::tempdir().unwrap();
+    let existing = directory.path().join("existing");
+    let created = directory.path().join("created");
+    fs::write(&existing, "before").unwrap();
+    let mutation = MetadataMutation::capture([existing.clone(), created.clone()]).unwrap();
+
+    fs::write(&existing, "after").unwrap();
+    fs::write(&created, "new").unwrap();
+    let error = mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert_eq!(error.to_string(), "operation failed");
+    assert_eq!(fs::read_to_string(existing).unwrap(), "before");
+    assert!(!created.exists());
+}
+
+#[test]
+fn keeps_mutations_after_success() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("manifest");
+    fs::write(&path, "before").unwrap();
+    let mutation = MetadataMutation::capture([path.clone()]).unwrap();
+
+    fs::write(&path, "after").unwrap();
+    mutation.finish(Ok(())).unwrap();
+
+    assert_eq!(fs::read_to_string(path).unwrap(), "after");
+}
+
+#[test]
+fn attempts_every_restoration_after_one_fails() {
+    let directory = tempfile::tempdir().unwrap();
+    let existing = directory.path().join("a-existing");
+    let unrestorable = directory.path().join("z-unrestorable");
+    fs::write(&existing, "before").unwrap();
+    let mutation = MetadataMutation::capture([existing.clone(), unrestorable.clone()]).unwrap();
+
+    fs::write(&existing, "after").unwrap();
+    fs::create_dir(&unrestorable).unwrap();
+    let error = mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert!(error.to_string().contains("operation failed"));
+    assert_eq!(fs::read_to_string(existing).unwrap(), "before");
+}

--- a/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
@@ -5,9 +5,7 @@ async fn capture(
     directory: &tempfile::TempDir,
     paths: impl IntoIterator<Item = std::path::PathBuf>,
 ) -> MetadataMutation {
-    MetadataMutation::capture(directory.path().join("locks"), directory.path().to_path_buf(), paths)
-        .await
-        .unwrap()
+    MetadataMutation::capture(directory.path().to_path_buf(), paths).await.unwrap()
 }
 
 #[tokio::test]
@@ -59,16 +57,14 @@ async fn attempts_every_restoration_after_one_fails() {
 }
 
 #[tokio::test]
-async fn serializes_metadata_transactions_for_the_same_workspace() {
+async fn serializes_metadata_transactions_for_the_same_workspace_without_a_store_key() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("manifest");
     fs::write(&path, "before").unwrap();
     let first = capture(&directory, [path.clone()]).await;
-    let lock_directory = directory.path().join("locks");
     let transaction_key = directory.path().to_path_buf();
-    let second = tokio::spawn(async move {
-        MetadataMutation::capture(lock_directory, transaction_key, [path]).await
-    });
+    let second =
+        tokio::spawn(async move { MetadataMutation::capture(transaction_key, [path]).await });
 
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     eprintln!(

--- a/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
@@ -126,6 +126,27 @@ async fn restoration_stays_in_the_parent_pinned_during_capture() {
     assert_eq!(fs::read_to_string(attacker.join("manifest")).unwrap(), "attacker");
 }
 
+#[cfg(windows)]
+#[tokio::test]
+async fn pinned_parent_cannot_be_replaced_during_restoration() {
+    let directory = tempfile::tempdir().unwrap();
+    let project = directory.path().join("project");
+    let moved = directory.path().join("moved-project");
+    fs::create_dir(&project).unwrap();
+    let path = project.join("manifest");
+    fs::write(&path, "before").unwrap();
+    let mutation = capture(&directory, [path.clone()]).await;
+
+    fs::write(&path, "after").unwrap();
+    let rename_error = fs::rename(&project, &moved).unwrap_err();
+    eprintln!("rename result while metadata parent is pinned: {rename_error:?}");
+    assert!(project.is_dir(), "the pinned metadata parent must remain at its validated path");
+    mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert_eq!(fs::read_to_string(path).unwrap(), "before");
+    fs::rename(project, moved).expect("parent can move after pinned handles are released");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn restoration_rejects_a_new_symlink_in_a_missing_parent_path() {

--- a/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/mutation/tests.rs
@@ -1,13 +1,22 @@
 use super::MetadataMutation;
 use std::fs;
 
-#[test]
-fn restores_changed_and_new_files_after_an_error() {
+async fn capture(
+    directory: &tempfile::TempDir,
+    paths: impl IntoIterator<Item = std::path::PathBuf>,
+) -> MetadataMutation {
+    MetadataMutation::capture(directory.path().join("locks"), directory.path().to_path_buf(), paths)
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn restores_changed_and_new_files_after_an_error() {
     let directory = tempfile::tempdir().unwrap();
     let existing = directory.path().join("existing");
     let created = directory.path().join("created");
     fs::write(&existing, "before").unwrap();
-    let mutation = MetadataMutation::capture([existing.clone(), created.clone()]).unwrap();
+    let mutation = capture(&directory, [existing.clone(), created.clone()]).await;
 
     fs::write(&existing, "after").unwrap();
     fs::write(&created, "new").unwrap();
@@ -15,15 +24,16 @@ fn restores_changed_and_new_files_after_an_error() {
 
     assert_eq!(error.to_string(), "operation failed");
     assert_eq!(fs::read_to_string(existing).unwrap(), "before");
+    eprintln!("created metadata path after rollback: {created:?}");
     assert!(!created.exists());
 }
 
-#[test]
-fn keeps_mutations_after_success() {
+#[tokio::test]
+async fn keeps_mutations_after_success() {
     let directory = tempfile::tempdir().unwrap();
     let path = directory.path().join("manifest");
     fs::write(&path, "before").unwrap();
-    let mutation = MetadataMutation::capture([path.clone()]).unwrap();
+    let mutation = capture(&directory, [path.clone()]).await;
 
     fs::write(&path, "after").unwrap();
     mutation.finish(Ok(())).unwrap();
@@ -31,18 +41,115 @@ fn keeps_mutations_after_success() {
     assert_eq!(fs::read_to_string(path).unwrap(), "after");
 }
 
-#[test]
-fn attempts_every_restoration_after_one_fails() {
+#[tokio::test]
+async fn attempts_every_restoration_after_one_fails() {
     let directory = tempfile::tempdir().unwrap();
     let existing = directory.path().join("a-existing");
     let unrestorable = directory.path().join("z-unrestorable");
     fs::write(&existing, "before").unwrap();
-    let mutation = MetadataMutation::capture([existing.clone(), unrestorable.clone()]).unwrap();
+    let mutation = capture(&directory, [existing.clone(), unrestorable.clone()]).await;
 
     fs::write(&existing, "after").unwrap();
     fs::create_dir(&unrestorable).unwrap();
     let error = mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
 
+    eprintln!("restoration failure: {error:?}");
     assert!(error.to_string().contains("operation failed"));
     assert_eq!(fs::read_to_string(existing).unwrap(), "before");
+}
+
+#[tokio::test]
+async fn serializes_metadata_transactions_for_the_same_workspace() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("manifest");
+    fs::write(&path, "before").unwrap();
+    let first = capture(&directory, [path.clone()]).await;
+    let lock_directory = directory.path().join("locks");
+    let transaction_key = directory.path().to_path_buf();
+    let second = tokio::spawn(async move {
+        MetadataMutation::capture(lock_directory, transaction_key, [path]).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    eprintln!(
+        "second metadata transaction finished while the first held its lock: {}",
+        second.is_finished(),
+    );
+    assert!(!second.is_finished());
+
+    drop(first);
+    tokio::time::timeout(std::time::Duration::from_secs(1), second)
+        .await
+        .expect("second transaction should acquire the released lock")
+        .unwrap()
+        .unwrap();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn restores_a_metadata_symlink_without_replacing_it_with_a_file() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let target = directory.path().join("target");
+    let path = directory.path().join("manifest");
+    fs::write(&target, "before").unwrap();
+    symlink("target", &path).unwrap();
+    let mutation = capture(&directory, [path.clone()]).await;
+
+    fs::remove_file(&path).unwrap();
+    fs::write(&path, "after").unwrap();
+    mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert_eq!(fs::read_link(&path).unwrap(), std::path::Path::new("target"));
+    assert_eq!(fs::read_to_string(target).unwrap(), "before");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn restoration_stays_in_the_parent_pinned_during_capture() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let project = directory.path().join("project");
+    let original = directory.path().join("original-project");
+    let attacker = directory.path().join("attacker");
+    fs::create_dir(&project).unwrap();
+    fs::create_dir(&attacker).unwrap();
+    let path = project.join("manifest");
+    fs::write(&path, "before").unwrap();
+    fs::write(attacker.join("manifest"), "attacker").unwrap();
+    let mutation = capture(&directory, [path]).await;
+
+    fs::rename(&project, &original).unwrap();
+    symlink(&attacker, &project).unwrap();
+    fs::write(original.join("manifest"), "after").unwrap();
+    mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert_eq!(fs::read_to_string(original.join("manifest")).unwrap(), "before");
+    assert_eq!(fs::read_to_string(attacker.join("manifest")).unwrap(), "attacker");
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn restoration_rejects_a_new_symlink_in_a_missing_parent_path() {
+    use std::os::unix::fs::symlink;
+
+    let directory = tempfile::tempdir().unwrap();
+    let project = directory.path().join("project");
+    let attacker = directory.path().join("attacker");
+    fs::create_dir(&project).unwrap();
+    fs::create_dir(&attacker).unwrap();
+    fs::write(attacker.join("config.toml"), "attacker").unwrap();
+    let path = project.join(".cargo/config.toml");
+    let mutation = capture(&directory, [path]).await;
+
+    symlink(&attacker, project.join(".cargo")).unwrap();
+    let error = mutation.finish(Err(miette::miette!("operation failed"))).unwrap_err();
+
+    assert!(
+        error.to_string().contains("operation failed"),
+        "rollback should retain the operation error: {error:?}",
+    );
+    assert_eq!(fs::read_to_string(attacker.join("config.toml")).unwrap(), "attacker");
 }

--- a/pnpm/crates/cli/src/ecosystem_install/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/tests.rs
@@ -1,4 +1,4 @@
-use super::run_installers;
+use super::EcosystemInstallCoordinator;
 use std::{
     future::poll_fn,
     sync::{
@@ -27,11 +27,10 @@ async fn polls_ecosystem_installers_concurrently() {
 
     tokio::time::timeout(
         Duration::from_secs(1),
-        run_installers(vec![
-            Box::pin(installer(0b001)),
-            Box::pin(installer(0b010)),
-            Box::pin(installer(0b100)),
-        ]),
+        EcosystemInstallCoordinator::new(installer(0b001))
+            .with_install(installer(0b010))
+            .with_install(installer(0b100))
+            .run(),
     )
     .await
     .expect("every installer must start without waiting for another to finish")

--- a/pnpm/crates/cli/src/ecosystem_install/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/tests.rs
@@ -3,7 +3,7 @@ use std::{
     future::poll_fn,
     sync::{
         Arc,
-        atomic::{AtomicU8, Ordering},
+        atomic::{AtomicBool, AtomicU8, Ordering},
     },
     task::Poll,
     time::Duration,
@@ -36,4 +36,25 @@ async fn polls_ecosystem_installers_concurrently() {
     .expect("every installer must start without waiting for another to finish")
     .unwrap();
     assert_eq!(started.load(Ordering::Acquire), 0b111);
+}
+
+#[tokio::test]
+async fn waits_for_every_installer_after_an_error() {
+    let completed = Arc::new(AtomicBool::new(false));
+    let remaining_install = {
+        let completed = Arc::clone(&completed);
+        async move {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            completed.store(true, Ordering::Release);
+            Ok(())
+        }
+    };
+
+    let result = EcosystemInstallCoordinator::new(async { Err(miette::miette!("failed")) })
+        .with_install(remaining_install)
+        .run()
+        .await;
+
+    assert_eq!(result.unwrap_err().to_string(), "failed");
+    assert!(completed.load(Ordering::Acquire));
 }

--- a/pnpm/crates/cli/src/ecosystem_install/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/tests.rs
@@ -39,7 +39,7 @@ async fn polls_ecosystem_installers_concurrently() {
 }
 
 #[tokio::test]
-async fn waits_for_every_installer_after_an_error() {
+async fn settlement_waits_for_every_installer_after_an_error() {
     let completed = Arc::new(AtomicBool::new(false));
     let remaining_install = {
         let completed = Arc::clone(&completed);
@@ -52,9 +52,31 @@ async fn waits_for_every_installer_after_an_error() {
 
     let result = EcosystemInstallCoordinator::new(async { Err(miette::miette!("failed")) })
         .with_install(remaining_install)
+        .run_to_settlement()
+        .await;
+
+    assert_eq!(result.unwrap_err().to_string(), "failed");
+    eprintln!("remaining installer completed: {}", completed.load(Ordering::Acquire));
+    assert!(completed.load(Ordering::Acquire));
+}
+
+#[tokio::test]
+async fn ordinary_run_remains_fail_fast() {
+    let started = Arc::new(AtomicBool::new(false));
+    let remaining_install = {
+        let started = Arc::clone(&started);
+        async move {
+            started.store(true, Ordering::Release);
+            std::future::pending::<miette::Result<()>>().await
+        }
+    };
+
+    let result = EcosystemInstallCoordinator::new(async { Err(miette::miette!("failed")) })
+        .with_install(remaining_install)
         .run()
         .await;
 
     assert_eq!(result.unwrap_err().to_string(), "failed");
-    assert!(completed.load(Ordering::Acquire));
+    eprintln!("remaining installer started: {}", started.load(Ordering::Acquire));
+    assert!(!started.load(Ordering::Acquire));
 }

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -173,7 +173,12 @@ fn mixed_add_restores_metadata_when_an_ecosystem_fails() {
     assert_eq!(std::fs::read_to_string(node_manifest_path).unwrap(), node_manifest);
     assert_eq!(std::fs::read(cargo_manifest_path).unwrap(), cargo_manifest);
     assert_eq!(std::fs::read(cargo_lock_path).unwrap(), cargo_lock);
+    eprintln!("wanted lockfile after rollback: {}", root.path().join("pnpm-lock.yaml").display());
     assert!(!root.path().join("pnpm-lock.yaml").exists());
+    eprintln!(
+        "current lockfile after rollback: {}",
+        root.path().join("node_modules/.pnpm/lock.yaml").display(),
+    );
     assert!(!root.path().join("node_modules/.pnpm/lock.yaml").exists());
 }
 

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -145,6 +145,39 @@ fn mixed_add_updates_node_and_cargo_projects_together() {
 }
 
 #[test]
+fn mixed_add_restores_metadata_when_an_ecosystem_fails() {
+    let (root, cache_dir) = cargo_add_project();
+    let local_package = root.path().join("local-package");
+    std::fs::create_dir(&local_package).expect("create local npm package");
+    std::fs::write(
+        local_package.join("package.json"),
+        r#"{"name":"local-package","version":"1.0.0"}"#,
+    )
+    .expect("write local npm manifest");
+    let node_manifest_path = root.path().join("package.json");
+    let cargo_manifest_path = root.path().join("Cargo.toml");
+    let cargo_lock_path = root.path().join("Cargo.lock");
+    let node_manifest = r#"{"name":"app","version":"1.0.0"}"#;
+    std::fs::write(&node_manifest_path, node_manifest).expect("write root npm manifest");
+    let cargo_manifest = std::fs::read(&cargo_manifest_path).expect("snapshot Cargo manifest");
+    let cargo_lock = std::fs::read(&cargo_lock_path).expect("snapshot Cargo lockfile");
+
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(root.path())
+        .with_env("PNPM_CONFIG_CACHE_DIR", &cache_dir)
+        .with_args(["add", "local-package@file:./local-package", "crate:foo@1", "--offline"])
+        .assert()
+        .failure();
+
+    assert_eq!(std::fs::read_to_string(node_manifest_path).unwrap(), node_manifest);
+    assert_eq!(std::fs::read(cargo_manifest_path).unwrap(), cargo_manifest);
+    assert_eq!(std::fs::read(cargo_lock_path).unwrap(), cargo_lock);
+    assert!(!root.path().join("pnpm-lock.yaml").exists());
+    assert!(!root.path().join("node_modules/.pnpm/lock.yaml").exists());
+}
+
+#[test]
 fn add_crate_in_a_cargo_workspace_member_updates_the_workspace_lockfile() {
     let root = TempDir::new().expect("create Cargo workspace");
     let cache_dir = root.path().join("cache");

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -180,6 +180,11 @@ fn mixed_add_restores_metadata_when_an_ecosystem_fails() {
         root.path().join("node_modules/.pnpm/lock.yaml").display(),
     );
     assert!(!root.path().join("node_modules/.pnpm/lock.yaml").exists());
+    eprintln!(
+        "modules manifest after rollback: {}",
+        root.path().join("node_modules/.modules.yaml").display(),
+    );
+    assert!(!root.path().join("node_modules/.modules.yaml").exists());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14566 and pnpm/rfcs#34. Stacked on pnpm/pnpm#14565.

- snapshot the Node.js and Cargo manifests and lockfiles before a mixed `pnpm add`
- wait for every in-flight ecosystem installer to settle after an error, then restore project metadata
- keep successful mixed adds concurrent and leave the direct npm-only install path unchanged
- cover commit, rollback, restoration-failure, and concurrent-settlement behavior

The existing integrated benchmark scenario `isolated-linker.fresh-restore.cold-cache.cold-store` was run twice for the exact coordinator and rollback revisions. The first run measured 1.450 ± 0.091s versus 1.477 ± 0.072s (1.02 ± 0.08×); the reverse-order run measured 1.461 ± 0.078s versus 1.455 ± 0.059s (1.00 ± 0.07×). The ranges overlap and show no reproducible npm-only regression.

## Squash Commit Body

```text
Wait for all mixed-ecosystem add operations to settle before restoring their captured manifests and lockfiles after a failure. This prevents a successful npm or Cargo arm from leaving the other ecosystem partially updated, while successful work remains concurrent and npm-only installs retain their direct path.

Related to pnpm/pnpm#14566.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. This bug affects only the v12 Cargo integration.
- [x] Added a changeset.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791165611&installation_model_id=426870&pr_number=14569&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14569&signature=8f2a62a8654d392fdfd62b1cb696daff6016b2aca1c0a8c7debbf21693b9b805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Failed dependency additions now restore project manifests, lockfiles, and related installation metadata.
  - Mixed Node.js and Cargo dependency additions no longer leave partial metadata changes after an error.
  - Failed mixed-ecosystem installs now complete cleanup before reporting errors.
  - Concurrent metadata updates are safely coordinated to prevent conflicting changes.
  - Failed installations now remove stale Node.js module metadata.

- **Tests**
  - Added coverage for metadata restoration, successful mutations, symlink handling, concurrent updates, and installer completion after errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->