### PR TITLE
test(stage): record approval order synchronously

### DIFF
--- a/pnpm/crates/cli/tests/suite/stage.rs
+++ b/pnpm/crates/cli/tests/suite/stage.rs
@@ -278,9 +278,9 @@ fn approve_downloads_every_tarball_before_approving_any_stage_with_one_otp() {
                 }));
                 server
                     .mock("GET", format!("/-/stage/{stage_id}/tarball").as_str())
-                    .with_chunked_body(move |writer| {
+                    .with_body_from_request(move |_| {
                         events.lock().expect("lock events").push(format!("tarball:{stage_id}"));
-                        writer.write_all(&tarball)
+                        tarball.clone()
                     })
                     .expect(1)
                     .create()
@@ -294,9 +294,9 @@ fn approve_downloads_every_tarball_before_approving_any_stage_with_one_otp() {
                 .mock("POST", format!("/-/stage/{stage_id}/approve").as_str())
                 .match_header("npm-otp", "123456")
                 .with_status(201)
-                .with_chunked_body(move |writer| {
+                .with_body_from_request(move |_| {
                     events.lock().expect("lock events").push(format!("approve:{stage_id}"));
-                    writer.write_all(br#"{"ok":true}"#)
+                    br#"{"ok":true}"#.to_vec()
                 })
                 .expect(1)
                 .create()
@@ -442,9 +442,9 @@ fn approve_derives_package_identity_and_aliases_from_tarballs() {
             server
                 .mock("POST", format!("/-/stage/{stage_id}/approve").as_str())
                 .with_status(201)
-                .with_chunked_body(move |writer| {
+                .with_body_from_request(move |_| {
                     approved.lock().expect("lock approvals").push(stage_id);
-                    writer.write_all(br#"{"ok":true}"#)
+                    br#"{"ok":true}"#.to_vec()
                 })
                 .expect(1)
                 .create()
@@ -512,9 +512,9 @@ fn approve_does_not_bind_an_npm_alias_tag_to_a_selected_version() {
             server
                 .mock("POST", format!("/-/stage/{stage_id}/approve").as_str())
                 .with_status(201)
-                .with_chunked_body(move |writer| {
+                .with_body_from_request(move |_| {
                     approved.lock().expect("lock approvals").push(stage_id);
-                    writer.write_all(br#"{"ok":true}"#)
+                    br#"{"ok":true}"#.to_vec()
                 })
                 .expect(1)
                 .create()


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Remove a scheduling race from three staging CLI tests by recording mock events before response headers are sent. Keep the strict assertions for tarball preflight, dependency order, and selection order.

The chunked response callbacks used separate worker threads, so the recorded event order could differ from request order. This is a test-only correction, not a change to production approval sorting. No changeset is needed.

Related to pnpm/pnpm#14586, where the intermittent assertion was discovered during local validation.

Validation:
- `just ready`: 10,145 tests passed, 5 skipped.
- Three affected tests repeated 100 times each: all 300 executions passed.
- Deliberately reversing production approval order made all three tests fail at their ordering assertions. That temporary mutation was removed before the full validation.
- All pre-push checks passed.

## Squash Commit Body

```text
Record mocked staging events before response headers are sent.

Mockito's chunked response callbacks run on separate worker threads.
The CLI accepts successful mutation responses without consuming their bodies,
so body-callback scheduling is not a reliable record of approval request order.

Use request-based response callbacks for deterministic event recording.
Preserve the strict preflight, dependency-order and selection-order assertions.
No production behavior or release notes change.

Related to pnpm/pnpm#14586.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. This change only affects Rust test fixtures.
- [x] Added or updated tests.
- [x] No changeset is required because no published behavior changes.
- [x] No documentation update is needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14596"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791234781&installation_model_id=426870&pr_number=14596&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14596&signature=66d9ad32c7ce123ab582d945d0f70bb24ef374d396b35113e291eb8da764a163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated CLI test mocks to return request-generated response bodies directly.
  - Preserved existing approval and event-ordering assertions while improving test response handling.
  - No user-facing behavior or exported functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->