### PR TITLE
fix(version): accept -m as a short alias for --message

### DIFF
--- a/.changeset/version-message-short-flag.md
+++ b/.changeset/version-message-short-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm version` now accepts `-m` as a short alias for `--message`, matching the documented usage [#14567](https://github.com/pnpm/pnpm/issues/14567).

--- a/.changeset/version-message-short-flag.md
+++ b/.changeset/version-message-short-flag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm version` now accepts `-m` as a short alias for `--message`, matching the documented usage [#14567](https://github.com/pnpm/pnpm/issues/14567).
+`pnpm version` now accepts `-m` as a short alias for `--message` [#14567](https://github.com/pnpm/pnpm/issues/14567).

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -13,6 +13,7 @@ use super::{
     reporter::{LogLevelSetting, ReporterType},
     store::StoreCommand,
     unlink::UnlinkArgs,
+    version::VersionArgs,
 };
 use clap::Parser;
 use pnpm_config::ColorMode;
@@ -35,6 +36,13 @@ fn add_args(argv: &[&str]) -> AddArgs {
     match CliArgs::try_parse_from(argv).expect("parses").command {
         CliCommand::Add(add) => add,
         other => panic!("expected add, got {other:?}"),
+    }
+}
+
+fn version_args(argv: &[&str]) -> VersionArgs {
+    match CliArgs::try_parse_from(argv).expect("parses").command {
+        CliCommand::Version(version) => version,
+        other => panic!("expected version, got {other:?}"),
     }
 }
 
@@ -566,6 +574,12 @@ fn runtime_alias_and_flags_parse() {
     assert!(!args.save_dev);
     assert!(args.save_prod);
     assert_eq!(args.params, ["set", "node", "22"]);
+}
+
+#[test]
+fn version_message_short_flag_is_an_alias_of_message() {
+    let args = version_args(&["pacquet", "version", "patch", "-m", "release %s"]);
+    assert_eq!(args.message.as_deref(), Some("release %s"));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -577,12 +577,6 @@ fn runtime_alias_and_flags_parse() {
 }
 
 #[test]
-fn version_message_short_flag_is_an_alias_of_message() {
-    let args = version_args(&["pacquet", "version", "patch", "-m", "release %s"]);
-    assert_eq!(args.message.as_deref(), Some("release %s"));
-}
-
-#[test]
 fn runtime_global_flag_parses_after_version() {
     let parsed = CliArgs::try_parse_from(["pacquet", "runtime", "set", "node", "22", "-g"])
         .expect("parses runtime global flag after params");
@@ -591,6 +585,15 @@ fn runtime_global_flag_parses_after_version() {
     };
     assert!(args.global);
     assert_eq!(args.params, ["set", "node", "22"]);
+}
+
+#[test]
+fn version_message_short_flag_is_an_alias_of_message() {
+    let short = version_args(&["pacquet", "version", "patch", "-m", "release %s"]);
+    let long = version_args(&["pacquet", "version", "patch", "--message", "release %s"]);
+    assert_eq!(short.message.as_deref(), Some("release %s"));
+    assert_eq!(short.message, long.message);
+    assert_eq!(short.params, ["patch"]);
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/version.rs
+++ b/pnpm/crates/cli/src/cli_args/version.rs
@@ -50,7 +50,7 @@ pub struct VersionArgs {
     pub allow_same_version: bool,
 
     /// Commit message. "%s" is replaced with the new version. Default is "%s".
-    #[clap(long)]
+    #[clap(long, short = 'm')]
     pub message: Option<String>,
 
     /// Don't create a commit or tag for the version bump. Git commits and


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

The Rust CLI declared `--message` on `pnpm version` as a long-only clap flag, so `-m` was rejected with `unexpected argument '-m' found` even though pnpm.io documents `--message, -m <message>`. This registers `short = 'm'` on the field, the same way every other aliased flag in `pnpm/crates/cli/src/cli_args/version.rs` does.

Fixes pnpm/pnpm#14567

The bug is v12 only. The TypeScript v11 CLI already accepts `-m`: nopt falls back to the option-type abbreviation table for a single-dash token it finds no shorthand for, and `message` is the only `pnpm version` option starting with `m`, so `-m` resolves to `--message` there without a `shorthands` entry. Confirmed on `main`, both through `parseCliArgs(['version', 'patch', '-m', 'release %s'])` and end to end against the built bundle, where `pnpm version patch -m "release %s"` produced the commit `release 1.0.1` and the tag `v1.0.1`. clap has no such fallback, which is why only v12 needed the change.

Verification performed:

- `version_message_short_flag_is_an_alias_of_message` in `pnpm/crates/cli/src/cli_args/tests.rs` asserts `-m` and `--message` land on the same field and that the bump positional survives. It fails on unmodified `main` with the issue's exact clap error.
- `cargo test -p pnpm-cli --lib cli_args::`: 1078 passed, 0 failed.
- `cargo nextest run -p pnpm-cli --test suite -E 'test(/^version::/)'`: 46 passed, 0 failed.
- `cargo fmt --check -p pnpm-cli` and `cargo clippy -p pnpm-cli --lib --tests`: clean.
- Manual end-to-end repro of the issue against the built binary: `pnpm version patch -m "message"` now succeeds and the commit carries the message.

## Squash Commit Body

The Rust CLI's `pnpm version` declared `--message` as a long-only clap flag, so `-m` was rejected even though it is documented as an alias (pnpm.io/cli/version). Register `short = 'm'` on the field, matching the alias convention other flags in the same crate already use.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version. (Only v12 is affected; see the note above.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users, it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (pnpm.io already documents `-m`; this makes the CLI match it.)

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `pnpm version` now accepts `-m` as a short alias for `--message`, alongside the existing long-form option. This provides a more concise way to supply a version message while preserving current usage.

- **Tests**
  - Added coverage confirming that the short and long option forms produce the same result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->