### PR TITLE
fix(patching): accept CRLF patch files

### DIFF
--- a/.changeset/quiet-patches-crlf.md
+++ b/.changeset/quiet-patches-crlf.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now applies patch files with CRLF line endings [pnpm/pnpm#14557](https://github.com/pnpm/pnpm/issues/14557).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,9 +1643,9 @@ checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "diffy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
+checksum = "3e3dc2f773b6aaa63b1a7684b8589f670a8a0146a510b74d23a401c882364b49"
 dependencies = [
  "hashbrown 0.17.0",
 ]

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -91,6 +91,27 @@ fn applies_modify_against_existing_file() {
 }
 
 #[test]
+fn applies_patch_with_crlf_line_endings() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("file.txt");
+    fs::write(&target, "one\ntwo\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let hunk = text_block_fnl! {
+        "@@ -1,2 +1,3 @@"
+        " one"
+        "+added"
+        " two"
+    };
+    let crlf_patch = format!("{FILE_TXT_PATCH_HEADER}{hunk}").replace('\n', "\r\n");
+    let patch = write_patch(patch_dir.path(), &crlf_patch);
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    let after = fs::read_to_string(target).unwrap();
+    assert_eq!(after, "one\nadded\r\ntwo\n");
+}
+
+#[test]
 fn applies_an_insertion_with_context_on_both_sides() {
     let original = text_block_fnl! {
         "one"


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14557 by updating `diffy` to 0.5.2, which accepts CRLF line endings in patch files. Adds a regression test covering a CRLF-encoded patch applied to an LF target file.

## Squash Commit Body

```text
Update `diffy` to 0.5.2 so pnpm v12 can parse patch file headers with CRLF line endings. Add a regression test that applies a CRLF-encoded patch to an LF target file.

Fixes pnpm/pnpm#14557.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14584"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791194383&installation_model_id=426870&pr_number=14584&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14584&signature=5e9b7b7757a89f06f645a4f2f58a2be2b1afe572ec7dfd8ad5cb82ae59b2495c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` now correctly applies patch files that use CRLF line endings, including when modifying files with LF line endings.

* **Documentation**
  * Added a patch release note documenting support for CRLF-terminated patch files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->