### PR TITLE
feat(cargo): share registry request authentication

### DIFF
--- a/.changeset/cargo-registry-auth.md
+++ b/.changeset/cargo-registry-auth.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Cargo index and crate downloads now use URL-matched credentials from pnpm configuration. The crates.io index also supports `CARGO_REGISTRY_TOKEN` and the token in `$CARGO_HOME/credentials.toml`, using Cargo's bare `Authorization` header format.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,6 +4408,7 @@ dependencies = [
  "tempfile",
  "text-block-macros",
  "tokio",
+ "toml",
  "tracing",
  "url",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ tower-http         = { version = "0.7.0", features = ["compression-gzip", "cors"
 tracing            = { version = "0.1.44" }
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 tokio              = { version = "1", features = ["rt", "rt-multi-thread", "macros", "fs", "io-util", "net", "signal", "sync"] }
+toml               = { version = "1.1.5" }
 url                = { version = "2.5.8" }
 walkdir            = { version = "2.5.0" }
 webpki-root-certs  = { version = "1.0.7" }

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -108,6 +108,7 @@ ssri                 = { workspace = true }
 tabled               = { workspace = true }
 tar                  = { workspace = true }
 tempfile             = { workspace = true }
+toml                 = { workspace = true }
 tokio                = { workspace = true, features = ["process"] }
 tracing              = { workspace = true }
 url                  = { workspace = true }

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -312,22 +312,26 @@ async fn ensure_lockfile(
 
 pub(crate) async fn latest_version(
     config: &Config,
+    auth_headers: &AuthHeaders,
     name: &str,
     http_client: &ThrottledClient,
 ) -> Result<String> {
-    let auth_headers = registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers)?;
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
     let index_file = fetch_sparse_index_file(
         name,
         CRATES_IO_SPARSE_INDEX,
         &cache_dir,
         http_client,
-        &auth_headers,
+        auth_headers,
         config.offline,
     )
     .await?;
     pnpm_cargo_resolver::latest_version(name, &index_file)
         .wrap_err_with(|| format!("select the latest version of crate {name}"))
+}
+
+pub(crate) fn crates_io_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {
+    registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers, config.offline)
 }
 
 async fn read_cargo_metadata(root_dir: &Path) -> Result<String> {
@@ -363,7 +367,7 @@ async fn fetch_sparse_index(
     metadata: &str,
     http_client: &Arc<ThrottledClient>,
 ) -> Result<BTreeMap<String, String>> {
-    let auth_headers = registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers)?;
+    let auth_headers = crates_io_auth_headers(config)?;
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
     let mut index_files = BTreeMap::new();
 

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -139,7 +139,7 @@ async fn install_workspace<Reporter: self::Reporter + 'static>(
     let (store_index_writer, writer_task) =
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
 
-    let auth_headers = Arc::new(AuthHeaders::default());
+    let auth_headers = Arc::clone(&config.auth_headers);
     let verified_files_cache = SharedVerifiedFilesCache::default();
     let logged_methods = Arc::new(AtomicU8::new(0));
     let retry_opts = RetryOpts {
@@ -313,11 +313,16 @@ pub(crate) async fn latest_version(
     name: &str,
     http_client: &ThrottledClient,
 ) -> Result<String> {
-    let auth_headers = AuthHeaders::default();
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
-    let index_file =
-        fetch_sparse_index_file(name, &cache_dir, http_client, &auth_headers, config.offline)
-            .await?;
+    let index_file = fetch_sparse_index_file(
+        name,
+        CRATES_IO_SPARSE_INDEX,
+        &cache_dir,
+        http_client,
+        &config.auth_headers,
+        config.offline,
+    )
+    .await?;
     pnpm_cargo_resolver::latest_version(name, &index_file)
         .wrap_err_with(|| format!("select the latest version of crate {name}"))
 }
@@ -355,7 +360,7 @@ async fn fetch_sparse_index(
     metadata: &str,
     http_client: &Arc<ThrottledClient>,
 ) -> Result<BTreeMap<String, String>> {
-    let auth_headers = Arc::new(AuthHeaders::default());
+    let auth_headers = Arc::clone(&config.auth_headers);
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
     let mut index_files = BTreeMap::new();
 
@@ -373,6 +378,7 @@ async fn fetch_sparse_index(
                 async move {
                     let contents = fetch_sparse_index_file(
                         &name,
+                        CRATES_IO_SPARSE_INDEX,
                         &cache_dir,
                         &http_client,
                         &auth_headers,
@@ -391,6 +397,7 @@ async fn fetch_sparse_index(
 
 async fn fetch_sparse_index_file(
     name: &str,
+    sparse_index: &str,
     cache_dir: &Path,
     http_client: &ThrottledClient,
     auth_headers: &AuthHeaders,
@@ -404,7 +411,7 @@ async fn fetch_sparse_index_file(
             .wrap_err_with(|| format!("read cached sparse index entry for {name}"));
     }
 
-    let url = format!("{CRATES_IO_SPARSE_INDEX}/{relative_path}");
+    let url = format!("{}/{relative_path}", sparse_index.trim_end_matches('/'));
     let response = http_client
         .get_bytes_with_secure_auth_headers(&url, auth_headers)
         .await

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -21,6 +21,8 @@ use std::{
     time::Duration,
 };
 
+mod registry_auth;
+
 #[cfg(unix)]
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -313,13 +315,14 @@ pub(crate) async fn latest_version(
     name: &str,
     http_client: &ThrottledClient,
 ) -> Result<String> {
+    let auth_headers = registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers)?;
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
     let index_file = fetch_sparse_index_file(
         name,
         CRATES_IO_SPARSE_INDEX,
         &cache_dir,
         http_client,
-        &config.auth_headers,
+        &auth_headers,
         config.offline,
     )
     .await?;
@@ -360,7 +363,7 @@ async fn fetch_sparse_index(
     metadata: &str,
     http_client: &Arc<ThrottledClient>,
 ) -> Result<BTreeMap<String, String>> {
-    let auth_headers = Arc::clone(&config.auth_headers);
+    let auth_headers = registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers)?;
     let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
     let mut index_files = BTreeMap::new();
 

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
@@ -2,7 +2,11 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::{EnvVar, EnvVarOs, GetHomeDir};
 use pnpm_network::AuthHeaders;
 use serde::Deserialize;
-use std::{fs, path::Path, path::PathBuf, sync::Arc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 const CARGO_HOME_ENV: &str = "CARGO_HOME";
 const CRATES_IO_TOKEN_ENV: &str = "CARGO_REGISTRY_TOKEN";
@@ -63,8 +67,9 @@ fn token_from_credentials(cargo_home: &Path) -> Result<Option<String>> {
                     .wrap_err_with(|| format!("read Cargo credentials from {}", path.display()));
             }
         };
-        let credentials: CargoCredentials = toml::from_str(&contents)
-            .map_err(|_| miette::miette!("parse Cargo credentials from {}", path.display()))?;
+        let parse_error = format!("parse Cargo credentials from {}", path.display());
+        let credentials: CargoCredentials =
+            toml::from_str(&contents).map_err(|_| miette::miette!(parse_error))?;
         return Ok(credentials.registry.and_then(|registry| nonempty(registry.token)));
     }
     Ok(None)
@@ -75,101 +80,4 @@ fn nonempty(value: Option<String>) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn configured() -> Arc<AuthHeaders> {
-        Arc::new(AuthHeaders::from_creds_map([
-            ("//index.crates.io/".to_string(), "Bearer pnpm-token".to_string()),
-            ("//npm.example/".to_string(), "Bearer npm-token".to_string()),
-        ]))
-    }
-
-    #[test]
-    fn no_cargo_token_reuses_the_configured_auth_map() {
-        let configured = configured();
-
-        let resolved = crates_io_from_sources(&configured, None, None).unwrap();
-
-        assert!(Arc::ptr_eq(&resolved, &configured));
-        assert_eq!(
-            resolved.for_url("https://index.crates.io/config.json"),
-            Some("Bearer pnpm-token".to_string()),
-        );
-    }
-
-    #[test]
-    fn credentials_token_is_bare_and_preserves_other_routes() {
-        let cargo_home = tempfile::tempdir().unwrap();
-        fs::write(
-            cargo_home.path().join("credentials.toml"),
-            "[registry]\ntoken = 'cargo-token'\n",
-        )
-        .unwrap();
-
-        let resolved =
-            crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
-
-        assert_eq!(
-            resolved.for_url("https://index.crates.io/se/rd/serde"),
-            Some("cargo-token".to_string()),
-        );
-        assert_eq!(
-            resolved.for_url("https://static.crates.io/crates/serde/serde-1.0.0.crate"),
-            None
-        );
-        assert_eq!(
-            resolved.for_url("https://npm.example/package"),
-            Some("Bearer npm-token".to_string()),
-        );
-    }
-
-    #[test]
-    fn environment_token_overrides_the_credentials_file() {
-        let cargo_home = tempfile::tempdir().unwrap();
-        fs::write(cargo_home.path().join("credentials.toml"), "not valid TOML = [").unwrap();
-
-        let resolved = crates_io_from_sources(
-            &configured(),
-            Some("environment-token".to_string()),
-            Some(cargo_home.path()),
-        )
-        .unwrap();
-
-        assert_eq!(
-            resolved.for_url("https://index.crates.io/config.json"),
-            Some("environment-token".to_string()),
-        );
-    }
-
-    #[test]
-    fn legacy_credentials_file_wins_when_both_exist() {
-        let cargo_home = tempfile::tempdir().unwrap();
-        fs::write(cargo_home.path().join("credentials"), "[registry]\ntoken = 'legacy'\n").unwrap();
-        fs::write(cargo_home.path().join("credentials.toml"), "[registry]\ntoken = 'toml'\n")
-            .unwrap();
-
-        let resolved =
-            crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
-
-        assert_eq!(
-            resolved.for_url("https://index.crates.io/config.json"),
-            Some("legacy".to_string()),
-        );
-    }
-
-    #[test]
-    fn malformed_credentials_do_not_leak_the_file_contents() {
-        let cargo_home = tempfile::tempdir().unwrap();
-        fs::write(
-            cargo_home.path().join("credentials.toml"),
-            "[registry]\ntoken = 'do-not-print-this'\ninvalid = [",
-        )
-        .unwrap();
-
-        let error = token_from_credentials(cargo_home.path()).unwrap_err().to_string();
-
-        assert!(error.contains("credentials.toml"), "{error}");
-        assert!(!error.contains("do-not-print-this"), "{error}");
-    }
-}
+mod tests;

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
@@ -1,0 +1,175 @@
+use miette::{IntoDiagnostic, Result, WrapErr};
+use pnpm_config::{EnvVar, EnvVarOs, GetHomeDir};
+use pnpm_network::AuthHeaders;
+use serde::Deserialize;
+use std::{fs, path::Path, path::PathBuf, sync::Arc};
+
+const CARGO_HOME_ENV: &str = "CARGO_HOME";
+const CRATES_IO_TOKEN_ENV: &str = "CARGO_REGISTRY_TOKEN";
+
+#[derive(Deserialize)]
+struct CargoCredentials {
+    registry: Option<RegistryCredentials>,
+}
+
+#[derive(Deserialize)]
+struct RegistryCredentials {
+    token: Option<String>,
+}
+
+pub(super) fn crates_io<Sys>(configured: &Arc<AuthHeaders>) -> Result<Arc<AuthHeaders>>
+where
+    Sys: EnvVar + EnvVarOs + GetHomeDir,
+{
+    let cargo_home = cargo_home::<Sys>();
+    crates_io_from_sources(configured, Sys::var(CRATES_IO_TOKEN_ENV), cargo_home.as_deref())
+}
+
+fn crates_io_from_sources(
+    configured: &Arc<AuthHeaders>,
+    env_token: Option<String>,
+    cargo_home: Option<&Path>,
+) -> Result<Arc<AuthHeaders>> {
+    let token = match nonempty(env_token) {
+        Some(token) => Some(token),
+        None => cargo_home.map(token_from_credentials).transpose()?.flatten(),
+    };
+    let Some(token) = token else { return Ok(Arc::clone(configured)) };
+
+    let mut auth_headers = (**configured).clone();
+    auth_headers.insert_url_header(super::CRATES_IO_SPARSE_INDEX, token);
+    Ok(Arc::new(auth_headers))
+}
+
+fn cargo_home<Sys>() -> Option<PathBuf>
+where
+    Sys: EnvVarOs + GetHomeDir,
+{
+    Sys::var_os(CARGO_HOME_ENV)
+        .filter(|path| !path.as_os_str().is_empty())
+        .map(PathBuf::from)
+        .or_else(|| Sys::home_dir().map(|home| home.join(".cargo")))
+}
+
+fn token_from_credentials(cargo_home: &Path) -> Result<Option<String>> {
+    for filename in ["credentials", "credentials.toml"] {
+        let path = cargo_home.join(filename);
+        let contents = match fs::read_to_string(&path) {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(error) => {
+                return Err(error)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("read Cargo credentials from {}", path.display()));
+            }
+        };
+        let credentials: CargoCredentials = toml::from_str(&contents)
+            .map_err(|_| miette::miette!("parse Cargo credentials from {}", path.display()))?;
+        return Ok(credentials.registry.and_then(|registry| nonempty(registry.token)));
+    }
+    Ok(None)
+}
+
+fn nonempty(value: Option<String>) -> Option<String> {
+    value.filter(|value| !value.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn configured() -> Arc<AuthHeaders> {
+        Arc::new(AuthHeaders::from_creds_map([
+            ("//index.crates.io/".to_string(), "Bearer pnpm-token".to_string()),
+            ("//npm.example/".to_string(), "Bearer npm-token".to_string()),
+        ]))
+    }
+
+    #[test]
+    fn no_cargo_token_reuses_the_configured_auth_map() {
+        let configured = configured();
+
+        let resolved = crates_io_from_sources(&configured, None, None).unwrap();
+
+        assert!(Arc::ptr_eq(&resolved, &configured));
+        assert_eq!(
+            resolved.for_url("https://index.crates.io/config.json"),
+            Some("Bearer pnpm-token".to_string()),
+        );
+    }
+
+    #[test]
+    fn credentials_token_is_bare_and_preserves_other_routes() {
+        let cargo_home = tempfile::tempdir().unwrap();
+        fs::write(
+            cargo_home.path().join("credentials.toml"),
+            "[registry]\ntoken = 'cargo-token'\n",
+        )
+        .unwrap();
+
+        let resolved =
+            crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
+
+        assert_eq!(
+            resolved.for_url("https://index.crates.io/se/rd/serde"),
+            Some("cargo-token".to_string()),
+        );
+        assert_eq!(
+            resolved.for_url("https://static.crates.io/crates/serde/serde-1.0.0.crate"),
+            None
+        );
+        assert_eq!(
+            resolved.for_url("https://npm.example/package"),
+            Some("Bearer npm-token".to_string()),
+        );
+    }
+
+    #[test]
+    fn environment_token_overrides_the_credentials_file() {
+        let cargo_home = tempfile::tempdir().unwrap();
+        fs::write(cargo_home.path().join("credentials.toml"), "not valid TOML = [").unwrap();
+
+        let resolved = crates_io_from_sources(
+            &configured(),
+            Some("environment-token".to_string()),
+            Some(cargo_home.path()),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved.for_url("https://index.crates.io/config.json"),
+            Some("environment-token".to_string()),
+        );
+    }
+
+    #[test]
+    fn legacy_credentials_file_wins_when_both_exist() {
+        let cargo_home = tempfile::tempdir().unwrap();
+        fs::write(cargo_home.path().join("credentials"), "[registry]\ntoken = 'legacy'\n").unwrap();
+        fs::write(cargo_home.path().join("credentials.toml"), "[registry]\ntoken = 'toml'\n")
+            .unwrap();
+
+        let resolved =
+            crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
+
+        assert_eq!(
+            resolved.for_url("https://index.crates.io/config.json"),
+            Some("legacy".to_string()),
+        );
+    }
+
+    #[test]
+    fn malformed_credentials_do_not_leak_the_file_contents() {
+        let cargo_home = tempfile::tempdir().unwrap();
+        fs::write(
+            cargo_home.path().join("credentials.toml"),
+            "[registry]\ntoken = 'do-not-print-this'\ninvalid = [",
+        )
+        .unwrap();
+
+        let error = token_from_credentials(cargo_home.path()).unwrap_err().to_string();
+
+        assert!(error.contains("credentials.toml"), "{error}");
+        assert!(!error.contains("do-not-print-this"), "{error}");
+    }
+}

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth.rs
@@ -21,10 +21,16 @@ struct RegistryCredentials {
     token: Option<String>,
 }
 
-pub(super) fn crates_io<Sys>(configured: &Arc<AuthHeaders>) -> Result<Arc<AuthHeaders>>
+pub(super) fn crates_io<Sys>(
+    configured: &Arc<AuthHeaders>,
+    offline: bool,
+) -> Result<Arc<AuthHeaders>>
 where
     Sys: EnvVar + EnvVarOs + GetHomeDir,
 {
+    if offline {
+        return Ok(Arc::clone(configured));
+    }
     let cargo_home = cargo_home::<Sys>();
     crates_io_from_sources(configured, Sys::var(CRATES_IO_TOKEN_ENV), cargo_home.as_deref())
 }

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
@@ -1,6 +1,27 @@
-use super::{crates_io_from_sources, token_from_credentials};
+use super::{crates_io, crates_io_from_sources, token_from_credentials};
+use pnpm_config::{EnvVar, EnvVarOs, GetHomeDir};
 use pnpm_network::AuthHeaders;
-use std::{fs, sync::Arc};
+use std::{ffi::OsString, fs, path::PathBuf, sync::Arc};
+
+struct NoCredentialAccess;
+
+impl EnvVar for NoCredentialAccess {
+    fn var(_name: &str) -> Option<String> {
+        panic!("offline auth resolution must not read environment variables")
+    }
+}
+
+impl EnvVarOs for NoCredentialAccess {
+    fn var_os(_name: &str) -> Option<OsString> {
+        panic!("offline auth resolution must not read environment variables")
+    }
+}
+
+impl GetHomeDir for NoCredentialAccess {
+    fn home_dir() -> Option<PathBuf> {
+        panic!("offline auth resolution must not inspect the home directory")
+    }
+}
 
 fn configured() -> Arc<AuthHeaders> {
     Arc::new(AuthHeaders::from_creds_map([
@@ -20,6 +41,15 @@ fn no_cargo_token_reuses_the_configured_auth_map() {
         resolved.for_url("https://index.crates.io/config.json"),
         Some("Bearer pnpm-token".to_string()),
     );
+}
+
+#[test]
+fn offline_mode_does_not_read_cargo_credentials() {
+    let configured = configured();
+
+    let resolved = crates_io::<NoCredentialAccess>(&configured, true).unwrap();
+
+    assert!(Arc::ptr_eq(&resolved, &configured));
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
@@ -1,0 +1,86 @@
+use super::{crates_io_from_sources, token_from_credentials};
+use pnpm_network::AuthHeaders;
+use std::{fs, sync::Arc};
+
+fn configured() -> Arc<AuthHeaders> {
+    Arc::new(AuthHeaders::from_creds_map([
+        ("//index.crates.io/".to_string(), "Bearer pnpm-token".to_string()),
+        ("//npm.example/".to_string(), "Bearer npm-token".to_string()),
+    ]))
+}
+
+#[test]
+fn no_cargo_token_reuses_the_configured_auth_map() {
+    let configured = configured();
+
+    let resolved = crates_io_from_sources(&configured, None, None).unwrap();
+
+    assert!(Arc::ptr_eq(&resolved, &configured));
+    assert_eq!(
+        resolved.for_url("https://index.crates.io/config.json"),
+        Some("Bearer pnpm-token".to_string()),
+    );
+}
+
+#[test]
+fn credentials_token_is_bare_and_preserves_other_routes() {
+    let cargo_home = tempfile::tempdir().unwrap();
+    fs::write(cargo_home.path().join("credentials.toml"), "[registry]\ntoken = 'cargo-token'\n")
+        .unwrap();
+
+    let resolved = crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
+
+    assert_eq!(
+        resolved.for_url("https://index.crates.io/se/rd/serde"),
+        Some("cargo-token".to_string()),
+    );
+    assert_eq!(resolved.for_url("https://static.crates.io/crates/serde/serde-1.0.0.crate"), None);
+    assert_eq!(
+        resolved.for_url("https://npm.example/package"),
+        Some("Bearer npm-token".to_string()),
+    );
+}
+
+#[test]
+fn environment_token_overrides_the_credentials_file() {
+    let cargo_home = tempfile::tempdir().unwrap();
+    fs::write(cargo_home.path().join("credentials.toml"), "not valid TOML = [").unwrap();
+
+    let resolved = crates_io_from_sources(
+        &configured(),
+        Some("environment-token".to_string()),
+        Some(cargo_home.path()),
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved.for_url("https://index.crates.io/config.json"),
+        Some("environment-token".to_string()),
+    );
+}
+
+#[test]
+fn legacy_credentials_file_wins_when_both_exist() {
+    let cargo_home = tempfile::tempdir().unwrap();
+    fs::write(cargo_home.path().join("credentials"), "[registry]\ntoken = 'legacy'\n").unwrap();
+    fs::write(cargo_home.path().join("credentials.toml"), "[registry]\ntoken = 'toml'\n").unwrap();
+
+    let resolved = crates_io_from_sources(&configured(), None, Some(cargo_home.path())).unwrap();
+
+    assert_eq!(resolved.for_url("https://index.crates.io/config.json"), Some("legacy".to_string()));
+}
+
+#[test]
+fn malformed_credentials_do_not_leak_the_file_contents() {
+    let cargo_home = tempfile::tempdir().unwrap();
+    fs::write(
+        cargo_home.path().join("credentials.toml"),
+        "[registry]\ntoken = 'do-not-print-this'\ninvalid = [",
+    )
+    .unwrap();
+
+    let error = token_from_credentials(cargo_home.path()).unwrap_err().to_string();
+
+    assert!(error.contains("credentials.toml"), "{error}");
+    assert!(!error.contains("do-not-print-this"), "{error}");
+}

--- a/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/registry_auth/tests.rs
@@ -31,10 +31,11 @@ fn configured() -> Arc<AuthHeaders> {
 }
 
 #[test]
-fn no_cargo_token_reuses_the_configured_auth_map() {
+fn missing_credentials_files_reuse_the_configured_auth_map() {
     let configured = configured();
+    let cargo_home = tempfile::tempdir().unwrap();
 
-    let resolved = crates_io_from_sources(&configured, None, None).unwrap();
+    let resolved = crates_io_from_sources(&configured, None, Some(cargo_home.path())).unwrap();
 
     assert!(Arc::ptr_eq(&resolved, &configured));
     assert_eq!(

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ArchiveStoreProjection, LockedCrate, MANAGED_CONFIG, MaterializeOptions, add_cargo_checksum,
-    discover_manifests, discover_manifests_with, materialize, parse_lockfile, sparse_index_path,
-    update_managed_config, workspace_root,
+    discover_manifests, discover_manifests_with, fetch_sparse_index_file, materialize,
+    parse_lockfile, sparse_index_path, update_managed_config, workspace_root,
 };
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
@@ -274,6 +274,38 @@ fn maps_crate_names_to_sparse_index_paths() {
     assert_eq!(sparse_index_path("ab").unwrap(), "2/ab");
     assert_eq!(sparse_index_path("abc").unwrap(), "3/a/abc");
     assert_eq!(sparse_index_path("Serde_JSON").unwrap(), "se/rd/serde_json");
+}
+
+#[tokio::test]
+async fn sparse_index_fetch_uses_configured_request_auth() {
+    let mut server = mockito::Server::new_async().await;
+    let response = r#"{"name":"demo","vers":"1.0.0","deps":[],"cksum":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","features":{},"yanked":false}"#;
+    let request = server
+        .mock("GET", "/de/mo/demo")
+        .match_header("authorization", "Bearer cargo-read-token")
+        .with_status(200)
+        .with_body(response)
+        .create_async()
+        .await;
+    let auth_headers = AuthHeaders::from_creds_map([(
+        pnpm_network::nerf_dart(&server.url()),
+        "Bearer cargo-read-token".to_string(),
+    )]);
+    let cache = tempfile::tempdir().unwrap();
+
+    let contents = fetch_sparse_index_file(
+        "demo",
+        &server.url(),
+        cache.path(),
+        &ThrottledClient::default(),
+        &auth_headers,
+        false,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(contents, response);
+    request.assert_async().await;
 }
 
 #[test]

--- a/pnpm/crates/cli/src/ecosystem_add.rs
+++ b/pnpm/crates/cli/src/ecosystem_add.rs
@@ -41,15 +41,30 @@ pub(crate) async fn prepare(
         ));
     }
 
+    let auth_headers = cargo_packages
+        .iter()
+        .any(|package| package.version_spec.is_none())
+        .then(|| cargo_deps::crates_io_auth_headers(config))
+        .transpose()?;
+
     let resolved = stream::iter(cargo_packages)
         .map(|package| {
             let http_client = Arc::clone(&http_client);
+            let auth_headers = auth_headers.clone();
             async move {
                 let version_spec = if let Some(version_spec) = package.version_spec.as_deref() {
                     version_spec.to_string()
                 } else {
-                    let version =
-                        cargo_deps::latest_version(config, &package.name, &http_client).await?;
+                    let auth_headers = auth_headers
+                        .as_deref()
+                        .expect("auth is prepared when a version lookup is needed");
+                    let version = cargo_deps::latest_version(
+                        config,
+                        auth_headers,
+                        &package.name,
+                        &http_client,
+                    )
+                    .await?;
                     saved_version(&version, save_exact, save_prefix)
                 };
                 Ok::<_, miette::Report>((package.name.clone(), version_spec))

--- a/pnpm/crates/network/src/auth.rs
+++ b/pnpm/crates/network/src/auth.rs
@@ -6,8 +6,9 @@
 //! the URL carries inline `user:password@`, that takes precedence and
 //! is encoded as a `Basic` header even when no per-host token matches.
 //!
-//! The map is built once per install from the merged `.npmrc` and is
-//! consulted on every metadata fetch and tarball download. The lookup
+//! Configuration readers build the map once per install from their native
+//! credential sources, and request code consults it on every metadata fetch
+//! and archive download. The lookup
 //! walks parts of the *request* URL: a tarball served from a CDN on a
 //! different host than the registry only matches keys keyed at the
 //! CDN's host (or a path prefix on that host). It does *not* fall
@@ -99,8 +100,9 @@ pub enum MetadataCacheScope {
 }
 
 /// Bag of `Authorization` header values keyed by the nerf-darted form
-/// of each registry URL. Pacquet builds one of these from the parsed
-/// `.npmrc` and shares it across every HTTP call made during install.
+/// of each registry URL. Ecosystem-specific configuration readers normalize
+/// their credentials into this request-facing form and share it across HTTP
+/// calls made during install.
 ///
 /// Construct via [`AuthHeaders::from_parts`], [`AuthHeaders::from_creds_map`],
 /// [`AuthHeaders::from_map`], or [`AuthHeaders::default`] (empty). Look up via
@@ -187,6 +189,31 @@ impl AuthHeaders {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.by_uri.is_empty() && self.scoped_by_scope.is_empty() && self.route_hook.is_none()
+    }
+
+    /// Overlay a ready-to-send `Authorization` header at `url`.
+    ///
+    /// This is the boundary for credential sources that are already scoped to
+    /// a concrete request URL and have no npm package-scope semantics. The
+    /// caller owns the authentication scheme: npm tokens include `Bearer`,
+    /// Cargo tokens are bare, and future readers may supply `Basic` or another
+    /// registry-defined value. An invalid or unsupported URL is ignored.
+    pub fn insert_url_header(&mut self, url: &str, header: String) {
+        let mut terminated;
+        let url = if url.ends_with('/') {
+            url
+        } else {
+            terminated = String::with_capacity(url.len() + 1);
+            terminated.push_str(url);
+            terminated.push('/');
+            &terminated
+        };
+        let uri = nerf_dart(url);
+        if uri.is_empty() {
+            return;
+        }
+        self.max_parts = self.max_parts.max(uri.split('/').count());
+        self.by_uri.insert(uri, AuthEntry::Header(header));
     }
 
     /// Build an [`AuthHeaders`] from `(nerf_darted_uri, header_value)`

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -134,8 +134,8 @@ fn a_url_header_overlays_only_its_request_route() {
     auth.insert_url_header("https://cargo.example/index", "cargo-token".to_string());
 
     assert_eq!(auth.for_url("https://cargo.example/index/crate"), Some("cargo-token".to_string()));
-    assert_eq!(auth.for_url("https://cargo.example/other"), Some("Bearer npm-token".to_string()),);
-    assert_eq!(auth.for_url("https://npm.example/package"), Some("Bearer keep-me".to_string()),);
+    assert_eq!(auth.for_url("https://cargo.example/other"), Some("Bearer npm-token".to_string()));
+    assert_eq!(auth.for_url("https://npm.example/package"), Some("Bearer keep-me".to_string()));
 }
 
 /// Records every `(url, package)` it is asked about and answers with a

--- a/pnpm/crates/network/src/auth/tests.rs
+++ b/pnpm/crates/network/src/auth/tests.rs
@@ -124,6 +124,20 @@ fn a_failing_token_helper_sends_no_credential_and_does_not_fall_back() {
     assert_eq!(auth.for_url("https://reg.com/pkg"), Some("Bearer root-token".to_owned()));
 }
 
+#[test]
+fn a_url_header_overlays_only_its_request_route() {
+    let mut auth = AuthHeaders::from_creds_map([
+        ("//cargo.example/".to_string(), "Bearer npm-token".to_string()),
+        ("//npm.example/".to_string(), "Bearer keep-me".to_string()),
+    ]);
+
+    auth.insert_url_header("https://cargo.example/index", "cargo-token".to_string());
+
+    assert_eq!(auth.for_url("https://cargo.example/index/crate"), Some("cargo-token".to_string()));
+    assert_eq!(auth.for_url("https://cargo.example/other"), Some("Bearer npm-token".to_string()),);
+    assert_eq!(auth.for_url("https://npm.example/package"), Some("Bearer keep-me".to_string()),);
+}
+
 /// Records every `(url, package)` it is asked about and answers with a
 /// fixed header, so a test can assert the hook — not the client
 /// credentials — drove the lookup.

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -12,9 +12,9 @@
 //! absolute-form URI and a decoded `Proxy-Authorization` header.
 
 use super::{
-    CappedDnsResolver, ForInstallsError, NetworkSettings, NoProxyMatcher, NoProxySetting,
-    PerRegistryTls, ProxyConfig, ProxyError, ThrottledClient, TlsConfig, bundled_root_certs,
-    origin_of, parse_proxy_url,
+    AuthHeaders, CappedDnsResolver, ForInstallsError, NetworkSettings, NoProxyMatcher,
+    NoProxySetting, PerRegistryTls, ProxyConfig, ProxyError, ThrottledClient, TlsConfig,
+    bundled_root_certs, nerf_dart, origin_of, parse_proxy_url,
 };
 use crate::proxy::{percent_decode_str, strip_userinfo};
 use pnpm_testing_utils::env_guard::EnvGuard;
@@ -519,6 +519,51 @@ async fn authorization_is_retained_on_same_origin_redirect() {
     assert_eq!(response.status(), 200);
     start_mock.assert_async().await;
     final_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn secure_auth_is_re_evaluated_for_each_redirect_target() {
+    let mut target = mockito::Server::new_async().await;
+    let target_mock = target
+        .mock("GET", "/final")
+        .match_header("authorization", mockito::Matcher::Missing)
+        .with_status(200)
+        .with_body("ok")
+        .expect(1)
+        .create_async()
+        .await;
+    let mut registry = mockito::Server::new_async().await;
+    let start_mock = registry
+        .mock("GET", "/start")
+        .match_header("authorization", "Bearer registry-token")
+        .with_status(302)
+        .with_header("location", "/same-origin")
+        .expect(1)
+        .create_async()
+        .await;
+    let same_origin_mock = registry
+        .mock("GET", "/same-origin")
+        .match_header("authorization", "Bearer registry-token")
+        .with_status(302)
+        .with_header("location", &format!("{}/final", target.url()))
+        .expect(1)
+        .create_async()
+        .await;
+    let auth_headers = AuthHeaders::from_creds_map([(
+        nerf_dart(&registry.url()),
+        "Bearer registry-token".to_string(),
+    )]);
+
+    let response = ThrottledClient::default()
+        .get_bytes_with_secure_auth_headers(&format!("{}/start", registry.url()), &auth_headers)
+        .await
+        .expect("follow redirects with per-target authentication");
+
+    assert_eq!(response.status, 200);
+    assert_eq!(response.body, b"ok");
+    start_mock.assert_async().await;
+    same_origin_mock.assert_async().await;
+    target_mock.assert_async().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Route Cargo sparse-index and crate archive requests through pnpm's existing URL-scoped authentication map instead of constructing empty maps.
- Add a shared URL-overlay operation whose caller owns the authorization scheme, so ecosystem-specific readers can normalize Cargo now and Python later without teaching the HTTP layer their configuration formats.
- Read the crates.io token from `CARGO_REGISTRY_TOKEN`, then `$CARGO_HOME/credentials` or `credentials.toml`, preserving Cargo's bare `Authorization` header format and file precedence.
- Keep the crates.io token scoped to `index.crates.io`; it is not sent to the separate static download host. Explicit pnpm URL-matched credentials can still authorize either request route.
- Resolve Cargo credentials only when Cargo sparse-index resolution is entered, so the npm-only install path does no additional environment or file-system work.

This is a partial step toward pnpm/pnpm#14566. The current Cargo proof remains crates.io-only; named/private registries and their credential-provider configuration belong with the alternative-registry slice.

Validation: `just ready` (10,041 tests passed, 5 skipped), plus the full pre-push TypeScript, rustdoc, Clippy, and custom-lint suite. Cargo authentication is prepared once for all unversioned crates in an add request, and offline cache-only resolution bypasses Cargo credential discovery.

## Squash Commit Body

```text
Route Cargo sparse-index and archive requests through pnpm's existing URL-scoped authentication map. Add a Cargo-specific token reader for crates.io while keeping credential discovery out of the shared request layer and outside npm-only installs.

Cargo tokens retain their bare Authorization form and are scoped to the crates.io index host. The design leaves named/private registries and credential-provider configuration to the alternative-registry slice.

Related to pnpm/pnpm#14566.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791183310&installation_model_id=426870&pr_number=14578&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14578&signature=46f6f345c2589e6df042c2074f12973b6811259eb10d3ae79b090aadb3d3131f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cargo registry authentication using credentials configured in pnpm.
  - Added support for `CARGO_REGISTRY_TOKEN` and Cargo credential files.
  - Added support for Cargo’s bare `Authorization` token format.
  - Cargo credentials are applied only to matching registry URLs.

- **Bug Fixes**
  - Improved authentication for sparse index requests, dependency resolution, and version lookups.
  - Environment-provided tokens take precedence over credential files.
  - Offline mode avoids reading environment variables and credential files.
  - Improved handling and reporting of malformed credential files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->