### PR TITLE
refactor(workspace): share ecosystem inventory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "ambient-id"
 version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +736,24 @@ checksum = "3264e2574e9ef2b53ce6f536dea83a69ac0bc600b762d1523ff83fe07230ce30"
 dependencies = [
  "byteorder",
  "cipher 0.4.4",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b5f74729fd2f44701d1a8eb47e906cdb3ccd9ec0f02baad85a744b791940b18"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
 ]
 
 [[package]]
@@ -1992,6 +2016,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,6 +2818,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3327,6 +3384,12 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "md-5"
@@ -5840,8 +5903,10 @@ dependencies = [
 name = "pnpm-workspace"
 version = "0.0.1"
 dependencies = [
+ "cap-primitives",
  "derive_more",
  "indexmap 2.14.0",
+ "libc",
  "miette 7.6.0",
  "pathdiff",
  "pnpm-catalogs-types",
@@ -6874,6 +6939,16 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -9327,6 +9402,16 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.11.1",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,7 @@ command-extra = { version = "1.0.0" }
 base64 = { version = "0.23.1" }
 bcrypt = { version = "0.19.1" }
 bytes = { version = "1.11.0" }
+cap-primitives = { version = "4.0.3" }
 cargo-lock = { version = "11.1.0" }
 cargo-util-schemas = { version = "0.14.2" }
 chrono = { version = "0.4.44", default-features = false, features = ["clock"] }

--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,8 @@ allow = [
 ]
 confidence-threshold = 0.8
 exceptions = [
+  # `cap-primitives` uses winx for descriptor-relative traversal on Windows.
+  { name = "winx", allow = ["Apache-2.0 WITH LLVM-exception"] },
   # The first-party `pnpr*` crates are licensed under PolyForm Shield (see
   # `pnpr/LICENSE.md`), not the MIT used by the rest of the workspace.
   # cargo-deny only recognizes the PolyForm-Noncommercial identifier for this

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,4 +1,4 @@
-use crate::ecosystem_install::InstallContext;
+use crate::ecosystem_install::{EcosystemWorkspaceInventory, InstallContext};
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::Config;
@@ -42,9 +42,13 @@ pub(crate) enum CargoLockfilePolicy {
 }
 
 pub(crate) struct CargoInstallOptions<'a> {
-    pub(crate) root_dir: &'a Path,
-    pub(crate) discover_projects: bool,
+    pub(crate) projects: CargoInstallProjects<'a>,
     pub(crate) lockfile_policy: CargoLockfilePolicy,
+}
+
+pub(crate) enum CargoInstallProjects<'a> {
+    Root(&'a Path),
+    Workspace(&'a EcosystemWorkspaceInventory),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,15 +82,16 @@ pub async fn install<Reporter: self::Reporter + 'static>(
     options: CargoInstallOptions<'_>,
 ) -> Result<()> {
     let InstallContext { config, http_client, lockfile_only, frozen_lockfile } = context;
-    let CargoInstallOptions { root_dir, discover_projects, lockfile_policy } = options;
+    let CargoInstallOptions { projects, lockfile_policy } = options;
     if !config.cargo.enabled {
         return Ok(());
     }
 
-    let roots = if discover_projects {
-        discover_workspace_roots(root_dir).await?
-    } else {
-        vec![root_dir.to_path_buf()]
+    let roots = match projects {
+        CargoInstallProjects::Root(root_dir) => vec![root_dir.to_path_buf()],
+        CargoInstallProjects::Workspace(inventory) => {
+            discover_workspace_roots(inventory.manifests("Cargo.toml").await?).await?
+        }
     };
     stream::iter(roots)
         .map(|root| {
@@ -192,87 +197,13 @@ pub(crate) async fn workspace_root(manifest_path: &Path) -> Result<PathBuf> {
         .map(|metadata| metadata.workspace_root)
 }
 
-async fn discover_workspace_roots(search_root: &Path) -> Result<Vec<PathBuf>> {
-    let search_root = search_root.to_path_buf();
-    let manifests = tokio::task::spawn_blocking(move || discover_manifests(&search_root))
-        .await
-        .into_diagnostic()
-        .wrap_err("join Cargo project discovery task")??;
-    let roots = stream::iter(manifests)
+async fn discover_workspace_roots(manifests: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let roots = stream::iter(manifests.iter().cloned())
         .map(|manifest| async move { workspace_root(&manifest).await })
         .buffer_unordered(8)
         .try_collect::<BTreeSet<_>>()
         .await?;
     Ok(roots.into_iter().collect())
-}
-
-fn discover_manifests(search_root: &Path) -> Result<Vec<PathBuf>> {
-    discover_manifests_with(search_root, |directory| fs::read_dir(directory))
-}
-
-fn discover_manifests_with(
-    search_root: &Path,
-    mut read_dir: impl FnMut(&Path) -> io::Result<fs::ReadDir>,
-) -> Result<Vec<PathBuf>> {
-    let mut pending = vec![search_root.to_path_buf()];
-    let mut manifests = Vec::new();
-    while let Some(directory) = pending.pop() {
-        let entries = match read_dir(&directory) {
-            Ok(entries) => entries,
-            Err(error) if directory != search_root && is_ignorable_discovery_error(&error) => {
-                continue;
-            }
-            Err(error) => {
-                return Err(error).into_diagnostic().wrap_err_with(|| {
-                    format!(
-                        "read directory while discovering Cargo projects at {}",
-                        directory.display(),
-                    )
-                });
-            }
-        };
-        for entry in entries {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(error) if is_ignorable_discovery_error(&error) => continue,
-                Err(error) => {
-                    return Err(error).into_diagnostic().wrap_err_with(|| {
-                        format!(
-                            "read entry while discovering Cargo projects at {}",
-                            directory.display(),
-                        )
-                    });
-                }
-            };
-            let file_type = match entry.file_type() {
-                Ok(file_type) => file_type,
-                Err(error) if is_ignorable_discovery_error(&error) => continue,
-                Err(error) => {
-                    return Err(error).into_diagnostic().wrap_err_with(|| {
-                        format!("inspect Cargo project candidate {}", entry.path().display())
-                    });
-                }
-            };
-            if file_type.is_symlink() {
-                continue;
-            }
-            if file_type.is_dir() {
-                if !matches!(
-                    entry.file_name().to_str(),
-                    Some(".git" | ".pnpm" | "node_modules" | "target"),
-                ) {
-                    pending.push(entry.path());
-                }
-            } else if file_type.is_file() && entry.file_name() == "Cargo.toml" {
-                manifests.push(entry.path());
-            }
-        }
-    }
-    Ok(manifests)
-}
-
-fn is_ignorable_discovery_error(error: &std::io::Error) -> bool {
-    matches!(error.kind(), std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied)
 }
 
 async fn ensure_lockfile(

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,4 +1,4 @@
-use crate::ecosystem_install::{EcosystemWorkspaceInventory, InstallContext};
+use crate::ecosystem_install::{EcosystemManifest, EcosystemWorkspaceInventory, InstallContext};
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::Config;
@@ -90,7 +90,7 @@ pub async fn install<Reporter: self::Reporter + 'static>(
     let roots = match projects {
         CargoInstallProjects::Root(root_dir) => vec![root_dir.to_path_buf()],
         CargoInstallProjects::Workspace(inventory) => {
-            discover_workspace_roots(inventory.manifests("Cargo.toml").await?).await?
+            discover_workspace_roots(inventory.manifests(EcosystemManifest::Cargo).await?).await?
         }
     };
     stream::iter(roots)

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ArchiveStoreProjection, LockedCrate, MANAGED_CONFIG, MaterializeOptions, add_cargo_checksum,
-    discover_manifests, discover_manifests_with, fetch_sparse_index_file, materialize,
-    parse_lockfile, sparse_index_path, update_managed_config, workspace_root,
+    fetch_sparse_index_file, materialize, parse_lockfile, sparse_index_path, update_managed_config,
+    workspace_root,
 };
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
@@ -306,39 +306,6 @@ async fn sparse_index_fetch_uses_configured_request_auth() {
 
     assert_eq!(contents, response);
     request.assert_async().await;
-}
-
-#[test]
-fn discovers_nested_cargo_manifests_without_scanning_generated_directories() {
-    let repository = tempfile::tempdir().unwrap();
-    let project = repository.path().join("rust/project");
-    let generated = repository.path().join("target/generated");
-    fs::create_dir_all(&project).unwrap();
-    fs::create_dir_all(&generated).unwrap();
-    fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
-    fs::write(generated.join("Cargo.toml"), "[workspace]\n").unwrap();
-
-    assert_eq!(discover_manifests(repository.path()).unwrap(), [project.join("Cargo.toml")]);
-}
-
-#[test]
-fn discovery_skips_unreadable_unrelated_directories() {
-    let repository = tempfile::tempdir().unwrap();
-    let project = repository.path().join("rust/project");
-    let unreadable = repository.path().join("unrelated");
-    fs::create_dir_all(&project).unwrap();
-    fs::create_dir_all(&unreadable).unwrap();
-    fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
-    let manifests = discover_manifests_with(repository.path(), |directory| {
-        if directory == unreadable {
-            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
-        } else {
-            fs::read_dir(directory)
-        }
-    })
-    .unwrap();
-
-    assert_eq!(manifests, [project.join("Cargo.toml")]);
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -439,6 +439,8 @@ impl InstallPipeline {
             )
             .await;
         }
+        let workspace_inventory =
+            ecosystem_install::EcosystemWorkspaceInventory::new(config_root.clone());
         let node_install = run_node_install::<Reporter>(
             plan,
             args,
@@ -456,8 +458,7 @@ impl InstallPipeline {
                 frozen_lockfile,
             },
             crate::cargo_deps::CargoInstallOptions {
-                root_dir: &config_root,
-                discover_projects: true,
+                projects: crate::cargo_deps::CargoInstallProjects::Workspace(&workspace_inventory),
                 lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::UseExisting,
             },
         );
@@ -720,8 +721,7 @@ async fn run_add_with_cargo<Reporter: self::Reporter + 'static>(
                 frozen_lockfile: false,
             },
             crate::cargo_deps::CargoInstallOptions {
-                root_dir: &cargo_root,
-                discover_projects: false,
+                projects: crate::cargo_deps::CargoInstallProjects::Root(&cargo_root),
                 lockfile_policy: crate::cargo_deps::CargoLockfilePolicy::Resolve,
             },
         );

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -4,8 +4,10 @@ use std::{future::Future, pin::Pin, sync::Arc};
 
 mod metadata_file;
 mod mutation;
+mod workspace_inventory;
 
 pub(crate) use mutation::MetadataMutation;
+pub(crate) use workspace_inventory::EcosystemWorkspaceInventory;
 
 type Installer<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
 

--- a/pnpm/crates/cli/src/ecosystem_install.rs
+++ b/pnpm/crates/cli/src/ecosystem_install.rs
@@ -7,7 +7,7 @@ mod mutation;
 mod workspace_inventory;
 
 pub(crate) use mutation::MetadataMutation;
-pub(crate) use workspace_inventory::EcosystemWorkspaceInventory;
+pub(crate) use workspace_inventory::{EcosystemManifest, EcosystemWorkspaceInventory};
 
 type Installer<'a> = Pin<Box<dyn Future<Output = miette::Result<()>> + Send + 'a>>;
 

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
@@ -2,10 +2,24 @@ use miette::{IntoDiagnostic, Result, WrapErr};
 use std::path::PathBuf;
 use tokio::sync::OnceCell;
 
-const MANIFEST_BASENAMES: &[&str] = &["Cargo.toml"];
 const IGNORED_DIRECTORY_BASENAMES: &[&str] = &[".git", ".pnpm", "node_modules", "target"];
 
-/// Lazily populated manifest inventory shared by enabled ecosystem installers.
+#[derive(Clone, Copy)]
+pub(crate) enum EcosystemManifest {
+    Cargo,
+}
+
+impl EcosystemManifest {
+    const ALL: &[Self] = &[Self::Cargo];
+
+    const fn basename(self) -> &'static str {
+        match self {
+            Self::Cargo => "Cargo.toml",
+        }
+    }
+}
+
+/// Manifest paths available to every ecosystem participating in an install.
 pub(crate) struct EcosystemWorkspaceInventory {
     workspace_root: PathBuf,
     contents: OnceCell<pnpm_workspace::WorkspaceInventory>,
@@ -16,16 +30,20 @@ impl EcosystemWorkspaceInventory {
         Self { workspace_root, contents: OnceCell::new() }
     }
 
-    pub(crate) async fn manifests(&self, basename: &str) -> Result<&[PathBuf]> {
+    pub(crate) async fn manifests(&self, manifest: EcosystemManifest) -> Result<&[PathBuf]> {
         let inventory = self
             .contents
             .get_or_try_init(|| {
                 let workspace_root = self.workspace_root.clone();
                 async move {
                     tokio::task::spawn_blocking(move || {
+                        let manifest_basenames = EcosystemManifest::ALL
+                            .iter()
+                            .map(|manifest| manifest.basename())
+                            .collect::<Vec<_>>();
                         pnpm_workspace::find_workspace_inventory(
                             &workspace_root,
-                            MANIFEST_BASENAMES,
+                            &manifest_basenames,
                             IGNORED_DIRECTORY_BASENAMES,
                         )
                     })
@@ -36,7 +54,9 @@ impl EcosystemWorkspaceInventory {
                 }
             })
             .await?;
-        Ok(inventory.manifests(basename))
+        Ok(inventory
+            .manifests(manifest.basename())
+            .expect("every ecosystem manifest basename is inventoried"))
     }
 }
 

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory.rs
@@ -1,0 +1,44 @@
+use miette::{IntoDiagnostic, Result, WrapErr};
+use std::path::PathBuf;
+use tokio::sync::OnceCell;
+
+const MANIFEST_BASENAMES: &[&str] = &["Cargo.toml"];
+const IGNORED_DIRECTORY_BASENAMES: &[&str] = &[".git", ".pnpm", "node_modules", "target"];
+
+/// Lazily populated manifest inventory shared by enabled ecosystem installers.
+pub(crate) struct EcosystemWorkspaceInventory {
+    workspace_root: PathBuf,
+    contents: OnceCell<pnpm_workspace::WorkspaceInventory>,
+}
+
+impl EcosystemWorkspaceInventory {
+    pub(crate) fn new(workspace_root: PathBuf) -> Self {
+        Self { workspace_root, contents: OnceCell::new() }
+    }
+
+    pub(crate) async fn manifests(&self, basename: &str) -> Result<&[PathBuf]> {
+        let inventory = self
+            .contents
+            .get_or_try_init(|| {
+                let workspace_root = self.workspace_root.clone();
+                async move {
+                    tokio::task::spawn_blocking(move || {
+                        pnpm_workspace::find_workspace_inventory(
+                            &workspace_root,
+                            MANIFEST_BASENAMES,
+                            IGNORED_DIRECTORY_BASENAMES,
+                        )
+                    })
+                    .await
+                    .into_diagnostic()
+                    .wrap_err("join ecosystem workspace discovery task")?
+                    .into_diagnostic()
+                }
+            })
+            .await?;
+        Ok(inventory.manifests(basename))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
@@ -1,4 +1,4 @@
-use super::EcosystemWorkspaceInventory;
+use super::{EcosystemManifest, EcosystemWorkspaceInventory};
 use std::fs;
 
 #[tokio::test]
@@ -9,8 +9,8 @@ async fn exposes_cargo_manifests_from_the_shared_inventory() {
     fs::write(cargo_project.join("Cargo.toml"), "[workspace]\n").unwrap();
     let inventory = EcosystemWorkspaceInventory::new(workspace.path().to_path_buf());
 
-    let first = inventory.manifests("Cargo.toml").await.unwrap();
-    let second = inventory.manifests("Cargo.toml").await.unwrap();
+    let first = inventory.manifests(EcosystemManifest::Cargo).await.unwrap();
+    let second = inventory.manifests(EcosystemManifest::Cargo).await.unwrap();
 
     assert_eq!(first, [cargo_project.join("Cargo.toml")]);
     assert!(std::ptr::eq(first, second));

--- a/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
+++ b/pnpm/crates/cli/src/ecosystem_install/workspace_inventory/tests.rs
@@ -1,0 +1,17 @@
+use super::EcosystemWorkspaceInventory;
+use std::fs;
+
+#[tokio::test]
+async fn exposes_cargo_manifests_from_the_shared_inventory() {
+    let workspace = tempfile::tempdir().unwrap();
+    let cargo_project = workspace.path().join("rust");
+    fs::create_dir_all(&cargo_project).unwrap();
+    fs::write(cargo_project.join("Cargo.toml"), "[workspace]\n").unwrap();
+    let inventory = EcosystemWorkspaceInventory::new(workspace.path().to_path_buf());
+
+    let first = inventory.manifests("Cargo.toml").await.unwrap();
+    let second = inventory.manifests("Cargo.toml").await.unwrap();
+
+    assert_eq!(first, [cargo_project.join("Cargo.toml")]);
+    assert!(std::ptr::eq(first, second));
+}

--- a/pnpm/crates/workspace/Cargo.toml
+++ b/pnpm/crates/workspace/Cargo.toml
@@ -15,14 +15,18 @@ pnpm-catalogs-types           = { workspace = true }
 pnpm-package-manifest         = { workspace = true }
 pnpm-workspace-projects-graph = { workspace = true }
 
-derive_more  = { workspace = true }
-indexmap     = { workspace = true }
-miette       = { workspace = true }
-pathdiff     = { workspace = true }
-rayon        = { workspace = true }
-serde        = { workspace = true }
-serde-saphyr = { workspace = true }
-wax          = { workspace = true }
+cap-primitives = { workspace = true }
+derive_more    = { workspace = true }
+indexmap       = { workspace = true }
+miette         = { workspace = true }
+pathdiff       = { workspace = true }
+rayon          = { workspace = true }
+serde          = { workspace = true }
+serde-saphyr   = { workspace = true }
+wax            = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -9,7 +9,7 @@ use std::{
 
 mod traversal;
 
-use traversal::{InventoryTraversalEvent, walk_workspace};
+use traversal::walk_workspace;
 
 /// Manifest paths grouped by basename.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -68,6 +68,7 @@ pub fn find_workspace_inventory(
         manifest_basenames,
         ignored_directory_basenames,
         |_| Ok(()),
+        |_| Ok(()),
     )
 }
 
@@ -75,21 +76,28 @@ fn find_workspace_inventory_with(
     workspace_root: &Path,
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
-    traversal_hook: impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    before_read: impl FnMut(&Path) -> io::Result<()>,
+    before_open_directory: impl FnMut(&Path) -> io::Result<()>,
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
     let requested: BTreeSet<&OsStr> = manifest_basenames.iter().map(OsStr::new).collect();
     let ignored: BTreeSet<&OsStr> = ignored_directory_basenames.iter().map(OsStr::new).collect();
     let mut manifests: BTreeMap<String, Vec<PathBuf>> =
         manifest_basenames.iter().map(|basename| ((*basename).to_string(), Vec::new())).collect();
 
-    walk_workspace(workspace_root, &ignored, traversal_hook, |path, file_name| {
-        if requested.contains(file_name)
-            && let Some(manifest_paths) =
-                file_name.to_str().and_then(|basename| manifests.get_mut(basename))
-        {
-            manifest_paths.push(path);
-        }
-    })?;
+    walk_workspace(
+        workspace_root,
+        &ignored,
+        before_read,
+        before_open_directory,
+        |path, file_name| {
+            if requested.contains(file_name)
+                && let Some(manifest_paths) =
+                    file_name.to_str().and_then(|basename| manifests.get_mut(basename))
+            {
+                manifest_paths.push(path);
+            }
+        },
+    )?;
 
     for manifest_paths in manifests.values_mut() {
         manifest_paths.sort();

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -3,9 +3,13 @@ use miette::Diagnostic;
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsStr,
-    fs, io,
+    io,
     path::{Path, PathBuf},
 };
+
+mod traversal;
+
+use traversal::{InventoryTraversalEvent, walk_workspace};
 
 /// Manifest paths grouped by basename.
 #[derive(Debug, Default, PartialEq, Eq)]
@@ -63,7 +67,7 @@ pub fn find_workspace_inventory(
         workspace_root,
         manifest_basenames,
         ignored_directory_basenames,
-        |directory| fs::read_dir(directory),
+        |_| Ok(()),
     )
 }
 
@@ -71,84 +75,26 @@ fn find_workspace_inventory_with(
     workspace_root: &Path,
     manifest_basenames: &[&str],
     ignored_directory_basenames: &[&str],
-    mut read_dir: impl FnMut(&Path) -> io::Result<fs::ReadDir>,
+    traversal_hook: impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
 ) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
     let requested: BTreeSet<&OsStr> = manifest_basenames.iter().map(OsStr::new).collect();
     let ignored: BTreeSet<&OsStr> = ignored_directory_basenames.iter().map(OsStr::new).collect();
     let mut manifests: BTreeMap<String, Vec<PathBuf>> =
         manifest_basenames.iter().map(|basename| ((*basename).to_string(), Vec::new())).collect();
-    let mut pending = vec![workspace_root.to_path_buf()];
 
-    while let Some(directory) = pending.pop() {
-        let entries = match read_dir(&directory) {
-            Ok(entries) => entries,
-            Err(error) if directory != workspace_root && is_ignorable_discovery_error(&error) => {
-                continue;
-            }
-            Err(source) => {
-                return Err(FindWorkspaceInventoryError::ReadDirectory { path: directory, source });
-            }
-        };
-        for entry in entries {
-            let entry = match entry {
-                Ok(entry) => entry,
-                Err(error) if is_ignorable_discovery_error(&error) => continue,
-                Err(source) => {
-                    return Err(FindWorkspaceInventoryError::ReadEntry {
-                        path: directory.clone(),
-                        source,
-                    });
-                }
-            };
-            match collect_inventory_entry(
-                &entry,
-                &requested,
-                &ignored,
-                &mut pending,
-                &mut manifests,
-            ) {
-                Ok(()) => {}
-                Err(error) if is_ignorable_discovery_error(&error) => continue,
-                Err(source) => {
-                    return Err(FindWorkspaceInventoryError::InspectCandidate {
-                        path: entry.path(),
-                        source,
-                    });
-                }
-            }
+    walk_workspace(workspace_root, &ignored, traversal_hook, |path, file_name| {
+        if requested.contains(file_name)
+            && let Some(manifest_paths) =
+                file_name.to_str().and_then(|basename| manifests.get_mut(basename))
+        {
+            manifest_paths.push(path);
         }
-    }
+    })?;
 
     for manifest_paths in manifests.values_mut() {
         manifest_paths.sort();
     }
     Ok(WorkspaceInventory { manifests })
-}
-
-fn collect_inventory_entry(
-    entry: &fs::DirEntry,
-    requested: &BTreeSet<&OsStr>,
-    ignored: &BTreeSet<&OsStr>,
-    pending: &mut Vec<PathBuf>,
-    manifests: &mut BTreeMap<String, Vec<PathBuf>>,
-) -> io::Result<()> {
-    let file_type = entry.file_type()?;
-    if file_type.is_symlink() {
-        return Ok(());
-    }
-    let file_name = entry.file_name();
-    if file_type.is_dir() {
-        if !ignored.contains(file_name.as_os_str()) {
-            pending.push(entry.path());
-        }
-    } else if file_type.is_file()
-        && requested.contains(file_name.as_os_str())
-        && let Some(manifest_paths) =
-            file_name.to_str().and_then(|basename| manifests.get_mut(basename))
-    {
-        manifest_paths.push(entry.path());
-    }
-    Ok(())
 }
 
 fn is_ignorable_discovery_error(error: &io::Error) -> bool {

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Manifest paths found by one repository traversal.
+/// Manifest paths grouped by basename.
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct WorkspaceInventory {
     manifests: BTreeMap<String, Vec<PathBuf>>,
@@ -15,22 +15,41 @@ pub struct WorkspaceInventory {
 
 impl WorkspaceInventory {
     /// Paths whose final component equals `basename`.
-    pub fn manifests(&self, basename: &str) -> &[PathBuf] {
-        self.manifests.get(basename).map_or(&[], Vec::as_slice)
+    pub fn manifests(&self, basename: &str) -> Option<&[PathBuf]> {
+        self.manifests.get(basename).map(Vec::as_slice)
     }
 }
 
 /// Error returned while building a [`WorkspaceInventory`].
 #[derive(Debug, Display, Error, Diagnostic)]
-#[display("Failed to walk workspace inventory under {}: {source}", root.display())]
-#[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_WALK_ERROR))]
-pub struct FindWorkspaceInventoryError {
-    root: PathBuf,
-    #[error(source)]
-    source: io::Error,
+#[non_exhaustive]
+pub enum FindWorkspaceInventoryError {
+    #[display("Failed to read workspace inventory directory {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_READ_DIRECTORY))]
+    ReadDirectory {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to read an entry in workspace inventory directory {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_READ_ENTRY))]
+    ReadEntry {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
+
+    #[display("Failed to inspect workspace inventory candidate {}: {source}", path.display())]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_INSPECT_CANDIDATE))]
+    InspectCandidate {
+        path: PathBuf,
+        #[error(source)]
+        source: io::Error,
+    },
 }
 
-/// Find the requested manifest basenames with one recursive traversal.
+/// Find paths whose final components match the requested manifest basenames.
 ///
 /// Directory symlinks are not followed. An entry that disappears or becomes
 /// unreadable during a nested traversal is skipped, while failure to read the
@@ -67,17 +86,34 @@ fn find_workspace_inventory_with(
                 continue;
             }
             Err(source) => {
-                return Err(workspace_inventory_error(workspace_root, source));
+                return Err(FindWorkspaceInventoryError::ReadDirectory { path: directory, source });
             }
         };
         for entry in entries {
-            match entry.and_then(|entry| {
-                collect_inventory_entry(&entry, &requested, &ignored, &mut pending, &mut manifests)
-            }) {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if is_ignorable_discovery_error(&error) => continue,
+                Err(source) => {
+                    return Err(FindWorkspaceInventoryError::ReadEntry {
+                        path: directory.clone(),
+                        source,
+                    });
+                }
+            };
+            match collect_inventory_entry(
+                &entry,
+                &requested,
+                &ignored,
+                &mut pending,
+                &mut manifests,
+            ) {
                 Ok(()) => {}
                 Err(error) if is_ignorable_discovery_error(&error) => continue,
                 Err(source) => {
-                    return Err(workspace_inventory_error(workspace_root, source));
+                    return Err(FindWorkspaceInventoryError::InspectCandidate {
+                        path: entry.path(),
+                        source,
+                    });
                 }
             }
         }
@@ -113,13 +149,6 @@ fn collect_inventory_entry(
         manifest_paths.push(entry.path());
     }
     Ok(())
-}
-
-fn workspace_inventory_error(
-    workspace_root: &Path,
-    source: io::Error,
-) -> FindWorkspaceInventoryError {
-    FindWorkspaceInventoryError { root: workspace_root.to_path_buf(), source }
 }
 
 fn is_ignorable_discovery_error(error: &io::Error) -> bool {

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -1,0 +1,130 @@
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    ffi::OsStr,
+    fs, io,
+    path::{Path, PathBuf},
+};
+
+/// Manifest paths found by one repository traversal.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct WorkspaceInventory {
+    manifests: BTreeMap<String, Vec<PathBuf>>,
+}
+
+impl WorkspaceInventory {
+    /// Paths whose final component equals `basename`.
+    pub fn manifests(&self, basename: &str) -> &[PathBuf] {
+        self.manifests.get(basename).map_or(&[], Vec::as_slice)
+    }
+}
+
+/// Error returned while building a [`WorkspaceInventory`].
+#[derive(Debug, Display, Error, Diagnostic)]
+#[display("Failed to walk workspace inventory under {}: {source}", root.display())]
+#[diagnostic(code(ERR_PNPM_WORKSPACE_INVENTORY_WALK_ERROR))]
+pub struct FindWorkspaceInventoryError {
+    root: PathBuf,
+    #[error(source)]
+    source: io::Error,
+}
+
+/// Find the requested manifest basenames with one recursive traversal.
+///
+/// Directory symlinks are not followed. An entry that disappears or becomes
+/// unreadable during a nested traversal is skipped, while failure to read the
+/// inventory root is reported.
+pub fn find_workspace_inventory(
+    workspace_root: &Path,
+    manifest_basenames: &[&str],
+    ignored_directory_basenames: &[&str],
+) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
+    find_workspace_inventory_with(
+        workspace_root,
+        manifest_basenames,
+        ignored_directory_basenames,
+        |directory| fs::read_dir(directory),
+    )
+}
+
+fn find_workspace_inventory_with(
+    workspace_root: &Path,
+    manifest_basenames: &[&str],
+    ignored_directory_basenames: &[&str],
+    mut read_dir: impl FnMut(&Path) -> io::Result<fs::ReadDir>,
+) -> Result<WorkspaceInventory, FindWorkspaceInventoryError> {
+    let requested: BTreeSet<&OsStr> = manifest_basenames.iter().map(OsStr::new).collect();
+    let ignored: BTreeSet<&OsStr> = ignored_directory_basenames.iter().map(OsStr::new).collect();
+    let mut manifests: BTreeMap<String, Vec<PathBuf>> =
+        manifest_basenames.iter().map(|basename| ((*basename).to_string(), Vec::new())).collect();
+    let mut pending = vec![workspace_root.to_path_buf()];
+
+    while let Some(directory) = pending.pop() {
+        let entries = match read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) if directory != workspace_root && is_ignorable_discovery_error(&error) => {
+                continue;
+            }
+            Err(source) => {
+                return Err(workspace_inventory_error(workspace_root, source));
+            }
+        };
+        for entry in entries {
+            match entry.and_then(|entry| {
+                collect_inventory_entry(&entry, &requested, &ignored, &mut pending, &mut manifests)
+            }) {
+                Ok(()) => {}
+                Err(error) if is_ignorable_discovery_error(&error) => continue,
+                Err(source) => {
+                    return Err(workspace_inventory_error(workspace_root, source));
+                }
+            }
+        }
+    }
+
+    for manifest_paths in manifests.values_mut() {
+        manifest_paths.sort();
+    }
+    Ok(WorkspaceInventory { manifests })
+}
+
+fn collect_inventory_entry(
+    entry: &fs::DirEntry,
+    requested: &BTreeSet<&OsStr>,
+    ignored: &BTreeSet<&OsStr>,
+    pending: &mut Vec<PathBuf>,
+    manifests: &mut BTreeMap<String, Vec<PathBuf>>,
+) -> io::Result<()> {
+    let file_type = entry.file_type()?;
+    if file_type.is_symlink() {
+        return Ok(());
+    }
+    let file_name = entry.file_name();
+    if file_type.is_dir() {
+        if !ignored.contains(file_name.as_os_str()) {
+            pending.push(entry.path());
+        }
+    } else if file_type.is_file()
+        && requested.contains(file_name.as_os_str())
+        && let Some(manifest_paths) =
+            file_name.to_str().and_then(|basename| manifests.get_mut(basename))
+    {
+        manifest_paths.push(entry.path());
+    }
+    Ok(())
+}
+
+fn workspace_inventory_error(
+    workspace_root: &Path,
+    source: io::Error,
+) -> FindWorkspaceInventoryError {
+    FindWorkspaceInventoryError { root: workspace_root.to_path_buf(), source }
+}
+
+fn is_ignorable_discovery_error(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -1,0 +1,80 @@
+use super::{find_workspace_inventory, find_workspace_inventory_with};
+use pretty_assertions::assert_eq;
+use std::fs;
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+
+#[test]
+fn discovers_multiple_manifest_kinds_in_one_inventory() {
+    let workspace = tempfile::tempdir().unwrap();
+    let node = workspace.path().join("packages/node");
+    let rust = workspace.path().join("packages/rust");
+    fs::create_dir_all(&node).unwrap();
+    fs::create_dir_all(&rust).unwrap();
+    fs::write(node.join("package.json"), "{}").unwrap();
+    fs::write(rust.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+    let inventory = find_workspace_inventory(
+        workspace.path(),
+        &["package.json", "Cargo.toml", "pyproject.toml"],
+        &[".git", ".pnpm", "node_modules", "target"],
+    )
+    .unwrap();
+
+    assert_eq!(inventory.manifests("package.json"), [node.join("package.json")]);
+    assert_eq!(inventory.manifests("Cargo.toml"), [rust.join("Cargo.toml")]);
+    assert!(inventory.manifests("pyproject.toml").is_empty());
+    assert!(inventory.manifests("unknown").is_empty());
+}
+
+#[test]
+fn prunes_generated_directories() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project = workspace.path().join("rust/project");
+    let generated = workspace.path().join("target/generated");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&generated).unwrap();
+    fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
+    fs::write(generated.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+    let inventory =
+        find_workspace_inventory(workspace.path(), &["Cargo.toml"], &["target"]).unwrap();
+
+    assert_eq!(inventory.manifests("Cargo.toml"), [project.join("Cargo.toml")]);
+}
+
+#[test]
+fn skips_unreadable_unrelated_directories() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project = workspace.path().join("rust/project");
+    let unreadable = workspace.path().join("unrelated");
+    fs::create_dir_all(&project).unwrap();
+    fs::create_dir_all(&unreadable).unwrap();
+    fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
+
+    let inventory =
+        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |directory| {
+            if directory == unreadable {
+                Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+            } else {
+                fs::read_dir(directory)
+            }
+        })
+        .unwrap();
+
+    assert_eq!(inventory.manifests("Cargo.toml"), [project.join("Cargo.toml")]);
+}
+
+#[cfg(unix)]
+#[test]
+fn does_not_follow_directory_symlinks() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+    symlink(outside.path(), workspace.path().join("linked")).unwrap();
+
+    let inventory = find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[]).unwrap();
+
+    assert!(inventory.manifests("Cargo.toml").is_empty());
+}

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -1,4 +1,4 @@
-use super::{InventoryTraversalEvent, find_workspace_inventory, find_workspace_inventory_with};
+use super::{find_workspace_inventory, find_workspace_inventory_with};
 use pretty_assertions::assert_eq;
 use std::fs;
 
@@ -53,16 +53,20 @@ fn skips_unreadable_unrelated_directories() {
     fs::create_dir_all(&unreadable).unwrap();
     fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
 
-    let inventory =
-        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
-            if matches!(event, InventoryTraversalEvent::BeforeRead(directory) if directory == unreadable)
-            {
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        |directory| {
+            if directory == unreadable {
                 Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
             } else {
                 Ok(())
             }
-        })
-        .unwrap();
+        },
+        |_| Ok(()),
+    )
+    .unwrap();
 
     assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [project.join("Cargo.toml")]);
 }
@@ -73,13 +77,19 @@ fn reports_the_nested_directory_that_failed() {
     let broken = workspace.path().join("broken");
     fs::create_dir_all(&broken).unwrap();
 
-    let error = find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
-        if matches!(event, InventoryTraversalEvent::BeforeRead(directory) if directory == broken) {
-            Err(std::io::Error::other("injected read failure"))
-        } else {
-            Ok(())
-        }
-    })
+    let error = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        |directory| {
+            if directory == broken {
+                Err(std::io::Error::other("injected read failure"))
+            } else {
+                Ok(())
+            }
+        },
+        |_| Ok(()),
+    )
     .unwrap_err()
     .to_string();
 
@@ -109,18 +119,20 @@ fn does_not_follow_a_directory_swapped_for_a_symlink_before_descent() {
     fs::create_dir(&candidate).unwrap();
     fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
 
-    let inventory =
-        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
-            if matches!(
-                event,
-                InventoryTraversalEvent::BeforeOpenDirectory(path) if path == candidate
-            ) {
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        |_| Ok(()),
+        |path| {
+            if path == candidate {
                 fs::remove_dir(&candidate)?;
                 symlink(outside.path(), &candidate)?;
             }
             Ok(())
-        })
-        .unwrap();
+        },
+    )
+    .unwrap();
 
     assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
 }

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -1,4 +1,4 @@
-use super::{find_workspace_inventory, find_workspace_inventory_with};
+use super::{InventoryTraversalEvent, find_workspace_inventory, find_workspace_inventory_with};
 use pretty_assertions::assert_eq;
 use std::fs;
 
@@ -54,11 +54,12 @@ fn skips_unreadable_unrelated_directories() {
     fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
 
     let inventory =
-        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |directory| {
-            if directory == unreadable {
+        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
+            if matches!(event, InventoryTraversalEvent::BeforeRead(directory) if directory == unreadable)
+            {
                 Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
             } else {
-                fs::read_dir(directory)
+                Ok(())
             }
         })
         .unwrap();
@@ -72,16 +73,15 @@ fn reports_the_nested_directory_that_failed() {
     let broken = workspace.path().join("broken");
     fs::create_dir_all(&broken).unwrap();
 
-    let error =
-        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |directory| {
-            if directory == broken {
-                Err(std::io::Error::other("injected read failure"))
-            } else {
-                fs::read_dir(directory)
-            }
-        })
-        .unwrap_err()
-        .to_string();
+    let error = find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
+        if matches!(event, InventoryTraversalEvent::BeforeRead(directory) if directory == broken) {
+            Err(std::io::Error::other("injected read failure"))
+        } else {
+            Ok(())
+        }
+    })
+    .unwrap_err()
+    .to_string();
 
     assert!(error.contains(&broken.display().to_string()), "{error}");
     assert!(error.contains("injected read failure"), "{error}");
@@ -96,6 +96,31 @@ fn does_not_follow_directory_symlinks() {
     symlink(outside.path(), workspace.path().join("linked")).unwrap();
 
     let inventory = find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[]).unwrap();
+
+    assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
+}
+
+#[cfg(unix)]
+#[test]
+fn does_not_follow_a_directory_swapped_for_a_symlink_before_descent() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let candidate = workspace.path().join("candidate");
+    fs::create_dir(&candidate).unwrap();
+    fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+
+    let inventory =
+        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |event| {
+            if matches!(
+                event,
+                InventoryTraversalEvent::BeforeOpenDirectory(path) if path == candidate
+            ) {
+                fs::remove_dir(&candidate)?;
+                symlink(outside.path(), &candidate)?;
+            }
+            Ok(())
+        })
+        .unwrap();
 
     assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
 }

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -22,10 +22,10 @@ fn discovers_multiple_manifest_kinds_in_one_inventory() {
     )
     .unwrap();
 
-    assert_eq!(inventory.manifests("package.json"), [node.join("package.json")]);
-    assert_eq!(inventory.manifests("Cargo.toml"), [rust.join("Cargo.toml")]);
-    assert!(inventory.manifests("pyproject.toml").is_empty());
-    assert!(inventory.manifests("unknown").is_empty());
+    assert_eq!(inventory.manifests("package.json").unwrap(), [node.join("package.json")]);
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [rust.join("Cargo.toml")]);
+    assert!(inventory.manifests("pyproject.toml").unwrap().is_empty());
+    assert!(inventory.manifests("unknown").is_none());
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn prunes_generated_directories() {
     let inventory =
         find_workspace_inventory(workspace.path(), &["Cargo.toml"], &["target"]).unwrap();
 
-    assert_eq!(inventory.manifests("Cargo.toml"), [project.join("Cargo.toml")]);
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [project.join("Cargo.toml")]);
 }
 
 #[test]
@@ -63,7 +63,28 @@ fn skips_unreadable_unrelated_directories() {
         })
         .unwrap();
 
-    assert_eq!(inventory.manifests("Cargo.toml"), [project.join("Cargo.toml")]);
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [project.join("Cargo.toml")]);
+}
+
+#[test]
+fn reports_the_nested_directory_that_failed() {
+    let workspace = tempfile::tempdir().unwrap();
+    let broken = workspace.path().join("broken");
+    fs::create_dir_all(&broken).unwrap();
+
+    let error =
+        find_workspace_inventory_with(workspace.path(), &["Cargo.toml"], &[], |directory| {
+            if directory == broken {
+                Err(std::io::Error::other("injected read failure"))
+            } else {
+                fs::read_dir(directory)
+            }
+        })
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains(&broken.display().to_string()), "{error}");
+    assert!(error.contains("injected read failure"), "{error}");
 }
 
 #[cfg(unix)]
@@ -76,5 +97,5 @@ fn does_not_follow_directory_symlinks() {
 
     let inventory = find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[]).unwrap();
 
-    assert!(inventory.manifests("Cargo.toml").is_empty());
+    assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
 }

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -1,0 +1,201 @@
+use super::{FindWorkspaceInventoryError, is_ignorable_discovery_error};
+use cap_primitives::{ambient_authority, fs};
+use std::{
+    collections::BTreeSet,
+    ffi::OsStr,
+    io,
+    path::{Path, PathBuf},
+};
+
+#[cfg(test)]
+pub(super) enum InventoryTraversalEvent<'a> {
+    BeforeRead(&'a Path),
+    BeforeOpenDirectory(&'a Path),
+}
+
+#[cfg(not(test))]
+pub(super) struct InventoryTraversalEvent<'a> {
+    _path: std::marker::PhantomData<&'a Path>,
+}
+
+impl<'a> InventoryTraversalEvent<'a> {
+    fn before_read(path: &'a Path) -> Self {
+        #[cfg(test)]
+        {
+            Self::BeforeRead(path)
+        }
+        #[cfg(not(test))]
+        {
+            let _ = path;
+            Self { _path: std::marker::PhantomData }
+        }
+    }
+
+    fn before_open_directory(path: &'a Path) -> Self {
+        #[cfg(test)]
+        {
+            Self::BeforeOpenDirectory(path)
+        }
+        #[cfg(not(test))]
+        {
+            let _ = path;
+            Self { _path: std::marker::PhantomData }
+        }
+    }
+}
+
+struct PendingDirectory {
+    path: PathBuf,
+    handle: std::fs::File,
+}
+
+pub(super) fn walk_workspace(
+    workspace_root: &Path,
+    ignored: &BTreeSet<&OsStr>,
+    mut traversal_hook: impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    mut visit_file: impl FnMut(PathBuf, &OsStr),
+) -> Result<(), FindWorkspaceInventoryError> {
+    let root_handle =
+        fs::open_ambient_dir(workspace_root, ambient_authority()).map_err(|source| {
+            FindWorkspaceInventoryError::ReadDirectory {
+                path: workspace_root.to_path_buf(),
+                source,
+            }
+        })?;
+    let mut pending =
+        vec![PendingDirectory { path: workspace_root.to_path_buf(), handle: root_handle }];
+
+    while let Some(directory) = pending.pop() {
+        match traversal_hook(InventoryTraversalEvent::before_read(&directory.path)) {
+            Ok(()) => {}
+            Err(error)
+                if directory.path != workspace_root && is_ignorable_discovery_error(&error) =>
+            {
+                continue;
+            }
+            Err(source) => {
+                return Err(FindWorkspaceInventoryError::ReadDirectory {
+                    path: directory.path,
+                    source,
+                });
+            }
+        }
+        let entries = match fs::read_base_dir(&directory.handle) {
+            Ok(entries) => entries,
+            Err(error)
+                if directory.path != workspace_root && is_ignorable_discovery_error(&error) =>
+            {
+                continue;
+            }
+            Err(source) => {
+                return Err(FindWorkspaceInventoryError::ReadDirectory {
+                    path: directory.path,
+                    source,
+                });
+            }
+        };
+        collect_directory_entries(
+            &directory,
+            entries,
+            ignored,
+            &mut traversal_hook,
+            &mut pending,
+            &mut visit_file,
+        )?;
+    }
+    Ok(())
+}
+
+fn collect_directory_entries(
+    directory: &PendingDirectory,
+    entries: fs::ReadDir,
+    ignored: &BTreeSet<&OsStr>,
+    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    pending: &mut Vec<PendingDirectory>,
+    visit_file: &mut impl FnMut(PathBuf, &OsStr),
+) -> Result<(), FindWorkspaceInventoryError> {
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) if is_ignorable_discovery_error(&error) => continue,
+            Err(source) => {
+                return Err(FindWorkspaceInventoryError::ReadEntry {
+                    path: directory.path.clone(),
+                    source,
+                });
+            }
+        };
+        collect_entry(directory, &entry, ignored, traversal_hook, pending, visit_file)?;
+    }
+    Ok(())
+}
+
+fn collect_entry(
+    directory: &PendingDirectory,
+    entry: &fs::DirEntry,
+    ignored: &BTreeSet<&OsStr>,
+    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    pending: &mut Vec<PendingDirectory>,
+    visit_file: &mut impl FnMut(PathBuf, &OsStr),
+) -> Result<(), FindWorkspaceInventoryError> {
+    let file_name = entry.file_name();
+    let path = directory.path.join(&file_name);
+    let file_type = match entry.file_type() {
+        Ok(file_type) => file_type,
+        Err(error) if is_ignorable_discovery_error(&error) => return Ok(()),
+        Err(source) => {
+            return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
+        }
+    };
+    if file_type.is_symlink() {
+        return Ok(());
+    }
+    if file_type.is_dir() {
+        collect_directory(directory, &file_name, path, ignored, traversal_hook, pending)
+    } else {
+        if file_type.is_file() {
+            visit_file(path, &file_name);
+        }
+        Ok(())
+    }
+}
+
+fn collect_directory(
+    parent: &PendingDirectory,
+    file_name: &OsStr,
+    path: PathBuf,
+    ignored: &BTreeSet<&OsStr>,
+    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    pending: &mut Vec<PendingDirectory>,
+) -> Result<(), FindWorkspaceInventoryError> {
+    if ignored.contains(file_name) {
+        return Ok(());
+    }
+    traversal_hook(InventoryTraversalEvent::before_open_directory(&path)).map_err(|source| {
+        FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
+    })?;
+    match fs::open_dir_nofollow(&parent.handle, Path::new(file_name)) {
+        Ok(handle) => pending.push(PendingDirectory { path, handle }),
+        Err(error) if is_changed_candidate_error(&error) => {}
+        Err(source) => {
+            return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
+        }
+    }
+    Ok(())
+}
+
+fn is_changed_candidate_error(error: &io::Error) -> bool {
+    is_ignorable_discovery_error(error)
+        || error.kind() == io::ErrorKind::NotADirectory
+        || is_symlink_loop(error)
+}
+
+#[cfg(unix)]
+fn is_symlink_loop(error: &io::Error) -> bool {
+    error.raw_os_error() == Some(libc::ELOOP)
+}
+
+#[cfg(not(unix))]
+fn is_symlink_loop(_error: &io::Error) -> bool {
+    false
+}

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -7,43 +7,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-#[cfg(test)]
-pub(super) enum InventoryTraversalEvent<'a> {
-    BeforeRead(&'a Path),
-    BeforeOpenDirectory(&'a Path),
-}
-
-#[cfg(not(test))]
-pub(super) struct InventoryTraversalEvent<'a> {
-    _path: std::marker::PhantomData<&'a Path>,
-}
-
-impl<'a> InventoryTraversalEvent<'a> {
-    fn before_read(path: &'a Path) -> Self {
-        #[cfg(test)]
-        {
-            Self::BeforeRead(path)
-        }
-        #[cfg(not(test))]
-        {
-            let _ = path;
-            Self { _path: std::marker::PhantomData }
-        }
-    }
-
-    fn before_open_directory(path: &'a Path) -> Self {
-        #[cfg(test)]
-        {
-            Self::BeforeOpenDirectory(path)
-        }
-        #[cfg(not(test))]
-        {
-            let _ = path;
-            Self { _path: std::marker::PhantomData }
-        }
-    }
-}
-
 struct PendingDirectory {
     path: PathBuf,
     handle: std::fs::File,
@@ -52,7 +15,8 @@ struct PendingDirectory {
 pub(super) fn walk_workspace(
     workspace_root: &Path,
     ignored: &BTreeSet<&OsStr>,
-    mut traversal_hook: impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    mut before_read: impl FnMut(&Path) -> io::Result<()>,
+    mut before_open_directory: impl FnMut(&Path) -> io::Result<()>,
     mut visit_file: impl FnMut(PathBuf, &OsStr),
 ) -> Result<(), FindWorkspaceInventoryError> {
     let root_handle =
@@ -66,7 +30,7 @@ pub(super) fn walk_workspace(
         vec![PendingDirectory { path: workspace_root.to_path_buf(), handle: root_handle }];
 
     while let Some(directory) = pending.pop() {
-        match traversal_hook(InventoryTraversalEvent::before_read(&directory.path)) {
+        match before_read(&directory.path) {
             Ok(()) => {}
             Err(error)
                 if directory.path != workspace_root && is_ignorable_discovery_error(&error) =>
@@ -98,7 +62,7 @@ pub(super) fn walk_workspace(
             &directory,
             entries,
             ignored,
-            &mut traversal_hook,
+            &mut before_open_directory,
             &mut pending,
             &mut visit_file,
         )?;
@@ -110,7 +74,7 @@ fn collect_directory_entries(
     directory: &PendingDirectory,
     entries: fs::ReadDir,
     ignored: &BTreeSet<&OsStr>,
-    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
     pending: &mut Vec<PendingDirectory>,
     visit_file: &mut impl FnMut(PathBuf, &OsStr),
 ) -> Result<(), FindWorkspaceInventoryError> {
@@ -125,7 +89,7 @@ fn collect_directory_entries(
                 });
             }
         };
-        collect_entry(directory, &entry, ignored, traversal_hook, pending, visit_file)?;
+        collect_entry(directory, &entry, ignored, before_open_directory, pending, visit_file)?;
     }
     Ok(())
 }
@@ -134,7 +98,7 @@ fn collect_entry(
     directory: &PendingDirectory,
     entry: &fs::DirEntry,
     ignored: &BTreeSet<&OsStr>,
-    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
     pending: &mut Vec<PendingDirectory>,
     visit_file: &mut impl FnMut(PathBuf, &OsStr),
 ) -> Result<(), FindWorkspaceInventoryError> {
@@ -151,7 +115,7 @@ fn collect_entry(
         return Ok(());
     }
     if file_type.is_dir() {
-        collect_directory(directory, &file_name, path, ignored, traversal_hook, pending)
+        collect_directory(directory, &file_name, path, ignored, before_open_directory, pending)
     } else {
         if file_type.is_file() {
             visit_file(path, &file_name);
@@ -165,13 +129,13 @@ fn collect_directory(
     file_name: &OsStr,
     path: PathBuf,
     ignored: &BTreeSet<&OsStr>,
-    traversal_hook: &mut impl FnMut(InventoryTraversalEvent<'_>) -> io::Result<()>,
+    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
     pending: &mut Vec<PendingDirectory>,
 ) -> Result<(), FindWorkspaceInventoryError> {
     if ignored.contains(file_name) {
         return Ok(());
     }
-    traversal_hook(InventoryTraversalEvent::before_open_directory(&path)).map_err(|source| {
+    before_open_directory(&path).map_err(|source| {
         FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
     })?;
     match fs::open_dir_nofollow(&parent.handle, Path::new(file_name)) {

--- a/pnpm/crates/workspace/src/lib.rs
+++ b/pnpm/crates/workspace/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod api;
 mod importer_id;
+mod inventory;
 mod manifest;
 mod project_manifest;
 mod projects;
@@ -20,6 +21,7 @@ mod root_finder;
 
 pub use api::{EnvVarOs, Host};
 pub use importer_id::importer_id_from_root_dir;
+pub use inventory::{FindWorkspaceInventoryError, WorkspaceInventory, find_workspace_inventory};
 pub use manifest::{
     InvalidWorkspaceManifestError, ReadWorkspaceManifestError, WORKSPACE_MANIFEST_FILENAME,
     WorkspaceManifest, read_workspace_manifest, workspace_package_patterns,


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#14566.

- Add a manifest-basename workspace inventory in `pnpm-workspace` that gathers several ecosystem manifest kinds in one traversal.
- Populate that inventory lazily and cache it for every enabled ecosystem installer in the command.
- Move Cargo manifest discovery out of the Cargo installer. Cargo now selects its manifests from the shared inventory before asking Cargo for unique workspace roots.
- Preserve the npm-only install path. The inventory is neither constructed nor traversed unless a non-Node.js ecosystem is enabled.
- Keep mixed-install concurrency unchanged. The blocking inventory walk is first polled from the Cargo future alongside the Node.js installer.

This is an internal architecture refactor with no user-visible behavior change, so it has no changeset. It intentionally does not introduce a stable ecosystem-adapter trait before the planned Python spike.

Validation: `just ready` passed with 10,059 tests, 5 skipped. The capability-based traversal also passed its targeted workspace and CLI tests, three mixed/Cargo end-to-end tests, `just dylint`, and `cargo check -p pnpm-workspace --target x86_64-pc-windows-msvc --locked`.

## Squash Commit Body

```text
Move repository manifest enumeration into pnpm-workspace and expose its result as a basename-indexed inventory. The CLI populates that inventory lazily only after non-Node.js installation is enabled, allowing Cargo and future ecosystem installers to share one traversal without putting allocations, filesystem work, or synchronization on npm-only installs.

Keep discovery within the concurrently-polled ecosystem future so Node.js resolution does not wait for the repository scan. Cargo retains ownership of interpreting Cargo.toml files and reducing them to Cargo workspace roots.

Related to pnpm/pnpm#14566.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added or updated tests.

---
Written by an agent (Codex, gpt-5.6-sol).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14581"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791187789&installation_model_id=426870&pr_number=14581&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14581&signature=4b965c6215ba0296335b0ff1f6091a2d5752b9b6670c28c06adabf55e940e899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-based Cargo installations now use a shared inventory of project manifests.
  * Cargo project discovery covers workspace manifests while skipping dependency and generated directories.

* **Bug Fixes**
  * Improved diagnostics and resilience when directories are unreadable or change during discovery.
  * Directory symlinks are no longer followed during workspace scanning.

* **Performance**
  * Workspace manifests are discovered once and reused during installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->