### PR TITLE
fix(workspace): normalize package directory patterns

### DIFF
--- a/.changeset/fix-workspace-path-normalization.md
+++ b/.changeset/fix-workspace-path-normalization.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Workspace package patterns now normalize `.` and `..` segments and repeated slashes before matching. Patterns such as `./packages/*` discover packages, and exclusions such as `!./packages/foo` exclude them correctly [#14571](https://github.com/pnpm/pnpm/issues/14571).

--- a/.changeset/fix-workspace-path-normalization.md
+++ b/.changeset/fix-workspace-path-normalization.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Workspace package patterns now normalize `.` and `..` segments and repeated slashes before matching. Patterns such as `./packages/*` discover packages, and exclusions such as `!./packages/foo` exclude them correctly [#14571](https://github.com/pnpm/pnpm/issues/14571).
+Workspace package patterns such as `./packages/*` now match. Exclusions such as `!./packages/foo` apply too. pnpm normalizes `.` segments, `..` segments, and repeated slashes in the `packages` field of `pnpm-workspace.yaml` before matching them [#14571](https://github.com/pnpm/pnpm/issues/14571).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5995,6 +5995,7 @@ dependencies = [
  "miette 7.6.0",
  "pathdiff",
  "pnpm-catalogs-types",
+ "pnpm-fs",
  "pnpm-package-manifest",
  "pnpm-workspace-projects-graph",
  "pretty_assertions",

--- a/pnpm/crates/cli/tests/suite/workspace_install.rs
+++ b/pnpm/crates/cli/tests/suite/workspace_install.rs
@@ -74,6 +74,60 @@ fn assert_frozen_outdated(workspace: &Path) {
 }
 
 #[test]
+fn normalized_workspace_patterns_select_install_list_and_script_projects() {
+    let manifest = |name: &str, dependency: &str| {
+        serde_json::json!({
+            "name": name,
+            "version": "1.0.0",
+            "dependencies": { dependency: "1.0.0" },
+            "scripts": { "probe": "node probe.cjs" },
+        })
+    };
+    let fixture =
+        two_project_workspace(&manifest("pkg-a", "is-positive"), &manifest("pkg-b", "is-negative"));
+    let workspace = &fixture.workspace;
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&yaml_path)
+        .unwrap()
+        .replace("  - 'pkg-a'\n  - 'pkg-b'\n", "  - './missing/../*'\n  - '!./pkg-b'\n");
+    fs::write(yaml_path, yaml).unwrap();
+    for name in ["pkg-a", "pkg-b"] {
+        fs::write(
+            workspace.join(name).join("probe.cjs"),
+            "require('node:fs').writeFileSync('script-ran', '')\n",
+        )
+        .unwrap();
+    }
+
+    pacquet_at(workspace).with_args(["install", "--ignore-scripts"]).assert().success();
+    let installed_a = workspace.join("pkg-a/node_modules/is-positive/package.json");
+    let installed_b = workspace.join("pkg-b/node_modules/is-negative/package.json");
+    dbg!(&installed_a, &installed_b);
+    assert!(installed_a.is_file());
+    assert!(!installed_b.exists());
+    let lockfile = read_lockfile(&workspace.join("pnpm-lock.yaml"));
+    dbg!(&lockfile.importers);
+    assert!(lockfile.importers.contains_key("pkg-a"));
+    assert!(!lockfile.importers.contains_key("pkg-b"));
+
+    let output =
+        pacquet_at(workspace).with_args(["ls", "-r", "--depth", "-1", "--json"]).output().unwrap();
+    assert!(output.status.success(), "list failed: {output:?}");
+    let projects: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let mut names =
+        projects.iter().map(|project| project["name"].as_str().unwrap()).collect::<Vec<_>>();
+    names.sort_unstable();
+    assert_eq!(names, vec!["pkg-a", "root"]);
+
+    pacquet_at(workspace).with_args(["-r", "run", "probe"]).assert().success();
+    let ran_a = workspace.join("pkg-a/script-ran");
+    let ran_b = workspace.join("pkg-b/script-ran");
+    dbg!(&ran_a, &ran_b);
+    assert!(ran_a.is_file());
+    assert!(!ran_b.exists());
+}
+
+#[test]
 fn recursive_install_false_selects_the_current_project_and_its_dependencies() {
     let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();

--- a/pnpm/crates/fs/src/lexical_normalize.rs
+++ b/pnpm/crates/fs/src/lexical_normalize.rs
@@ -1,5 +1,5 @@
 use std::{
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     path::{Component, MAIN_SEPARATOR_STR, Path, PathBuf},
 };
 
@@ -20,30 +20,13 @@ use std::{
 /// not exist yet, where [`std::fs::canonicalize`] cannot help.
 #[must_use]
 pub fn lexical_normalize(path: &Path) -> PathBuf {
-    // Always rebuilt component-by-component, never copied verbatim:
-    // besides the dot components, the rebuild also strips trailing and
-    // doubled separators, and callers compare and hash the results.
-    let mut kept: Vec<Component<'_>> = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => match kept.last() {
-                Some(Component::Normal(_)) => {
-                    kept.pop();
-                }
-                Some(Component::RootDir | Component::Prefix(_)) => {}
-                _ => kept.push(Component::ParentDir),
-            },
-            Component::CurDir => {}
-            other => kept.push(other),
-        }
-    }
     // Concatenated by hand rather than through `PathBuf::push`: on Windows,
     // `push` takes a component that looks like a drive prefix (`C:tools`,
     // legal in the middle of a path) for the start of a new path and
     // discards everything before it.
     let mut out = OsString::with_capacity(path.as_os_str().len());
     let mut needs_separator = false;
-    for component in kept {
+    for component in normalize_components(path.components()) {
         match component {
             Component::Prefix(prefix) => out.push(prefix.as_os_str()),
             Component::RootDir => out.push(MAIN_SEPARATOR_STR),
@@ -57,6 +40,62 @@ pub fn lexical_normalize(path: &Path) -> PathBuf {
         }
     }
     PathBuf::from(out)
+}
+
+/// Normalize a POSIX path lexically on every platform, preserving a trailing
+/// slash and returning `.` for an empty result. Backslashes remain literal.
+#[must_use]
+pub fn lexical_normalize_posix(path: &str) -> String {
+    let root = path.starts_with('/').then_some(Component::RootDir);
+    let components = path.split('/').filter(|part| !part.is_empty()).map(|part| match part {
+        "." => Component::CurDir,
+        ".." => Component::ParentDir,
+        _ => Component::Normal(OsStr::new(part)),
+    });
+    let mut normalized = String::with_capacity(path.len());
+    for component in normalize_components(root.into_iter().chain(components)) {
+        if component == Component::RootDir {
+            normalized.push('/');
+        } else {
+            if !normalized.is_empty() && !normalized.ends_with('/') {
+                normalized.push('/');
+            }
+            normalized
+                .push_str(component.as_os_str().to_str().expect("components came from UTF-8"));
+        }
+    }
+    if normalized.is_empty() {
+        normalized.push('.');
+    }
+    if path.ends_with('/') && !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    normalized
+}
+
+/// Drop `.` components and cancel each `..` against the component it follows,
+/// keeping the components the callers rebuild a path from. Callers rebuild
+/// component-by-component and never copy verbatim: besides the dot
+/// components, the rebuild also strips trailing and doubled separators, and
+/// callers compare and hash the results.
+fn normalize_components<'path>(
+    components: impl Iterator<Item = Component<'path>>,
+) -> Vec<Component<'path>> {
+    let mut kept = Vec::new();
+    for component in components {
+        match component {
+            Component::ParentDir => match kept.last() {
+                Some(Component::Normal(_)) => {
+                    kept.pop();
+                }
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => kept.push(Component::ParentDir),
+            },
+            Component::CurDir => {}
+            other => kept.push(other),
+        }
+    }
+    kept
 }
 
 #[cfg(test)]

--- a/pnpm/crates/fs/src/lexical_normalize.rs
+++ b/pnpm/crates/fs/src/lexical_normalize.rs
@@ -73,11 +73,11 @@ pub fn lexical_normalize_posix(path: &str) -> String {
     normalized
 }
 
-/// Drop `.` components and cancel each `..` against the component it follows,
-/// keeping the components the callers rebuild a path from. Callers rebuild
-/// component-by-component and never copy verbatim: besides the dot
-/// components, the rebuild also strips trailing and doubled separators, and
-/// callers compare and hash the results.
+/// Drop `.` components and cancel each `..` against the component it follows.
+///
+/// Callers rebuild the path component-by-component from this list instead of
+/// copying the input verbatim, so trailing and doubled separators are stripped
+/// as well: the results get compared and hashed.
 fn normalize_components<'path>(
     components: impl Iterator<Item = Component<'path>>,
 ) -> Vec<Component<'path>> {

--- a/pnpm/crates/fs/src/lexical_normalize.rs
+++ b/pnpm/crates/fs/src/lexical_normalize.rs
@@ -73,11 +73,6 @@ pub fn lexical_normalize_posix(path: &str) -> String {
     normalized
 }
 
-/// Drop `.` components and cancel each `..` against the component it follows.
-///
-/// Callers rebuild the path component-by-component from this list instead of
-/// copying the input verbatim, so trailing and doubled separators are stripped
-/// as well: the results get compared and hashed.
 fn normalize_components<'path>(
     components: impl Iterator<Item = Component<'path>>,
 ) -> Vec<Component<'path>> {

--- a/pnpm/crates/fs/src/lexical_normalize/tests.rs
+++ b/pnpm/crates/fs/src/lexical_normalize/tests.rs
@@ -1,4 +1,4 @@
-use super::lexical_normalize;
+use super::{lexical_normalize, lexical_normalize_posix};
 use std::path::Path;
 
 #[test]
@@ -72,4 +72,32 @@ fn keeps_windows_prefixes() {
         Path::new(r"\\server\share\bar"),
     );
     assert_eq!(lexical_normalize(Path::new(r"\foo\..\bar")), Path::new(r"\bar"));
+}
+
+#[test]
+fn posix_normalization_preserves_relative_roots_and_trailing_slashes() {
+    for (path, expected) in [
+        ("", "."),
+        ("././", "./"),
+        ("foo/../", "./"),
+        ("foo/../../bar//", "../bar/"),
+        ("../../foo/../bar", "../../bar"),
+        ("///foo/../../bar//", "/bar/"),
+        ("/../../", "/"),
+    ] {
+        assert_eq!(lexical_normalize_posix(path), expected, "path: {path}");
+    }
+}
+
+#[test]
+fn posix_normalization_preserves_backslashes_and_drive_like_components() {
+    for (path, expected) in [
+        (r"./packages/foo\[bar\]", r"packages/foo\[bar\]"),
+        (r"foo\bar/../baz", "baz"),
+        (r"C:\foo\..\bar", r"C:\foo\..\bar"),
+        ("C:/../bar", "bar"),
+        ("./.hidden/../visible", "visible"),
+    ] {
+        assert_eq!(lexical_normalize_posix(path), expected, "path: {path}");
+    }
 }

--- a/pnpm/crates/fs/src/lib.rs
+++ b/pnpm/crates/fs/src/lib.rs
@@ -14,7 +14,7 @@ pub use background_drop::background_drop;
 pub use dir_lock::DirLock;
 pub use ensure_file::*;
 pub use is_subdir::is_subdir;
-pub use lexical_normalize::lexical_normalize;
+pub use lexical_normalize::{lexical_normalize, lexical_normalize_posix};
 pub use realpath_missing::realpath_missing;
 pub use relative_path::relative_path;
 pub use remove_dirent::remove_dirent;

--- a/pnpm/crates/workspace/Cargo.toml
+++ b/pnpm/crates/workspace/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace  = true
 
 [dependencies]
 pnpm-catalogs-types           = { workspace = true }
+pnpm-fs                       = { workspace = true }
 pnpm-package-manifest         = { workspace = true }
 pnpm-workspace-projects-graph = { workspace = true }
 

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -17,6 +17,7 @@
 use crate::project_manifest::{ReadProjectManifestError, read_exact_project_manifest};
 use derive_more::{Display, Error};
 use miette::Diagnostic;
+use pnpm_fs::lexical_normalize_posix;
 use pnpm_package_manifest::{PackageManifest, PackageManifestError};
 use rayon::prelude::*;
 use std::{
@@ -122,22 +123,23 @@ pub fn find_workspace_projects_no_check(
     // inside `Glob::new()`, so split them out and feed them through
     // `.not()` instead. `!/...` remains a no-op: relative workspace
     // paths never match that absolute form.
-    let mut include_patterns: Vec<&str> = Vec::new();
+    let mut include_patterns = Vec::new();
     let mut user_negation_globs: Vec<String> = Vec::new();
     for pattern in patterns {
         if let Some(body) = pattern.strip_prefix('!') {
             if body.starts_with('/') {
                 continue;
             }
-            for normalized in normalize_manifest_patterns(body) {
+            let Some(directory) = normalize_directory_pattern(body) else { continue };
+            for normalized in normalize_manifest_patterns(&directory) {
                 Glob::new(&normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
                     pattern: pattern.clone(),
                     message: err.to_string(),
                 })?;
                 user_negation_globs.push(normalized);
             }
-        } else {
-            include_patterns.push(pattern);
+        } else if let Some(normalized) = normalize_directory_pattern(pattern) {
+            include_patterns.push(WorkspacePattern { source: pattern, normalized });
         }
     }
 
@@ -168,7 +170,7 @@ pub fn find_workspace_projects_no_check(
     // glob fails before any pattern pays for a workspace walk. The fast
     // paths accept only meta-character-free patterns, which cannot fail
     // to parse.
-    for pattern in &include_patterns {
+    for WorkspacePattern { source, normalized: pattern } in &include_patterns {
         if specialized_pattern(pattern).is_some() {
             continue;
         }
@@ -177,7 +179,7 @@ pub fn find_workspace_projects_no_check(
                 continue;
             };
             Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: (*pattern).to_string(),
+                pattern: (*source).to_string(),
                 message: err.to_string(),
             })?;
         }
@@ -262,13 +264,13 @@ pub fn find_workspace_projects_no_check(
 /// kinds are absorbed, how the fast paths and the generic walk divide
 /// the pattern space — lives there; this is its per-pattern body.
 fn collect_pattern_manifests(
-    pattern: &str,
+    pattern: &WorkspacePattern<'_>,
     workspace_root: &Path,
     dot_pruning_ignore_template: &wax::Any<'_>,
     user_negations: &wax::Any<'_>,
 ) -> Result<BTreeSet<PathBuf>, FindWorkspaceProjectsError> {
     let mut manifest_paths: BTreeSet<PathBuf> = BTreeSet::new();
-    match specialized_pattern(pattern) {
+    match specialized_pattern(&pattern.normalized) {
         Some(SpecializedPattern::ChildrenOf(parent)) => {
             collect_manifests_in_children(
                 &workspace_root.join(parent),
@@ -290,7 +292,7 @@ fn collect_pattern_manifests(
         None => {}
     }
 
-    for normalized in normalize_manifest_patterns(pattern) {
+    for normalized in normalize_manifest_patterns(&pattern.normalized) {
         let Some((walk_root, normalized)) = split_parent_prefix(workspace_root, &normalized) else {
             continue;
         };
@@ -299,12 +301,12 @@ fn collect_pattern_manifests(
         }
         let glob =
             Glob::new(normalized).map_err(|err| FindWorkspaceProjectsError::InvalidGlob {
-                pattern: pattern.to_string(),
+                pattern: pattern.source.to_string(),
                 message: err.to_string(),
             })?;
 
         let invalid_glob = |err: wax::BuildError| FindWorkspaceProjectsError::InvalidGlob {
-            pattern: pattern.to_string(),
+            pattern: pattern.source.to_string(),
             message: err.to_string(),
         };
         match positional_dot_ignores(normalized) {
@@ -377,12 +379,18 @@ const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**
 const DOT_COMPONENT_IGNORE_PATTERN: &str = "**/.*/**";
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
-fn normalize_directory_pattern(pattern: &str) -> Option<&str> {
-    let trimmed = pattern.trim_end_matches('/');
-    if trimmed.is_empty() || trimmed == "." {
+struct WorkspacePattern<'source> {
+    source: &'source str,
+    normalized: String,
+}
+
+fn normalize_directory_pattern(pattern: &str) -> Option<String> {
+    let mut normalized = lexical_normalize_posix(pattern);
+    normalized.truncate(normalized.trim_end_matches('/').len());
+    if normalized.is_empty() || normalized == "." {
         return None;
     }
-    Some(trimmed)
+    Some(normalized)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -392,7 +400,7 @@ enum SpecializedPattern<'pattern> {
 }
 
 fn specialized_pattern(pattern: &str) -> Option<SpecializedPattern<'_>> {
-    let pattern = normalize_directory_pattern(pattern)?;
+    let pattern = pattern.trim_end_matches('/');
     if let Some(parent) = pattern.strip_suffix("/*") {
         return is_safe_relative_literal(parent).then_some(SpecializedPattern::ChildrenOf(parent));
     }
@@ -408,8 +416,7 @@ fn is_safe_relative_literal(pattern: &str) -> bool {
 }
 
 fn normalize_manifest_patterns(pattern: &str) -> Vec<String> {
-    let Some(trimmed) = normalize_directory_pattern(pattern) else { return Vec::new() };
-    PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{trimmed}/{basename}")).collect()
+    PROJECT_MANIFEST_BASENAMES.iter().map(|basename| format!("{pattern}/{basename}")).collect()
 }
 
 fn collect_manifests_in_children(

--- a/pnpm/crates/workspace/src/projects.rs
+++ b/pnpm/crates/workspace/src/projects.rs
@@ -379,6 +379,8 @@ const IGNORE_PATTERNS: &[&str] = &["**/node_modules/**", "**/bower_components/**
 const DOT_COMPONENT_IGNORE_PATTERN: &str = "**/.*/**";
 const PROJECT_MANIFEST_BASENAMES: &[&str] = &["package.json", "package.yaml"];
 
+/// A configured include pattern. `normalized` drives discovery; `source` is
+/// the text an invalid-glob diagnostic quotes back to the user.
 struct WorkspacePattern<'source> {
     source: &'source str,
     normalized: String,

--- a/pnpm/crates/workspace/src/projects/tests.rs
+++ b/pnpm/crates/workspace/src/projects/tests.rs
@@ -6,6 +6,8 @@ use pretty_assertions::assert_eq;
 use std::{fs, io::ErrorKind, path::Path};
 use tempfile::TempDir;
 
+mod normalization;
+
 fn make_project(root: &std::path::Path, rel: &str, name: &str) {
     let dir = root.join(rel);
     fs::create_dir_all(&dir).unwrap();

--- a/pnpm/crates/workspace/src/projects/tests/normalization.rs
+++ b/pnpm/crates/workspace/src/projects/tests/normalization.rs
@@ -43,7 +43,7 @@ fn normalizes_literal_and_glob_patterns() {
         );
     }
     assert_eq!(find_project_names(tmp.path(), &["./packages/.hidden"]), vec!["root", "hidden"]);
-    assert_eq!(find_project_names(tmp.path(), &["./projects/foo/bar/baz"]), vec!["root", "nested"],);
+    assert_eq!(find_project_names(tmp.path(), &["./projects/foo/bar/baz"]), vec!["root", "nested"]);
     assert_eq!(find_project_names(tmp.path(), &["././", "packages/../"]), vec!["root"]);
     assert_eq!(
         find_project_names(tmp.path(), &["packages/alpha", "./packages/./alpha"]),

--- a/pnpm/crates/workspace/src/projects/tests/normalization.rs
+++ b/pnpm/crates/workspace/src/projects/tests/normalization.rs
@@ -1,0 +1,108 @@
+use super::{find_project_names, make_project, make_yaml_project};
+use crate::{FindWorkspaceProjectsError, FindWorkspaceProjectsOpts, find_workspace_projects};
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+#[test]
+fn normalizes_literal_and_glob_patterns() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_yaml_project(tmp.path(), "packages/beta", "beta");
+    make_project(tmp.path(), "packages/.hidden", "hidden");
+    make_project(tmp.path(), "projects/foo/bar/baz", "nested");
+
+    for pattern in [
+        "./packages/alpha",
+        "././packages/alpha/",
+        "./packages/./alpha",
+        "packages/./alpha",
+        "packages/alpha/.",
+        "packages//alpha",
+        ".//packages/alpha",
+        "packages/missing/../alpha",
+    ] {
+        assert_eq!(
+            find_project_names(tmp.path(), &[pattern]),
+            vec!["root", "alpha"],
+            "pattern: {pattern}",
+        );
+    }
+    for pattern in [
+        "./packages/*",
+        "././packages/*",
+        "./packages/**",
+        "./packages/{alpha,beta}",
+        "packages//./*",
+        "packages/missing/../*",
+    ] {
+        assert_eq!(
+            find_project_names(tmp.path(), &[pattern]),
+            vec!["root", "alpha", "beta"],
+            "pattern: {pattern}",
+        );
+    }
+    assert_eq!(find_project_names(tmp.path(), &["./packages/.hidden"]), vec!["root", "hidden"]);
+    assert_eq!(find_project_names(tmp.path(), &["./projects/foo/bar/baz"]), vec!["root", "nested"],);
+    assert_eq!(find_project_names(tmp.path(), &["././", "packages/../"]), vec!["root"]);
+    assert_eq!(
+        find_project_names(tmp.path(), &["packages/alpha", "./packages/./alpha"]),
+        vec!["root", "alpha"],
+    );
+}
+
+#[test]
+fn normalizes_negations_for_specialized_and_generic_patterns() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+    make_yaml_project(tmp.path(), "packages/beta", "beta");
+
+    for include in ["packages/*", "./packages/**"] {
+        for exclude in [
+            "!./packages/alpha",
+            "!././packages/alpha/",
+            "!packages/./alpha",
+            "!./packages//alpha",
+            "!packages/missing/../alpha",
+        ] {
+            assert_eq!(
+                find_project_names(tmp.path(), &[include, exclude]),
+                vec!["root", "beta"],
+                "patterns: {include}, {exclude}",
+            );
+        }
+    }
+}
+
+#[test]
+fn normalizes_patterns_above_the_workspace_root() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), "workspace", "root");
+    make_project(tmp.path(), "shared/alpha", "alpha");
+    make_project(tmp.path(), "shared/beta", "beta");
+    let workspace = tmp.path().join("workspace");
+
+    for pattern in ["./../shared/*", "././../shared/*", "../shared/missing/../*"] {
+        assert_eq!(
+            find_project_names(&workspace, &[pattern, "!./../shared/./alpha"]),
+            vec!["beta", "root"],
+            "pattern: {pattern}",
+        );
+    }
+}
+
+#[test]
+fn invalid_normalized_globs_report_the_original_pattern() {
+    let tmp = TempDir::new().unwrap();
+    for source in ["./packages//[", "!./packages//["] {
+        let result = find_workspace_projects(
+            tmp.path(),
+            &FindWorkspaceProjectsOpts { patterns: Some(vec![source.to_string()]) },
+        );
+        let Err(FindWorkspaceProjectsError::InvalidGlob { pattern, .. }) = result else {
+            panic!("expected an invalid glob for {source}");
+        };
+        assert_eq!(pattern, source);
+    }
+}

--- a/pnpm/crates/workspace/src/projects/tests/normalization.rs
+++ b/pnpm/crates/workspace/src/projects/tests/normalization.rs
@@ -106,3 +106,18 @@ fn invalid_normalized_globs_report_the_original_pattern() {
         assert_eq!(pattern, source);
     }
 }
+
+#[test]
+fn negations_that_normalize_to_the_workspace_root_are_dropped() {
+    let tmp = TempDir::new().unwrap();
+    make_project(tmp.path(), ".", "root");
+    make_project(tmp.path(), "packages/alpha", "alpha");
+
+    for exclude in ["!.", "!./", "!packages/.."] {
+        assert_eq!(
+            find_project_names(tmp.path(), &["packages/*", exclude]),
+            vec!["root", "alpha"],
+            "exclude: {exclude}",
+        );
+    }
+}

--- a/pnpm11/workspace/projects-reader/test/normalizePatterns.ts
+++ b/pnpm11/workspace/projects-reader/test/normalizePatterns.ts
@@ -1,0 +1,63 @@
+import path from 'node:path'
+
+import { expect, test } from '@jest/globals'
+import { findPackages } from '@pnpm/workspace.projects-reader'
+
+const root = path.join(import.meta.dirname, 'findPackages-fixtures/many-pkgs-2')
+
+test.each([
+  './components/component-1',
+  '././components/component-1/',
+  './components/./component-1',
+  'components/./component-1',
+  'components/component-1/.',
+  'components//component-1',
+  './/components/component-1',
+  'components/missing/../component-1',
+])('normalizes literal pattern %s', async (pattern) => {
+  const projects = await findPackages(root, { patterns: [pattern], includeRoot: true })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-1', 'many-pkgs-2'])
+})
+
+test.each([
+  './components/*',
+  '././components/*',
+  './components/**',
+  './components/{component-1,component-2}',
+  'components//./*',
+  'components/missing/../*',
+])('normalizes glob pattern %s', async (pattern) => {
+  const projects = await findPackages(root, { patterns: [pattern], includeRoot: true })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-1', 'component-2', 'many-pkgs-2'])
+})
+
+test.each([
+  '!./components/component-1',
+  '!././components/component-1/',
+  '!components/./component-1',
+  '!./components//component-1',
+  '!components/missing/../component-1',
+].flatMap((pattern) => ['components/*', './components/**'].map((include) => ({ include, pattern }))))('normalizes $pattern with $include', async ({ include, pattern }) => {
+  const projects = await findPackages(root, { patterns: [include, pattern], includeRoot: true })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-2', 'many-pkgs-2'])
+})
+
+test.each([
+  './../many-pkgs-2/components/*',
+  '././../many-pkgs-2/components/*',
+  '../many-pkgs-2/components/missing/../*',
+])('normalizes parent-relative pattern %s', async (pattern) => {
+  const projects = await findPackages(root, {
+    patterns: [pattern, '!./../many-pkgs-2/components/./component-1'],
+    includeRoot: true,
+  })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-2', 'many-pkgs-2'])
+})
+
+test('deduplicates normalized patterns and preserves the workspace root', async () => {
+  const projects = await findPackages(root, {
+    patterns: ['././', 'components/../', 'components/component-1', './components/./component-1'],
+    includeRoot: true,
+  })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-1', 'many-pkgs-2'])
+})

--- a/pnpm11/workspace/projects-reader/test/normalizePatterns.ts
+++ b/pnpm11/workspace/projects-reader/test/normalizePatterns.ts
@@ -61,3 +61,12 @@ test('deduplicates normalized patterns and preserves the workspace root', async 
   })
   expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-1', 'many-pkgs-2'])
 })
+
+test.each([
+  '!.',
+  '!./',
+  '!components/..',
+])('drops negation %s that normalizes to the workspace root', async (pattern) => {
+  const projects = await findPackages(root, { patterns: ['components/*', pattern], includeRoot: true })
+  expect(projects.map(({ manifest }) => manifest.name).sort()).toStrictEqual(['component-1', 'component-2', 'many-pkgs-2'])
+})


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Normalize workspace package directory patterns before discovering projects. Leading and internal `.` segments, `..` segments, and repeated slashes now work in both inclusion and exclusion rules, matching pnpm11's lexical path handling.

Fixes pnpm/pnpm#14571.

Validation:
- `just ready`: 10,077 Rust tests passed, 5 skipped; workspace check, Clippy, formatting, and spelling passed. Incremental compilation and debug symbols were disabled to fit the available disk space.
- The projects-reader Jest suites: 35 tests passed.
- `pnpm run compile-only` and `pnpm run lint --quiet` passed using pnpm 12 command aliases.
- `cargo doc --no-deps --workspace --all-features --document-private-items` passed with warnings denied.
- The POSIX helper matched Node.js `path.posix.normalize()` for 32,208 generated paths.

## Squash Commit Body

```text
Workspace discovery passed directory patterns to wax without the POSIX path
normalization that pnpm11 receives from tinyglobby. This could omit projects
from installs and recursive commands, or include projects a negation excluded.

Add a POSIX normalization entry point to pnpm-fs, sharing the existing dot and
parent-component reduction with native-path normalization. POSIX separators
are interpreted consistently on every platform, preserving glob backslashes.
Normalize each configured pattern before selecting the existing literal,
one-level wildcard, or generic glob discovery path. Preserve the original
pattern in invalid-glob diagnostics.

The TypeScript implementation already normalizes these paths through
tinyglobby. Add matching TypeScript regression coverage alongside Rust
filesystem/discovery tests and a CLI install/list/recursive-script test.

Fixes pnpm/pnpm#14571.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] The change is implemented in both the TypeScript CLI and the Rust
  `pnpm/` port, or the description notes what still needs porting.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791191472&installation_model_id=426870&pr_number=14582&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14582&signature=c569f5bdb8cd040e1c556f711ce81182c5b6788ad543fd745dd736dd970090cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace package patterns now correctly resolve `.`, `..`, repeated slashes, and trailing separators.
  * Relative, parent-relative, glob, and negated patterns consistently include or exclude the intended packages.
  * Pattern handling is consistent across recursive installs, package listings, and script execution.
  * Invalid patterns continue to report the original user-provided pattern.

* **Tests**
  * Added coverage for normalized workspace patterns across package discovery and recursive commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->