### PR TITLE
fix(package-manager): anchor local overrides during freshness checks

### DIFF
--- a/.changeset/frozen-local-overrides.md
+++ b/.changeset/frozen-local-overrides.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm install --frozen-lockfile` rejecting generated lockfiles for workspace projects using relative `file:` or `link:` overrides [#14555](https://github.com/pnpm/pnpm/issues/14555).

--- a/.changeset/frozen-local-overrides.md
+++ b/.changeset/frozen-local-overrides.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `pnpm install --frozen-lockfile` rejecting generated lockfiles for workspace projects using relative `file:` or `link:` overrides [#14555](https://github.com/pnpm/pnpm/issues/14555).
+Fixed `pnpm install --frozen-lockfile` rejecting a lockfile that pnpm had just generated. The rejection happened when `pnpm.overrides` pointed a dependency at a relative `file:` or `link:` path and the workspace had projects below the lockfile directory [#14555](https://github.com/pnpm/pnpm/issues/14555).

--- a/pnpm/crates/cli/tests/suite/lockfile_dir.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_dir.rs
@@ -5,11 +5,16 @@
 //! and the importer ids, which become the paths from the pin down to each
 //! project. Every project keeps its own `node_modules` of symlinks.
 
-use crate::_utils::{append_workspace_yaml_key, pacquet_in};
+use crate::_utils::{
+    ManifestDeps, append_workspace_yaml_key, pacquet_in, read_manifest, write_project_manifest,
+};
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pnpm_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    fixtures::minimal_tarball,
+};
 use serde_json::json;
 use std::{fs, path::Path, process::Command};
 
@@ -270,4 +275,53 @@ fn a_pin_overrides_dedicated_per_project_lockfiles() {
     );
 
     drop(mock_instance);
+}
+
+#[test]
+fn frozen_replay_resolves_local_overrides_from_the_custom_lockfile_dir() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let lockfile_dir = root.path();
+    fs::write(lockfile_dir.join("vendored.tgz"), minimal_tarball("vendored", "1.0.0"))
+        .expect("write tarball at the lockfile root");
+    write_project_manifest(&lockfile_dir.join("linked"), "linked", ManifestDeps::default());
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages: ['packages/*']\n\
+         lockfileDir: ..\n\
+         storeDir: ../pacquet-store\n\
+         cacheDir: ../pacquet-cache\n\
+         enableGlobalVirtualStore: false\n\
+         offline: true\n\
+         overrides:\n  vendored: file:./vendored.tgz\n  linked: link:./linked\n",
+    )
+    .expect("write workspace settings");
+    for (project, name) in [(".", "root"), ("packages/a", "a")] {
+        write_project_manifest(
+            &workspace.join(project),
+            name,
+            ManifestDeps {
+                prod: &[("vendored", "^1.0.0"), ("linked", "^1.0.0")],
+                ..ManifestDeps::default()
+            },
+        );
+    }
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile_path = lockfile_dir.join("pnpm-lock.yaml");
+    let lockfile =
+        fs::read(&lockfile_path).expect("read generated lockfile at the custom location");
+
+    pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_eq!(fs::read(&lockfile_path).unwrap(), lockfile);
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "frozen replay must keep the lockfile at the custom location",
+    );
+    for project in [".", "packages/a"] {
+        for name in ["vendored", "linked"] {
+            let installed = read_manifest(&workspace.join(project).join("node_modules").join(name));
+            assert_eq!(installed["name"], name);
+            assert_eq!(installed["version"], "1.0.0");
+        }
+    }
 }

--- a/pnpm/crates/cli/tests/suite/lockfile_only.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_only.rs
@@ -6,6 +6,8 @@
 //! `--frozen-lockfile --lockfile-only` combination still validates the
 //! on-disk lockfile against the manifest and fails when it is stale.
 
+mod local_overrides;
+
 use crate::_utils;
 pub use _utils::append_workspace_yaml_key;
 

--- a/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
@@ -1,0 +1,91 @@
+use crate::_utils::{ManifestDeps, pacquet_in, read_manifest, write_project_manifest};
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::{bin::CommandTempCwd, fixtures::minimal_tarball, fs::bump_mtime};
+use std::fs;
+
+#[test]
+fn frozen_replay_installs_local_overrides_at_different_importer_depths() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project_manifest(&workspace, "root", ManifestDeps::default());
+    write_project_manifest(&workspace.join("linked"), "linked", ManifestDeps::default());
+    fs::write(workspace.join("vendored.tgz"), minimal_tarball("vendored", "1.0.0"))
+        .expect("write local tarball");
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages: ['packages/*', 'packages/nested/*']\n\
+         storeDir: ../pacquet-store\n\
+         cacheDir: ../pacquet-cache\n\
+         enableGlobalVirtualStore: false\n\
+         offline: true\n\
+         overrides:\n  vendored: file:./vendored.tgz\n  linked: link:./linked\n",
+    )
+    .expect("write workspace settings");
+    for (project, name) in [("packages/a", "a"), ("packages/nested/b", "b")] {
+        write_project_manifest(
+            &workspace.join(project),
+            name,
+            ManifestDeps {
+                prod: &[("vendored", "^1.0.0")],
+                dev: &[("linked", "^1.0.0")],
+                ..ManifestDeps::default()
+            },
+        );
+    }
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read(&lockfile_path).expect("read generated lockfile");
+
+    pacquet_in(&workspace).with_args(["install", "--frozen-lockfile"]).assert().success();
+    assert_eq!(fs::read(&lockfile_path).unwrap(), lockfile);
+    for project in ["packages/a", "packages/nested/b"] {
+        for name in ["vendored", "linked"] {
+            let installed = read_manifest(&workspace.join(project).join("node_modules").join(name));
+            assert_eq!(installed["name"], name);
+            assert_eq!(installed["version"], "1.0.0");
+        }
+    }
+
+    drop(root);
+}
+
+#[test]
+fn exec_content_check_accepts_a_root_relative_link_override() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project_manifest(&workspace.join("linked"), "linked", ManifestDeps::default());
+    for (project, name, spec) in
+        [(".", "root", "link:linked"), ("packages/nested/a", "a", "link:../../../linked")]
+    {
+        write_project_manifest(
+            &workspace.join(project),
+            name,
+            ManifestDeps { prod: &[("linked", spec)], ..ManifestDeps::default() },
+        );
+    }
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "packages: ['packages/nested/*']\n\
+         storeDir: ../pacquet-store\n\
+         cacheDir: ../pacquet-cache\n\
+         enableGlobalVirtualStore: false\n\
+         offline: true\n\
+         verifyDepsBeforeRun: error\n\
+         overrides:\n  linked: link:./linked\n",
+    )
+    .expect("write workspace settings");
+
+    pacquet.with_arg("install").assert().success();
+    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile = fs::read(&lockfile_path).expect("read generated lockfile");
+    bump_mtime(&workspace.join("packages/nested/a/package.json"));
+
+    pacquet_in(&workspace.join("packages/nested/a"))
+        .with_args(["exec", "node", "-p", "require('linked/package.json').version"])
+        .assert()
+        .success()
+        .stdout("1.0.0\n");
+    assert_eq!(fs::read(&lockfile_path).unwrap(), lockfile);
+
+    drop(root);
+}

--- a/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
@@ -1,3 +1,8 @@
+//! Local `pnpm.overrides` targets (`file:` / `link:`) name a path from
+//! the lockfile directory, so a freshness check has to reconstruct the
+//! very specifiers the writer recorded no matter which importer it runs
+//! from or where the lockfile is pinned.
+
 use crate::_utils::{
     ManifestDeps, append_workspace_yaml_key, pacquet_in, read_manifest, write_project_manifest,
 };
@@ -64,18 +69,13 @@ fn exec_content_check_accepts_a_link_override_from_a_custom_lockfile_dir() {
 
 fn assert_exec_content_check_accepts_link_override(custom_lockfile_dir: bool) {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    let (lockfile_dir, root_spec, nested_spec) = if custom_lockfile_dir {
-        (root.path(), "link:../linked", "link:../../../../linked")
-    } else {
-        (workspace.as_path(), "link:linked", "link:../../../linked")
-    };
+    let lockfile_dir = if custom_lockfile_dir { root.path() } else { workspace.as_path() };
     write_project_manifest(&lockfile_dir.join("linked"), "linked", ManifestDeps::default());
-    for (project, name, spec) in [(".", "root", root_spec), ("packages/nested/a", "a", nested_spec)]
-    {
+    for (project, name) in [(".", "root"), ("packages/nested/a", "a")] {
         write_project_manifest(
             &workspace.join(project),
             name,
-            ManifestDeps { prod: &[("linked", spec)], ..ManifestDeps::default() },
+            ManifestDeps { prod: &[("linked", "^1.0.0")], ..ManifestDeps::default() },
         );
     }
     fs::write(

--- a/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
@@ -1,4 +1,6 @@
-use crate::_utils::{ManifestDeps, pacquet_in, read_manifest, write_project_manifest};
+use crate::_utils::{
+    ManifestDeps, append_workspace_yaml_key, pacquet_in, read_manifest, write_project_manifest,
+};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{bin::CommandTempCwd, fixtures::minimal_tarball, fs::bump_mtime};
@@ -52,10 +54,23 @@ fn frozen_replay_installs_local_overrides_at_different_importer_depths() {
 
 #[test]
 fn exec_content_check_accepts_a_root_relative_link_override() {
+    assert_exec_content_check_accepts_link_override(false);
+}
+
+#[test]
+fn exec_content_check_accepts_a_link_override_from_a_custom_lockfile_dir() {
+    assert_exec_content_check_accepts_link_override(true);
+}
+
+fn assert_exec_content_check_accepts_link_override(custom_lockfile_dir: bool) {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    write_project_manifest(&workspace.join("linked"), "linked", ManifestDeps::default());
-    for (project, name, spec) in
-        [(".", "root", "link:linked"), ("packages/nested/a", "a", "link:../../../linked")]
+    let (lockfile_dir, root_spec, nested_spec) = if custom_lockfile_dir {
+        (root.path(), "link:../linked", "link:../../../../linked")
+    } else {
+        (workspace.as_path(), "link:linked", "link:../../../linked")
+    };
+    write_project_manifest(&lockfile_dir.join("linked"), "linked", ManifestDeps::default());
+    for (project, name, spec) in [(".", "root", root_spec), ("packages/nested/a", "a", nested_spec)]
     {
         write_project_manifest(
             &workspace.join(project),
@@ -74,9 +89,12 @@ fn exec_content_check_accepts_a_root_relative_link_override() {
          overrides:\n  linked: link:./linked\n",
     )
     .expect("write workspace settings");
+    if custom_lockfile_dir {
+        append_workspace_yaml_key(&workspace, "lockfileDir", "..");
+    }
 
     pacquet.with_arg("install").assert().success();
-    let lockfile_path = workspace.join("pnpm-lock.yaml");
+    let lockfile_path = lockfile_dir.join("pnpm-lock.yaml");
     let lockfile = fs::read(&lockfile_path).expect("read generated lockfile");
     bump_mtime(&workspace.join("packages/nested/a/package.json"));
 

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -87,6 +87,7 @@ pub async fn wanted_lockfile_satisfies_workspace(
         .collect();
     check_lockfile_freshness(
         lockfile,
+        &lockfile_root,
         &manifest_freshness_inputs,
         config,
         catalogs,
@@ -106,6 +107,7 @@ pub async fn wanted_lockfile_satisfies_workspace(
 
 pub(super) struct FastUpdateLockfileOptions<'a, 'manifest> {
     pub(super) lockfile: Option<&'a Lockfile>,
+    pub(super) lockfile_dir: &'a Path,
     pub(super) manifests: &'a [(String, &'manifest PackageManifest)],
     pub(super) project_manifests: &'a [(PathBuf, &'manifest PackageManifest)],
     pub(super) config: &'a Config,
@@ -146,6 +148,7 @@ pub(super) async fn try_fast_update_lockfile<Reporter: pnpm_reporter::Reporter>(
     )?;
     check_lockfile_freshness(
         &candidate,
+        opts.lockfile_dir,
         opts.manifests,
         opts.config,
         opts.catalogs,
@@ -230,6 +233,7 @@ pub(super) fn removed_importer_id<'a>(
 /// [`pnpm_hooks::current_pnpmfile_checksum`]).
 pub(super) async fn check_lockfile_freshness(
     lockfile: &Lockfile,
+    lockfile_dir: &Path,
     manifest_freshness_inputs: &[(String, &PackageManifest)],
     config: &Config,
     catalogs: &Catalogs,
@@ -290,6 +294,7 @@ pub(super) async fn check_lockfile_freshness(
             }
             check_importer_satisfies(
                 lockfile,
+                lockfile_dir,
                 manifest,
                 importer_id,
                 config,
@@ -380,6 +385,7 @@ pub(crate) fn check_lockfile_settings_drift(
 /// importer snapshot.
 pub(crate) fn check_importer_satisfies(
     lockfile: &Lockfile,
+    lockfile_dir: &Path,
     manifest: &PackageManifest,
     importer_id: &str,
     config: &Config,
@@ -403,24 +409,24 @@ pub(crate) fn check_importer_satisfies(
     // comparison needs done up front: applying `pnpm.overrides` and dropping
     // `link:` deps under `exclude_links_from_lockfile`.
     let normalized_manifest_holder;
-    let manifest_for_freshness: &PackageManifest = if parsed_overrides.is_some()
-        || config.exclude_links_from_lockfile
-    {
-        let root_dir = manifest.path().parent().unwrap_or_else(|| Path::new("."));
-        normalized_manifest_holder = {
-            let mut cloned: PackageManifest = manifest.clone();
-            if let Some(parsed) = parsed_overrides {
-                crate::VersionsOverrider::new(parsed, root_dir).apply(&mut cloned, Some(root_dir));
-            }
-            if config.exclude_links_from_lockfile {
-                exclude_linked_dependencies(&mut cloned);
-            }
-            cloned
+    let manifest_for_freshness: &PackageManifest =
+        if parsed_overrides.is_some() || config.exclude_links_from_lockfile {
+            let project_dir = manifest.path().parent().unwrap_or_else(|| Path::new("."));
+            normalized_manifest_holder = {
+                let mut cloned: PackageManifest = manifest.clone();
+                if let Some(parsed) = parsed_overrides {
+                    crate::VersionsOverrider::new(parsed, lockfile_dir)
+                        .apply(&mut cloned, Some(project_dir));
+                }
+                if config.exclude_links_from_lockfile {
+                    exclude_linked_dependencies(&mut cloned);
+                }
+                cloned
+            };
+            &normalized_manifest_holder
+        } else {
+            manifest
         };
-        &normalized_manifest_holder
-    } else {
-        manifest
-    };
 
     // Build the `ignoredOptionalDependencies` filter set: iterate
     // `manifest.optionalDependencies` and delete matches from BOTH the
@@ -546,3 +552,6 @@ impl From<FreshnessCheckError> for InstallError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -383,6 +383,11 @@ pub(crate) fn check_lockfile_settings_drift(
 /// Per-importer slice of the freshness gate: the manifest of the
 /// project at `importer_id` must still be satisfied by the lockfile's
 /// importer snapshot.
+///
+/// `lockfile_dir` is the directory the lockfile was written from. A
+/// relative `link:` / `file:` override target names a path from there,
+/// so anchoring the overrider anywhere else rewrites the manifest to
+/// specifiers the lockfile never recorded.
 pub(crate) fn check_importer_satisfies(
     lockfile: &Lockfile,
     lockfile_dir: &Path,

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness/tests.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness/tests.rs
@@ -1,0 +1,78 @@
+use super::{WantedLockfileSatisfactionCheck, wanted_lockfile_satisfies_workspace};
+use pnpm_catalogs_types::Catalogs;
+use pnpm_config::Config;
+use pnpm_lockfile::Lockfile;
+use pnpm_package_manifest::PackageManifest;
+use std::fs;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn workspace_satisfaction_uses_pinned_lockfile_dir_for_local_overrides() {
+    let root = tempdir().expect("create fixture directory");
+    let workspace_dir = root.path().join("workspace");
+    let project_dir = workspace_dir.join("pkgs/a");
+    let lockfile_dir = root.path().join("locks");
+    fs::create_dir_all(&project_dir).expect("create nested project");
+    fs::create_dir_all(&lockfile_dir).expect("create lockfile directory");
+    fs::write(workspace_dir.join("package.json"), r#"{"name":"root","private":true}"#)
+        .expect("write root manifest");
+    fs::write(workspace_dir.join("pnpm-workspace.yaml"), "packages:\n  - pkgs/*\n")
+        .expect("write workspace manifest");
+    fs::write(project_dir.join("package.json"), r#"{"name":"a","dependencies":{"foo":"*"}}"#)
+        .expect("write nested manifest");
+    let manifest =
+        PackageManifest::from_path(project_dir.join("package.json")).expect("read nested manifest");
+    let mut config = Config::new();
+    config.workspace_dir = Some(workspace_dir);
+    config.lockfile_dir = Some(lockfile_dir);
+    config.ignore_pnpmfile = true;
+    config.overrides =
+        Some(indexmap::IndexMap::from([("foo".to_string(), "link:./foo".to_string())]));
+    let lockfile: Lockfile = serde_saphyr::from_str(
+        r"lockfileVersion: '9.0'
+overrides:
+  foo: link:./foo
+importers:
+  ../workspace: {}
+  ../workspace/pkgs/a:
+    dependencies:
+      foo:
+        specifier: link:../../../locks/foo
+        version: link:../../../locks/foo
+",
+    )
+    .expect("parse lockfile");
+    let catalogs = Catalogs::new();
+    let check = WantedLockfileSatisfactionCheck {
+        config: &config,
+        manifest: &manifest,
+        catalogs: &catalogs,
+        lockfile: &lockfile,
+        ignore_manifest_check: false,
+    };
+    assert!(
+        wanted_lockfile_satisfies_workspace(&check).await,
+        "a nested project's override must resolve from the pinned lockfile directory",
+    );
+
+    let mut stale_lockfile = lockfile.clone();
+    stale_lockfile
+        .importers
+        .get_mut("../workspace/pkgs/a")
+        .expect("nested importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .values_mut()
+        .next()
+        .expect("foo dependency")
+        .specifier = "link:foo".to_string();
+    assert!(
+        !wanted_lockfile_satisfies_workspace(&WantedLockfileSatisfactionCheck {
+            lockfile: &stale_lockfile,
+            ..check
+        })
+        .await,
+        "an override incorrectly anchored at the nested project must be rejected",
+    );
+}

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -760,6 +760,7 @@ where
             Some(current) if lockfile.is_none() && !frozen_lockfile && prefer_frozen_lockfile => {
                 check_lockfile_freshness(
                     current,
+                    &workspace_root,
                     &manifest_freshness_inputs,
                     config,
                     &catalogs,
@@ -804,6 +805,7 @@ where
         let fast_updated_lockfile = if can_fast_update_lockfile {
             try_fast_update_lockfile::<Reporter>(FastUpdateLockfileOptions {
                 lockfile,
+                lockfile_dir: &workspace_root,
                 manifests: &manifest_freshness_inputs,
                 project_manifests: &project_manifests,
                 config,
@@ -984,6 +986,7 @@ where
             // again inside the frozen branch below.
             check_lockfile_freshness(
                 lockfile,
+                &workspace_root,
                 &manifest_freshness_inputs,
                 config,
                 &catalogs,
@@ -1014,6 +1017,7 @@ where
             if prefer_frozen_lockfile {
                 match check_lockfile_freshness(
                     lockfile,
+                    &workspace_root,
                     &manifest_freshness_inputs,
                     config,
                     &catalogs,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -105,9 +105,13 @@ pub enum Decision {
 
 /// Inputs to [`check_optimistic_repeat_install`].
 pub struct OptimisticRepeatInstallCheck<'a> {
-    /// The directory containing `pnpm-workspace.yaml` (or the project
-    /// root when no workspace manifest exists — same fallback as
-    /// [`Install::run`](crate::Install::run)).
+    /// The root the install recorded its lockfile and workspace state
+    /// against, which importer ids and relative local `pnpm.overrides`
+    /// targets are named from too. The directory containing
+    /// `pnpm-workspace.yaml` (or the project root when no workspace
+    /// manifest exists — same fallback as
+    /// [`Install::run`](crate::Install::run)), unless the configuration
+    /// pins the lockfile somewhere else.
     pub workspace_root: &'a Path,
     pub config: &'a Config,
     pub node_linker: NodeLinker,

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/manifest_agreement.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/manifest_agreement.rs
@@ -138,6 +138,7 @@ pub(crate) fn modified_manifests_match_lockfile(
             pnpm_workspace::importer_id_from_root_dir(workspace_root, project.root_dir);
         if let Err(error) = crate::install::check_importer_satisfies(
             wanted,
+            workspace_root,
             project.manifest,
             &importer_id,
             config,


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14555.

An unchanged workspace using a root-relative local override could generate
`specifier: file:../../vendored.tgz` and then reject it during frozen install
because the checker computed `file:vendored.tgz`. The checker now receives the
same lockfile directory as the writer and still expresses the result relative
to each importer. This also covers custom `lockfileDir`, optimistic content
checks, fast-update validation, and pnpr's satisfaction check. No filesystem
reads or path-discovery passes are added.

This is a Rust-only parity fix. The TypeScript CLI already constructs the
override hook with `lockfileDir` and applies it with each project's directory.
The three original CLI regression scenarios pass unchanged on pnpm 11.25.0; no
TypeScript port is needed.

Validation on macOS arm64:

- `just ready`: 9,958 tests passed, five existing skips; formatting, type
  checks, and workspace Clippy passed.
- The pre-push hook passed TypeScript compilation/bundling and lint, plus
  Rust formatting, Clippy, rustdoc, Dylint, spelling, and TOML formatting.
- Seven targeted mutation experiments were detected by the retained tests.
  The three original CLI regressions fail on the unmodified release binary and pass
  on the patched release binary and pnpm 11.25.0.
- Release A/B measurements across 128-member workspaces, twelve cases, and
  forty interleaved samples per case showed median changes of -2.4% to +3.0%,
  within observed sample variability. Peak RSS changed by less than 1%.

### Test-only follow-up

[Commit 7b637b8cd1](https://github.com/pnpm/pnpm/commit/7b637b8cd1213295b9b3defad805230a04bafd03)
extends the existing exec fixture to cover `lockfileDir: ..` with a nested
importer, a relative `link:` override, and a touched manifest that forces
content validation. The default-root case is retained. No runtime code changes.

- All ten related lockfile-directory/local-override CLI tests passed.
- A caller mutation that passes the discovered workspace directory instead
  of the configured lockfile directory makes only the new custom-root exec
  test fail. The default-root case still passes. This checks directory
  propagation; the mutant fails when looking up the wanted lockfile.
- The new combined case exposes a separate limitation in published pnpm
  11.25.0: custom-root exec verification fails even without overrides.
  The original three cross-version scenarios still pass on that version.
  This test-only follow-up does not change or fix that v11 behavior.

The push triggered a [fresh Linux integrated-benchmark run](https://github.com/pnpm/pnpm/actions/runs/34058442866).

## Squash Commit Body

```text
The writer resolves relative local overrides from the lockfile directory,
but freshness checks constructed their override handler from each
importer's directory. Nested importers therefore failed frozen replay
even when neither manifests nor configuration had changed.

Pass the existing lockfile directory through all freshness-check callers
and keep the importer directory separate when applying overrides. Reuse
the existing path conversion without changing the generated lockfile.

Add regression coverage for default and custom lockfile roots, exec
content checks, and pnpr satisfaction. The TypeScript CLI already follows
these directory semantics.

Fixes pnpm/pnpm#14555.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-6-astra).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791170114&installation_model_id=426870&pr_number=14572&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14572&signature=7ccca4390d4cc6dac9076cbe25843205c7d08c3bc4314d98cd7da1a8e41641ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm install --frozen-lockfile` rejecting lockfiles for workspace projects using relative `file:` or `link:` overrides.
  - Local overrides now resolve correctly from custom lockfile locations and across projects at different workspace depths.
  - Improved compatibility for root-relative `link:` overrides during `pnpm exec` checks.
  - Fixed frozen-lockfile replay after generating lockfiles with `--lockfile-only` when local overrides are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->