### PR TITLE
fix(ci): allow pnpm v12 install scripts in tag upgrade check

### DIFF
--- a/.github/workflows/update-latest.yml
+++ b/.github/workflows/update-latest.yml
@@ -136,14 +136,10 @@ jobs:
           cd "$work"
           mkdir -p "$work/from"
           printf '{"name":"pnpm-upgrade-check","version":"0.0.0","private":true}\n' >"$work/from/package.json"
-          # `--allow-build` is what makes this install the starting point rather
-          # than a fake one: pnpm blocks dependency build scripts by default, and
-          # `@pnpm/exe`'s setup.js is what swaps its placeholder bin for the real
-          # native. Without it every run reproduces the exact breakage this gate
-          # exists to catch (the placeholder surviving) and blames the release.
+          # Both v12 wrappers need install scripts to set up their native binary.
           pn add "${package}@${FROM}" \
             --dir "$work/from" \
-            --allow-build=@pnpm/exe \
+            --allow-build="$package" \
             --registry="$REGISTRY"
           # Drive through the bin shim rather than a path into the package: the
           # entry point differs by major (pnpm.cjs in v10, pnpm.mjs in v11) and


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Fix the Tag workflow failing with `ERR_PNPM_IGNORED_BUILDS` when promoting pnpm v12. The upgrade check now allows install scripts for the wrapper being installed. Both v12 wrappers need these scripts to set up their native binary.

Addresses the [failed 12.3.4 promotion](https://github.com/pnpm/pnpm/actions/runs/33968520505).

Validation: ran the complete updated upgrade-check script locally with the workflow's pinned pnpm 11.13.1 against published 12.3.4. Both `pnpm` and `@pnpm/exe` passed installation, self-update, version verification, and `doctor --offline`. Shell syntax, `git diff --check`, and the required pre-push build and lint checks also passed.

## Squash Commit Body

```text
The upgrade check only allowed install scripts for `@pnpm/exe`, so
installing the pnpm v12 wrapper failed before self-update could run.
Allow scripts for the package selected by the existing wrapper loop.
This preserves verification of both published wrappers and allows
pnpm v12 promotions to proceed through the upgrade gate.

Verified both published 12.3.4 wrappers using the workflow's pinned
pnpm 11.13.1, including self-update and doctor --offline.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. This fix is confined to the shared release workflow.

No published packages changed, so no changeset is needed. The existing upgrade check was exercised against both published wrappers; no new test files or documentation changes are needed.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791221012&installation_model_id=426870&pr_number=14592&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14592&signature=8671969919e5c2a7951fcb31b865cbd053dea56d5c3f7d2b28cbe09c4196eea7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved upgrade verification to allow required build steps for both supported package wrappers.
  * Updated the related workflow documentation to reflect the broader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->