### PR TITLE
fix(cmd-shim): retry locked bin removal and replacement

### DIFF
--- a/.changeset/retry-locked-bin-files.md
+++ b/.changeset/retry-locked-bin-files.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+On Windows, pnpm now retries removing command shims that are temporarily locked by another process during installation [#14549](https://github.com/pnpm/pnpm/issues/14549).

--- a/.changeset/retry-locked-bin-files.md
+++ b/.changeset/retry-locked-bin-files.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-On Windows, pnpm now retries removing command shims that are temporarily locked by another process during installation [#14549](https://github.com/pnpm/pnpm/issues/14549).
+On Windows, pnpm now retries removing and replacing command shims that another process has temporarily locked during installation [#14549](https://github.com/pnpm/pnpm/issues/14549).

--- a/pnpm/crates/cmd-shim/Cargo.toml
+++ b/pnpm/crates/cmd-shim/Cargo.toml
@@ -28,5 +28,8 @@ walkdir     = { workspace = true }
 [dev-dependencies]
 tempfile = { workspace = true }
 
+[target.'cfg(windows)'.dev-dependencies]
+pnpm-fs = { workspace = true, features = ["test"] }
+
 [lints]
 workspace = true

--- a/pnpm/crates/cmd-shim/src/capabilities.rs
+++ b/pnpm/crates/cmd-shim/src/capabilities.rs
@@ -262,7 +262,7 @@ impl FsWrite for Host {
                 };
             let written = tmp.write_all(bytes);
             drop(tmp);
-            let result = written.and_then(|()| std::fs::rename(&tmp_path, path));
+            let result = written.and_then(|()| pnpm_fs::rename_with_retry(&tmp_path, path));
             if result.is_err() {
                 let _ = std::fs::remove_file(&tmp_path);
             }

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -1057,6 +1057,10 @@ where
 }
 
 #[cfg(windows)]
+#[expect(
+    clippy::extra_unused_type_parameters,
+    reason = "The Windows no-op shares the generic signature of the Unix implementation."
+)]
 fn link_symlinked_executable<Sys>(
     _target_path: &Path,
     _shim_path: &Path,
@@ -1174,11 +1178,8 @@ fn replace_shim<Sys: FsWrite>(path: &Path, bytes: &[u8]) -> Result<(), LinkBinsE
 /// EROFS, `AppArmor` deny, ...) surfaces as [`LinkBinsError::RemoveStaleBin`]
 /// so a real failure isn't hidden behind a silent skip.
 fn remove_stale_bin(path: &Path) -> Result<(), LinkBinsError> {
-    match std::fs::remove_file(path) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(LinkBinsError::RemoveStaleBin { path: path.to_path_buf(), error }),
-    }
+    remove_if_exists(path)
+        .map_err(|error| LinkBinsError::RemoveStaleBin { path: path.to_path_buf(), error })
 }
 
 /// Append `<ext>` to `path` as a *new* extension segment (`foo` becomes
@@ -1212,7 +1213,7 @@ pub fn remove_bin(bin_path: &Path) -> io::Result<()> {
 }
 
 fn remove_if_exists(path: &Path) -> io::Result<()> {
-    match std::fs::remove_file(path) {
+    match pnpm_fs::remove_file_with_retry(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error),

--- a/pnpm/crates/cmd-shim/src/link_bins.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins.rs
@@ -1057,10 +1057,6 @@ where
 }
 
 #[cfg(windows)]
-#[expect(
-    clippy::extra_unused_type_parameters,
-    reason = "The Windows no-op shares the generic signature of the Unix implementation."
-)]
 fn link_symlinked_executable<Sys>(
     _target_path: &Path,
     _shim_path: &Path,

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     BinOrigin, LinkBinsError, LinkBinsOptions, PackageBinSource, ShimTargetCache, link_bins,
-    link_bins_of_packages, link_bins_of_packages_cached,
+    link_bins_of_packages, link_bins_of_packages_cached, remove_bin,
 };
 use crate::{
     capabilities::{
@@ -26,6 +26,66 @@ use std::fs::metadata;
 #[cfg(windows)]
 use std::fs::remove_file;
 use tempfile::tempdir;
+
+#[test]
+fn removing_bin_entries_preserves_their_targets() {
+    let tmp = tempdir().unwrap();
+    let target = tmp.path().join("node.exe");
+    write_file(&target, "node binary").unwrap();
+    let bins_dir = tmp.path().join(".bin");
+    create_dir_all(&bins_dir).unwrap();
+    let bin = bins_dir.join("node");
+    std::fs::hard_link(&target, &bin).unwrap();
+    if cfg!(windows) {
+        std::fs::hard_link(&target, bins_dir.join("node.exe")).unwrap();
+        write_file(bins_dir.join("node.cmd"), "old shim").unwrap();
+    }
+
+    remove_bin(&bin).unwrap();
+    remove_bin(&bin).expect("removing an already removed command must succeed");
+
+    assert_eq!(std::fs::read_dir(&bins_dir).unwrap().count(), 0);
+    assert_eq!(read_to_string(&target).unwrap(), "node binary");
+
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&target, &bin).unwrap();
+        remove_bin(&bin).unwrap();
+        assert_eq!(std::fs::read_dir(&bins_dir).unwrap().count(), 0);
+        assert_eq!(read_to_string(&target).unwrap(), "node binary");
+    }
+}
+
+#[test]
+#[cfg_attr(windows, ignore = "Windows retries directory deletion errors as possible file locks")]
+fn bin_cleanup_and_replacement_preserve_deletion_errors() {
+    let tmp = tempdir().unwrap();
+    let pkg_dir = tmp.path().join("node_modules/foo");
+    create_dir_all(&pkg_dir).unwrap();
+    write_file(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+    let bins_dir = tmp.path().join("node_modules/.bin");
+    let shim = bins_dir.join("foo");
+    create_dir_all(&shim).unwrap();
+    let preserved = shim.join("keep");
+    write_file(&preserved, "untouched").unwrap();
+    let expected = std::fs::remove_file(&shim).unwrap_err().raw_os_error();
+
+    let error = remove_bin(&shim).expect_err("a directory must not be silently removed");
+    assert_eq!(error.raw_os_error(), expected);
+
+    let error = link_bins_of_packages::<Host>(
+        &[PackageBinSource::new(pkg_dir, Arc::new(json!({"name": "foo", "bin": "cli.js"})))],
+        &bins_dir,
+        &LinkBinsOptions::default(),
+    )
+    .expect_err("replacement must stop when the old entry cannot be removed");
+    let LinkBinsError::RemoveStaleBin { path, error } = error else {
+        panic!("unexpected replacement error: {error:?}");
+    };
+    assert_eq!(path, shim);
+    assert_eq!(error.raw_os_error(), expected);
+    assert_eq!(read_to_string(preserved).unwrap(), "untouched");
+}
 
 #[test]
 fn writes_shim_flavors_matching_host_platform() {
@@ -1462,7 +1522,7 @@ fn prefer_symlinked_executables_links_bins_as_relative_symlinks() {
     let options =
         LinkBinsOptions { prefer_symlinked_executables: true, ..LinkBinsOptions::default() };
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(pkg_dir.clone(), Arc::new(manifest_value))],
+        &[PackageBinSource::new(pkg_dir, Arc::new(manifest_value))],
         &bins_dir,
         &options,
     )
@@ -1489,7 +1549,7 @@ fn prefer_symlinked_executables_links_bins_as_relative_symlinks() {
     {
         use std::os::unix::fs::PermissionsExt;
         assert_eq!(
-            metadata(pkg_dir.join("cli.js")).unwrap().permissions().mode() & 0o777,
+            metadata(&bin).unwrap().permissions().mode() & 0o777,
             0o755,
             "the target file gets the executable bits, like pnpm's ensureExecutable",
         );

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -60,7 +60,10 @@ fn removing_bin_entries_preserves_their_targets() {
 }
 
 #[test]
-#[cfg_attr(windows, ignore = "Windows retries directory deletion errors as possible file locks")]
+#[cfg_attr(
+    windows,
+    ignore = "Windows spends the retry budget on the permanent error: pnpm/pnpm#14682"
+)]
 fn bin_cleanup_and_replacement_preserve_deletion_errors() {
     let tmp = tempdir().unwrap();
     let pkg_dir = tmp.path().join("node_modules/node");
@@ -1525,7 +1528,7 @@ fn prefer_symlinked_executables_links_bins_as_relative_symlinks() {
     let options =
         LinkBinsOptions { prefer_symlinked_executables: true, ..LinkBinsOptions::default() };
     link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(pkg_dir, Arc::new(manifest_value))],
+        &[PackageBinSource::new(pkg_dir.clone(), Arc::new(manifest_value))],
         &bins_dir,
         &options,
     )
@@ -1552,7 +1555,7 @@ fn prefer_symlinked_executables_links_bins_as_relative_symlinks() {
     {
         use std::os::unix::fs::PermissionsExt;
         assert_eq!(
-            metadata(&bin).unwrap().permissions().mode() & 0o777,
+            metadata(pkg_dir.join("cli.js")).unwrap().permissions().mode() & 0o777,
             0o755,
             "the target file gets the executable bits, like pnpm's ensureExecutable",
         );

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -63,11 +63,11 @@ fn removing_bin_entries_preserves_their_targets() {
 #[cfg_attr(windows, ignore = "Windows retries directory deletion errors as possible file locks")]
 fn bin_cleanup_and_replacement_preserve_deletion_errors() {
     let tmp = tempdir().unwrap();
-    let pkg_dir = tmp.path().join("node_modules/foo");
+    let pkg_dir = tmp.path().join("node_modules/node");
     create_dir_all(&pkg_dir).unwrap();
-    write_file(pkg_dir.join("cli.js"), "#!/usr/bin/env node\n").unwrap();
+    write_file(pkg_dir.join("node.exe"), "node binary").unwrap();
     let bins_dir = tmp.path().join("node_modules/.bin");
-    let shim = bins_dir.join("foo");
+    let shim = bins_dir.join(if cfg!(windows) { "node.exe" } else { "node" });
     create_dir_all(&shim).unwrap();
     let preserved = shim.join("keep");
     write_file(&preserved, "untouched").unwrap();
@@ -77,7 +77,7 @@ fn bin_cleanup_and_replacement_preserve_deletion_errors() {
     assert_eq!(error.raw_os_error(), expected);
 
     let error = link_bins_of_packages::<Host>(
-        &[PackageBinSource::new(pkg_dir, Arc::new(json!({"name": "foo", "bin": "cli.js"})))],
+        &[PackageBinSource::new(pkg_dir, Arc::new(json!({"name": "node", "bin": "node.exe"})))],
         &bins_dir,
         &LinkBinsOptions::default(),
     )

--- a/pnpm/crates/cmd-shim/src/link_bins/tests.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests.rs
@@ -27,6 +27,9 @@ use std::fs::metadata;
 use std::fs::remove_file;
 use tempfile::tempdir;
 
+#[cfg(windows)]
+mod windows_native;
+
 #[test]
 fn removing_bin_entries_preserves_their_targets() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
@@ -1,0 +1,94 @@
+use crate::{
+    capabilities::Host,
+    link_bins::{LinkBinsOptions, PackageBinSource, link_bins_of_packages, remove_bin},
+    shim::is_shim_pointing_at,
+};
+use pnpm_fs::test_support::with_file_removal_observer;
+use serde_json::json;
+use std::{
+    fmt::Debug,
+    fs,
+    os::windows::fs::OpenOptionsExt,
+    path::Path,
+    sync::{Arc, mpsc},
+};
+use tempfile::tempdir;
+
+fn assert_recovers_after_lock<Error: Debug>(
+    path: &Path,
+    operation: impl FnOnce() -> Result<(), Error>,
+) {
+    // Permit normal reads and writes, but omit FILE_SHARE_DELETE.
+    let mut handle =
+        Some(fs::OpenOptions::new().read(true).share_mode(0x1 | 0x2).open(path).unwrap());
+    let (sender, receiver) = mpsc::channel();
+    let result = with_file_removal_observer(
+        path,
+        move |attempt| {
+            sender.send(attempt.as_ref().copied().map_err(std::io::Error::raw_os_error)).unwrap();
+            if attempt.is_err() {
+                // Release only after a real failed deletion, not after a scheduled delay.
+                drop(handle.take());
+            }
+        },
+        operation,
+    );
+    let attempts: Vec<_> = receiver.try_iter().collect();
+    eprintln!("removal result: {result:?}; real filesystem attempts: {attempts:?}");
+    result.expect("the operation must recover after the deny-delete handle closes");
+    assert!(matches!(attempts.first(), Some(Err(Some(5 | 32 | 33)))));
+    assert_eq!(attempts.last(), Some(&Ok(())));
+}
+
+#[test]
+fn cleanup_recovers_after_transient_lock() {
+    let root = tempdir().unwrap();
+    let target = root.path().join("program");
+    fs::write(&target, "program content").unwrap();
+    let bins = root.path().join(".bin");
+    fs::create_dir(&bins).unwrap();
+    let shim = bins.join("foo");
+    fs::hard_link(&target, &shim).unwrap();
+    for suffix in ["cmd", "ps1", "exe"] {
+        fs::write(bins.join(format!("foo.{suffix}")), "old shim").unwrap();
+    }
+
+    assert_recovers_after_lock(&shim, || remove_bin(&shim));
+
+    assert_eq!(fs::read_dir(&bins).unwrap().count(), 0);
+    assert_eq!(fs::read_to_string(target).unwrap(), "program content");
+}
+
+#[test]
+fn replacement_recovers_after_transient_lock() {
+    let root = tempdir().unwrap();
+    let package = root.path().join("foo");
+    fs::create_dir(&package).unwrap();
+    let target = package.join("cli.js");
+    let content = "#!/usr/bin/env node\nconsole.log('new target')\n";
+    fs::write(&target, content).unwrap();
+    let bins = root.path().join(".bin");
+    fs::create_dir(&bins).unwrap();
+    let shim = bins.join("foo");
+    fs::write(&shim, "stale shim pointing at an obsolete program").unwrap();
+    let packages = [PackageBinSource::new(
+        package,
+        Arc::new(json!({"name": "foo", "version": "1.0.0", "bin": "cli.js"})),
+    )];
+    let pool = rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap();
+
+    assert_recovers_after_lock(&shim, || {
+        pool.install(|| {
+            link_bins_of_packages::<Host>(&packages, &bins, &LinkBinsOptions::default())
+        })
+    });
+
+    let body = fs::read_to_string(&shim).unwrap();
+    eprintln!("replacement shim:\n{body}");
+    assert!(is_shim_pointing_at(&body, &target));
+    for suffix in ["cmd", "ps1"] {
+        let body = fs::read_to_string(bins.join(format!("foo.{suffix}"))).unwrap();
+        assert!(!body.is_empty(), "missing Windows shim body for {suffix}");
+    }
+    assert_eq!(fs::read_to_string(target).unwrap(), content);
+}

--- a/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
@@ -59,8 +59,7 @@ fn cleanup_recovers_after_transient_lock() {
     assert_eq!(fs::read_to_string(target).unwrap(), "program content");
 }
 
-/// An ordinary shim is replaced by renaming a sibling temp file over it,
-/// so the lock lands on the rename rather than on a removal.
+/// Here the lock lands on the replacement rename, not on a removal.
 #[test]
 fn shim_replacement_recovers_after_transient_lock() {
     let root = tempdir().unwrap();
@@ -88,8 +87,7 @@ fn shim_replacement_recovers_after_transient_lock() {
     assert_eq!(fs::read_to_string(target).unwrap(), content);
 }
 
-/// A Node.js binary entry is still removed before the new link is laid down,
-/// which is the remaining delete-before-replace path.
+/// A Node.js entry is the one bin still deleted before it is replaced.
 #[test]
 fn node_binary_replacement_recovers_after_transient_lock() {
     let root = tempdir().unwrap();

--- a/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
+++ b/pnpm/crates/cmd-shim/src/link_bins/tests/windows_native.rs
@@ -3,7 +3,7 @@ use crate::{
     link_bins::{LinkBinsOptions, PackageBinSource, link_bins_of_packages, remove_bin},
     shim::is_shim_pointing_at,
 };
-use pnpm_fs::test_support::with_file_removal_observer;
+use pnpm_fs::test_support::with_retry_observer;
 use serde_json::json;
 use std::{
     fmt::Debug,
@@ -22,19 +22,19 @@ fn assert_recovers_after_lock<Error: Debug>(
     let mut handle =
         Some(fs::OpenOptions::new().read(true).share_mode(0x1 | 0x2).open(path).unwrap());
     let (sender, receiver) = mpsc::channel();
-    let result = with_file_removal_observer(
+    let result = with_retry_observer(
         path,
         move |attempt| {
             sender.send(attempt.as_ref().copied().map_err(std::io::Error::raw_os_error)).unwrap();
             if attempt.is_err() {
-                // Release only after a real failed deletion, not after a scheduled delay.
+                // Release only after a real failed attempt, not after a scheduled delay.
                 drop(handle.take());
             }
         },
         operation,
     );
     let attempts: Vec<_> = receiver.try_iter().collect();
-    eprintln!("removal result: {result:?}; real filesystem attempts: {attempts:?}");
+    eprintln!("operation result: {result:?}; real filesystem attempts: {attempts:?}");
     result.expect("the operation must recover after the deny-delete handle closes");
     assert!(matches!(attempts.first(), Some(Err(Some(5 | 32 | 33)))));
     assert_eq!(attempts.last(), Some(&Ok(())));
@@ -59,8 +59,10 @@ fn cleanup_recovers_after_transient_lock() {
     assert_eq!(fs::read_to_string(target).unwrap(), "program content");
 }
 
+/// An ordinary shim is replaced by renaming a sibling temp file over it,
+/// so the lock lands on the rename rather than on a removal.
 #[test]
-fn replacement_recovers_after_transient_lock() {
+fn shim_replacement_recovers_after_transient_lock() {
     let root = tempdir().unwrap();
     let package = root.path().join("foo");
     fs::create_dir(&package).unwrap();
@@ -75,6 +77,37 @@ fn replacement_recovers_after_transient_lock() {
         package,
         Arc::new(json!({"name": "foo", "version": "1.0.0", "bin": "cli.js"})),
     )];
+
+    assert_recovers_after_lock(&shim, || {
+        link_bins_of_packages::<Host>(&packages, &bins, &LinkBinsOptions::default())
+    });
+
+    let body = fs::read_to_string(&shim).unwrap();
+    eprintln!("replacement shim:\n{body}");
+    assert!(is_shim_pointing_at(&body, &target));
+    assert_eq!(fs::read_to_string(target).unwrap(), content);
+}
+
+/// A Node.js binary entry is still removed before the new link is laid down,
+/// which is the remaining delete-before-replace path.
+#[test]
+fn node_binary_replacement_recovers_after_transient_lock() {
+    let root = tempdir().unwrap();
+    let package = root.path().join("node");
+    fs::create_dir(&package).unwrap();
+    let target = package.join("node.exe");
+    let content = "new node binary";
+    fs::write(&target, content).unwrap();
+    let bins = root.path().join(".bin");
+    fs::create_dir(&bins).unwrap();
+    let shim = bins.join("node.exe");
+    let old_target = root.path().join("old-node.exe");
+    fs::write(&old_target, "old node binary").unwrap();
+    fs::hard_link(&old_target, &shim).unwrap();
+    let packages = [PackageBinSource::new(
+        package,
+        Arc::new(json!({"name": "node", "version": "1.0.0", "bin": "node.exe"})),
+    )];
     let pool = rayon::ThreadPoolBuilder::new().num_threads(2).build().unwrap();
 
     assert_recovers_after_lock(&shim, || {
@@ -83,12 +116,7 @@ fn replacement_recovers_after_transient_lock() {
         })
     });
 
-    let body = fs::read_to_string(&shim).unwrap();
-    eprintln!("replacement shim:\n{body}");
-    assert!(is_shim_pointing_at(&body, &target));
-    for suffix in ["cmd", "ps1"] {
-        let body = fs::read_to_string(bins.join(format!("foo.{suffix}"))).unwrap();
-        assert!(!body.is_empty(), "missing Windows shim body for {suffix}");
-    }
+    assert_eq!(fs::read_to_string(shim).unwrap(), content);
+    assert_eq!(fs::read_to_string(old_target).unwrap(), "old node binary");
     assert_eq!(fs::read_to_string(target).unwrap(), content);
 }

--- a/pnpm/crates/fs/Cargo.toml
+++ b/pnpm/crates/fs/Cargo.toml
@@ -10,6 +10,9 @@ keywords.workspace   = true
 license.workspace    = true
 repository.workspace = true
 
+[features]
+test = []
+
 [dependencies]
 derive_more = { workspace = true }
 dunce       = { workspace = true }

--- a/pnpm/crates/fs/src/lib.rs
+++ b/pnpm/crates/fs/src/lib.rs
@@ -23,3 +23,6 @@ pub use symlink_dir::*;
 pub use write_atomic::{write_atomic, write_atomic_private};
 
 pub mod file_mode;
+
+#[cfg(all(windows, feature = "test"))]
+pub mod test_support;

--- a/pnpm/crates/fs/src/lib.rs
+++ b/pnpm/crates/fs/src/lib.rs
@@ -18,7 +18,7 @@ pub use lexical_normalize::{lexical_normalize, lexical_normalize_posix};
 pub use realpath_missing::realpath_missing;
 pub use relative_path::relative_path;
 pub use remove_dirent::remove_dirent;
-pub use retry::{remove_dir_all_with_retry, rename_with_retry};
+pub use retry::{remove_dir_all_with_retry, remove_file_with_retry, rename_with_retry};
 pub use symlink_dir::*;
 pub use write_atomic::{write_atomic, write_atomic_private};
 

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -26,7 +26,12 @@ pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
 
 /// Remove a file with the retry policy of [`rename_with_retry`].
 pub fn remove_file_with_retry(path: &Path) -> io::Result<()> {
-    retry_transient_file_locks(|| fs::remove_file(path))
+    retry_transient_file_locks(|| {
+        let result = fs::remove_file(path);
+        #[cfg(all(windows, feature = "test"))]
+        crate::test_support::notify_file_removal(path, &result);
+        result
+    })
 }
 
 /// Remove a directory tree with the retry policy of [`rename_with_retry`].

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -24,6 +24,11 @@ pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
     retry_transient_file_locks(|| fs::rename(src, dst))
 }
 
+/// Remove a file with the retry policy of [`rename_with_retry`].
+pub fn remove_file_with_retry(path: &Path) -> io::Result<()> {
+    retry_transient_file_locks(|| fs::remove_file(path))
+}
+
 /// Remove a directory tree with the retry policy of [`rename_with_retry`].
 pub fn remove_dir_all_with_retry(path: &Path) -> io::Result<()> {
     retry_transient_file_locks(|| fs::remove_dir_all(path))

--- a/pnpm/crates/fs/src/retry.rs
+++ b/pnpm/crates/fs/src/retry.rs
@@ -21,7 +21,12 @@ pub(crate) const ERROR_LOCK_VIOLATION: i32 = 33;
 /// there usually mean a permanent permissions or mount-point problem, so
 /// retrying would only delay the failure.
 pub fn rename_with_retry(src: &Path, dst: &Path) -> io::Result<()> {
-    retry_transient_file_locks(|| fs::rename(src, dst))
+    retry_transient_file_locks(|| {
+        let result = fs::rename(src, dst);
+        #[cfg(all(windows, feature = "test"))]
+        crate::test_support::notify_attempt(dst, &result);
+        result
+    })
 }
 
 /// Remove a file with the retry policy of [`rename_with_retry`].
@@ -29,7 +34,7 @@ pub fn remove_file_with_retry(path: &Path) -> io::Result<()> {
     retry_transient_file_locks(|| {
         let result = fs::remove_file(path);
         #[cfg(all(windows, feature = "test"))]
-        crate::test_support::notify_file_removal(path, &result);
+        crate::test_support::notify_attempt(path, &result);
         result
     })
 }

--- a/pnpm/crates/fs/src/test_support.rs
+++ b/pnpm/crates/fs/src/test_support.rs
@@ -1,0 +1,58 @@
+//! Coordination for tests that exercise real Windows file removal.
+
+use std::{
+    collections::{HashMap, hash_map::Entry},
+    io,
+    path::{Path, PathBuf},
+    sync::{Arc, LazyLock, Mutex, PoisonError},
+};
+
+type Observer = Arc<Mutex<Box<dyn FnMut(&io::Result<()>) + Send>>>;
+
+static OBSERVERS: LazyLock<Mutex<HashMap<PathBuf, Observer>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Observe completed removal attempts for exactly `path` while `operation` runs.
+///
+/// The observer runs synchronously after the real filesystem call, including
+/// attempts on worker threads. It must not recursively remove the same path
+/// or wait for another observer to run.
+/// Registration is removed when the operation returns or unwinds.
+pub fn with_file_removal_observer<Output>(
+    path: &Path,
+    observer: impl FnMut(&io::Result<()>) + Send + 'static,
+    operation: impl FnOnce() -> Output,
+) -> Output {
+    let path = path.to_path_buf();
+    {
+        let mut observers = OBSERVERS.lock().unwrap_or_else(PoisonError::into_inner);
+        match observers.entry(path.clone()) {
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(Mutex::new(Box::new(observer))));
+            }
+            Entry::Occupied(_) => panic!("a removal observer is already registered for {path:?}"),
+        }
+    }
+    let _registration = Registration(path);
+    operation()
+}
+
+struct Registration(PathBuf);
+
+impl Drop for Registration {
+    fn drop(&mut self) {
+        let observer = OBSERVERS.lock().unwrap_or_else(PoisonError::into_inner).remove(&self.0);
+        drop(observer);
+    }
+}
+
+#[cfg(test)]
+mod tests;
+
+pub(crate) fn notify_file_removal(path: &Path, result: &io::Result<()>) {
+    let observer =
+        OBSERVERS.lock().unwrap_or_else(PoisonError::into_inner).get(path).map(Arc::clone);
+    if let Some(observer) = observer {
+        observer.lock().unwrap_or_else(PoisonError::into_inner)(result);
+    }
+}

--- a/pnpm/crates/fs/src/test_support.rs
+++ b/pnpm/crates/fs/src/test_support.rs
@@ -1,4 +1,5 @@
-//! Coordination for tests that exercise real Windows file removal.
+//! Coordination for tests that exercise the real Windows retries in
+//! [`crate::retry`].
 
 use std::{
     collections::{HashMap, hash_map::Entry},
@@ -12,13 +13,14 @@ type Observer = Arc<Mutex<Box<dyn FnMut(&io::Result<()>) + Send>>>;
 static OBSERVERS: LazyLock<Mutex<HashMap<PathBuf, Observer>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-/// Observe completed removal attempts for exactly `path` while `operation` runs.
+/// Observe completed retry attempts against exactly `path` while `operation`
+/// runs: a removal of `path`, or a rename onto it.
 ///
 /// The observer runs synchronously after the real filesystem call, including
-/// attempts on worker threads. It must not recursively remove the same path
+/// attempts on worker threads. It must not itself touch the same path
 /// or wait for another observer to run.
 /// Registration is removed when the operation returns or unwinds.
-pub fn with_file_removal_observer<Output>(
+pub fn with_retry_observer<Output>(
     path: &Path,
     observer: impl FnMut(&io::Result<()>) + Send + 'static,
     operation: impl FnOnce() -> Output,
@@ -30,7 +32,7 @@ pub fn with_file_removal_observer<Output>(
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(Mutex::new(Box::new(observer))));
             }
-            Entry::Occupied(_) => panic!("a removal observer is already registered for {path:?}"),
+            Entry::Occupied(_) => panic!("a retry observer is already registered for {path:?}"),
         }
     }
     let _registration = Registration(path);
@@ -49,7 +51,7 @@ impl Drop for Registration {
 #[cfg(test)]
 mod tests;
 
-pub(crate) fn notify_file_removal(path: &Path, result: &io::Result<()>) {
+pub(crate) fn notify_attempt(path: &Path, result: &io::Result<()>) {
     let observer =
         OBSERVERS.lock().unwrap_or_else(PoisonError::into_inner).get(path).map(Arc::clone);
     if let Some(observer) = observer {

--- a/pnpm/crates/fs/src/test_support/tests.rs
+++ b/pnpm/crates/fs/src/test_support/tests.rs
@@ -1,0 +1,35 @@
+use super::{notify_file_removal, with_file_removal_observer};
+use std::panic::catch_unwind;
+use tempfile::tempdir;
+
+#[test]
+fn observer_is_removed_when_its_callback_panics() {
+    let root = tempdir().unwrap();
+    let path = root.path().join("shim");
+    let result = catch_unwind(|| {
+        with_file_removal_observer(
+            &path,
+            |_| panic!("observer failure"),
+            || notify_file_removal(&path, &Ok(())),
+        );
+    });
+    assert!(result.is_err(), "the observer must have run and panicked");
+    with_file_removal_observer(&path, |_| {}, || notify_file_removal(&path, &Ok(())));
+}
+
+#[test]
+fn duplicate_registration_does_not_remove_the_original_observer() {
+    let root = tempdir().unwrap();
+    let path = root.path().join("shim");
+    let (sender, receiver) = std::sync::mpsc::channel();
+    with_file_removal_observer(
+        &path,
+        move |_| sender.send(()).unwrap(),
+        || {
+            let result = catch_unwind(|| with_file_removal_observer(&path, |_| {}, || {}));
+            assert!(result.is_err(), "duplicate registration must be rejected");
+            notify_file_removal(&path, &Ok(()));
+        },
+    );
+    assert_eq!(receiver.try_iter().count(), 1);
+}

--- a/pnpm/crates/fs/src/test_support/tests.rs
+++ b/pnpm/crates/fs/src/test_support/tests.rs
@@ -1,4 +1,4 @@
-use super::{notify_file_removal, with_file_removal_observer};
+use super::{notify_attempt, with_retry_observer};
 use std::panic::catch_unwind;
 use tempfile::tempdir;
 
@@ -7,14 +7,14 @@ fn observer_is_removed_when_its_callback_panics() {
     let root = tempdir().unwrap();
     let path = root.path().join("shim");
     let result = catch_unwind(|| {
-        with_file_removal_observer(
+        with_retry_observer(
             &path,
             |_| panic!("observer failure"),
-            || notify_file_removal(&path, &Ok(())),
+            || notify_attempt(&path, &Ok(())),
         );
     });
     assert!(result.is_err(), "the observer must have run and panicked");
-    with_file_removal_observer(&path, |_| {}, || notify_file_removal(&path, &Ok(())));
+    with_retry_observer(&path, |_| {}, || notify_attempt(&path, &Ok(())));
 }
 
 #[test]
@@ -22,13 +22,13 @@ fn duplicate_registration_does_not_remove_the_original_observer() {
     let root = tempdir().unwrap();
     let path = root.path().join("shim");
     let (sender, receiver) = std::sync::mpsc::channel();
-    with_file_removal_observer(
+    with_retry_observer(
         &path,
         move |_| sender.send(()).unwrap(),
         || {
-            let result = catch_unwind(|| with_file_removal_observer(&path, |_| {}, || {}));
+            let result = catch_unwind(|| with_retry_observer(&path, |_| {}, || {}));
             assert!(result.is_err(), "duplicate registration must be rejected");
-            notify_file_removal(&path, &Ok(()));
+            notify_attempt(&path, &Ok(()));
         },
     );
     assert_eq!(receiver.try_iter().count(), 1);


### PR DESCRIPTION
## Summary

On Windows, a scanner or another process can briefly hold a command entry open without delete sharing, and an install that removes or replaces that entry fails. The Rust CLI aborted on the first such failure. Route the bin-linking deletion and replacement paths through the existing `pnpm-fs` bounded file-lock retry policy.

Two paths reach a locked `.bin` entry:

- Deletion, through `remove_bin` and `remove_stale_bin`. A Node.js binary entry is still removed before its new link is laid down, and `pnpm remove -g` deletes the entry outright.
- The atomic replacement rename, which is what an ordinary shim now takes. `Host::write_replace` writes a sibling temp file and renames it over the shim, so the lock lands on the rename rather than on a removal.

Both now retry. Final errors still fail the install; this PR does not implement warn-and-continue after the retries are exhausted.

The TypeScript CLI already retries deletion through `@zkochan/rimraf`, so no TypeScript implementation change is included. The Rust path keeps its existing retry budget and classifier; its timing is not identical to the TypeScript path. Also resolve two Windows-only Clippy findings in the touched module without changing behavior.

Add native Windows regression tests for all three paths: `remove_bin`, the shim replacement rename, and `node.exe` replacement through `link_bins_of_packages::<Host>` on Rayon workers. Each test holds a real file handle without delete sharing, observes an actual failed attempt, then closes the handle so production retries can recover. A default-off Windows test feature provides per-path observation. Normal production builds contain no observation registry or callback calls.

Validation:

- Workspace `cargo check --all-targets`, Clippy with `--deny warnings`, `taplo`, `typos`, and rustdoc pass through the repository pre-push hook. `cargo-dylint` is not installed locally and was skipped with a warning.
- `pnpm-cmd-shim` and `pnpm-fs` pass all 185 tests, and every crate that depends on `pnpm-cmd-shim` passes all 1,177 tests.
- Cross-target `x86_64-pc-windows-msvc` check, Clippy with `--deny warnings`, and rustdoc pass, including with the `test` feature enabled.
- Native Windows 2025 execution passed for the deletion and `node.exe` replacement tests in the [fork validation run](https://github.com/zhsama/pnpm/actions/runs/33974361011), each recording `[Err(Some(32)), Ok(())]`. Three native ablations proved those tests detect the regression: removing retry fails both, bypassing only cleanup fails only cleanup, and bypassing only replacement fails only replacement.
- The shim replacement rename test is new and has not run on native Windows yet. CI must confirm it.

Known limitation, still unresolved: the existing classifier retries permanent `PermissionDenied` errors too. A native Windows directory-occupant probe returned error 5 after 603 attempts and 60.0004645 seconds, preserving the directory and its child. This PR does not change that policy, which applies to every existing `pnpm-fs` caller and needs its own evaluation.

Fixes pnpm/pnpm#14549.

## Squash Commit Body

```text
Retry transient Windows file-lock errors when removing a command entry,
replacing a Node.js binary link, or renaming a new shim over an existing
one. Reuse the existing pnpm-fs retry policy, and share the shim-level
NotFound handling while preserving final errors and replacement error
context.

The TypeScript CLI already has bounded removal retries. Rust retains its
existing timing and classifier, including its known delay for permanent
PermissionDenied errors. Persistent failures remain fatal.

Add consumer-level coverage for deletion, link target preservation,
idempotence, and cleanup/replacement error propagation. Native Windows
tests use deny-delete handles and release them after a real failed
attempt, covering all three locked paths. A default-off test feature
supplies observation without changing production builds.

Fixes pnpm/pnpm#14549.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] The description explains why no TypeScript implementation change is included and identifies the remaining retry-policy limitation.
- [x] Added a `pacquet` patch changeset.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791172636&installation_model_id=426870&pr_number=14573&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14573&signature=46ef7a916cd1f3ac7028d6acf6b103c04230eeecaf8dcabf6cbe26a657d7bf5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows installation reliability by retrying removal of command shims temporarily locked by another process.
  - Preserved linked and symlinked target files when cleaning up command entries.
  - Improved error handling when command entries cannot be removed during cleanup.
  - Stale command replacement now stops safely if the existing entry cannot be removed.
  - Improved reliability when replacing command shims by retrying transient file-operation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
