### PR TITLE
refactor(tarball): separate archive store projections

### DIFF
--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -8,7 +8,7 @@ use pnpm_reporter::Reporter;
 use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexWriter,
 };
-use pnpm_tarball::DownloadTarballToStore;
+use pnpm_tarball::{ArchiveStoreProjection, IngestTarballToStore};
 use serde::{Deserialize, Serialize};
 use ssri::{Algorithm, Integrity};
 use std::{
@@ -489,7 +489,7 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     let integrity = Integrity::from_hex(&package.checksum, Algorithm::Sha256)
         .into_diagnostic()
         .wrap_err_with(|| format!("decode checksum for {package_id}"))?;
-    let mut cas_paths = DownloadTarballToStore {
+    let mut cas_paths = IngestTarballToStore {
         http_client: &http_client,
         store_dir,
         store_index,
@@ -509,7 +509,7 @@ async fn materialize<Reporter: self::Reporter + 'static>(
         ignore_file_pattern: None,
         offline,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::RawArchive,
     }
     .run_without_mem_cache::<Reporter>()
     .await

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,13 +1,13 @@
 use super::{
-    LockedCrate, MANAGED_CONFIG, MaterializeOptions, add_cargo_checksum, discover_manifests,
-    discover_manifests_with, materialize, parse_lockfile, sparse_index_path, update_managed_config,
-    workspace_root,
+    ArchiveStoreProjection, LockedCrate, MANAGED_CONFIG, MaterializeOptions, add_cargo_checksum,
+    discover_manifests, discover_manifests_with, materialize, parse_lockfile, sparse_index_path,
+    update_managed_config, workspace_root,
 };
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::{
     CafsFileInfo, PackageFilesIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex,
-    StoreIndexWriter, store_index_key,
+    StoreIndexWriter,
 };
 use ssri::{Algorithm, Integrity};
 use std::{
@@ -210,7 +210,7 @@ async fn repairs_a_preseeded_slot_from_verified_store_metadata() {
     StoreIndex::open_in(store_dir)
         .unwrap()
         .set(
-            &store_index_key(&integrity.to_string(), package_id),
+            &ArchiveStoreProjection::RawArchive.store_index_key(&integrity.to_string(), package_id),
             &PackageFilesIndex {
                 manifest: None,
                 requires_build: Some(false),

--- a/pnpm/crates/cli/src/cli_args/store/add.rs
+++ b/pnpm/crates/cli/src/cli_args/store/add.rs
@@ -13,7 +13,7 @@ use pnpm_resolving_default_resolver::standalone::{StandaloneChainOptions, build_
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
 use pnpm_resolving_resolver_base::{ResolveOptions, WantedDependency};
 use pnpm_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
-use pnpm_tarball::DownloadTarballToStore;
+use pnpm_tarball::IngestTarballToStore;
 use ssri::Integrity;
 use std::{path::Path, sync::Arc};
 
@@ -198,7 +198,7 @@ async fn add_one<Reporter: self::Reporter>(args: AddOne<'_>) -> miette::Result<S
         .into());
     };
 
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client,
         store_dir: &config.store_dir,
         store_index,
@@ -223,7 +223,7 @@ async fn add_one<Reporter: self::Reporter>(args: AddOne<'_>) -> miette::Result<S
         ignore_file_pattern: None,
         offline: config.offline,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: pnpm_tarball::ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<Reporter>()
     .await

--- a/pnpm/crates/deps-restorer/src/custom_fetcher.rs
+++ b/pnpm/crates/deps-restorer/src/custom_fetcher.rs
@@ -6,7 +6,7 @@ use pnpm_hooks::{
 };
 use pnpm_lockfile::LockfileResolution;
 use pnpm_reporter::Reporter;
-use pnpm_tarball::{DownloadTarballToStore, FetchErrorDetails, FetchedTarball, TarballError};
+use pnpm_tarball::{FetchErrorDetails, FetchedTarball, IngestTarballToStore, TarballError};
 use serde::Deserialize;
 use serde_json::Value;
 use ssri::Integrity;
@@ -36,7 +36,7 @@ impl CustomFetcherSession {
 
     pub async fn resolve_tarball_integrity<Reporter: self::Reporter>(
         &self,
-        download: DownloadTarballToStore<'_>,
+        download: IngestTarballToStore<'_>,
         original: &LockfileResolution,
         opts: Value,
     ) -> Result<LockfileResolution, InstallPackageBySnapshotError> {
@@ -81,13 +81,13 @@ impl CustomFetcherSession {
 
     pub(crate) async fn fetch<Reporter: self::Reporter>(
         &self,
-        download: DownloadTarballToStore<'_>,
+        download: IngestTarballToStore<'_>,
         original: &LockfileResolution,
         opts: Value,
     ) -> Result<CustomFetchOutcome, InstallPackageBySnapshotError> {
         let package_id = download.package_id;
         let locked = original.checkable_integrity();
-        let download = DownloadTarballToStore { package_integrity: locked, ..download };
+        let download = IngestTarballToStore { package_integrity: locked, ..download };
         if let Some(integrity) = locked
             && let Some(tarball) = self
                 .completed
@@ -228,7 +228,7 @@ fn decode_resolution(
 /// discovery calls this, so there is nothing to hash and nothing to verify; the
 /// install pass materializes such a resolution through its own dispatch.
 async fn fetch_custom_tarball<Reporter: self::Reporter>(
-    download: DownloadTarballToStore<'_>,
+    download: IngestTarballToStore<'_>,
     resolution: &LockfileResolution,
     lockfile_dir: &Path,
 ) -> Result<Option<Arc<FetchedTarball>>, InstallPackageBySnapshotError> {
@@ -250,12 +250,12 @@ async fn fetch_custom_tarball<Reporter: self::Reporter>(
 }
 
 async fn fetch_location<Reporter: self::Reporter>(
-    download: &DownloadTarballToStore<'_>,
+    download: &IngestTarballToStore<'_>,
     location: TarballLocation,
     lockfile_dir: &Path,
 ) -> Result<Arc<FetchedTarball>, TarballError> {
     let url = local_file_tarball_install_url(location.tarball.as_str().into(), lockfile_dir);
-    DownloadTarballToStore {
+    IngestTarballToStore {
         package_url: &url,
         package_integrity: download
             .package_integrity
@@ -268,7 +268,7 @@ async fn fetch_location<Reporter: self::Reporter>(
 }
 
 async fn run_callback<Reporter: self::Reporter>(
-    download: &DownloadTarballToStore<'_>,
+    download: &IngestTarballToStore<'_>,
     lockfile_dir: &Path,
     callback: &FetcherCallback,
     verified: &mut Vec<Arc<FetchedTarball>>,

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot.rs
@@ -26,8 +26,8 @@ use pnpm_store_dir::{
     git_hosted_store_index_key,
 };
 use pnpm_tarball::{
-    DownloadTarballToStore, DownloadZipArchiveToStore, IgnoreEntryFilter, MemCache,
-    PrefetchedCasPaths, SharedReportedProgressKeys, TarballError,
+    IgnoreEntryFilter, IngestTarballToStore, IngestZipArchiveToStore, MemCache, PrefetchedCasPaths,
+    SharedReportedProgressKeys, TarballError,
 };
 use std::{
     borrow::Cow,
@@ -69,7 +69,7 @@ pub struct InstallPackageBySnapshot<'a> {
     pub prefetched_cas_paths: Option<&'a PrefetchedCasPaths>,
     /// Install-scoped shared in-flight tarball cache. When present, the
     /// registry/tarball download routes through
-    /// [`DownloadTarballToStore::run_with_mem_cache`] so it parks on (or
+    /// [`IngestTarballToStore::run_with_mem_cache`] so it parks on (or
     /// reuses) a download already in flight or completed for the same
     /// URL, rather than racing a second fetch of the same bytes. Both
     /// background prefetchers feed it: the pnpr client's
@@ -85,7 +85,7 @@ pub struct InstallPackageBySnapshot<'a> {
     /// emitted `fetched` or `found_in_store`.
     pub progress_reported: Option<&'a SharedReportedProgressKeys>,
     /// Install-scoped `verifiedFilesCache` shared across every
-    /// per-snapshot fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// per-snapshot fetch. See `IngestTarballToStore::verified_files_cache`
     /// for the rationale.
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
     /// Install-scoped dedupe state for `pnpm:package-import-method`.
@@ -368,7 +368,7 @@ impl InstallPackageBySnapshot<'_> {
             pnpm_config::ScriptsPrependNodePath::WarnOnly => ExecScriptsPrependNodePath::WarnOnly,
         };
 
-        let download = DownloadTarballToStore {
+        let download = IngestTarballToStore {
             http_client,
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
@@ -388,7 +388,9 @@ impl InstallPackageBySnapshot<'_> {
             ignore_file_pattern: None,
             offline: config.offline,
             progress_reported: progress_reported.cloned(),
-            append_manifest: None,
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: None,
+            },
         };
         let custom_fetch = if let Some(session) = custom_fetcher_session {
             let opts = serde_json::json!({
@@ -436,7 +438,7 @@ impl InstallPackageBySnapshot<'_> {
                 let (tarball_url, integrity) =
                     tarball_url_and_integrity(resolution, package_key, config)?;
                 let tarball_url = local_file_tarball_install_url(tarball_url, self.workspace_root);
-                let download = DownloadTarballToStore {
+                let download = IngestTarballToStore {
                     package_url: &tarball_url,
                     package_integrity: integrity,
                     ..download.clone()
@@ -756,7 +758,7 @@ pub(crate) fn local_file_tarball_install_url<'a>(
 /// recorded integrity pins nothing (absent, or the empty SRI string an
 /// edited lockfile can carry) is refused here rather than fetched
 /// unchecked. See
-/// [`pnpm_tarball::DownloadTarballToStore::package_integrity`] for
+/// [`pnpm_tarball::IngestTarballToStore::package_integrity`] for
 /// what an unverified fetch does.
 ///
 /// # Panics
@@ -1028,17 +1030,17 @@ fn archive_filter_for(package_key: &PackageKey) -> Option<Arc<IgnoreEntryFilter>
 /// per-file `{relative_path → cas_path}` map the snapshot's virtual
 /// directory needs. Dispatches on the archive type:
 ///
-/// - [`BinaryArchive::Tarball`] uses [`DownloadTarballToStore`]
+/// - [`BinaryArchive::Tarball`] uses [`IngestTarballToStore`]
 ///   with `package_unpacked_size: None` (binary archives don't
 ///   carry that hint).
-/// - [`BinaryArchive::Zip`] uses [`DownloadZipArchiveToStore`]
+/// - [`BinaryArchive::Zip`] uses [`IngestZipArchiveToStore`]
 ///   with `archive_prefix: binary.prefix.as_deref()` so the runtime
 ///   archive's top-level wrapper (e.g.
 ///   `node-v22.0.0-darwin-arm64/`) is stripped before the CAS keys
 ///   are written.
 #[expect(
     clippy::too_many_arguments,
-    reason = "matches the field set DownloadTarballToStore / DownloadZipArchiveToStore need"
+    reason = "matches the field set IngestTarballToStore / IngestZipArchiveToStore need"
 )]
 async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
     binary: &BinaryResolution,
@@ -1065,7 +1067,7 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
     // bin linking and `dlx` look at.
     let manifest_bytes = synthesize_runtime_manifest_bytes(package_key, binary)?;
     let cas_paths = match binary.archive {
-        BinaryArchive::Tarball => DownloadTarballToStore {
+        BinaryArchive::Tarball => IngestTarballToStore {
             http_client,
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
@@ -1087,12 +1089,14 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             // Cold-batch binary tarball download: emits `fetched`
             // directly, so no network-fetched tracking is needed.
             progress_reported: None,
-            append_manifest: Some(&manifest_bytes),
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: Some(&manifest_bytes),
+            },
         }
         .run_without_mem_cache::<Reporter>()
         .await
         .map_err(InstallPackageBySnapshotError::DownloadTarball)?,
-        BinaryArchive::Zip => DownloadZipArchiveToStore {
+        BinaryArchive::Zip => IngestZipArchiveToStore {
             http_client,
             store_dir: &config.store_dir,
             store_index: store_index.cloned(),
@@ -1110,7 +1114,9 @@ async fn fetch_binary_resolution_to_cas<Reporter: self::Reporter>(
             archive_prefix: binary.prefix.as_deref(),
             ignore_file_pattern,
             offline: config.offline,
-            append_manifest: Some(&manifest_bytes),
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: Some(&manifest_bytes),
+            },
         }
         .run_without_mem_cache::<Reporter>()
         .await

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -1482,7 +1482,7 @@ async fn an_unpinned_delegate_to_a_directory_keeps_its_resolution() {
 
     let resolution = session
         .resolve_tarball_integrity::<pnpm_reporter::SilentReporter>(
-            pnpm_tarball::DownloadTarballToStore {
+            pnpm_tarball::IngestTarballToStore {
                 http_client: &pnpm_network::ThrottledClient::default(),
                 store_dir: &config.store_dir,
                 store_index: None,
@@ -1502,7 +1502,9 @@ async fn an_unpinned_delegate_to_a_directory_keeps_its_resolution() {
                 ignore_file_pattern: None,
                 offline: true,
                 progress_reported: None,
-                append_manifest: None,
+                store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                    append_manifest: None,
+                },
             },
             &unpinned,
             serde_json::json!({ "lockfileDir": store_tmp.path() }),

--- a/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_by_snapshot/tests.rs
@@ -1178,7 +1178,8 @@ fn build_runtime_tarball_fixture() -> Vec<u8> {
 /// `getBinName` with `dlx_read_manifest`.
 #[tokio::test]
 async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_index_row() {
-    use pnpm_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter, store_index_key};
+    use pnpm_store_dir::{SharedVerifiedFilesCache, StoreIndex, StoreIndexWriter};
+    use pnpm_tarball::ArchiveStoreProjection;
     use std::sync::atomic::AtomicU8;
 
     let archive_tmp = tempfile::tempdir().expect("tempdir");
@@ -1272,8 +1273,13 @@ async fn installing_a_runtime_persists_the_synthesized_manifest_into_the_store_i
     // The persisted row must carry the synthesized `package.json` in both
     // its `files` map and its bundled `manifest` — this is the copy a warm
     // materialization reads back.
-    let index_key =
-        store_index_key(&integrity.to_string(), &package_key.without_peer().to_string());
+    let LockfileResolution::Binary(binary) = &metadata.resolution else {
+        unreachable!("the fixture uses a binary resolution")
+    };
+    let manifest_bytes = synthesize_runtime_manifest_bytes(&package_key, binary)
+        .expect("synthesize the runtime manifest");
+    let index_key = ArchiveStoreProjection::Package { append_manifest: Some(&manifest_bytes) }
+        .store_index_key(&integrity.to_string(), &package_key.without_peer().to_string());
     let row = StoreIndex::open_in(&config.store_dir)
         .expect("open the store index")
         .get(&index_key)

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry.rs
@@ -12,7 +12,7 @@ use pnpm_network::ThrottledClient;
 use pnpm_reporter::{LogEvent, LogLevel, ProgressLog, ProgressMessage, Reporter};
 use pnpm_resolving_resolver_base::ResolveResult;
 use pnpm_store_dir::{SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreIndexWriter};
-use pnpm_tarball::{DownloadTarballToStore, MemCache, TarballError};
+use pnpm_tarball::{IngestTarballToStore, MemCache, TarballError};
 use serde_json::Value;
 use ssri::Integrity;
 use std::{
@@ -46,13 +46,13 @@ pub struct InstallPackageFromRegistry<'a> {
     pub store_index: Option<&'a SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<&'a Arc<StoreIndexWriter>>,
     /// Install-scoped `verifiedFilesCache` shared across every
-    /// per-package fetch. See `DownloadTarballToStore::verified_files_cache`
+    /// per-package fetch. See `IngestTarballToStore::verified_files_cache`
     /// for the rationale.
     pub verified_files_cache: &'a SharedVerifiedFilesCache,
     /// Warm-cache prefetch result built once per install via
     /// [`pnpm_tarball::prefetch_cas_paths`] — `cache_key →
     /// Arc<cas_paths>`. When `Some`, the
-    /// `DownloadTarballToStore::run_without_mem_cache` cache-lookup
+    /// `IngestTarballToStore::run_without_mem_cache` cache-lookup
     /// branch reads from here before falling back to the per-snapshot
     /// `SQLite` lookup, avoiding `Arc<Mutex<StoreIndex>>` contention on
     /// the resolve hot path.
@@ -87,7 +87,7 @@ pub struct InstallPackageFromRegistry<'a> {
 /// Error type of [`InstallPackageFromRegistry`].
 #[derive(Debug, Display, Error, Diagnostic)]
 pub enum InstallPackageFromRegistryError {
-    DownloadTarballToStore(#[error(source)] TarballError),
+    IngestTarballToStore(#[error(source)] TarballError),
     ImportIndexedDir(#[error(source)] ImportIndexedDirError),
     SymlinkPackage(#[error(source)] SymlinkPackageError),
 
@@ -174,7 +174,7 @@ impl InstallPackageFromRegistry<'_> {
             }));
 
             // TODO: skip when it already exists in store?
-            let download = DownloadTarballToStore {
+            let download = IngestTarballToStore {
                 http_client,
                 store_dir: &config.store_dir,
                 store_index: store_index.cloned(),
@@ -197,14 +197,16 @@ impl InstallPackageFromRegistry<'_> {
                 // progress directly; no resolve-time prefetch shares a
                 // dedupe set with it.
                 progress_reported: None,
-                append_manifest: None,
+                store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                    append_manifest: None,
+                },
             };
             let cas_paths = if revision_addressed {
                 download.run_revision_addressed_with_mem_cache::<Reporter>(tarball_mem_cache).await
             } else {
                 download.run_with_mem_cache::<Reporter>(tarball_mem_cache).await
             }
-            .map_err(InstallPackageFromRegistryError::DownloadTarballToStore)?;
+            .map_err(InstallPackageFromRegistryError::IngestTarballToStore)?;
 
             tracing::info!(target: "pacquet::import", ?save_path, ?symlink_path, "Import package");
 

--- a/pnpm/crates/env-installer/src/install_config_deps.rs
+++ b/pnpm/crates/env-installer/src/install_config_deps.rs
@@ -24,7 +24,7 @@ use pnpm_reporter::{
     Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage, SkippedOptionalReason,
 };
 use pnpm_store_dir::SharedVerifiedFilesCache;
-use pnpm_tarball::DownloadTarballToStore;
+use pnpm_tarball::IngestTarballToStore;
 use ssri::Integrity;
 use std::{
     collections::{BTreeMap, HashSet},
@@ -175,7 +175,7 @@ async fn materialize<Reporter: self::Reporter>(
     dir: &Path,
 ) -> Result<(), ConfigDepError> {
     let package_id = format!("{name}@{version}");
-    let cas_paths = DownloadTarballToStore {
+    let cas_paths = IngestTarballToStore {
         http_client: opts.http_client,
         store_dir: opts.store_dir,
         store_index: None,
@@ -195,7 +195,7 @@ async fn materialize<Reporter: self::Reporter>(
         ignore_file_pattern: None,
         offline: opts.offline,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: pnpm_tarball::ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<Reporter>()
     .await

--- a/pnpm/crates/git-fetcher/src/fetcher.rs
+++ b/pnpm/crates/git-fetcher/src/fetcher.rs
@@ -90,7 +90,7 @@ pub struct GitFetcher<'a> {
 }
 
 /// Output of [`GitFetcher::run`]. Mirrors the shape of
-/// `DownloadTarballToStore::run_without_mem_cache`'s return so the
+/// `IngestTarballToStore::run_without_mem_cache`'s return so the
 /// caller can hand it straight into `CreateVirtualDirBySnapshot`.
 #[derive(Debug)]
 pub struct GitFetchOutput {

--- a/pnpm/crates/git-fetcher/src/tarball_fetcher/tests.rs
+++ b/pnpm/crates/git-fetcher/src/tarball_fetcher/tests.rs
@@ -18,7 +18,7 @@ fn allow_all_builds<'a>() -> AllowBuildRef<'a> {
 }
 
 /// Build the `cas_paths` map the dispatcher would hand the fetcher
-/// after `DownloadTarballToStore` finishes: a fresh `StoreDir`, a few
+/// after `IngestTarballToStore` finishes: a fresh `StoreDir`, a few
 /// files written via `write_cas_file`, and a `path → cas_path` map.
 fn write_to_cas(store_dir: &StoreDir, files: &[(&str, &[u8], bool)]) -> HashMap<String, PathBuf> {
     let mut out = HashMap::new();

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/resolver_setup.rs
@@ -388,7 +388,7 @@ pub(super) async fn build_resolver_chain<Reporter: pnpm_reporter::Reporter + 'st
         Box::new(local_path_resolver),
     ]);
 
-    // The install pass later calls `DownloadTarballToStore::run_with_mem_cache`
+    // The install pass later calls `IngestTarballToStore::run_with_mem_cache`
     // for the same URLs and either picks up `CacheValue::Available`
     // immediately or briefly blocks on the per-URL `Notify`. See
     // `prefetching_resolver.rs` for the full design rationale.

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -16,7 +16,7 @@ use pnpm_store_dir::{
     SharedVerifiedFilesCache, StoreIndex, StoreIndexError, StoreIndexWriter,
     git_hosted_store_index_key,
 };
-use pnpm_tarball::{DownloadTarballToStore, MemCache, TarballError};
+use pnpm_tarball::{IngestTarballToStore, MemCache, TarballError};
 use std::{
     cmp::Ordering,
     collections::BTreeSet,
@@ -220,7 +220,7 @@ impl WritePackageForPatch<'_> {
         let verified_files_cache = SharedVerifiedFilesCache::default();
 
         let result = async {
-            let cas_paths = DownloadTarballToStore {
+            let cas_paths = IngestTarballToStore {
                 http_client,
                 store_dir: &config.store_dir,
                 store_index: store_index.clone(),
@@ -240,7 +240,9 @@ impl WritePackageForPatch<'_> {
                 ignore_file_pattern: None,
                 offline: config.offline,
                 progress_reported: None,
-                append_manifest: None,
+                store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                    append_manifest: None,
+                },
             }
             .run_with_mem_cache::<Reporter>(tarball_mem_cache)
             .await

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -12,11 +12,11 @@
 //! resolver chain with [`PrefetchingResolver`]. After the inner
 //! resolver claims a wanted dep, the wrapper inspects the result and,
 //! for tarball-shaped resolutions, [`tokio::spawn`]s a
-//! [`DownloadTarballToStore`] in the background.
+//! [`IngestTarballToStore`] in the background.
 //!
 //! The download lands its result in the shared [`MemCache`]. Later, when
 //! [`crate::InstallPackageFromRegistry`] calls
-//! [`DownloadTarballToStore::run_with_mem_cache`] for the same URL, the
+//! [`IngestTarballToStore::run_with_mem_cache`] for the same URL, the
 //! `MemCache` either returns `CacheValue::Available` immediately (the
 //! prefetch is already done) or briefly blocks on the `Notify` (the
 //! prefetch is still in flight). Errors are surfaced to the install
@@ -49,7 +49,7 @@ use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndexWriter,
 };
 use pnpm_tarball::{
-    DownloadTarballToStore, FetchTarballForResolution, MemCache, RetryOpts,
+    FetchTarballForResolution, IngestTarballToStore, MemCache, RetryOpts,
     SharedReportedProgressKeys,
 };
 use std::{marker::PhantomData, path::Path, sync::Arc};
@@ -130,7 +130,7 @@ struct OwnedFetchCtx {
 /// with the rest of the tree walk.
 ///
 /// Generic over `Reporter: self::Reporter` so
-/// [`DownloadTarballToStore`]'s `pnpm:progress` emits route through
+/// [`IngestTarballToStore`]'s `pnpm:progress` emits route through
 /// the same reporter the install pass uses. The wrapper itself
 /// doesn't hold a `Reporter` value (`Reporter` is a static trait);
 /// `PhantomData` carries the type through.
@@ -231,7 +231,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let resolution = cell
             .get_or_try_init(|| async {
                 if let Some(session) = self.ctx.custom_fetcher_session.as_ref() {
-                    let download = DownloadTarballToStore {
+                    let download = IngestTarballToStore {
                         http_client: &self.ctx.http_client,
                         store_dir: self.ctx.store_dir,
                         store_index: self.ctx.store_index.clone(),
@@ -251,7 +251,9 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                         ignore_file_pattern: None,
                         offline: self.ctx.offline,
                         progress_reported: Some(Arc::clone(&self.ctx.progress_reported)),
-                        append_manifest: None,
+                        store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                            append_manifest: None,
+                        },
                     };
                     let opts = serde_json::json!({
                         "pkg": result.name_ver.as_ref().map_or_else(
@@ -325,7 +327,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         // integrity. Mirrors the gate in
         // `install_package_from_registry::extract_tarball`; other
         // resolution shapes are not fetched through
-        // `DownloadTarballToStore` at all.
+        // `IngestTarballToStore` at all.
         let Ok((package_url, integrity)) = extract_tarball(&result.resolution) else {
             return;
         };
@@ -389,7 +391,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             //
             // Result is intentionally discarded — the `MemCache`
             // carries success / failure state to the install path.
-            let download = DownloadTarballToStore {
+            let download = IngestTarballToStore {
                 http_client: &http_client,
                 store_dir,
                 store_index,
@@ -409,7 +411,9 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
                 ignore_file_pattern: None,
                 offline,
                 progress_reported: Some(progress_reported),
-                append_manifest: None,
+                store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                    append_manifest: None,
+                },
             };
             let _ = if revision_addressed {
                 download.run_revision_addressed_with_mem_cache::<Reporter>(&mem_cache).await

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -10,7 +10,7 @@
 //!
 //! Each download lands its result in the shared [`MemCache`] keyed by
 //! tarball URL and fetch policy; the later install pass picks it up via
-//! [`DownloadTarballToStore::run_with_mem_cache`] (an immediate
+//! [`IngestTarballToStore::run_with_mem_cache`] (an immediate
 //! `CacheValue::Available` hit, or a brief park on the per-URL `Notify`
 //! while the prefetch finishes).
 
@@ -26,7 +26,7 @@ use pnpm_store_dir::{
     SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexError,
     StoreIndexWriter, store_index_key,
 };
-use pnpm_tarball::{DownloadTarballToStore, MemCache, RetryOpts, TarballError};
+use pnpm_tarball::{IngestTarballToStore, MemCache, RetryOpts, TarballError};
 use ssri::Integrity;
 use std::{
     collections::{HashMap, HashSet},
@@ -128,7 +128,7 @@ async fn run_tarball_download(
         revision_addressed,
     } = download;
 
-    let download = DownloadTarballToStore {
+    let download = IngestTarballToStore {
         http_client: &http_client,
         store_dir,
         store_index,
@@ -152,7 +152,7 @@ async fn run_tarball_download(
         // against — the frozen materialization install emits its own
         // progress as it consumes each tarball from the mem cache.
         progress_reported: None,
-        append_manifest: None,
+        store_projection: pnpm_tarball::ArchiveStoreProjection::Package { append_manifest: None },
     };
     if revision_addressed {
         download.run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache).await

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -26,7 +26,40 @@ use pnpm_store_dir::{
 };
 use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
 
-/// This subroutine downloads and extracts a tarball to the store directory.
+/// Controls how archive files are projected into pnpm's content-addressable store.
+///
+/// Package archives get pnpm's `package.json` completion marker and may receive a
+/// synthesized manifest. Raw archives preserve their regular-file contents exactly;
+/// their ecosystem adapter owns any additional metadata and install layout.
+#[derive(Debug, Clone, Copy)]
+pub enum ArchiveStoreProjection<'a> {
+    /// Project the archive as an npm-compatible package. The archive receives
+    /// pnpm's completion marker when it has no `package.json`; runtime archives
+    /// may additionally supply the manifest that should be synthesized.
+    Package { append_manifest: Option<&'a [u8]> },
+    /// Preserve the archive's regular files without adding npm package files.
+    /// The ecosystem adapter owns all post-ingestion metadata and layout.
+    RawArchive,
+}
+
+impl ArchiveStoreProjection<'_> {
+    pub(crate) fn package_content_check(self, strict: bool) -> PackageContentCheck {
+        match self {
+            Self::Package { .. } if strict => PackageContentCheck::Strict,
+            Self::Package { .. } => PackageContentCheck::Warn,
+            Self::RawArchive => PackageContentCheck::Skip,
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PackageContentCheck {
+    Strict,
+    Warn,
+    Skip,
+}
+
+/// This subroutine ingests a tarball into the content-addressable store.
 ///
 /// It returns a CAS map of files in the tarball.
 ///
@@ -36,13 +69,13 @@ use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
 /// best-effort [`Self::run_with_mem_cache`] reports a sibling failure).
 #[derive(Clone)]
 #[must_use]
-pub struct DownloadTarballToStore<'a> {
+pub struct IngestTarballToStore<'a> {
     pub http_client: &'a ThrottledClient,
     pub store_dir: &'static StoreDir,
     /// Shared read-only handle to the `SQLite` store index. `None` when the
     /// store does not (yet) have an `index.db`, in which case every cache
     /// lookup short-circuits to a network fetch. Callers open this once per
-    /// install and pass the same handle to every [`DownloadTarballToStore`]
+    /// install and pass the same handle to every [`IngestTarballToStore`]
     /// so we don't reopen the DB per package.
     pub store_index: Option<SharedReadonlyStoreIndex>,
     /// Handle to the batched store-index writer. Each successful tarball
@@ -86,7 +119,7 @@ pub struct DownloadTarballToStore<'a> {
     /// per-file stat in `check_pkg_files_integrity` once per
     /// (snapshot × file) instead of once per (file). Allocate one
     /// `Arc<DashSet<PathBuf>>` at install bootstrap and pass the same
-    /// handle to every [`DownloadTarballToStore`].
+    /// handle to every [`IngestTarballToStore`].
     pub verified_files_cache: SharedVerifiedFilesCache,
     /// Expected hash of the tarball bytes. `None` for a lockfile entry
     /// recording no `integrity`, the shape pnpm wrote for git-host
@@ -170,18 +203,9 @@ pub struct DownloadTarballToStore<'a> {
     /// threads this set through, because resolve-time prefetches can
     /// otherwise report the same package again in the warm batch.
     pub progress_reported: Option<SharedReportedProgressKeys>,
-    /// Synthesized `package.json` to fold into the freshly extracted
-    /// archive, mirroring pnpm's `appendManifest`. Runtime archives
-    /// (Node.js / Bun / Deno) ship no manifest of their own, so without
-    /// this the store-index row records no `package.json`: every later
-    /// *warm* materialization then lands a manifest-less slot, and the
-    /// warm-batch bin linker (which reads `PackageFilesIndex.manifest`)
-    /// links no bin. When `Some`, the bytes are written to the CAFS and
-    /// recorded in the row's `files` map and bundled `manifest` before
-    /// the row is queued, so warm and cold installs see the same slot.
-    /// `None` (ordinary registry/tarball packages) is a no-op — they
-    /// carry their own `package.json`. See `apply_append_manifest`.
-    pub append_manifest: Option<&'a [u8]>,
+    /// Ecosystem-owned projection policy applied after verified extraction and
+    /// before the store-index row is queued.
+    pub store_projection: ArchiveStoreProjection<'a>,
 }
 
 /// Project [`TarballError`] onto pnpm's `requestRetryLogger`'s
@@ -1054,7 +1078,7 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
 /// Store-index key a tarball fetch reads and writes its
 /// [`PackageFilesIndex`] row at, or `None` when the resolution carries
 /// no integrity to address the row by. See
-/// [`DownloadTarballToStore::package_integrity`].
+/// [`IngestTarballToStore::package_integrity`].
 pub(crate) fn store_index_cache_key(
     package_integrity: Option<&Integrity>,
     package_id: &str,

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -43,6 +43,22 @@ pub enum ArchiveStoreProjection<'a> {
 }
 
 impl ArchiveStoreProjection<'_> {
+    /// Build the store-index key for this projection.
+    ///
+    /// Package keys must stay byte-for-byte compatible with pnpm's existing
+    /// store. Raw archives use a separate namespace so they never reuse legacy
+    /// rows that were projected as npm packages (and therefore may contain a
+    /// synthesized `package.json`).
+    #[must_use]
+    pub fn store_index_key(self, integrity: &str, package_id: &str) -> String {
+        match self {
+            Self::Package { .. } => store_index_key(integrity, package_id),
+            Self::RawArchive => {
+                format!("raw-archive\t{}", store_index_key(integrity, package_id))
+            }
+        }
+    }
+
     pub(crate) fn package_content_check(self, strict: bool) -> PackageContentCheck {
         match self {
             Self::Package { .. } if strict => PackageContentCheck::Strict,
@@ -1082,6 +1098,8 @@ pub(crate) async fn fetch_and_extract_with_retry<Reporter: self::Reporter>(
 pub(crate) fn store_index_cache_key(
     package_integrity: Option<&Integrity>,
     package_id: &str,
+    store_projection: ArchiveStoreProjection<'_>,
 ) -> Option<String> {
-    package_integrity.map(|integrity| store_index_key(&integrity.to_string(), package_id))
+    package_integrity
+        .map(|integrity| store_projection.store_index_key(&integrity.to_string(), package_id))
 }

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -43,17 +43,18 @@ pub enum ArchiveStoreProjection<'a> {
 }
 
 impl ArchiveStoreProjection<'_> {
-    /// Package keys must stay byte-for-byte compatible with pnpm's existing
-    /// store. Raw archives use a separate namespace so they never reuse legacy
-    /// rows that were projected as npm packages (and therefore may contain a
-    /// synthesized `package.json`).
+    /// Ordinary package keys stay byte-for-byte compatible with pnpm's existing
+    /// store. Projections that change the archive's file set use separate
+    /// namespaces so they cannot reuse an incompatible row.
     #[must_use]
     pub fn store_index_key(self, integrity: &str, package_id: &str) -> String {
+        let base_key = store_index_key(integrity, package_id);
         match self {
-            Self::Package { .. } => store_index_key(integrity, package_id),
-            Self::RawArchive => {
-                format!("raw-archive\t{}", store_index_key(integrity, package_id))
+            Self::Package { append_manifest: None } => base_key,
+            Self::Package { append_manifest: Some(manifest) } => {
+                format!("package-manifest\t{}\t{base_key}", manifest_integrity(manifest))
             }
+            Self::RawArchive => format!("raw-archive\t{base_key}"),
         }
     }
 
@@ -70,11 +71,11 @@ impl ArchiveStoreProjection<'_> {
             (Self::RawArchive, false) => format!("raw-archive:{package_url}"),
             (Self::RawArchive, true) => format!("revision-addressed:raw-archive:{package_url}"),
             (Self::Package { append_manifest: Some(manifest) }, revision_addressed) => {
-                let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
-                opts.input(manifest);
-                let manifest_integrity = opts.result();
                 let revision_prefix = if revision_addressed { "revision-addressed:" } else { "" };
-                format!("{revision_prefix}package-manifest:{manifest_integrity}:{package_url}")
+                format!(
+                    "{revision_prefix}package-manifest:{}:{package_url}",
+                    manifest_integrity(manifest),
+                )
             }
         }
     }
@@ -86,6 +87,12 @@ impl ArchiveStoreProjection<'_> {
             Self::RawArchive => PackageContentCheck::Skip,
         }
     }
+}
+
+fn manifest_integrity(manifest: &[u8]) -> Integrity {
+    let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
+    opts.input(manifest);
+    opts.result()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -115,10 +115,6 @@ pub(crate) enum PackageContentCheck {
     Skip,
 }
 
-/// This subroutine ingests a tarball into the content-addressable store.
-///
-/// It returns a CAS map of files in the tarball.
-///
 /// `Clone` is cheap — every field is a reference, a `Copy` scalar, or an
 /// `Arc` — so a caller can keep a copy to retry through a different entry
 /// point (e.g. fall back to [`Self::run_without_mem_cache`] after a

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -42,7 +42,7 @@ pub enum ArchiveStoreProjection<'a> {
     RawArchive,
 }
 
-impl ArchiveStoreProjection<'_> {
+impl<'a> ArchiveStoreProjection<'a> {
     /// Ordinary package keys stay byte-for-byte compatible with pnpm's existing
     /// store. Projections that change the archive's file set use separate
     /// namespaces so they cannot reuse an incompatible row.
@@ -85,6 +85,19 @@ impl ArchiveStoreProjection<'_> {
             Self::Package { .. } if strict => PackageContentCheck::Strict,
             Self::Package { .. } => PackageContentCheck::Warn,
             Self::RawArchive => PackageContentCheck::Skip,
+        }
+    }
+
+    pub(crate) fn legacy_synthesized_store_row(
+        self,
+        integrity: &str,
+        package_id: &str,
+    ) -> Option<(String, &'a [u8])> {
+        match self {
+            Self::Package { append_manifest: Some(manifest) } => {
+                Some((store_index_key(integrity, package_id), manifest))
+            }
+            Self::Package { append_manifest: None } | Self::RawArchive => None,
         }
     }
 }

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -43,8 +43,6 @@ pub enum ArchiveStoreProjection<'a> {
 }
 
 impl ArchiveStoreProjection<'_> {
-    /// Build the store-index key for this projection.
-    ///
     /// Package keys must stay byte-for-byte compatible with pnpm's existing
     /// store. Raw archives use a separate namespace so they never reuse legacy
     /// rows that were projected as npm packages (and therefore may contain a
@@ -55,6 +53,28 @@ impl ArchiveStoreProjection<'_> {
             Self::Package { .. } => store_index_key(integrity, package_id),
             Self::RawArchive => {
                 format!("raw-archive\t{}", store_index_key(integrity, package_id))
+            }
+        }
+    }
+
+    /// Ordinary package keys stay byte-for-byte compatible with the URL keys
+    /// inserted by resolve-time fetches. Only projections that can produce a
+    /// different file set receive a discriminator; synthesized manifests are
+    /// content-addressed so equal projections still share work.
+    pub(crate) fn mem_cache_key(self, package_url: &str, revision_addressed: bool) -> String {
+        match (self, revision_addressed) {
+            (Self::Package { append_manifest: None }, false) => package_url.to_string(),
+            (Self::Package { append_manifest: None }, true) => {
+                format!("revision-addressed:{package_url}")
+            }
+            (Self::RawArchive, false) => format!("raw-archive:{package_url}"),
+            (Self::RawArchive, true) => format!("revision-addressed:raw-archive:{package_url}"),
+            (Self::Package { append_manifest: Some(manifest) }, revision_addressed) => {
+                let mut opts = IntegrityOpts::new().algorithm(Algorithm::Sha256);
+                opts.input(manifest);
+                let manifest_integrity = opts.result();
+                let revision_prefix = if revision_addressed { "revision-addressed:" } else { "" };
+                format!("{revision_prefix}package-manifest:{manifest_integrity}:{package_url}")
             }
         }
     }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -193,7 +193,7 @@ pub struct FetchedTarball {
     pub requires_build: bool,
 }
 
-impl<'a> DownloadTarballToStore<'a> {
+impl<'a> IngestTarballToStore<'a> {
     /// Execute the subroutine with an in-memory cache.
     ///
     /// # Caller invariant: stable filter per URL
@@ -206,7 +206,7 @@ impl<'a> DownloadTarballToStore<'a> {
     /// it holds because URLs encode `(name, version, integrity)` and filters
     /// are keyed by package name.
     ///
-    /// [`ignore_file_pattern`]: DownloadTarballToStore::ignore_file_pattern
+    /// [`ignore_file_pattern`]: IngestTarballToStore::ignore_file_pattern
     pub async fn run_with_mem_cache<Reporter: self::Reporter>(
         self,
         mem_cache: &'a MemCache,
@@ -228,7 +228,7 @@ impl<'a> DownloadTarballToStore<'a> {
         mem_cache: &'a MemCache,
         revision_addressed: bool,
     ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
-        let &DownloadTarballToStore {
+        let &IngestTarballToStore {
             package_url,
             package_id,
             package_integrity,
@@ -418,7 +418,7 @@ impl<'a> DownloadTarballToStore<'a> {
         &self,
         revision_addressed: bool,
     ) -> Result<HashMap<String, PathBuf>, TarballError> {
-        let &DownloadTarballToStore {
+        let &IngestTarballToStore {
             store_dir,
             package_integrity,
             package_url,
@@ -427,6 +427,7 @@ impl<'a> DownloadTarballToStore<'a> {
             verify_store_integrity,
             strict_store_pkg_content_check,
             prefetched_cas_paths,
+            store_projection,
             ..
         } = self;
 
@@ -445,7 +446,7 @@ impl<'a> DownloadTarballToStore<'a> {
         // Deep-clones the inner map, unlike the `Arc`-preserving path
         // in `run_with_mem_cache`: this signature returns an owned
         // `HashMap`, and widening it would reach into
-        // `DownloadTarballToStore`'s return type. Affordable because
+        // `IngestTarballToStore`'s return type. Affordable because
         // only cache-miss snapshots reach here, where the clone is
         // dwarfed by the download it avoids.
         if let Some(prefetched) = prefetched_cas_paths
@@ -467,7 +468,7 @@ impl<'a> DownloadTarballToStore<'a> {
                 store_dir,
                 cache_key,
                 verify_store_integrity,
-                strict_store_pkg_content_check,
+                store_projection.package_content_check(strict_store_pkg_content_check),
                 Arc::clone(&self.verified_files_cache),
             )
             .await?;
@@ -496,7 +497,7 @@ impl<'a> DownloadTarballToStore<'a> {
         record_computed_integrity: bool,
         revision_addressed: bool,
     ) -> Result<FetchedTarball, TarballError> {
-        let &DownloadTarballToStore {
+        let &IngestTarballToStore {
             http_client,
             store_dir,
             package_integrity,
@@ -507,7 +508,7 @@ impl<'a> DownloadTarballToStore<'a> {
             requester,
             retry_opts,
             auth_headers,
-            append_manifest,
+            store_projection,
             ..
         } = self;
         let cache_key = store_index_cache_key(package_integrity, package_id);
@@ -568,12 +569,22 @@ impl<'a> DownloadTarballToStore<'a> {
             )
             .await?;
 
-        // Fold the synthesized runtime `package.json` into the row before
-        // it is persisted, so warm reinstalls (which read the row) get it.
-        if let Some(manifest_bytes) = append_manifest {
-            apply_append_manifest(store_dir, manifest_bytes, &mut cas_paths, &mut pkg_files_idx)?;
+        match store_projection {
+            ArchiveStoreProjection::Package { append_manifest } => {
+                // Fold a synthesized runtime `package.json` into the row before
+                // it is persisted, so warm reinstalls get the same package view.
+                if let Some(manifest_bytes) = append_manifest {
+                    apply_append_manifest(
+                        store_dir,
+                        manifest_bytes,
+                        &mut cas_paths,
+                        &mut pkg_files_idx,
+                    )?;
+                }
+                apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
+            }
+            ArchiveStoreProjection::RawArchive => {}
         }
-        apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
 
         let manifest = pkg_files_idx.manifest.clone();
         // Only legacy cache rows omit this; fresh extraction always records it.
@@ -638,7 +649,7 @@ pub struct ResolvedTarball {
 /// fetch here to fill `manifest` + `integrity` into its
 /// `ResolveResult`. Passing a `mem_cache` warms it (keyed by URL) so
 /// the install pass's
-/// [`DownloadTarballToStore::run_with_mem_cache`] reuses the extraction
+/// [`IngestTarballToStore::run_with_mem_cache`] reuses the extraction
 /// without a second download.
 pub struct FetchTarballForResolution<'a> {
     pub http_client: &'a ThrottledClient,

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -234,6 +234,7 @@ impl<'a> IngestTarballToStore<'a> {
             package_integrity,
             prefetched_cas_paths,
             requester,
+            store_projection,
             ..
         } = &self;
         let mem_cache_key = if revision_addressed {
@@ -241,7 +242,7 @@ impl<'a> IngestTarballToStore<'a> {
         } else {
             package_url.to_string()
         };
-        let cache_key = store_index_cache_key(package_integrity, package_id);
+        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
 
         // Hands the `Arc` on without deep-cloning the per-file map:
@@ -441,7 +442,7 @@ impl<'a> IngestTarballToStore<'a> {
         // The lookup is best-effort. A missing `index.db`, a missing row,
         // an undecodable entry, or any CAFS file that has gone missing
         // from disk all fall through to the download path below.
-        let cache_key = store_index_cache_key(package_integrity, package_id);
+        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
         // Deep-clones the inner map, unlike the `Arc`-preserving path
         // in `run_with_mem_cache`: this signature returns an owned
@@ -511,7 +512,7 @@ impl<'a> IngestTarballToStore<'a> {
             store_projection,
             ..
         } = self;
-        let cache_key = store_index_cache_key(package_integrity, package_id);
+        let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
         let store_index_writer = self.store_index_writer.clone();
         // `Option<Arc<IgnoreEntryFilter>>` isn't `Copy`, so it can't
@@ -601,8 +602,9 @@ impl<'a> IngestTarballToStore<'a> {
         // is dropped with a `warn!` and the next install misses on this
         // cache key, matching the read path's stance.
         let cache_key = cache_key.or_else(|| {
-            record_computed_integrity
-                .then(|| store_index_key(&computed_integrity.to_string(), package_id))
+            record_computed_integrity.then(|| {
+                store_projection.store_index_key(&computed_integrity.to_string(), package_id)
+            })
         });
         match (cache_key, store_index_writer) {
             (Some(index_key), Some(writer)) => writer.queue(index_key, pkg_files_idx),

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -163,8 +163,9 @@ pub enum CacheValue {
 
 /// Internal in-memory cache of tarballs.
 ///
-/// The key is the tarball URL, prefixed for revision-addressed fetches so
-/// redirect and retry policies never share a result.
+/// Ordinary package entries retain their tarball URL key. Revision-addressed
+/// fetches and projections that produce different file sets add a discriminator
+/// so incompatible network policies or archive views never share a result.
 pub type MemCache = DashMap<String, Arc<RwLock<CacheValue>>>;
 
 /// Install-scoped set of store-index cache keys
@@ -198,13 +199,13 @@ impl<'a> IngestTarballToStore<'a> {
     ///
     /// # Caller invariant: stable filter per URL
     ///
-    /// The cache is keyed on `package_url` and whether the request uses the
-    /// revision-addressed network policy. Within either policy, a second
-    /// caller fetching the same URL with a different [`ignore_file_pattern`]
-    /// silently receives the map the first caller's filter produced. Every
-    /// fetch of a URL must use the same filter. Nothing enforces this; today
-    /// it holds because URLs encode `(name, version, integrity)` and filters
-    /// are keyed by package name.
+    /// The cache is keyed on `package_url`, the archive projection, and
+    /// whether the request uses the revision-addressed network policy. Within
+    /// one key, a second caller fetching the same URL with a different
+    /// [`ignore_file_pattern`] silently receives the map the first caller's
+    /// filter produced. Every fetch of a URL must use the same filter. Nothing
+    /// enforces this; today it holds because URLs encode
+    /// `(name, version, integrity)` and filters are keyed by package name.
     ///
     /// [`ignore_file_pattern`]: IngestTarballToStore::ignore_file_pattern
     pub async fn run_with_mem_cache<Reporter: self::Reporter>(
@@ -237,18 +238,14 @@ impl<'a> IngestTarballToStore<'a> {
             store_projection,
             ..
         } = &self;
-        let mem_cache_key = if revision_addressed {
-            format!("revision-addressed:{package_url}")
-        } else {
-            package_url.to_string()
-        };
+        let mem_cache_key = store_projection.mem_cache_key(package_url, revision_addressed);
         let cache_key = store_index_cache_key(package_integrity, package_id, store_projection);
         let progress_key = self.progress_reported.as_ref().zip(cache_key.as_deref());
 
         // Hands the `Arc` on without deep-cloning the per-file map:
         // on a warm install every snapshot takes this path, and by 1k+
         // snapshots that clone dominates the memory traffic. The `Arc`
-        // is also stashed in `mem_cache` by URL so peer-resolved
+        // is also stashed under a projection-aware URL key so peer-resolved
         // variants of one package share it.
         if let Some(prefetched) = prefetched_cas_paths
             && let Some(cache_key) = cache_key.as_deref()
@@ -572,8 +569,6 @@ impl<'a> IngestTarballToStore<'a> {
 
         match store_projection {
             ArchiveStoreProjection::Package { append_manifest } => {
-                // Fold a synthesized runtime `package.json` into the row before
-                // it is persisted, so warm reinstalls get the same package view.
                 if let Some(manifest_bytes) = append_manifest {
                     apply_append_manifest(
                         store_dir,

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -475,6 +475,27 @@ impl<'a> IngestTarballToStore<'a> {
                 emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
                 return Ok(cas_paths);
             }
+            if let (
+                Some(package_integrity),
+                ArchiveStoreProjection::Package { append_manifest: Some(_) },
+            ) = (package_integrity, store_projection)
+            {
+                let cached = load_legacy_synthesized_cas_paths::<Reporter>(
+                    self.store_index.clone(),
+                    store_dir,
+                    &package_integrity.to_string(),
+                    package_id,
+                    verify_store_integrity,
+                    Arc::clone(&self.verified_files_cache),
+                    store_projection,
+                )
+                .await?;
+                if let Some(cas_paths) = cached {
+                    tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing compatible legacy CAFS entry — skipping download");
+                    emit_progress_found_in_store::<Reporter>(package_id, requester, progress_key);
+                    return Ok(cas_paths);
+                }
+            }
         }
         self.fetch_and_extract_inner::<Reporter>(false, revision_addressed)
             .await

--- a/pnpm/crates/tarball/src/prefetch.rs
+++ b/pnpm/crates/tarball/src/prefetch.rs
@@ -5,8 +5,8 @@
 //! store-index lookups entirely.
 
 use super::{
-    Arc, HashMap, IntoParallelIterator, PackageContentCheck, ParallelIterator, PathBuf,
-    TarballError,
+    Arc, ArchiveStoreProjection, HashMap, IntoParallelIterator, PackageContentCheck,
+    ParallelIterator, PathBuf, TarballError,
 };
 use pnpm_package_manifest::{files_include_install_scripts, manifest_requires_build};
 use pnpm_reporter::{GlobalLog, LogEvent, LogLevel};
@@ -396,6 +396,53 @@ pub(crate) async fn load_cached_cas_paths<Reporter: crate::Reporter>(
             Ok(None)
         }
     }
+}
+
+/// Reuse a pre-projection-key runtime row only when its synthesized
+/// `package.json` is byte-for-byte the one requested by this projection.
+/// This keeps offline upgrades working without letting two runtime manifests
+/// share the legacy row.
+pub(crate) async fn load_legacy_synthesized_cas_paths<Reporter: crate::Reporter>(
+    index: Option<SharedReadonlyStoreIndex>,
+    store_dir: &'static StoreDir,
+    integrity: &str,
+    package_id: &str,
+    verify_store_integrity: bool,
+    verified_files_cache: SharedVerifiedFilesCache,
+    store_projection: ArchiveStoreProjection<'_>,
+) -> Result<Option<HashMap<String, PathBuf>>, TarballError> {
+    let Some((legacy_key, expected_manifest)) =
+        store_projection.legacy_synthesized_store_row(integrity, package_id)
+    else {
+        return Ok(None);
+    };
+    let Some(cas_paths) = load_cached_cas_paths::<Reporter>(
+        index,
+        store_dir,
+        legacy_key,
+        verify_store_integrity,
+        PackageContentCheck::Skip,
+        verified_files_cache,
+    )
+    .await?
+    else {
+        return Ok(None);
+    };
+    let Some(package_json_path) = cas_paths.get("package.json") else {
+        return Ok(None);
+    };
+    let Ok(cached_manifest) = tokio::fs::read(package_json_path).await else {
+        return Ok(None);
+    };
+    if cached_manifest != expected_manifest {
+        tracing::debug!(
+            target: "pacquet::download",
+            ?package_id,
+            "legacy store row has a different synthesized manifest; treating it as a miss",
+        );
+        return Ok(None);
+    }
+    Ok(Some(cas_paths))
 }
 
 /// Read every requested row's undecoded bytes, holding the store-index

--- a/pnpm/crates/tarball/src/prefetch.rs
+++ b/pnpm/crates/tarball/src/prefetch.rs
@@ -4,7 +4,10 @@
 //! the install fans out, so the warm batch can skip per-package
 //! store-index lookups entirely.
 
-use super::{Arc, HashMap, IntoParallelIterator, ParallelIterator, PathBuf, TarballError};
+use super::{
+    Arc, HashMap, IntoParallelIterator, PackageContentCheck, ParallelIterator, PathBuf,
+    TarballError,
+};
 use pnpm_package_manifest::{files_include_install_scripts, manifest_requires_build};
 use pnpm_reporter::{GlobalLog, LogEvent, LogLevel};
 use pnpm_store_dir::{
@@ -284,11 +287,11 @@ enum CachedRow {
 /// the timestamp. With it off, a missing or corrupt blob surfaces later,
 /// when the caller tries to import it.
 ///
-/// `strict_store_pkg_content_check` is pnpm's `strictStorePkgContentCheck`:
-/// a row whose bundled manifest names another package fails the install
-/// under it, and is used with a warning without it. Either way the row
-/// is never silently swapped for a download — that would hide a broken
-/// lockfile behind a slow install.
+/// `package_content_check` carries pnpm's `strictStorePkgContentCheck`
+/// policy for package projections. [`PackageContentCheck::Strict`]
+/// rejects an identity mismatch, [`PackageContentCheck::Warn`] reports
+/// and uses the row, and [`PackageContentCheck::Skip`] omits this
+/// npm-specific check for a raw archive projection.
 ///
 /// `index` is opened once per install and passed in repeatedly, so the
 /// `Connection::open` + PRAGMA cost is not paid per package.
@@ -297,7 +300,7 @@ pub(crate) async fn load_cached_cas_paths<Reporter: crate::Reporter>(
     store_dir: &'static StoreDir,
     cache_key: String,
     verify_store_integrity: bool,
-    strict_store_pkg_content_check: bool,
+    package_content_check: PackageContentCheck,
     verified_files_cache: SharedVerifiedFilesCache,
 ) -> Result<Option<HashMap<String, PathBuf>>, TarballError> {
     let Some(index) = index else { return Ok(None) };
@@ -326,8 +329,15 @@ pub(crate) async fn load_cached_cas_paths<Reporter: crate::Reporter>(
             }
         };
 
-        let mismatch = pnpm_store_dir::pkg_content_mismatch(entry.manifest.as_ref(), &cache_key);
-        if strict_store_pkg_content_check && let Some(mismatch) = mismatch {
+        let mismatch = match package_content_check {
+            PackageContentCheck::Strict | PackageContentCheck::Warn => {
+                pnpm_store_dir::pkg_content_mismatch(entry.manifest.as_ref(), &cache_key)
+            }
+            PackageContentCheck::Skip => None,
+        };
+        if package_content_check == PackageContentCheck::Strict
+            && let Some(mismatch) = mismatch
+        {
             return CachedRow::Rejected(mismatch);
         }
 

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -1,9 +1,9 @@
 use super::{
-    FetchTarballForResolution, MAX_UNTRUSTED_PREALLOC_BYTES, MemCache, RetryOpts,
-    SharedReportedProgressKeys, auth_header_for_package_download,
+    ArchiveStoreProjection, FetchTarballForResolution, MAX_UNTRUSTED_PREALLOC_BYTES, MemCache,
+    RetryOpts, SharedReportedProgressKeys, auth_header_for_package_download,
     download::{
-        DownloadTarballToStore, download_priority, fetch_and_extract_with_retry,
-        is_transient_error, slow_download_warning,
+        IngestTarballToStore, download_priority, fetch_and_extract_with_retry, is_transient_error,
+        slow_download_warning,
     },
     error::{HttpStatusError, NetworkError, TarballError, VerifyChecksumError},
     extract::{
@@ -281,7 +281,7 @@ fn tempdir_with_leaked_path() -> (TempDir, &'static StoreDir) {
 #[cfg(not(target_os = "windows"))]
 async fn packages_under_orgs_should_work() {
     let (store_dir, store_path) = tempdir_with_leaked_path();
-    let cas_files = DownloadTarballToStore {
+    let cas_files = IngestTarballToStore {
         http_client: &ThrottledClient::default(),
         store_dir: store_path,
         store_index: None,
@@ -301,7 +301,7 @@ async fn packages_under_orgs_should_work() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -347,7 +347,7 @@ async fn network_fetch_records_progress_key() {
     let pkg_id = "@fastify/error@3.3.0";
     let progress_reported = SharedReportedProgressKeys::default();
 
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &ThrottledClient::default(),
         store_dir: store_path,
         store_index: None,
@@ -367,7 +367,7 @@ async fn network_fetch_records_progress_key() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -385,7 +385,7 @@ async fn network_fetch_records_progress_key() {
 #[tokio::test]
 async fn should_throw_error_on_checksum_mismatch() {
     let (store_dir, store_path) = tempdir_with_leaked_path();
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &ThrottledClient::default(),
         store_dir: store_path,
         store_index: None,
@@ -405,7 +405,7 @@ async fn should_throw_error_on_checksum_mismatch() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -468,7 +468,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
     // key to prevent a later warm/cold pass from counting the same
     // package status again.
     let progress_reported = SharedReportedProgressKeys::default();
-    let download = DownloadTarballToStore {
+    let download = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -492,7 +492,7 @@ async fn reuses_cached_cas_paths_when_index_entry_is_live() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     };
     let cas_paths = download
         .run_without_mem_cache::<SilentReporter>()
@@ -543,7 +543,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
     // somewhere to point even though we never read it.
     let (_keep, store_path) = tempdir_with_leaked_path();
 
-    let cas_paths = DownloadTarballToStore {
+    let cas_paths = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         // No SQLite handle: any fall-through to the per-snapshot
@@ -567,7 +567,7 @@ async fn reuses_prefetched_cas_paths_when_provided() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -841,7 +841,7 @@ async fn falls_through_when_cafs_file_missing() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -861,7 +861,7 @@ async fn falls_through_when_cafs_file_missing() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -912,7 +912,7 @@ async fn store_row_holding_another_package_fails_the_read() {
     let index_key = store_index_key(&pkg_integrity.to_string(), pkg_id);
     seed_row_holding_another_package(store_path, &index_key);
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -932,7 +932,7 @@ async fn store_row_holding_another_package_fails_the_read() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -973,7 +973,7 @@ async fn store_row_holding_another_package_only_warns_when_not_strict() {
     seed_row_holding_another_package(store_path, &index_key);
 
     EVENTS.lock().unwrap().clear();
-    let cas_paths = DownloadTarballToStore {
+    let cas_paths = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -995,7 +995,7 @@ async fn store_row_holding_another_package_only_warns_when_not_strict() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -1053,7 +1053,7 @@ async fn falls_through_when_digest_is_malformed() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -1073,7 +1073,7 @@ async fn falls_through_when_digest_is_malformed() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1123,7 +1123,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -1143,7 +1143,7 @@ async fn falls_through_when_cafs_path_is_a_directory() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -1203,7 +1203,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
     index.set(&index_key, &entry).unwrap();
     drop(index);
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &fast_fail_client(),
         store_dir: store_path,
         store_index: StoreIndex::shared_readonly_in(store_path),
@@ -1223,7 +1223,7 @@ async fn falls_through_when_cafs_path_is_a_symlink() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2203,6 +2203,106 @@ fn gzipped_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
     encoder.finish().expect("finish gzip")
 }
 
+#[tokio::test]
+async fn raw_archive_projection_does_not_inject_an_npm_manifest() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("artifact.tgz");
+    std::fs::write(&tarball_path, gzipped_tar(&[("artifact/README.md", b"raw")])).unwrap();
+    let package_url = format!("file:{}", tarball_path.display());
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+
+    let cas_paths = IngestTarballToStore {
+        http_client: &fast_fail_client(),
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: None,
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &package_url,
+        package_id: "artifact@1.0.0",
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        store_projection: ArchiveStoreProjection::RawArchive,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect("a local raw archive should be ingested");
+
+    assert_eq!(cas_paths.keys().collect::<Vec<_>>(), ["README.md"]);
+    drop((store_dir, local_dir));
+}
+
+#[tokio::test]
+async fn raw_archive_projection_skips_npm_identity_checks_on_store_hits() {
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    store_path.init().unwrap();
+    let contents = b"raw artifact";
+    let (cas_path, file_hash) = store_path.write_cas_file(contents, false).unwrap();
+    let integrity = integrity("sha256-q80k8iD1xuGM3a48ipTFD+P7KQnhs4e5Blnos+dQpJM=");
+    let package_id = "crate:artifact@1.0.0";
+    StoreIndex::open_in(store_path)
+        .unwrap()
+        .set(
+            &store_index_key(&integrity.to_string(), package_id),
+            &PackageFilesIndex {
+                manifest: Some(serde_json::json!({ "name": "unrelated", "version": "2.0.0" })),
+                requires_build: Some(false),
+                requires_prepare: None,
+                algo: "sha512".to_string(),
+                files: HashMap::from([(
+                    "README.md".to_string(),
+                    CafsFileInfo {
+                        digest: format!("{file_hash:x}"),
+                        mode: 0o644,
+                        size: contents.len() as u64,
+                        checked_at: None,
+                    },
+                )]),
+                side_effects: None,
+                remote_side_effects_quarantine: None,
+            },
+        )
+        .unwrap();
+
+    let cas_paths = IngestTarballToStore {
+        http_client: &fast_fail_client(),
+        store_dir: store_path,
+        store_index: StoreIndex::shared_readonly_in(store_path),
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: Some(&integrity),
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: "https://example.test/artifact.tgz",
+        package_id,
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        store_projection: ArchiveStoreProjection::RawArchive,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect("raw archive cache hits must not use npm package identity semantics");
+
+    assert_eq!(cas_paths, HashMap::from([("README.md".to_string(), cas_path)]));
+    drop(store_dir);
+}
+
 /// The local resolver maps this to `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`,
 /// so the error kind has to survive.
 #[tokio::test]
@@ -2238,7 +2338,7 @@ async fn fetch_and_extract_records_expected_or_computed_integrity() {
         let expected = package_integrity.unwrap_or(&sha512);
         let (store_dir, store_path) = tempdir_with_leaked_path();
         let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
-        let result = DownloadTarballToStore {
+        let result = IngestTarballToStore {
             http_client: &client,
             store_dir: store_path,
             store_index: None,
@@ -2258,7 +2358,7 @@ async fn fetch_and_extract_records_expected_or_computed_integrity() {
             ignore_file_pattern: None,
             offline: true,
             progress_reported: None,
-            append_manifest: None,
+            store_projection: ArchiveStoreProjection::Package { append_manifest: None },
         }
         .fetch_and_extract::<SilentReporter>()
         .await
@@ -2298,7 +2398,7 @@ async fn run_without_mem_cache_fetches_unverified_and_writes_no_index_row() {
     let package_url = format!("file:{}", tarball_path.display());
     let client = fast_fail_client();
     let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
-    let cas_paths = DownloadTarballToStore {
+    let cas_paths = IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -2318,7 +2418,7 @@ async fn run_without_mem_cache_fetches_unverified_and_writes_no_index_row() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -2470,7 +2570,7 @@ async fn revision_addressed_mem_cache_does_not_retry_a_failed_prefetch() {
     let mem_cache = MemCache::default();
     let auth_headers = AuthHeaders::default();
     let verified_files_cache = SharedVerifiedFilesCache::default();
-    let download = || DownloadTarballToStore {
+    let download = || IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -2490,7 +2590,7 @@ async fn revision_addressed_mem_cache_does_not_retry_a_failed_prefetch() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     };
 
     let (first, second) = futures_util::future::join(
@@ -2542,7 +2642,7 @@ async fn revision_addressed_mem_cache_does_not_reuse_a_redirect_permitting_fetch
     let mem_cache = MemCache::default();
     let auth_headers = AuthHeaders::default();
     let verified_files_cache = SharedVerifiedFilesCache::default();
-    let download = || DownloadTarballToStore {
+    let download = || IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -2562,7 +2662,7 @@ async fn revision_addressed_mem_cache_does_not_reuse_a_redirect_permitting_fetch
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     };
 
     download()
@@ -3054,7 +3154,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
 
                 let auth_headers: &'static AuthHeaders =
                     Box::leak(Box::new(AuthHeaders::default()));
-                let make_dts = |url: &'static str| DownloadTarballToStore {
+                let make_dts = |url: &'static str| IngestTarballToStore {
                     http_client: client,
                     store_dir: store_path,
                     store_index: None,
@@ -3074,7 +3174,7 @@ fn run_with_mem_cache_does_not_deadlock_on_dashmap_shard_contention() {
                     ignore_file_pattern: None,
                     offline: false,
                     progress_reported: None,
-                    append_manifest: None,
+                    store_projection: ArchiveStoreProjection::Package { append_manifest: None },
                 };
 
                 // Spawn each task and yield once before the next so the
@@ -3354,7 +3454,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
     let verified_files_cache = SharedVerifiedFilesCache::default();
 
     // First requester: silent legacy owner.
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -3374,7 +3474,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_with_mem_cache::<pnpm_reporter::SilentReporter>(&mem_cache)
     .await
@@ -3385,7 +3485,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
     // because no shared progress set says this package status was
     // already reported.
     EVENTS.lock().unwrap().clear();
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -3405,7 +3505,7 @@ async fn mem_cache_hit_emits_found_in_store_against_callers_reporter() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -3483,7 +3583,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
     let pkg_id = "@fastify/error@3.3.0";
 
     EVENTS.lock().unwrap().clear();
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -3503,7 +3603,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -3523,7 +3623,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
     );
 
     EVENTS.lock().unwrap().clear();
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -3543,7 +3643,7 @@ async fn mem_cache_hit_skips_package_status_when_progress_already_reported() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: Some(SharedReportedProgressKeys::clone(&progress_reported)),
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_with_mem_cache::<RecordingReporter>(&mem_cache)
     .await
@@ -3598,7 +3698,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
 
     let url = format!("{}/pkg.tgz", server.url());
     // Leak the inputs so concurrent tasks can each construct a
-    // borrow-style `DownloadTarballToStore` without lifetime
+    // borrow-style `IngestTarballToStore` without lifetime
     // gymnastics on the spawned futures. The test scope is short and
     // the leak is negligible.
     let client: &'static ThrottledClient = Box::leak(Box::new(ThrottledClient::default()));
@@ -3607,7 +3707,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
     let mem_cache: &'static MemCache = Box::leak(Box::new(MemCache::default()));
     let auth_headers: &'static AuthHeaders = Box::leak(Box::<AuthHeaders>::default());
 
-    let make_dts = || DownloadTarballToStore {
+    let make_dts = || IngestTarballToStore {
         http_client: client,
         store_dir: store_path,
         store_index: None,
@@ -3627,7 +3727,7 @@ async fn run_with_mem_cache_recovers_from_owning_fetch_error() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     };
 
     // Drive both calls concurrently. One hits the `else` branch and
@@ -3898,7 +3998,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
     let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
     let verified_files_cache = SharedVerifiedFilesCache::default();
 
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: None,
@@ -3918,7 +4018,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -3940,7 +4040,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
     .expect("index opens after the first install");
 
     EVENTS.lock().unwrap().clear();
-    DownloadTarballToStore {
+    IngestTarballToStore {
         http_client: &client,
         store_dir: store_path,
         store_index: Some(store_index),
@@ -3960,7 +4060,7 @@ async fn found_in_store_event_fires_on_cache_hit() {
         ignore_file_pattern: None,
         offline: false,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<RecordingReporter>()
     .await
@@ -4418,7 +4518,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
     let pkg_integrity = integrity(FASTIFY_ERROR_INTEGRITY);
     let pkg_id = "@fastify/error@3.3.0";
 
-    let err = DownloadTarballToStore {
+    let err = IngestTarballToStore {
         http_client: &ThrottledClient::default(),
         store_dir: store_path,
         store_index: None,
@@ -4438,7 +4538,7 @@ async fn offline_mode_skips_network_on_cache_miss() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await
@@ -4492,7 +4592,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
     let mut prefetched: PrefetchedCasPaths = HashMap::new();
     prefetched.insert(cache_key, Arc::new(HashMap::new()));
 
-    let cas_paths = DownloadTarballToStore {
+    let cas_paths = IngestTarballToStore {
         http_client: &ThrottledClient::default(),
         store_dir: store_path,
         store_index: None,
@@ -4512,7 +4612,7 @@ async fn offline_mode_still_uses_prefetched_cache() {
         ignore_file_pattern: None,
         offline: true,
         progress_reported: None,
-        append_manifest: None,
+        store_projection: ArchiveStoreProjection::Package { append_manifest: None },
     }
     .run_without_mem_cache::<SilentReporter>()
     .await

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2207,6 +2207,7 @@ fn gzipped_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
 fn package_projection_preserves_existing_store_index_keys() {
     let integrity = integrity("sha256-q80k8iD1xuGM3a48ipTFD+P7KQnhs4e5Blnos+dQpJM=");
     let package_id = "artifact@1.0.0";
+    let legacy_key = store_index_key(&integrity.to_string(), package_id);
 
     assert_eq!(
         store_index_cache_key(
@@ -2214,7 +2215,15 @@ fn package_projection_preserves_existing_store_index_keys() {
             package_id,
             ArchiveStoreProjection::Package { append_manifest: None },
         ),
-        Some(store_index_key(&integrity.to_string(), package_id)),
+        Some(legacy_key.clone()),
+    );
+    assert_ne!(
+        store_index_cache_key(
+            Some(&integrity),
+            package_id,
+            ArchiveStoreProjection::Package { append_manifest: Some(br#"{"name":"runtime"}"#) },
+        ),
+        Some(legacy_key),
     );
 }
 
@@ -2363,6 +2372,90 @@ async fn mem_cache_partitions_synthesized_package_manifests_by_content() {
     assert_eq!(std::fs::read(&second["package.json"]).unwrap(), second_manifest);
     assert_eq!(mem_cache.len(), 2);
     drop((store_dir, local_dir));
+}
+
+#[tokio::test]
+async fn store_index_partitions_synthesized_package_manifests_by_content() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("artifact.tgz");
+    let archive = gzipped_tar(&[("artifact/README.md", b"archive")]);
+    std::fs::write(&tarball_path, &archive).unwrap();
+    let package_url = format!("file:{}", tarball_path.display());
+    let mut integrity_opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    integrity_opts.input(&archive);
+    let package_integrity = integrity_opts.result();
+    let package_id = "runtime:artifact@1.0.0";
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    let client = fast_fail_client();
+    let auth_headers = AuthHeaders::default();
+    let first_manifest = br#"{"name":"first"}"#;
+    let second_manifest = br#"{"name":"second"}"#;
+
+    for manifest in [first_manifest.as_slice(), second_manifest.as_slice()] {
+        let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
+        IngestTarballToStore {
+            http_client: &client,
+            store_dir: store_path,
+            store_index: StoreIndex::shared_readonly_in(store_path),
+            store_index_writer: Some(Arc::clone(&writer)),
+            verify_store_integrity: true,
+            strict_store_pkg_content_check: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
+            package_integrity: Some(&package_integrity),
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url: &package_url,
+            package_id,
+            requester: "",
+            prefetched_cas_paths: None,
+            retry_opts: test_retry_opts(),
+            auth_headers: &auth_headers,
+            ignore_file_pattern: None,
+            offline: true,
+            progress_reported: None,
+            store_projection: ArchiveStoreProjection::Package { append_manifest: Some(manifest) },
+        }
+        .run_without_mem_cache::<SilentReporter>()
+        .await
+        .expect("each synthesized manifest should be ingested independently");
+        drop(writer);
+        writer_task.await.expect("writer task").expect("writer flushed");
+    }
+
+    std::fs::remove_file(&tarball_path).unwrap();
+    let store_index = StoreIndex::shared_readonly_in(store_path);
+    for manifest in [first_manifest.as_slice(), second_manifest.as_slice()] {
+        let files = IngestTarballToStore {
+            http_client: &client,
+            store_dir: store_path,
+            store_index: store_index.clone(),
+            store_index_writer: None,
+            verify_store_integrity: true,
+            strict_store_pkg_content_check: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
+            package_integrity: Some(&package_integrity),
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url: &package_url,
+            package_id,
+            requester: "",
+            prefetched_cas_paths: None,
+            retry_opts: test_retry_opts(),
+            auth_headers: &auth_headers,
+            ignore_file_pattern: None,
+            offline: true,
+            progress_reported: None,
+            store_projection: ArchiveStoreProjection::Package { append_manifest: Some(manifest) },
+        }
+        .run_without_mem_cache::<SilentReporter>()
+        .await
+        .expect("the matching synthesized manifest should be read from the store");
+        assert_eq!(std::fs::read(&files["package.json"]).unwrap(), manifest);
+    }
+
+    let index = StoreIndex::open_in(store_path).expect("open store index");
+    assert_eq!(index.keys().expect("read index keys").len(), 2);
+    drop((index, store_dir, local_dir));
 }
 
 #[tokio::test]

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2459,6 +2459,97 @@ async fn store_index_partitions_synthesized_package_manifests_by_content() {
 }
 
 #[tokio::test]
+async fn synthesized_projection_reuses_only_a_matching_legacy_row_offline() {
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    store_path.init().unwrap();
+    let package_id = "artifact@1.0.0";
+    let package_integrity = integrity(
+        "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysPYCfdwTgVb0suyqF4bmI3ZJno7K1aUa6Q==",
+    );
+    let manifest = br#"{"name":"artifact","version":"1.0.0"}"#;
+    let readme = b"legacy runtime archive";
+    let (_, manifest_hash) = store_path.write_cas_file(manifest, false).unwrap();
+    let (_, readme_hash) = store_path.write_cas_file(readme, false).unwrap();
+    let legacy_key = store_index_key(&package_integrity.to_string(), package_id);
+    StoreIndex::open_in(store_path)
+        .unwrap()
+        .set(
+            &legacy_key,
+            &PackageFilesIndex {
+                manifest: Some(serde_json::from_slice(manifest).unwrap()),
+                requires_build: Some(false),
+                requires_prepare: None,
+                algo: "sha512".to_string(),
+                files: HashMap::from([
+                    (
+                        "README.md".to_string(),
+                        CafsFileInfo {
+                            digest: format!("{readme_hash:x}"),
+                            mode: 0o644,
+                            size: readme.len() as u64,
+                            checked_at: None,
+                        },
+                    ),
+                    (
+                        "package.json".to_string(),
+                        CafsFileInfo {
+                            digest: format!("{manifest_hash:x}"),
+                            mode: 0o644,
+                            size: manifest.len() as u64,
+                            checked_at: None,
+                        },
+                    ),
+                ]),
+                side_effects: None,
+                remote_side_effects_quarantine: None,
+            },
+        )
+        .unwrap();
+
+    let client = fast_fail_client();
+    let auth_headers = AuthHeaders::default();
+    let store_index = StoreIndex::shared_readonly_in(store_path);
+    let ingest = |append_manifest| IngestTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: store_index.clone(),
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: Some(&package_integrity),
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: "https://example.test/runtime.tgz",
+        package_id,
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &auth_headers,
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        store_projection: ArchiveStoreProjection::Package {
+            append_manifest: Some(append_manifest),
+        },
+    };
+
+    let files = ingest(manifest)
+        .run_without_mem_cache::<SilentReporter>()
+        .await
+        .expect("a matching legacy runtime row should remain available offline");
+    assert_eq!(std::fs::read(&files["package.json"]).unwrap(), manifest);
+    assert_eq!(std::fs::read(&files["README.md"]).unwrap(), readme);
+
+    let error = ingest(br#"{"name":"other","version":"1.0.0"}"#)
+        .run_without_mem_cache::<SilentReporter>()
+        .await
+        .expect_err("a different synthesized manifest must not reuse the legacy row");
+    assert!(matches!(error, TarballError::NoOfflineTarball { .. }));
+    drop(store_dir);
+}
+
+#[tokio::test]
 async fn raw_archive_projection_does_not_inject_an_npm_manifest() {
     let local_dir = tempdir().unwrap();
     let tarball_path = local_dir.path().join("artifact.tgz");

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -2218,6 +2218,153 @@ fn package_projection_preserves_existing_store_index_keys() {
     );
 }
 
+#[test]
+fn ordinary_package_projection_preserves_existing_mem_cache_keys() {
+    let package_url = "https://example.test/artifact.tgz";
+    let package = ArchiveStoreProjection::Package { append_manifest: None };
+
+    assert_eq!(package.mem_cache_key(package_url, false), package_url);
+    assert_eq!(
+        package.mem_cache_key(package_url, true),
+        format!("revision-addressed:{package_url}"),
+    );
+}
+
+#[test]
+fn mem_cache_keys_include_every_file_set_discriminator() {
+    let package_url = "https://example.test/artifact.tgz";
+    let raw = ArchiveStoreProjection::RawArchive.mem_cache_key(package_url, false);
+    let first_manifest =
+        ArchiveStoreProjection::Package { append_manifest: Some(br#"{"name":"first"}"#) }
+            .mem_cache_key(package_url, false);
+    let same_manifest =
+        ArchiveStoreProjection::Package { append_manifest: Some(br#"{"name":"first"}"#) }
+            .mem_cache_key(package_url, false);
+    let second_manifest =
+        ArchiveStoreProjection::Package { append_manifest: Some(br#"{"name":"second"}"#) }
+            .mem_cache_key(package_url, false);
+
+    assert_ne!(raw, package_url);
+    assert_eq!(first_manifest, same_manifest);
+    assert_ne!(first_manifest, second_manifest);
+}
+
+#[tokio::test]
+async fn mem_cache_partitions_raw_and_package_projections_in_both_orders() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("artifact.tgz");
+    std::fs::write(&tarball_path, gzipped_tar(&[("artifact/README.md", b"archive")])).unwrap();
+    let package_url = format!("file:{}", tarball_path.display());
+    let client = fast_fail_client();
+    let auth_headers = AuthHeaders::default();
+
+    for package_first in [true, false] {
+        let (store_dir, store_path) = tempdir_with_leaked_path();
+        let mem_cache = MemCache::default();
+        let ingest = |store_projection| IngestTarballToStore {
+            http_client: &client,
+            store_dir: store_path,
+            store_index: None,
+            store_index_writer: None,
+            verify_store_integrity: true,
+            strict_store_pkg_content_check: true,
+            verified_files_cache: SharedVerifiedFilesCache::default(),
+            package_integrity: None,
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url: &package_url,
+            package_id: "artifact@1.0.0",
+            requester: "",
+            prefetched_cas_paths: None,
+            retry_opts: test_retry_opts(),
+            auth_headers: &auth_headers,
+            ignore_file_pattern: None,
+            offline: true,
+            progress_reported: None,
+            store_projection,
+        };
+
+        let (package_files, raw_files) = if package_first {
+            let package_files = ingest(ArchiveStoreProjection::Package { append_manifest: None })
+                .run_with_mem_cache::<SilentReporter>(&mem_cache)
+                .await
+                .unwrap();
+            let raw_files = ingest(ArchiveStoreProjection::RawArchive)
+                .run_with_mem_cache::<SilentReporter>(&mem_cache)
+                .await
+                .unwrap();
+            (package_files, raw_files)
+        } else {
+            let raw_files = ingest(ArchiveStoreProjection::RawArchive)
+                .run_with_mem_cache::<SilentReporter>(&mem_cache)
+                .await
+                .unwrap();
+            let package_files = ingest(ArchiveStoreProjection::Package { append_manifest: None })
+                .run_with_mem_cache::<SilentReporter>(&mem_cache)
+                .await
+                .unwrap();
+            (package_files, raw_files)
+        };
+
+        let mut package_names = package_files.keys().map(String::as_str).collect::<Vec<_>>();
+        package_names.sort_unstable();
+        assert_eq!(package_names, ["README.md", "package.json"]);
+        assert_eq!(raw_files.keys().map(String::as_str).collect::<Vec<_>>(), ["README.md"]);
+        assert_eq!(mem_cache.len(), 2);
+        drop(store_dir);
+    }
+
+    drop(local_dir);
+}
+
+#[tokio::test]
+async fn mem_cache_partitions_synthesized_package_manifests_by_content() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("artifact.tgz");
+    std::fs::write(&tarball_path, gzipped_tar(&[("artifact/README.md", b"archive")])).unwrap();
+    let package_url = format!("file:{}", tarball_path.display());
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    let client = fast_fail_client();
+    let auth_headers = AuthHeaders::default();
+    let mem_cache = MemCache::default();
+    let ingest = |append_manifest| IngestTarballToStore {
+        http_client: &client,
+        store_dir: store_path,
+        store_index: None,
+        store_index_writer: None,
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: None,
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &package_url,
+        package_id: "artifact@1.0.0",
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &auth_headers,
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        store_projection: ArchiveStoreProjection::Package {
+            append_manifest: Some(append_manifest),
+        },
+    };
+    let first_manifest = br#"{"name":"first"}"#;
+    let second_manifest = br#"{"name":"second"}"#;
+
+    let first =
+        ingest(first_manifest).run_with_mem_cache::<SilentReporter>(&mem_cache).await.unwrap();
+    let second =
+        ingest(second_manifest).run_with_mem_cache::<SilentReporter>(&mem_cache).await.unwrap();
+
+    assert_eq!(std::fs::read(&first["package.json"]).unwrap(), first_manifest);
+    assert_eq!(std::fs::read(&second["package.json"]).unwrap(), second_manifest);
+    assert_eq!(mem_cache.len(), 2);
+    drop((store_dir, local_dir));
+}
+
 #[tokio::test]
 async fn raw_archive_projection_does_not_inject_an_npm_manifest() {
     let local_dir = tempdir().unwrap();

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -3,7 +3,7 @@ use super::{
     RetryOpts, SharedReportedProgressKeys, auth_header_for_package_download,
     download::{
         IngestTarballToStore, download_priority, fetch_and_extract_with_retry, is_transient_error,
-        slow_download_warning,
+        slow_download_warning, store_index_cache_key,
     },
     error::{HttpStatusError, NetworkError, TarballError, VerifyChecksumError},
     extract::{
@@ -2203,6 +2203,21 @@ fn gzipped_tar(entries: &[(&str, &[u8])]) -> Vec<u8> {
     encoder.finish().expect("finish gzip")
 }
 
+#[test]
+fn package_projection_preserves_existing_store_index_keys() {
+    let integrity = integrity("sha256-q80k8iD1xuGM3a48ipTFD+P7KQnhs4e5Blnos+dQpJM=");
+    let package_id = "artifact@1.0.0";
+
+    assert_eq!(
+        store_index_cache_key(
+            Some(&integrity),
+            package_id,
+            ArchiveStoreProjection::Package { append_manifest: None },
+        ),
+        Some(store_index_key(&integrity.to_string(), package_id)),
+    );
+}
+
 #[tokio::test]
 async fn raw_archive_projection_does_not_inject_an_npm_manifest() {
     let local_dir = tempdir().unwrap();
@@ -2252,7 +2267,12 @@ async fn raw_archive_projection_skips_npm_identity_checks_on_store_hits() {
     StoreIndex::open_in(store_path)
         .unwrap()
         .set(
-            &store_index_key(&integrity.to_string(), package_id),
+            &store_index_cache_key(
+                Some(&integrity),
+                package_id,
+                ArchiveStoreProjection::RawArchive,
+            )
+            .unwrap(),
             &PackageFilesIndex {
                 manifest: Some(serde_json::json!({ "name": "unrelated", "version": "2.0.0" })),
                 requires_build: Some(false),
@@ -2301,6 +2321,92 @@ async fn raw_archive_projection_skips_npm_identity_checks_on_store_hits() {
 
     assert_eq!(cas_paths, HashMap::from([("README.md".to_string(), cas_path)]));
     drop(store_dir);
+}
+
+#[tokio::test]
+async fn raw_archive_projection_ignores_legacy_package_rows() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("artifact.tgz");
+    let archive = gzipped_tar(&[("artifact/README.md", b"fresh raw artifact")]);
+    std::fs::write(&tarball_path, &archive).unwrap();
+    let package_url = format!("file:{}", tarball_path.display());
+    let mut integrity_opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    integrity_opts.input(&archive);
+    let integrity = integrity_opts.result();
+    let package_id = "crate:artifact@1.0.0";
+
+    let (store_dir, store_path) = tempdir_with_leaked_path();
+    store_path.init().unwrap();
+    let legacy_contents = b"{}";
+    let (_, legacy_file_hash) = store_path.write_cas_file(legacy_contents, false).unwrap();
+    let legacy_key = store_index_key(&integrity.to_string(), package_id);
+    StoreIndex::open_in(store_path)
+        .unwrap()
+        .set(
+            &legacy_key,
+            &PackageFilesIndex {
+                manifest: None,
+                requires_build: Some(false),
+                requires_prepare: None,
+                algo: "sha512".to_string(),
+                files: HashMap::from([(
+                    "package.json".to_string(),
+                    CafsFileInfo {
+                        digest: format!("{legacy_file_hash:x}"),
+                        mode: 0o644,
+                        size: legacy_contents.len() as u64,
+                        checked_at: None,
+                    },
+                )]),
+                side_effects: None,
+                remote_side_effects_quarantine: None,
+            },
+        )
+        .unwrap();
+
+    let (writer, writer_task) = StoreIndexWriter::spawn(store_path);
+    let cas_paths = IngestTarballToStore {
+        http_client: &fast_fail_client(),
+        store_dir: store_path,
+        store_index: StoreIndex::shared_readonly_in(store_path),
+        store_index_writer: Some(Arc::clone(&writer)),
+        verify_store_integrity: true,
+        strict_store_pkg_content_check: true,
+        verified_files_cache: SharedVerifiedFilesCache::default(),
+        package_integrity: Some(&integrity),
+        package_unpacked_size: None,
+        package_file_count: None,
+        package_url: &package_url,
+        package_id,
+        requester: "",
+        prefetched_cas_paths: None,
+        retry_opts: test_retry_opts(),
+        auth_headers: &AuthHeaders::default(),
+        ignore_file_pattern: None,
+        offline: true,
+        progress_reported: None,
+        store_projection: ArchiveStoreProjection::RawArchive,
+    }
+    .run_without_mem_cache::<SilentReporter>()
+    .await
+    .expect("a legacy npm-projected row must not satisfy a raw archive read");
+
+    assert_eq!(cas_paths.keys().collect::<Vec<_>>(), ["README.md"]);
+    assert_eq!(std::fs::read(&cas_paths["README.md"]).unwrap(), b"fresh raw artifact");
+
+    drop(writer);
+    writer_task.await.expect("writer task").expect("writer flushed");
+    let raw_key =
+        store_index_cache_key(Some(&integrity), package_id, ArchiveStoreProjection::RawArchive)
+            .unwrap();
+    assert_ne!(raw_key, legacy_key);
+
+    let index = StoreIndex::open_in(store_path).expect("open store index");
+    assert!(index.get(&legacy_key).unwrap().is_some(), "legacy row is retained");
+    let raw_entry = index.get(&raw_key).unwrap().expect("raw row is indexed separately");
+    assert_eq!(raw_entry.files.keys().collect::<Vec<_>>(), ["README.md"]);
+
+    drop((index, store_dir, local_dir));
 }
 
 /// The local resolver maps this to `ERR_PNPM_LINKED_PKG_DIR_NOT_FOUND`,

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -10,7 +10,8 @@ use super::{
     STREAM_ENTRY_BUFFER_MAX, TarballError, UNIX_EPOCH, VerifyChecksumError,
     allocate_tarball_buffer, apply_append_manifest, apply_placeholder_manifest,
     auth_header_for_package_download, emit_progress_found_in_store, is_transient_error,
-    load_cached_cas_paths, post_download_semaphore, tarball_error_to_request_retry,
+    load_cached_cas_paths, load_legacy_synthesized_cas_paths, post_download_semaphore,
+    tarball_error_to_request_retry,
 };
 use pnpm_fs::file_mode;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
@@ -608,7 +609,7 @@ impl IngestZipArchiveToStore<'_> {
             return Ok((**cas_paths).clone());
         }
         let cached = load_cached_cas_paths::<Reporter>(
-            store_index,
+            store_index.clone(),
             store_dir,
             cache_key,
             verify_store_integrity,
@@ -620,6 +621,24 @@ impl IngestZipArchiveToStore<'_> {
             tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing cached CAFS entry — skipping zip download");
             emit_progress_found_in_store::<Reporter>(package_id, requester, None);
             return Ok(cas_paths);
+        }
+        if matches!(store_projection, ArchiveStoreProjection::Package { append_manifest: Some(_) })
+        {
+            let cached = load_legacy_synthesized_cas_paths::<Reporter>(
+                store_index,
+                store_dir,
+                &package_integrity.to_string(),
+                package_id,
+                verify_store_integrity,
+                Arc::clone(&self.verified_files_cache),
+                store_projection,
+            )
+            .await?;
+            if let Some(cas_paths) = cached {
+                tracing::info!(target: "pacquet::download", ?package_url, ?package_id, "Reusing compatible legacy CAFS entry — skipping zip download");
+                emit_progress_found_in_store::<Reporter>(package_id, requester, None);
+                return Ok(cas_paths);
+            }
         }
 
         // Offline-mode gate (zip archive). Same shape as the tarball

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -20,7 +20,7 @@ use pnpm_reporter::{
 };
 use pnpm_store_dir::{
     CafsFileInfo, FileHash, PackageFilesIndex, SharedReadonlyStoreIndex, SharedVerifiedFilesCache,
-    StoreDir, StoreIndexWriter, WriteCasFileFromReaderError, store_index_key,
+    StoreDir, StoreIndexWriter, WriteCasFileFromReaderError,
 };
 use ssri::Integrity;
 
@@ -594,7 +594,8 @@ impl IngestZipArchiveToStore<'_> {
         // so clone it out by hand.
         let ignore_file_pattern = self.ignore_file_pattern.clone();
 
-        let cache_key = store_index_key(&package_integrity.to_string(), package_id);
+        let cache_key =
+            store_projection.store_index_key(&package_integrity.to_string(), package_id);
         if let Some(prefetched) = prefetched_cas_paths
             && let Some(cas_paths) = prefetched.get(&cache_key)
         {
@@ -671,7 +672,8 @@ impl IngestZipArchiveToStore<'_> {
             ArchiveStoreProjection::RawArchive => {}
         }
 
-        let index_key = store_index_key(&package_integrity.to_string(), package_id);
+        let index_key =
+            store_projection.store_index_key(&package_integrity.to_string(), package_id);
         if let Some(writer) = store_index_writer {
             writer.queue(index_key, pkg_files_idx);
         } else {

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -555,7 +555,6 @@ pub struct IngestZipArchiveToStore<'a> {
     /// [`TarballError::NoOfflineTarball`] rather than hitting the
     /// network.
     pub offline: bool,
-    /// Synthesized `package.json` to fold into the extracted archive.
     /// Ecosystem-owned projection policy applied after verified extraction.
     pub store_projection: ArchiveStoreProjection<'a>,
 }
@@ -657,8 +656,6 @@ impl IngestZipArchiveToStore<'_> {
 
         match store_projection {
             ArchiveStoreProjection::Package { append_manifest } => {
-                // Fold a synthesized runtime `package.json` into the row before
-                // it is persisted, so warm reinstalls get the same package view.
                 if let Some(manifest_bytes) = append_manifest {
                     apply_append_manifest(
                         store_dir,

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -5,12 +5,12 @@
 //! same CAS write and progress reporting, different container format.
 
 use super::{
-    Arc, Component, Cursor, Duration, HashMap, HttpStatusError, IgnoreEntryFilter, Instant,
-    NetworkError, PathBuf, PrefetchedCasPaths, Read, STREAM_ENTRY_BUFFER_MAX, TarballError,
-    UNIX_EPOCH, VerifyChecksumError, allocate_tarball_buffer, apply_append_manifest,
-    apply_placeholder_manifest, auth_header_for_package_download, emit_progress_found_in_store,
-    is_transient_error, load_cached_cas_paths, post_download_semaphore,
-    tarball_error_to_request_retry,
+    Arc, ArchiveStoreProjection, Component, Cursor, Duration, HashMap, HttpStatusError,
+    IgnoreEntryFilter, Instant, NetworkError, PathBuf, PrefetchedCasPaths, Read,
+    STREAM_ENTRY_BUFFER_MAX, TarballError, UNIX_EPOCH, VerifyChecksumError,
+    allocate_tarball_buffer, apply_append_manifest, apply_placeholder_manifest,
+    auth_header_for_package_download, emit_progress_found_in_store, is_transient_error,
+    load_cached_cas_paths, post_download_semaphore, tarball_error_to_request_retry,
 };
 use pnpm_fs::file_mode;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
@@ -506,7 +506,7 @@ pub(crate) async fn fetch_and_extract_zip_with_retry<Reporter: self::Reporter>(
     }
 }
 
-/// Counterpart to [`crate::download::DownloadTarballToStore`] for zip-archive binary
+/// Counterpart to [`crate::download::IngestTarballToStore`] for zip-archive binary
 /// resolutions: the zip flow downloads the body, verifies the
 /// integrity hash, then walks zip entries and writes each to the CAFS
 /// — with the `prefix` field stripped from each entry path before the
@@ -515,17 +515,17 @@ pub(crate) async fn fetch_and_extract_zip_with_retry<Reporter: self::Reporter>(
 /// downstream consumers' paths.
 ///
 /// The store-index lookup, prefetch cache reuse, and store-index
-/// writer queueing match [`crate::download::DownloadTarballToStore`] — runtime
+/// writer queueing match [`crate::download::IngestTarballToStore`] — runtime
 /// artifacts share the same `index.db` schema as ordinary npm
 /// packages.
 #[must_use]
-pub struct DownloadZipArchiveToStore<'a> {
+pub struct IngestZipArchiveToStore<'a> {
     pub http_client: &'a ThrottledClient,
     pub store_dir: &'static StoreDir,
     pub store_index: Option<SharedReadonlyStoreIndex>,
     pub store_index_writer: Option<Arc<StoreIndexWriter>>,
     pub verify_store_integrity: bool,
-    /// See [`crate::download::DownloadTarballToStore::strict_store_pkg_content_check`].
+    /// See [`crate::download::IngestTarballToStore::strict_store_pkg_content_check`].
     pub strict_store_pkg_content_check: bool,
     pub verified_files_cache: SharedVerifiedFilesCache,
     pub package_integrity: &'a Integrity,
@@ -546,32 +546,30 @@ pub struct DownloadZipArchiveToStore<'a> {
     /// consumers see paths relative to the package root rather than
     /// the runtime-version-stamped wrapper directory.
     pub archive_prefix: Option<&'a str>,
-    /// See [`crate::download::DownloadTarballToStore::ignore_file_pattern`] — the
+    /// See [`crate::download::IngestTarballToStore::ignore_file_pattern`] — the
     /// per-fetch archive filter is shared by both archive types.
     pub ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
-    /// See [`crate::download::DownloadTarballToStore::offline`]. Same semantics for
+    /// See [`crate::download::IngestTarballToStore::offline`]. Same semantics for
     /// the zip-archive path: when both cache lookups miss and
     /// `offline` is `true`, the fetcher fails with
     /// [`TarballError::NoOfflineTarball`] rather than hitting the
     /// network.
     pub offline: bool,
     /// Synthesized `package.json` to fold into the extracted archive.
-    /// See [`crate::download::DownloadTarballToStore::append_manifest`] — same
-    /// `appendManifest` semantics for the zip path, used for the
-    /// runtime archives (e.g. Deno / Bun) that arrive as zips.
-    pub append_manifest: Option<&'a [u8]>,
+    /// Ecosystem-owned projection policy applied after verified extraction.
+    pub store_projection: ArchiveStoreProjection<'a>,
 }
 
-impl DownloadZipArchiveToStore<'_> {
+impl IngestZipArchiveToStore<'_> {
     /// Execute the subroutine without an in-memory cache. Mirrors
-    /// [`crate::download::DownloadTarballToStore::run_without_mem_cache`] — same
+    /// [`crate::download::IngestTarballToStore::run_without_mem_cache`] — same
     /// prefetch-cas-paths reuse, same SQLite-index lookup, same
     /// store-index writer queue — only the network and extract
     /// path differs (zip instead of gzip + tar).
     pub async fn run_without_mem_cache<Reporter: self::Reporter>(
         &self,
     ) -> Result<HashMap<String, PathBuf>, TarballError> {
-        let &DownloadZipArchiveToStore {
+        let &IngestZipArchiveToStore {
             http_client,
             store_dir,
             package_integrity,
@@ -584,14 +582,14 @@ impl DownloadZipArchiveToStore<'_> {
             retry_opts,
             auth_headers,
             archive_prefix,
-            append_manifest,
+            store_projection,
             ..
         } = self;
         let store_index = self.store_index.clone();
         let store_index_writer = self.store_index_writer.clone();
         let verified_files_cache = Arc::clone(&self.verified_files_cache);
         // See the matching note in
-        // [`crate::download::DownloadTarballToStore::run_without_mem_cache`]: the
+        // [`crate::download::IngestTarballToStore::run_without_mem_cache`]: the
         // Arc-wrapped filter can't ride along in the deref pattern,
         // so clone it out by hand.
         let ignore_file_pattern = self.ignore_file_pattern.clone();
@@ -614,7 +612,7 @@ impl DownloadZipArchiveToStore<'_> {
             store_dir,
             cache_key,
             verify_store_integrity,
-            strict_store_pkg_content_check,
+            store_projection.package_content_check(strict_store_pkg_content_check),
             verified_files_cache,
         )
         .await?;
@@ -656,12 +654,22 @@ impl DownloadZipArchiveToStore<'_> {
         )
         .await?;
 
-        // Fold the synthesized runtime `package.json` into the row before
-        // it is persisted, so warm reinstalls (which read the row) get it.
-        if let Some(manifest_bytes) = append_manifest {
-            apply_append_manifest(store_dir, manifest_bytes, &mut cas_paths, &mut pkg_files_idx)?;
+        match store_projection {
+            ArchiveStoreProjection::Package { append_manifest } => {
+                // Fold a synthesized runtime `package.json` into the row before
+                // it is persisted, so warm reinstalls get the same package view.
+                if let Some(manifest_bytes) = append_manifest {
+                    apply_append_manifest(
+                        store_dir,
+                        manifest_bytes,
+                        &mut cas_paths,
+                        &mut pkg_files_idx,
+                    )?;
+                }
+                apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
+            }
+            ArchiveStoreProjection::RawArchive => {}
         }
-        apply_placeholder_manifest(store_dir, &mut cas_paths, &mut pkg_files_idx)?;
 
         let index_key = store_index_key(&package_integrity.to_string(), package_id);
         if let Some(writer) = store_index_writer {

--- a/pnpm/tasks/micro-benchmark/src/main.rs
+++ b/pnpm/tasks/micro-benchmark/src/main.rs
@@ -12,7 +12,7 @@ use pipe_trait::Pipe;
 use pnpm_network::{AuthHeaders, ThrottledClient};
 use pnpm_registry::Package;
 use pnpm_store_dir::StoreDir;
-use pnpm_tarball::{DownloadTarballToStore, RetryOpts};
+use pnpm_tarball::{ArchiveStoreProjection, IngestTarballToStore, RetryOpts};
 use project_root::get_project_root;
 use ssri::Integrity;
 use tar::{Builder, Header};
@@ -53,7 +53,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 dir.path().to_path_buf().pipe(StoreDir::from).pipe(Box::new).pipe(Box::leak);
             let http_client = ThrottledClient::new_for_installs();
 
-            let cas_map = DownloadTarballToStore {
+            let cas_map = IngestTarballToStore {
                 http_client: &http_client,
                 store_dir,
                 store_index: None,
@@ -73,7 +73,7 @@ fn bench_tarball(criterion: &mut Criterion, server: &mut ServerGuard, fixtures_f
                 ignore_file_pattern: None,
                 offline: false,
                 progress_reported: None,
-                append_manifest: None,
+                store_projection: ArchiveStoreProjection::Package { append_manifest: None },
             }
             .run_without_mem_cache::<pnpm_reporter::SilentReporter>()
             .await
@@ -116,7 +116,7 @@ fn bench_concurrent_tarballs(criterion: &mut Criterion, server: &mut ServerGuard
             let http_client = ThrottledClient::new_for_installs();
             future::try_join_all(packages.iter().map(|package| async {
                 let auth_headers = AuthHeaders::default();
-                DownloadTarballToStore {
+                IngestTarballToStore {
                     http_client: &http_client,
                     store_dir,
                     store_index: None,
@@ -136,7 +136,7 @@ fn bench_concurrent_tarballs(criterion: &mut Criterion, server: &mut ServerGuard
                     ignore_file_pattern: None,
                     offline: false,
                     progress_reported: None,
-                    append_manifest: None,
+                    store_projection: ArchiveStoreProjection::Package { append_manifest: None },
                 }
                 .run_without_mem_cache::<pnpm_reporter::SilentReporter>()
                 .await


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14566 and pnpm/rfcs#34.

- rename the shared tarball and zip operations around artifact ingestion instead of npm-specific downloading
- make the store projection explicit: npm archives retain placeholder/synthesized `package.json` behavior, while raw archives preserve their regular files
- have raw projections skip npm-only store identity validation
- namespace raw store-index rows so legacy package-projected Cargo rows trigger a one-time clean re-ingestion
- partition in-memory and persistent cache rows by every file-set-changing projection input while retaining ordinary npm URL and store keys byte-for-byte
- preserve offline runtime upgrades by accepting a legacy synthesized-manifest row only when its `package.json` bytes match the requested projection
- select the raw projection for Cargo, keeping `.cargo-checksum.json` generation and crate layout in the Cargo adapter
- preserve the existing npm install call path with a static enum policy and no new allocation, task, collection, or discovery work

No changeset is included because this is an internal Rust refactor with no published-package or user-facing behavior change.

The existing integrated benchmark scenario `isolated-linker.fresh-restore.cold-cache.cold-store` was run in both orders for the exact revisions. The first run measured 1.447 ± 0.085s for this commit versus 1.540 ± 0.089s for its parent (1.06 ± 0.09×); the reverse-order run measured 1.500 ± 0.051s versus 1.486 ± 0.067s (1.01 ± 0.06×). The ranges overlap and show no reproducible npm-only regression.

After the persistent store-index isolation fix, the same scenario was rerun for exact revisions `90d8ec52a1` and `e426da4b2a`. It measured 1.468 ± 0.070s versus 1.461 ± 0.051s in the first order (1.00 ± 0.06×), and 1.492 ± 0.043s versus 1.453 ± 0.045s in reverse order (1.03 ± 0.04×). These ranges also overlap. The hosted integrated and micro-benchmark checks are the performance gate for the final head.

## Squash Commit Body

```text
Make archive ingestion an ecosystem-neutral store primitive by requiring callers to select either npm package projection or raw archive projection. Keep npm's synthesized and placeholder package manifests intact, while Cargo receives exact archive files and continues to own its checksum metadata and install layout.

Related to pnpm/pnpm#14566.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. This internal refactor affects only the Rust v12 implementation.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791174524&installation_model_id=426870&pr_number=14574&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14574&signature=26af8dd29afc64ae16b82d80481d5134c4b3c6c7f7e7f128cd1f0643babd9298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for ingesting raw archives without adding package manifests.
  - Package and raw-archive content now use distinct storage projections and cache entries.
  - Added configurable package content verification for cached archives.

- **Bug Fixes**
  - Improved archive ingestion for package and ZIP workflows while preserving manifest handling.
  - Prevented raw archives from reusing package-projected entries.
  - Preserved compatibility with existing package storage and cache entries.
  - Corrected handling of synthesized manifests and legacy cached entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
