### PR TITLE
fix(tarball): retain permits until extraction completes

### DIFF
--- a/.changeset/extraction-permit-lifetime.md
+++ b/.changeset/extraction-permit-lifetime.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Keep archive extraction within its concurrency limits when an install is cancelled while extraction is still running.

--- a/.changeset/extraction-permit-lifetime.md
+++ b/.changeset/extraction-permit-lifetime.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Keep archive extraction within its concurrency limits when an install is cancelled while extraction is still running.
+pnpm now keeps archive extraction within its concurrency limit when an install abandons a download whose extraction is still running. The extraction slot was released as soon as the install stopped waiting for it, letting the next extraction start too early [#14585](https://github.com/pnpm/pnpm/issues/14585).

--- a/pnpm/crates/tarball/src/download.rs
+++ b/pnpm/crates/tarball/src/download.rs
@@ -11,6 +11,7 @@ use super::{
     local_file_tarball_path, non_gzip_body_error, open_local_tarball, post_download_semaphore,
     read_local_tarball_buffer, stream_extract_gzipped_channel, streaming_extract_semaphore,
 };
+use crate::extraction_task::spawn_extraction;
 use futures_util::{Stream, StreamExt};
 use pnpm_network::{
     AuthHeaders, MAX_THROUGHPUT_PRIORITY, RetryOpts, ThrottledClient, redact_url_for_display,
@@ -24,6 +25,7 @@ use pnpm_store_dir::{
     StoreIndexWriter, store_index_key,
 };
 use ssri::{Algorithm, Integrity, IntegrityChecker, IntegrityOpts};
+use tokio::sync::SemaphorePermit;
 
 /// Controls how archive files are projected into pnpm's content-addressable store.
 ///
@@ -370,7 +372,7 @@ pub(crate) async fn extract_tarball_buffer(
     store_dir: &'static StoreDir,
     ignore_file_pattern: Option<Arc<IgnoreEntryFilter>>,
 ) -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
-    let _post_download_permit = post_download_semaphore()
+    let post_download_permit = post_download_semaphore()
         .acquire()
         .await
         .expect("post-download semaphore shouldn't be closed this soon");
@@ -379,7 +381,8 @@ pub(crate) async fn extract_tarball_buffer(
 
     let expected_integrity = expected_integrity.cloned();
     let package_url_owned = package_url.to_string();
-    let result = tokio::task::spawn_blocking(
+    let result = spawn_extraction(
+        post_download_permit,
         move || -> Result<(Integrity, HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
             let integrity = verify_tarball_integrity(
                 &buffer,
@@ -495,6 +498,7 @@ async fn extract_body_while_downloading<Reporter, Body, Guard>(
     mut hasher: BodyHasher,
     progress: &mut BodyProgress<'_>,
     network_permit: Guard,
+    streaming_permit: SemaphorePermit<'static>,
     http_client: &ThrottledClient,
     package_url: &str,
     store_dir: &'static StoreDir,
@@ -508,7 +512,7 @@ where
 
     let (chunk_tx, chunk_rx) = body_chunk_channel();
     let extractor_ignore = ignore_file_pattern.clone();
-    let extract_task = tokio::task::spawn_blocking(move || {
+    let extract_task = spawn_extraction(streaming_permit, move || {
         stream_extract_gzipped_channel(chunk_rx, store_dir, extractor_ignore.as_deref())
     });
     // The body is hashed to its end no matter what the extractor does
@@ -753,7 +757,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
     if is_gzip
         && attempt == 0
         && expected_size.is_some_and(|size| size >= STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD)
-        && let Ok(_streaming_permit) = streaming_extract_semaphore().try_acquire()
+        && let Ok(streaming_permit) = streaming_extract_semaphore().try_acquire()
     {
         for chunk in &prefix {
             progress.on_chunk::<Reporter>(chunk.len());
@@ -764,6 +768,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
             BodyHasher::new(expected_integrity),
             &mut progress,
             client,
+            streaming_permit,
             http_client,
             package_url,
             store_dir,
@@ -805,7 +810,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
                 // The buffer's capacity has doubled past what arrived;
                 // hand the extractor the bytes, not the headroom.
                 buf.shrink_to_fit();
-                let _streaming_permit = streaming_extract_semaphore()
+                let streaming_permit = streaming_extract_semaphore()
                     .acquire()
                     .await
                     .expect("streaming-extract semaphore shouldn't be closed this soon");
@@ -815,6 +820,7 @@ pub(crate) async fn fetch_and_extract_once<Reporter: self::Reporter>(
                     BodyHasher::new(expected_integrity),
                     &mut progress,
                     client,
+                    streaming_permit,
                     http_client,
                     package_url,
                     store_dir,

--- a/pnpm/crates/tarball/src/extraction_task.rs
+++ b/pnpm/crates/tarball/src/extraction_task.rs
@@ -1,0 +1,16 @@
+use tokio::{sync::SemaphorePermit, task::JoinHandle};
+
+/// Keep extraction capacity occupied until the blocking task exits, even if its
+/// caller stops awaiting it.
+pub(crate) fn spawn_extraction<Output: Send + 'static>(
+    permit: SemaphorePermit<'static>,
+    extract: impl FnOnce() -> Output + Send + 'static,
+) -> JoinHandle<Output> {
+    tokio::task::spawn_blocking(move || {
+        let _permit = permit;
+        extract()
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/tarball/src/extraction_task/tests.rs
+++ b/pnpm/crates/tarball/src/extraction_task/tests.rs
@@ -1,0 +1,83 @@
+use super::spawn_extraction;
+use pretty_assertions::assert_eq;
+use std::sync::mpsc;
+use tokio::{
+    runtime::Builder,
+    sync::{Semaphore, oneshot},
+};
+
+#[tokio::test]
+async fn cancelled_waiter_keeps_capacity_until_running_extraction_exits() {
+    let semaphore = Box::leak(Box::new(Semaphore::new(1)));
+    let permit = semaphore.acquire().await.unwrap();
+    let (started_tx, started_rx) = oneshot::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let (finished_tx, finished_rx) = oneshot::channel();
+    let extraction = spawn_extraction(permit, move || {
+        started_tx.send(()).unwrap();
+        let _ = release_rx.recv();
+        let _ = finished_tx.send(());
+    });
+    let waiter = tokio::spawn(extraction);
+    started_rx.await.unwrap();
+
+    waiter.abort();
+    let error = waiter.await.unwrap_err();
+    let available_while_running = semaphore.available_permits();
+    release_tx.send(()).unwrap();
+    finished_rx.await.unwrap();
+    let _returned_permit = semaphore.acquire().await.unwrap();
+
+    assert!(error.is_cancelled(), "waiter result: {error:?}");
+    assert_eq!(available_while_running, 0);
+}
+
+#[test]
+fn cancelled_waiter_keeps_capacity_for_queued_extraction() {
+    let runtime = Builder::new_current_thread().max_blocking_threads(1).build().unwrap();
+    runtime.block_on(async {
+        let semaphore = Box::leak(Box::new(Semaphore::new(1)));
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let blocker = tokio::task::spawn_blocking(move || {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.recv();
+        });
+        started_rx.await.unwrap();
+
+        let permit = semaphore.acquire().await.unwrap();
+        let (finished_tx, finished_rx) = oneshot::channel();
+        let extraction = spawn_extraction(permit, move || finished_tx.send(42).unwrap());
+        let waiter = tokio::spawn(extraction);
+        waiter.abort();
+        let error = waiter.await.unwrap_err();
+        let available_while_queued = semaphore.available_permits();
+        release_tx.send(()).unwrap();
+        blocker.await.unwrap();
+        assert_eq!(finished_rx.await.unwrap(), 42);
+        let _returned_permit = semaphore.acquire().await.unwrap();
+
+        assert!(error.is_cancelled(), "waiter result: {error:?}");
+        assert_eq!(available_while_queued, 0);
+    });
+}
+
+#[tokio::test]
+async fn extraction_returns_result_and_releases_capacity_on_error() {
+    let semaphore = Box::leak(Box::new(Semaphore::new(1)));
+    let permit = semaphore.acquire().await.unwrap();
+    let result = spawn_extraction(permit, || Err::<(), _>("invalid archive")).await.unwrap();
+
+    assert_eq!(result, Err("invalid archive"));
+    assert_eq!(semaphore.available_permits(), 1);
+}
+
+#[tokio::test]
+async fn extraction_releases_capacity_on_panic() {
+    let semaphore = Box::leak(Box::new(Semaphore::new(1)));
+    let permit = semaphore.acquire().await.unwrap();
+    let error = spawn_extraction(permit, || panic!("extraction failed")).await.unwrap_err();
+
+    assert!(error.is_panic(), "extraction result: {error:?}");
+    assert_eq!(semaphore.available_permits(), 1);
+}

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -3,6 +3,7 @@ mod archive_retry;
 mod download;
 mod error;
 mod extract;
+mod extraction_task;
 mod ingestion;
 mod local_tarball;
 mod prefetch;

--- a/pnpm/crates/tarball/src/local_tarball.rs
+++ b/pnpm/crates/tarball/src/local_tarball.rs
@@ -202,11 +202,11 @@ pub async fn read_local_tarball_metadata(
     let (file, size) = open_local_tarball(path).await?;
     let buffer = read_local_tarball_buffer(file, path, &package_url, size).await?;
 
-    let _post_download_permit = post_download_semaphore()
+    let post_download_permit = post_download_semaphore()
         .acquire()
         .await
         .expect("post-download semaphore shouldn't be closed this soon");
-    tokio::task::spawn_blocking(move || {
+    crate::extraction_task::spawn_extraction(post_download_permit, move || {
         let integrity = verify_tarball_integrity(&buffer, None, package_url)?;
         let (manifest, has_manifest_entry) =
             read_bundled_manifest_from_archive(&buffer, &tarball_path)?;

--- a/pnpm/crates/tarball/src/local_tarball.rs
+++ b/pnpm/crates/tarball/src/local_tarball.rs
@@ -9,6 +9,7 @@ use super::{
     normalize_bundled_manifest, oversized_manifest_error, post_download_semaphore,
     tar_entry_payload, verify_tarball_integrity,
 };
+use crate::extraction_task::spawn_extraction;
 use pnpm_package_manifest::parse_manifest_bytes;
 use ssri::Integrity;
 use tar::Archive;
@@ -206,7 +207,7 @@ pub async fn read_local_tarball_metadata(
         .acquire()
         .await
         .expect("post-download semaphore shouldn't be closed this soon");
-    crate::extraction_task::spawn_extraction(post_download_permit, move || {
+    spawn_extraction(post_download_permit, move || {
         let integrity = verify_tarball_integrity(&buffer, None, package_url)?;
         let (manifest, has_manifest_entry) =
             read_bundled_manifest_from_archive(&buffer, &tarball_path)?;

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -305,7 +305,7 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
     };
     drop(client);
 
-    let _post_download_permit = post_download_semaphore()
+    let post_download_permit = post_download_semaphore()
         .acquire()
         .await
         .expect("post-download semaphore shouldn't be closed this soon");
@@ -315,7 +315,8 @@ pub(crate) async fn fetch_and_extract_zip_once<Reporter: self::Reporter>(
     let package_integrity = package_integrity.clone();
     let package_url_owned = package_url.to_string();
     let archive_prefix_owned: Option<String> = archive_prefix.map(str::to_string);
-    let result = tokio::task::spawn_blocking(
+    let result = crate::extraction_task::spawn_extraction(
+        post_download_permit,
         move || -> Result<(HashMap<String, PathBuf>, PackageFilesIndex), TarballError> {
             crate::download::verify_tarball_integrity(
                 &buffer,

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -252,8 +252,9 @@ pub(crate) fn write_zip_entry_to_cas(
 /// extract every file entry into the CAFS. Mirrors
 /// [`crate::download::fetch_and_extract_once`] one-for-one (same network permit
 /// shape, same post-download semaphore gate, same retry-friendly
-/// errors) — only the `spawn_blocking` body differs: integrity check
-/// then [`extract_zip_entries`] instead of the gzip + tar path.
+/// errors) — only the [`crate::extraction_task::spawn_extraction`] body
+/// differs: integrity check then [`extract_zip_entries`] instead of the
+/// gzip + tar path.
 ///
 /// Writes directly into the CAS via [`StoreDir::write_cas_file`]
 /// rather than extracting to a temp dir and importing each file.

--- a/pnpm/crates/tarball/src/zip_archive.rs
+++ b/pnpm/crates/tarball/src/zip_archive.rs
@@ -249,12 +249,12 @@ pub(crate) fn write_zip_entry_to_cas(
 
 /// Run one full zip-archive fetch attempt: hit the network, drain the
 /// body into RAM, verify the integrity hash, then walk the zip and
-/// extract every file entry into the CAFS. Mirrors
-/// [`crate::download::fetch_and_extract_once`] one-for-one (same network permit
-/// shape, same post-download semaphore gate, same retry-friendly
-/// errors) — only the [`crate::extraction_task::spawn_extraction`] body
-/// differs: integrity check then [`extract_zip_entries`] instead of the
-/// gzip + tar path.
+/// extract every file entry into the CAFS.
+///
+/// Keep this in step with [`crate::download::fetch_and_extract_once`]:
+/// the two share a network permit shape, a post-download semaphore
+/// gate, and a retry classification, and a change to one that is not
+/// mirrored in the other silently splits the two archive formats.
 ///
 /// Writes directly into the CAS via [`StoreDir::write_cas_file`]
 /// rather than extracting to a temp dir and importing each file.


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Cancelling an install future can release an extraction permit while its blocking job is still running. This admits more archive work than the extraction limit allows. Transfer the permits into the blocking jobs for buffered tarballs, both streaming admission paths, ZIP archives, and local tarball metadata reads.

Closes https://github.com/pnpm/pnpm/issues/14585.

A private spawning helper requires each extraction job to take its permit. The semaphore pools, admission timing, network-permit lifetime, retries, and archive checks stay the same. This is a Rust v12 task-lifetime fix. The v11 worker pool returns workers from their completion-message handler and does not have this cancellation behavior.

Validation:

- All 134 `pnpm-tarball` tests pass, including four new lifecycle tests.
- Both running and queued cancellation tests fail when permit retention is deliberately removed; the fix was then restored with `git restore` and the full crate suite passed.
- Push-hook TypeScript build/lint, Rust format, Clippy, rustdoc, custom Dylint rules, spelling, and TOML format checks passed.
- `just ready` passed: workspace check, 10,092 tests, formatting, spelling, and Clippy. Five tests were skipped by the suite configuration.
- The full run reported two non-fatal Nextest output-pipe warnings. The affected pnpm CLI test passed without the warning on a separate run; the other warning was in an unchanged pnpr test.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Transfer extraction semaphore permits into the blocking tasks they protect.
Dropping an async caller does not stop a running blocking task, so the caller
must not release its slot while that task still uses CPU or performs I/O.

Use one private spawn boundary for buffered tar, streaming tar, ZIP, and local
metadata extraction. Preserve the existing admission pools and network guards.
Test cancelled waiters for running and queued tasks, plus error and panic cleanup.

Closes https://github.com/pnpm/pnpm/issues/14585.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14587"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791196313&installation_model_id=426870&pr_number=14587&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14587&signature=cd6481c8b85357573c48c313c6a456417b6db83893499c1295c6cab22acb2ee2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Archive extraction now respects concurrency limits when an installation is cancelled during extraction.
  - Extraction capacity remains reserved until active work finishes, preventing cancelled operations from starting too many concurrent extractions.
  - Errors and panics during extraction continue to be reported while correctly releasing capacity afterward.
  - Archive downloads and extraction now maintain consistent progress reporting and retry behavior across supported archive types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->