### PR TITLE
fix(package-manager): name the entry that could not be removed from node_modules

### DIFF
--- a/.changeset/remove-modules-dir-error-path.md
+++ b/.changeset/remove-modules-dir-error-path.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` now names the file or directory that could not be removed. It previously reported only the underlying OS error, such as "Access is denied (os error 5)".
+`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` now names the file or directory in `node_modules` that pnpm could not clean up. It previously reported only the underlying OS error, such as "Access is denied (os error 5)".

--- a/.changeset/remove-modules-dir-error-path.md
+++ b/.changeset/remove-modules-dir-error-path.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` now names the file or directory that could not be removed. It previously reported only the underlying OS error, so a message such as "Access is denied (os error 5)" gave no way to tell which entry under `node_modules` was at fault.

--- a/.changeset/remove-modules-dir-error-path.md
+++ b/.changeset/remove-modules-dir-error-path.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` now names the file or directory that could not be removed. It previously reported only the underlying OS error, so a message such as "Access is denied (os error 5)" gave no way to tell which entry under `node_modules` was at fault.
+`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` now names the file or directory that could not be removed. It previously reported only the underlying OS error, such as "Access is denied (os error 5)".

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -710,16 +710,34 @@ pub enum InstallError {
     #[display("Failed to remove the git branch lockfiles: {_0}")]
     CleanGitBranchLockfiles(#[error(source)] std::io::Error),
 
-    /// `path` is the entry the removal was working on: the file or
-    /// directory the user has to act on.
-    // Not `{path:?}`: entries arrive canonicalized, so Debug would print
-    // the verbatim prefix and escape every separator.
+    /// An entry could not be removed while the install was clearing the
+    /// modules directory. `path` is that entry: the file or directory
+    /// the user has to act on.
+    // This variant and `ReadModulesDir` render their path through
+    // `dunce::simplified` and `Display` rather than `{path:?}`: the
+    // purge walks a canonicalized modules directory, so `Debug` would
+    // print the verbatim prefix and escape every separator.
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR))]
     #[display(
         "Failed to remove {} from the modules directory: {error}",
         dunce::simplified(path).display()
     )]
     RemoveModulesDir {
+        path: PathBuf,
+        #[error(source)]
+        error: std::io::Error,
+    },
+
+    /// The modules directory at `path` could not be listed, so the
+    /// install cannot tell what is left in it. Shares the code of
+    /// [`InstallError::RemoveModulesDir`] because both mean the same
+    /// thing to a user: the modules directory could not be cleared.
+    #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR))]
+    #[display(
+        "Failed to read the modules directory at {}: {error}",
+        dunce::simplified(path).display()
+    )]
+    ReadModulesDir {
         path: PathBuf,
         #[error(source)]
         error: std::io::Error,

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -710,9 +710,27 @@ pub enum InstallError {
     #[display("Failed to remove the git branch lockfiles: {_0}")]
     CleanGitBranchLockfiles(#[error(source)] std::io::Error),
 
+    /// `path` is the entry the removal was working on, which is what a
+    /// user needs in order to act: release the handle on that file, or
+    /// fix its permissions. Without it an `Access is denied (os error 5)`
+    /// naming nothing leaves the whole modules directory as the search
+    /// space.
+    ///
+    /// Rendered through `dunce::simplified` and `Path::display` rather
+    /// than `{:?}` so the path stays copy-pasteable: the entries come
+    /// from a canonicalized modules directory, so `{:?}` would print
+    /// the `\\?\` verbatim prefix removed in #13990 and double every
+    /// separator.
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR))]
-    #[display("Failed to remove modules directory contents: {_0}")]
-    RemoveModulesDir(#[error(source)] std::io::Error),
+    #[display(
+        "Failed to remove {} from the modules directory: {error}",
+        dunce::simplified(path).display()
+    )]
+    RemoveModulesDir {
+        path: PathBuf,
+        #[error(source)]
+        error: std::io::Error,
+    },
 
     #[display(
         "Cannot safely repair the filtered install because the modules directory at {modules_dir:?} is outside the workspace root at {workspace_root:?}"

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -710,17 +710,10 @@ pub enum InstallError {
     #[display("Failed to remove the git branch lockfiles: {_0}")]
     CleanGitBranchLockfiles(#[error(source)] std::io::Error),
 
-    /// `path` is the entry the removal was working on, which is what a
-    /// user needs in order to act: release the handle on that file, or
-    /// fix its permissions. Without it an `Access is denied (os error 5)`
-    /// naming nothing leaves the whole modules directory as the search
-    /// space.
-    ///
-    /// Rendered through `dunce::simplified` and `Path::display` rather
-    /// than `{:?}` so the path stays copy-pasteable: the entries come
-    /// from a canonicalized modules directory, so `{:?}` would print
-    /// the `\\?\` verbatim prefix removed in #13990 and double every
-    /// separator.
+    /// `path` is the entry the removal was working on: the file or
+    /// directory the user has to act on.
+    // Not `{path:?}`: entries arrive canonicalized, so Debug would print
+    // the verbatim prefix and escape every separator.
     #[diagnostic(code(ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR))]
     #[display(
         "Failed to remove {} from the modules directory: {error}",

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -164,7 +164,12 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                                 Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                                     continue;
                                 }
-                                Err(err) => return Err(InstallError::RemoveModulesDir(err)),
+                                Err(err) => {
+                                    return Err(InstallError::RemoveModulesDir {
+                                        path: target.clone(),
+                                        error: err,
+                                    });
+                                }
                             };
                             let file_name = entry.file_name();
                             let file_name_str = file_name.to_string_lossy();
@@ -202,17 +207,25 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                                     && let Err(err) = std::fs::remove_dir_all(entry.path())
                                     && err.kind() != std::io::ErrorKind::NotFound
                                 {
-                                    return Err(InstallError::RemoveModulesDir(err));
+                                    return Err(InstallError::RemoveModulesDir {
+                                        path: entry.path(),
+                                        error: err,
+                                    });
                                 }
                             } else if let Err(err) = std::fs::remove_file(entry.path())
                                 && err.kind() != std::io::ErrorKind::NotFound
                             {
-                                return Err(InstallError::RemoveModulesDir(err));
+                                return Err(InstallError::RemoveModulesDir {
+                                    path: entry.path(),
+                                    error: err,
+                                });
                             }
                         }
                     }
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(err) => return Err(InstallError::RemoveModulesDir(err)),
+                    Err(err) => {
+                        return Err(InstallError::RemoveModulesDir { path: target, error: err });
+                    }
                 }
             }
         } else {

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -165,7 +165,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                                     continue;
                                 }
                                 Err(err) => {
-                                    return Err(InstallError::RemoveModulesDir {
+                                    return Err(InstallError::ReadModulesDir {
                                         path: target,
                                         error: err,
                                     });
@@ -197,26 +197,27 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                                 continue;
                             }
 
+                            let entry_path = entry.path();
                             if entry.file_type().is_ok_and(|t| t.is_dir()) {
                                 #[cfg(windows)]
-                                let is_removed = pnpm_fs::remove_symlink_dir(&entry.path()).is_ok();
+                                let is_removed = pnpm_fs::remove_symlink_dir(&entry_path).is_ok();
                                 #[cfg(not(windows))]
                                 let is_removed = false;
 
                                 if !is_removed
-                                    && let Err(err) = std::fs::remove_dir_all(entry.path())
+                                    && let Err(err) = std::fs::remove_dir_all(&entry_path)
                                     && err.kind() != std::io::ErrorKind::NotFound
                                 {
                                     return Err(InstallError::RemoveModulesDir {
-                                        path: entry.path(),
+                                        path: entry_path,
                                         error: err,
                                     });
                                 }
-                            } else if let Err(err) = std::fs::remove_file(entry.path())
+                            } else if let Err(err) = std::fs::remove_file(&entry_path)
                                 && err.kind() != std::io::ErrorKind::NotFound
                             {
                                 return Err(InstallError::RemoveModulesDir {
-                                    path: entry.path(),
+                                    path: entry_path,
                                     error: err,
                                 });
                             }
@@ -224,7 +225,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                     }
                     Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
                     Err(err) => {
-                        return Err(InstallError::RemoveModulesDir { path: target, error: err });
+                        return Err(InstallError::ReadModulesDir { path: target, error: err });
                     }
                 }
             }

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -166,7 +166,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
                                 }
                                 Err(err) => {
                                     return Err(InstallError::RemoveModulesDir {
-                                        path: target.clone(),
+                                        path: target,
                                         error: err,
                                     });
                                 }

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10934,3 +10934,36 @@ fn recorded_verified_file_integrity_report(verified: VerifiedFileIntegrity) -> V
     let messages = MESSAGES.lock().unwrap().clone();
     dbg!(messages)
 }
+
+#[test]
+fn remove_modules_dir_names_the_entry_and_carries_the_diagnostic_code() {
+    let path = std::path::PathBuf::from("project").join("node_modules").join("left-pad");
+    let error = InstallError::RemoveModulesDir {
+        path: path.clone(),
+        error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+    };
+
+    let rendered = error.to_string();
+    assert!(rendered.contains(&path.display().to_string()), "got: {rendered}");
+    assert!(rendered.contains("denied"), "source error must survive: {rendered}");
+    assert_eq!(
+        miette::Diagnostic::code(&error).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR"),
+    );
+}
+
+/// Entries reach this variant from a canonicalized modules directory, so
+/// on Windows they carry a `\\?\` prefix that must not reach the user.
+#[test]
+#[cfg_attr(not(windows), ignore = "verbatim prefixes only exist on Windows")]
+fn remove_modules_dir_renders_a_copy_pasteable_windows_path() {
+    let error = InstallError::RemoveModulesDir {
+        path: std::path::PathBuf::from(r"\\?\C:\project\node_modules\is-odd"),
+        error: std::io::Error::from_raw_os_error(5),
+    };
+
+    let rendered = error.to_string();
+    assert!(rendered.contains(r"C:\project\node_modules\is-odd"), "got: {rendered}");
+    assert!(!rendered.contains(r"\\?\"), "verbatim prefix must not reach the user: {rendered}");
+    assert!(!rendered.contains(r"\\"), "separators must not be escaped: {rendered}");
+}

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10950,6 +10950,11 @@ fn remove_modules_dir_names_the_entry_and_carries_the_diagnostic_code() {
         miette::Diagnostic::code(&error).map(|code| code.to_string()).as_deref(),
         Some("ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR"),
     );
+
+    let source = std::error::Error::source(&error).expect("the io error stays in the source chain");
+    let io_error =
+        source.downcast_ref::<std::io::Error>().expect("the source is the original io::Error");
+    assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
 }
 
 /// Entries reach this variant from a canonicalized modules directory, so

--- a/pnpm/crates/package-manager/src/install/tests.rs
+++ b/pnpm/crates/package-manager/src/install/tests.rs
@@ -10935,6 +10935,21 @@ fn recorded_verified_file_integrity_report(verified: VerifiedFileIntegrity) -> V
     dbg!(messages)
 }
 
+fn assert_purge_diagnostic(error: &InstallError, path: &std::path::Path) {
+    let rendered = error.to_string();
+    assert!(rendered.contains(&path.display().to_string()), "got: {rendered}");
+    assert!(rendered.contains("denied"), "source error must survive: {rendered}");
+    assert_eq!(
+        miette::Diagnostic::code(error).map(|code| code.to_string()).as_deref(),
+        Some("ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR"),
+    );
+
+    let source = std::error::Error::source(error).expect("the io error stays in the source chain");
+    let io_error =
+        source.downcast_ref::<std::io::Error>().expect("the source is the original io::Error");
+    assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+}
+
 #[test]
 fn remove_modules_dir_names_the_entry_and_carries_the_diagnostic_code() {
     let path = std::path::PathBuf::from("project").join("node_modules").join("left-pad");
@@ -10943,32 +10958,41 @@ fn remove_modules_dir_names_the_entry_and_carries_the_diagnostic_code() {
         error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
     };
 
-    let rendered = error.to_string();
-    assert!(rendered.contains(&path.display().to_string()), "got: {rendered}");
-    assert!(rendered.contains("denied"), "source error must survive: {rendered}");
-    assert_eq!(
-        miette::Diagnostic::code(&error).map(|code| code.to_string()).as_deref(),
-        Some("ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR"),
-    );
-
-    let source = std::error::Error::source(&error).expect("the io error stays in the source chain");
-    let io_error =
-        source.downcast_ref::<std::io::Error>().expect("the source is the original io::Error");
-    assert_eq!(io_error.kind(), std::io::ErrorKind::PermissionDenied);
+    assert_purge_diagnostic(&error, &path);
 }
 
-/// Entries reach this variant from a canonicalized modules directory, so
+#[test]
+fn read_modules_dir_names_the_directory_and_carries_the_diagnostic_code() {
+    let path = std::path::PathBuf::from("project").join("node_modules");
+    let error = InstallError::ReadModulesDir {
+        path: path.clone(),
+        error: std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied"),
+    };
+
+    assert_purge_diagnostic(&error, &path);
+}
+
+/// Paths reach both variants from a canonicalized modules directory, so
 /// on Windows they carry a `\\?\` prefix that must not reach the user.
 #[test]
 #[cfg_attr(not(windows), ignore = "verbatim prefixes only exist on Windows")]
-fn remove_modules_dir_renders_a_copy_pasteable_windows_path() {
-    let error = InstallError::RemoveModulesDir {
-        path: std::path::PathBuf::from(r"\\?\C:\project\node_modules\is-odd"),
-        error: std::io::Error::from_raw_os_error(5),
-    };
+fn the_purge_diagnostics_render_copy_pasteable_windows_paths() {
+    let io_error = || std::io::Error::from_raw_os_error(5);
+    let errors = [
+        InstallError::RemoveModulesDir {
+            path: std::path::PathBuf::from(r"\\?\C:\project\node_modules\is-odd"),
+            error: io_error(),
+        },
+        InstallError::ReadModulesDir {
+            path: std::path::PathBuf::from(r"\\?\C:\project\node_modules"),
+            error: io_error(),
+        },
+    ];
 
-    let rendered = error.to_string();
-    assert!(rendered.contains(r"C:\project\node_modules\is-odd"), "got: {rendered}");
-    assert!(!rendered.contains(r"\\?\"), "verbatim prefix must not reach the user: {rendered}");
-    assert!(!rendered.contains(r"\\"), "separators must not be escaped: {rendered}");
+    for error in errors {
+        let rendered = error.to_string();
+        assert!(rendered.contains(r"C:\project\node_modules"), "got: {rendered}");
+        assert!(!rendered.contains(r"\\?\"), "verbatim prefix must not reach the user: {rendered}");
+        assert!(!rendered.contains(r"\\"), "separators must not be escaped: {rendered}");
+    }
 }


### PR DESCRIPTION
`ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` reports the OS error and nothing else, so
every entry under `node_modules` is a suspect. On 12.3.4, Windows 11:

```
Error: ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR

  × installing dependencies
  ╰─▶ Failed to remove modules directory contents: 拒绝访问。 (os error 5)
```

(`拒绝访问` is "Access is denied" on a zh-CN Windows.)

With this change, the same failure on the same machine:

```
  ╰─▶ Failed to remove
      C:\Users\me\AppData\Local\Temp\pxverify2\node_modules\is-odd from the
      modules directory: 拒绝访问。 (os error 5)
```

## Where it came from

I hit this upgrading an existing project from pnpm 11 to pnpm 12 on Windows. From a clean
directory, an install with `pnpm@11` followed by an install with `pnpm@12` fails on the
first v12 run and succeeds on the second, three times out of three:

```
cycle 1: v12 run 1 exit=1 [ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR]  run 2 exit=0
cycle 2: v12 run 1 exit=1 [ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR]  run 2 exit=0
cycle 3: v12 run 1 exit=1 [ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR]  run 2 exit=0
```

Narrowing down which entry was at fault took a bisect by hand, and I still got it wrong:
working from the outside I concluded the junctions pnpm 11 leaves *inside* `.pnpm` were
responsible. The patched binary answered it in one run, and the answer was the top-level
`node_modules/is-odd` junction instead.

**This PR does not fix that failure.** I have a reliable reproduction but not a confident
account of the mechanism, so I am not guessing at a fix. What I can fix is the part that
made the reproduction far harder to narrow down than it needed to be. If the underlying
upgrade failure is of interest, I am happy to open a separate issue with the full
reproduction.

It is a different failure from the transient Windows file-lock family in #14349, #14407
and #14549: those depend on another process holding a handle and clear on a retry, while
this one reproduces from a clean state every time and is specific to a pnpm 11 tree.

## The change

`RemoveModulesDir` becomes a struct variant carrying the path, the way
`PruneDirectDepsError::RemoveBin { path, error }` and
`InstallError::UnsafeFilteredModulesDir { modules_dir, workspace_root }` already do. It
names the entry the `remove_dir_all` and `remove_file` failures were on. The two
`read_dir` failures have the modules directory itself, so they build a sibling
`ReadModulesDir { path, error }` variant that says the directory could not be read; it
carries the same `ERR_PNPM_PACKAGE_MANAGER_REMOVE_MODULES_DIR` code, so no new error code
reaches users. Neither variant has other consumers in the workspace.

It renders through `dunce::simplified` and `Path::display` rather than `{:?}`. The entries
come from a canonicalized modules directory, so `{:?}` prints the `\\?\` verbatim prefix
that #13990 removed from user-visible paths, and doubles every separator:

```
Failed to remove "\\\\?\\C:\\Users\\me\\...\\node_modules\\is-odd" from the modules directory
```

A path a user is meant to act on should be copy-pasteable. `dunce` is already a dependency
of this crate, and `path.display()` in an error is the shape used in `auth-commands` and
`cli`.

## Same shape, not included

Two variants in `InstallError` still wrap a bare `io::Error`:

- `CleanGitBranchLockfiles`, where a path would help for the same reason
- `ProjectLifecycleThreadPool`, where there is no path to name

I left them alone because I have not hit either. Happy to include
`CleanGitBranchLockfiles` here if you would rather it move in one go.

## Testing

`cargo test -p pnpm-package-manager` passes except for
`link_manifest_link_deps::tests::relink_replaces_stale_symlink`, which fails identically on
an unmodified checkout of this branch's base: it creates a real symlink and this machine
has no `SeCreateSymbolicLinkPrivilege`. `cargo fmt -- --check` is clean.

Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14605"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791272593&installation_model_id=426870&pr_number=14605&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14605&signature=67a12a8ad7bf87ee78bbe275fbc083c47e8c003c14366506e06f2fc756ce7a0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module cleanup errors by identifying the specific file or directory that could not be removed.
  * Error messages now include a clear, copyable path alongside the underlying operating system error.
  * Diagnostics preserve original operating system details, including permission-related failures, making cleanup problems easier to troubleshoot.
  * Paths are normalized for easier copying across supported platforms, including Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
