### PR TITLE
fix(config): use native separators in the Windows store and virtual store defaults

### DIFF
--- a/.changeset/windows-native-path-separators.md
+++ b/.changeset/windows-native-path-separators.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-On Windows, `pnpm store path` now prints a path that uses backslashes throughout. The `storeDir` and `virtualStoreDir` values recorded in `node_modules/.modules.yaml` use backslashes as well. Both previously carried forward slashes in the middle of the path, so they did not match the values pnpm 11 writes for the same directory.
+On Windows, `pnpm store path` now prints a path that uses backslashes throughout. The `storeDir` and `virtualStoreDir` values recorded in `node_modules/.modules.yaml` use backslashes as well. These paths previously carried forward slashes in the middle, so they did not match what pnpm 11 writes for the same directory.

--- a/.changeset/windows-native-path-separators.md
+++ b/.changeset/windows-native-path-separators.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+On Windows, `pnpm store path` now prints a path that uses backslashes throughout. The `storeDir` and `virtualStoreDir` values recorded in `node_modules/.modules.yaml` use backslashes as well. Both previously carried forward slashes in the middle of the path, so they did not match the values pnpm 11 writes for the same directory.

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -418,7 +418,7 @@ fn create_deploy_install_config(
 ) -> Config {
     let mut deploy_config = base_config.clone();
     deploy_config.modules_dir = deploy_dir.join("node_modules");
-    deploy_config.virtual_store_dir = deploy_dir.join("node_modules/.pnpm");
+    deploy_config.virtual_store_dir = deploy_dir.join("node_modules").join(".pnpm");
     // The deploy directory owns the lockfile this install runs against —
     // the generated one for a shared deploy, its own resolution for the
     // legacy path. A `lockfileDir` pinning the *source* workspace's

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -631,7 +631,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         config.extra_env = extra_env;
     }
     if virtual_store_dir_cleared {
-        config.virtual_store_dir = base_dir.join("node_modules/.pnpm");
+        config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
     }
     for (key, value) in [
         ("preferFrozenLockfile", changed_prefer_frozen_lockfile),

--- a/pnpm/crates/config/src/defaults.rs
+++ b/pnpm/crates/config/src/defaults.rs
@@ -53,7 +53,7 @@ fn default_store_dir_windows(home_dir: &Path, current_dir: &Path) -> PathBuf {
         get_drive_letter(home_dir).expect("home dir is an absolute path with drive letter");
 
     if current_drive == home_drive {
-        return home_dir.join("AppData/Local/pnpm/store");
+        return home_dir.join("AppData").join("Local").join("pnpm").join("store");
     }
 
     PathBuf::from(format!(r"{current_drive}:\.pnpm-store"))
@@ -242,7 +242,7 @@ where
 
 pub fn default_virtual_store_dir() -> PathBuf {
     // TODO: find directory with package.json
-    env::current_dir().expect("current directory is unavailable").join("node_modules/.pnpm")
+    env::current_dir().expect("current directory is unavailable").join("node_modules").join(".pnpm")
 }
 
 /// Default for `enableGlobalVirtualStore`: `false` — every project keeps

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -1,9 +1,10 @@
 use super::{
     PNPM_VERSION, default_cache_dir, default_child_concurrency,
     default_child_concurrency_with_parallelism, default_config_dir, default_fetch_timeout,
-    default_store_dir, default_unsafe_perm, default_user_agent, default_workspace_concurrency,
-    install_command_for, is_unsafe_perm_posix, resolve_child_concurrency,
-    resolve_child_concurrency_with_parallelism, resolve_configured_state_dir,
+    default_store_dir, default_unsafe_perm, default_user_agent, default_virtual_store_dir,
+    default_workspace_concurrency, install_command_for, is_unsafe_perm_posix,
+    resolve_child_concurrency, resolve_child_concurrency_with_parallelism,
+    resolve_configured_state_dir,
 };
 use crate::api::{EnvVar, GetCurrentDir, GetHomeDir};
 use pnpm_store_dir::{STORE_VERSION, StoreDir};
@@ -375,6 +376,11 @@ fn test_default_store_dir_with_windows_diff_drive() {
     assert_eq!(store_dir, Path::new(r"D:\.pnpm-store"));
 }
 
+/// Compares the rendered string rather than the `Path`. On Windows
+/// `Path` equality is separator-insensitive — it compares components,
+/// so a value built by joining an `"a/b/c"` literal still satisfies an
+/// `assert_eq!` against the backslash form, while the forward slashes
+/// survive into `.modules.yaml` and `pnpm store path`.
 #[cfg(windows)]
 #[test]
 fn test_dynamic_default_store_dir_with_windows_same_drive() {
@@ -382,7 +388,21 @@ fn test_dynamic_default_store_dir_with_windows_same_drive() {
     let home_dir = Path::new("C:\\Users\\user");
 
     let store_dir = default_store_dir_windows(home_dir, current_dir);
-    assert_eq!(store_dir, Path::new(r"C:\Users\user\AppData\Local\pnpm\store"));
+    assert_eq!(store_dir.to_str().unwrap(), r"C:\Users\user\AppData\Local\pnpm\store");
+}
+
+/// `default_virtual_store_dir` joins onto the current directory, so the
+/// separator it appends is what lands in the `virtualStoreDir` recorded
+/// in `.modules.yaml`. Compares the string for the same reason as above.
+#[cfg(windows)]
+#[test]
+fn test_default_virtual_store_dir_uses_native_separators() {
+    let virtual_store_dir = default_virtual_store_dir();
+    let rendered = virtual_store_dir.to_str().unwrap();
+    assert!(
+        rendered.ends_with(r"\node_modules\.pnpm"),
+        "virtual store dir {rendered:?} must end with a backslash-separated suffix"
+    );
 }
 
 #[test]

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -393,9 +393,10 @@ fn test_dynamic_default_store_dir_with_windows_same_drive() {
 
 /// `default_virtual_store_dir` joins onto the current directory, so the
 /// separator it appends is what lands in the `virtualStoreDir` recorded
-/// in `.modules.yaml`. Compares the rendered string for the same reason
-/// as above, through `display` so a working directory that is not valid
-/// Unicode renders lossily instead of panicking before the assertion.
+/// in `.modules.yaml`. Compares the rendered string for the reason given
+/// on `test_dynamic_default_store_dir_with_windows_same_drive`, through
+/// `display` so a working directory that is not valid Unicode renders
+/// lossily instead of panicking before the assertion.
 #[test]
 #[cfg_attr(not(windows), ignore = "only one path separator style is tested")]
 fn test_default_virtual_store_dir_uses_native_separators() {

--- a/pnpm/crates/config/src/defaults/tests.rs
+++ b/pnpm/crates/config/src/defaults/tests.rs
@@ -393,15 +393,17 @@ fn test_dynamic_default_store_dir_with_windows_same_drive() {
 
 /// `default_virtual_store_dir` joins onto the current directory, so the
 /// separator it appends is what lands in the `virtualStoreDir` recorded
-/// in `.modules.yaml`. Compares the string for the same reason as above.
-#[cfg(windows)]
+/// in `.modules.yaml`. Compares the rendered string for the same reason
+/// as above, through `display` so a working directory that is not valid
+/// Unicode renders lossily instead of panicking before the assertion.
 #[test]
+#[cfg_attr(not(windows), ignore = "only one path separator style is tested")]
 fn test_default_virtual_store_dir_uses_native_separators() {
     let virtual_store_dir = default_virtual_store_dir();
-    let rendered = virtual_store_dir.to_str().unwrap();
+    let rendered = virtual_store_dir.display().to_string();
     assert!(
         rendered.ends_with(r"\node_modules\.pnpm"),
-        "virtual store dir {rendered:?} must end with a backslash-separated suffix"
+        "virtual store dir {rendered:?} must end with a backslash-separated suffix",
     );
 }
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3349,7 +3349,7 @@ impl Config {
         // `modulesDir`/`virtualStoreDir` defaults are resolved against
         // `pnpmConfig.dir`.
         self.modules_dir = start_dir.join("node_modules");
-        self.virtual_store_dir = start_dir.join("node_modules/.pnpm");
+        self.virtual_store_dir = start_dir.join("node_modules").join(".pnpm");
 
         // Read the project/workspace .npmrc plus trusted user-level sources
         // and apply only the auth/network subset. Everything else is
@@ -3659,7 +3659,7 @@ impl Config {
             // been applied yet at this point in the cascade.
             self.modules_dir = base_dir.join("node_modules");
             if !virtual_store_dir_explicit {
-                self.virtual_store_dir = base_dir.join("node_modules/.pnpm");
+                self.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
             }
             // The workspace root is structural context (env-lockfile reads/
             // writes, pin persistence), not a "setting" — set it whenever a


### PR DESCRIPTION
On Windows, `pnpm store path` prints a path with forward slashes in the middle of it, and
the same string is written into `node_modules/.modules.yaml`.

Observed on pnpm 12.3.4, Windows 11, with `storeDir` unset and `PNPM_HOME` empty:

```
pnpm 11.25.0   C:\Users\me\AppData\Local\pnpm\store\v11
pnpm 12.3.4    C:\Users\me\AppData/Local/pnpm/store\v11
```

The recorded state diverges the same way. A fresh `pnpm install` in the same directory
writes:

```jsonc
// pnpm 11.25.0
"storeDir": "C:\\Users\\me\\AppData\\Local\\pnpm\\store\\v11",
// pnpm 12.3.4
"storeDir": "C:\\Users\\me\\AppData/Local/pnpm/store\\v11",
"virtualStoreDir": "C:\\...\\project\\node_modules/.pnpm",
```

## Cause

`Path::join` appends a literal as-is, so a literal that already contains a separator keeps
it. Six places build a path that way:

| Location | Field |
| --- | --- |
| `config/defaults.rs` `default_store_dir_windows` | `store_dir` |
| `config/defaults.rs` `default_virtual_store_dir` | `virtual_store_dir` |
| `config/lib.rs` `--dir` fixup | `virtual_store_dir` |
| `config/lib.rs` workspace base | `virtual_store_dir` |
| `cli/config_deps.rs` reset path | `virtual_store_dir` |
| `cli/cli_args/deploy.rs` deploy config | `virtual_store_dir` |

Each `virtual_store_dir` line sits directly below a `modules_dir = <base>.join("node_modules")`
that is already correct, because a single component carries no separator to preserve.

The remaining literals in `defaults.rs` are in Linux and macOS branches, where `/` is
already the native separator, so they are unaffected.

This matters beyond the printed path because `store_path.rs` states the goal explicitly:
the `storeDir` written to `.modules.yaml` and the path printed by `store path` should
match the value pnpm produces, so switching between the two CLIs does not trip
`ERR_PNPM_UNEXPECTED_STORE`. On Windows the same-drive default does not currently meet
that.

## Why the existing test passes

`test_dynamic_default_store_dir_with_windows_same_drive` already asserts the correct
backslash form, and it passes against the buggy value. On Windows `Path` equality
compares components rather than bytes, so `Path::new(r"a\b") == Path::new("a/b")` holds:

```
produced raw : "C:\\Users\\user\\AppData/Local/pnpm/store"
expected raw : "C:\\Users\\user\\AppData\\Local\\pnpm\\store"
Path eq      : true
string eq    : false
```

Both tests in this PR compare the rendered string instead. Before the source change they
fail; after it they pass:

```
before   test result: FAILED. 23 passed; 2 failed
after    test result: ok.     25 passed; 0 failed
```

`cargo test -p pnpm-config` passes. `cargo fmt -p pnpm-config -p pnpm-cli -- --check` is
clean; the import block in `defaults/tests.rs` is rewrapped only because rustfmt requires
it after adding `default_virtual_store_dir` to the list.

## Same defect, not included

Three more `Path::join` calls embed a separator, in paths that do not reach
`.modules.yaml`:

- `deps-restorer/link_bins.rs`, twice: `self_pkg_dir.join("node_modules/.bin")`
- `cli/engine_pm/install.rs`: `store_dir.tmp().join("engine-locks/package-manager-env.lock")`
- `cli/github_actions.rs`: `root.join(".github/workflows")`, which is interpolated into an
  error message a Windows user would see

I left them out to keep this PR to the fields it describes. Happy to add them here or open
a separate PR, whichever you prefer.

## Scope

I did not touch the cross-drive branch or `resolve_store_dir`.

I have no reproduction for a user-facing failure that this causes on its own, so I have
not claimed one. What is verifiable is the divergence from pnpm 11 in both the printed
path and the recorded `.modules.yaml` fields.

Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On Windows, `pnpm store path` now consistently displays paths with native backslashes.
  * Paths recorded for `storeDir` and `virtualStoreDir` in `node_modules/.modules.yaml` now use Windows-native separators, matching paths generated by pnpm.
  * Default virtual store and store directory paths now maintain consistent formatting across supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->