### PR TITLE
refactor(pnpr): name storage after documents and blobs

### DIFF
--- a/.changeset/pnpr-document-write-conflict-name.md
+++ b/.changeset/pnpr-document-write-conflict-name.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A publish that loses a write race now reports the error as `document_write_conflict` on every registry surface. The message names the package document [#14599](https://github.com/pnpm/pnpm/issues/14599).

--- a/.changeset/pnpr-reject-url-delimiters-in-package-names.md
+++ b/.changeset/pnpr-reject-url-delimiters-in-package-names.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+pnpr now rejects a package name that carries `?`, `#`, `%`, whitespace, or a control character. A percent-encoded delimiter let a request read an upstream package under a name the access rules had not checked.

--- a/.changeset/pnpr-reject-url-delimiters-in-package-names.md
+++ b/.changeset/pnpr-reject-url-delimiters-in-package-names.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-pnpr now rejects a package name that carries `?`, `#`, `%`, whitespace, or a control character. A percent-encoded delimiter let a request read an upstream package under a name the access rules had not checked.
+pnpr now rejects a package name that carries `?`, `#`, `%`, whitespace, or a control character. Artifact filenames are held to the same rule. A percent-encoded delimiter let a request read an upstream package under a name the access rules had not checked.

--- a/pnpr/AGENTS.md
+++ b/pnpr/AGENTS.md
@@ -47,7 +47,7 @@ pnpr/
     config/        -> package "pnpr-config"        (the YAML config: parsing and validation)
     error/         -> package "pnpr-error"         (the error type every layer returns)
     osv/           -> package "pnpr-osv"           (the OSV advisory index)
-    package-name/  -> package "pnpr-package-name"  (npm package-name parsing)
+    package-name/  -> package "pnpr-package-name"  (a validated package name)
     registry/      -> package "pnpr-registry"      (the registry routing table)
     route/         -> package "pnpr-route"         (classifies a fetch route public or private)
     search/        -> package "pnpr-search"        (the local /-/v1/search index scan)

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -178,9 +178,9 @@ pub enum RegistryError {
         packages: String,
     },
 
-    #[display("Hosted packument for package {package:?} changed while writing")]
+    #[display("Hosted document for package {package:?} changed while writing")]
     #[from(skip)]
-    PackumentWriteConflict {
+    DocumentWriteConflict {
         #[error(not(source))]
         package: String,
     },
@@ -329,7 +329,7 @@ impl RegistryError {
             RegistryError::VersionAlreadyPublished { .. } => "version_already_published",
             RegistryError::ArtifactAlreadyPublished { .. } => "artifact_already_published",
             RegistryError::PublishNotRecorded { .. } => "publish_not_recorded",
-            RegistryError::PackumentWriteConflict { .. } => "packument_write_conflict",
+            RegistryError::DocumentWriteConflict { .. } => "document_write_conflict",
             RegistryError::RevisionReferenceLimit { .. } => "revision_reference_limit",
             RegistryError::RevisionReferenceWriteConflict { .. } => {
                 "revision_reference_write_conflict"
@@ -422,7 +422,7 @@ impl RegistryError {
             RegistryError::VersionAlreadyPublished { .. }
             | RegistryError::ArtifactAlreadyPublished { .. }
             | RegistryError::PublishNotRecorded { .. }
-            | RegistryError::PackumentWriteConflict { .. }
+            | RegistryError::DocumentWriteConflict { .. }
             | RegistryError::RevisionReferenceLimit { .. }
             | RegistryError::RevisionReferenceWriteConflict { .. } => StatusCode::CONFLICT,
             RegistryError::NotFound => StatusCode::NOT_FOUND,

--- a/pnpr/crates/package-name/Cargo.toml
+++ b/pnpr/crates/package-name/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name                 = "pnpr-package-name"
 version              = "0.0.1"
-description          = "npm package-name parsing and the tarball names derived from it"
+description          = "a validated package name and the npm tarball names derived from it"
 publish              = false
 authors.workspace    = true
 edition.workspace    = true

--- a/pnpr/crates/package-name/src/lib.rs
+++ b/pnpr/crates/package-name/src/lib.rs
@@ -1,8 +1,10 @@
 use pnpr_error::RegistryError;
 
-/// A package name validated to be safe for use as a filesystem path
+/// The name of a package in any ecosystem — an npm package, a crate, a
+/// Python project — validated to be safe for use as a filesystem path
 /// segment (no traversal, no absolute-path prefixes) and well-formed
-/// enough to send upstream.
+/// enough to send upstream. Callers canonicalize the name for their
+/// ecosystem first; this is what the storage layer keys a package by.
 #[derive(Debug, Clone)]
 pub struct PackageName {
     raw: String,
@@ -79,16 +81,24 @@ impl PackageName {
 // `:` is rejected because on Windows `C:foo` is a drive-relative *prefix*
 // component: `PathBuf::join` treats it as a new path rather than a child
 // segment, so a `:`-carrying name or filename could escape the storage or
-// cache root. No legitimate package name, semver version, or tarball
-// basename carries a `:`.
+// cache root.
+//
+// `?`, `#`, `%`, whitespace, and control characters are rejected because a name
+// reaches an upstream by interpolation into its URL: the request path is
+// percent-decoded before it gets here, so `foo#bar` and `foo?bar` fetch `foo`
+// while being authorized and cached under a name of their own.
+//
+// No package name, semver version, or artifact filename in any ecosystem this
+// serves carries one of these.
 fn is_safe_segment(segment: &str) -> bool {
     !segment.is_empty()
         && !segment.starts_with('.')
-        && !segment.contains('/')
-        && !segment.contains('\\')
-        && !segment.contains(':')
-        && !segment.contains('\0')
         && segment != ".."
+        && !segment.chars().any(|character| {
+            matches!(character, '/' | '\\' | ':' | '?' | '#' | '%')
+                || character.is_whitespace()
+                || character.is_control()
+        })
 }
 
 /// Whether `filename` is safe to use as a single on-disk path segment (no

--- a/pnpr/crates/package-name/src/tests.rs
+++ b/pnpr/crates/package-name/src/tests.rs
@@ -49,3 +49,18 @@ fn rejects_windows_drive_prefixes() {
     let name = PackageName::parse("foo").unwrap();
     assert!(name.parse_tarball_name("foo-1.0.0:x.tgz").is_err());
 }
+
+/// A name is interpolated into an upstream URL, so a `?`, `#`, or `%` in it
+/// would address a different package there than the one it is authorized and
+/// cached under.
+#[test]
+fn rejects_url_delimiters_and_blanks() {
+    for raw in ["foo?bar", "foo#bar", "foo%2fbar", "foo bar", "foo\tbar", "foo\u{7f}bar"] {
+        assert!(PackageName::parse(raw).is_err(), "{raw:?}");
+        assert!(!is_safe_path_segment(raw), "{raw:?}");
+    }
+    assert!(PackageName::parse("@scope/foo?bar").is_err());
+    assert!(PackageName::parse("@sco?pe/foo").is_err());
+    let name = PackageName::parse("foo").unwrap();
+    assert!(name.parse_tarball_name("foo-1.0.0?x.tgz").is_err());
+}

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -639,7 +639,7 @@ async fn serve_registry_version_manifest(
                 Ok(org) => org,
                 Err(err) => return err.into_response(),
             };
-            match state.inner.storage.for_hosted(&org).read_hosted_packument(&name).await {
+            match state.inner.storage.for_hosted(&org).read_hosted_document(&name).await {
                 Ok(Some(bytes)) => bytes,
                 Ok(None) => return not_found(),
                 Err(err) => return err.into_response(),
@@ -851,7 +851,7 @@ async fn load_upstream_packument(
         && let Some(bytes) = timed(
             "packument:cache_read",
             name.as_str(),
-            state.inner.storage.read_upstream_packument(namespace, name, ttl),
+            state.inner.storage.read_upstream_document(namespace, name, ttl),
         )
         .await?
     {
@@ -875,7 +875,7 @@ async fn load_upstream_packument(
                 && let Err(err) = state
                     .inner
                     .storage
-                    .write_upstream_packument(namespace, name, &fetched.bytes)
+                    .write_upstream_document(namespace, name, &fetched.bytes)
                     .await
             {
                 tracing::warn!(?err, package = %name.as_str(), "upstream packument cache write failed");
@@ -900,12 +900,12 @@ async fn load_upstream_packument(
         }
         // `load_upstream_packument` sends no conditional validators (the upstream
         // cache refetches stale entries rather than revalidating — see
-        // `Store::read_upstream_packument`), so a well-behaved upstream never
+        // `Store::read_upstream_document`), so a well-behaved upstream never
         // answers 304 here. If one does anyway, "not modified" means the cached
         // body is current, so serve it (fresh or stale) rather than a spurious
         // 404 that a client could cache as "package gone".
         PackumentFetch::NotModified => {
-            state.inner.storage.read_upstream_packument_any(namespace, name).await
+            state.inner.storage.read_upstream_document_any(namespace, name).await
         }
     }
 }
@@ -924,8 +924,7 @@ async fn recover_stale_upstream_packument(
     if !err.is_transient_upstream_error() || !upstream.caches() {
         return Err(err);
     }
-    let Some(bytes) = state.inner.storage.read_upstream_packument_any(namespace, name).await?
-    else {
+    let Some(bytes) = state.inner.storage.read_upstream_document_any(namespace, name).await? else {
         return Err(err);
     };
     // The upstream error may embed credentials in its request URL, so only its
@@ -990,7 +989,7 @@ async fn load_packument_for_read(
                 HostedGate::MaskNotFound => return Ok(None),
                 HostedGate::Denied(err) => return Err(err),
             };
-            state.inner.storage.for_hosted(&org).read_hosted_packument(name).await
+            state.inner.storage.for_hosted(&org).read_hosted_document(name).await
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => Ok(None),
     }
@@ -1134,11 +1133,11 @@ async fn serve_tarball_via_upstream(
         Ok(FetchOutcome::NotFound) => return not_found(),
         Err(err) => return err.into_response(),
     };
-    let write =
-        match state.inner.storage.open_upstream_tarball_tmp(&namespace, &name, &filename).await {
-            Ok(write) => write,
-            Err(err) => return err.into_response(),
-        };
+    let write = match state.inner.storage.open_upstream_blob_tmp(&namespace, &name, &filename).await
+    {
+        Ok(write) => write,
+        Err(err) => return err.into_response(),
+    };
     if !upstream.caches() {
         // Fetch-through: verify and stream from the temp file, then remove it,
         // so a `cache: false` upstream's tarball is never persisted.
@@ -1201,7 +1200,7 @@ async fn serve_upstream_revision_tarball(
     };
     let namespace = upstream_cache_namespace(state, registry);
     if upstream.caches() {
-        match state.inner.storage.open_upstream_revision_tarball(&namespace, digest).await {
+        match state.inner.storage.open_upstream_revision_blob(&namespace, digest).await {
             Ok(Some((file, len))) => {
                 return revision_tarball_response(
                     streaming::stream_file(file),
@@ -1221,11 +1220,11 @@ async fn serve_upstream_revision_tarball(
         Ok(FetchOutcome::NotFound) => return not_found(),
         Err(err) => return err.into_response(),
     };
-    let write =
-        match state.inner.storage.open_upstream_revision_tarball_tmp(&namespace, digest).await {
-            Ok(write) => write,
-            Err(err) => return err.into_response(),
-        };
+    let write = match state.inner.storage.open_upstream_revision_blob_tmp(&namespace, digest).await
+    {
+        Ok(write) => write,
+        Err(err) => return err.into_response(),
+    };
     if !upstream.caches() {
         return match streaming::download_verified_to_temp(
             response,
@@ -1366,7 +1365,7 @@ async fn hosted_original_is_current(
     version: &str,
     digest: &str,
 ) -> Result<bool, RegistryError> {
-    let Some(bytes) = storage.read_hosted_packument(package).await? else {
+    let Some(bytes) = storage.read_hosted_document(package).await? else {
         return Ok(false);
     };
     let packument = serde_json::from_slice::<HostedRevisionPackument>(&bytes)?;
@@ -1387,7 +1386,7 @@ async fn open_hosted_revision_tarball(
     integrity: &Integrity,
 ) -> Response {
     let filename = package.tarball_name_for_version(version);
-    match storage.open_hosted_tarball(package, &filename).await {
+    match storage.open_hosted_blob(package, &filename).await {
         Ok(Some((body, len))) => revision_tarball_response(body, len, digest, integrity),
         Ok(None) => not_found(),
         Err(err) => err.into_response(),
@@ -1474,7 +1473,7 @@ async fn cached_upstream_tarball(
     match timed(
         "tarball:cache_read",
         name.as_str(),
-        state.inner.storage.open_upstream_tarball(namespace, name, filename),
+        state.inner.storage.open_upstream_blob(namespace, name, filename),
     )
     .await
     {
@@ -1843,7 +1842,7 @@ async fn serve_hosted_packument(
     };
     // A hosted org has no upstream fallback: a package it does not host is a
     // definitive not-found. Reads come from the org's own storage namespace.
-    match state.inner.storage.for_hosted(&org).read_hosted_packument(name).await {
+    match state.inner.storage.for_hosted(&org).read_hosted_document(name).await {
         Ok(Some(bytes)) => match packument_response(
             name,
             &bytes,
@@ -1878,7 +1877,7 @@ async fn serve_hosted_tarball(
     if let Err(err) = ensure_osv_allowed(state, name, &name_version) {
         return err.into_response();
     }
-    match state.inner.storage.for_hosted(&org).open_hosted_tarball(name, &filename).await {
+    match state.inner.storage.for_hosted(&org).open_hosted_blob(name, &filename).await {
         Ok(Some((body, len))) => tarball_response(body, len),
         Ok(None) => not_found(),
         Err(err) => {
@@ -2004,7 +2003,7 @@ fn expected_tarball_dist(
 }
 
 fn tarball_stream_error(
-    err: streaming::TarballStreamError,
+    err: streaming::BlobStreamError,
     name: &PackageName,
     filename: &str,
 ) -> RegistryError {
@@ -2012,21 +2011,21 @@ fn tarball_stream_error(
 }
 
 fn tarball_stream_error_for_package(
-    err: streaming::TarballStreamError,
+    err: streaming::BlobStreamError,
     package: &str,
     filename: &str,
 ) -> RegistryError {
     match err {
-        streaming::TarballStreamError::Upstream { url, source } => {
+        streaming::BlobStreamError::Upstream { url, source } => {
             RegistryError::UpstreamBody { url, source }
         }
-        streaming::TarballStreamError::Io(err) => RegistryError::Io(err),
-        streaming::TarballStreamError::Integrity(err) => tarball_integrity_error(
+        streaming::BlobStreamError::Io(err) => RegistryError::Io(err),
+        streaming::BlobStreamError::Integrity(err) => tarball_integrity_error(
             package,
             filename,
             format!("integrity verification failed: {err}"),
         ),
-        streaming::TarballStreamError::TooLarge { limit, received } => tarball_integrity_error(
+        streaming::BlobStreamError::TooLarge { limit, received } => tarball_integrity_error(
             package,
             filename,
             format!("tarball body exceeds {limit} byte limit (received {received} bytes)"),

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -45,7 +45,7 @@ use pnpr_error::RegistryError;
 use pnpr_package_name::{PackageName, is_safe_path_segment};
 use pnpr_policy::Identity;
 use pnpr_registry::Ecosystem;
-use pnpr_storage::{PACKUMENT_WRITE_RETRIES, PackumentUpdate};
+use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentUpdate};
 use std::{collections::HashMap, fmt::Display};
 
 const ECOSYSTEM: Ecosystem = Ecosystem::Cargo;
@@ -518,7 +518,7 @@ async fn set_yanked(
         .inner
         .storage
         .for_hosted(&target.org)
-        .update_hosted_packument_with_retry(&key, PACKUMENT_WRITE_RETRIES, |existing| {
+        .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
             let Some(bytes) = existing else { return Ok(None) };
             let mut document = CrateDocument::parse(bytes)?;
             let Some(entry) = document.version_mut(version) else { return Ok(None) };
@@ -527,8 +527,8 @@ async fn set_yanked(
         })
         .await;
     match outcome {
-        Ok(PackumentUpdate::Written) => json_response(StatusCode::OK, &ok_json()),
-        Ok(PackumentUpdate::NotFound) => not_found(),
+        Ok(DocumentUpdate::Written) => json_response(StatusCode::OK, &ok_json()),
+        Ok(DocumentUpdate::NotFound) => not_found(),
         Err(err) => error_response(err),
     }
 }

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -150,7 +150,7 @@ pub(super) async fn read_hosted_document<Document: HostedDocument>(
         .inner
         .storage
         .for_hosted(&org)
-        .read_hosted_packument(key)
+        .read_hosted_document(key)
         .await?
         .map(|bytes| Document::parse(&bytes).map_err(RegistryError::Json))
         .transpose()
@@ -179,13 +179,13 @@ pub(super) async fn store_hosted_artifact<Document: HostedDocument + Send>(
     let staged = stage_hosted_artifact(state, org, key, filename, bytes, &refuse, addition).await?;
     let outcome = commit_publishes(state, vec![staged]).await?;
     if outcome.lost_blobs.iter().any(|lost| lost.filename == filename) {
-        return Err(RegistryError::PackumentWriteConflict { package: key.as_str().to_string() });
+        return Err(RegistryError::DocumentWriteConflict { package: key.as_str().to_string() });
     }
     // Another writer recorded this blob's entry between the read and the
     // commit, so what the store serves under it is theirs. Answer with the
     // duplicate error `refuse` would have given had it seen their document.
     if !outcome.unrecorded.is_empty()
-        && let Some(stored) = state.inner.storage.for_hosted(org).read_hosted_packument(key).await?
+        && let Some(stored) = state.inner.storage.for_hosted(org).read_hosted_document(key).await?
     {
         refuse(&Document::parse(&stored).map_err(RegistryError::Json)?)?;
     }
@@ -207,7 +207,7 @@ pub(super) async fn stage_hosted_artifact<Document: HostedDocument + Send>(
     addition: Document,
 ) -> Result<StagedPublish, RegistryError> {
     let storage = state.inner.storage.for_hosted(org);
-    let stored = storage.read_hosted_packument_for_update(key).await?;
+    let stored = storage.read_hosted_document_for_update(key).await?;
     let mut document = match &stored {
         Some(stored) => Document::parse(&stored.bytes).map_err(RegistryError::Json)?,
         None => Document::empty(key.as_str()),
@@ -215,7 +215,7 @@ pub(super) async fn stage_hosted_artifact<Document: HostedDocument + Send>(
     refuse(&document)?;
     document.merge(addition, &HashSet::new());
 
-    let slot = storage.reserve_hosted_tarball(key, filename).await?;
+    let slot = storage.reserve_hosted_blob(key, filename).await?;
     if let Err(err) = tokio::fs::write(&slot.tmp_path, bytes).await {
         // Nothing owns this slot yet: not the journal, and not a `StagedPublish`
         // the caller could clean up.

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -122,7 +122,7 @@ pub(super) async fn serve_hosted_blob(
     filename: &str,
 ) -> Result<Response, RegistryError> {
     let org = hosted_read_namespace(state, identity, source, key.as_str())?;
-    let blob = state.inner.storage.for_hosted(&org).open_hosted_tarball(key, filename).await?;
+    let blob = state.inner.storage.for_hosted(&org).open_hosted_blob(key, filename).await?;
     Ok(match blob {
         Some((body, len)) => tarball_response(body, len),
         None => not_found(),
@@ -170,7 +170,7 @@ pub(super) async fn load_upstream_document(
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     let storage = &state.inner.storage;
     let ttl = upstream.maxage().unwrap_or(state.inner.config.packument_ttl);
-    if let Some(bytes) = storage.read_upstream_packument(namespace, request.name, ttl).await? {
+    if let Some(bytes) = storage.read_upstream_document(namespace, request.name, ttl).await? {
         return Ok(Some(bytes));
     }
     let fetched = upstream.fetch_document(request.relative_path, request.accept, request.limit);
@@ -179,14 +179,14 @@ pub(super) async fn load_upstream_document(
         FetchOutcome::NotFound => Ok(None),
     }) {
         Ok(Some(bytes)) => {
-            storage.write_upstream_packument(namespace, request.name, &bytes).await?;
+            storage.write_upstream_document(namespace, request.name, &bytes).await?;
             Ok(Some(bytes))
         }
         Ok(None) => {
             storage.remove_upstream_package(namespace, request.name).await?;
             Ok(None)
         }
-        Err(err) => match storage.read_upstream_packument_any(namespace, request.name).await? {
+        Err(err) => match storage.read_upstream_document_any(namespace, request.name).await? {
             Some(stale) => {
                 tracing::warn!(
                     ?err,
@@ -226,8 +226,7 @@ pub(super) async fn serve_upstream_artifact(
         Ok(FetchOutcome::NotFound) => return not_found(),
         Err(err) => return err.into_response(),
     };
-    let write = match state.inner.storage.open_upstream_tarball_tmp(namespace, name, filename).await
-    {
+    let write = match state.inner.storage.open_upstream_blob_tmp(namespace, name, filename).await {
         Ok(write) => write,
         Err(err) => return err.into_response(),
     };

--- a/pnpr/crates/pnpr/src/server/package_mutation.rs
+++ b/pnpr/crates/pnpr/src/server/package_mutation.rs
@@ -8,7 +8,7 @@ use serde_json::{Value, json};
 use pnpr_error::RegistryError;
 use pnpr_package_name::PackageName;
 use pnpr_policy::Identity;
-use pnpr_storage::{PACKUMENT_WRITE_RETRIES, PackumentUpdate, PackumentWrite, publish::now_iso};
+use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentUpdate, DocumentWrite, publish::now_iso};
 
 use pnpr_upstream::tarball_basename;
 
@@ -76,7 +76,7 @@ pub(super) async fn update_packument(
     // packument writers (publish / dist-tag), so the client-supplied
     // rewrite can't interleave with a concurrent merge.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
-    let hosted_packument = match storage.read_hosted_packument_for_update(&name).await {
+    let hosted_packument = match storage.read_hosted_document_for_update(&name).await {
         Ok(Some(packument)) => packument,
         Ok(None) => {
             return RegistryError::BadRequest {
@@ -101,12 +101,12 @@ pub(super) async fn update_packument(
         Err(err) => return RegistryError::Json(err).into_response(),
     };
     match storage
-        .write_hosted_packument_if_current(&name, &bytes, Some(&hosted_packument.version))
+        .write_hosted_document_if_current(&name, &bytes, Some(&hosted_packument.version))
         .await
     {
-        Ok(PackumentWrite::Written) => {}
-        Ok(PackumentWrite::Conflict) => {
-            return RegistryError::PackumentWriteConflict { package: name.as_str().to_string() }
+        Ok(DocumentWrite::Written) => {}
+        Ok(DocumentWrite::Conflict) => {
+            return RegistryError::DocumentWriteConflict { package: name.as_str().to_string() }
                 .into_response();
         }
         Err(err) => return err.into_response(),
@@ -334,7 +334,7 @@ pub(super) async fn delete_tarball(
     // Serialize against same-package publishers so a delete can't race a
     // stage-and-commit and remove a tarball mid-write.
     let _packument_guard = state.inner.package_locks.lock(name.as_str()).await;
-    if let Err(err) = hosted_storage(state, Some(&org)).remove_tarball(&name, &canonical).await {
+    if let Err(err) = hosted_storage(state, Some(&org)).remove_blob(&name, &canonical).await {
         return err.into_response();
     }
     let body = json!({ "ok": true });
@@ -462,7 +462,7 @@ where
 
     let _ = tag; // the tag name is captured by the `mutate` closure.
     let outcome = storage
-        .update_hosted_packument_with_retry(&name, PACKUMENT_WRITE_RETRIES, |existing_bytes| {
+        .update_hosted_document_with_retry(&name, DOCUMENT_WRITE_RETRIES, |existing_bytes| {
             // A hosted org has no upstream, so a dist-tag change starts from the
             // org's own packument; a package it does not host can't be tagged.
             let Some(bytes) = existing_bytes else {
@@ -498,8 +498,8 @@ where
         })
         .await;
     match outcome {
-        Ok(PackumentUpdate::Written) => {}
-        Ok(PackumentUpdate::NotFound) => return not_found(),
+        Ok(DocumentUpdate::Written) => {}
+        Ok(DocumentUpdate::NotFound) => return not_found(),
         Err(err) => return err.into_response(),
     }
     let body = json!({ "ok": true });

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -15,7 +15,7 @@ use pnpr_package_name::PackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{Ecosystem, Registry};
 use pnpr_storage::{
-    HostedPackumentVersion,
+    HostedDocumentVersion,
     journal::{CommitOutcome, JournaledPublish, JournaledRevisionRef},
     publish::{
         PendingAttachment, extract_attachments, merge_manifest, now_iso,
@@ -396,8 +396,8 @@ pub(super) struct StagedPublish {
     /// The document to record, merged with what the store held when it was
     /// read: a packument, a crate document, a project document.
     pub(super) document: Vec<u8>,
-    pub(super) base_version: Option<HostedPackumentVersion>,
-    pub(super) slots: Vec<pnpr_storage::TarballSlot>,
+    pub(super) base_version: Option<HostedDocumentVersion>,
+    pub(super) slots: Vec<pnpr_storage::BlobSlot>,
     pub(super) revision_refs: Vec<JournaledRevisionRef>,
     /// Hosted-org storage namespace this publish targets, or `None` for the
     /// flat (path-less) hosted store. Threaded into the commit and journal so
@@ -419,7 +419,7 @@ pub(super) async fn stage_publish(
     let ValidatedPublish { name, incoming, prepared } = doc;
     let storage = hosted_storage(state, org);
 
-    let hosted_packument = storage.read_hosted_packument_for_update(&name).await?;
+    let hosted_packument = storage.read_hosted_document_for_update(&name).await?;
     let (hosted_bytes, base_version) = match hosted_packument {
         Some(packument) => (Some(packument.bytes), Some(packument.version)),
         None => (None, None),
@@ -498,7 +498,7 @@ pub(super) async fn stage_publish(
     // along the way so a bad upload leaves no on-disk artifact.
     let mut written_slots = Vec::with_capacity(prepared.len());
     for PreparedAttachment { attachment, canonical, version: _, dist } in prepared {
-        let slot = match storage.reserve_hosted_tarball(&name, &canonical).await {
+        let slot = match storage.reserve_hosted_blob(&name, &canonical).await {
             Ok(slot) => slot,
             Err(err) => {
                 cleanup_tmp_slots(written_slots).await;
@@ -625,7 +625,7 @@ pub(super) fn publish_created_response() -> Response {
 /// already wrote. Errors are swallowed: the caller is already
 /// returning an error response, and a leftover `*.tmp.*` file is
 /// harmless beyond a small amount of disk.
-pub(super) async fn cleanup_tmp_slots(slots: Vec<pnpr_storage::TarballSlot>) {
+pub(super) async fn cleanup_tmp_slots(slots: Vec<pnpr_storage::BlobSlot>) {
     for slot in slots {
         let _ = tokio::fs::remove_file(&slot.tmp_path).await;
     }

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -801,7 +801,7 @@ async fn published_package_survives_wiping_the_proxy_cache() {
     assert_eq!(body_bytes(response.into_body()).await, bytes);
 }
 
-/// When the same tarball filename exists in both stores, `open_tarball`
+/// When the same tarball filename exists in both stores, `open_hosted_blob`
 /// serves the hosted copy — a stale proxied copy can't shadow it.
 #[tokio::test]
 async fn hosted_tarball_is_preferred_over_a_cached_copy() {
@@ -1551,7 +1551,7 @@ async fn unpublish_partial_writes_modified_packument() {
 }
 
 /// Deleting a hosted tarball must also drop any proxied copy with the
-/// same filename, so `open_tarball`'s cache fallback can't keep serving
+/// same filename, so `open_hosted_blob`'s cache fallback can't keep serving
 /// the just-removed version.
 #[tokio::test]
 async fn unpublish_tarball_also_clears_the_proxied_copy() {

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4924,3 +4924,29 @@ async fn a_prefix_that_is_not_valid_utf8_is_not_found() {
         app.oneshot(Request::get("/%ff/-/whoami").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+/// A percent-encoded `#` or `?` is decoded before the handler sees it, so a
+/// name carrying one would be authorized and cached under itself while the
+/// upstream URL it is interpolated into addresses the bare name before the
+/// delimiter.
+#[tokio::test]
+async fn url_delimiters_in_a_package_name_are_rejected() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bare = upstream
+        .mock("GET", "/foo")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"name":"foo","versions":{}}"#)
+        .expect(0)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let config = config_for(&upstream.url(), tmp.path().to_path_buf());
+
+    for path in ["/foo%23bar", "/foo%3Fbar", "/foo%25bar", "/foo%20bar"] {
+        let app = router(config.clone());
+        let response = app.oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{path}");
+    }
+    bare.assert_async().await;
+}

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -128,7 +128,7 @@ pub async fn local_search_names(
         }
         if matches!(query, SearchText::Maintainer(_)) {
             let Ok(parsed) = PackageName::parse(&name) else { continue };
-            let Ok(Some(bytes)) = storage.read_hosted_packument(&parsed).await else { continue };
+            let Ok(Some(bytes)) = storage.read_hosted_document(&parsed).await else { continue };
             let Ok(packument) = serde_json::from_slice::<Value>(&bytes) else { continue };
             if !packument_has_maintainer(&packument, &needle) {
                 continue;
@@ -143,7 +143,7 @@ pub async fn local_search_names(
 pub async fn local_search_entry(storage: &Storage, name: &str) -> Value {
     let entry = async {
         let parsed = PackageName::parse(name).ok()?;
-        let bytes = storage.read_hosted_packument(&parsed).await.ok()??;
+        let bytes = storage.read_hosted_document(&parsed).await.ok()??;
         let packument = serde_json::from_slice::<Value>(&bytes).ok()?;
         build_search_entry(name, &packument)
     }

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -1,4 +1,4 @@
-use crate::{HostedRevisionRefWrite, PackumentWrite};
+use crate::{DocumentWrite, HostedRevisionRefWrite};
 use async_trait::async_trait;
 use axum::body::Body;
 use object_store::UpdateVersion;
@@ -11,37 +11,37 @@ use std::{
 };
 
 /// The pluggable store behind a hosted registry: a local directory, an
-/// S3-compatible bucket, or anything else that can hold packuments,
-/// tarballs, revision references, and staged publishes.
+/// S3-compatible bucket, or anything else that can hold documents,
+/// blobs, revision references, and staged publishes.
 ///
 /// Only the hosted side is pluggable. The disposable proxy cache is always
 /// local, because its contents are re-fetchable and its value is being fast.
 ///
 /// Implementations own the differences the rest of the registry should not
-/// see: whether writes are compare-and-set, whether a tarball is promoted by
+/// see: whether writes are compare-and-set, whether a blob is promoted by
 /// rename or by upload, and how a namespace maps onto paths or key prefixes.
 #[async_trait]
 pub(crate) trait HostedBackend: Debug + Send + Sync {
-    async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>>;
+    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>>;
 
-    /// Read a packument together with the token [`Self::write_packument_if_current`]
+    /// Read a document together with the token [`Self::write_document_if_current`]
     /// needs to detect a concurrent writer.
-    async fn read_packument_for_update(
+    async fn read_document_for_update(
         &self,
         name: &PackageName,
-    ) -> Result<Option<HostedPackumentForUpdate>>;
+    ) -> Result<Option<HostedDocumentForUpdate>>;
 
-    /// Write only if the stored packument is still at `version`. A backend
-    /// without compare-and-set reports [`PackumentWrite::Written`]
+    /// Write only if the stored document is still at `version`. A backend
+    /// without compare-and-set reports [`DocumentWrite::Written`]
     /// unconditionally — it serializes writers by another means.
-    async fn write_packument_if_current(
+    async fn write_document_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
-        version: Option<&HostedPackumentVersion>,
-    ) -> Result<PackumentWrite>;
+        version: Option<&HostedDocumentVersion>,
+    ) -> Result<DocumentWrite>;
 
-    async fn open_tarball(
+    async fn open_blob(
         &self,
         name: &PackageName,
         filename: &str,
@@ -50,19 +50,19 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     /// Reserve the local staging path the publish flow decodes into. Always
     /// local: the bytes are verified on the way in, before the backend sees
     /// them.
-    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf>;
+    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf>;
 
-    /// Promote a staged tarball to its final home, consuming the tmp file
-    /// unless the outcome is [`TarballFinalize::Conflict`] — those bytes stay
+    /// Promote a staged blob to its final home, consuming the tmp file
+    /// unless the outcome is [`BlobFinalize::Conflict`] — those bytes stay
     /// put so journal roll-forward can re-detect them.
-    async fn finalize_tarball(
+    async fn finalize_blob(
         &self,
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballFinalize>;
+    ) -> Result<BlobFinalize>;
 
-    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool>;
+    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool>;
 
     async fn remove_package(&self, name: &PackageName) -> Result<bool>;
 
@@ -86,7 +86,7 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     /// namespace so two orgs hosting the same `name@version` never collide.
     fn namespaced(&self, segment: &str) -> Arc<dyn HostedBackend>;
 
-    /// The local directory this backend stages tarballs in, and with them the
+    /// The local directory this backend stages blobs in, and with them the
     /// commit journal that rolls a staged publish forward after a crash. Local
     /// even when the final home is a bucket: the decode/verify step writes
     /// through `std::fs` and needs a real path.
@@ -102,32 +102,32 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
 }
 
 #[derive(Debug)]
-pub struct HostedPackumentForUpdate {
+pub struct HostedDocumentForUpdate {
     pub bytes: Vec<u8>,
-    pub version: HostedPackumentVersion,
+    pub version: HostedDocumentVersion,
 }
 
-/// What a backend needs to recognize the packument it handed out, so a
+/// What a backend needs to recognize the document it handed out, so a
 /// read-modify-write can refuse to clobber a concurrent publisher.
 #[derive(Debug, Clone)]
-pub enum HostedPackumentVersion {
+pub enum HostedDocumentVersion {
     /// The backend offers no compare-and-set. It is single-writer by
     /// construction, so there is nothing to compare against.
     Unversioned,
     ObjectVersion(UpdateVersion),
 }
 
-/// Outcome of promoting a staged tarball into the hosted store.
+/// Outcome of promoting a staged blob into the hosted store.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TarballFinalize {
-    /// The tarball was promoted: created on S3, or renamed into place on the
+pub enum BlobFinalize {
+    /// The blob was promoted: created on S3, or renamed into place on the
     /// single-node FS backend, which owns its store exclusively.
     Written,
     /// An object with byte-identical content already occupied the key, so
     /// promotion was a no-op. Safe — the published artifact is exactly ours.
     AlreadyIdentical,
     /// A *different* object already occupies the key: a concurrent publisher
-    /// won this version's tarball. A published version's tarball is immutable,
+    /// won this version's blob. A published version's blob is immutable,
     /// so the caller must not overwrite it and should surface a write conflict
     /// rather than advertise an integrity that no longer matches the bytes.
     Conflict,

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -31,8 +31,8 @@
 //! what was published between the failed apply and the restart.
 
 use crate::{
-    COMMIT_DOCUMENT_WRITE_RETRIES, HostedPackumentVersion, HostedRevisionRefWrite, PackumentUpdate,
-    PackumentWrite, Storage, TarballFinalize, TarballSlot, is_canonical_revision_ref_owner,
+    BlobFinalize, BlobSlot, COMMIT_DOCUMENT_WRITE_RETRIES, DocumentUpdate, DocumentWrite,
+    HostedDocumentVersion, HostedRevisionRefWrite, Storage, is_canonical_revision_ref_owner,
     unique_tmp_path,
 };
 use pnpr_config::Config;
@@ -125,8 +125,8 @@ pub struct JournaledPublish<'publish> {
     /// The version of the stored document `document` was computed from, when
     /// the publish read one. While the store is still at that version the
     /// commit writes `document` as it is; otherwise it merges.
-    pub base_version: Option<&'publish HostedPackumentVersion>,
-    pub slots: &'publish [TarballSlot],
+    pub base_version: Option<&'publish HostedDocumentVersion>,
+    pub slots: &'publish [BlobSlot],
     pub revision_refs: &'publish [JournaledRevisionRef],
 }
 
@@ -213,7 +213,7 @@ struct SealedTxn {
     /// The stored-document version each sealed package was computed from,
     /// positionally. Empty when startup recovery reopens the transaction,
     /// which always merges instead.
-    base_versions: Vec<Option<HostedPackumentVersion>>,
+    base_versions: Vec<Option<HostedDocumentVersion>>,
 }
 
 impl PublishJournal {
@@ -402,17 +402,17 @@ impl SealedTxn {
                 // no journal state left to retry from. Propagate it instead so
                 // the apply aborts and the entry survives for a later attempt.
                 if fs::try_exists(&blob.tmp_path).await? {
-                    let slot = TarballSlot::from_parts(
+                    let slot = BlobSlot::from_parts(
                         blob.tmp_path.clone(),
                         name.clone(),
                         blob.filename.clone(),
                     );
-                    match store.finalize_tarball_slot(slot).await? {
-                        TarballFinalize::Written | TarballFinalize::AlreadyIdentical => {}
+                    match store.finalize_blob_slot(slot).await? {
+                        BlobFinalize::Written | BlobFinalize::AlreadyIdentical => {}
                         // Another writer placed different bytes under this
                         // filename. Keep the tmp file so a retry detects the
                         // same conflict, and leave the entry out of the merge.
-                        TarballFinalize::Conflict => {
+                        BlobFinalize::Conflict => {
                             lost_tmp_paths.push(blob.tmp_path.as_path());
                             lost_blobs.insert(blob.filename.clone());
                         }
@@ -468,13 +468,9 @@ impl SealedTxn {
             {
                 written = matches!(
                     store
-                        .write_hosted_packument_if_current(
-                            &name,
-                            &journaled,
-                            base_version.as_ref(),
-                        )
+                        .write_hosted_document_if_current(&name, &journaled, base_version.as_ref(),)
                         .await?,
-                    PackumentWrite::Written,
+                    DocumentWrite::Written,
                 );
                 if written {
                     progress.wrote_documents.insert(package.id());
@@ -482,7 +478,7 @@ impl SealedTxn {
             }
             if !written {
                 let update = store
-                    .update_hosted_packument_with_retry(
+                    .update_hosted_document_with_retry(
                         &name,
                         COMMIT_DOCUMENT_WRITE_RETRIES,
                         |existing| {
@@ -497,10 +493,10 @@ impl SealedTxn {
                     )
                     .await?;
                 match update {
-                    PackumentUpdate::Written => {
+                    DocumentUpdate::Written => {
                         progress.wrote_documents.insert(package.id());
                     }
-                    PackumentUpdate::NotFound => outcome.unrecorded.push(package.id()),
+                    DocumentUpdate::NotFound => outcome.unrecorded.push(package.id()),
                 }
             }
             for revision_ref in claimed.into_values().flatten() {

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -3,7 +3,7 @@ use super::{
     JournaledRevisionRef, MANIFEST_FILE, Manifest, PackageId, SealedTxn, cleanup_lost_tmp_paths,
     sync_dir,
 };
-use crate::{HostedRevisionRefWrite, Storage, TarballFinalize, publish::merge_journaled_packument};
+use crate::{BlobFinalize, HostedRevisionRefWrite, Storage, publish::merge_journaled_packument};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use object_store::{ObjectStore, memory::InMemory};
 use pnpr_config::HostedStoreConfig;
@@ -220,7 +220,7 @@ async fn commit_drops_a_version_that_cannot_reserve_a_revision_reference() {
         storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
 
     assert_eq!(outcome.reference_limit, Some(crate::MAX_HOSTED_REVISION_REFS));
-    let hosted = storage.read_hosted_packument(&name).await.unwrap().unwrap();
+    let hosted = storage.read_hosted_document(&name).await.unwrap().unwrap();
     let hosted: serde_json::Value = serde_json::from_slice(&hosted).unwrap();
     assert_eq!(hosted["versions"], json!({}));
     assert_eq!(hosted["dist-tags"], json!({}));
@@ -305,7 +305,7 @@ async fn commit_only_removes_transaction_owned_references_for_a_dropped_version(
         storage.read_hosted_revision_refs(&previously_owned_digest).await.unwrap(),
         vec![record],
     );
-    let hosted = storage.read_hosted_packument(&name).await.unwrap().unwrap();
+    let hosted = storage.read_hosted_document(&name).await.unwrap().unwrap();
     let hosted: serde_json::Value = serde_json::from_slice(&hosted).unwrap();
     assert_eq!(hosted["versions"], json!({}));
 }
@@ -324,11 +324,11 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
     let later_name = PackageName::parse("later-pkg").unwrap();
     let filename = "conflicted-pkg-1.0.0.tgz";
 
-    let winner = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
+    let winner = storage.reserve_hosted_blob(&conflicted_name, filename).await.unwrap();
     fs::write(&winner.tmp_path, b"winner").await.unwrap();
-    assert_eq!(storage.finalize_tarball_slot(winner).await.unwrap(), TarballFinalize::Written);
+    assert_eq!(storage.finalize_blob_slot(winner).await.unwrap(), BlobFinalize::Written);
 
-    let loser = storage.reserve_hosted_tarball(&conflicted_name, filename).await.unwrap();
+    let loser = storage.reserve_hosted_blob(&conflicted_name, filename).await.unwrap();
     fs::write(&loser.tmp_path, b"loser").await.unwrap();
     let loser_tmp_path = loser.tmp_path.clone();
     let conflicted_slots = [loser];
@@ -397,12 +397,12 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
         .await
         .unwrap();
 
-    let conflicted_hosted = storage.read_hosted_packument(&conflicted_name).await.unwrap().unwrap();
+    let conflicted_hosted = storage.read_hosted_document(&conflicted_name).await.unwrap().unwrap();
     let conflicted_hosted: serde_json::Value = serde_json::from_slice(&conflicted_hosted).unwrap();
     assert_eq!(conflicted_hosted["versions"], json!({}));
     assert_eq!(conflicted_hosted["dist-tags"], json!({}));
     assert_eq!(conflicted_hosted["time"].get("1.0.0"), None);
-    let later_hosted = storage.read_hosted_packument(&later_name).await.unwrap().unwrap();
+    let later_hosted = storage.read_hosted_document(&later_name).await.unwrap().unwrap();
     let later_hosted: serde_json::Value = serde_json::from_slice(&later_hosted).unwrap();
     assert_eq!(later_hosted["versions"]["2.0.0"]["version"], "2.0.0");
     #[cfg(unix)]
@@ -532,4 +532,49 @@ async fn commit_keeps_the_journal_entry_when_the_retry_fails_too() {
         .map(|entry| entry.unwrap().file_name())
         .collect();
     assert_eq!(journal_entries.len(), 1, "{journal_entries:?}");
+}
+
+#[tokio::test]
+async fn recovery_applies_a_journal_with_the_alias_manifest_keys() {
+    let tmp = tempdir().unwrap();
+    let storage =
+        Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
+            .unwrap();
+    let name = PackageName::parse("pkg").unwrap();
+    let slot = storage.reserve_hosted_blob(&name, "pkg-1.0.0.tgz").await.unwrap();
+    fs::write(&slot.tmp_path, b"tarball bytes").await.unwrap();
+
+    let txn_dir = tmp.path().join("hosted").join(JOURNAL_DIR).join("0000000000000001-1-0");
+    fs::create_dir_all(&txn_dir).await.unwrap();
+    fs::write(
+        txn_dir.join("packument-0.json"),
+        serde_json::to_vec(&json!({
+            "name": "pkg",
+            "versions": { "1.0.0": { "version": "1.0.0" } },
+        }))
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    fs::write(
+        txn_dir.join(MANIFEST_FILE),
+        serde_json::to_vec(&json!({
+            "packages": [{
+                "name": "pkg",
+                "packument_file": "packument-0.json",
+                "tarballs": [{ "filename": "pkg-1.0.0.tgz", "tmp_path": slot.tmp_path }],
+            }],
+        }))
+        .unwrap(),
+    )
+    .await
+    .unwrap();
+    fs::write(txn_dir.join(super::COMMIT_MARKER), b"").await.unwrap();
+
+    storage.publish_journal().recover(&storage, &NpmDocuments).await.unwrap();
+
+    let hosted = storage.read_hosted_document(&name).await.unwrap().unwrap();
+    let hosted: serde_json::Value = serde_json::from_slice(&hosted).unwrap();
+    assert_eq!(hosted["versions"]["1.0.0"]["version"], "1.0.0");
+    assert!(storage.open_hosted_blob(&name, "pkg-1.0.0.tgz").await.unwrap().is_some());
 }

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -28,9 +28,9 @@ use tokio::{
 };
 
 pub(crate) use self::backend::HostedBackend;
-pub use self::backend::{HostedPackumentForUpdate, HostedPackumentVersion, TarballFinalize};
+pub use self::backend::{BlobFinalize, HostedDocumentForUpdate, HostedDocumentVersion};
 
-const PACKUMENT_FILE: &str = "package.json";
+const DOCUMENT_FILE: &str = "package.json";
 pub(crate) const HOSTED_REVISION_REFS_DIR: &str = ".revisions/sha512";
 pub(crate) const HOSTED_REVISION_REF_INDEX_FILE: &str = "index.json";
 /// Bounds both the persisted candidate set and work triggered by one digest request.
@@ -170,52 +170,52 @@ impl HostedRevisionRefIndex {
 /// on POSIX as long as src and dest sit in the same directory (they do).
 static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 const MAX_TEMP_CREATE_ATTEMPTS: usize = 16;
-pub const PACKUMENT_WRITE_RETRIES: usize = 8;
+pub const DOCUMENT_WRITE_RETRIES: usize = 8;
 /// Retries the commit path allows the document write: higher than the
 /// request-path budget because a sealed transaction has to converge, and a
 /// startup recovery may be racing every other replica's recovery at once.
 pub(crate) const COMMIT_DOCUMENT_WRITE_RETRIES: usize = 32;
-const PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 5;
-const MAX_PACKUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 250;
+const DOCUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 5;
+const MAX_DOCUMENT_WRITE_CONFLICT_DELAY_MS: u64 = 250;
 
-pub(crate) fn packument_write_conflict_delay(attempt: usize) -> Duration {
-    let delay = PACKUMENT_WRITE_CONFLICT_DELAY_MS
+pub(crate) fn document_write_conflict_delay(attempt: usize) -> Duration {
+    let delay = DOCUMENT_WRITE_CONFLICT_DELAY_MS
         .saturating_mul(1_u64 << attempt.min(6))
-        .min(MAX_PACKUMENT_WRITE_CONFLICT_DELAY_MS);
+        .min(MAX_DOCUMENT_WRITE_CONFLICT_DELAY_MS);
     Duration::from_millis(delay)
 }
 
-pub(crate) async fn wait_after_packument_write_conflict(attempt: usize) {
-    tokio::time::sleep(packument_write_conflict_delay(attempt)).await;
+pub(crate) async fn wait_after_document_write_conflict(attempt: usize) {
+    tokio::time::sleep(document_write_conflict_delay(attempt)).await;
 }
 
-/// Handle returned from [`Storage::open_upstream_tarball_tmp`]. The caller
+/// Handle returned from [`Storage::open_upstream_blob_tmp`]. The caller
 /// writes through [`Self::write_all`] (and on success calls [`Self::finalize`] to
 /// atomically promote the temp file to the final cache path). The temp
 /// path remains armed until promotion succeeds, so cancellation and
 /// every error path remove it through [`Drop`].
-pub struct TarballWrite {
+pub struct BlobWrite {
     file: Option<fs::File>,
     tmp_path: Option<PathBuf>,
     final_path: PathBuf,
 }
 
-/// A reserved slot for a hosted-tarball write. The publish flow writes
-/// the decoded + verified tarball to `tmp_path` (a local file) inside a
+/// A reserved slot for a hosted-blob write. The publish flow writes
+/// the decoded + verified bytes to `tmp_path` (a local file) inside a
 /// blocking task, then promotes it to its final home — a rename on the
 /// fs backend, an upload on the S3 backend — via
-/// [`Storage::finalize_tarball_slot`], which recomputes the
+/// [`Storage::finalize_blob_slot`], which recomputes the
 /// destination from `name`/`filename`.
 #[derive(Debug)]
-pub struct TarballSlot {
+pub struct BlobSlot {
     pub tmp_path: PathBuf,
     name: PackageName,
     filename: String,
 }
 
-impl TarballSlot {
+impl BlobSlot {
     /// Rebuild a slot from its journaled parts so startup recovery can
-    /// re-run [`Storage::finalize_tarball_slot`] on it.
+    /// re-run [`Storage::finalize_blob_slot`] on it.
     pub(crate) fn from_parts(tmp_path: PathBuf, name: PackageName, filename: String) -> Self {
         Self { tmp_path, name, filename }
     }
@@ -225,11 +225,11 @@ impl TarballSlot {
     }
 }
 
-impl TarballWrite {
+impl BlobWrite {
     pub async fn write_all(&mut self, bytes: &[u8]) -> std::io::Result<()> {
         match self.file.as_mut() {
             Some(file) => file.write_all(bytes).await,
-            None => Err(std::io::Error::other("tarball cache writer is closed")),
+            None => Err(std::io::Error::other("blob cache writer is closed")),
         }
     }
 
@@ -237,7 +237,7 @@ impl TarballWrite {
     pub async fn finalize(mut self) -> std::io::Result<()> {
         match self.file.as_mut() {
             Some(file) => file.sync_all().await?,
-            None => return Err(std::io::Error::other("tarball cache writer is closed")),
+            None => return Err(std::io::Error::other("blob cache writer is closed")),
         }
         drop(self.file.take());
         if let Some(parent) = self.final_path.parent() {
@@ -246,7 +246,7 @@ impl TarballWrite {
         let tmp_path = self
             .tmp_path
             .as_ref()
-            .ok_or_else(|| std::io::Error::other("tarball cache temp path is missing"))?;
+            .ok_or_else(|| std::io::Error::other("blob cache temp path is missing"))?;
         fs::rename(tmp_path, &self.final_path).await?;
         self.tmp_path = None;
         Ok(())
@@ -259,14 +259,14 @@ impl TarballWrite {
     /// temp file between verification and streaming.
     pub async fn into_temp_file(mut self) -> std::io::Result<(fs::File, u64, PathBuf)> {
         let Some(mut file) = self.file.take() else {
-            return Err(std::io::Error::other("tarball cache writer is closed"));
+            return Err(std::io::Error::other("blob cache writer is closed"));
         };
         file.sync_all().await?;
         let len = file.metadata().await?.len();
         let tmp_path = self
             .tmp_path
             .take()
-            .ok_or_else(|| std::io::Error::other("tarball cache temp path is missing"))?;
+            .ok_or_else(|| std::io::Error::other("blob cache temp path is missing"))?;
         file.seek(SeekFrom::Start(0)).await?;
         Ok((file, len, tmp_path))
     }
@@ -282,7 +282,7 @@ impl TarballWrite {
     }
 }
 
-impl Drop for TarballWrite {
+impl Drop for BlobWrite {
     fn drop(&mut self) {
         drop(self.file.take());
         let Some(tmp_path) = self.tmp_path.take() else { return };
@@ -290,13 +290,13 @@ impl Drop for TarballWrite {
             Ok(()) => {}
             Err(err) if err.kind() == ErrorKind::NotFound => {}
             Err(err) => {
-                tracing::warn!(?err, path = %tmp_path.display(), "tarball cache temp cleanup failed");
+                tracing::warn!(?err, path = %tmp_path.display(), "blob cache temp cleanup failed");
             }
         }
     }
 }
 
-/// A cached upstream packument, read at a granularity that avoids loading the
+/// A cached upstream document, read at a granularity that avoids loading the
 /// (potentially multi-MB) body when it isn't needed:
 ///
 /// * `Fresh` — within the TTL; the body is read and ready to serve.
@@ -304,7 +304,7 @@ impl Drop for TarballWrite {
 ///   refetches a stale entry rather than revalidating it, so the caller treats
 ///   `Stale` as a miss.
 #[derive(Debug)]
-pub enum CachedPackument {
+pub enum CachedDocument {
     Fresh(Vec<u8>),
     Stale,
 }
@@ -329,14 +329,15 @@ pub enum CachedPackument {
 /// <root>/
 ///   <package>/
 ///     package.json
-///     <basename>-<version>.tgz
+///     <blob filename>
 ///   .revisions/sha512/<digest>/
 ///     index.json
 ///     <package-version-hash>.json
 /// ```
 ///
 /// For scoped packages the package directory is `<root>/@scope/<name>/`.
-/// Tarballs sit flat alongside `package.json` — no `-/` subdirectory.
+/// A package's document is always `package.json`; its blobs sit flat
+/// beside it (`<basename>-<version>.tgz` on npm) — no `-/` subdirectory.
 /// This is the layout `@pnpm/registry-mock` (and verdaccio itself)
 /// publishes, so a populated verdaccio storage can be served directly
 /// in static mode.
@@ -347,76 +348,76 @@ pub struct Storage {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PackumentWrite {
+pub enum DocumentWrite {
     Written,
     Conflict,
 }
 
-/// Outcome of [`Storage::update_hosted_packument_with_retry`].
+/// Outcome of [`Storage::update_hosted_document_with_retry`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PackumentUpdate {
+pub enum DocumentUpdate {
     Written,
-    /// `build` returned `Ok(None)`, so nothing was written: the packument
+    /// `build` returned `Ok(None)`, so nothing was written: the document
     /// the caller wanted to change does not exist, or the change it computed
     /// turned out to be no change at all.
     NotFound,
 }
 
 /// The single-node filesystem backend. It owns its directory tree
-/// exclusively, so a packument write needs no compare-and-set and a tarball
+/// exclusively, so a document write needs no compare-and-set and a blob
 /// is promoted by rename.
 #[async_trait]
 impl HostedBackend for Store {
-    async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        Store::read_packument_any_age(self, name).await
+    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        Store::read_document_any_age(self, name).await
     }
 
-    async fn read_packument_for_update(
+    async fn read_document_for_update(
         &self,
         name: &PackageName,
-    ) -> Result<Option<HostedPackumentForUpdate>> {
-        Ok(Store::read_packument_any_age(self, name).await?.map(|bytes| HostedPackumentForUpdate {
+    ) -> Result<Option<HostedDocumentForUpdate>> {
+        Ok(Store::read_document_any_age(self, name).await?.map(|bytes| HostedDocumentForUpdate {
             bytes,
-            version: HostedPackumentVersion::Unversioned,
+            version: HostedDocumentVersion::Unversioned,
         }))
     }
 
-    async fn write_packument_if_current(
+    async fn write_document_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
-        _version: Option<&HostedPackumentVersion>,
-    ) -> Result<PackumentWrite> {
-        Store::write_packument(self, name, bytes).await?;
-        Ok(PackumentWrite::Written)
+        _version: Option<&HostedDocumentVersion>,
+    ) -> Result<DocumentWrite> {
+        Store::write_document(self, name, bytes).await?;
+        Ok(DocumentWrite::Written)
     }
 
-    async fn open_tarball(
+    async fn open_blob(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
-        Ok(Store::open_tarball(self, name, filename)
+        Ok(Store::open_blob(self, name, filename)
             .await?
             .map(|(file, len)| (streaming::stream_file(file), Some(len))))
     }
 
-    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
-        Store::reserve_tarball_tmp(self, name, filename).await
+    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+        Store::reserve_blob_tmp(self, name, filename).await
     }
 
-    async fn finalize_tarball(
+    async fn finalize_blob(
         &self,
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballFinalize> {
-        Store::finalize_tarball(self, tmp_path, name, filename).await?;
-        Ok(TarballFinalize::Written)
+    ) -> Result<BlobFinalize> {
+        Store::finalize_blob(self, tmp_path, name, filename).await?;
+        Ok(BlobFinalize::Written)
     }
 
-    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        Store::remove_tarball(self, name, filename).await
+    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        Store::remove_blob(self, name, filename).await
     }
 
     async fn remove_package(&self, name: &PackageName) -> Result<bool> {
@@ -563,101 +564,100 @@ impl Storage {
 
     // --- Authoritative (hosted) store -----------------------------------
 
-    /// Read the authoritative packument for `name`, fresh or stale.
+    /// Read the authoritative document for `name`, fresh or stale.
     /// Hosted content has no TTL — it is the source of truth.
-    pub async fn read_hosted_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        self.hosted.read_packument(name).await
+    pub async fn read_hosted_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        self.hosted.read_document(name).await
     }
 
-    pub async fn read_hosted_packument_for_update(
+    pub async fn read_hosted_document_for_update(
         &self,
         name: &PackageName,
-    ) -> Result<Option<HostedPackumentForUpdate>> {
-        self.hosted.read_packument_for_update(name).await
+    ) -> Result<Option<HostedDocumentForUpdate>> {
+        self.hosted.read_document_for_update(name).await
     }
 
-    pub async fn write_hosted_packument_if_current(
+    pub async fn write_hosted_document_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
-        version: Option<&HostedPackumentVersion>,
-    ) -> Result<PackumentWrite> {
-        self.hosted.write_packument_if_current(name, bytes, version).await
+        version: Option<&HostedDocumentVersion>,
+    ) -> Result<DocumentWrite> {
+        self.hosted.write_document_if_current(name, bytes, version).await
     }
 
-    /// Read the hosted packument, transform it, and conditionally write it
+    /// Read the hosted document, transform it, and conditionally write it
     /// back under compare-and-swap, retrying on conflict with capped backoff.
     ///
-    /// `build` receives the current hosted bytes (`None` when the packument is
+    /// `build` receives the current hosted bytes (`None` when the document is
     /// absent) and returns the bytes to write, or `Ok(None)` to abort as
-    /// [`PackumentUpdate::NotFound`]; a `build` error aborts without retrying.
+    /// [`DocumentUpdate::NotFound`]; a `build` error aborts without retrying.
     /// After `retries` conflicts the write is surfaced as
-    /// [`RegistryError::PackumentWriteConflict`]. Both the dist-tag request
+    /// [`RegistryError::DocumentWriteConflict`]. Both the dist-tag request
     /// path and journal roll-forward go through here so their conflict handling
     /// stays in one place.
-    pub async fn update_hosted_packument_with_retry<Build>(
+    pub async fn update_hosted_document_with_retry<Build>(
         &self,
         name: &PackageName,
         retries: usize,
         mut build: Build,
-    ) -> Result<PackumentUpdate>
+    ) -> Result<DocumentUpdate>
     where
         Build: FnMut(Option<&[u8]>) -> Result<Option<Vec<u8>>>,
     {
         for attempt in 0..retries {
-            let existing = self.read_hosted_packument_for_update(name).await?;
+            let existing = self.read_hosted_document_for_update(name).await?;
             let (existing_bytes, version) = match existing {
-                Some(packument) => (Some(packument.bytes), Some(packument.version)),
+                Some(document) => (Some(document.bytes), Some(document.version)),
                 None => (None, None),
             };
             let Some(new_bytes) = build(existing_bytes.as_deref())? else {
-                return Ok(PackumentUpdate::NotFound);
+                return Ok(DocumentUpdate::NotFound);
             };
-            match self.write_hosted_packument_if_current(name, &new_bytes, version.as_ref()).await?
-            {
-                PackumentWrite::Written => return Ok(PackumentUpdate::Written),
-                PackumentWrite::Conflict => {
+            match self.write_hosted_document_if_current(name, &new_bytes, version.as_ref()).await? {
+                DocumentWrite::Written => return Ok(DocumentUpdate::Written),
+                DocumentWrite::Conflict => {
                     if attempt + 1 < retries {
-                        wait_after_packument_write_conflict(attempt).await;
+                        wait_after_document_write_conflict(attempt).await;
                     }
                 }
             }
         }
-        Err(RegistryError::PackumentWriteConflict { package: name.as_str().to_string() })
+        Err(RegistryError::DocumentWriteConflict { package: name.as_str().to_string() })
     }
 
-    /// Open a tarball from the authoritative hosted store. Hosted
+    /// Open a blob from the authoritative hosted store. Hosted
     /// publish writes verify their SRI before finalization, and static
     /// storage remains operator-controlled rather than an upstream cache.
-    pub async fn open_hosted_tarball(
+    pub async fn open_hosted_blob(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
-        self.hosted.open_tarball(name, filename).await
+        self.hosted.open_blob(name, filename).await
     }
 
-    /// Reserve a staging slot for a tarball this server hosts. The
+    /// Reserve a staging slot for a blob this server hosts. The
     /// publish flow streams the decode + hash + write through
     /// `std::fs` inside `spawn_blocking` and only needs the path;
-    /// finalize with [`Self::finalize_tarball_slot`].
-    pub async fn reserve_hosted_tarball(
+    /// finalize with [`Self::finalize_blob_slot`].
+    pub async fn reserve_hosted_blob(
         &self,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballSlot> {
-        let tmp_path = self.hosted.reserve_tarball_tmp(name, filename).await?;
-        Ok(TarballSlot { tmp_path, name: name.clone(), filename: filename.to_string() })
+    ) -> Result<BlobSlot> {
+        let tmp_path = self.hosted.reserve_blob_tmp(name, filename).await?;
+        Ok(BlobSlot { tmp_path, name: name.clone(), filename: filename.to_string() })
     }
 
-    /// Remove a single tarball file from both stores. The
+    /// Remove a single blob from both stores. The
     /// partial-unpublish flow calls this after PUT'ing the modified
-    /// packument back; clearing the proxied mirror too stops
+    /// document back; clearing the proxied mirror too stops
     /// the proxy cache from serving a stale copy of the just-removed
     /// version.
-    pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        let hosted = self.hosted.remove_tarball(name, filename).await?;
-        let cached = self.cached.remove_tarball(name, filename).await?;
+    pub async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        let hosted = self.hosted.remove_blob(name, filename).await?;
+        let cached = self.cached.remove_blob(name, filename).await?;
         Ok(hosted || cached)
     }
 
@@ -672,56 +672,56 @@ impl Storage {
 
     // --- Per-upstream private cache (the `/~<name>/` registry endpoint) ----
     //
-    // A private upstream's packuments and tarballs are cached under a namespace
+    // A private upstream's documents and blobs are cached under a namespace
     // derived from the upstream and its rotation generation, kept separate from
     // the shared public mirror so they can never be served on the public path
     // or under another upstream. A rotation (new generation) moves to a fresh
     // namespace, so entries fetched with a since-rotated credential age out.
 
-    /// A fresh cached packument for an upstream route, or `None` when it is
+    /// A fresh cached document for an upstream route, or `None` when it is
     /// absent or older than `ttl`. The upstream path refetches a stale entry
     /// rather than conditionally revalidating it.
-    pub async fn read_upstream_packument(
+    pub async fn read_upstream_document(
         &self,
         namespace: &str,
         name: &PackageName,
         ttl: Duration,
     ) -> Result<Option<Vec<u8>>> {
-        match self.cached.namespaced(namespace).read_packument_entry(name, ttl).await? {
-            Some(CachedPackument::Fresh(bytes)) => Ok(Some(bytes)),
-            Some(CachedPackument::Stale) | None => Ok(None),
+        match self.cached.namespaced(namespace).read_document_entry(name, ttl).await? {
+            Some(CachedDocument::Fresh(bytes)) => Ok(Some(bytes)),
+            Some(CachedDocument::Stale) | None => Ok(None),
         }
     }
 
-    /// The cached upstream packument regardless of freshness (fresh or stale).
+    /// The cached upstream document regardless of freshness (fresh or stale).
     /// A defensive fallback for an unsolicited upstream `304`: the upstream path
     /// sends no conditional validators, so a `304` means "unchanged" and the
     /// cached body — even past `ttl` — is the right thing to serve rather than
     /// a spurious `404`.
-    pub async fn read_upstream_packument_any(
+    pub async fn read_upstream_document_any(
         &self,
         namespace: &str,
         name: &PackageName,
     ) -> Result<Option<Vec<u8>>> {
         // `Duration::MAX` classifies any existing entry as fresh, so its body
         // is returned regardless of age (the stale arm can't be reached here).
-        match self.cached.namespaced(namespace).read_packument_entry(name, Duration::MAX).await? {
-            Some(CachedPackument::Fresh(bytes)) => Ok(Some(bytes)),
-            Some(CachedPackument::Stale) | None => Ok(None),
+        match self.cached.namespaced(namespace).read_document_entry(name, Duration::MAX).await? {
+            Some(CachedDocument::Fresh(bytes)) => Ok(Some(bytes)),
+            Some(CachedDocument::Stale) | None => Ok(None),
         }
     }
 
-    pub async fn write_upstream_packument(
+    pub async fn write_upstream_document(
         &self,
         namespace: &str,
         name: &PackageName,
         bytes: &[u8],
     ) -> Result<()> {
-        self.cached.namespaced(namespace).write_packument(name, bytes).await
+        self.cached.namespaced(namespace).write_document(name, bytes).await
     }
 
-    /// Purge an upstream's cached entry for `name` — the packument and any
-    /// cached tarballs. Called on a definitive upstream 404: without the
+    /// Purge an upstream's cached entry for `name` — the document and any
+    /// cached blobs. Called on a definitive upstream 404: without the
     /// purge, the stale entry would linger past its TTL and a later transient
     /// outage could resurrect the unpublished package through the
     /// stale-if-error fallback.
@@ -733,46 +733,46 @@ impl Storage {
         self.cached.namespaced(namespace).remove_package(name).await
     }
 
-    pub async fn open_upstream_tarball_tmp(
+    pub async fn open_upstream_blob_tmp(
         &self,
         namespace: &str,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballWrite> {
-        self.cached.namespaced(namespace).open_tarball_tmp(name, filename).await
+    ) -> Result<BlobWrite> {
+        self.cached.namespaced(namespace).open_blob_tmp(name, filename).await
     }
 
-    pub async fn open_upstream_tarball(
+    pub async fn open_upstream_blob(
         &self,
         namespace: &str,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(fs::File, u64)>> {
-        self.cached.namespaced(namespace).open_tarball(name, filename).await
+        self.cached.namespaced(namespace).open_blob(name, filename).await
     }
 
-    pub async fn open_upstream_revision_tarball_tmp(
+    pub async fn open_upstream_revision_blob_tmp(
         &self,
         namespace: &str,
         digest: &str,
-    ) -> Result<TarballWrite> {
+    ) -> Result<BlobWrite> {
         validate_revision_digest(digest)?;
-        self.cached.namespaced(namespace).open_revision_tarball_tmp(digest).await
+        self.cached.namespaced(namespace).open_revision_blob_tmp(digest).await
     }
 
-    pub async fn open_upstream_revision_tarball(
+    pub async fn open_upstream_revision_blob(
         &self,
         namespace: &str,
         digest: &str,
     ) -> Result<Option<(fs::File, u64)>> {
         validate_revision_digest(digest)?;
-        self.cached.namespaced(namespace).open_revision_tarball(digest).await
+        self.cached.namespaced(namespace).open_revision_blob(digest).await
     }
 
-    /// Promote a tmp tarball written by the publish flow to its final
+    /// Promote a tmp blob written by the publish flow to its final
     /// home: a rename on the fs backend, an upload on the S3 backend.
-    pub async fn finalize_tarball_slot(&self, slot: TarballSlot) -> Result<TarballFinalize> {
-        self.hosted.finalize_tarball(&slot.tmp_path, &slot.name, &slot.filename).await
+    pub async fn finalize_blob_slot(&self, slot: BlobSlot) -> Result<BlobFinalize> {
+        self.hosted.finalize_blob(&slot.tmp_path, &slot.name, &slot.filename).await
     }
 
     /// The commit journal for this storage's publish flow. It lives in
@@ -883,8 +883,8 @@ impl Store {
     }
 
     /// A disposable store rooted at a sub-path of this one. Used to give a
-    /// private `/~<name>/` route its own cache namespace so its packuments
-    /// and tarballs never collide with the public mirror or another upstream.
+    /// private `/~<name>/` route its own cache namespace so its documents
+    /// and blobs never collide with the public mirror or another upstream.
     fn namespaced(&self, prefix: &str) -> Store {
         Store {
             root: self.root.join(prefix),
@@ -892,12 +892,12 @@ impl Store {
         }
     }
 
-    async fn read_packument_entry(
+    async fn read_document_entry(
         &self,
         name: &PackageName,
         ttl: Duration,
-    ) -> Result<Option<CachedPackument>> {
-        let path = self.packument_path(name);
+    ) -> Result<Option<CachedDocument>> {
+        let path = self.document_path(name);
         let metadata = match fs::metadata(&path).await {
             Ok(m) => m,
             Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
@@ -907,16 +907,16 @@ impl Store {
         let age = SystemTime::now().duration_since(mtime).unwrap_or(Duration::ZERO);
         if age <= ttl {
             // Fresh: read the body and serve it.
-            Ok(Some(CachedPackument::Fresh(fs::read(&path).await?)))
+            Ok(Some(CachedDocument::Fresh(fs::read(&path).await?)))
         } else {
             // Stale: treated as a miss so the caller refetches from the upstream
             // (there is no conditional revalidation), so the body isn't read here.
-            Ok(Some(CachedPackument::Stale))
+            Ok(Some(CachedDocument::Stale))
         }
     }
 
-    async fn read_packument_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        let path = self.packument_path(name);
+    async fn read_document_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        let path = self.document_path(name);
         match fs::read(&path).await {
             Ok(bytes) => Ok(Some(bytes)),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
@@ -924,17 +924,17 @@ impl Store {
         }
     }
 
-    async fn write_packument(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
-        let path = self.packument_path(name);
+    async fn write_document(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+        let path = self.document_path(name);
         write_atomic(&path, bytes).await
     }
 
-    async fn open_tarball(
+    async fn open_blob(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(fs::File, u64)>> {
-        let path = self.tarball_path(name, filename);
+        let path = self.blob_path(name, filename);
         let file = match fs::File::open(&path).await {
             Ok(f) => f,
             Err(err) if err.kind() == ErrorKind::NotFound => {
@@ -961,13 +961,13 @@ impl Store {
         Ok(Some((file, len)))
     }
 
-    async fn open_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<TarballWrite> {
-        let final_path = self.tarball_path(name, filename);
-        self.open_tarball_tmp_at(final_path).await
+    async fn open_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<BlobWrite> {
+        let final_path = self.blob_path(name, filename);
+        self.open_blob_tmp_at(final_path).await
     }
 
-    async fn open_revision_tarball(&self, digest: &str) -> Result<Option<(fs::File, u64)>> {
-        let file = match fs::File::open(self.revision_tarball_path(digest)).await {
+    async fn open_revision_blob(&self, digest: &str) -> Result<Option<(fs::File, u64)>> {
+        let file = match fs::File::open(self.revision_blob_path(digest)).await {
             Ok(file) => file,
             Err(err) if err.kind() == ErrorKind::NotFound => return Ok(None),
             Err(err) => return Err(err.into()),
@@ -976,36 +976,36 @@ impl Store {
         Ok(Some((file, len)))
     }
 
-    async fn open_revision_tarball_tmp(&self, digest: &str) -> Result<TarballWrite> {
-        self.open_tarball_tmp_at(self.revision_tarball_path(digest)).await
+    async fn open_revision_blob_tmp(&self, digest: &str) -> Result<BlobWrite> {
+        self.open_blob_tmp_at(self.revision_blob_path(digest)).await
     }
 
-    async fn open_tarball_tmp_at(&self, final_path: PathBuf) -> Result<TarballWrite> {
+    async fn open_blob_tmp_at(&self, final_path: PathBuf) -> Result<BlobWrite> {
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
         let (file, tmp_path) = create_tmp_file(&final_path).await?;
-        Ok(TarballWrite { file: Some(file), tmp_path: Some(tmp_path), final_path })
+        Ok(BlobWrite { file: Some(file), tmp_path: Some(tmp_path), final_path })
     }
 
     /// Reserve a tmp path in the destination package directory so the
-    /// publish flow can write there and [`Self::finalize_tarball`] can
+    /// publish flow can write there and [`Self::finalize_blob`] can
     /// rename within the same directory (atomic on POSIX).
-    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
-        let final_path = self.tarball_path(name, filename);
+    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+        let final_path = self.blob_path(name, filename);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
         Ok(unique_tmp_path(&final_path))
     }
 
-    async fn finalize_tarball(
+    async fn finalize_blob(
         &self,
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
     ) -> Result<()> {
-        let final_path = self.tarball_path(name, filename);
+        let final_path = self.blob_path(name, filename);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
         }
@@ -1025,12 +1025,12 @@ impl Store {
         }
     }
 
-    /// Remove a single tarball file. Returns `Ok(false)` when the file
+    /// Remove a single blob file. Returns `Ok(false)` when the file
     /// is already gone; the pnpm unpublish flow always issues a DELETE
-    /// after the packument-update PUT, and a benign 404 here would
+    /// after the document-update PUT, and a benign 404 here would
     /// surface as a real error to the caller.
-    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        match fs::remove_file(self.tarball_path(name, filename)).await {
+    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        match fs::remove_file(self.blob_path(name, filename)).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
             Err(err) => Err(err.into()),
@@ -1041,7 +1041,7 @@ impl Store {
     /// directories holding a `package.json`. Layout is
     /// `<root>/<pkg>/package.json` for unscoped and
     /// `<root>/@scope/<name>/package.json` for scoped, so a two-level
-    /// walk suffices and avoids descending into tarball-adjacent junk.
+    /// walk suffices and avoids descending into blob-adjacent junk.
     /// Hidden entries (the `.pnpr-cache` sibling) are skipped.
     ///
     /// Per-entry stat/read failures are tolerated (the entry is just
@@ -1064,7 +1064,7 @@ impl Store {
             if name_str.starts_with('.') {
                 continue;
             }
-            if fs::try_exists(entry_path.join(PACKUMENT_FILE)).await.unwrap_or(false) {
+            if fs::try_exists(entry_path.join(DOCUMENT_FILE)).await.unwrap_or(false) {
                 names.push(name_str.into_owned());
                 continue;
             }
@@ -1072,7 +1072,7 @@ impl Store {
                 && let Ok(mut inner) = fs::read_dir(&entry_path).await
             {
                 while let Some(child) = inner.next_entry().await? {
-                    if fs::try_exists(child.path().join(PACKUMENT_FILE)).await.unwrap_or(false) {
+                    if fs::try_exists(child.path().join(DOCUMENT_FILE)).await.unwrap_or(false) {
                         names.push(format!("{name_str}/{}", child.file_name().to_string_lossy()));
                     }
                 }
@@ -1132,15 +1132,15 @@ impl Store {
         self.root.join(name.as_str())
     }
 
-    fn packument_path(&self, name: &PackageName) -> PathBuf {
-        self.package_dir(name).join(PACKUMENT_FILE)
+    fn document_path(&self, name: &PackageName) -> PathBuf {
+        self.package_dir(name).join(DOCUMENT_FILE)
     }
 
-    fn tarball_path(&self, name: &PackageName, filename: &str) -> PathBuf {
+    fn blob_path(&self, name: &PackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
     }
 
-    fn revision_tarball_path(&self, digest: &str) -> PathBuf {
+    fn revision_blob_path(&self, digest: &str) -> PathBuf {
         self.root.join(".revisions").join("sha512").join(digest)
     }
 

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -2,8 +2,8 @@
 //!
 //! The hosted store is pnpr's source of truth — packages published
 //! through its API plus the content served in static mode. When the
-//! YAML `s3:` block is present, those authoritative packuments and
-//! tarballs live in an object store instead of on local disk, so the
+//! YAML `s3:` block is present, those authoritative documents and
+//! blobs live in an object store instead of on local disk, so the
 //! durable data can be replicated by the provider and shared by
 //! several stateless pnpr replicas.
 //!
@@ -14,10 +14,10 @@
 //! only the hosted store is pluggable.
 
 use crate::{
-    HOSTED_REVISION_REF_INDEX_FILE, HOSTED_REVISION_REFS_DIR, HostedBackend,
-    HostedPackumentForUpdate, HostedPackumentVersion, HostedRevisionRefIndex,
-    HostedRevisionRefWrite, PackumentWrite, STAGED_DIR, TarballFinalize, staged_id_of_meta_object,
-    wait_after_packument_write_conflict,
+    BlobFinalize, DocumentWrite, HOSTED_REVISION_REF_INDEX_FILE, HOSTED_REVISION_REFS_DIR,
+    HostedBackend, HostedDocumentForUpdate, HostedDocumentVersion, HostedRevisionRefIndex,
+    HostedRevisionRefWrite, STAGED_DIR, staged_id_of_meta_object,
+    wait_after_document_write_conflict,
 };
 use async_trait::async_trait;
 use axum::body::Body;
@@ -35,7 +35,7 @@ use std::{
 };
 use tokio::fs;
 
-const PACKUMENT_FILE: &str = "package.json";
+const DOCUMENT_FILE: &str = "package.json";
 const REVISION_REF_WRITE_RETRIES: usize = 32;
 
 /// Object-store-backed hosted store. Mirrors the verdaccio-shaped
@@ -47,7 +47,7 @@ pub struct S3Store {
     store: Arc<dyn ObjectStore>,
     /// Normalized prefix: empty or `.../`-terminated.
     prefix: String,
-    /// Local directory the publish flow stages decoded tarballs in
+    /// Local directory the publish flow stages decoded blobs in
     /// before they're uploaded. The decode/verify step writes through
     /// `std::fs` inside `spawn_blocking`, so it needs a real path even
     /// when the final home is a bucket; a subdirectory of the
@@ -59,12 +59,12 @@ pub struct S3Store {
 }
 
 #[derive(Debug)]
-pub(crate) struct S3PackumentForUpdate {
+pub(crate) struct S3DocumentForUpdate {
     pub(crate) bytes: Vec<u8>,
     pub(crate) version: UpdateVersion,
 }
 
-/// Subdirectory of the proxy-cache root where hosted tarballs are
+/// Subdirectory of the proxy-cache root where hosted blobs are
 /// staged before upload. Its own directory keeps the decode/verify tmp
 /// files away from the cache's `<pkg>/` package directories.
 const STAGING_SUBDIR: &str = "pnpr-hosted-staging";
@@ -98,32 +98,32 @@ impl S3Store {
         }
     }
 
-    pub async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        match self.store.get(&self.packument_key(name)).await {
+    pub async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        match self.store.get(&self.document_key(name)).await {
             Ok(result) => Ok(Some(result.bytes().await?.to_vec())),
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }
 
-    pub(crate) async fn read_packument_for_update(
+    pub(crate) async fn read_document_for_update(
         &self,
         name: &PackageName,
-    ) -> Result<Option<S3PackumentForUpdate>> {
-        match self.store.get(&self.packument_key(name)).await {
+    ) -> Result<Option<S3DocumentForUpdate>> {
+        match self.store.get(&self.document_key(name)).await {
             Ok(result) => {
                 let version = UpdateVersion {
                     e_tag: result.meta.e_tag.clone(),
                     version: result.meta.version.clone(),
                 };
-                Ok(Some(S3PackumentForUpdate { bytes: result.bytes().await?.to_vec(), version }))
+                Ok(Some(S3DocumentForUpdate { bytes: result.bytes().await?.to_vec(), version }))
             }
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }
 
-    pub(crate) async fn write_packument_if_current(
+    pub(crate) async fn write_document_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
@@ -136,7 +136,7 @@ impl S3Store {
         match self
             .store
             .put_opts(
-                &self.packument_key(name),
+                &self.document_key(name),
                 PutPayload::from(bytes.to_vec()),
                 PutOptions { mode, ..PutOptions::default() },
             )
@@ -152,15 +152,15 @@ impl S3Store {
         }
     }
 
-    /// Open a hosted tarball for streaming. `Ok(None)` means the object
+    /// Open a hosted blob for streaming. `Ok(None)` means the object
     /// doesn't exist so the caller can fall through to the proxy cache
     /// or upstream.
-    pub async fn open_tarball(
+    pub async fn open_blob(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
-        match self.store.get(&self.tarball_key(name, filename)).await {
+        match self.store.get(&self.blob_key(name, filename)).await {
             Ok(result) => {
                 let len = result.meta.size;
                 let stream = result
@@ -174,25 +174,25 @@ impl S3Store {
     }
 
     /// Reserve a local staging path for the publish flow to decode and
-    /// verify a tarball into; [`Self::upload_tarball`] promotes it to
+    /// verify a blob into; [`Self::upload_blob`] promotes it to
     /// the bucket once the verification passes.
     pub async fn staging_tmp_path(&self, _name: &PackageName, filename: &str) -> Result<PathBuf> {
         fs::create_dir_all(&self.staging_dir).await?;
         Ok(crate::unique_tmp_path(&self.staging_dir.join(filename)))
     }
 
-    pub async fn upload_tarball(
+    pub async fn upload_blob(
         &self,
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballFinalize> {
+    ) -> Result<BlobFinalize> {
         let bytes = fs::read(tmp_path).await?;
-        let key = self.tarball_key(name, filename);
-        // Create-only. A published version's tarball is immutable, so an object
+        let key = self.blob_key(name, filename);
+        // Create-only. A published version's blob is immutable, so an object
         // already at this key belongs to a concurrent publisher of the same
         // version. Overwriting it would corrupt that artifact against the
-        // integrity its packument records, so tolerate only byte-identical
+        // integrity its document records, so tolerate only byte-identical
         // content and otherwise report a conflict.
         match self
             .store
@@ -203,7 +203,7 @@ impl S3Store {
             )
             .await
         {
-            Ok(_) => Ok(TarballFinalize::Written),
+            Ok(_) => Ok(BlobFinalize::Written),
             Err(
                 object_store::Error::AlreadyExists { .. }
                 | object_store::Error::Precondition { .. },
@@ -211,17 +211,17 @@ impl S3Store {
                 let ours = fs::read(tmp_path).await?;
                 let existing = self.store.get(&key).await?.bytes().await?;
                 if existing.as_ref() == ours.as_slice() {
-                    Ok(TarballFinalize::AlreadyIdentical)
+                    Ok(BlobFinalize::AlreadyIdentical)
                 } else {
-                    Ok(TarballFinalize::Conflict)
+                    Ok(BlobFinalize::Conflict)
                 }
             }
             Err(err) => Err(err.into()),
         }
     }
 
-    pub async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        match self.store.delete(&self.tarball_key(name, filename)).await {
+    pub async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        match self.store.delete(&self.blob_key(name, filename)).await {
             Ok(()) => Ok(true),
             Err(object_store::Error::NotFound { .. }) => Ok(false),
             Err(err) => Err(err.into()),
@@ -257,7 +257,7 @@ impl S3Store {
             let Some(rest) = key.strip_prefix(self.prefix.as_str()) else {
                 continue;
             };
-            if let Some(name) = rest.strip_suffix(&format!("/{PACKUMENT_FILE}")) {
+            if let Some(name) = rest.strip_suffix(&format!("/{DOCUMENT_FILE}")) {
                 names.push(name.to_string());
             }
         }
@@ -308,7 +308,7 @@ impl S3Store {
                     | object_store::Error::Precondition { .. },
                 ) => {
                     if attempt + 1 < REVISION_REF_WRITE_RETRIES {
-                        wait_after_packument_write_conflict(attempt).await;
+                        wait_after_document_write_conflict(attempt).await;
                     }
                 }
                 Err(err) => return Err(err.into()),
@@ -347,7 +347,7 @@ impl S3Store {
                     object_store::Error::NotFound { .. } | object_store::Error::Precondition { .. },
                 ) => {
                     if attempt + 1 < REVISION_REF_WRITE_RETRIES {
-                        wait_after_packument_write_conflict(attempt).await;
+                        wait_after_document_write_conflict(attempt).await;
                     }
                 }
                 Err(err) => return Err(err.into()),
@@ -387,7 +387,7 @@ impl S3Store {
                     object_store::Error::NotFound { .. } | object_store::Error::Precondition { .. },
                 ) => {
                     if attempt + 1 < REVISION_REF_WRITE_RETRIES {
-                        wait_after_packument_write_conflict(attempt).await;
+                        wait_after_document_write_conflict(attempt).await;
                     }
                 }
                 Err(err) => return Err(err.into()),
@@ -422,11 +422,11 @@ impl S3Store {
         }
     }
 
-    fn packument_key(&self, name: &PackageName) -> ObjectPath {
-        ObjectPath::from(format!("{}{}/{PACKUMENT_FILE}", self.prefix, name.as_str()))
+    fn document_key(&self, name: &PackageName) -> ObjectPath {
+        ObjectPath::from(format!("{}{}/{DOCUMENT_FILE}", self.prefix, name.as_str()))
     }
 
-    fn tarball_key(&self, name: &PackageName, filename: &str) -> ObjectPath {
+    fn blob_key(&self, name: &PackageName, filename: &str) -> ObjectPath {
         ObjectPath::from(format!("{}{}/{filename}", self.prefix, name.as_str()))
     }
 
@@ -485,75 +485,75 @@ impl S3Store {
 #[cfg(test)]
 mod tests;
 
-/// The S3-compatible object-store backend. Packument writes are
+/// The S3-compatible object-store backend. Document writes are
 /// compare-and-set on the object's version, so concurrent publishers on
-/// separate nodes cannot lose each other's writes, and a tarball is promoted
+/// separate nodes cannot lose each other's writes, and a blob is promoted
 /// by upload rather than rename.
 #[async_trait]
 impl HostedBackend for S3Store {
-    async fn read_packument(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
-        S3Store::read_packument(self, name).await
+    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+        S3Store::read_document(self, name).await
     }
 
-    async fn read_packument_for_update(
+    async fn read_document_for_update(
         &self,
         name: &PackageName,
-    ) -> Result<Option<HostedPackumentForUpdate>> {
-        Ok(S3Store::read_packument_for_update(self, name).await?.map(|packument| {
-            HostedPackumentForUpdate {
-                bytes: packument.bytes,
-                version: HostedPackumentVersion::ObjectVersion(packument.version),
+    ) -> Result<Option<HostedDocumentForUpdate>> {
+        Ok(S3Store::read_document_for_update(self, name).await?.map(|document| {
+            HostedDocumentForUpdate {
+                bytes: document.bytes,
+                version: HostedDocumentVersion::ObjectVersion(document.version),
             }
         }))
     }
 
-    async fn write_packument_if_current(
+    async fn write_document_if_current(
         &self,
         name: &PackageName,
         bytes: &[u8],
-        version: Option<&HostedPackumentVersion>,
-    ) -> Result<PackumentWrite> {
+        version: Option<&HostedDocumentVersion>,
+    ) -> Result<DocumentWrite> {
         let version = match version {
-            Some(HostedPackumentVersion::ObjectVersion(version)) => Some(version),
-            Some(HostedPackumentVersion::Unversioned) | None => None,
+            Some(HostedDocumentVersion::ObjectVersion(version)) => Some(version),
+            Some(HostedDocumentVersion::Unversioned) | None => None,
         };
-        if S3Store::write_packument_if_current(self, name, bytes, version).await? {
-            Ok(PackumentWrite::Written)
+        if S3Store::write_document_if_current(self, name, bytes, version).await? {
+            Ok(DocumentWrite::Written)
         } else {
-            Ok(PackumentWrite::Conflict)
+            Ok(DocumentWrite::Conflict)
         }
     }
 
-    async fn open_tarball(
+    async fn open_blob(
         &self,
         name: &PackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
-        S3Store::open_tarball(self, name, filename).await
+        S3Store::open_blob(self, name, filename).await
     }
 
-    async fn reserve_tarball_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
         self.staging_tmp_path(name, filename).await
     }
 
-    async fn finalize_tarball(
+    async fn finalize_blob(
         &self,
         tmp_path: &Path,
         name: &PackageName,
         filename: &str,
-    ) -> Result<TarballFinalize> {
-        let outcome = self.upload_tarball(tmp_path, name, filename).await?;
+    ) -> Result<BlobFinalize> {
+        let outcome = self.upload_blob(tmp_path, name, filename).await?;
         // Keep the staged tmp on a Conflict so journal roll-forward can
         // re-detect it and exclude the version whose bytes we don't own;
         // once the object is ours there is nothing left to promote.
-        if outcome != TarballFinalize::Conflict {
+        if outcome != BlobFinalize::Conflict {
             let _ = fs::remove_file(tmp_path).await;
         }
         Ok(outcome)
     }
 
-    async fn remove_tarball(&self, name: &PackageName, filename: &str) -> Result<bool> {
-        S3Store::remove_tarball(self, name, filename).await
+    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+        S3Store::remove_blob(self, name, filename).await
     }
 
     async fn remove_package(&self, name: &PackageName) -> Result<bool> {

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -34,43 +34,43 @@ async fn collect(body: Body) -> Vec<u8> {
     axum::body::to_bytes(body, usize::MAX).await.expect("read body").to_vec()
 }
 
-/// Stage a tarball through the same path the publish flow uses: write
+/// Stage a blob through the same path the publish flow uses: write
 /// the decoded bytes to the reserved local tmp file, then upload.
 /// (Cleaning up the staging file belongs to the `HostedBackend` impl, not
-/// to `upload_tarball`, so it stays behind here.)
+/// to `upload_blob`, so it stays behind here.)
 async fn upload(store: &S3Store, name: &PackageName, filename: &str, bytes: &[u8]) {
     let tmp = store.staging_tmp_path(name, filename).await.expect("reserve staging path");
     tokio::fs::write(&tmp, bytes).await.expect("write staging file");
-    store.upload_tarball(&tmp, name, filename).await.expect("upload");
+    store.upload_blob(&tmp, name, filename).await.expect("upload");
 }
 
-async fn write_packument(store: &S3Store, name: &PackageName, bytes: &[u8]) {
-    assert!(store.write_packument_if_current(name, bytes, None).await.unwrap());
+async fn write_document(store: &S3Store, name: &PackageName, bytes: &[u8]) {
+    assert!(store.write_document_if_current(name, bytes, None).await.unwrap());
 }
 
 #[tokio::test]
-async fn packument_roundtrips_and_missing_is_none() {
+async fn document_roundtrips_and_missing_is_none() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");
-    assert_eq!(store.read_packument(&name).await.unwrap(), None);
-    write_packument(&store, &name, br#"{"name":"is-positive"}"#).await;
+    assert_eq!(store.read_document(&name).await.unwrap(), None);
+    write_document(&store, &name, br#"{"name":"is-positive"}"#).await;
     assert_eq!(
-        store.read_packument(&name).await.unwrap().as_deref(),
+        store.read_document(&name).await.unwrap().as_deref(),
         Some(&br#"{"name":"is-positive"}"#[..]),
     );
 }
 
 #[tokio::test]
-async fn stale_packument_update_is_rejected() {
+async fn stale_document_update_is_rejected() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("racer");
-    store.write_packument_if_current(&name, br#"{"name":"racer"}"#, None).await.unwrap();
+    store.write_document_if_current(&name, br#"{"name":"racer"}"#, None).await.unwrap();
 
-    let first_read = store.read_packument_for_update(&name).await.unwrap().unwrap();
-    let second_read = store.read_packument_for_update(&name).await.unwrap().unwrap();
+    let first_read = store.read_document_for_update(&name).await.unwrap().unwrap();
+    let second_read = store.read_document_for_update(&name).await.unwrap().unwrap();
 
     let first_written = store
-        .write_packument_if_current(
+        .write_document_if_current(
             &name,
             br#"{"name":"racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#,
             Some(&first_read.version),
@@ -80,7 +80,7 @@ async fn stale_packument_update_is_rejected() {
     assert!(first_written);
 
     let second_written = store
-        .write_packument_if_current(
+        .write_document_if_current(
             &name,
             br#"{"name":"racer","versions":{"2.0.0":{"version":"2.0.0"}}}"#,
             Some(&second_read.version),
@@ -89,22 +89,22 @@ async fn stale_packument_update_is_rejected() {
         .unwrap();
     assert!(!second_written);
     assert_eq!(
-        store.read_packument(&name).await.unwrap().as_deref(),
+        store.read_document(&name).await.unwrap().as_deref(),
         Some(&br#"{"name":"racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#[..]),
     );
 }
 
 #[tokio::test]
-async fn deleted_packument_update_is_rejected() {
+async fn deleted_document_update_is_rejected() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("removed-racer");
-    write_packument(&store, &name, br#"{"name":"removed-racer"}"#).await;
+    write_document(&store, &name, br#"{"name":"removed-racer"}"#).await;
 
-    let read = store.read_packument_for_update(&name).await.unwrap().unwrap();
+    let read = store.read_document_for_update(&name).await.unwrap().unwrap();
     store.remove_package(&name).await.unwrap();
 
     let written = store
-        .write_packument_if_current(
+        .write_document_if_current(
             &name,
             br#"{"name":"removed-racer","versions":{"1.0.0":{"version":"1.0.0"}}}"#,
             Some(&read.version),
@@ -112,49 +112,46 @@ async fn deleted_packument_update_is_rejected() {
         .await
         .unwrap();
     assert!(!written);
-    assert!(store.read_packument(&name).await.unwrap().is_none());
+    assert!(store.read_document(&name).await.unwrap().is_none());
 }
 
 #[tokio::test]
-async fn concurrent_tarball_finalize_does_not_overwrite() {
-    use crate::TarballFinalize;
+async fn concurrent_blob_finalize_does_not_overwrite() {
+    use crate::BlobFinalize;
     let (store, _staging) = store_with_prefix("");
     let name = pkg("racer");
     let file = "racer-1.0.0.tgz";
 
     let tmp = store.staging_tmp_path(&name, file).await.unwrap();
     tokio::fs::write(&tmp, b"tarball A").await.unwrap();
-    assert_eq!(store.upload_tarball(&tmp, &name, file).await.unwrap(), TarballFinalize::Written);
+    assert_eq!(store.upload_blob(&tmp, &name, file).await.unwrap(), BlobFinalize::Written);
 
     // Re-promoting byte-identical content is a tolerated no-op, so idempotent
     // journal roll-forward and concurrent identical publishes don't conflict.
     let tmp = store.staging_tmp_path(&name, file).await.unwrap();
     tokio::fs::write(&tmp, b"tarball A").await.unwrap();
-    assert_eq!(
-        store.upload_tarball(&tmp, &name, file).await.unwrap(),
-        TarballFinalize::AlreadyIdentical,
-    );
+    assert_eq!(store.upload_blob(&tmp, &name, file).await.unwrap(), BlobFinalize::AlreadyIdentical);
 
     // Different bytes for the same version's key are rejected without
-    // overwriting the first writer's tarball.
+    // overwriting the first writer's blob.
     let tmp = store.staging_tmp_path(&name, file).await.unwrap();
     tokio::fs::write(&tmp, b"tarball B").await.unwrap();
-    assert_eq!(store.upload_tarball(&tmp, &name, file).await.unwrap(), TarballFinalize::Conflict);
+    assert_eq!(store.upload_blob(&tmp, &name, file).await.unwrap(), BlobFinalize::Conflict);
 
-    let (body, _len) = store.open_tarball(&name, file).await.unwrap().unwrap();
+    let (body, _len) = store.open_blob(&name, file).await.unwrap().unwrap();
     assert_eq!(collect(body).await, b"tarball A");
 }
 
 #[tokio::test]
-async fn tarball_uploads_streams_and_reports_length() {
+async fn blob_uploads_streams_and_reports_length() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");
-    assert!(store.open_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap().is_none());
+    assert!(store.open_blob(&name, "is-positive-1.0.0.tgz").await.unwrap().is_none());
 
     let payload = b"a fake tarball payload";
     upload(&store, &name, "is-positive-1.0.0.tgz", payload).await;
 
-    let (body, len) = store.open_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap().unwrap();
+    let (body, len) = store.open_blob(&name, "is-positive-1.0.0.tgz").await.unwrap().unwrap();
     assert_eq!(len, Some(payload.len() as u64));
     assert_eq!(collect(body).await, payload);
 }
@@ -163,38 +160,38 @@ async fn tarball_uploads_streams_and_reports_length() {
 async fn scoped_keys_and_prefix_are_honored() {
     let (store, _staging) = store_with_prefix("packages");
     let name = pkg("@scope/thing");
-    write_packument(&store, &name, br#"{"name":"@scope/thing"}"#).await;
+    write_document(&store, &name, br#"{"name":"@scope/thing"}"#).await;
     upload(&store, &name, "thing-1.0.0.tgz", b"scoped tarball").await;
 
-    let (body, _len) = store.open_tarball(&name, "thing-1.0.0.tgz").await.unwrap().unwrap();
+    let (body, _len) = store.open_blob(&name, "thing-1.0.0.tgz").await.unwrap().unwrap();
     assert_eq!(collect(body).await, b"scoped tarball");
-    assert!(store.read_packument(&name).await.unwrap().is_some());
+    assert!(store.read_document(&name).await.unwrap().is_some());
 }
 
 #[tokio::test]
-async fn remove_tarball_then_package() {
+async fn remove_blob_then_package() {
     let (store, _staging) = store_with_prefix("");
     let name = pkg("is-positive");
-    write_packument(&store, &name, b"{}").await;
+    write_document(&store, &name, b"{}").await;
     upload(&store, &name, "is-positive-1.0.0.tgz", b"payload").await;
 
-    assert!(store.remove_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap());
+    assert!(store.remove_blob(&name, "is-positive-1.0.0.tgz").await.unwrap());
     // S3 (and the in-memory store) deletes are idempotent and don't
     // report whether the key existed, so a second delete still succeeds.
-    store.remove_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap();
-    assert!(store.open_tarball(&name, "is-positive-1.0.0.tgz").await.unwrap().is_none());
+    store.remove_blob(&name, "is-positive-1.0.0.tgz").await.unwrap();
+    assert!(store.open_blob(&name, "is-positive-1.0.0.tgz").await.unwrap().is_none());
 
     store.remove_package(&name).await.unwrap();
-    assert!(store.read_packument(&name).await.unwrap().is_none());
+    assert!(store.read_document(&name).await.unwrap().is_none());
 }
 
 #[tokio::test]
 async fn lists_hosted_package_names() {
     for prefix in ["", "packages"] {
         let (store, _staging) = store_with_prefix(prefix);
-        write_packument(&store, &pkg("is-positive"), b"{}").await;
-        write_packument(&store, &pkg("@scope/thing"), b"{}").await;
-        // A stray tarball-only key must not be mistaken for a package.
+        write_document(&store, &pkg("is-positive"), b"{}").await;
+        write_document(&store, &pkg("@scope/thing"), b"{}").await;
+        // A stray blob-only key must not be mistaken for a package.
         upload(&store, &pkg("is-positive"), "is-positive-1.0.0.tgz", b"x").await;
 
         let mut names = store.list_package_names().await.unwrap();

--- a/pnpr/crates/storage/src/streaming.rs
+++ b/pnpr/crates/storage/src/streaming.rs
@@ -1,4 +1,4 @@
-//! Streaming helpers for the tarball path.
+//! Streaming helpers for the blob path.
 //!
 //! Three flows live here:
 //!
@@ -9,7 +9,7 @@
 //!   temp file for mirror-less pass-through.
 //! * [`stream_file`] yields an already verified file to the response.
 
-use crate::TarballWrite;
+use crate::BlobWrite;
 use axum::body::{Body, Bytes};
 use futures_util::{Stream, StreamExt, stream};
 use pnpm_network::ThrottledResponse;
@@ -19,7 +19,7 @@ use tokio::{fs::File, io::AsyncReadExt};
 
 /// Chunk size for reading from a cached file. 64 KiB keeps syscall
 /// overhead low without buffering a meaningful fraction of a
-/// multi-MB tarball.
+/// multi-MB blob.
 const READ_CHUNK: usize = 64 * 1024;
 
 pub fn parse_integrity(value: &str) -> Result<Integrity, ssri::Error> {
@@ -43,7 +43,7 @@ pub fn integrity_checker(integrity: &Integrity) -> Result<IntegrityChecker, ssri
 }
 
 #[derive(Debug)]
-pub enum TarballStreamError {
+pub enum BlobStreamError {
     Upstream { url: String, source: io::Error },
     Io(io::Error),
     Integrity(ssri::Error),
@@ -62,21 +62,21 @@ pub enum TarballStreamError {
 /// so it can't poison a future client, and every install client re-verifies
 /// what it received against its own expected integrity and rejects bad bytes.
 /// On any such failure — or a dropped client connection — the temp file is
-/// abandoned (and [`TarballWrite`]'s `Drop` removes it as a backstop).
+/// abandoned (and [`BlobWrite`]'s `Drop` removes it as a backstop).
 pub fn stream_verified_to_cache(
     response: ThrottledResponse,
-    write: TarballWrite,
+    write: BlobWrite,
     integrity: &Integrity,
     max_bytes: u64,
-) -> Result<Body, TarballStreamError> {
+) -> Result<Body, BlobStreamError> {
     // Reject an upstream that already declares an oversize body up front, so it
     // surfaces as an error response instead of a failure mid-stream.
     if let Some(received) = response.content_length()
         && received > max_bytes
     {
-        return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+        return Err(BlobStreamError::TooLarge { limit: max_bytes, received });
     }
-    let checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
+    let checker = integrity_checker(integrity).map_err(BlobStreamError::Integrity)?;
     let state = TeeState {
         url: redact_url(response.url()),
         upstream: Box::pin(response.bytes_stream()),
@@ -96,11 +96,11 @@ pub fn stream_verified_to_cache(
                         url = %state.url,
                         received,
                         limit,
-                        "proxied tarball exceeded the size limit mid-stream",
+                        "proxied blob exceeded the size limit mid-stream",
                     );
                     abandon(state.write.take()).await;
                     return Some((
-                        Err(io::Error::other(format!("tarball exceeds {limit} bytes"))),
+                        Err(io::Error::other(format!("blob exceeds {limit} bytes"))),
                         None,
                     ));
                 }
@@ -112,7 +112,7 @@ pub fn stream_verified_to_cache(
                         Err(err) => {
                             tracing::warn!(
                                 ?err,
-                                "tarball cache write failed; serving without caching",
+                                "blob cache write failed; serving without caching",
                             );
                             write.abandon().await;
                         }
@@ -123,7 +123,7 @@ pub fn stream_verified_to_cache(
                 Some((Ok(chunk), Some(state)))
             }
             Some(Err(source)) => {
-                tracing::warn!(url = %state.url, ?source, "upstream tarball stream failed mid-download");
+                tracing::warn!(url = %state.url, ?source, "upstream blob stream failed mid-download");
                 abandon(state.write.take()).await;
                 Some((Err(io::Error::other(source)), None))
             }
@@ -131,7 +131,7 @@ pub fn stream_verified_to_cache(
                 match state.checker.result() {
                     Ok(_) => finalize(state.write.take()).await,
                     Err(err) => {
-                        tracing::warn!(url = %state.url, ?err, "proxied tarball failed integrity; not caching it");
+                        tracing::warn!(url = %state.url, ?err, "proxied blob failed integrity; not caching it");
                         abandon(state.write.take()).await;
                     }
                 }
@@ -142,17 +142,17 @@ pub fn stream_verified_to_cache(
     Ok(Body::from_stream(body))
 }
 
-/// Promote a fully-streamed, SRI-matched tarball to the cache, logging (not
+/// Promote a fully-streamed, SRI-matched blob to the cache, logging (not
 /// failing — the client already has the bytes) if the rename can't complete.
-async fn finalize(write: Option<TarballWrite>) {
+async fn finalize(write: Option<BlobWrite>) {
     if let Some(write) = write
         && let Err(err) = write.finalize().await
     {
-        tracing::warn!(?err, "promoting verified tarball to cache failed");
+        tracing::warn!(?err, "promoting verified blob to cache failed");
     }
 }
 
-async fn abandon(write: Option<TarballWrite>) {
+async fn abandon(write: Option<BlobWrite>) {
     if let Some(write) = write {
         write.abandon().await;
     }
@@ -173,10 +173,10 @@ fn redact_url(url: &reqwest::Url) -> String {
 /// stream, the cache writer (dropped once caching is abandoned), the running
 /// SRI checker, and the size budget.
 struct TeeState {
-    /// The upstream tarball URL, kept only to tag failure logs.
+    /// The upstream blob URL, kept only to tag failure logs.
     url: String,
     upstream: Pin<Box<dyn Stream<Item = io::Result<Bytes>> + Send>>,
-    write: Option<TarballWrite>,
+    write: Option<BlobWrite>,
     checker: IntegrityChecker,
     written: u64,
     max_bytes: u64,
@@ -184,50 +184,50 @@ struct TeeState {
 
 pub async fn download_verified_to_temp(
     response: ThrottledResponse,
-    mut write: TarballWrite,
+    mut write: BlobWrite,
     integrity: &Integrity,
     max_bytes: u64,
-) -> Result<(File, u64, PathBuf), TarballStreamError> {
+) -> Result<(File, u64, PathBuf), BlobStreamError> {
     if let Err(err) = download_verified(response, &mut write, integrity, max_bytes).await {
         write.abandon().await;
         return Err(err);
     }
-    write.into_temp_file().await.map_err(TarballStreamError::Io)
+    write.into_temp_file().await.map_err(BlobStreamError::Io)
 }
 
 async fn download_verified(
     response: ThrottledResponse,
-    write: &mut TarballWrite,
+    write: &mut BlobWrite,
     integrity: &Integrity,
     max_bytes: u64,
-) -> Result<u64, TarballStreamError> {
+) -> Result<u64, BlobStreamError> {
     let url = response.url().to_string();
     if let Some(received) = response.content_length()
         && received > max_bytes
     {
-        return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+        return Err(BlobStreamError::TooLarge { limit: max_bytes, received });
     }
     let mut upstream = Box::pin(response.bytes_stream());
-    let mut checker = integrity_checker(integrity).map_err(TarballStreamError::Integrity)?;
+    let mut checker = integrity_checker(integrity).map_err(BlobStreamError::Integrity)?;
     let mut written = 0u64;
     while let Some(chunk_result) = upstream.next().await {
         let chunk = match chunk_result {
             Ok(chunk) => chunk,
-            Err(source) => return Err(TarballStreamError::Upstream { url, source }),
+            Err(source) => return Err(BlobStreamError::Upstream { url, source }),
         };
         let received = written.saturating_add(chunk.len() as u64);
         if received > max_bytes {
-            return Err(TarballStreamError::TooLarge { limit: max_bytes, received });
+            return Err(BlobStreamError::TooLarge { limit: max_bytes, received });
         }
         if let Err(err) = write.write_all(&chunk).await {
-            return Err(TarballStreamError::Io(err));
+            return Err(BlobStreamError::Io(err));
         }
         checker.input(&chunk);
         written = received;
     }
 
     if let Err(err) = checker.result() {
-        return Err(TarballStreamError::Integrity(err));
+        return Err(BlobStreamError::Integrity(err));
     }
     Ok(written)
 }
@@ -290,7 +290,7 @@ impl Drop for RemoveOnDropFile {
             Ok(()) => {}
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
             Err(err) => {
-                tracing::warn!(?err, path = %path.display(), "temporary tarball cleanup failed");
+                tracing::warn!(?err, path = %path.display(), "temporary blob cleanup failed");
             }
         }
     }

--- a/pnpr/crates/storage/src/streaming/tests.rs
+++ b/pnpr/crates/storage/src/streaming/tests.rs
@@ -1,4 +1,4 @@
-use super::{TarballStreamError, integrity_checker, parse_integrity, stream_verified_to_cache};
+use super::{BlobStreamError, integrity_checker, parse_integrity, stream_verified_to_cache};
 use crate::Storage;
 use futures_util::StreamExt;
 use pnpr_config::HostedStoreConfig;
@@ -89,7 +89,7 @@ async fn spawn_response(bytes: &'static [u8]) -> String {
     format!("http://{addr}/foo/-/foo-1.0.0.tgz")
 }
 
-fn tarball_tmp_entries(dir: &Path) -> Vec<String> {
+fn blob_tmp_entries(dir: &Path) -> Vec<String> {
     let mut entries = dir
         .read_dir()
         .map(|entries| {
@@ -106,17 +106,17 @@ fn tarball_tmp_entries(dir: &Path) -> Vec<String> {
     entries
 }
 
-async fn await_nonempty_tarball_tmp(dir: &Path) -> Vec<String> {
+async fn await_nonempty_blob_tmp(dir: &Path) -> Vec<String> {
     let deadline = std::time::Instant::now() + Duration::from_secs(2);
     loop {
-        let entries = tarball_tmp_entries(dir);
+        let entries = blob_tmp_entries(dir);
         if entries
             .iter()
             .any(|name| std::fs::metadata(dir.join(name)).is_ok_and(|metadata| metadata.len() > 0))
         {
             return entries;
         }
-        assert!(std::time::Instant::now() < deadline, "tarball body was not written to tmp");
+        assert!(std::time::Instant::now() < deadline, "blob body was not written to tmp");
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }
@@ -134,20 +134,20 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
     let name = PackageName::parse("foo").unwrap();
     let write =
-        storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
+        storage.open_upstream_blob_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 
     let body = stream_verified_to_cache(response, write, &integrity, u64::MAX).unwrap();
     let mut chunks = body.into_data_stream();
     // Pull the first chunk so the tee writes the body's start to the tmp file.
     chunks.next().await.expect("first chunk").expect("first chunk is ok");
     let package_dir = cache.join("~public/test").join("foo");
-    let in_flight = await_nonempty_tarball_tmp(&package_dir).await;
-    assert_eq!(in_flight.len(), 1, "expected one in-flight tarball writer");
+    let in_flight = await_nonempty_blob_tmp(&package_dir).await;
+    assert_eq!(in_flight.len(), 1, "expected one in-flight blob writer");
 
     // Dropping the body mid-stream models a client disconnect: the tee's
-    // `TarballWrite` is dropped and removes the tmp file.
+    // `BlobWrite` is dropped and removes the tmp file.
     drop(chunks);
-    assert!(tarball_tmp_entries(&package_dir).is_empty());
+    assert!(blob_tmp_entries(&package_dir).is_empty());
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());
 
     release.notify_one();
@@ -166,16 +166,16 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
     let name = PackageName::parse("foo").unwrap();
     let write =
-        storage.open_upstream_tarball_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
+        storage.open_upstream_blob_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 
     // An upstream that declares an oversize body is rejected up front, before
     // any bytes stream, so the caller turns it into an error response.
     let err = stream_verified_to_cache(response, write, &integrity, 3).unwrap_err();
-    assert!(matches!(err, TarballStreamError::TooLarge { limit: 3, received } if received > 3));
+    assert!(matches!(err, BlobStreamError::TooLarge { limit: 3, received } if received > 3));
 
     // The temp file the rejected writer held is removed (its `Drop`).
     let package_dir = cache.join("~public/test").join("foo");
-    assert!(tarball_tmp_entries(&package_dir).is_empty());
+    assert!(blob_tmp_entries(&package_dir).is_empty());
     assert!(!package_dir.join("foo-1.0.0.tgz").exists());
 }
 

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AsyncWriteExt, ErrorKind, HostedRevisionRefWrite, HostedStoreConfig, MAX_HOSTED_REVISION_REFS,
-    PackageName, RegistryError, Storage, TarballWrite, create_tmp_file_with, fs,
+    AsyncWriteExt, BlobWrite, ErrorKind, HostedRevisionRefWrite, HostedStoreConfig,
+    MAX_HOSTED_REVISION_REFS, PackageName, RegistryError, Storage, create_tmp_file_with, fs,
 };
 use tempfile::TempDir;
 
@@ -14,11 +14,11 @@ fn pkg(name: &str) -> PackageName {
 }
 
 #[test]
-fn packument_write_conflict_delay_caps_growth() {
-    assert_eq!(super::packument_write_conflict_delay(0).as_millis(), 5);
-    assert_eq!(super::packument_write_conflict_delay(1).as_millis(), 10);
-    assert_eq!(super::packument_write_conflict_delay(6).as_millis(), 250);
-    assert_eq!(super::packument_write_conflict_delay(32).as_millis(), 250);
+fn document_write_conflict_delay_caps_growth() {
+    assert_eq!(super::document_write_conflict_delay(0).as_millis(), 5);
+    assert_eq!(super::document_write_conflict_delay(1).as_millis(), 10);
+    assert_eq!(super::document_write_conflict_delay(6).as_millis(), 250);
+    assert_eq!(super::document_write_conflict_delay(32).as_millis(), 250);
 }
 
 #[tokio::test]
@@ -134,7 +134,7 @@ async fn concurrent_hosted_revision_ref_writes_cannot_exceed_the_limit() {
 }
 
 #[tokio::test]
-async fn hosted_tarball_under_non_directory_package_path_is_an_error() {
+async fn hosted_blob_under_non_directory_package_path_is_an_error() {
     let tmp = TempDir::new().unwrap();
     let storage = storage_in(&tmp);
     let name = pkg("foo");
@@ -142,8 +142,8 @@ async fn hosted_tarball_under_non_directory_package_path_is_an_error() {
     fs::create_dir_all(&storage_root).await.unwrap();
     fs::write(storage_root.join("foo"), b"not a directory").await.unwrap();
 
-    let Err(err) = storage.open_hosted_tarball(&name, "foo-1.0.0.tgz").await else {
-        panic!("expected hosted tarball open to fail");
+    let Err(err) = storage.open_hosted_blob(&name, "foo-1.0.0.tgz").await else {
+        panic!("expected hosted blob open to fail");
     };
     match err {
         RegistryError::Io(err) => assert_eq!(err.kind(), ErrorKind::NotADirectory),
@@ -206,7 +206,7 @@ async fn temp_file_creation_does_not_follow_symlink_candidate() {
 }
 
 #[tokio::test]
-async fn failed_tarball_finalize_removes_tmp_file() {
+async fn failed_blob_finalize_removes_tmp_file() {
     let tmp = TempDir::new().unwrap();
     let tmp_path = tmp.path().join("foo-1.0.0.tgz.tmp.test");
     let final_path = tmp.path().join("foo-1.0.0.tgz");
@@ -214,7 +214,7 @@ async fn failed_tarball_finalize_removes_tmp_file() {
     fs::write(final_path.join("block-rename"), b"occupied").await.unwrap();
 
     let file = fs::File::create(&tmp_path).await.unwrap();
-    let mut write = TarballWrite { file: Some(file), tmp_path: Some(tmp_path.clone()), final_path };
+    let mut write = BlobWrite { file: Some(file), tmp_path: Some(tmp_path.clone()), final_path };
     write.write_all(b"tarball").await.unwrap();
 
     assert!(write.finalize().await.is_err());


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

The pnpr storage layer serves three ecosystems but was named for one:
`read_upstream_packument` caches a Cargo index file or a Simple API page,
`open_hosted_tarball` opens a wheel, `reserve_hosted_tarball` reserves a
`.crate`. This renames the vocabulary to document and blob across
`pnpr-storage` (both the filesystem and the S3 backend) and its callers.

No behavior changes from the rename. The one externally visible effect is the
name of the publish write-conflict error: `RegistryError::DocumentWriteConflict`,
logged as `document_write_conflict`, with a message that names the package
document rather than an npm packument. That message is what a `cargo publish`
or `twine upload` conflict returns today.

`PackageName` keeps its name. The issue proposed "package key", but the type
holds a package's name and never a version, while `PackageKey` already means
`name@version` elsewhere in this repo (`pnpm_lockfile::PackageKey`,
`pnpm-cargo-resolver`'s `PackageKey`). A crate and a Python project have names
too, so `packument` and `tarball` were the only npm-flavored words here. The
npm surfaces keep those two, which are accurate there.

It also carries one fix that is not a rename, found while reviewing the crate
this touches. A request path is percent-decoded before a handler parses a name
from it, and a name is interpolated into the upstream URL, so `GET /foo%23bar`
was authorized and cached as `foo#bar` while fetching `foo` — a package rule
naming `foo` never ran. Names and artifact filenames now reject `?`, `#`, `%`,
whitespace, and control characters, none of which appear in an npm, Cargo, or
Python package name, version, or artifact filename. It has its own changeset.

Rebased on main, so the journal-manifest half of this rename is not in the diff
— pnpm/pnpm#14606 landed `document_file` / `blobs` with the same serde aliases.
What this PR adds there is the recovery test those aliases never had.

Related to pnpm/pnpm#14599 (the "Rename the storage vocabulary" follow-up).

## Squash Commit Body

```text
The storage layer serves three ecosystems but was named for one. Rename its
vocabulary so a Cargo index file and a Simple API page are documents and a
`.crate` and a wheel are blobs.

`pnpr-storage` now exposes `read_hosted_document`, `open_hosted_blob`,
`reserve_hosted_blob`, `finalize_blob_slot` and their peers on both the
filesystem and the S3 backend, and a publish write conflict is
`RegistryError::DocumentWriteConflict`, logged as `document_write_conflict`.
`PackageName` keeps its name: it holds a package's name and never a version,
and a name is what a crate and a Python project have too. The npm surfaces
keep their own packument and tarball vocabulary, which is accurate there.

Separately, a name now rejects `?`, `#`, `%`, whitespace, and control
characters. A request path is percent-decoded before a handler parses a name
from it, and a name is interpolated into the upstream URL, so `GET /foo%23bar`
was authorized and cached as `foo#bar` while fetching `foo` — a package rule
that named `foo` never ran.

The journal manifest's `packument_file` and `tarballs` aliases had no
coverage, so a sealed entry that spells its keys that way now has a recovery
test.

Related to pnpm/pnpm#14599.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added publish protocol negotiation to the registry handshake.
  - Improved publishing reliability across supported package ecosystems with staged uploads and recovery.

- **Bug Fixes**
  - Package names and artifact filenames containing URL delimiters, whitespace, or control characters are now rejected with `400 Bad Request`.
  - Publish write-conflict errors now identify the affected package document.
  - Failed uploads clean up temporary files more reliably.

- **Documentation**
  - Updated package validation and publishing terminology in user-facing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->