### PR TITLE
fix(executor): preserve emulated script arguments

### DIFF
--- a/.changeset/shell-emulator-literal-arguments.md
+++ b/.changeset/shell-emulator-literal-arguments.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/exec.lifecycle": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+Fixed argument forwarding on Windows when `shellEmulator` is enabled. Paths ending in a backslash, line breaks, and literal shell expressions are preserved [pnpm/pnpm#14548](https://github.com/pnpm/pnpm/issues/14548).

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -2,10 +2,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::bin::CommandTempCwd;
 use serde_json::json;
-use std::{
-    fs,
-    time::{Duration, Instant},
-};
+use std::{fs, time::Duration};
 
 #[cfg(unix)]
 fn write_executable(path: &std::path::Path, body: &str) {
@@ -957,19 +954,22 @@ fn regexp_selected_scripts_cancel_siblings_after_failure() {
             "name": "test",
             "version": "0.0.0",
             "scripts": {
-                "dev:slow": r#"node -e "require('fs').writeFileSync('slow-started', ''); setTimeout(() => {}, 5000)""#,
-                "dev:fail": r#"node -e "const fs = require('fs'); const wait = () => fs.existsSync('slow-started') ? process.exit(1) : setTimeout(wait, 10); wait()""#,
+                "dev:slow": r#"node -e "const fs = require('fs'); fs.writeFileSync('slow-started', ''); setTimeout(() => fs.writeFileSync('slow-finished', ''), 30000)""#,
+                "dev:fail": r#"node -e "const fs = require('fs'); const wait = () => fs.existsSync('slow-started') ? process.exit(17) : setTimeout(wait, 10); wait()""#,
             },
         })
         .to_string(),
     )
     .expect("write package.json");
 
-    let start = Instant::now();
-    pacquet.with_args(["--workspace-concurrency=2", "run", "/^dev:/"]).assert().failure();
+    assert_cmd::Command::from_std(pacquet)
+        .args(["--workspace-concurrency=2", "run", "/^dev:/"])
+        .timeout(Duration::from_mins(1))
+        .assert()
+        .code(17);
     assert!(
-        start.elapsed() < Duration::from_secs(4),
-        "a failed script should cancel its in-flight sibling",
+        !workspace.join("slow-finished").exists(),
+        "the slow script must be cancelled before its watchdog completes",
     );
 
     drop(root);
@@ -1107,6 +1107,46 @@ mod shell_emulator {
         assert_eq!(marker.trim(), "emulated");
 
         drop(root);
+    }
+
+    #[test]
+    fn preserves_literal_arguments() {
+        let args = [
+            r"C:\Program Files\tool\",
+            "",
+            "'it''s'",
+            r#"a"b"#,
+            "$PNPM_QUOTING_TEST",
+            "$(echo expanded)",
+            "a;b",
+            "*",
+            "line\nbreak",
+            "中文",
+        ];
+
+        for streamed in [false, true] {
+            let CommandTempCwd { mut pacquet, root, workspace, .. } = CommandTempCwd::init();
+            write_project(&workspace, &json!({ "record": "node record-args.cjs" }), true);
+            fs::write(
+                workspace.join("record-args.cjs"),
+                "require('node:fs').writeFileSync('args.json', JSON.stringify(process.argv.slice(2)))",
+            )
+            .expect("write argument recorder");
+
+            if streamed {
+                pacquet.args(["--recursive", "--include-workspace-root", "--stream"]);
+            }
+            pacquet.args(["run", "record"]).args(args).env("PNPM_QUOTING_TEST", "expanded");
+            pacquet.assert().success();
+
+            let recorded: Vec<String> = serde_json::from_slice(
+                &fs::read(workspace.join("args.json")).expect("read recorded arguments"),
+            )
+            .expect("parse recorded arguments");
+            assert_eq!(recorded, args, "streamed: {streamed}");
+
+            drop(root);
+        }
     }
 
     #[test]

--- a/pnpm/crates/executor/src/run_script.rs
+++ b/pnpm/crates/executor/src/run_script.rs
@@ -111,7 +111,7 @@ pub struct RunScript<'a> {
 /// Run a single user script in the foreground, sending its output where
 /// [`RunScript::output`] says.
 pub fn run_script(opts: &RunScript<'_>) -> Result<ScriptExit, RunScriptError> {
-    let command = build_command(opts.script, opts.args);
+    let command = build_command(opts.script, opts.args, opts.shell_emulator);
 
     // The `scriptShell` value is validated even when the emulator will
     // run the script, matching pnpm's `runLifecycleHook`, which rejects a
@@ -235,13 +235,13 @@ fn run_piped(
         .map_err(|source| RunScriptError::Wait { script: command.to_string(), source })
 }
 
-/// Append shell-quoted `args` to `script`: `shlex`-style quoting on
-/// POSIX and per-argument `JSON.stringify` on Windows.
-fn build_command(script: &str, args: &[String]) -> String {
+/// Append shell-quoted `args` to `script`: POSIX quoting for the shell
+/// emulator and Unix shells, and per-argument JSON quoting for native Windows shells.
+fn build_command(script: &str, args: &[String], shell_emulator: bool) -> String {
     if args.is_empty() {
         return script.to_string();
     }
-    let quoted = if cfg!(windows) {
+    let quoted = if cfg!(windows) && !shell_emulator {
         args.iter().map(|arg| Value::String(arg.clone()).to_string()).collect::<Vec<_>>().join(" ")
     } else {
         args.iter().map(|arg| posix_quote(arg)).collect::<Vec<_>>().join(" ")

--- a/pnpm/crates/executor/src/run_script/tests.rs
+++ b/pnpm/crates/executor/src/run_script/tests.rs
@@ -23,14 +23,16 @@ fn posix_quote_escapes_embedded_single_quotes() {
 
 #[test]
 fn build_command_without_args_returns_script_unchanged() {
-    assert_eq!(build_command("tsc --build", &[]), "tsc --build");
+    for shell_emulator in [false, true] {
+        assert_eq!(build_command("tsc --build", &[], shell_emulator), "tsc --build");
+    }
 }
 
 #[test]
 #[cfg_attr(target_os = "windows", ignore = "asserts POSIX quoting; Windows uses JSON.stringify")]
 fn build_command_appends_quoted_args() {
     let args = ["plain".to_string(), "needs quoting".to_string()];
-    assert_eq!(build_command("echo", &args), "echo plain 'needs quoting'");
+    assert_eq!(build_command("echo", &args, false), "echo plain 'needs quoting'");
 }
 
 fn manifest() -> serde_json::Value {

--- a/pnpm11/exec/lifecycle/src/runLifecycleHook.ts
+++ b/pnpm11/exec/lifecycle/src/runLifecycleHook.ts
@@ -92,7 +92,7 @@ Please unset the scriptShell option, or configure it to a .exe instead.
   }
   if (opts.args?.length && m.scripts?.[stage]) {
     // It is impossible to quote a command line argument that contains newline for Windows cmd.
-    const escapedArgs = isWindows()
+    const escapedArgs = isWindows() && !opts.shellEmulator
       ? opts.args.map((arg) => JSON.stringify(arg)).join(' ')
       : shellQuote(opts.args)
     m.scripts[stage] = `${m.scripts[stage]} ${escapedArgs}`

--- a/pnpm11/exec/lifecycle/test/index.ts
+++ b/pnpm11/exec/lifecycle/test/index.ts
@@ -142,6 +142,36 @@ test('runLifecycleHook() escapes the args passed to the script', async () => {
   expect((await import(path.join(pkgRoot, 'output.json'))).default).toStrictEqual(['Revert "feature (#1)"'])
 })
 
+test('runLifecycleHook() preserves literal arguments with the shell emulator', async () => {
+  const pkgRoot = f.find('escape-args')
+  const { default: pkg } = await import(path.join(pkgRoot, 'package.json'))
+  await fs.promises.rm(path.join(pkgRoot, 'output.json'), { force: true })
+  const args = [
+    'C:\\Program Files\\tool\\',
+    '',
+    '\'it\'\'s\'',
+    'a"b',
+    '$PNPM_QUOTING_TEST',
+    '$(echo expanded)',
+    'a;b',
+    '*',
+    'line\nbreak',
+    '中文',
+  ]
+  await runLifecycleHook('echo', pkg, {
+    depPath: '/escape-args/1.0.0',
+    pkgRoot,
+    rootModulesDir,
+    unsafePerm: true,
+    shellEmulator: true,
+    extraEnv: { PNPM_QUOTING_TEST: 'expanded' },
+    args,
+  })
+
+  const recorded = JSON.parse(await fs.promises.readFile(path.join(pkgRoot, 'output.json'), 'utf8'))
+  expect(recorded).toStrictEqual(args)
+})
+
 test('runLifecycleHook() passes newline correctly', async () => {
   const pkgRoot = f.find('escape-newline')
   const { default: pkg } = await import(path.join(pkgRoot, 'package.json'))


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14548.

Use POSIX argument quoting whenever `shellEmulator` is enabled, including on Windows, in both the Rust executor and the TypeScript lifecycle implementation. Windows JSON-style quoting does not preserve literal arguments for the emulator: the Rust parser rejects the reported trailing-backslash path, and shell expressions can be expanded instead of reaching the script unchanged. Native Windows shell quoting is unchanged.

The regression tests record the child process's actual arguments, including a trailing-backslash path, empty arguments, quotes, shell expressions, a newline, and Unicode. Rust covers both direct and recursive streamed execution; TypeScript covers the lifecycle boundary.

The existing sibling-cancellation test also failed during full-suite validation because its four-second assertion included process startup. Replace that assertion with a completion marker, a distinct failure code, and a bounded watchdog. A control experiment confirmed that the exit code alone cannot distinguish cancellation from natural completion.

Validation:

- Final Rust `just ready`: passed, including 9,954 tests and workspace Clippy. Five existing tests remain skipped; this PR adds no skips.
- TypeScript lifecycle: 19 tests passed in a source-identical short-path checkout. This avoids macOS Unix-domain socket path limits in existing IPC fixtures.
- Full TypeScript compile, CLI bundle, spellcheck, metadata validation, ESLint, and Rust documentation checks passed. The normal commit and pre-push hooks passed without bypasses. The hook reported that Dylint is not installed locally, so that check remains for CI.
- Ablation: the reduced 10-argument corpus still detected all 15 tested fault variants; removing any one argument missed at least one variant. Three quoting implementations agreed on 37,449 deterministic inputs.
- Native Windows execution remains to be confirmed by CI. Local Windows-quoting branch experiments are not a substitute for Windows CI.

## Squash Commit Body

```text
Select POSIX argument quoting whenever the shell emulator parses a script,
including on Windows. Keep native Windows shell quoting unchanged and
apply the same selection in the TypeScript lifecycle implementation.

Cover literal arguments through the direct and recursive CLI paths and the
TypeScript lifecycle boundary.

Replace the cancellation regression's startup-sensitive four-second
assertion with a completion marker, distinct exit code and bounded watchdog.
The existing timing assertion failed under full-suite startup load.

Fixes pnpm/pnpm#14548
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791180963&installation_model_id=426870&pr_number=14576&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14576&signature=c06be9f9087a6a1646873020e48bad1fe86bc47625bad958b94ac4f79f12dafd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows argument forwarding when the shell emulator is enabled.
  - Paths ending in backslashes, line breaks, quotes, variables, wildcards, shell expressions, and Unicode characters are now preserved as literal arguments.
  - Improved argument handling for lifecycle scripts and recursive workspace commands using the shell emulator.

- **Tests**
  - Added coverage for special-character arguments across supported command execution scenarios, including lifecycle hooks and recursive workspace commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
