### PR TITLE
feat(pnpr): journal the Cargo and Python publish transactions

### DIFF
--- a/.changeset/journaled-publish-for-every-surface.md
+++ b/.changeset/journaled-publish-for-every-surface.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A `cargo publish` or `twine upload` that pnpr accepted is now recorded in one crash-safe step, as an npm publish already was. If the server stops between storing the file and recording it in the crate or project document, the next startup completes the publish instead of leaving a file nothing points at.

--- a/.changeset/journaled-publish-for-every-surface.md
+++ b/.changeset/journaled-publish-for-every-surface.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-A `cargo publish` or `twine upload` that pnpr accepted is now recorded in one crash-safe step, as an npm publish already was. If the server stops between storing the file and recording it in the crate or project document, the next startup completes the publish instead of leaving a file nothing points at.
+pnpr now stores an uploaded crate or Python distribution and records it in the registry document in one crash-safe step, as it already does for an npm publish. A server that stopped between the two steps left behind a file that nothing pointed at. The next startup now finishes the publish.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6358,6 +6358,7 @@ dependencies = [
  "pnpr-config",
  "pnpr-error",
  "pnpr-package-name",
+ "pnpr-registry",
  "reqwest",
  "serde",
  "serde_json",

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -26,7 +26,7 @@ pub use pnpr_policy::{AccessList, AccessToken, Identity, PackageRule, PackageRul
 pub use pnpr_registry::{
     ConcreteKind, Ecosystem, PackagePattern, Registries, Registry, RegistryConfigError, Resolved,
 };
-pub use pnpr_storage::journal::recover_publish_journal;
 pub use server::{
-    router, router_with_auth, serve, serve_listener, try_router, try_router_with_auth,
+    recover_publish_journal, router, router_with_auth, serve, serve_listener, try_router,
+    try_router_with_auth,
 };

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1,5 +1,6 @@
 mod authentication;
 mod cargo;
+mod documents;
 mod ecosystem;
 mod package_mutation;
 mod publishing;
@@ -12,6 +13,7 @@ mod tests;
 
 use self::{
     authentication::{Action, AuthedCaller, authenticate, authorize},
+    documents::RegistryDocuments,
     package_mutation::{
         delete_package, delete_tarball, get_dist_tags, remove_dist_tag, set_dist_tag,
         update_packument,
@@ -238,13 +240,21 @@ fn load_active_osv_index(config: &Config) -> pnpr_error::Result<Option<Arc<pnpr_
     }
 }
 
+/// Bring the publish journal to a consistent state: apply every sealed
+/// transaction, discard every unsealed one. [`serve`] and [`serve_listener`]
+/// call this before binding; an embedder that builds a router directly should
+/// call it itself on startup, before serving requests.
+pub async fn recover_publish_journal(config: &Config) -> pnpr_error::Result<()> {
+    pnpr_storage::journal::recover_publish_journal(config, &RegistryDocuments).await
+}
+
 /// Run startup side effects and load the auth backends. The registry
 /// needs publish-journal recovery; auth loads on every tier because the
 /// account endpoints (which mint and manage tokens) are always served,
 /// and every mounted surface consults caller identity.
 async fn load_startup_auth(config: &Config) -> pnpr_error::Result<AuthState> {
     if config.registry.enabled {
-        pnpr_storage::journal::recover_publish_journal(config).await?;
+        recover_publish_journal(config).await?;
     }
     AuthState::load(&config.auth, &config.backend).await
 }

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -18,11 +18,11 @@
 
 use super::{
     Action, AppState, AuthedCaller, RegistrySource, TargetRegistry, authorize,
+    documents::{read_hosted_document, store_hosted_artifact},
     ecosystem::{
         UpstreamDocument, addressed_registry, caller_scoped, is_fetchable_artifact_url,
-        load_upstream_document, read_hosted_document, registry_endpoint, registry_requires_auth,
-        serve_hosted_blob, serve_upstream_artifact, sha256_hex, sha256_integrity,
-        store_hosted_artifact, upstream_for,
+        load_upstream_document, registry_endpoint, registry_requires_auth, serve_hosted_blob,
+        serve_upstream_artifact, sha256_hex, sha256_integrity, upstream_for,
     },
     json_response, not_found,
     publishing::{PublishTarget, resolve_publish_target_for},
@@ -365,26 +365,20 @@ async fn put_publish(
     };
     let filename = crate_filename(&metadata.name, &metadata.vers);
     let entry = metadata.into_index_entry(cksum);
-    let stored = store_hosted_artifact::<CrateDocument>(
+    let vers = entry.vers.clone();
+    let stored = store_hosted_artifact(
         &state,
         &org,
         &key,
         &filename,
         &archive,
-        |document| match document.version(&entry.vers) {
+        |document: &CrateDocument| match document.version(&vers) {
             Some(_) => Err(RegistryError::BadRequest {
-                reason: format!("crate version `{}` is already uploaded", entry.vers),
+                reason: format!("crate version `{vers}` is already uploaded"),
             }),
             None => Ok(()),
         },
-        |document| {
-            // The document carries the name as first published, not the
-            // lowercase key it is stored under.
-            if document.versions.is_empty() {
-                document.name.clone_from(&entry.name);
-            }
-            document.versions.push(entry.clone());
-        },
+        CrateDocument { name: entry.name.clone(), versions: vec![entry] },
     )
     .await;
     match stored {

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -163,8 +163,9 @@ pub(super) async fn read_hosted_document<Document: HostedDocument>(
 /// Writers of the same key on this instance are serialized by the package
 /// lock; `refuse` rejects a document the publish must not land on (an entry
 /// already present) before anything is written. Across instances the blob's
-/// immutable slot decides: a publish whose bytes lose it records nothing and
-/// reports the conflict.
+/// immutable slot decides: a publish whose bytes lose it reports the
+/// conflict, and one that finds its entry already recorded by the writer that
+/// won answers `refuse` on the document that writer left.
 pub(super) async fn store_hosted_artifact<Document: HostedDocument>(
     state: &AppState,
     org: &str,
@@ -207,6 +208,11 @@ pub(super) async fn store_hosted_artifact<Document: HostedDocument>(
         .await?;
     if outcome.lost_blobs.iter().any(|lost| lost == filename) {
         return Err(RegistryError::PackumentWriteConflict { package: key.as_str().to_string() });
+    }
+    if !outcome.unrecorded.is_empty()
+        && let Some(stored) = storage.read_hosted_packument(key).await?
+    {
+        refuse(&Document::parse(&stored).map_err(RegistryError::Json)?)?;
     }
     Ok(())
 }

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -155,10 +155,7 @@ pub(super) async fn read_hosted_document<Document: HostedDocument>(
 
 /// Publish one blob: store `bytes` as `filename` under `key` in the hosted
 /// namespace `org` and record `addition` — the document holding just that
-/// blob's entry — in the project's document, as a single journaled
-/// transaction. A crash between the two leaves the journal entry, which
-/// startup recovery applies, so the store never holds a blob no document
-/// mentions.
+/// blob's entry — in the project's document, as one journaled transaction.
 ///
 /// Writers of the same key on this instance are serialized by the package
 /// lock; `refuse` rejects a document the publish must not land on (an entry

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -1,0 +1,212 @@
+//! The hosted document each surface keeps per package, and the journaled
+//! publish that records a blob in one.
+//!
+//! A hosted registry stores one document per package — an npm packument, a
+//! crate's index entries, a Python project's file list — beside the blobs it
+//! serves. Publishing a blob and recording it in the document has to be one
+//! operation: a blob no document mentions is invisible, and a document entry
+//! with no blob behind it is a broken download. [`store_hosted_artifact`]
+//! makes it one, through the same commit journal the npm publish flow uses,
+//! and [`RegistryDocuments`] gives that journal the per-ecosystem merge rule
+//! it re-runs when a transaction is applied after a crash.
+
+use super::{AppState, hosted_read_namespace};
+use pnpr_cargo::{CrateDocument, crate_filename};
+use pnpr_error::RegistryError;
+use pnpr_package_name::PackageName;
+use pnpr_policy::Identity;
+use pnpr_pypi::ProjectDocument;
+use pnpr_registry::Ecosystem;
+use pnpr_storage::{
+    journal::{DocumentMerge, HostedDocuments, JournaledPublish},
+    publish::merge_journaled_packument,
+};
+use std::{collections::HashSet, slice};
+
+/// The per-project document a hosted registry keeps in its document slot: a
+/// crate's index entries, a Python project's file list. Read through
+/// [`read_hosted_document`] and written through [`store_hosted_artifact`].
+pub(super) trait HostedDocument: Sized {
+    /// The ecosystem whose surface publishes this document.
+    const ECOSYSTEM: Ecosystem;
+
+    fn empty(name: &str) -> Self;
+    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error>;
+    fn to_bytes(&self) -> Vec<u8>;
+
+    /// Take on every entry of `addition` this document does not already have,
+    /// and report whether that added anything. An entry is skipped when its
+    /// blob filename is in `lost_blobs`, which names the blobs a transaction
+    /// failed to place: those bytes are not the ones the store serves, so
+    /// nothing may point at them.
+    ///
+    /// Entries already here win, which is what makes a re-applied publish
+    /// safe: what was published in the meantime stays, and only what is
+    /// genuinely missing is added.
+    fn merge(&mut self, addition: Self, lost_blobs: &HashSet<String>) -> bool;
+}
+
+impl HostedDocument for CrateDocument {
+    const ECOSYSTEM: Ecosystem = Ecosystem::Cargo;
+
+    fn empty(name: &str) -> Self {
+        CrateDocument::new(name)
+    }
+
+    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        CrateDocument::parse(bytes)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        CrateDocument::to_bytes(self)
+    }
+
+    fn merge(&mut self, addition: Self, lost_blobs: &HashSet<String>) -> bool {
+        let before = self.versions.len();
+        for entry in addition.versions {
+            if self.version(&entry.vers).is_some()
+                || lost_blobs.contains(&crate_filename(&entry.name, &entry.vers))
+            {
+                continue;
+            }
+            // The document carries the name as first published, not the
+            // lowercase key it is stored under.
+            if self.versions.is_empty() {
+                self.name.clone_from(&entry.name);
+            }
+            self.versions.push(entry);
+        }
+        self.versions.len() != before
+    }
+}
+
+impl HostedDocument for ProjectDocument {
+    const ECOSYSTEM: Ecosystem = Ecosystem::Pypi;
+
+    fn empty(name: &str) -> Self {
+        ProjectDocument::new(name)
+    }
+
+    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        ProjectDocument::parse(bytes)
+    }
+
+    fn to_bytes(&self) -> Vec<u8> {
+        ProjectDocument::to_bytes(self)
+    }
+
+    fn merge(&mut self, addition: Self, lost_blobs: &HashSet<String>) -> bool {
+        let before = self.files.len();
+        for file in addition.files {
+            if self.file(&file.filename).is_some() || lost_blobs.contains(&file.filename) {
+                continue;
+            }
+            self.files.push(file);
+        }
+        self.files.len() != before
+    }
+}
+
+/// Every hosted document format pnpr serves, as the publish journal sees
+/// them. The journal carries documents as opaque bytes; this resolves the
+/// ecosystem it recorded back to the merge rule for that format, both when a
+/// publish commits and when startup recovery re-applies a sealed one.
+pub(super) struct RegistryDocuments;
+
+impl HostedDocuments for RegistryDocuments {
+    fn merge(&self, merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>, RegistryError> {
+        match merge.ecosystem {
+            Ecosystem::Npm => merge_journaled_packument(&merge),
+            Ecosystem::Cargo => merge_into_stored::<CrateDocument>(&merge),
+            Ecosystem::Pypi => merge_into_stored::<ProjectDocument>(&merge),
+        }
+    }
+}
+
+fn merge_into_stored<Document: HostedDocument>(
+    merge: &DocumentMerge<'_>,
+) -> Result<Option<Vec<u8>>, RegistryError> {
+    let journaled = Document::parse(merge.journaled).map_err(RegistryError::Json)?;
+    let mut stored = match merge.existing {
+        Some(bytes) => Document::parse(bytes).map_err(RegistryError::Json)?,
+        None => Document::empty(merge.name.as_str()),
+    };
+    Ok(stored.merge(journaled, merge.lost_blobs).then(|| stored.to_bytes()))
+}
+
+/// The hosted document of `key` through `source`'s read gate: `None` when the
+/// project is absent (or masked from `identity`).
+pub(super) async fn read_hosted_document<Document: HostedDocument>(
+    state: &AppState,
+    identity: &Identity,
+    source: &str,
+    key: &PackageName,
+) -> Result<Option<Document>, RegistryError> {
+    let org = hosted_read_namespace(state, identity, source, key.as_str())?;
+    state
+        .inner
+        .storage
+        .for_hosted(&org)
+        .read_hosted_packument(key)
+        .await?
+        .map(|bytes| Document::parse(&bytes).map_err(RegistryError::Json))
+        .transpose()
+}
+
+/// Publish one blob: store `bytes` as `filename` under `key` in the hosted
+/// namespace `org` and record `addition` — the document holding just that
+/// blob's entry — in the project's document, as a single journaled
+/// transaction. A crash between the two leaves the journal entry, which
+/// startup recovery applies, so the store never holds a blob no document
+/// mentions.
+///
+/// Writers of the same key on this instance are serialized by the package
+/// lock; `refuse` rejects a document the publish must not land on (an entry
+/// already present) before anything is written. Across instances the blob's
+/// immutable slot decides: a publish whose bytes lose it records nothing and
+/// reports the conflict.
+pub(super) async fn store_hosted_artifact<Document: HostedDocument>(
+    state: &AppState,
+    org: &str,
+    key: &PackageName,
+    filename: &str,
+    bytes: &[u8],
+    refuse: impl Fn(&Document) -> Result<(), RegistryError>,
+    addition: Document,
+) -> Result<(), RegistryError> {
+    let _guard = state.inner.package_locks.lock(key.as_str()).await;
+    let storage = state.inner.storage.for_hosted(org);
+    let stored = storage.read_hosted_packument_for_update(key).await?;
+    let mut document = match &stored {
+        Some(stored) => Document::parse(&stored.bytes).map_err(RegistryError::Json)?,
+        None => Document::empty(key.as_str()),
+    };
+    refuse(&document)?;
+    document.merge(addition, &HashSet::new());
+    let document = document.to_bytes();
+
+    let slot = storage.reserve_hosted_tarball(key, filename).await?;
+    tokio::fs::write(&slot.tmp_path, bytes).await?;
+    let outcome = state
+        .inner
+        .storage
+        .publish_journal()
+        .commit(
+            &state.inner.storage,
+            &[JournaledPublish {
+                name: key,
+                org: Some(org),
+                ecosystem: Document::ECOSYSTEM,
+                document: &document,
+                base_version: stored.as_ref().map(|stored| &stored.version),
+                slots: slice::from_ref(&slot),
+                revision_refs: &[],
+            }],
+            &RegistryDocuments,
+        )
+        .await?;
+    if outcome.lost_blobs.iter().any(|lost| lost == filename) {
+        return Err(RegistryError::PackumentWriteConflict { package: key.as_str().to_string() });
+    }
+    Ok(())
+}

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -6,9 +6,9 @@
 //! the registry graph is consulted for that ecosystem only, so one router can
 //! front every ecosystem. This module holds the pieces the Cargo and Python
 //! surfaces both need: addressing (which registry, which endpoint URL, which
-//! cache headers), the anonymous-readability check, the hosted document and
-//! blob flows, and the proxy cache for an upstream's metadata documents and
-//! artifacts.
+//! cache headers), the anonymous-readability check, hosted blob downloads,
+//! and the proxy cache for an upstream's metadata documents and artifacts.
+//! The documents themselves live in [`super::documents`].
 
 use super::{
     Action, AppState, MAX_TARBALL_BYTES, RegistrySource, authorize, authorized_upstream,
@@ -17,13 +17,11 @@ use super::{
     upstream_cache_namespace,
 };
 use axum::response::{IntoResponse, Response};
-use pnpr_cargo::CrateDocument;
 use pnpr_error::RegistryError;
 use pnpr_package_name::PackageName;
 use pnpr_policy::Identity;
-use pnpr_pypi::ProjectDocument;
 use pnpr_registry::{Ecosystem, Registry};
-use pnpr_storage::{PACKUMENT_WRITE_RETRIES, TarballFinalize, streaming};
+use pnpr_storage::streaming;
 use pnpr_upstream::{FetchOutcome, FetchedDocument, Upstream};
 use sha2::{Digest, Sha256};
 use ssri::{Algorithm, Integrity};
@@ -114,62 +112,6 @@ pub(super) fn hosted_sources(
         .collect()
 }
 
-/// The per-project document a hosted registry keeps in its document slot: a
-/// crate's index entries, a Python project's file list. Read and written
-/// through [`read_hosted_document`] and [`store_hosted_artifact`].
-pub(super) trait HostedDocument: Sized {
-    fn empty(name: &str) -> Self;
-    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error>;
-    fn to_bytes(&self) -> Vec<u8>;
-}
-
-impl HostedDocument for CrateDocument {
-    fn empty(name: &str) -> Self {
-        CrateDocument::new(name)
-    }
-
-    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-        CrateDocument::parse(bytes)
-    }
-
-    fn to_bytes(&self) -> Vec<u8> {
-        CrateDocument::to_bytes(self)
-    }
-}
-
-impl HostedDocument for ProjectDocument {
-    fn empty(name: &str) -> Self {
-        ProjectDocument::new(name)
-    }
-
-    fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
-        ProjectDocument::parse(bytes)
-    }
-
-    fn to_bytes(&self) -> Vec<u8> {
-        ProjectDocument::to_bytes(self)
-    }
-}
-
-/// The hosted document of `key` through `source`'s read gate: `None` when the
-/// project is absent (or masked from `identity`).
-pub(super) async fn read_hosted_document<Document: HostedDocument>(
-    state: &AppState,
-    identity: &Identity,
-    source: &str,
-    key: &PackageName,
-) -> Result<Option<Document>, RegistryError> {
-    let org = hosted_read_namespace(state, identity, source, key.as_str())?;
-    state
-        .inner
-        .storage
-        .for_hosted(&org)
-        .read_hosted_packument(key)
-        .await?
-        .map(|bytes| Document::parse(&bytes).map_err(RegistryError::Json))
-        .transpose()
-}
-
 /// A hosted blob of `key` through `source`'s read gate, as a download
 /// response; a 404 when the blob is absent.
 pub(super) async fn serve_hosted_blob(
@@ -185,52 +127,6 @@ pub(super) async fn serve_hosted_blob(
         Some((body, len)) => tarball_response(body, len),
         None => not_found(),
     })
-}
-
-/// Store a blob under `key` in the hosted namespace `org` and record it in
-/// the project's document, serialized against other writers of the key on
-/// this instance. `refuse` rejects a document the write must not land on (a
-/// version or filename already present) — before the blob is written, and
-/// again on the document as it stands at write time; `record` adds the
-/// blob's entry to the document.
-pub(super) async fn store_hosted_artifact<Document: HostedDocument + Send>(
-    state: &AppState,
-    org: &str,
-    key: &PackageName,
-    filename: &str,
-    bytes: &[u8],
-    refuse: impl Fn(&Document) -> Result<(), RegistryError> + Send + Sync,
-    record: impl Fn(&mut Document) + Send + Sync,
-) -> Result<(), RegistryError> {
-    let _guard = state.inner.package_locks.lock(key.as_str()).await;
-    let storage = state.inner.storage.for_hosted(org);
-    if let Some(existing) = storage.read_hosted_packument(key).await? {
-        refuse(&Document::parse(&existing)?)?;
-    }
-    let slot = storage.reserve_hosted_tarball(key, filename).await?;
-    tokio::fs::write(&slot.tmp_path, bytes).await?;
-    let tmp_path = slot.tmp_path.clone();
-    match storage.finalize_tarball_slot(slot).await? {
-        TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
-        TarballFinalize::Conflict => {
-            tokio::fs::remove_file(tmp_path).await?;
-            return Err(RegistryError::PackumentWriteConflict {
-                package: key.as_str().to_string(),
-            });
-        }
-    }
-    storage
-        .update_hosted_packument_with_retry(key, PACKUMENT_WRITE_RETRIES, |existing| {
-            let mut document = match existing {
-                Some(bytes) => Document::parse(bytes)?,
-                None => Document::empty(key.as_str()),
-            };
-            refuse(&document)?;
-            record(&mut document);
-            Ok(Some(document.to_bytes()))
-        })
-        .await?;
-    Ok(())
 }
 
 /// The upstream behind `source`, authorized for `identity` to read `key`,

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -15,7 +15,7 @@ use pnpr_package_name::PackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{Ecosystem, Registry};
 use pnpr_storage::{
-    HostedPackumentVersion, PackumentWrite, TarballFinalize,
+    HostedPackumentVersion,
     journal::{JournaledPublish, JournaledRevisionRef},
     publish::{
         PendingAttachment, extract_attachments, merge_manifest, now_iso,
@@ -25,8 +25,8 @@ use pnpr_storage::{
 
 use super::{
     Action, AppState, AuthedCaller, HostedGate, HostedOriginalRef, RegistrySource, WriteTarget,
-    authorize, authorized_upstream, default_registry_target, hosted_gate, hosted_storage,
-    resolve_ecosystem_source, resolve_write_target,
+    authorize, authorized_upstream, default_registry_target, documents::RegistryDocuments,
+    hosted_gate, hosted_storage, resolve_ecosystem_source, resolve_write_target,
 };
 
 /// Where a publish of `package` writes, given an optional explicit `/~<name>/`.
@@ -548,132 +548,40 @@ fn staged_hosted_original_ref(
     Some(JournaledRevisionRef { filename: attachment.canonical.clone(), digest, ref_id, bytes })
 }
 
-/// Make every staged publish visible. The full intent — merged
-/// packument bytes, revision references, and staged tmp-file locations — is sealed into
-/// the commit journal first, so a crash or I/O failure mid-apply can
-/// never leave the batch partially published: startup recovery rolls
-/// a sealed transaction forward. If sealing itself fails, nothing was
-/// promoted and the staged tmp files are cleaned up here.
+/// Make every staged publish visible, as one journaled transaction: a crash
+/// or I/O failure mid-apply can never leave the batch partially published,
+/// because startup recovery applies whatever the seal committed.
 ///
-/// Within each package, tarballs are promoted before the packument so
-/// a successful packument write never advertises a tarball that's
-/// missing from disk.
+/// A version whose tarball lost its immutable slot to another replica is
+/// dropped from the packument the transaction writes, which keeps the store
+/// consistent with the tarball that won. One that could not claim a
+/// digest-reference slot is dropped the same way, but reported: the publisher
+/// asked for a version that is not there.
 pub(super) async fn commit_publishes(
     state: &AppState,
     staged: Vec<StagedPublish>,
 ) -> Result<(), RegistryError> {
-    let journal = state.inner.storage.publish_journal();
     let entries: Vec<JournaledPublish<'_>> = staged
         .iter()
         .map(|stage| JournaledPublish {
             name: &stage.name,
             org: stage.org.as_deref(),
-            packument: &stage.merged_bytes,
+            ecosystem: Ecosystem::Npm,
+            document: &stage.merged_bytes,
+            base_version: stage.base_version.as_ref(),
             slots: &stage.slots,
             revision_refs: &stage.original_refs,
         })
         .collect();
-    let sealed = journal.seal(&entries).await;
-    drop(entries);
-    let txn = match sealed {
-        Ok(txn) => txn,
-        Err(err) => {
-            for stage in staged {
-                cleanup_tmp_slots(stage.slots).await;
-            }
-            return Err(err);
-        }
-    };
-    let revision_ref_owner = txn.revision_ref_owner().to_string();
-    // Past the seal the transaction is committed: the apply below is pure
-    // roll-forward, and failures must NOT clean up the staged files. If
-    // the apply fails partway, complete it immediately via the same
-    // idempotent recovery path so a running server never leaves the batch
-    // partially visible; startup recovery is the final backstop if even
-    // that fails.
-    let apply_result = async {
-        for stage in staged {
-            // Promote into the package's hosted namespace (or the flat
-            // store when it has none) — the same target the journal recorded,
-            // so an inline failure and a startup roll-forward land identically.
-            let store = hosted_storage(state, stage.org.as_deref());
-            for slot in stage.slots {
-                match store.finalize_tarball_slot(slot).await? {
-                    TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
-                    // A concurrent replica already promoted a different tarball
-                    // for this version. Its bytes are immutable, so abort the
-                    // apply rather than advertise our integrity against them.
-                    // The seal's roll-forward re-runs from the journal, where it
-                    // drops the version we lost and re-merges the rest.
-                    TarballFinalize::Conflict => {
-                        return Err(RegistryError::PackumentWriteConflict {
-                            package: stage.name.as_str().to_string(),
-                        });
-                    }
-                }
-            }
-            for original in &stage.original_refs {
-                store
-                    .write_hosted_revision_ref(
-                        &original.digest,
-                        &original.ref_id,
-                        &revision_ref_owner,
-                        &original.bytes,
-                    )
-                    .await?;
-            }
-            match store
-                .write_hosted_packument_if_current(
-                    &stage.name,
-                    &stage.merged_bytes,
-                    stage.base_version.as_ref(),
-                )
-                .await?
-            {
-                PackumentWrite::Written => {
-                    for original in &stage.original_refs {
-                        store
-                            .commit_hosted_revision_ref(
-                                &original.digest,
-                                &original.ref_id,
-                                &revision_ref_owner,
-                            )
-                            .await?;
-                    }
-                }
-                // Tarballs are already promoted at this point. A conflict means
-                // another replica advanced the packument since staging, so the
-                // base version is stale. Surfacing it drops into the seal's
-                // roll-forward path (the caller), which re-reads the current
-                // packument and re-merges this transaction's journaled manifest —
-                // re-referencing the promoted tarballs — rather than leaving them
-                // orphaned. Only if roll-forward and startup recovery both never
-                // converge would a promoted tarball stay unreferenced.
-                PackumentWrite::Conflict => {
-                    return Err(RegistryError::PackumentWriteConflict {
-                        package: stage.name.as_str().to_string(),
-                    });
-                }
-            }
-        }
-        Ok::<(), RegistryError>(())
-    }
-    .await;
-    match apply_result {
-        Ok(()) => {
-            txn.finish().await;
-            Ok(())
-        }
-        Err(apply_err) => {
-            tracing::warn!(error = %apply_err, "publish apply failed after seal; rolling forward");
-            let report_conflict =
-                matches!(&apply_err, RegistryError::RevisionReferenceLimit { .. });
-            match txn.roll_forward(&state.inner.storage).await {
-                Ok(()) if report_conflict => Err(apply_err),
-                Ok(()) => Ok(()),
-                Err(_) => Err(apply_err),
-            }
-        }
+    let outcome = state
+        .inner
+        .storage
+        .publish_journal()
+        .commit(&state.inner.storage, &entries, &RegistryDocuments)
+        .await?;
+    match outcome.reference_limit {
+        Some(limit) => Err(RegistryError::RevisionReferenceLimit { limit }),
+        None => Ok(()),
     }
 }
 

--- a/pnpr/crates/pnpr/src/server/pypi.rs
+++ b/pnpr/crates/pnpr/src/server/pypi.rs
@@ -17,11 +17,11 @@
 
 use super::{
     Action, AppState, AuthedCaller, HostedGate, RegistrySource, TargetRegistry, authorize,
+    documents::{read_hosted_document, store_hosted_artifact},
     ecosystem::{
         UpstreamDocument, addressed_registry, caller_scoped, hosted_sources,
-        is_fetchable_artifact_url, load_upstream_document, read_hosted_document, registry_endpoint,
-        serve_hosted_blob, serve_upstream_artifact, sha256_hex, sha256_integrity,
-        store_hosted_artifact, upstream_for,
+        is_fetchable_artifact_url, load_upstream_document, registry_endpoint, serve_hosted_blob,
+        serve_upstream_artifact, sha256_hex, sha256_integrity, upstream_for,
     },
     hosted_gate, not_found, private_no_cache,
     publishing::{PublishTarget, resolve_publish_target_for},
@@ -410,19 +410,19 @@ async fn upload_file(
         size: Some(upload.content.len() as u64),
         upload_time: Some(now_iso()),
     };
-    store_hosted_artifact::<ProjectDocument>(
+    store_hosted_artifact(
         state,
         &org,
         &key,
         &upload.filename,
         &upload.content,
-        |document| match document.file(&entry.filename) {
+        |document: &ProjectDocument| match document.file(&upload.filename) {
             Some(_) => Err(RegistryError::BadRequest {
-                reason: format!("File already exists: {:?}", entry.filename),
+                reason: format!("File already exists: {:?}", upload.filename),
             }),
             None => Ok(()),
         },
-        |document| document.files.push(entry.clone()),
+        ProjectDocument { name: project.clone(), files: vec![entry] },
     )
     .await
 }

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -205,7 +205,6 @@ async fn publish_then_resolve_and_download_a_hosted_crate() {
     // Storage layout: the hosted org namespace, keyed by the lowercase name.
     assert!(tmp.path().join("crates/demo/demo-0.1.0.crate").is_file());
     assert!(tmp.path().join("crates/demo/package.json").is_file());
-    // The publish went through the commit journal and left nothing behind.
     assert!(std::fs::read_dir(tmp.path().join(".pnpr-journal")).unwrap().next().is_none());
 
     // The crate is reachable at its one sparse-index path only.
@@ -729,9 +728,8 @@ fn fabricate_crashed_crate_publish(storage: &Path, archive: &[u8]) -> PathBuf {
     tmp_path
 }
 
-/// A `cargo publish` that crashed after its archive was staged and before the
-/// crate document recorded it is completed on the next startup: both halves
-/// land, so the store never holds an archive no index file mentions.
+/// Both halves land, so the store never holds an archive that no index file
+/// mentions.
 #[tokio::test]
 async fn a_crashed_publish_is_completed_on_startup() {
     let tmp = TempDir::new().unwrap();
@@ -766,7 +764,7 @@ async fn a_crashed_publish_is_completed_on_startup() {
 }
 
 /// Applying a sealed transaction adds its version to the document as it
-/// stands, so a crate published between the crash and the restart survives.
+/// stands rather than to the one the crashed publish read.
 #[tokio::test]
 async fn a_crashed_publish_keeps_what_was_published_while_it_was_down() {
     let tmp = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -11,9 +11,12 @@ use axum::{
     http::{Request, StatusCode, header},
 };
 use common::{HostedSource, body_bytes, find_file, mixed_router_config, sha256_hex};
-use pnpr::{AuthState, Config, Ecosystem, router_with_auth};
+use pnpr::{AuthState, Config, Ecosystem, recover_publish_journal, router_with_auth};
 use serde_json::{Value, json};
-use std::{io::Write as _, path::PathBuf};
+use std::{
+    io::Write as _,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -202,6 +205,8 @@ async fn publish_then_resolve_and_download_a_hosted_crate() {
     // Storage layout: the hosted org namespace, keyed by the lowercase name.
     assert!(tmp.path().join("crates/demo/demo-0.1.0.crate").is_file());
     assert!(tmp.path().join("crates/demo/package.json").is_file());
+    // The publish went through the commit journal and left nothing behind.
+    assert!(std::fs::read_dir(tmp.path().join(".pnpr-journal")).unwrap().next().is_none());
 
     // The crate is reachable at its one sparse-index path only.
     for wrong in ["/cargo/index/3/d/demo", "/cargo/index/de/mo/Demo", "/cargo/index/DE/MO/demo"] {
@@ -684,4 +689,111 @@ async fn upstream_sparse_index_rejects_invalid_utf8_before_serving_or_downloadin
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
     corrected.assert_async().await;
     config_mock.assert_async().await;
+}
+
+/// The on-disk state a crash between staging the archive and recording it in
+/// the crate document leaves behind: the staged tmp file plus the sealed
+/// journal entry that says where it belongs.
+fn fabricate_crashed_crate_publish(storage: &Path, archive: &[u8]) -> PathBuf {
+    let crate_dir = storage.join("crates/demo");
+    std::fs::create_dir_all(&crate_dir).unwrap();
+    let tmp_path = crate_dir.join("demo-0.1.0.crate.tmp.999.0");
+    std::fs::write(&tmp_path, archive).unwrap();
+
+    let txn_dir = storage.join(".pnpr-journal").join("0000000000000001-999-0");
+    std::fs::create_dir_all(&txn_dir).unwrap();
+    let document = json!({
+        "name": "demo",
+        "versions": [{
+            "name": "demo",
+            "vers": "0.1.0",
+            "deps": [],
+            "cksum": sha256_hex(archive),
+            "features": {},
+            "yanked": false,
+        }],
+    });
+    std::fs::write(txn_dir.join("document-0.json"), serde_json::to_vec(&document).unwrap())
+        .unwrap();
+    let manifest = json!({
+        "packages": [{
+            "name": "demo",
+            "ecosystem": "cargo",
+            "org": "crates",
+            "document_file": "document-0.json",
+            "blobs": [{ "filename": "demo-0.1.0.crate", "tmp_path": tmp_path }],
+        }],
+    });
+    std::fs::write(txn_dir.join("manifest.json"), serde_json::to_vec(&manifest).unwrap()).unwrap();
+    std::fs::write(txn_dir.join("commit"), b"").unwrap();
+    tmp_path
+}
+
+/// A `cargo publish` that crashed after its archive was staged and before the
+/// crate document recorded it is completed on the next startup: both halves
+/// land, so the store never holds an archive no index file mentions.
+#[tokio::test]
+async fn a_crashed_publish_is_completed_on_startup() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let config = cargo_config(storage.clone(), "http://upstream.invalid/", "$all");
+    let archive = crate_archive("demo", "0.1.0");
+    let tmp_path = fabricate_crashed_crate_publish(&storage, &archive);
+
+    recover_publish_journal(&config).await.unwrap();
+
+    assert!(!tmp_path.exists(), "the staged archive should be promoted away");
+    assert!(std::fs::read_dir(storage.join(".pnpr-journal")).unwrap().next().is_none());
+    let app = router_with_auth(config, AuthState::in_memory());
+    let response = app
+        .clone()
+        .oneshot(Request::get("/cargo/index/de/mo/demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let index = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    let entry: Value = serde_json::from_str(index.lines().next().unwrap()).unwrap();
+    assert_eq!(entry["vers"], "0.1.0");
+    assert_eq!(entry["cksum"], sha256_hex(&archive));
+    let response = app
+        .oneshot(
+            Request::get("/cargo/api/v1/crates/demo/0.1.0/download").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, archive);
+}
+
+/// Applying a sealed transaction adds its version to the document as it
+/// stands, so a crate published between the crash and the restart survives.
+#[tokio::test]
+async fn a_crashed_publish_keeps_what_was_published_while_it_was_down() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let config = cargo_config(storage.clone(), "http://upstream.invalid/", "$all");
+    let app = router_with_auth(config.clone(), auth);
+    let archive = crate_archive("demo", "0.2.0");
+    let response = app
+        .oneshot(publish_request(Some(&token), publish_body(&metadata("demo", "0.2.0"), &archive)))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    fabricate_crashed_crate_publish(&storage, &crate_archive("demo", "0.1.0"));
+
+    recover_publish_journal(&config).await.unwrap();
+
+    let app = router_with_auth(config, AuthState::in_memory());
+    let response = app
+        .oneshot(Request::get("/cargo/index/de/mo/demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let index = String::from_utf8(body_bytes(response.into_body()).await).unwrap();
+    let versions: Vec<Value> = index
+        .lines()
+        .map(|line| serde_json::from_str::<Value>(line).unwrap()["vers"].clone())
+        .collect();
+    assert_eq!(versions, vec!["0.2.0", "0.1.0"]);
 }

--- a/pnpr/crates/pnpr/tests/journal_recovery.rs
+++ b/pnpr/crates/pnpr/tests/journal_recovery.rs
@@ -73,6 +73,10 @@ fn packument(name: &str, version: &str, tarball: &[u8]) -> Value {
 /// `sealed`, the `commit` marker is present too. With `org`, the manifest
 /// records the hosted-org namespace the publish targeted, matching what
 /// an org-routed publish journals.
+///
+/// The manifest is written with the `packument_file` / `tarballs` keys an
+/// earlier pnpr wrote, so these tests also cover recovering a journal a
+/// running server sealed before the upgrade.
 fn fabricate_crashed_publish_in(
     storage: &Path,
     org: Option<&str>,

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -485,7 +485,8 @@ async fn conflicting_object_store_upload_does_not_publish_metadata_or_leave_stag
             let path = entry.unwrap().path();
             if path.is_dir() {
                 staged.extend(staged_files(&path));
-            } else if path.to_string_lossy().contains(".tmp") {
+            } else if path.file_name().is_some_and(|name| name.to_string_lossy().contains(".tmp."))
+            {
                 staged.push(path);
             }
         }

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -495,8 +495,12 @@ async fn conflicting_object_store_upload_does_not_publish_metadata_or_leave_stag
     // known to have reached the disk, and a journal entry that comes back
     // needs them to re-detect the conflict. Windows offers no way to confirm
     // that, so there they stay.
+    let staged = staged_files(tmp.path());
     if cfg!(unix) {
-        assert_eq!(staged_files(tmp.path()), Vec::<PathBuf>::new());
+        assert_eq!(staged, Vec::<PathBuf>::new());
+    } else {
+        assert_eq!(staged.len(), 1, "{staged:?}");
+        assert_eq!(std::fs::read(&staged[0]).unwrap(), b"losing artifact");
     }
 }
 

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -12,9 +12,9 @@ use axum::{
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use common::{HostedSource, PUBLIC_URL, body_bytes, find_file, mixed_router_config, sha256_hex};
-use pnpr::{AuthState, Config, Ecosystem, router_with_auth};
+use pnpr::{AuthState, Config, Ecosystem, recover_publish_journal, router_with_auth};
 use serde_json::{Value, json};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 use tower::ServiceExt;
 
@@ -113,6 +113,8 @@ async fn uploads_a_wheel_and_serves_the_simple_pages_and_the_file() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     assert!(tmp.path().join("python/demo-pkg").join(filename).is_file());
+    // The upload went through the commit journal and left nothing behind.
+    assert!(std::fs::read_dir(tmp.path().join(".pnpr-journal")).unwrap().next().is_none());
 
     // PEP 691 JSON, with the file URL pointing back at this registry.
     let response = app.clone().oneshot(get("/pypi/simple/demo-pkg/", Some(JSON))).await.unwrap();
@@ -564,4 +566,104 @@ async fn hosted_downloads_reject_files_absent_from_publication_metadata() {
         app.oneshot(get(&format!("/pypi/files/demo-pkg/{published}"), None)).await.unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(body_bytes(response.into_body()).await, b"published wheel");
+}
+
+/// The on-disk state a crash between staging an uploaded file and recording
+/// it in the project document leaves behind: the staged tmp file plus the
+/// sealed journal entry that says where it belongs.
+fn fabricate_crashed_upload(storage: &Path, filename: &str, wheel: &[u8]) -> PathBuf {
+    let project_dir = storage.join("python/demo-pkg");
+    std::fs::create_dir_all(&project_dir).unwrap();
+    let tmp_path = project_dir.join(format!("{filename}.tmp.999.0"));
+    std::fs::write(&tmp_path, wheel).unwrap();
+
+    let txn_dir = storage.join(".pnpr-journal").join("0000000000000001-999-0");
+    std::fs::create_dir_all(&txn_dir).unwrap();
+    let document = json!({
+        "name": "demo-pkg",
+        "files": [{
+            "filename": filename,
+            "hashes": { "sha256": sha256_hex(wheel) },
+            "yanked": false,
+            "size": wheel.len(),
+        }],
+    });
+    std::fs::write(txn_dir.join("document-0.json"), serde_json::to_vec(&document).unwrap())
+        .unwrap();
+    let manifest = json!({
+        "packages": [{
+            "name": "demo-pkg",
+            "ecosystem": "pypi",
+            "org": "python",
+            "document_file": "document-0.json",
+            "blobs": [{ "filename": filename, "tmp_path": tmp_path }],
+        }],
+    });
+    std::fs::write(txn_dir.join("manifest.json"), serde_json::to_vec(&manifest).unwrap()).unwrap();
+    std::fs::write(txn_dir.join("commit"), b"").unwrap();
+    tmp_path
+}
+
+/// An upload that crashed after its file was staged and before the project
+/// document recorded it is completed on the next startup: both halves land,
+/// so the store never holds a file no Simple API page mentions.
+#[tokio::test]
+async fn a_crashed_upload_is_completed_on_startup() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let config = pypi_config(storage.clone(), "http://upstream.invalid/");
+    let wheel = b"PK\x03\x04 crashed wheel".to_vec();
+    let filename = "demo_pkg-1.0.0-py3-none-any.whl";
+    let tmp_path = fabricate_crashed_upload(&storage, filename, &wheel);
+
+    recover_publish_journal(&config).await.unwrap();
+
+    assert!(!tmp_path.exists(), "the staged file should be promoted away");
+    assert!(std::fs::read_dir(storage.join(".pnpr-journal")).unwrap().next().is_none());
+    let app = router_with_auth(config, AuthState::in_memory());
+    let response = app.clone().oneshot(get("/pypi/simple/demo-pkg/", Some(JSON))).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let page: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(page["files"][0]["filename"], filename);
+    assert_eq!(page["files"][0]["hashes"]["sha256"], sha256_hex(&wheel));
+    let response =
+        app.oneshot(get(&format!("/pypi/files/demo-pkg/{filename}"), None)).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, wheel);
+}
+
+/// Applying a sealed transaction adds its file to the document as it stands,
+/// so an upload accepted between the crash and the restart survives.
+#[tokio::test]
+async fn a_crashed_upload_keeps_what_was_uploaded_while_it_was_down() {
+    let tmp = TempDir::new().unwrap();
+    let storage = tmp.path().to_path_buf();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let config = pypi_config(storage.clone(), "http://upstream.invalid/");
+    let published = "demo_pkg-2.0.0-py3-none-any.whl";
+    let response = router_with_auth(config.clone(), auth)
+        .oneshot(upload_request(
+            Some(&token),
+            wheel_upload("demo-pkg", "2.0.0", published, b"published while down"),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    fabricate_crashed_upload(&storage, "demo_pkg-1.0.0-py3-none-any.whl", b"crashed wheel");
+
+    recover_publish_journal(&config).await.unwrap();
+
+    let response = router_with_auth(config, AuthState::in_memory())
+        .oneshot(get("/pypi/simple/demo-pkg/", Some(JSON)))
+        .await
+        .unwrap();
+    let page: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let filenames: Vec<&str> = page["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| file["filename"].as_str().unwrap())
+        .collect();
+    assert_eq!(filenames, vec![published, "demo_pkg-1.0.0-py3-none-any.whl"]);
 }

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -113,7 +113,6 @@ async fn uploads_a_wheel_and_serves_the_simple_pages_and_the_file() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     assert!(tmp.path().join("python/demo-pkg").join(filename).is_file());
-    // The upload went through the commit journal and left nothing behind.
     assert!(std::fs::read_dir(tmp.path().join(".pnpr-journal")).unwrap().next().is_none());
 
     // PEP 691 JSON, with the file URL pointing back at this registry.
@@ -604,9 +603,8 @@ fn fabricate_crashed_upload(storage: &Path, filename: &str, wheel: &[u8]) -> Pat
     tmp_path
 }
 
-/// An upload that crashed after its file was staged and before the project
-/// document recorded it is completed on the next startup: both halves land,
-/// so the store never holds a file no Simple API page mentions.
+/// Both halves land, so the store never holds a file that no Simple API page
+/// mentions.
 #[tokio::test]
 async fn a_crashed_upload_is_completed_on_startup() {
     let tmp = TempDir::new().unwrap();
@@ -632,8 +630,8 @@ async fn a_crashed_upload_is_completed_on_startup() {
     assert_eq!(body_bytes(response.into_body()).await, wheel);
 }
 
-/// Applying a sealed transaction adds its file to the document as it stands,
-/// so an upload accepted between the crash and the restart survives.
+/// Applying a sealed transaction adds its file to the document as it stands
+/// rather than to the one the crashed upload read.
 #[tokio::test]
 async fn a_crashed_upload_keeps_what_was_uploaded_while_it_was_down() {
     let tmp = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -479,17 +479,25 @@ async fn conflicting_object_store_upload_does_not_publish_metadata_or_leave_stag
         app.oneshot(get("/pypi/simple/demo-pkg/", Some(JSON))).await.unwrap().status(),
         StatusCode::NOT_FOUND,
     );
-    fn assert_no_staged_files(path: &std::path::Path) {
+    fn staged_files(path: &Path) -> Vec<PathBuf> {
+        let mut staged = Vec::new();
         for entry in std::fs::read_dir(path).unwrap() {
             let path = entry.unwrap().path();
             if path.is_dir() {
-                assert_no_staged_files(&path);
-            } else {
-                assert!(!path.to_string_lossy().contains(".tmp"), "{}", path.display());
+                staged.extend(staged_files(&path));
+            } else if path.to_string_lossy().contains(".tmp") {
+                staged.push(path);
             }
         }
+        staged
     }
-    assert_no_staged_files(tmp.path());
+    // The losing bytes are cleaned up only once removing the journal entry is
+    // known to have reached the disk, and a journal entry that comes back
+    // needs them to re-detect the conflict. Windows offers no way to confirm
+    // that, so there they stay.
+    if cfg!(unix) {
+        assert_eq!(staged_files(tmp.path()), Vec::<PathBuf>::new());
+    }
 }
 
 #[tokio::test]

--- a/pnpr/crates/storage/Cargo.toml
+++ b/pnpr/crates/storage/Cargo.toml
@@ -15,6 +15,7 @@ pnpm-network      = { workspace = true }
 pnpr-config       = { workspace = true }
 pnpr-error        = { workspace = true }
 pnpr-package-name = { workspace = true }
+pnpr-registry     = { workspace = true }
 pnpm-crypto-hash  = { workspace = true }
 async-trait       = { workspace = true }
 axum              = { workspace = true }

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -109,7 +109,7 @@ pub struct HostedPackumentForUpdate {
 
 /// What a backend needs to recognize the packument it handed out, so a
 /// read-modify-write can refuse to clobber a concurrent publisher.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum HostedPackumentVersion {
     /// The backend offers no compare-and-set. It is single-writer by
     /// construction, so there is nothing to compare against.

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -31,8 +31,9 @@
 //! what was published between the failed apply and the restart.
 
 use crate::{
-    COMMIT_DOCUMENT_WRITE_RETRIES, HostedPackumentVersion, HostedRevisionRefWrite, PackumentWrite,
-    Storage, TarballFinalize, TarballSlot, is_canonical_revision_ref_owner, unique_tmp_path,
+    COMMIT_DOCUMENT_WRITE_RETRIES, HostedPackumentVersion, HostedRevisionRefWrite, PackumentUpdate,
+    PackumentWrite, Storage, TarballFinalize, TarballSlot, is_canonical_revision_ref_owner,
+    unique_tmp_path,
 };
 use pnpr_config::Config;
 use pnpr_error::{RegistryError, Result};
@@ -71,8 +72,7 @@ struct Manifest {
 struct ManifestPackage {
     name: String,
     /// The ecosystem whose document format this package's document is in.
-    /// Defaulted for back-compat with journals written before pnpr served
-    /// more than npm.
+    /// An entry that names none holds an npm packument.
     #[serde(default)]
     ecosystem: Ecosystem,
     /// Hosted-org storage namespace this package publishes into, or `None` for
@@ -160,6 +160,10 @@ pub struct CommitOutcome {
     /// Set when an entry could not claim a digest-reference slot, to the
     /// limit that was reached.
     pub reference_limit: Option<usize>,
+    /// Packages whose merge left the stored document exactly as it was:
+    /// every entry this transaction journaled for them was already recorded,
+    /// or was lost with its blob. Nothing of theirs became newly visible.
+    pub unrecorded: Vec<String>,
 }
 
 /// Handle to the journal directory of one [`Storage`].
@@ -195,18 +199,30 @@ impl PublishJournal {
         packages: &[JournaledPublish<'_>],
         documents: &dyn HostedDocuments,
     ) -> Result<CommitOutcome> {
-        match self.seal(packages).await {
-            Ok(txn) => txn.apply(storage, documents).await.inspect_err(|err| {
-                tracing::warn!(
-                    %err,
-                    "publish apply failed after the seal; startup recovery will complete it",
-                );
-            }),
+        let txn = match self.seal(packages).await {
+            Ok(txn) => txn,
             Err(err) => {
                 for slot in packages.iter().flat_map(|package| package.slots) {
                     let _ = fs::remove_file(&slot.tmp_path).await;
                 }
-                Err(err)
+                return Err(err);
+            }
+        };
+        let dir = txn.dir.clone();
+        match txn.apply(storage, documents).await {
+            Ok(outcome) => Ok(outcome),
+            Err(err) => {
+                tracing::warn!(%err, "publish apply failed after the seal; retrying it");
+                // An apply can stop with some of the batch already promoted,
+                // and past the seal there is nothing to undo. Run the same
+                // idempotent apply once more so a running server does not
+                // leave the batch half-visible until the next restart; a
+                // second failure keeps the sealed entry for startup recovery
+                // and reports the failure that started it.
+                match SealedTxn::reopen(dir) {
+                    Ok(txn) => txn.apply(storage, documents).await.map_err(|_| err),
+                    Err(_) => Err(err),
+                }
             }
         }
     }
@@ -406,7 +422,7 @@ impl SealedTxn {
                 );
             }
             if !written {
-                store
+                let update = store
                     .update_hosted_packument_with_retry(
                         &name,
                         COMMIT_DOCUMENT_WRITE_RETRIES,
@@ -421,6 +437,9 @@ impl SealedTxn {
                         },
                     )
                     .await?;
+                if update == PackumentUpdate::NotFound {
+                    outcome.unrecorded.push(package.name.clone());
+                }
             }
             for revision_ref in claimed.into_values().flatten() {
                 store

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -1,18 +1,24 @@
 //! Crash-atomic commit journal for the publish flow.
 //!
-//! A publish (single-package or batch) stages every tarball into a tmp
-//! file and holds the merged packuments in memory; making the result
-//! visible then takes several non-atomic steps — one rename/upload per
-//! tarball, one packument write per package. A crash in the middle of
-//! those steps could leave some packages of a batch published and
-//! others not. The journal closes that window: before anything is
-//! promoted, the full intent — the merged packument bytes, revision
-//! references, and locations of the staged tmp files — is persisted under
-//! `.pnpr-journal/<txn>/` and sealed with a single atomic rename of the
-//! `commit` marker. [`recover_publish_journal`] runs at startup, before
-//! the server accepts requests: sealed transactions are rolled forward
-//! (every apply step is idempotent) and unsealed ones are rolled back,
+//! A publish stages every blob into a tmp file and computes the document of
+//! each package it touches in memory; making the result visible then takes
+//! several non-atomic steps — one rename/upload per blob, one document write
+//! per package. A crash in the middle of those steps could leave a blob that
+//! no document mentions, or some packages of a batch published and others
+//! not. The journal closes that window: before anything is promoted, the full
+//! intent — the computed document bytes, revision references, and locations
+//! of the staged tmp files — is persisted under `.pnpr-journal/<txn>/` and
+//! sealed with a single atomic rename of the `commit` marker.
+//! [`PublishJournal::commit`] then applies it, and [`recover_publish_journal`]
+//! runs at startup, before the server accepts requests: sealed transactions
+//! are applied (every step is idempotent) and unsealed ones are rolled back,
 //! so a publish is either fully visible or fully absent.
+//!
+//! Every surface publishes this way — an npm packument, a Cargo crate
+//! document, a Python project document. The journal carries each package's
+//! document as opaque bytes and asks the caller's [`HostedDocuments`] to
+//! merge them into what the store holds, so the merge rule stays with the
+//! ecosystem whose format it belongs to.
 //!
 //! Once a transaction is sealed, the publish *will* become visible —
 //! if applying it fails at request time (e.g. the S3 backend is briefly
@@ -20,20 +26,18 @@
 //! completes on the next startup. An operator can abort a sealed-but-
 //! unapplied transaction by deleting its directory.
 //!
-//! Roll-forward re-merges the journaled packument into whatever is on
-//! disk at recovery time (rather than overwriting), so replaying an old
-//! sealed transaction cannot erase versions published between the
-//! failed apply and the restart.
+//! Applying merges the journaled document into whatever is on disk (rather
+//! than overwriting it), so replaying an old sealed transaction cannot erase
+//! what was published between the failed apply and the restart.
 
 use crate::{
-    HostedRevisionRefWrite, RECOVERY_PACKUMENT_WRITE_RETRIES, Storage, TarballFinalize,
-    TarballSlot, is_canonical_revision_ref_owner,
-    publish::{merge_manifest, now_iso},
-    unique_tmp_path,
+    COMMIT_DOCUMENT_WRITE_RETRIES, HostedPackumentVersion, HostedRevisionRefWrite, PackumentWrite,
+    Storage, TarballFinalize, TarballSlot, is_canonical_revision_ref_owner, unique_tmp_path,
 };
 use pnpr_config::Config;
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::PackageName;
+use pnpr_registry::Ecosystem;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -66,25 +70,32 @@ struct Manifest {
 #[derive(Debug, Serialize, Deserialize)]
 struct ManifestPackage {
     name: String,
+    /// The ecosystem whose document format this package's document is in.
+    /// Defaulted for back-compat with journals written before pnpr served
+    /// more than npm.
+    #[serde(default)]
+    ecosystem: Ecosystem,
     /// Hosted-org storage namespace this package publishes into, or `None` for
     /// the flat (path-less) hosted store. Recovery namespaces the roll-forward
     /// by it so a crash mid-commit promotes into the right org. Defaulted for
     /// back-compat with journals written before org registries existed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     org: Option<String>,
-    /// File inside the transaction directory holding the merged
-    /// packument bytes.
-    packument_file: String,
-    tarballs: Vec<ManifestTarball>,
+    /// File inside the transaction directory holding the computed
+    /// document bytes.
+    #[serde(alias = "packument_file")]
+    document_file: String,
+    #[serde(alias = "tarballs")]
+    blobs: Vec<ManifestBlob>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     revision_refs: Vec<JournaledRevisionRef>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct ManifestTarball {
-    /// Canonical on-disk tarball filename (`<basename>-<version>.tgz`).
+struct ManifestBlob {
+    /// Canonical on-disk filename (`<basename>-<version>.tgz` for npm).
     filename: String,
-    /// The staged tmp file holding the verified tarball bytes.
+    /// The staged tmp file holding the verified bytes.
     tmp_path: PathBuf,
 }
 
@@ -98,13 +109,57 @@ pub struct JournaledRevisionRef {
 
 /// One package of a publish about to be committed, borrowed from the
 /// handler's staged state.
-pub struct JournaledPublish<'a> {
-    pub name: &'a PackageName,
+pub struct JournaledPublish<'publish> {
+    pub name: &'publish PackageName,
     /// Hosted-org storage namespace, or `None` for the flat hosted store.
-    pub org: Option<&'a str>,
-    pub packument: &'a [u8],
-    pub slots: &'a [TarballSlot],
-    pub revision_refs: &'a [JournaledRevisionRef],
+    pub org: Option<&'publish str>,
+    pub ecosystem: Ecosystem,
+    /// The document the publish computed, to be merged into the stored one.
+    pub document: &'publish [u8],
+    /// The version of the stored document `document` was computed from, when
+    /// the publish read one. While the store is still at that version the
+    /// commit writes `document` as it is; otherwise it merges.
+    pub base_version: Option<&'publish HostedPackumentVersion>,
+    pub slots: &'publish [TarballSlot],
+    pub revision_refs: &'publish [JournaledRevisionRef],
+}
+
+/// One hosted document to bring up to date as a transaction is applied.
+pub struct DocumentMerge<'txn> {
+    pub ecosystem: Ecosystem,
+    pub name: &'txn PackageName,
+    /// The document as the store holds it, `None` when the package has none.
+    pub existing: Option<&'txn [u8]>,
+    /// The document the transaction computed when it was sealed.
+    pub journaled: &'txn [u8],
+    /// Canonical filenames of the blobs the transaction failed to place.
+    /// An entry backed by one of them must not be recorded: the bytes it
+    /// describes are not the ones the store serves.
+    pub lost_blobs: &'txn HashSet<String>,
+}
+
+/// How each ecosystem's hosted document is merged. The journal carries
+/// documents as opaque bytes, so the surface that owns the format supplies
+/// this. Startup recovery re-runs the same merge, which is why
+/// [`recover_publish_journal`] takes it too.
+pub trait HostedDocuments: Send + Sync {
+    /// The bytes to store for the merged document, or `None` when the merge
+    /// records nothing — a transaction that lost every blob it staged leaves
+    /// the stored document exactly as it is, and writes none where there was
+    /// none.
+    fn merge(&self, merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>>;
+}
+
+/// What a committed transaction could not record. Its document was written
+/// without those entries, so the store never advertises what it does not
+/// hold; the surface decides what to report to the publisher.
+#[derive(Debug, Default)]
+pub struct CommitOutcome {
+    /// Canonical filenames whose immutable slot another writer already owned.
+    pub lost_blobs: Vec<String>,
+    /// Set when an entry could not claim a digest-reference slot, to the
+    /// limit that was reached.
+    pub reference_limit: Option<usize>,
 }
 
 /// Handle to the journal directory of one [`Storage`].
@@ -113,12 +168,15 @@ pub struct PublishJournal {
 }
 
 /// A sealed transaction: the journal entry is durable and carries the
-/// commit marker. Call [`Self::finish`] after the publish is fully
-/// applied; dropping it without finishing just leaves the entry for
-/// startup recovery to (idempotently) re-apply.
-pub struct SealedTxn {
+/// commit marker, so the publish it holds will become visible — through
+/// [`Self::apply`] here, or through startup recovery.
+struct SealedTxn {
     dir: PathBuf,
     revision_ref_owner: String,
+    /// The stored-document version each sealed package was computed from,
+    /// positionally. Empty when startup recovery reopens the transaction,
+    /// which always merges instead.
+    base_versions: Vec<Option<HostedPackumentVersion>>,
 }
 
 impl PublishJournal {
@@ -126,26 +184,54 @@ impl PublishJournal {
         Self { root }
     }
 
+    /// Seal `packages` and make them visible: one journaled transaction over
+    /// every blob and document the publish touches. Until the seal nothing
+    /// has been promoted, so a failure there removes the staged tmp files and
+    /// leaves no trace; past it the transaction is committed, so a failure to
+    /// apply leaves the entry for startup recovery rather than undoing it.
+    pub async fn commit(
+        &self,
+        storage: &Storage,
+        packages: &[JournaledPublish<'_>],
+        documents: &dyn HostedDocuments,
+    ) -> Result<CommitOutcome> {
+        match self.seal(packages).await {
+            Ok(txn) => txn.apply(storage, documents).await.inspect_err(|err| {
+                tracing::warn!(
+                    %err,
+                    "publish apply failed after the seal; startup recovery will complete it",
+                );
+            }),
+            Err(err) => {
+                for slot in packages.iter().flat_map(|package| package.slots) {
+                    let _ = fs::remove_file(&slot.tmp_path).await;
+                }
+                Err(err)
+            }
+        }
+    }
+
     /// Persist the full intent of the publish and seal it with the
     /// commit marker. After this returns `Ok`, the publish is
     /// committed: either the caller applies it now, or startup
     /// recovery does.
-    pub async fn seal(&self, packages: &[JournaledPublish<'_>]) -> Result<SealedTxn> {
+    async fn seal(&self, packages: &[JournaledPublish<'_>]) -> Result<SealedTxn> {
         let revision_ref_owner = txn_id();
         let dir = self.root.join(&revision_ref_owner);
         fs::create_dir_all(&dir).await?;
         let mut manifest = Manifest { packages: Vec::with_capacity(packages.len()) };
         for (index, package) in packages.iter().enumerate() {
-            let packument_file = format!("packument-{index}.json");
-            write_synced(&dir.join(&packument_file), package.packument).await?;
+            let document_file = format!("document-{index}.json");
+            write_synced(&dir.join(&document_file), package.document).await?;
             manifest.packages.push(ManifestPackage {
                 name: package.name.as_str().to_string(),
+                ecosystem: package.ecosystem,
                 org: package.org.map(str::to_string),
-                packument_file,
-                tarballs: package
+                document_file,
+                blobs: package
                     .slots
                     .iter()
-                    .map(|slot| ManifestTarball {
+                    .map(|slot| ManifestBlob {
                         filename: slot.filename().to_string(),
                         tmp_path: slot.tmp_path.clone(),
                     })
@@ -163,13 +249,14 @@ impl PublishJournal {
         write_synced(&marker_tmp, b"").await?;
         fs::rename(&marker_tmp, &marker).await?;
         let _ = sync_dir(&dir).await;
-        Ok(SealedTxn { dir, revision_ref_owner })
+        let base_versions = packages.iter().map(|package| package.base_version.cloned()).collect();
+        Ok(SealedTxn { dir, revision_ref_owner, base_versions })
     }
 
-    /// Roll every journal entry to a consistent state: sealed
-    /// transactions forward, unsealed ones back. Must run before the
-    /// server accepts requests — it takes no package locks.
-    pub async fn recover(&self, storage: &Storage) -> Result<()> {
+    /// Bring every journal entry to a consistent state: sealed transactions
+    /// are applied, unsealed ones rolled back. Must run before the server
+    /// accepts requests — it takes no package locks.
+    pub async fn recover(&self, storage: &Storage, documents: &dyn HostedDocuments) -> Result<()> {
         let mut entries = match fs::read_dir(&self.root).await {
             Ok(read_dir) => read_dir,
             Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
@@ -190,9 +277,8 @@ impl PublishJournal {
             // rollback, which would delete an already-committed publish.
             // Abort recovery so startup fails loudly instead.
             if fs::try_exists(dir.join(COMMIT_MARKER)).await? {
-                let revision_ref_owner = revision_ref_owner(&dir)?;
-                roll_forward(storage, &dir, revision_ref_owner).await?;
-                tracing::info!(txn = %dir.display(), "rolled publish journal entry forward");
+                SealedTxn::reopen(dir.clone())?.apply(storage, documents).await?;
+                tracing::info!(txn = %dir.display(), "applied publish journal entry");
             } else {
                 roll_back(&dir).await;
                 tracing::info!(txn = %dir.display(), "rolled publish journal entry back");
@@ -203,211 +289,183 @@ impl PublishJournal {
 }
 
 impl SealedTxn {
-    #[must_use]
-    pub fn revision_ref_owner(&self) -> &str {
-        &self.revision_ref_owner
+    /// Reopen a sealed transaction from its journal directory, the way
+    /// startup recovery does: with no base versions, so every document is
+    /// merged into what the store holds rather than written over it.
+    fn reopen(dir: PathBuf) -> Result<Self> {
+        let revision_ref_owner = revision_ref_owner(&dir)?.to_string();
+        Ok(Self { dir, revision_ref_owner, base_versions: Vec::new() })
     }
 
-    /// Apply the sealed transaction now, completing any apply steps that
-    /// have not run yet, and remove the journal entry. This is the same
-    /// idempotent roll-forward startup recovery performs; commit calls it
-    /// to self-heal when the inline apply fails partway, so a running
-    /// server never leaves a sealed batch partially visible until the
-    /// next restart.
-    pub async fn roll_forward(self, storage: &Storage) -> Result<()> {
-        roll_forward(storage, &self.dir, &self.revision_ref_owner).await
-    }
-
-    /// Remove the journal entry once the publish is fully applied.
-    /// Best-effort: a leftover sealed entry is simply re-applied
-    /// (idempotently) by the next startup recovery.
-    pub async fn finish(self) {
-        let _ = fs::remove_dir_all(&self.dir).await;
-    }
-}
-
-/// Roll the publish journal of the storage configured in `config` to a
-/// consistent state. `pnpr::serve` and `pnpr::serve_listener`
-/// call this before binding; embedders that build a router directly
-/// should call it themselves on startup.
-pub async fn recover_publish_journal(config: &Config) -> Result<()> {
-    let storage =
-        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
-    storage.publish_journal().recover(&storage).await
-}
-
-/// Re-apply a sealed transaction. Every step tolerates having already
-/// run before the crash: a tmp file that's gone was already promoted,
-/// and the packument is re-merged into the current on-disk state
-/// instead of overwriting it.
-async fn roll_forward(storage: &Storage, dir: &Path, revision_ref_owner: &str) -> Result<()> {
-    let manifest: Manifest = serde_json::from_slice(&fs::read(dir.join(MANIFEST_FILE)).await?)?;
-    let mut conflicted_tmp_paths = Vec::new();
-    for package in &manifest.packages {
-        let name = PackageName::parse(&package.name)?;
-        // Roll forward into the package's hosted namespace (or the flat
-        // store when it has none), so a crash mid-commit promotes the staged
-        // tarballs and packument into exactly the store the publish targeted.
-        let store = match &package.org {
-            Some(org) => storage.for_hosted(org),
-            None => storage.clone(),
-        };
-        let mut conflicted_versions = HashSet::new();
-        for tarball in &package.tarballs {
-            // A missing tmp file was already promoted before the crash, so
-            // skip it. But never read an I/O error as "missing": that would
-            // skip promotion, write the packument anyway, and delete the
-            // journal entry — advertising a tarball with nothing on disk and
-            // no journal state left to retry from. Propagate it instead so
-            // recovery aborts and the entry survives for a later attempt.
-            if fs::try_exists(&tarball.tmp_path).await? {
-                let slot = TarballSlot::from_parts(
-                    tarball.tmp_path.clone(),
-                    name.clone(),
-                    tarball.filename.clone(),
-                );
-                match store.finalize_tarball_slot(slot).await? {
-                    TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
-                    // Another replica finalized different bytes for this version.
-                    // Keep the tmp file so a retry detects the same conflict, and
-                    // exclude the losing version from the merge below.
-                    TarballFinalize::Conflict => {
-                        conflicted_tmp_paths.push(tarball.tmp_path.as_path());
-                        let (_, version) = name.parse_tarball_name(&tarball.filename)?;
-                        conflicted_versions.insert(version);
-                    }
-                }
-            }
-        }
-        let mut journaled: serde_json::Value =
-            serde_json::from_slice(&fs::read(dir.join(&package.packument_file)).await?)?;
-        let revision_refs = package
-            .revision_refs
-            .iter()
-            .map(|revision_ref| {
-                let (_, version) = name.parse_tarball_name(&revision_ref.filename)?;
-                Ok((revision_ref, version))
-            })
-            .collect::<Result<Vec<_>>>()?;
-        let mut applied_revision_refs: HashMap<String, Vec<&JournaledRevisionRef>> = HashMap::new();
-        for (revision_ref, version) in revision_refs {
-            if conflicted_versions.contains(&version) {
-                continue;
-            }
-            match store
-                .write_hosted_revision_ref(
-                    &revision_ref.digest,
-                    &revision_ref.ref_id,
-                    revision_ref_owner,
-                    &revision_ref.bytes,
-                )
-                .await
-            {
-                Ok(HostedRevisionRefWrite::Claimed | HostedRevisionRefWrite::AlreadyClaimed) => {
-                    applied_revision_refs.entry(version).or_default().push(revision_ref);
-                }
-                Ok(HostedRevisionRefWrite::Committed) => {}
-                Err(pnpr_error::RegistryError::RevisionReferenceLimit { .. }) => {
-                    conflicted_versions.insert(version.clone());
-                    if let Some(applied) = applied_revision_refs.remove(&version) {
-                        for applied_ref in applied {
-                            store
-                                .remove_hosted_revision_ref(
-                                    &applied_ref.digest,
-                                    &applied_ref.ref_id,
-                                    revision_ref_owner,
-                                )
-                                .await?;
+    /// Run every step of the sealed transaction that has not run yet, then
+    /// remove the journal entry. Each step tolerates having already run
+    /// before a crash: a tmp file that is gone was already promoted, and the
+    /// document is merged into what the store holds rather than overwriting
+    /// it, so an interrupted apply just runs again — which is what startup
+    /// recovery does.
+    async fn apply(
+        self,
+        storage: &Storage,
+        documents: &dyn HostedDocuments,
+    ) -> Result<CommitOutcome> {
+        let manifest: Manifest =
+            serde_json::from_slice(&fs::read(self.dir.join(MANIFEST_FILE)).await?)?;
+        let mut outcome = CommitOutcome::default();
+        let mut lost_tmp_paths = Vec::new();
+        for (index, package) in manifest.packages.iter().enumerate() {
+            let name = PackageName::parse(&package.name)?;
+            // Promote into the package's hosted namespace (or the flat store
+            // when it has none), so the commit and a later startup recovery
+            // land in exactly the store the publish targeted.
+            let store = match &package.org {
+                Some(org) => storage.for_hosted(org),
+                None => storage.clone(),
+            };
+            let mut lost_blobs = HashSet::new();
+            for blob in &package.blobs {
+                // A missing tmp file was already promoted before the crash, so
+                // skip it. But never read an I/O error as "missing": that would
+                // skip promotion, write the document anyway, and delete the
+                // journal entry — advertising a blob with nothing on disk and
+                // no journal state left to retry from. Propagate it instead so
+                // the apply aborts and the entry survives for a later attempt.
+                if fs::try_exists(&blob.tmp_path).await? {
+                    let slot = TarballSlot::from_parts(
+                        blob.tmp_path.clone(),
+                        name.clone(),
+                        blob.filename.clone(),
+                    );
+                    match store.finalize_tarball_slot(slot).await? {
+                        TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
+                        // Another writer placed different bytes under this
+                        // filename. Keep the tmp file so a retry detects the
+                        // same conflict, and leave the entry out of the merge.
+                        TarballFinalize::Conflict => {
+                            lost_tmp_paths.push(blob.tmp_path.as_path());
+                            lost_blobs.insert(blob.filename.clone());
                         }
                     }
                 }
-                Err(err) => return Err(err),
             }
+            let mut claimed: HashMap<&str, Vec<&JournaledRevisionRef>> = HashMap::new();
+            for revision_ref in &package.revision_refs {
+                if lost_blobs.contains(&revision_ref.filename) {
+                    continue;
+                }
+                match store
+                    .write_hosted_revision_ref(
+                        &revision_ref.digest,
+                        &revision_ref.ref_id,
+                        &self.revision_ref_owner,
+                        &revision_ref.bytes,
+                    )
+                    .await
+                {
+                    Ok(
+                        HostedRevisionRefWrite::Claimed | HostedRevisionRefWrite::AlreadyClaimed,
+                    ) => {
+                        claimed.entry(&revision_ref.filename).or_default().push(revision_ref);
+                    }
+                    Ok(HostedRevisionRefWrite::Committed) => {}
+                    Err(RegistryError::RevisionReferenceLimit { limit }) => {
+                        outcome.reference_limit = Some(limit);
+                        lost_blobs.insert(revision_ref.filename.clone());
+                        if let Some(claimed_refs) = claimed.remove(revision_ref.filename.as_str()) {
+                            for claimed_ref in claimed_refs {
+                                store
+                                    .remove_hosted_revision_ref(
+                                        &claimed_ref.digest,
+                                        &claimed_ref.ref_id,
+                                        &self.revision_ref_owner,
+                                    )
+                                    .await?;
+                            }
+                        }
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+            let journaled = fs::read(self.dir.join(&package.document_file)).await?;
+            let mut written = false;
+            // The journaled document was computed from `base_version` of the
+            // stored one, so while the store is still there it is exactly what
+            // to write — no second read, no merge. Recovery carries no base
+            // version and always merges.
+            if lost_blobs.is_empty()
+                && let Some(base_version) = self.base_versions.get(index)
+            {
+                written = matches!(
+                    store
+                        .write_hosted_packument_if_current(
+                            &name,
+                            &journaled,
+                            base_version.as_ref(),
+                        )
+                        .await?,
+                    PackumentWrite::Written,
+                );
+            }
+            if !written {
+                store
+                    .update_hosted_packument_with_retry(
+                        &name,
+                        COMMIT_DOCUMENT_WRITE_RETRIES,
+                        |existing| {
+                            documents.merge(DocumentMerge {
+                                ecosystem: package.ecosystem,
+                                name: &name,
+                                existing,
+                                journaled: &journaled,
+                                lost_blobs: &lost_blobs,
+                            })
+                        },
+                    )
+                    .await?;
+            }
+            for revision_ref in claimed.into_values().flatten() {
+                store
+                    .commit_hosted_revision_ref(
+                        &revision_ref.digest,
+                        &revision_ref.ref_id,
+                        &self.revision_ref_owner,
+                    )
+                    .await?;
+            }
+            outcome.lost_blobs.extend(lost_blobs);
         }
-        if !conflicted_versions.is_empty() {
-            drop_conflicted_versions(&mut journaled, &conflicted_versions);
-        }
-        write_merged_packument(&store, &name, &journaled).await?;
-        for revision_ref in applied_revision_refs.into_values().flatten() {
-            store
-                .commit_hosted_revision_ref(
-                    &revision_ref.digest,
-                    &revision_ref.ref_id,
-                    revision_ref_owner,
-                )
-                .await?;
-        }
+        // Remove the journal before cleaning lost tmp files so an interruption
+        // cannot leave a retry that has lost the evidence needed to detect the
+        // conflict.
+        fs::remove_dir_all(&self.dir).await?;
+        // Only clean conflict evidence after the journal removal is durable.
+        let journal_removal_is_durable = match self.dir.parent() {
+            Some(parent) => sync_dir(parent).await.is_ok(),
+            None => false,
+        };
+        cleanup_lost_tmp_paths(&lost_tmp_paths, journal_removal_is_durable).await;
+        Ok(outcome)
     }
-    // Remove the journal before cleaning conflicted tmp files so an interruption
-    // cannot leave a retry that has lost the evidence needed to detect conflict.
-    fs::remove_dir_all(dir).await?;
-    // Only clean conflict evidence after the journal removal is durable.
-    let journal_removal_is_durable = match dir.parent() {
-        Some(parent) => sync_dir(parent).await.is_ok(),
-        None => false,
-    };
-    cleanup_conflicted_tmp_paths(&conflicted_tmp_paths, journal_removal_is_durable).await;
-    Ok(())
 }
 
-async fn cleanup_conflicted_tmp_paths(tmp_paths: &[&Path], journal_removal_is_durable: bool) {
+/// Bring the publish journal of the storage configured in `config` to a
+/// consistent state. `pnpr::serve` and `pnpr::serve_listener`
+/// call this before binding; embedders that build a router directly
+/// should call it themselves on startup.
+pub async fn recover_publish_journal(
+    config: &Config,
+    documents: &dyn HostedDocuments,
+) -> Result<()> {
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
+    storage.publish_journal().recover(&storage, documents).await
+}
+
+async fn cleanup_lost_tmp_paths(tmp_paths: &[&Path], journal_removal_is_durable: bool) {
     if !journal_removal_is_durable {
         return;
     }
     for tmp_path in tmp_paths {
         let _ = fs::remove_file(tmp_path).await;
-    }
-}
-
-async fn write_merged_packument(
-    store: &Storage,
-    name: &PackageName,
-    journaled: &serde_json::Value,
-) -> Result<()> {
-    store
-        .update_hosted_packument_with_retry(
-            name,
-            RECOVERY_PACKUMENT_WRITE_RETRIES,
-            |existing_bytes| {
-                let existing: Option<serde_json::Value> = match existing_bytes {
-                    Some(bytes) => Some(serde_json::from_slice(bytes)?),
-                    None => None,
-                };
-                let merged =
-                    merge_manifest(existing.as_ref(), journaled, existing.as_ref(), &now_iso());
-                Ok(Some(serde_json::to_vec_pretty(&merged)?))
-            },
-        )
-        .await?;
-    Ok(())
-}
-
-/// Drop from a journaled manifest every version that lost an immutable tarball
-/// slot or could not reserve a bounded digest-reference slot. The journal keeps
-/// each staged attachment's canonical filename, so callers resolve that name to
-/// the version before reaching this helper instead of trusting a publisher-
-/// supplied `dist.tarball` URL as the transaction identity.
-fn drop_conflicted_versions(journaled: &mut serde_json::Value, conflicted: &HashSet<String>) {
-    let Some(versions) = journaled.get_mut("versions").and_then(serde_json::Value::as_object_mut)
-    else {
-        return;
-    };
-    let mut removed_versions = HashSet::new();
-    versions.retain(|version, _| {
-        let keep = !conflicted.contains(version);
-        if !keep {
-            removed_versions.insert(version.clone());
-        }
-        keep
-    });
-
-    if let Some(tags) = journaled.get_mut("dist-tags").and_then(serde_json::Value::as_object_mut) {
-        tags.retain(|_, version| {
-            version.as_str().is_none_or(|version| !removed_versions.contains(version))
-        });
-    }
-    if let Some(time) = journaled.get_mut("time").and_then(serde_json::Value::as_object_mut) {
-        time.retain(|version, _| !removed_versions.contains(version));
     }
 }
 
@@ -420,8 +478,8 @@ async fn roll_back(dir: &Path) {
         && let Ok(manifest) = serde_json::from_slice::<Manifest>(&bytes)
     {
         for package in &manifest.packages {
-            for tarball in &package.tarballs {
-                let _ = fs::remove_file(&tarball.tmp_path).await;
+            for blob in &package.blobs {
+                let _ = fs::remove_file(&blob.tmp_path).await;
             }
         }
     }

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -220,7 +220,16 @@ impl PublishJournal {
                 // second failure keeps the sealed entry for startup recovery
                 // and reports the failure that started it.
                 match SealedTxn::reopen(dir) {
-                    Ok(txn) => txn.apply(storage, documents).await.map_err(|_| err),
+                    // A retry cannot attribute a document that already holds
+                    // this transaction's entries: the first attempt may have
+                    // written them and then failed to clean up after itself.
+                    // Reporting them as recorded by someone else would tell a
+                    // publisher their publish was a duplicate of itself.
+                    Ok(txn) => txn
+                        .apply(storage, documents)
+                        .await
+                        .map(|outcome| CommitOutcome { unrecorded: Vec::new(), ..outcome })
+                        .map_err(|_| err),
                     Err(_) => Err(err),
                 }
             }

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -200,9 +200,10 @@ impl PublishJournal {
 
     /// Seal `packages` and make them visible: one journaled transaction over
     /// every blob and document the publish touches. Until the seal nothing
-    /// has been promoted, so a failure there removes the staged tmp files and
-    /// leaves no trace; past it the transaction is committed, so a failure to
-    /// apply leaves the entry for startup recovery rather than undoing it.
+    /// has been promoted, so a failure there takes the staged tmp files and
+    /// the half-written entry with it and leaves no trace; past it the
+    /// transaction is committed, so a failure to apply leaves the entry for
+    /// startup recovery rather than undoing it.
     pub async fn commit(
         &self,
         storage: &Storage,
@@ -248,41 +249,56 @@ impl PublishJournal {
     async fn seal(&self, packages: &[JournaledPublish<'_>]) -> Result<SealedTxn> {
         let revision_ref_owner = txn_id();
         let dir = self.root.join(&revision_ref_owner);
-        fs::create_dir_all(&dir).await?;
-        let mut manifest = Manifest { packages: Vec::with_capacity(packages.len()) };
-        for (index, package) in packages.iter().enumerate() {
-            let document_file = format!("document-{index}.json");
-            write_synced(&dir.join(&document_file), package.document).await?;
-            manifest.packages.push(ManifestPackage {
-                name: package.name.as_str().to_string(),
-                ecosystem: package.ecosystem,
-                org: package.org.map(str::to_string),
-                document_file,
-                blobs: package
-                    .slots
-                    .iter()
-                    .map(|slot| ManifestBlob {
-                        filename: slot.filename().to_string(),
-                        tmp_path: slot.tmp_path.clone(),
-                    })
-                    .collect(),
-                revision_refs: package.revision_refs.to_vec(),
-            });
+        if let Err(err) = write_transaction(&dir, packages).await {
+            // Nothing of an unsealed transaction may become visible. Startup
+            // recovery would roll this one back, but removing it here keeps a
+            // publisher that keeps failing from piling up directories.
+            let _ = fs::remove_dir_all(&dir).await;
+            return Err(err);
         }
-        write_synced(&dir.join(MANIFEST_FILE), &serde_json::to_vec_pretty(&manifest)?).await?;
-        let _ = sync_dir(&dir).await;
-        // The seal itself: a single same-directory rename, atomic on
-        // POSIX. Recovery treats a directory without this marker as an
-        // aborted transaction and rolls it back.
-        let marker = dir.join(COMMIT_MARKER);
-        let marker_tmp = unique_tmp_path(&marker);
-        write_synced(&marker_tmp, b"").await?;
-        fs::rename(&marker_tmp, &marker).await?;
-        let _ = sync_dir(&dir).await;
         let base_versions = packages.iter().map(|package| package.base_version.cloned()).collect();
         Ok(SealedTxn { dir, revision_ref_owner, base_versions })
     }
+}
 
+/// Write the transaction's documents and manifest and seal them with the
+/// commit marker, the single atomic rename that commits the publish.
+async fn write_transaction(dir: &Path, packages: &[JournaledPublish<'_>]) -> Result<()> {
+    fs::create_dir_all(dir).await?;
+    let mut manifest = Manifest { packages: Vec::with_capacity(packages.len()) };
+    for (index, package) in packages.iter().enumerate() {
+        let document_file = format!("document-{index}.json");
+        write_synced(&dir.join(&document_file), package.document).await?;
+        manifest.packages.push(ManifestPackage {
+            name: package.name.as_str().to_string(),
+            ecosystem: package.ecosystem,
+            org: package.org.map(str::to_string),
+            document_file,
+            blobs: package
+                .slots
+                .iter()
+                .map(|slot| ManifestBlob {
+                    filename: slot.filename().to_string(),
+                    tmp_path: slot.tmp_path.clone(),
+                })
+                .collect(),
+            revision_refs: package.revision_refs.to_vec(),
+        });
+    }
+    write_synced(&dir.join(MANIFEST_FILE), &serde_json::to_vec_pretty(&manifest)?).await?;
+    let _ = sync_dir(dir).await;
+    // The seal itself: a single same-directory rename, atomic on
+    // POSIX. Recovery treats a directory without this marker as an
+    // aborted transaction and rolls it back.
+    let marker = dir.join(COMMIT_MARKER);
+    let marker_tmp = unique_tmp_path(&marker);
+    write_synced(&marker_tmp, b"").await?;
+    fs::rename(&marker_tmp, &marker).await?;
+    let _ = sync_dir(dir).await;
+    Ok(())
+}
+
+impl PublishJournal {
     /// Bring every journal entry to a consistent state: sealed transactions
     /// are applied, unsealed ones rolled back. Must run before the server
     /// accepts requests — it takes no package locks.

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -166,6 +166,16 @@ pub struct CommitOutcome {
     pub unrecorded: Vec<String>,
 }
 
+/// What one attempt at applying a transaction got done. A failed attempt
+/// reports its progress too: the retry needs to know which documents this
+/// transaction has already written to tell its own entries from another
+/// writer's.
+#[derive(Debug, Default)]
+struct ApplyProgress {
+    outcome: CommitOutcome,
+    wrote_documents: HashSet<String>,
+}
+
 /// Handle to the journal directory of one [`Storage`].
 pub struct PublishJournal {
     root: PathBuf,
@@ -209,31 +219,26 @@ impl PublishJournal {
             }
         };
         let dir = txn.dir.clone();
-        match txn.apply(storage, documents).await {
-            Ok(outcome) => Ok(outcome),
-            Err(err) => {
-                tracing::warn!(%err, "publish apply failed after the seal; retrying it");
-                // An apply can stop with some of the batch already promoted,
-                // and past the seal there is nothing to undo. Run the same
-                // idempotent apply once more so a running server does not
-                // leave the batch half-visible until the next restart; a
-                // second failure keeps the sealed entry for startup recovery
-                // and reports the failure that started it.
-                match SealedTxn::reopen(dir) {
-                    // A retry cannot attribute a document that already holds
-                    // this transaction's entries: the first attempt may have
-                    // written them and then failed to clean up after itself.
-                    // Reporting them as recorded by someone else would tell a
-                    // publisher their publish was a duplicate of itself.
-                    Ok(txn) => txn
-                        .apply(storage, documents)
-                        .await
-                        .map(|outcome| CommitOutcome { unrecorded: Vec::new(), ..outcome })
-                        .map_err(|_| err),
-                    Err(_) => Err(err),
-                }
-            }
+        let mut first = ApplyProgress::default();
+        let Err(err) = txn.apply(storage, documents, &mut first).await else {
+            return Ok(first.outcome);
+        };
+        tracing::warn!(%err, "publish apply failed after the seal; retrying it");
+        // An apply can stop with some of the batch already promoted, and past
+        // the seal there is nothing to undo. Run the same idempotent apply
+        // once more so a running server does not leave the batch half-visible
+        // until the next restart; a second failure keeps the sealed entry for
+        // startup recovery and reports the failure that started it.
+        let Ok(txn) = SealedTxn::reopen(dir) else { return Err(err) };
+        let mut retry = ApplyProgress::default();
+        if txn.apply(storage, documents, &mut retry).await.is_err() {
+            return Err(err);
         }
+        // An entry the first attempt wrote is this transaction's own, and the
+        // retry finding it in place says nothing about another writer.
+        // Reporting it would tell a publisher their publish duplicated itself.
+        retry.outcome.unrecorded.retain(|package| !first.wrote_documents.contains(package));
+        Ok(retry.outcome)
     }
 
     /// Persist the full intent of the publish and seal it with the
@@ -302,7 +307,9 @@ impl PublishJournal {
             // rollback, which would delete an already-committed publish.
             // Abort recovery so startup fails loudly instead.
             if fs::try_exists(dir.join(COMMIT_MARKER)).await? {
-                SealedTxn::reopen(dir.clone())?.apply(storage, documents).await?;
+                SealedTxn::reopen(dir.clone())?
+                    .apply(storage, documents, &mut ApplyProgress::default())
+                    .await?;
                 tracing::info!(txn = %dir.display(), "applied publish journal entry");
             } else {
                 roll_back(&dir).await;
@@ -332,10 +339,11 @@ impl SealedTxn {
         self,
         storage: &Storage,
         documents: &dyn HostedDocuments,
-    ) -> Result<CommitOutcome> {
+        progress: &mut ApplyProgress,
+    ) -> Result<()> {
         let manifest: Manifest =
             serde_json::from_slice(&fs::read(self.dir.join(MANIFEST_FILE)).await?)?;
-        let mut outcome = CommitOutcome::default();
+        let outcome = &mut progress.outcome;
         let mut lost_tmp_paths = Vec::new();
         for (index, package) in manifest.packages.iter().enumerate() {
             let name = PackageName::parse(&package.name)?;
@@ -429,6 +437,9 @@ impl SealedTxn {
                         .await?,
                     PackumentWrite::Written,
                 );
+                if written {
+                    progress.wrote_documents.insert(package.name.clone());
+                }
             }
             if !written {
                 let update = store
@@ -446,8 +457,11 @@ impl SealedTxn {
                         },
                     )
                     .await?;
-                if update == PackumentUpdate::NotFound {
-                    outcome.unrecorded.push(package.name.clone());
+                match update {
+                    PackumentUpdate::Written => {
+                        progress.wrote_documents.insert(package.name.clone());
+                    }
+                    PackumentUpdate::NotFound => outcome.unrecorded.push(package.name.clone()),
                 }
             }
             for revision_ref in claimed.into_values().flatten() {
@@ -471,7 +485,7 @@ impl SealedTxn {
             None => false,
         };
         cleanup_lost_tmp_paths(&lost_tmp_paths, journal_removal_is_durable).await;
-        Ok(outcome)
+        Ok(())
     }
 }
 

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -6,11 +6,14 @@ use crate::{HostedRevisionRefWrite, Storage, TarballFinalize, publish::merge_jou
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use object_store::{ObjectStore, memory::InMemory};
 use pnpr_config::HostedStoreConfig;
-use pnpr_error::Result;
+use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::PackageName;
 use pnpr_registry::Ecosystem;
 use serde_json::json;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use tempfile::tempdir;
 use tokio::fs;
 
@@ -30,6 +33,23 @@ struct RecordsNothing;
 
 impl HostedDocuments for RecordsNothing {
     fn merge(&self, _merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+}
+
+/// A merge that fails once and then records nothing: the shape of a first
+/// apply that wrote its document and failed afterwards, whose retry finds the
+/// entries already there.
+#[derive(Default)]
+struct FailsThenRecordsNothing {
+    merges: AtomicUsize,
+}
+
+impl HostedDocuments for FailsThenRecordsNothing {
+    fn merge(&self, _merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        if self.merges.fetch_add(1, Ordering::Relaxed) == 0 {
+            return Err(RegistryError::Internal { reason: "merge failed".to_string() });
+        }
         Ok(None)
     }
 }
@@ -375,4 +395,29 @@ async fn commit_reports_a_package_whose_merge_recorded_nothing() {
 
     assert_eq!(outcome.unrecorded, vec!["pkg".to_string()]);
     assert!(outcome.lost_blobs.is_empty());
+}
+
+/// An apply that fails partway is re-run before the commit gives up, and what
+/// its first attempt already recorded is not held against the publisher: the
+/// entries the retry finds in place may be the ones it wrote itself.
+#[tokio::test]
+async fn commit_retries_a_failed_apply_and_keeps_its_own_writes_unreported() {
+    let tmp = tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let storage = Storage::new(
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
+        tmp.path().join("hosted"),
+        tmp.path().join("cache"),
+    )
+    .unwrap();
+    let name = PackageName::parse("pkg").unwrap();
+    let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
+    let entries = [npm_publish(&name, &document, &[])];
+    storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
+
+    let documents = FailsThenRecordsNothing::default();
+    let outcome = storage.publish_journal().commit(&storage, &entries, &documents).await.unwrap();
+
+    assert_eq!(documents.merges.load(Ordering::Relaxed), 2, "the failed apply is re-run");
+    assert!(outcome.unrecorded.is_empty());
 }

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -24,6 +24,16 @@ impl HostedDocuments for NpmDocuments {
     }
 }
 
+/// A merge that records nothing, the way an ecosystem document merge answers
+/// when every entry the transaction journaled is already stored.
+struct RecordsNothing;
+
+impl HostedDocuments for RecordsNothing {
+    fn merge(&self, _merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        Ok(None)
+    }
+}
+
 /// A journaled npm publish of `packument` for `name`, with no staged blobs
 /// unless the test adds them.
 fn npm_publish<'publish>(
@@ -338,4 +348,31 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
         !fs::try_exists(&txn_dir).await.unwrap(),
         "완료된 트랜잭션은 journal을 제거해야 합니다",
     );
+}
+
+/// A commit whose merge records nothing reports the package, so the surface
+/// can tell its publisher that what the store serves under that name is not
+/// what they uploaded.
+#[tokio::test]
+async fn commit_reports_a_package_whose_merge_recorded_nothing() {
+    let tmp = tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let storage = Storage::new(
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
+        tmp.path().join("hosted"),
+        tmp.path().join("cache"),
+    )
+    .unwrap();
+    let name = PackageName::parse("pkg").unwrap();
+    let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
+    let entries = [npm_publish(&name, &document, &[])];
+    storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
+
+    // The document is on disk now, so this commit's `base_version: None` is
+    // stale and the merge decides what to write.
+    let outcome =
+        storage.publish_journal().commit(&storage, &entries, &RecordsNothing).await.unwrap();
+
+    assert_eq!(outcome.unrecorded, vec!["pkg".to_string()]);
+    assert!(outcome.lost_blobs.is_empty());
 }

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -1,114 +1,65 @@
 use super::{
-    JournaledPublish, JournaledRevisionRef, MANIFEST_FILE, Manifest, cleanup_conflicted_tmp_paths,
-    drop_conflicted_versions, revision_ref_owner, roll_forward, sync_dir,
+    DocumentMerge, HostedDocuments, JournaledPublish, JournaledRevisionRef, MANIFEST_FILE,
+    Manifest, SealedTxn, cleanup_lost_tmp_paths, sync_dir,
 };
-use crate::{HostedRevisionRefWrite, Storage, TarballFinalize};
+use crate::{HostedRevisionRefWrite, Storage, TarballFinalize, publish::merge_journaled_packument};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use object_store::{ObjectStore, memory::InMemory};
 use pnpr_config::HostedStoreConfig;
+use pnpr_error::Result;
 use pnpr_package_name::PackageName;
+use pnpr_registry::Ecosystem;
 use serde_json::json;
-use std::{collections::HashSet, sync::Arc};
+use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::fs;
 
-#[test]
-fn drop_conflicted_versions_removes_only_the_lost_versions() {
-    let mut journaled = json!({
-        "versions": {
-            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
-            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
-            // A version outside the conflict set is kept as-is.
-            "3.0.0": { "dist": {} },
-        }
-    });
-    let conflicted: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
+/// The npm half of what the server passes in, which is all these tests
+/// commit.
+struct NpmDocuments;
 
-    drop_conflicted_versions(&mut journaled, &conflicted);
-
-    let versions = journaled["versions"].as_object().unwrap();
-    assert!(!versions.contains_key("1.0.0"));
-    assert!(versions.contains_key("2.0.0"));
-    assert!(versions.contains_key("3.0.0"));
+impl HostedDocuments for NpmDocuments {
+    fn merge(&self, merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        merge_journaled_packument(&merge)
+    }
 }
 
-#[test]
-fn drop_conflicted_versions_tolerates_a_missing_versions_map() {
-    let mut journaled = json!({ "name": "pkg" });
-    let conflicted: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
-    drop_conflicted_versions(&mut journaled, &conflicted);
-    assert_eq!(journaled, json!({ "name": "pkg" }));
-}
-
-#[test]
-fn drop_conflicted_versions_uses_the_canonical_attachment_version() {
-    let mut journaled = json!({
-        "versions": {
-            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/publisher-chosen-name.tgz" } },
-            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/another-name.tgz" } },
-            "3.0.0": { "dist": { "tarball": "http://host/pkg/-/" } },
-        }
-    });
-    let conflicted: HashSet<String> =
-        ["1.0.0".to_string(), "2.0.0".to_string()].into_iter().collect();
-
-    drop_conflicted_versions(&mut journaled, &conflicted);
-
-    let versions = journaled["versions"].as_object().unwrap();
-    let remaining_versions: Vec<_> = versions.keys().map(String::as_str).collect();
-    assert_eq!(remaining_versions, vec!["3.0.0"]);
-}
-
-#[test]
-fn drop_conflicted_versions_removes_references_to_lost_versions() {
-    let mut journaled = json!({
-        "versions": {
-            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
-            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
-        },
-        "dist-tags": {
-            "latest": "1.0.0",
-            "next": "2.0.0",
-            "opaque": 42,
-        },
-        "time": {
-            "1.0.0": "2026-07-01T00:00:00.000Z",
-            "2.0.0": "2026-07-02T00:00:00.000Z",
-            "modified": "2026-07-03T00:00:00.000Z",
-        },
-    });
-    let conflicted: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
-
-    drop_conflicted_versions(&mut journaled, &conflicted);
-
-    assert_eq!(journaled["dist-tags"], json!({ "next": "2.0.0", "opaque": 42 }));
-    assert_eq!(
-        journaled["time"],
-        json!({
-            "2.0.0": "2026-07-02T00:00:00.000Z",
-            "modified": "2026-07-03T00:00:00.000Z",
-        }),
-    );
+/// A journaled npm publish of `packument` for `name`, with no staged blobs
+/// unless the test adds them.
+fn npm_publish<'publish>(
+    name: &'publish PackageName,
+    packument: &'publish [u8],
+    revision_refs: &'publish [JournaledRevisionRef],
+) -> JournaledPublish<'publish> {
+    JournaledPublish {
+        name,
+        org: None,
+        ecosystem: Ecosystem::Npm,
+        document: packument,
+        base_version: None,
+        slots: &[],
+        revision_refs,
+    }
 }
 
 #[tokio::test]
-async fn cleanup_keeps_conflicted_tmp_when_journal_removal_is_not_durable() {
+async fn cleanup_keeps_a_lost_tmp_blob_when_journal_removal_is_not_durable() {
     let tmp = tempdir().unwrap();
     let tmp_path = tmp.path().join("conflicted.tmp");
     fs::write(&tmp_path, b"loser").await.unwrap();
 
-    cleanup_conflicted_tmp_paths(&[tmp_path.as_path()], false).await;
+    cleanup_lost_tmp_paths(&[tmp_path.as_path()], false).await;
 
     assert!(fs::try_exists(tmp_path).await.unwrap());
 }
 
 #[tokio::test]
-async fn cleanup_removes_conflicted_tmp_when_journal_removal_is_durable() {
+async fn cleanup_removes_a_lost_tmp_blob_when_journal_removal_is_durable() {
     let tmp = tempdir().unwrap();
     let tmp_path = tmp.path().join("conflicted.tmp");
     fs::write(&tmp_path, b"loser").await.unwrap();
 
-    cleanup_conflicted_tmp_paths(&[tmp_path.as_path()], true).await;
+    cleanup_lost_tmp_paths(&[tmp_path.as_path()], true).await;
 
     assert!(!fs::try_exists(tmp_path).await.unwrap());
 }
@@ -122,7 +73,7 @@ async fn sync_dir_reports_success_for_a_directory() {
 }
 
 #[tokio::test]
-async fn roll_forward_persists_revision_references() {
+async fn commit_persists_revision_references() {
     let tmp = tempdir().unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let storage = Storage::new(
@@ -145,15 +96,9 @@ async fn roll_forward_persists_revision_references() {
         ref_id: "a".repeat(64),
         bytes: record.clone(),
     }];
-    let entries = [JournaledPublish {
-        name: &name,
-        org: None,
-        packument: &packument,
-        slots: &[],
-        revision_refs: &revision_refs,
-    }];
+    let entries = [npm_publish(&name, &packument, &revision_refs)];
 
-    storage.publish_journal().seal(&entries).await.unwrap().roll_forward(&storage).await.unwrap();
+    storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
 
     assert_eq!(storage.read_hosted_revision_refs(&digest).await.unwrap(), vec![record.clone()]);
     assert_eq!(
@@ -166,7 +111,7 @@ async fn roll_forward_persists_revision_references() {
 }
 
 #[tokio::test]
-async fn roll_forward_drops_a_version_that_cannot_reserve_a_revision_reference() {
+async fn commit_drops_a_version_that_cannot_reserve_a_revision_reference() {
     let tmp = tempdir().unwrap();
     let storage =
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
@@ -197,16 +142,12 @@ async fn roll_forward_drops_a_version_that_cannot_reserve_a_revision_reference()
         ref_id: "f".repeat(64),
         bytes: br#"{"package":"pkg","version":"1.0.0"}"#.to_vec(),
     }];
-    let entries = [JournaledPublish {
-        name: &name,
-        org: None,
-        packument: &packument,
-        slots: &[],
-        revision_refs: &revision_refs,
-    }];
+    let entries = [npm_publish(&name, &packument, &revision_refs)];
 
-    storage.publish_journal().seal(&entries).await.unwrap().roll_forward(&storage).await.unwrap();
+    let outcome =
+        storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
 
+    assert_eq!(outcome.reference_limit, Some(crate::MAX_HOSTED_REVISION_REFS));
     let hosted = storage.read_hosted_packument(&name).await.unwrap().unwrap();
     let hosted: serde_json::Value = serde_json::from_slice(&hosted).unwrap();
     assert_eq!(hosted["versions"], json!({}));
@@ -219,7 +160,7 @@ async fn roll_forward_drops_a_version_that_cannot_reserve_a_revision_reference()
 }
 
 #[tokio::test]
-async fn roll_forward_only_removes_transaction_owned_references_for_a_dropped_version() {
+async fn commit_only_removes_transaction_owned_references_for_a_dropped_version() {
     let tmp = tempdir().unwrap();
     let storage =
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
@@ -266,16 +207,10 @@ async fn roll_forward_only_removes_transaction_owned_references_for_a_dropped_ve
             bytes: record.clone(),
         },
     ];
-    let entries = [JournaledPublish {
-        name: &name,
-        org: None,
-        packument: &packument,
-        slots: &[],
-        revision_refs: &revision_refs,
-    }];
+    let entries = [npm_publish(&name, &packument, &revision_refs)];
 
     let txn = storage.publish_journal().seal(&entries).await.unwrap();
-    let revision_ref_owner = txn.revision_ref_owner().to_string();
+    let revision_ref_owner = txn.revision_ref_owner.clone();
     storage
         .write_hosted_revision_ref(&transaction_owned_digest, &ref_id, &revision_ref_owner, &record)
         .await
@@ -288,7 +223,7 @@ async fn roll_forward_only_removes_transaction_owned_references_for_a_dropped_ve
         .commit_hosted_revision_ref(&previously_owned_digest, &ref_id, "previous-owner")
         .await
         .unwrap();
-    txn.roll_forward(&storage).await.unwrap();
+    txn.apply(&storage, &NpmDocuments).await.unwrap();
 
     assert_eq!(
         storage.read_hosted_revision_refs(&transaction_owned_digest).await.unwrap(),
@@ -304,7 +239,7 @@ async fn roll_forward_only_removes_transaction_owned_references_for_a_dropped_ve
 }
 
 #[tokio::test]
-async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure() {
+async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
     let tmp = tempdir().unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let storage = Storage::new(
@@ -345,24 +280,22 @@ async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure(
     .unwrap();
     let entries = [
         JournaledPublish {
-            name: &conflicted_name,
-            org: None,
-            packument: &conflicted_packument,
             slots: &conflicted_slots,
-            revision_refs: &[],
+            ..npm_publish(&conflicted_name, &conflicted_packument, &[])
         },
-        JournaledPublish {
-            name: &later_name,
-            org: None,
-            packument: b"not-json",
-            slots: &[],
-            revision_refs: &[],
-        },
+        npm_publish(&later_name, b"not-json", &[]),
     ];
-    let txn = storage.publish_journal().seal(&entries).await.unwrap();
-    let txn_dir = txn.dir.clone();
+    let txn_dir = storage.publish_journal().seal(&entries).await.unwrap().dir;
 
-    drop(txn.roll_forward(&storage).await.unwrap_err());
+    // Reopened the way startup recovery does: every document is merged, so
+    // the second package's unparsable one fails the apply partway.
+    drop(
+        SealedTxn::reopen(txn_dir.clone())
+            .unwrap()
+            .apply(&storage, &NpmDocuments)
+            .await
+            .unwrap_err(),
+    );
     assert!(
         fs::try_exists(&loser_tmp_path).await.unwrap(),
         "충돌한 임시 tarball은 트랜잭션 재시도를 위해 남아 있어야 합니다",
@@ -382,11 +315,11 @@ async fn roll_forward_preserves_tarball_conflict_across_a_later_package_failure(
     });
     let later =
         manifest.packages.iter().find(|package| package.name == later_name.as_str()).unwrap();
-    fs::write(txn_dir.join(&later.packument_file), serde_json::to_vec(&later_packument).unwrap())
+    fs::write(txn_dir.join(&later.document_file), serde_json::to_vec(&later_packument).unwrap())
         .await
         .unwrap();
 
-    roll_forward(&storage, &txn_dir, revision_ref_owner(&txn_dir).unwrap()).await.unwrap();
+    SealedTxn::reopen(txn_dir.clone()).unwrap().apply(&storage, &NpmDocuments).await.unwrap();
 
     let conflicted_hosted = storage.read_hosted_packument(&conflicted_name).await.unwrap().unwrap();
     let conflicted_hosted: serde_json::Value = serde_json::from_slice(&conflicted_hosted).unwrap();

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    DocumentMerge, HostedDocuments, JournaledPublish, JournaledRevisionRef, MANIFEST_FILE,
-    Manifest, SealedTxn, cleanup_lost_tmp_paths, sync_dir,
+    DocumentMerge, HostedDocuments, JOURNAL_DIR, JournaledPublish, JournaledRevisionRef,
+    MANIFEST_FILE, Manifest, SealedTxn, cleanup_lost_tmp_paths, sync_dir,
 };
 use crate::{HostedRevisionRefWrite, Storage, TarballFinalize, publish::merge_journaled_packument};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -51,6 +51,19 @@ impl HostedDocuments for FailsThenRecordsNothing {
             return Err(RegistryError::Internal { reason: "merge failed".to_string() });
         }
         Ok(None)
+    }
+}
+
+/// A merge that fails every time, naming the attempt it failed on.
+#[derive(Default)]
+struct AlwaysFails {
+    merges: AtomicUsize,
+}
+
+impl HostedDocuments for AlwaysFails {
+    fn merge(&self, _merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        let attempt = self.merges.fetch_add(1, Ordering::Relaxed);
+        Err(RegistryError::Internal { reason: format!("merge failed on attempt {attempt}") })
     }
 }
 
@@ -420,4 +433,33 @@ async fn commit_retries_a_failed_apply_and_keeps_its_own_writes_unreported() {
 
     assert_eq!(documents.merges.load(Ordering::Relaxed), 2, "the failed apply is re-run");
     assert!(outcome.unrecorded.is_empty());
+}
+
+/// When the retry fails too, the commit reports the failure that started it
+/// and leaves the sealed entry behind, which is what startup recovery picks up.
+#[tokio::test]
+async fn commit_keeps_the_journal_entry_when_the_retry_fails_too() {
+    let tmp = tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let storage = Storage::new(
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
+        tmp.path().join("hosted"),
+        tmp.path().join("cache"),
+    )
+    .unwrap();
+    let name = PackageName::parse("pkg").unwrap();
+    let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
+    let entries = [npm_publish(&name, &document, &[])];
+    storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
+
+    let documents = AlwaysFails::default();
+    let err = storage.publish_journal().commit(&storage, &entries, &documents).await.unwrap_err();
+
+    assert_eq!(documents.merges.load(Ordering::Relaxed), 2);
+    assert!(err.to_string().contains("attempt 0"), "{err}");
+    let journal_entries: Vec<_> = std::fs::read_dir(tmp.path().join("cache").join(JOURNAL_DIR))
+        .unwrap()
+        .map(|entry| entry.unwrap().file_name())
+        .collect();
+    assert_eq!(journal_entries.len(), 1, "{journal_entries:?}");
 }

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    DocumentMerge, HostedDocuments, JOURNAL_DIR, JournaledPublish, JournaledRevisionRef,
-    MANIFEST_FILE, Manifest, SealedTxn, cleanup_lost_tmp_paths, sync_dir,
+    ApplyProgress, DocumentMerge, HostedDocuments, JOURNAL_DIR, JournaledPublish,
+    JournaledRevisionRef, MANIFEST_FILE, Manifest, SealedTxn, cleanup_lost_tmp_paths, sync_dir,
 };
 use crate::{HostedRevisionRefWrite, Storage, TarballFinalize, publish::merge_journaled_packument};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
@@ -37,9 +37,9 @@ impl HostedDocuments for RecordsNothing {
     }
 }
 
-/// A merge that fails once and then records nothing: the shape of a first
-/// apply that wrote its document and failed afterwards, whose retry finds the
-/// entries already there.
+/// A merge that fails the first time it is asked and records nothing after:
+/// an apply that never got the document written, whose retry finds an entry
+/// that must therefore be someone else's.
 #[derive(Default)]
 struct FailsThenRecordsNothing {
     merges: AtomicUsize,
@@ -49,6 +49,30 @@ impl HostedDocuments for FailsThenRecordsNothing {
     fn merge(&self, _merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
         if self.merges.fetch_add(1, Ordering::Relaxed) == 0 {
             return Err(RegistryError::Internal { reason: "merge failed".to_string() });
+        }
+        Ok(None)
+    }
+}
+
+/// A merge that writes the first package it is asked about and fails on
+/// `fails`, then records nothing for either: an apply that got one document
+/// written before it stopped, whose retry finds both entries in place.
+struct WritesOneThenFails {
+    fails: &'static str,
+    written: AtomicUsize,
+    failed: AtomicUsize,
+}
+
+impl HostedDocuments for WritesOneThenFails {
+    fn merge(&self, merge: DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+        if merge.name.as_str() == self.fails {
+            if self.failed.fetch_add(1, Ordering::Relaxed) == 0 {
+                return Err(RegistryError::Internal { reason: "merge failed".to_string() });
+            }
+            return Ok(None);
+        }
+        if self.written.fetch_add(1, Ordering::Relaxed) == 0 {
+            return Ok(Some(merge.journaled.to_vec()));
         }
         Ok(None)
     }
@@ -266,7 +290,7 @@ async fn commit_only_removes_transaction_owned_references_for_a_dropped_version(
         .commit_hosted_revision_ref(&previously_owned_digest, &ref_id, "previous-owner")
         .await
         .unwrap();
-    txn.apply(&storage, &NpmDocuments).await.unwrap();
+    txn.apply(&storage, &NpmDocuments, &mut ApplyProgress::default()).await.unwrap();
 
     assert_eq!(
         storage.read_hosted_revision_refs(&transaction_owned_digest).await.unwrap(),
@@ -335,7 +359,7 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
     drop(
         SealedTxn::reopen(txn_dir.clone())
             .unwrap()
-            .apply(&storage, &NpmDocuments)
+            .apply(&storage, &NpmDocuments, &mut ApplyProgress::default())
             .await
             .unwrap_err(),
     );
@@ -362,7 +386,11 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
         .await
         .unwrap();
 
-    SealedTxn::reopen(txn_dir.clone()).unwrap().apply(&storage, &NpmDocuments).await.unwrap();
+    SealedTxn::reopen(txn_dir.clone())
+        .unwrap()
+        .apply(&storage, &NpmDocuments, &mut ApplyProgress::default())
+        .await
+        .unwrap();
 
     let conflicted_hosted = storage.read_hosted_packument(&conflicted_name).await.unwrap().unwrap();
     let conflicted_hosted: serde_json::Value = serde_json::from_slice(&conflicted_hosted).unwrap();
@@ -410,11 +438,11 @@ async fn commit_reports_a_package_whose_merge_recorded_nothing() {
     assert!(outcome.lost_blobs.is_empty());
 }
 
-/// An apply that fails partway is re-run before the commit gives up, and what
-/// its first attempt already recorded is not held against the publisher: the
-/// entries the retry finds in place may be the ones it wrote itself.
+/// An apply that fails before writing a document is re-run, and an entry the
+/// retry then finds in place was recorded by another writer: this transaction
+/// never wrote one, so the publisher hears about it.
 #[tokio::test]
-async fn commit_retries_a_failed_apply_and_keeps_its_own_writes_unreported() {
+async fn commit_reports_an_entry_the_retry_found_recorded_by_another_writer() {
     let tmp = tempdir().unwrap();
     let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
     let storage = Storage::new(
@@ -432,7 +460,44 @@ async fn commit_retries_a_failed_apply_and_keeps_its_own_writes_unreported() {
     let outcome = storage.publish_journal().commit(&storage, &entries, &documents).await.unwrap();
 
     assert_eq!(documents.merges.load(Ordering::Relaxed), 2, "the failed apply is re-run");
-    assert!(outcome.unrecorded.is_empty());
+    assert_eq!(outcome.unrecorded, vec!["pkg".to_string()]);
+}
+
+/// The entries the first attempt wrote itself are not reported: the retry
+/// finds them in place because this transaction put them there, and calling
+/// that a duplicate would tell a publisher their publish duplicated itself.
+#[tokio::test]
+async fn commit_does_not_report_what_its_own_first_attempt_wrote() {
+    let tmp = tempdir().unwrap();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let storage = Storage::new(
+        &HostedStoreConfig::ObjectStore { store: object_store, prefix: String::new() },
+        tmp.path().join("hosted"),
+        tmp.path().join("cache"),
+    )
+    .unwrap();
+    let written_name = PackageName::parse("written-pkg").unwrap();
+    let failed_name = PackageName::parse("failed-pkg").unwrap();
+    let written_document =
+        serde_json::to_vec(&json!({ "name": "written-pkg", "versions": {} })).unwrap();
+    let failed_document =
+        serde_json::to_vec(&json!({ "name": "failed-pkg", "versions": {} })).unwrap();
+    let entries = [
+        npm_publish(&written_name, &written_document, &[]),
+        npm_publish(&failed_name, &failed_document, &[]),
+    ];
+    // Both documents exist, so neither commit below can take the write-as-is
+    // path and every package goes through the merge.
+    storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
+
+    let documents = WritesOneThenFails {
+        fails: "failed-pkg",
+        written: AtomicUsize::new(0),
+        failed: AtomicUsize::new(0),
+    };
+    let outcome = storage.publish_journal().commit(&storage, &entries, &documents).await.unwrap();
+
+    assert_eq!(outcome.unrecorded, vec!["failed-pkg".to_string()]);
 }
 
 /// When the retry fails too, the commit reports the failure that started it

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -356,8 +356,9 @@ pub enum PackumentWrite {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PackumentUpdate {
     Written,
-    /// The `build` closure reported that the packument does not exist
-    /// (returned `Ok(None)`), so there was nothing to update.
+    /// `build` returned `Ok(None)`, so nothing was written: the packument
+    /// the caller wanted to change does not exist, or the change it computed
+    /// turned out to be no change at all.
     NotFound,
 }
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -171,7 +171,10 @@ impl HostedRevisionRefIndex {
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 const MAX_TEMP_CREATE_ATTEMPTS: usize = 16;
 pub const PACKUMENT_WRITE_RETRIES: usize = 8;
-pub(crate) const RECOVERY_PACKUMENT_WRITE_RETRIES: usize = 32;
+/// Retries the commit path allows the document write: higher than the
+/// request-path budget because a sealed transaction has to converge, and a
+/// startup recovery may be racing every other replica's recovery at once.
+pub(crate) const COMMIT_DOCUMENT_WRITE_RETRIES: usize = 32;
 const PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 5;
 const MAX_PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 250;
 

--- a/pnpr/crates/storage/src/publish.rs
+++ b/pnpr/crates/storage/src/publish.rs
@@ -9,13 +9,16 @@
 //! it inside [`tokio::task::spawn_blocking`] without blocking the
 //! async runtime, and so these helpers stay easy to unit-test.
 
-use crate::streaming::{integrity_checker, parse_integrity};
+use crate::{
+    journal::DocumentMerge,
+    streaming::{integrity_checker, parse_integrity},
+};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64, read::DecoderReader};
-use pnpr_error::RegistryError;
+use pnpr_error::{RegistryError, Result};
 use serde_json::{Map, Value};
 use ssri::{Algorithm, IntegrityOpts};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fmt::Write as FmtWrite,
     fs::File,
     io::{Cursor, Read, Write},
@@ -388,6 +391,58 @@ fn merge_versions(existing: Option<&Value>, incoming: &Value, hosted: Option<&Va
         }
     }
     Value::Object(merged)
+}
+
+/// The npm half of the journal's [`crate::journal::HostedDocuments`]: merge a
+/// journaled packument into the packument the store holds, minus the versions
+/// whose tarball the transaction lost. Publishing and startup recovery both
+/// land here, so a re-applied transaction adds its versions to whatever was
+/// published in the meantime instead of erasing it.
+pub fn merge_journaled_packument(merge: &DocumentMerge<'_>) -> Result<Option<Vec<u8>>> {
+    let mut journaled: Value = serde_json::from_slice(merge.journaled)?;
+    if !merge.lost_blobs.is_empty() {
+        let lost_versions = merge
+            .lost_blobs
+            .iter()
+            .map(|filename| merge.name.parse_tarball_name(filename).map(|(_, version)| version))
+            .collect::<Result<HashSet<String>>>()?;
+        drop_lost_versions(&mut journaled, &lost_versions);
+    }
+    let existing: Option<Value> = match merge.existing {
+        Some(bytes) => Some(serde_json::from_slice(bytes)?),
+        None => None,
+    };
+    let merged = merge_manifest(existing.as_ref(), &journaled, existing.as_ref(), &now_iso());
+    Ok(Some(serde_json::to_vec_pretty(&merged)?))
+}
+
+/// Drop from a journaled packument every version the transaction could not
+/// place: one whose tarball slot another writer already owned, or that could
+/// not reserve a bounded digest-reference slot. The journal keeps each staged
+/// attachment's canonical filename, so callers resolve that name to the
+/// version before reaching this helper instead of trusting a publisher-
+/// supplied `dist.tarball` URL as the transaction identity.
+fn drop_lost_versions(journaled: &mut Value, lost: &HashSet<String>) {
+    let Some(versions) = journaled.get_mut("versions").and_then(Value::as_object_mut) else {
+        return;
+    };
+    let mut removed_versions = HashSet::new();
+    versions.retain(|version, _| {
+        let keep = !lost.contains(version);
+        if !keep {
+            removed_versions.insert(version.clone());
+        }
+        keep
+    });
+
+    if let Some(tags) = journaled.get_mut("dist-tags").and_then(Value::as_object_mut) {
+        tags.retain(|_, version| {
+            version.as_str().is_none_or(|version| !removed_versions.contains(version))
+        });
+    }
+    if let Some(time) = journaled.get_mut("time").and_then(Value::as_object_mut) {
+        time.retain(|version, _| !removed_versions.contains(version));
+    }
 }
 
 /// Format the current time as an ISO-8601 / RFC-3339 string with

--- a/pnpr/crates/storage/src/publish/tests.rs
+++ b/pnpr/crates/storage/src/publish/tests.rs
@@ -1,11 +1,13 @@
 use super::{
-    extract_attachments, merge_manifest, now_iso, sha1_hex_from_integrity_opts,
-    stream_decode_verify_and_write,
+    DocumentMerge, drop_lost_versions, extract_attachments, merge_journaled_packument,
+    merge_manifest, now_iso, sha1_hex_from_integrity_opts, stream_decode_verify_and_write,
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use pnpr_package_name::PackageName;
+use pnpr_registry::Ecosystem;
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
-use std::path::PathBuf;
+use std::{collections::HashSet, path::PathBuf};
 use tempfile::TempDir;
 
 fn sri_sha512(bytes: &[u8]) -> String {
@@ -343,4 +345,129 @@ fn merge_drops_attachments_if_present() {
     });
     let merged: Value = merge_manifest(None, &incoming, None, "now");
     assert!(merged.get("_attachments").is_none());
+}
+
+#[test]
+fn drop_lost_versions_removes_only_the_lost_versions() {
+    let mut journaled = json!({
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+            // A version outside the conflict set is kept as-is.
+            "3.0.0": { "dist": {} },
+        }
+    });
+    let lost: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
+
+    drop_lost_versions(&mut journaled, &lost);
+
+    let versions = journaled["versions"].as_object().unwrap();
+    assert!(!versions.contains_key("1.0.0"));
+    assert!(versions.contains_key("2.0.0"));
+    assert!(versions.contains_key("3.0.0"));
+}
+
+#[test]
+fn drop_lost_versions_tolerates_a_missing_versions_map() {
+    let mut journaled = json!({ "name": "pkg" });
+    let lost: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
+    drop_lost_versions(&mut journaled, &lost);
+    assert_eq!(journaled, json!({ "name": "pkg" }));
+}
+
+#[test]
+fn merging_a_journaled_packument_adds_its_versions_to_the_stored_one() {
+    let name = PackageName::parse("pkg").unwrap();
+    let stored = serde_json::to_vec(&json!({
+        "name": "pkg",
+        "versions": { "1.0.0": { "version": "1.0.0" } },
+        "dist-tags": { "latest": "1.0.0" },
+    }))
+    .unwrap();
+    let journaled = serde_json::to_vec(&json!({
+        "name": "pkg",
+        "versions": { "2.0.0": { "version": "2.0.0" } },
+        "dist-tags": { "latest": "2.0.0" },
+    }))
+    .unwrap();
+
+    let merged = merge_journaled_packument(&DocumentMerge {
+        ecosystem: Ecosystem::Npm,
+        name: &name,
+        existing: Some(&stored),
+        journaled: &journaled,
+        lost_blobs: &HashSet::new(),
+    })
+    .unwrap()
+    .unwrap();
+
+    let merged: Value = serde_json::from_slice(&merged).unwrap();
+    assert_eq!(merged["versions"]["1.0.0"]["version"], "1.0.0");
+    assert_eq!(merged["versions"]["2.0.0"]["version"], "2.0.0");
+    assert_eq!(merged["dist-tags"]["latest"], "2.0.0");
+}
+
+/// The canonical tarball filename names the version, not the publisher-chosen
+/// `dist.tarball` URL the packument carries.
+#[test]
+fn merging_a_journaled_packument_drops_the_versions_of_lost_blobs() {
+    let name = PackageName::parse("pkg").unwrap();
+    let journaled = serde_json::to_vec(&json!({
+        "name": "pkg",
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/publisher-chosen-name.tgz" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+        },
+        "dist-tags": { "latest": "1.0.0" },
+    }))
+    .unwrap();
+    let lost_blobs: HashSet<String> = std::iter::once("pkg-1.0.0.tgz".to_string()).collect();
+
+    let merged = merge_journaled_packument(&DocumentMerge {
+        ecosystem: Ecosystem::Npm,
+        name: &name,
+        existing: None,
+        journaled: &journaled,
+        lost_blobs: &lost_blobs,
+    })
+    .unwrap()
+    .unwrap();
+
+    let merged: Value = serde_json::from_slice(&merged).unwrap();
+    let versions: Vec<_> =
+        merged["versions"].as_object().unwrap().keys().map(String::as_str).collect();
+    assert_eq!(versions, vec!["2.0.0"]);
+    assert_eq!(merged["dist-tags"], json!({}));
+}
+
+#[test]
+fn drop_lost_versions_removes_references_to_lost_versions() {
+    let mut journaled = json!({
+        "versions": {
+            "1.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-1.0.0.tgz" } },
+            "2.0.0": { "dist": { "tarball": "http://host/pkg/-/pkg-2.0.0.tgz" } },
+        },
+        "dist-tags": {
+            "latest": "1.0.0",
+            "next": "2.0.0",
+            "opaque": 42,
+        },
+        "time": {
+            "1.0.0": "2026-07-01T00:00:00.000Z",
+            "2.0.0": "2026-07-02T00:00:00.000Z",
+            "modified": "2026-07-03T00:00:00.000Z",
+        },
+    });
+    let lost: HashSet<String> = std::iter::once("1.0.0".to_string()).collect();
+
+    drop_lost_versions(&mut journaled, &lost);
+
+    assert_eq!(journaled["dist-tags"], json!({ "next": "2.0.0", "opaque": 42 }));
+    assert_eq!(
+        journaled["time"],
+        json!({
+            "2.0.0": "2026-07-02T00:00:00.000Z",
+            "modified": "2026-07-03T00:00:00.000Z",
+        }),
+    );
 }


### PR DESCRIPTION
## Summary

The Cargo and Python surfaces published in two steps: reserve a blob, finalize it, then update the project document. Neither step went through the commit journal the npm surface uses, so a crash between finalizing the blob and writing the document left a blob nothing mentions. Harmless to readers, but inconsistent, and a second copy of a problem the npm publish flow had already solved.

This makes "store the blob, then record it in the document" one journaled operation that all three surfaces use.

- `pnpr-storage`'s journal now carries a document of any ecosystem. A journal entry records the `ecosystem` beside the computed document bytes; the caller supplies a `HostedDocuments` implementation that merges a journaled document into what the store holds, so the merge rule stays with the surface whose format it is (npm's is `publish::merge_journaled_packument`, Cargo's and Python's are entry-wise unions in `server/documents.rs`).
- `PublishJournal::commit` seals, applies, and removes the entry. The apply is exactly the code path startup recovery runs, so the npm publish flow no longer keeps an inline second copy of it: `commit_publishes` shrank from ~130 lines of promote/write/roll-forward to building the entries and reporting the outcome.
- Committing keeps the optimistic write the npm flow had: while the store is still at the document version the publish read, the computed document is written as-is; otherwise it is merged with retry. Recovery carries no base version and always merges.
- `store_hosted_artifact` (Cargo `PUT api/v1/crates/new`, Python `POST legacy/`) now stages the blob and the document it computed and commits them together.
- A blob whose immutable slot another writer already owns is left out of the document, and a transaction that ends up recording nothing writes no document at all — so a fully lost upload no longer creates an empty project page. A commit reports those packages, and the surface answers a publisher whose entry another replica recorded first with the same duplicate error the pre-write check gives.
- A post-seal apply that fails partway re-runs once from the journal before returning, so a running server does not leave a batch half-visible until the next restart (what the npm flow did inline before).

The journal manifest's `packument_file` / `tarballs` keys are now `document_file` / `blobs`, read through serde aliases so a journal a running server sealed before the upgrade still recovers. The existing recovery tests fabricate the old spelling, which keeps that covered.

Related to pnpm/pnpm#14599 (the first follow-up; the storage vocabulary rename and the rest stay open).

## Squash Commit Body

```text
The Cargo and Python surfaces reserved a blob, finalized it, then updated
the project document, all outside the commit journal the npm surface uses.
A crash between the finalize and the document write left a blob nothing
mentions: harmless to readers, but inconsistent, and a second copy of a
problem npm had already solved.

The journal now carries a document of any ecosystem. Each entry records
the ecosystem beside the computed document bytes, and the caller supplies
a `HostedDocuments` merge that both the commit and startup recovery run
for that format, so the merge rule stays with the surface that owns it.
Committing is one operation for every surface — seal, apply, remove the
entry — and the apply is exactly what recovery runs, so the npm publish
flow no longer keeps an inline second copy of it.

`store_hosted_artifact` now stages the blob and the document it computed
and commits them together. A blob whose immutable slot another writer
already owns is left out of the document, and a transaction that ends up
recording nothing writes no document at all; the surface reports that as
the duplicate publish it is. A post-seal apply that fails partway re-runs
once from the journal, as the npm flow did inline before.

Related to pnpm/pnpm#14599.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpr only; it has no TypeScript counterpart.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (No user-facing surface changed.)

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crash-safe publishing for Cargo and PyPI packages.
  * Interrupted uploads can now be completed automatically when the registry restarts.
  * Package metadata and uploaded files are recovered together, preserving successful uploads.

* **Bug Fixes**
  * Improved handling of concurrent or conflicting publishes.
  * Prevented incomplete uploads from appearing in package metadata.
  * Added cleanup and retry handling for interrupted publishing transactions.

* **Tests**
  * Added coverage for recovery, conflict handling, and preserving uploads made before an interruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->