### PR TITLE
fix(package-manager): respect separate lockfiles before run

### DIFF
--- a/.changeset/verify-deps-separate-lockfiles.md
+++ b/.changeset/verify-deps-separate-lockfiles.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm run` now respects separate workspace lockfiles when checking dependency state [#14588](https://github.com/pnpm/pnpm/issues/14588).

--- a/.changeset/verify-deps-separate-lockfiles.md
+++ b/.changeset/verify-deps-separate-lockfiles.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The `verifyDepsBeforeRun` check no longer reports a changed workspace structure after a successful install when `sharedWorkspaceLockfile` is false. `pnpm run` and `pnpm exec` now check the project they run in, which is the project the install recorded [#14588](https://github.com/pnpm/pnpm/issues/14588).
+`pnpm run` and `pnpm exec` now check the project they run in when `sharedWorkspaceLockfile` is false, which is the project the install recorded. `verifyDepsBeforeRun` reported a changed workspace structure on every run in such a workspace, even directly after a successful install [#14588](https://github.com/pnpm/pnpm/issues/14588).

--- a/.changeset/verify-deps-separate-lockfiles.md
+++ b/.changeset/verify-deps-separate-lockfiles.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run` and `pnpm exec` now check the project they run in when `sharedWorkspaceLockfile` is false, which is the project the install recorded. `verifyDepsBeforeRun` reported a changed workspace structure on every run in such a workspace, even directly after a successful install [#14588](https://github.com/pnpm/pnpm/issues/14588).
+`pnpm run` and `pnpm exec` now check only the project they run in when `sharedWorkspaceLockfile` is false. `verifyDepsBeforeRun` reported a changed workspace structure on every run in such a workspace, even directly after a successful install [#14588](https://github.com/pnpm/pnpm/issues/14588).

--- a/.changeset/verify-deps-separate-lockfiles.md
+++ b/.changeset/verify-deps-separate-lockfiles.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run` now respects separate workspace lockfiles when checking dependency state [#14588](https://github.com/pnpm/pnpm/issues/14588).
+The `verifyDepsBeforeRun` check no longer reports a changed workspace structure after a successful install when `sharedWorkspaceLockfile` is false. `pnpm run` and `pnpm exec` now check the project they run in, which is the project the install recorded [#14588](https://github.com/pnpm/pnpm/issues/14588).

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -275,6 +275,35 @@ fn error_action_follows_the_dependency_state() {
     drop(root);
 }
 
+/// Dedicated workspace lockfiles record one project in each workspace
+/// state file. The pre-run check must validate the project being run,
+/// rather than comparing that state to every workspace package.
+#[cfg(unix)]
+#[test]
+fn separate_lockfiles_check_only_the_active_workspace_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let root_marker = workspace.join("root-marker.txt");
+    write_manifest(&workspace, &root_marker);
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "verifyDepsBeforeRun: error\nsharedWorkspaceLockfile: false\npackages:\n  - packages/*\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+
+    let project = workspace.join("packages/project");
+    fs::create_dir_all(&project).expect("create workspace project");
+    let project_marker = project.join("project-marker.txt");
+    write_manifest(&project, &project_marker);
+
+    pacquet.with_arg("install").assert().success();
+    pacquet_in(&workspace).with_args(["run", "hello"]).assert().success();
+    pacquet_in(&project).with_args(["run", "hello"]).assert().success();
+    assert!(root_marker.exists(), "the root script must run");
+    assert!(project_marker.exists(), "the workspace script must run");
+
+    drop(root);
+}
+
 /// `warn` reports the drift but still runs the script.
 #[cfg(unix)]
 #[test]

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -301,11 +301,29 @@ fn separate_lockfiles_check_only_the_active_workspace_project() {
     assert!(root_marker.exists(), "the root script must run");
     assert!(project_marker.exists(), "the workspace script must run");
 
+    // The check is scoped to the active project, not skipped: a
+    // dependency the project's own lockfile does not carry still fails.
+    write_manifest_with_dependency_groups(
+        &project,
+        &project_marker,
+        json!({ "dependencies": { "@pnpm.e2e/foo": "100.0.0" } }),
+    );
+    bump_mtime(&project.join("package.json"));
+    let output =
+        pacquet_in(&project).with_args(["run", "hello"]).output().expect("spawn pacquet run");
+    assert!(!output.status.success(), "an out-of-sync project must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_VERIFY_DEPS_BEFORE_RUN"),
+        "expected the verify-deps error:\n{stderr}",
+    );
+
     drop(root);
 }
 
-/// A workspace root only needs `pnpm-workspace.yaml`; a package manifest is
-/// required by the nested project that owns its dedicated lockfile and state.
+/// A workspace root needs no package manifest of its own. With dedicated
+/// lockfiles the gate reads the manifest of the nested project that owns
+/// the lockfile and the state.
 #[cfg(unix)]
 #[test]
 fn separate_lockfiles_allow_a_nested_project_without_a_root_manifest() {
@@ -324,6 +342,37 @@ fn separate_lockfiles_allow_a_nested_project_without_a_root_manifest() {
     pacquet_in(&project).with_arg("install").assert().success();
     pacquet_in(&project).with_args(["run", "hello"]).assert().success();
     assert!(marker.exists(), "the nested workspace script must run");
+
+    drop(root);
+}
+
+/// One shared lockfile covers every project, so a command run from a
+/// directory that has no manifest of its own is still checked against
+/// the workspace root's state.
+#[cfg(unix)]
+#[test]
+fn a_shared_lockfile_is_checked_from_a_directory_without_a_manifest() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(&workspace, &workspace.join("marker.txt"));
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "verifyDepsBeforeRun: error\npackages:\n  - packages/*\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+    let tools = workspace.join("tools");
+    fs::create_dir_all(&tools).expect("create the directory without a manifest");
+
+    let output =
+        pacquet_in(&tools).with_args(["exec", "true"]).output().expect("spawn pacquet exec");
+    assert!(!output.status.success(), "exec before any install must fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_VERIFY_DEPS_BEFORE_RUN"),
+        "expected the verify-deps error:\n{stderr}",
+    );
+
+    pacquet.with_arg("install").assert().success();
+    pacquet_in(&tools).with_args(["exec", "true"]).assert().success();
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
+++ b/pnpm/crates/cli/tests/suite/verify_deps_before_run.rs
@@ -304,6 +304,30 @@ fn separate_lockfiles_check_only_the_active_workspace_project() {
     drop(root);
 }
 
+/// A workspace root only needs `pnpm-workspace.yaml`; a package manifest is
+/// required by the nested project that owns its dedicated lockfile and state.
+#[cfg(unix)]
+#[test]
+fn separate_lockfiles_allow_a_nested_project_without_a_root_manifest() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        "verifyDepsBeforeRun: error\nsharedWorkspaceLockfile: false\npackages:\n  - packages/*\n",
+    )
+    .expect("write pnpm-workspace.yaml");
+
+    let project = workspace.join("packages/project");
+    fs::create_dir_all(&project).expect("create workspace project");
+    let marker = project.join("project-marker.txt");
+    write_manifest(&project, &marker);
+
+    pacquet_in(&project).with_arg("install").assert().success();
+    pacquet_in(&project).with_args(["run", "hello"]).assert().success();
+    assert!(marker.exists(), "the nested workspace script must run");
+
+    drop(root);
+}
+
 /// `warn` reports the drift but still runs the script.
 #[cfg(unix)]
 #[test]

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -165,6 +165,16 @@ pub fn check_deps_status_before_run_at(
         return cannot_check();
     };
     let workspace_root = workspace_dir_opt.clone().unwrap_or_else(|| dir.to_path_buf());
+    let manifest = match pnpm_workspace::read_project_manifest_only(dir) {
+        Ok(manifest) => manifest,
+        Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound { .. }) => {
+            return None;
+        }
+        Err(_) => return cannot_check(),
+    };
+    let Some(manifest_dir) = manifest.path().parent() else {
+        return cannot_check();
+    };
     let root_manifest = match pnpm_workspace::read_project_manifest_only(&workspace_root) {
         Ok(manifest) => manifest,
         Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
@@ -182,8 +192,9 @@ pub fn check_deps_status_before_run_at(
         None => None,
     };
     // A pinned `lockfileDir` is where the install left the state and the
-    // lockfile; the root manifest above stays where the workspace put it.
-    let lockfile_root = config.lockfile_dir.clone().unwrap_or_else(|| workspace_root.clone());
+    // lockfile. With dedicated workspace lockfiles it is the active
+    // project's directory, just as it is during install.
+    let lockfile_root = lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
     // pnpm reports "cannot check" straight from the missing workspace
     // state, before any project discovery — a fresh project (the common
     // out-of-sync case) must not pay for the workspace-projects walk
@@ -199,13 +210,20 @@ pub fn check_deps_status_before_run_at(
             Err(_) => return cannot_check(),
         },
     };
-    let Ok(workspace_projects) =
-        load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
-    else {
-        return cannot_check();
+    let workspace_projects = if config.shares_one_lockfile() {
+        let Ok(projects) = load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
+        else {
+            return cannot_check();
+        };
+        projects
+    } else {
+        None
     };
-    let project_manifests =
-        build_project_manifests_list(&root_manifest, workspace_projects.as_deref());
+    let project_manifests = if config.shares_one_lockfile() {
+        build_project_manifests_list(&root_manifest, workspace_projects.as_deref())
+    } else {
+        vec![(lockfile_root.clone(), &manifest)]
+    };
     let lockfile = if config.lockfile {
         LazyLockfile::deferred(lockfile_root.clone(), config.wanted_lockfile_selection())
     } else {

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -175,15 +175,6 @@ pub fn check_deps_status_before_run_at(
     let Some(manifest_dir) = manifest.path().parent() else {
         return cannot_check();
     };
-    let root_manifest = match pnpm_workspace::read_project_manifest_only(&workspace_root) {
-        Ok(manifest) => manifest,
-        Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
-            if workspace_dir_opt.is_none() =>
-        {
-            return None;
-        }
-        Err(_) => return cannot_check(),
-    };
     let workspace_manifest = match workspace_dir_opt.as_deref() {
         Some(dir) => match pnpm_workspace::read_workspace_manifest(dir) {
             Ok(manifest) => manifest,
@@ -219,8 +210,24 @@ pub fn check_deps_status_before_run_at(
     } else {
         None
     };
+    let root_manifest = if config.shares_one_lockfile() {
+        Some(match pnpm_workspace::read_project_manifest_only(&workspace_root) {
+            Ok(manifest) => manifest,
+            Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound {
+                ..
+            }) if workspace_dir_opt.is_none() => {
+                return None;
+            }
+            Err(_) => return cannot_check(),
+        })
+    } else {
+        None
+    };
     let project_manifests = if config.shares_one_lockfile() {
-        build_project_manifests_list(&root_manifest, workspace_projects.as_deref())
+        let Some(root_manifest) = root_manifest.as_ref() else {
+            return cannot_check();
+        };
+        build_project_manifests_list(root_manifest, workspace_projects.as_deref())
     } else {
         vec![(lockfile_root.clone(), &manifest)]
     };

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -139,12 +139,14 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
 /// [`OptimisticRepeatInstallCheck`] inputs from a bare directory and run
 /// [`crate::check_deps_status_before_run`].
 ///
-/// Returns `None` when `dir` has no manifest and no enclosing workspace:
-/// the run/exec command is about to fail with its own missing-manifest
-/// error, and reporting "outdated" would only trigger an install that
-/// can do nothing but crash with `NO_PKG_MANIFEST` (the same guard
-/// pnpm's `checkDepsStatus` applies when it finds neither a root
-/// manifest nor a workspace).
+/// Returns `None` when there is no manifest to check against. Outside a
+/// workspace the run/exec command is about to fail with its own
+/// missing-manifest error, and reporting "outdated" would only trigger
+/// an install that can do nothing but crash with `NO_PKG_MANIFEST` (the
+/// same guard pnpm's `checkDepsStatus` applies when it finds neither a
+/// root manifest nor a workspace). Under dedicated per-project
+/// lockfiles a directory with no manifest of its own owns no lockfile
+/// and no state either.
 ///
 /// Any other discovery failure conservatively reports the dependencies
 /// as unverifiable ("Cannot check whether dependencies are outdated"),
@@ -165,15 +167,21 @@ pub fn check_deps_status_before_run_at(
         return cannot_check();
     };
     let workspace_root = workspace_dir_opt.clone().unwrap_or_else(|| dir.to_path_buf());
-    let manifest = match pnpm_workspace::read_project_manifest_only(dir) {
+    // One shared lockfile is written at the workspace root, whose
+    // manifest heads the importer list the install recorded. Dedicated
+    // per-project lockfiles give every project its own lockfile, state
+    // and single-importer list, so the gate reads the manifest of the
+    // project the command runs in.
+    let shares_one_lockfile = config.shares_one_lockfile();
+    let manifest_dir = if shares_one_lockfile { workspace_root.as_path() } else { dir };
+    let manifest = match pnpm_workspace::read_project_manifest_only(manifest_dir) {
         Ok(manifest) => manifest,
-        Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound { .. }) => {
+        Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
+            if workspace_dir_opt.is_none() || !shares_one_lockfile =>
+        {
             return None;
         }
         Err(_) => return cannot_check(),
-    };
-    let Some(manifest_dir) = manifest.path().parent() else {
-        return cannot_check();
     };
     let workspace_manifest = match workspace_dir_opt.as_deref() {
         Some(dir) => match pnpm_workspace::read_workspace_manifest(dir) {
@@ -183,8 +191,8 @@ pub fn check_deps_status_before_run_at(
         None => None,
     };
     // A pinned `lockfileDir` is where the install left the state and the
-    // lockfile. With dedicated workspace lockfiles it is the active
-    // project's directory, just as it is during install.
+    // lockfile; otherwise it follows the manifest read above, just as it
+    // does during install.
     let lockfile_root = lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
     // pnpm reports "cannot check" straight from the missing workspace
     // state, before any project discovery — a fresh project (the common
@@ -201,36 +209,18 @@ pub fn check_deps_status_before_run_at(
             Err(_) => return cannot_check(),
         },
     };
-    let workspace_projects = if config.shares_one_lockfile() {
-        let Ok(projects) = load_workspace_projects(&workspace_root, workspace_manifest.as_ref())
-        else {
-            return cannot_check();
-        };
-        projects
-    } else {
-        None
-    };
-    let root_manifest = if config.shares_one_lockfile() {
-        Some(match pnpm_workspace::read_project_manifest_only(&workspace_root) {
-            Ok(manifest) => manifest,
-            Err(pnpm_workspace::ReadProjectManifestOnlyError::NoImporterManifestFound {
-                ..
-            }) if workspace_dir_opt.is_none() => {
-                return None;
-            }
+    // The sibling projects only belong in the comparison when one
+    // lockfile and one state file cover them all; a dedicated-lockfile
+    // install records this project alone.
+    let workspace_projects = if shares_one_lockfile {
+        match load_workspace_projects(&workspace_root, workspace_manifest.as_ref()) {
+            Ok(projects) => projects,
             Err(_) => return cannot_check(),
-        })
+        }
     } else {
         None
     };
-    let project_manifests = if config.shares_one_lockfile() {
-        let Some(root_manifest) = root_manifest.as_ref() else {
-            return cannot_check();
-        };
-        build_project_manifests_list(root_manifest, workspace_projects.as_deref())
-    } else {
-        vec![(lockfile_root.clone(), &manifest)]
-    };
+    let project_manifests = build_project_manifests_list(&manifest, workspace_projects.as_deref());
     let lockfile = if config.lockfile {
         LazyLockfile::deferred(lockfile_root.clone(), config.wanted_lockfile_selection())
     } else {


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14588.

`verifyDepsBeforeRun` now checks the state written for the active project when `sharedWorkspaceLockfile` is false. This matches installation's per-project lockfile and state boundary, so root and workspace package scripts can run after installation.

## Squash Commit Body

```text
The pre-run gate used the workspace root for the state and compared it against every workspace package. That cannot match the one-project state written with sharedWorkspaceLockfile disabled.

Resolve the active manifest first. Use its lockfile root and a one-project manifest list for separate lockfiles, while keeping full workspace validation for shared lockfiles. Add root and nested workspace regression coverage.

Fixes pnpm/pnpm#14588.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791208917&installation_model_id=426870&pr_number=14589&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14589&signature=7125147fb12e573e08eca4f6c5b8ce719dcb9824a9a94789f3baab2980a4111e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `pnpm run` and `pnpm exec` now correctly respect separate lockfiles in workspaces.
  - Dependency checks before running commands are limited to the active project when per-project lockfiles are configured.
  - Commands run from workspace roots or individual projects now validate only the relevant dependency state, including projects without a root manifest.
  - Shared lockfile workflows continue to validate workspace-wide dependency state, including appropriate pre-install checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->