### PR TITLE
fix(audit): net the summary counts against ignored advisories

### DIFF
--- a/.changeset/audit-summary-net-of-ignored.md
+++ b/.changeset/audit-summary-net-of-ignored.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/deps.compliance.commands": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary [#14535](https://github.com/pnpm/pnpm/issues/14535). The headline total and the per-severity counts now describe the same advisories the exit code is based on, and each severity keeps its `(N ignored)` note. When every advisory is suppressed, the summary reads `No known vulnerabilities found (1 ignored)` instead of reporting a vulnerability alongside a zero exit code.

--- a/.changeset/audit-summary-net-of-ignored.md
+++ b/.changeset/audit-summary-net-of-ignored.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary [#14535](https://github.com/pnpm/pnpm/issues/14535). The headline total and the per-severity counts now describe the same advisories the exit code is based on, and each severity keeps its `(N ignored)` note. When every advisory is suppressed, the summary reads `No known vulnerabilities found (1 ignored)` instead of reporting a vulnerability alongside a zero exit code.
+`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the per-severity counts now describe the same advisories the exit code is based on, and each severity keeps its `(N ignored)` note. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code. It now reads `No known vulnerabilities found (1 ignored)` [#14535](https://github.com/pnpm/pnpm/issues/14535).

--- a/.changeset/audit-summary-net-of-ignored.md
+++ b/.changeset/audit-summary-net-of-ignored.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the `Severity:` breakdown now describe the same advisories the exit code is based on. Suppressed advisories are reported on their own line, `2 ignored: 1 moderate | 1 critical`. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code [#14535](https://github.com/pnpm/pnpm/issues/14535).
+`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the `Severity:` breakdown now count only the advisories that survive the `ignoreGhsas` filter. Suppressed advisories get their own line, `2 ignored: 1 moderate | 1 critical`. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code [#14535](https://github.com/pnpm/pnpm/issues/14535).

--- a/.changeset/audit-summary-net-of-ignored.md
+++ b/.changeset/audit-summary-net-of-ignored.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the `Severity:` breakdown now count only the advisories that survive the `ignoreGhsas` filter. Suppressed advisories get their own line, `2 ignored: 1 moderate | 1 critical`. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code [#14535](https://github.com/pnpm/pnpm/issues/14535).
+`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the `Severity:` breakdown now count only the advisories that survive the `ignoreGhsas` filter. Suppressed advisories get their own line, `2 ignored: 1 moderate | 1 critical`. A run whose advisories were all suppressed printed a red `1 vulnerabilities found` next to a zero exit code. It now reads `All found vulnerabilities were already reviewed and decided to be ignored` [#14535](https://github.com/pnpm/pnpm/issues/14535).

--- a/.changeset/audit-summary-net-of-ignored.md
+++ b/.changeset/audit-summary-net-of-ignored.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the per-severity counts now describe the same advisories the exit code is based on, and each severity keeps its `(N ignored)` note. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code. It now reads `No known vulnerabilities found (1 ignored)` [#14535](https://github.com/pnpm/pnpm/issues/14535).
+`pnpm audit` no longer counts advisories suppressed by `auditConfig` in its summary. The headline total and the `Severity:` breakdown now describe the same advisories the exit code is based on. Suppressed advisories are reported on their own line, `2 ignored: 1 moderate | 1 critical`. A run whose only advisory was suppressed printed a red `1 vulnerabilities found` next to a zero exit code [#14535](https://github.com/pnpm/pnpm/issues/14535).

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -364,13 +364,12 @@ impl AuditArgs {
             return Ok(AuditOutcome::Clean);
         }
 
-        let total_vulnerability_count = report.metadata.vulnerabilities.total();
         let ignored = filter_ignored_advisories(&mut report, state.config);
 
         let output = if self.json {
             render_json_report(&report, audit_level)?
         } else {
-            render_text_report(&report, audit_level, total_vulnerability_count, &ignored)
+            render_text_report(&report, audit_level, &ignored)
         };
         print_command_output(&output);
 

--- a/pnpm/crates/cli/src/cli_args/audit.rs
+++ b/pnpm/crates/cli/src/cli_args/audit.rs
@@ -671,16 +671,6 @@ fn filter_ignored_advisories(
     ignored
 }
 
-fn count_for_level(counts: &AuditVulnerabilityCounts, level: ConfigAuditLevel) -> usize {
-    match level {
-        ConfigAuditLevel::Info => counts.info,
-        ConfigAuditLevel::Low => counts.low,
-        ConfigAuditLevel::Moderate => counts.moderate,
-        ConfigAuditLevel::High => counts.high,
-        ConfigAuditLevel::Critical => counts.critical,
-    }
-}
-
 fn parse_audit_level(value: &str) -> Option<ConfigAuditLevel> {
     match value {
         "info" => Some(ConfigAuditLevel::Info),

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -87,8 +87,6 @@ pub(crate) fn render_advisory(advisory: &AuditAdvisory) -> String {
     format!("{table}\n")
 }
 
-/// The summary describes the same advisory set the exit code is based on, so
-/// the reported counts are net of the advisories `auditConfig` suppressed.
 pub(crate) fn report_summary(
     vulnerabilities: &AuditVulnerabilityCounts,
     ignored: &AuditVulnerabilityCounts,

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -103,7 +103,12 @@ pub(crate) fn report_summary(
     };
     let total_vulnerability_count = found.total();
     if total_vulnerability_count == 0 {
-        return format!("No known vulnerabilities found{ignored_summary}\n");
+        let headline = if total_ignored_count == 0 {
+            "No known vulnerabilities found"
+        } else {
+            "All found vulnerabilities were already reviewed and decided to be ignored"
+        };
+        return format!("{headline}{ignored_summary}\n");
     }
     format!(
         "{} vulnerabilities found\nSeverity: {}{ignored_summary}",

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -91,41 +91,33 @@ pub(crate) fn report_summary(
     vulnerabilities: &AuditVulnerabilityCounts,
     ignored: &AuditVulnerabilityCounts,
 ) -> String {
-    let severities = vulnerabilities
+    let found = vulnerabilities
         .entries()
-        .into_iter()
-        .map(|(level, count)| {
-            let ignored_count = count_for_level(ignored, level);
-            (level, count.saturating_sub(ignored_count), ignored_count)
-        })
-        .collect::<Vec<_>>();
-    let total_vulnerability_count: usize = severities.iter().map(|(_, count, _)| count).sum();
+        .map(|(level, count)| (level, count.saturating_sub(count_for_level(ignored, level))));
+    let total_ignored_count = ignored.total();
+    let ignored_summary = if total_ignored_count > 0 {
+        format!("\n{total_ignored_count} ignored: {}", list_severity_counts(&ignored.entries()))
+    } else {
+        String::new()
+    };
+    let total_vulnerability_count: usize = found.iter().map(|(_, count)| count).sum();
     if total_vulnerability_count == 0 {
-        let total_ignored_count: usize =
-            severities.iter().map(|(_, _, ignored_count)| ignored_count).sum();
-        return if total_ignored_count > 0 {
-            format!("No known vulnerabilities found ({total_ignored_count} ignored)\n")
-        } else {
-            "No known vulnerabilities found\n".to_string()
-        };
+        return format!("No known vulnerabilities found{ignored_summary}\n");
     }
-    let rendered_severities = severities
-        .into_iter()
-        .filter(|(_, count, ignored_count)| *count > 0 || *ignored_count > 0)
-        .map(|(level, count, ignored_count)| {
-            let label = if ignored_count > 0 {
-                format!("{count} {} ({ignored_count} ignored)", severity_name(level))
-            } else {
-                format!("{count} {}", severity_name(level))
-            };
-            color_severity(level, &label)
-        })
-        .collect::<Vec<_>>()
-        .join(" | ");
     format!(
-        "{} vulnerabilities found\nSeverity: {rendered_severities}",
+        "{} vulnerabilities found\nSeverity: {}{ignored_summary}",
         red(&total_vulnerability_count.to_string()),
+        list_severity_counts(&found),
     )
+}
+
+fn list_severity_counts(severities: &[(ConfigAuditLevel, usize)]) -> String {
+    severities
+        .iter()
+        .filter(|(_, count)| *count > 0)
+        .map(|(level, count)| color_severity(*level, &format!("{count} {}", severity_name(*level))))
+        .collect::<Vec<_>>()
+        .join(" | ")
 }
 
 pub(crate) fn bold(text: &str) -> String {

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -2,7 +2,7 @@
 
 use super::{
     AuditAdvisory, AuditReport, AuditVulnerabilityCounts, ConfigAuditLevel, IntoDiagnostic,
-    MAX_PATHS_COUNT, OwoColorize, Stream, count_for_level, severity_name, severity_number,
+    MAX_PATHS_COUNT, OwoColorize, Stream, severity_name, severity_number,
 };
 
 pub(crate) fn render_json_report(
@@ -36,7 +36,11 @@ pub(crate) fn render_text_report(
     for advisory in advisories {
         output.push_str(&render_advisory(advisory));
     }
-    output.push_str(&report_summary(&report.metadata.vulnerabilities, ignored));
+    let mut found = AuditVulnerabilityCounts::default();
+    for advisory in report.advisories.values() {
+        found.increment(advisory.severity);
+    }
+    output.push_str(&report_summary(&found, ignored));
     output
 }
 
@@ -88,26 +92,23 @@ pub(crate) fn render_advisory(advisory: &AuditAdvisory) -> String {
 }
 
 pub(crate) fn report_summary(
-    vulnerabilities: &AuditVulnerabilityCounts,
+    found: &AuditVulnerabilityCounts,
     ignored: &AuditVulnerabilityCounts,
 ) -> String {
-    let found = vulnerabilities
-        .entries()
-        .map(|(level, count)| (level, count.saturating_sub(count_for_level(ignored, level))));
     let total_ignored_count = ignored.total();
     let ignored_summary = if total_ignored_count > 0 {
         format!("\n{total_ignored_count} ignored: {}", list_severity_counts(&ignored.entries()))
     } else {
         String::new()
     };
-    let total_vulnerability_count: usize = found.iter().map(|(_, count)| count).sum();
+    let total_vulnerability_count = found.total();
     if total_vulnerability_count == 0 {
         return format!("No known vulnerabilities found{ignored_summary}\n");
     }
     format!(
         "{} vulnerabilities found\nSeverity: {}{ignored_summary}",
         red(&total_vulnerability_count.to_string()),
-        list_severity_counts(&found),
+        list_severity_counts(&found.entries()),
     )
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/render.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/render.rs
@@ -22,7 +22,6 @@ pub(crate) fn render_json_report(
 pub(crate) fn render_text_report(
     report: &AuditReport,
     audit_level: ConfigAuditLevel,
-    total_vulnerability_count: usize,
     ignored: &AuditVulnerabilityCounts,
 ) -> String {
     let mut advisories = report
@@ -37,11 +36,7 @@ pub(crate) fn render_text_report(
     for advisory in advisories {
         output.push_str(&render_advisory(advisory));
     }
-    output.push_str(&report_summary(
-        &report.metadata.vulnerabilities,
-        total_vulnerability_count,
-        ignored,
-    ));
+    output.push_str(&report_summary(&report.metadata.vulnerabilities, ignored));
     output
 }
 
@@ -92,20 +87,34 @@ pub(crate) fn render_advisory(advisory: &AuditAdvisory) -> String {
     format!("{table}\n")
 }
 
+/// The summary describes the same advisory set the exit code is based on, so
+/// the reported counts are net of the advisories `auditConfig` suppressed.
 pub(crate) fn report_summary(
     vulnerabilities: &AuditVulnerabilityCounts,
-    total_vulnerability_count: usize,
     ignored: &AuditVulnerabilityCounts,
 ) -> String {
-    if total_vulnerability_count == 0 {
-        return "No known vulnerabilities found\n".to_string();
-    }
     let severities = vulnerabilities
         .entries()
         .into_iter()
-        .filter(|(_, count)| *count > 0)
         .map(|(level, count)| {
             let ignored_count = count_for_level(ignored, level);
+            (level, count.saturating_sub(ignored_count), ignored_count)
+        })
+        .collect::<Vec<_>>();
+    let total_vulnerability_count: usize = severities.iter().map(|(_, count, _)| count).sum();
+    if total_vulnerability_count == 0 {
+        let total_ignored_count: usize =
+            severities.iter().map(|(_, _, ignored_count)| ignored_count).sum();
+        return if total_ignored_count > 0 {
+            format!("No known vulnerabilities found ({total_ignored_count} ignored)\n")
+        } else {
+            "No known vulnerabilities found\n".to_string()
+        };
+    }
+    let rendered_severities = severities
+        .into_iter()
+        .filter(|(_, count, ignored_count)| *count > 0 || *ignored_count > 0)
+        .map(|(level, count, ignored_count)| {
             let label = if ignored_count > 0 {
                 format!("{count} {} ({ignored_count} ignored)", severity_name(level))
             } else {
@@ -116,7 +125,7 @@ pub(crate) fn report_summary(
         .collect::<Vec<_>>()
         .join(" | ");
     format!(
-        "{} vulnerabilities found\nSeverity: {severities}",
+        "{} vulnerabilities found\nSeverity: {rendered_severities}",
         red(&total_vulnerability_count.to_string()),
     )
 }

--- a/pnpm/crates/cli/src/cli_args/audit/report.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/report.rs
@@ -108,10 +108,6 @@ impl AuditVulnerabilityCounts {
         }
     }
 
-    pub(crate) fn total(&self) -> usize {
-        self.info + self.low + self.moderate + self.high + self.critical
-    }
-
     pub(crate) fn entries(&self) -> [(ConfigAuditLevel, usize); 5] {
         [
             (ConfigAuditLevel::Info, self.info),

--- a/pnpm/crates/cli/src/cli_args/audit/report.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/report.rs
@@ -108,6 +108,10 @@ impl AuditVulnerabilityCounts {
         }
     }
 
+    pub(crate) fn total(&self) -> usize {
+        self.info + self.low + self.moderate + self.high + self.critical
+    }
+
     pub(crate) fn entries(&self) -> [(ConfigAuditLevel, usize); 5] {
         [
             (ConfigAuditLevel::Info, self.info),

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -980,9 +980,66 @@ fn text_report_separates_advisory_table_from_summary() {
     };
 
     let output =
-        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+        render_text_report(&report, ConfigAuditLevel::Low, &AuditVulnerabilityCounts::default());
     let summary_start = output.find("1 vulnerabilities found").unwrap();
     assert_eq!(output.as_bytes()[summary_start - 1], b'\n');
+}
+
+#[test]
+fn text_report_summary_omits_advisories_fully_suppressed_by_ignore_ghsas() {
+    let report = AuditReport {
+        advisories: BTreeMap::new(),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 1,
+                critical: 0,
+            },
+            dependencies: 1,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 1,
+        },
+    };
+    let ignored = AuditVulnerabilityCounts { info: 0, low: 0, moderate: 0, high: 1, critical: 0 };
+
+    let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
+
+    assert_eq!(output, "No known vulnerabilities found (1 ignored)\n");
+}
+
+#[test]
+fn text_report_summary_subtracts_ignored_advisories_from_severity_counts() {
+    let report = AuditReport {
+        advisories: BTreeMap::from([(
+            "1".to_string(),
+            advisory(1, "high issue", ConfigAuditLevel::High, "GHSA-high-3333-4444"),
+        )]),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 1,
+                high: 2,
+                critical: 0,
+            },
+            dependencies: 3,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 3,
+        },
+    };
+    let ignored = AuditVulnerabilityCounts { info: 0, low: 0, moderate: 1, high: 1, critical: 0 };
+
+    let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
+
+    assert!(output.contains("1 vulnerabilities found"), "headline is net of ignored:\n{output}");
+    assert!(
+        output.ends_with("Severity: 0 moderate (1 ignored) | 1 high (1 ignored)"),
+        "per-severity counts are net of ignored:\n{output}",
+    );
 }
 
 #[test]
@@ -1008,7 +1065,7 @@ fn text_report_shows_none_when_patched_version_was_unpublished() {
     };
 
     let output =
-        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+        render_text_report(&report, ConfigAuditLevel::Low, &AuditVulnerabilityCounts::default());
     assert!(output.contains("Patched versions"), "row label should be present:\n{output}");
     assert!(
         output.contains("Patched versions    │ None"),
@@ -1043,7 +1100,7 @@ fn text_report_shows_unknown_when_patched_version_cannot_be_inferred() {
     };
 
     let output =
-        render_text_report(&report, ConfigAuditLevel::Low, 1, &AuditVulnerabilityCounts::default());
+        render_text_report(&report, ConfigAuditLevel::Low, &AuditVulnerabilityCounts::default());
     assert!(
         output.contains("Patched versions    │ (unknown)"),
         "a non-inferable range renders as (unknown):\n{output}",

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1012,7 +1012,35 @@ fn text_report_summary_omits_advisories_fully_suppressed_by_ignore_ghsas() {
 }
 
 #[test]
-fn text_report_summary_subtracts_ignored_advisories_from_severity_counts() {
+fn text_report_summary_counts_advisories_rather_than_registry_metadata() {
+    // The registry repeated one advisory id under two packages, so the
+    // metadata counts it twice while the report keeps a single entry.
+    let report = AuditReport {
+        advisories: BTreeMap::new(),
+        metadata: AuditMetadata {
+            vulnerabilities: AuditVulnerabilityCounts {
+                info: 0,
+                low: 0,
+                moderate: 0,
+                high: 2,
+                critical: 0,
+            },
+            dependencies: 2,
+            dev_dependencies: 0,
+            optional_dependencies: 0,
+            total_dependencies: 2,
+        },
+    };
+    let ignored = AuditVulnerabilityCounts { info: 0, low: 0, moderate: 0, high: 1, critical: 0 };
+
+    let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
+
+    eprintln!("REPORT:\n{output}\n");
+    assert_eq!(output, "No known vulnerabilities found\n1 ignored: 1 high\n");
+}
+
+#[test]
+fn text_report_summary_excludes_ignored_advisories_from_severity_counts() {
     let report = AuditReport {
         advisories: BTreeMap::from([(
             "1".to_string(),

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1008,7 +1008,11 @@ fn text_report_summary_omits_advisories_fully_suppressed_by_ignore_ghsas() {
     let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
 
     eprintln!("REPORT:\n{output}\n");
-    assert_eq!(output, "No known vulnerabilities found\n1 ignored: 1 high\n");
+    assert_eq!(
+        output,
+        "All found vulnerabilities were already reviewed and decided to be ignored\n\
+         1 ignored: 1 high\n",
+    );
 }
 
 #[test]
@@ -1036,7 +1040,11 @@ fn text_report_summary_counts_advisories_rather_than_registry_metadata() {
     let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
 
     eprintln!("REPORT:\n{output}\n");
-    assert_eq!(output, "No known vulnerabilities found\n1 ignored: 1 high\n");
+    assert_eq!(
+        output,
+        "All found vulnerabilities were already reviewed and decided to be ignored\n\
+         1 ignored: 1 high\n",
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1035,10 +1035,23 @@ fn text_report_summary_subtracts_ignored_advisories_from_severity_counts() {
 
     let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
 
-    assert!(output.contains("1 vulnerabilities found"), "headline is net of ignored:\n{output}");
-    assert!(
-        output.ends_with("Severity: 0 moderate (1 ignored) | 1 high (1 ignored)"),
-        "per-severity counts are net of ignored:\n{output}",
+    assert_eq!(
+        output,
+        "┌─────────────────────┬───────────────────────────────────────────────────┐\n\
+         │ high                │ high issue                                        │\n\
+         ├─────────────────────┼───────────────────────────────────────────────────┤\n\
+         │ Package             │ pkg                                               │\n\
+         ├─────────────────────┼───────────────────────────────────────────────────┤\n\
+         │ Vulnerable versions │ <2.0.0                                            │\n\
+         ├─────────────────────┼───────────────────────────────────────────────────┤\n\
+         │ Patched versions    │ >=2.0.0                                           │\n\
+         ├─────────────────────┼───────────────────────────────────────────────────┤\n\
+         │ Paths               │ .>pkg                                             │\n\
+         ├─────────────────────┼───────────────────────────────────────────────────┤\n\
+         │ More info           │ https://github.com/advisories/GHSA-high-3333-4444 │\n\
+         └─────────────────────┴───────────────────────────────────────────────────┘\n\
+         1 vulnerabilities found\n\
+         Severity: 0 moderate (1 ignored) | 1 high (1 ignored)",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1007,7 +1007,8 @@ fn text_report_summary_omits_advisories_fully_suppressed_by_ignore_ghsas() {
 
     let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
 
-    assert_eq!(output, "No known vulnerabilities found (1 ignored)\n");
+    eprintln!("REPORT:\n{output}\n");
+    assert_eq!(output, "No known vulnerabilities found\n1 ignored: 1 high\n");
 }
 
 #[test]
@@ -1052,7 +1053,8 @@ fn text_report_summary_subtracts_ignored_advisories_from_severity_counts() {
          │ More info           │ https://github.com/advisories/GHSA-high-3333-4444 │\n\
          └─────────────────────┴───────────────────────────────────────────────────┘\n\
          1 vulnerabilities found\n\
-         Severity: 0 moderate (1 ignored) | 1 high (1 ignored)",
+         Severity: 1 high\n\
+         2 ignored: 1 moderate | 1 high",
     );
 }
 

--- a/pnpm/crates/cli/src/cli_args/audit/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/audit/tests.rs
@@ -1035,6 +1035,7 @@ fn text_report_summary_subtracts_ignored_advisories_from_severity_counts() {
 
     let output = render_text_report(&report, ConfigAuditLevel::Low, &ignored);
 
+    eprintln!("REPORT:\n{output}\n");
     assert_eq!(
         output,
         "┌─────────────────────┬───────────────────────────────────────────────────┐\n\

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -354,7 +354,11 @@ fn audit_ignores_configured_ghsas_in_text_report() {
     assert_success(&output);
     let stdout = stdout(&output);
     eprintln!("STDOUT:\n{stdout}\n");
-    assert_eq!(stdout, "No known vulnerabilities found\n1 ignored: 1 high\n");
+    assert_eq!(
+        stdout,
+        "All found vulnerabilities were already reviewed and decided to be ignored\n\
+         1 ignored: 1 high\n",
+    );
     mock.assert();
 }
 

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -352,9 +352,7 @@ fn audit_ignores_configured_ghsas_in_text_report() {
         pacquet.arg("audit").arg("--audit-level").arg("moderate").output().expect("run pacquet");
 
     assert_success(&output);
-    let stdout = stdout(&output);
-    assert!(!stdout.contains("ignored vulnerability"));
-    assert_eq!(stdout, "No known vulnerabilities found (1 ignored)\n");
+    assert_eq!(stdout(&output), "No known vulnerabilities found (1 ignored)\n");
     mock.assert();
 }
 
@@ -395,9 +393,10 @@ fn audit_keeps_reporting_advisories_that_are_not_ignored() {
 
     assert_eq!(output.status.code(), Some(1));
     let stdout = stdout(&output);
+    eprintln!("STDOUT:\n{stdout}\n");
     assert!(!stdout.contains("ignored vulnerability"));
     assert!(
-        stdout.ends_with("1 vulnerabilities found\nSeverity: 1 moderate | 0 high (1 ignored)\n")
+        stdout.ends_with("1 vulnerabilities found\nSeverity: 1 moderate | 0 high (1 ignored)\n"),
     );
     mock.assert();
 }

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -354,7 +354,7 @@ fn audit_ignores_configured_ghsas_in_text_report() {
     assert_success(&output);
     let stdout = stdout(&output);
     assert!(!stdout.contains("ignored vulnerability"));
-    assert!(stdout.contains("1 high (1 ignored)"));
+    assert_eq!(stdout, "No known vulnerabilities found (1 ignored)\n");
     mock.assert();
 }
 

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -352,7 +352,9 @@ fn audit_ignores_configured_ghsas_in_text_report() {
         pacquet.arg("audit").arg("--audit-level").arg("moderate").output().expect("run pacquet");
 
     assert_success(&output);
-    assert_eq!(stdout(&output), "No known vulnerabilities found (1 ignored)\n");
+    let stdout = stdout(&output);
+    eprintln!("STDOUT:\n{stdout}\n");
+    assert_eq!(stdout, "No known vulnerabilities found\n1 ignored: 1 high\n");
     mock.assert();
 }
 
@@ -395,9 +397,7 @@ fn audit_keeps_reporting_advisories_that_are_not_ignored() {
     let stdout = stdout(&output);
     eprintln!("STDOUT:\n{stdout}\n");
     assert!(!stdout.contains("ignored vulnerability"));
-    assert!(
-        stdout.ends_with("1 vulnerabilities found\nSeverity: 1 moderate | 0 high (1 ignored)\n"),
-    );
+    assert!(stdout.ends_with("1 vulnerabilities found\nSeverity: 1 moderate\n1 ignored: 1 high\n"));
     mock.assert();
 }
 

--- a/pnpm/crates/cli/tests/suite/audit.rs
+++ b/pnpm/crates/cli/tests/suite/audit.rs
@@ -359,6 +359,50 @@ fn audit_ignores_configured_ghsas_in_text_report() {
 }
 
 #[test]
+fn audit_keeps_reporting_advisories_that_are_not_ignored() {
+    let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
+    let mut registry = mockito::Server::new();
+    let mock = audit_mock(
+        &mut registry,
+        &format!(
+            "{{\n{},\n{}\n}}",
+            advisory_entry(
+                "vulnerable",
+                301,
+                "high",
+                "<2.0.0",
+                "ignored vulnerability",
+                "GHSA-ignr-1111-2222",
+            ),
+            advisory_entry(
+                "moderate-pkg",
+                302,
+                "moderate",
+                "<2.0.0",
+                "visible vulnerability",
+                "GHSA-visi-1111-2222",
+            ),
+        ),
+    )
+    .create();
+    write_audit_workspace(
+        &workspace,
+        &registry.url(),
+        "auditConfig:\n  ignoreGhsas:\n    - GHSA-ignr-1111-2222\n",
+    );
+
+    let output = pacquet.arg("audit").output().expect("run pacquet audit");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = stdout(&output);
+    assert!(!stdout.contains("ignored vulnerability"));
+    assert!(
+        stdout.ends_with("1 vulnerabilities found\nSeverity: 1 moderate | 0 high (1 ignored)\n")
+    );
+    mock.assert();
+}
+
+#[test]
 fn audit_ignores_configured_ghsas_in_json_report() {
     let CommandTempCwd { mut pacquet, workspace, root: _root, .. } = CommandTempCwd::init();
     let mut registry = mockito::Server::new();

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -449,26 +449,33 @@ function isFixWithoutMethod (fix: AuditOptions['fix']): boolean {
 }
 
 function reportSummary (vulnerabilities: AuditVulnerabilityCounts, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {
-  const severities = Object.entries(vulnerabilities)
-    .map(([auditLevel, vulnerabilitiesCount]) => {
-      const ignoredCount = ignoredVulnerabilities[auditLevel as AuditLevelString]
-      return {
-        auditLevel: auditLevel as AuditLevelString,
-        count: vulnerabilitiesCount - ignoredCount,
-        ignoredCount,
-      }
-    })
-  const totalVulnerabilityCount = severities.reduce((sum, { count }) => sum + count, 0)
+  const auditLevels = Object.keys(vulnerabilities) as AuditLevelString[]
+  const found = auditLevels.map((auditLevel) => ({
+    auditLevel,
+    count: vulnerabilities[auditLevel] - ignoredVulnerabilities[auditLevel],
+  }))
+  const ignored = auditLevels.map((auditLevel) => ({
+    auditLevel,
+    count: ignoredVulnerabilities[auditLevel],
+  }))
+  const totalIgnoredCount = sumSeverityCounts(ignored)
+  const ignoredSummary = totalIgnoredCount === 0 ? '' : `\n${totalIgnoredCount} ignored: ${listSeverityCounts(ignored)}`
+  const totalVulnerabilityCount = sumSeverityCounts(found)
   if (totalVulnerabilityCount === 0) {
-    const totalIgnoredCount = severities.reduce((sum, { ignoredCount }) => sum + ignoredCount, 0)
-    return `No known vulnerabilities found${totalIgnoredCount > 0 ? ` (${totalIgnoredCount} ignored)` : ''}\n`
+    return `No known vulnerabilities found${ignoredSummary}\n`
   }
-  return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${
-    severities
-      .filter(({ count, ignoredCount }) => count > 0 || ignoredCount > 0)
-      .map(({ auditLevel, count, ignoredCount }) => AUDIT_COLOR[auditLevel](`${count} ${auditLevel}${ignoredCount > 0 ? ` (${ignoredCount} ignored)` : ''}`))
-      .join(' | ')
-  }`
+  return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${listSeverityCounts(found)}${ignoredSummary}`
+}
+
+function sumSeverityCounts (severities: Array<{ count: number }>): number {
+  return severities.reduce((sum, { count }) => sum + count, 0)
+}
+
+function listSeverityCounts (severities: Array<{ auditLevel: AuditLevelString, count: number }>): string {
+  return severities
+    .filter(({ count }) => count > 0)
+    .map(({ auditLevel, count }) => AUDIT_COLOR[auditLevel](`${count} ${auditLevel}`))
+    .join(' | ')
 }
 
 export function formatFixWithUpdateOutput (result: FixWithUpdateResult, auditReport: AuditReport): string {

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -462,7 +462,10 @@ function reportSummary (vulnerabilities: AuditVulnerabilityCounts, ignoredVulner
   const ignoredSummary = totalIgnoredCount === 0 ? '' : `\n${totalIgnoredCount} ignored: ${listSeverityCounts(ignored)}`
   const totalVulnerabilityCount = sumSeverityCounts(found)
   if (totalVulnerabilityCount === 0) {
-    return `No known vulnerabilities found${ignoredSummary}\n`
+    const headline = totalIgnoredCount === 0
+      ? 'No known vulnerabilities found'
+      : 'All found vulnerabilities were already reviewed and decided to be ignored'
+    return `${headline}${ignoredSummary}\n`
   }
   return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${listSeverityCounts(found)}${ignoredSummary}`
 }

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -448,10 +448,6 @@ function isFixWithoutMethod (fix: AuditOptions['fix']): boolean {
   return fix === '' || fix === true || fix === 'true'
 }
 
-/**
- * Counts are net of what `auditConfig` suppressed, so the summary describes
- * the same advisory set the exit code is based on.
- */
 function reportSummary (vulnerabilities: AuditVulnerabilityCounts, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {
   const severities = Object.entries(vulnerabilities)
     .map(([auditLevel, vulnerabilitiesCount]) => {

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -386,8 +386,6 @@ ${newIgnores.join('\n')}`,
     high: 0,
     critical: 0,
   }
-  const totalVulnerabilityCount = Object.values(vulnerabilities)
-    .reduce((sum: number, vulnerabilitiesCount: number) => sum + vulnerabilitiesCount, 0)
   const ignoreGhsas = opts.auditConfig?.ignoreGhsas
   if (ignoreGhsas?.length) {
     // Compare GHSA ids after normalizing so stored entries with varying
@@ -437,7 +435,7 @@ ${newIgnores.join('\n')}`,
   }
   return {
     exitCode: output ? 1 : 0,
-    output: `${output}${reportSummary(auditReport.metadata.vulnerabilities, totalVulnerabilityCount, ignoredVulnerabilities)}`,
+    output: `${output}${reportSummary(vulnerabilities, ignoredVulnerabilities)}`,
   }
 }
 
@@ -450,12 +448,29 @@ function isFixWithoutMethod (fix: AuditOptions['fix']): boolean {
   return fix === '' || fix === true || fix === 'true'
 }
 
-function reportSummary (vulnerabilities: AuditVulnerabilityCounts, totalVulnerabilityCount: number, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {
-  if (totalVulnerabilityCount === 0) return 'No known vulnerabilities found\n'
+/**
+ * Counts are net of what `auditConfig` suppressed, so the summary describes
+ * the same advisory set the exit code is based on.
+ */
+function reportSummary (vulnerabilities: AuditVulnerabilityCounts, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {
+  const severities = Object.entries(vulnerabilities)
+    .map(([auditLevel, vulnerabilitiesCount]) => {
+      const ignoredCount = ignoredVulnerabilities[auditLevel as AuditLevelString]
+      return {
+        auditLevel: auditLevel as AuditLevelString,
+        count: vulnerabilitiesCount - ignoredCount,
+        ignoredCount,
+      }
+    })
+  const totalVulnerabilityCount = severities.reduce((sum, { count }) => sum + count, 0)
+  if (totalVulnerabilityCount === 0) {
+    const totalIgnoredCount = severities.reduce((sum, { ignoredCount }) => sum + ignoredCount, 0)
+    return `No known vulnerabilities found${totalIgnoredCount > 0 ? ` (${totalIgnoredCount} ignored)` : ''}\n`
+  }
   return `${chalk.red(totalVulnerabilityCount)} vulnerabilities found\nSeverity: ${
-    Object.entries(vulnerabilities)
-      .filter(([_auditLevel, vulnerabilitiesCount]) => vulnerabilitiesCount > 0)
-      .map(([auditLevel, vulnerabilitiesCount]) => AUDIT_COLOR[auditLevel as AuditLevelString](`${vulnerabilitiesCount as string} ${auditLevel}${ignoredVulnerabilities[auditLevel as AuditLevelString] > 0 ? ` (${ignoredVulnerabilities[auditLevel as AuditLevelString]} ignored)` : ''}`))
+    severities
+      .filter(({ count, ignoredCount }) => count > 0 || ignoredCount > 0)
+      .map(({ auditLevel, count, ignoredCount }) => AUDIT_COLOR[auditLevel](`${count} ${auditLevel}${ignoredCount > 0 ? ` (${ignoredCount} ignored)` : ''}`))
       .join(' | ')
   }`
 }

--- a/pnpm11/deps/compliance/commands/src/audit/audit.ts
+++ b/pnpm11/deps/compliance/commands/src/audit/audit.ts
@@ -378,7 +378,6 @@ ${JSON.stringify(vulnOverrides, null, 2)}`
 ${newIgnores.join('\n')}`,
     }
   }
-  const vulnerabilities = auditReport.metadata.vulnerabilities
   const ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts = {
     info: 0,
     low: 0,
@@ -433,6 +432,10 @@ ${newIgnores.join('\n')}`,
       ['More info', advisory.url],
     ], AUDIT_TABLE_OPTIONS)
   }
+  const vulnerabilities: AuditVulnerabilityCounts = { info: 0, low: 0, moderate: 0, high: 0, critical: 0 }
+  for (const { severity } of Object.values(auditReport.advisories)) {
+    vulnerabilities[severity] += 1
+  }
   return {
     exitCode: output ? 1 : 0,
     output: `${output}${reportSummary(vulnerabilities, ignoredVulnerabilities)}`,
@@ -450,10 +453,7 @@ function isFixWithoutMethod (fix: AuditOptions['fix']): boolean {
 
 function reportSummary (vulnerabilities: AuditVulnerabilityCounts, ignoredVulnerabilities: IgnoredAuditVulnerabilityCounts): string {
   const auditLevels = Object.keys(vulnerabilities) as AuditLevelString[]
-  const found = auditLevels.map((auditLevel) => ({
-    auditLevel,
-    count: vulnerabilities[auditLevel] - ignoredVulnerabilities[auditLevel],
-  }))
+  const found = auditLevels.map((auditLevel) => ({ auditLevel, count: vulnerabilities[auditLevel] }))
   const ignored = auditLevels.map((auditLevel) => ({
     auditLevel,
     count: ignoredVulnerabilities[auditLevel],

--- a/pnpm11/deps/compliance/commands/test/audit/__snapshots__/index.ts.snap
+++ b/pnpm11/deps/compliance/commands/test/audit/__snapshots__/index.ts.snap
@@ -5319,8 +5319,8 @@ exports[`plugin-commands-audit audit: advisories in ignoreGhsas do not show up 1
 ├─────────────────────┼────────────────────────────────────────────────────────┤
 │ More info           │ https://github.com/advisories/GHSA-r4q5-vmmm-2653      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
-111 vulnerabilities found
-Severity: 8 low | 42 moderate (2 ignored) | 46 high (2 ignored) | 15 critical"
+107 vulnerabilities found
+Severity: 8 low | 40 moderate (2 ignored) | 44 high (2 ignored) | 15 critical"
 `;
 
 exports[`plugin-commands-audit audit: advisories in ignoreGhsas do not show up when JSON output is used 1`] = `

--- a/pnpm11/deps/compliance/commands/test/audit/__snapshots__/index.ts.snap
+++ b/pnpm11/deps/compliance/commands/test/audit/__snapshots__/index.ts.snap
@@ -5320,7 +5320,8 @@ exports[`plugin-commands-audit audit: advisories in ignoreGhsas do not show up 1
 │ More info           │ https://github.com/advisories/GHSA-r4q5-vmmm-2653      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 107 vulnerabilities found
-Severity: 8 low | 40 moderate (2 ignored) | 44 high (2 ignored) | 15 critical"
+Severity: 8 low | 40 moderate | 44 high | 15 critical
+4 ignored: 2 moderate | 2 high"
 `;
 
 exports[`plugin-commands-audit audit: advisories in ignoreGhsas do not show up when JSON output is used 1`] = `

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -406,6 +406,25 @@ describe('plugin-commands-audit', () => {
     expect(stripAnsi(output)).toMatchSnapshot()
   })
 
+  test('audit: summary is net of advisories suppressed by ignoreGhsas', async () => {
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, responses.INFO_VULN_RESP)
+
+    const { exitCode, output } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      auditLevel: 'info',
+      dir: hasVulnerabilitiesDir,
+      rootProjectManifestDir: hasVulnerabilitiesDir,
+      auditConfig: {
+        ignoreGhsas: ['GHSA-info-info-info'],
+      },
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stripAnsi(output)).toBe('No known vulnerabilities found (1 ignored)\n')
+  })
+
   test('audit: advisories in ignoreGhsas do not show up when JSON output is used', async () => {
     const tmp = f.prepare('has-vulnerabilities')
 

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -422,7 +422,7 @@ describe('plugin-commands-audit', () => {
     })
 
     expect(exitCode).toBe(0)
-    expect(stripAnsi(output)).toBe('No known vulnerabilities found\n1 ignored: 1 info\n')
+    expect(stripAnsi(output)).toBe('All found vulnerabilities were already reviewed and decided to be ignored\n1 ignored: 1 info\n')
   })
 
   test('audit: the summary counts the advisories it prints, not the registry metadata', async () => {
@@ -460,7 +460,7 @@ describe('plugin-commands-audit', () => {
     })
 
     expect(exitCode).toBe(0)
-    expect(stripAnsi(output)).toBe('No known vulnerabilities found\n1 ignored: 1 info\n')
+    expect(stripAnsi(output)).toBe('All found vulnerabilities were already reviewed and decided to be ignored\n1 ignored: 1 info\n')
   })
 
   test('audit: advisories outside ignoreGhsas stay counted in the summary', async () => {

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -425,6 +425,44 @@ describe('plugin-commands-audit', () => {
     expect(stripAnsi(output)).toBe('No known vulnerabilities found\n1 ignored: 1 info\n')
   })
 
+  test('audit: the summary counts the advisories it prints, not the registry metadata', async () => {
+    // The registry repeated one advisory id, which the report collapses into a
+    // single entry while its metadata counts the advisory twice.
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, {
+        axios: [
+          {
+            id: 100,
+            url: 'https://github.com/advisories/GHSA-info-info-info',
+            title: 'just some info',
+            severity: 'info',
+            vulnerable_versions: '*',
+          },
+          {
+            id: 100,
+            url: 'https://github.com/advisories/GHSA-info-info-info',
+            title: 'just some info',
+            severity: 'info',
+            vulnerable_versions: '*',
+          },
+        ],
+      })
+
+    const { exitCode, output } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      auditLevel: 'info',
+      dir: hasVulnerabilitiesDir,
+      rootProjectManifestDir: hasVulnerabilitiesDir,
+      auditConfig: {
+        ignoreGhsas: ['GHSA-info-info-info'],
+      },
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stripAnsi(output)).toBe('No known vulnerabilities found\n1 ignored: 1 info\n')
+  })
+
   test('audit: advisories outside ignoreGhsas stay counted in the summary', async () => {
     getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
       .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -425,6 +425,58 @@ describe('plugin-commands-audit', () => {
     expect(stripAnsi(output)).toBe('No known vulnerabilities found (1 ignored)\n')
   })
 
+  test('audit: advisories outside ignoreGhsas stay counted in the summary', async () => {
+    getMockAgent().get(AUDIT_REGISTRY.replace(/\/$/, ''))
+      .intercept({ path: '/-/npm/v1/security/advisories/bulk', method: 'POST' })
+      .reply(200, {
+        axios: [
+          {
+            id: 100,
+            url: 'https://github.com/advisories/GHSA-info-info-info',
+            title: 'just some info',
+            severity: 'info',
+            vulnerable_versions: '*',
+          },
+          {
+            id: 101,
+            url: 'https://github.com/advisories/GHSA-high-high-high',
+            title: 'something high',
+            severity: 'high',
+            vulnerable_versions: '*',
+          },
+        ],
+      })
+
+    const { exitCode, output } = await audit.handler({
+      ...AUDIT_REGISTRY_OPTS,
+      auditLevel: 'info',
+      dir: hasVulnerabilitiesDir,
+      rootProjectManifestDir: hasVulnerabilitiesDir,
+      auditConfig: {
+        ignoreGhsas: ['GHSA-info-info-info'],
+      },
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stripAnsi(output)).toBe(`┌─────────────────────┬────────────────────────────────────────────────────────┐
+│ high                │ something high                                         │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Package             │ axios                                                  │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Vulnerable versions │ *                                                      │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Patched versions    │ (unknown)                                              │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ Paths               │ .>karma>log4js>axios                                   │
+│                     │                                                        │
+│                     │ .>axios                                                │
+├─────────────────────┼────────────────────────────────────────────────────────┤
+│ More info           │ https://github.com/advisories/GHSA-high-high-high      │
+└─────────────────────┴────────────────────────────────────────────────────────┘
+1 vulnerabilities found
+Severity: 0 info (1 ignored) | 1 high`)
+  })
+
   test('audit: advisories in ignoreGhsas do not show up when JSON output is used', async () => {
     const tmp = f.prepare('has-vulnerabilities')
 

--- a/pnpm11/deps/compliance/commands/test/audit/index.ts
+++ b/pnpm11/deps/compliance/commands/test/audit/index.ts
@@ -422,7 +422,7 @@ describe('plugin-commands-audit', () => {
     })
 
     expect(exitCode).toBe(0)
-    expect(stripAnsi(output)).toBe('No known vulnerabilities found (1 ignored)\n')
+    expect(stripAnsi(output)).toBe('No known vulnerabilities found\n1 ignored: 1 info\n')
   })
 
   test('audit: advisories outside ignoreGhsas stay counted in the summary', async () => {
@@ -474,7 +474,8 @@ describe('plugin-commands-audit', () => {
 │ More info           │ https://github.com/advisories/GHSA-high-high-high      │
 └─────────────────────┴────────────────────────────────────────────────────────┘
 1 vulnerabilities found
-Severity: 0 info (1 ignored) | 1 high`)
+Severity: 1 high
+1 ignored: 1 info`)
   })
 
   test('audit: advisories in ignoreGhsas do not show up when JSON output is used', async () => {


### PR DESCRIPTION
## Summary

`pnpm audit` computed its summary from `metadata.vulnerabilities`, which the `ignoreGhsas` filter never reduces, while the exit code comes from the advisories that survive that filter. The two disagreed by construction: a project whose only advisory was suppressed by `auditConfig` printed a red `1 vulnerabilities found` and a `1 high` severity breakdown, then exited `0`. In CI the exit code says pass while the log says `high`, and the log is what people read.

Both stacks had the same defect, so this fixes both, as the triage note asked:

- `pnpm11/deps/compliance/commands/src/audit/audit.ts` computed `totalVulnerabilityCount` before the filter ran and passed the pre-filter map to `reportSummary`.
- `pnpm/crates/cli/src/cli_args/audit.rs` computed `total_vulnerability_count` from `report.metadata.vulnerabilities.total()` before `filter_ignored_advisories` ran, and `render.rs::report_summary` printed the same pre-filter map.

In both, the summary now counts the advisories left after the filter, so its numbers come from the same map the advisory tables are rendered from and the exit code is decided by. Suppressed advisories keep their own line under the breakdown, so nothing is hidden, and a run whose advisories were all suppressed says so rather than claiming nothing was found.

Counting the surviving advisories rather than subtracting the ignored counts from the metadata also settles a case the subtraction got wrong. The metadata counts every advisory the registry sent, while both report builders store advisories by id, so a registry that repeats an id leaves the metadata above the set that can be filtered. Netting the two then reported a vulnerability that no table lists and no exit code reflects.

`metadata` itself is not modified, so `pnpm audit --json` output is unchanged. The exit-code logic is untouched.

Two things I deliberately left alone:

- The accuracy of the `(N ignored)` counter itself, pnpm/pnpm#10646 and pnpm/pnpm#10968. Different defect, and this change does not depend on it.
- The summary counts every severity, while `--audit-level` filters both the tables and the exit code, so `pnpm audit --audit-level moderate` can print `8 low` with no `low` table above it. That is the same class of disagreement from a different cause, it is not what pnpm/pnpm#14535 reports, and folding it in would change more output than the issue asks for. Happy to follow up separately if you want it.

### Before and after

Project with one advisory, suppressed:

```json
{ "dependencies": { "tunnel-agent": "0.4.3" } }
```

```yaml
auditConfig:
  ignoreGhsas:
    - GHSA-xc7v-wxcw-j472
```

Before:

```
$ pnpm audit
1 vulnerabilities found
Severity: 1 moderate (1 ignored)
$ echo $?
0
```

After:

```
$ pnpm audit
All found vulnerabilities were already reviewed and decided to be ignored
1 ignored: 1 moderate
$ echo $?
0
```

A run with nothing to suppress still reads `No known vulnerabilities found`.

Partial suppression, one advisory suppressed and two reported. The advisory tables are identical either way, so only the summary lines are shown:

```
before:  3 vulnerabilities found
         Severity: 2 moderate (1 ignored) | 1 critical

after:   2 vulnerabilities found
         Severity: 1 moderate | 1 critical
         1 ignored: 1 moderate
```

The table above that summary lists two advisories in both cases, so the headline now matches what is printed. Exit code stays `1`, as before.

The ignored counts moved out of the `Severity:` line because netting them there produced entries like `0 high (1 ignored)` whenever every advisory at a severity was suppressed. `Severity:` now lists only what is left to act on, and the line below it accounts for what was suppressed.

## Squash Commit Body

```text
`pnpm audit` computed the summary's headline total and per-severity counts from
`metadata.vulnerabilities`, which the ignore filter never reduces, while the exit
code derives from the advisories that survive that filter. A run whose only
advisory was suppressed by `auditConfig` printed a red `1 vulnerabilities found`
next to a zero exit code.

`reportSummary` (v11) and `report_summary` (v12) are now handed the counts of the
advisories left after the filter, the same map the tables are rendered from and
the exit code is decided by. The suppressed counts get their own line under the
breakdown, `2 ignored: 1 moderate | 1 critical`, and a run whose advisories were
all suppressed reads `All found vulnerabilities were already reviewed and decided
to be ignored` rather than claiming nothing was found.

Counting the surviving advisories also settles a case that subtracting the
ignored counts from the metadata got wrong: the metadata counts every advisory
the registry sent, while both report builders store advisories by id, so a
repeated id left the metadata above the set that can be filtered.

`metadata` is not modified, so `pnpm audit --json` is unchanged, and the
exit-code logic is untouched. `render_text_report` no longer needs the pre-filter
total.

Closes pnpm/pnpm#14535
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

## Tests

New, in `pnpm11/.../test/audit/index.ts`:

- `audit: summary is net of advisories suppressed by ignoreGhsas` asserts `All found vulnerabilities were already reviewed and decided to be ignored` / `1 ignored: 1 info` and exit code `0`.
- `audit: advisories outside ignoreGhsas stay counted in the summary` serves one info and one high advisory, ignores the info one, and asserts the exact output: the high advisory stays counted at `1 vulnerabilities found`, and `1 ignored: 1 info` follows the breakdown.
- `audit: the summary counts the advisories it prints, not the registry metadata` serves the same advisory id twice and ignores it, so the metadata counts two where the report keeps one.

New, on the pacquet side:

- `pnpm/crates/cli/src/cli_args/audit/tests.rs`: `text_report_summary_omits_advisories_fully_suppressed_by_ignore_ghsas`, `text_report_summary_excludes_ignored_advisories_from_severity_counts` (comparing the whole rendered report), and `text_report_summary_counts_advisories_rather_than_registry_metadata`.
- `pnpm/crates/cli/tests/suite/audit.rs`: `audit_keeps_reporting_advisories_that_are_not_ignored`, the end-to-end partial-suppression case.

Each of the three summary-counting tests was checked against the unfixed source and fails there.

Updated:

- `pnpm/crates/cli/tests/suite/audit.rs`: `audit_ignores_configured_ghsas_in_text_report` covered exactly this case, asserting `1 high (1 ignored)` on a successful exit. Tightened to assert the whole stdout.
- The `advisories in ignoreGhsas do not show up` snapshot: `111 vulnerabilities found` / `8 low | 42 moderate (2 ignored) | 46 high (2 ignored) | 15 critical` becomes `107` / `8 low | 40 moderate | 44 high | 15 critical` plus `4 ignored: 2 moderate | 2 high`. Four suppressed advisories, four fewer counted.

## Verification

- `pnpm --filter @pnpm/deps.compliance.commands run compile` (tsgo build + eslint): clean
- `pnpm --filter @pnpm/deps.compliance.commands test test/audit`: 6 suites, 81 tests, 5 snapshots passed
- `cargo test -p pnpm-cli --lib cli_args::audit`: 58 passed
- `cargo test -p pnpm-cli --test suite audit::`: 51 passed
- `cargo fmt --all -- --check`, `cargo clippy --all-targets -p pnpm-cli -- -D warnings`, `cargo dylint --all --workspace`, `typos pnpm pnpr`: clean

---
Written by an agent (Claude Code, claude-opus-5).
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14600"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791248574&installation_model_id=426870&pr_number=14600&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14600&signature=761386dacac245c8024c3893d223e38f4f34d94c52d62f1fe30cb8f15efb18c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm audit` summaries now exclude advisories suppressed by audit configuration from vulnerability totals and severity counts.
  * Suppressed advisories are reported separately, including per-severity ignored counts.
  * Visible advisories continue to determine the audit result and exit status.
  * When no advisories remain, the report distinguishes between no known vulnerabilities and advisories that were all reviewed and ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
