### PR TITLE
refactor(pnpr): give the npm surface explicit routes

### DIFF
--- a/.changeset/npm-surface-explicit-routes.md
+++ b/.changeset/npm-surface-explicit-routes.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A URL pnpr's npm surface does not serve now answers `404`. A URL it serves only for other methods answers `405`.

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -15,6 +15,7 @@ mod tests;
 use self::{
     authentication::{Action, AuthedCaller, authenticate, authorize},
     documents::RegistryDocuments,
+    ecosystem::{addressed_registry, caller_scoped},
     package_mutation::{
         delete_package, delete_tarball, get_dist_tags, remove_dist_tag, set_dist_tag,
         update_packument,
@@ -413,11 +414,7 @@ async fn shutdown_signal() {
 // --------------------------------------------------------------------
 // Account routes — adduser/login, whoami, profile, token list and
 // revocation, logout. Mounted on every tier (see the router construction
-// in `router_with_auth_and_osv`). Each has a `/~<prefix>/`-addressed twin
-// whose `/{prefix}/...` route pattern also matches a non-`~` first
-// segment; that shape is not an account URL, so the handler 404s it —
-// though route-level layers still run first (an oversized body to a
-// non-`~` login path is the body cap's 413, not a 404).
+// in `router_with_auth_and_osv`), each with a `/~<name>/`-addressed twin.
 // --------------------------------------------------------------------
 
 /// The registry a `~<name>` path segment addresses, or `None` for a segment
@@ -432,14 +429,12 @@ pub(super) fn tilde_registry(segment: &str) -> Option<&str> {
 /// when it arrived on the path-less base.
 ///
 /// Every route that answers under a registry prefix is registered twice — once
-/// bare, once under `/{prefix}` — pointing at the same handler. This extractor
-/// is what tells the two apart, so a handler states once that it is
+/// bare, once under `/~{registry}` — pointing at the same handler. This
+/// extractor is what tells the two apart, so a handler states once that it is
 /// prefix-aware instead of needing a near-identical twin.
 ///
-/// A `{prefix}` segment that is present but is not a well-formed `~<name>`
-/// rejects with 404: the prefixed registration exists only to serve that
-/// shape, and falling through to the base behaviour would let any first
-/// segment reach an endpoint the route never meant to expose.
+/// A bare `~` names no registry, so it rejects with 404 rather than reading as
+/// the path-less base.
 pub(super) struct TargetRegistry(pub(super) Option<String>);
 
 impl<RouterState: Send + Sync> FromRequestParts<RouterState> for TargetRegistry {
@@ -455,10 +450,10 @@ impl<RouterState: Send + Sync> FromRequestParts<RouterState> for TargetRegistry 
         let params = RawPathParams::from_request_parts(parts, &()).await.map_err(|err| {
             match err {
                 // The client sent a segment that percent-decodes to invalid
-                // UTF-8. It cannot be a well-formed `~<name>`, so answer it the
-                // same 404 every other malformed prefix gets rather than a 500
-                // — a bad URL is not a server fault, and rendering it as one
-                // would also let a client fill the error log.
+                // UTF-8. It cannot be a registry name, so answer it the same
+                // 404 every other malformed prefix gets rather than a 500 — a
+                // bad URL is not a server fault, and rendering it as one would
+                // also let a client fill the error log.
                 RawPathParamsRejection::InvalidUtf8InPathParam(_) => RegistryError::NotFound,
                 // The matched route registered no path parameters at all, which
                 // means the route table and this extractor disagree. Fail closed
@@ -469,12 +464,13 @@ impl<RouterState: Send + Sync> FromRequestParts<RouterState> for TargetRegistry 
             }
             .into_response()
         })?;
-        let Some((_, prefix)) = params.iter().find(|(name, _)| *name == "prefix") else {
+        let Some((_, registry)) = params.iter().find(|(name, _)| *name == "registry") else {
             return Ok(Self(None));
         };
-        tilde_registry(prefix)
-            .map(|registry| Self(Some(registry.to_string())))
-            .ok_or_else(|| RegistryError::NotFound.into_response())
+        if registry.is_empty() {
+            return Err(RegistryError::NotFound.into_response());
+        }
+        Ok(Self(Some(registry.to_string())))
     }
 }
 
@@ -533,7 +529,7 @@ async fn delete_token_by_key(
 }
 
 /// The account routes capture their own parameter alongside the optional
-/// `{prefix}`, so each needs a named shape rather than a bare `Path<String>`:
+/// `{registry}`, so each needs a named shape rather than a bare `Path<String>`:
 /// the prefixed registration captures two segments and a single-value `Path`
 /// would refuse to deserialize it.
 #[derive(Deserialize)]
@@ -555,49 +551,44 @@ struct TokenKeyPath {
 // Handler bodies.
 // --------------------------------------------------------------------
 
+/// The base a served packument's `dist.tarball` URLs are rewritten onto: the
+/// `/~<name>/` endpoint the client addressed, so tarball requests come back
+/// through it (where this server re-checks access and proxies the bytes), or
+/// the bare host for the path-less base.
+fn npm_tarball_base(state: &AppState, registry: Option<&str>) -> String {
+    match registry {
+        Some(registry) => upstream_tarball_base(&state.inner.config.public_url, registry),
+        None => state.inner.config.public_url.clone(),
+    }
+}
+
 async fn serve_packument(
     state: &AppState,
     identity: &Identity,
     headers: &HeaderMap,
+    registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
-    // The path-less base is an alias for the default-target registry: every
-    // request routes through the registry graph (authoritatively, no
-    // fall-through). With no default target the bare host has no registry.
-    match default_registry_target(state) {
-        Some(target) => {
-            // The path-less base: tarball URLs stay canonical for the bare host.
-            let base = state.inner.config.public_url.clone();
-            let response =
-                serve_registry_packument(state, identity, headers, &target, raw_name, &base).await;
-            private_if_caller_gated(state, raw_name, response)
-        }
-        None => not_found(),
-    }
+    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let base = npm_tarball_base(state, registry);
+    let response =
+        serve_registry_packument(state, identity, headers, &target, raw_name, &base).await;
+    caller_scoped(state, Ecosystem::Npm, registry, Some(raw_name), response)
 }
 
 async fn serve_version_manifest(
     state: &AppState,
     identity: &Identity,
+    registry: Option<&str>,
     raw_name: &str,
     version_or_tag: &str,
 ) -> Response {
-    match default_registry_target(state) {
-        Some(target) => {
-            let base = state.inner.config.public_url.clone();
-            let response = serve_registry_version_manifest(
-                state,
-                identity,
-                &target,
-                raw_name,
-                version_or_tag,
-                &base,
-            )
+    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let base = npm_tarball_base(state, registry);
+    let response =
+        serve_registry_version_manifest(state, identity, &target, raw_name, version_or_tag, &base)
             .await;
-            private_if_caller_gated(state, raw_name, response)
-        }
-        None => not_found(),
-    }
+    caller_scoped(state, Ecosystem::Npm, registry, Some(raw_name), response)
 }
 
 /// Serve a single version's manifest (`GET <base>/<pkg>/<version-or-tag>`)
@@ -1659,24 +1650,6 @@ fn resolves_to_private_source(
     }
 }
 
-/// Apply the private-cache headers to a path-less response whenever it can
-/// vary by caller — the default-target resolution for `package` lands on a
-/// source whose effective per-package access denies anonymous callers (so the
-/// same URL answers differently depending on `Authorization`, even through a
-/// public registry). These are the same headers the `/~<name>/` surface applies
-/// unconditionally, so the two URL surfaces for the same content get the same
-/// defense against a shared HTTP cache replaying an authenticated response to
-/// an anonymous caller. A publicly-readable resolution stays cacheable: the
-/// path-less base is the hot install path.
-fn private_if_caller_gated(state: &AppState, package: &str, response: Response) -> Response {
-    match default_registry_target(state) {
-        Some(target) if resolves_to_private_source(state, &target, Ecosystem::Npm, package) => {
-            private_no_cache(response)
-        }
-        _ => response,
-    }
-}
-
 /// Serve a packument addressed to `/~<name>/<pkg>` through the registry graph.
 async fn serve_registry_packument(
     state: &AppState,
@@ -1891,19 +1864,13 @@ async fn serve_hosted_tarball(
 async fn serve_tarball(
     state: &AppState,
     identity: &Identity,
+    registry: Option<&str>,
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    // The path-less base is an alias for the default-target registry — see
-    // `serve_packument`. With no default target the bare host has no registry.
-    match default_registry_target(state) {
-        Some(target) => {
-            let response =
-                serve_registry_tarball(state, identity, &target, raw_name, filename).await;
-            private_if_caller_gated(state, raw_name, response)
-        }
-        None => not_found(),
-    }
+    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let response = serve_registry_tarball(state, identity, &target, raw_name, filename).await;
+    caller_scoped(state, Ecosystem::Npm, registry, Some(raw_name), response)
 }
 
 /// The version a tarball request resolves to, plus that version's declared

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -57,12 +57,11 @@ const INDEX_CONFIG_LIMIT: usize = 64 * 1024;
 const INDEX_CONFIG_KEY: &str = "config.json";
 
 /// The Cargo routes, each registered for the default target (`/cargo/...`)
-/// and for a named registry (`/cargo/~<name>/...`). A static `index` or `api`
-/// segment wins over `{prefix}` at the same position, and a registry name
-/// always carries its `~`, so the two forms never overlap.
+/// and for a named registry (`/cargo/~<name>/...`). The `~` is part of the
+/// route, so the two forms never overlap.
 pub(super) fn routes() -> Router<AppState> {
     let mut router = Router::new();
-    for base in ["/cargo", "/cargo/{prefix}"] {
+    for base in ["/cargo", "/cargo/~{registry}"] {
         router = router
             .route(&format!("{base}/index/config.json"), get(get_index_config))
             .route(&format!("{base}/index/{{a}}/{{b}}"), get(get_index_file))

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -49,10 +49,13 @@ pub(super) fn registry_endpoint(
     }
 }
 
-/// The cache headers a response on an ecosystem surface needs: a named
-/// registry's responses are always caller-scoped (like npm's `/~<name>/`
-/// surface), the default target's only when `package` resolves to a
-/// caller-gated source, so the hot public install path stays cacheable.
+/// The cache headers a response needs so a shared HTTP cache can never replay
+/// an authenticated response to an anonymous caller. A named registry's
+/// responses are always caller-scoped. The default target's are scoped only
+/// when `package` resolves to a source whose effective per-package access
+/// denies anonymous callers, so a URL that answers differently depending on
+/// `Authorization` says so. A publicly-readable resolution stays cacheable:
+/// the path-less base is the hot install path.
 pub(super) fn caller_scoped(
     state: &AppState,
     ecosystem: Ecosystem,

--- a/pnpr/crates/pnpr/src/server/pypi.rs
+++ b/pnpr/crates/pnpr/src/server/pypi.rs
@@ -59,7 +59,7 @@ const PAGE_LIMIT: usize = 64 * 1024 * 1024;
 /// trailing slash the Simple API spells its URLs with.
 pub(super) fn routes() -> Router<AppState> {
     let mut router = Router::new();
-    for base in ["/pypi", "/pypi/{prefix}"] {
+    for base in ["/pypi", "/pypi/~{registry}"] {
         router = router
             .route(&format!("{base}/{SIMPLE_PATH}"), get(get_project_list))
             .route(&format!("{base}/{SIMPLE_PATH}/"), get(get_project_list))

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -3,7 +3,7 @@ use std::{sync::Arc, time::Duration};
 use axum::{
     Router,
     body::Body,
-    extract::{DefaultBodyLimit, OriginalUri, Path, Request, State},
+    extract::{DefaultBodyLimit, Path, RawQuery, Request, State},
     http::{HeaderMap, HeaderValue, Method, header},
     middleware,
     response::Response,
@@ -22,24 +22,23 @@ use tracing::Span;
 
 use pnpr_auth::AuthState;
 use pnpr_config::Config;
+use pnpr_registry::Ecosystem;
 use pnpr_storage::Storage;
 use pnpr_upstream::Upstream;
+use serde::Deserialize;
 
 use super::{
     AppInner, AppState, AuthedCaller, MAX_ARTIFACT_BLOB_BODY_BYTES,
     MAX_ARTIFACT_PUBLISH_BODY_BYTES, MAX_ARTIFACT_RESOLVE_BODY_BYTES, MAX_LOGIN_BODY_BYTES,
-    MAX_PUBLISH_BODY_BYTES, StripedLocks, authenticate, batch, cargo,
-    compute_upstream_cache_namespace, default_registry_target, delete_package,
-    delete_session_token, delete_tarball, delete_token_by_key, get_dist_tags, get_org_teams,
-    get_profile, get_team_members, get_token_list, get_whoami, loggable_uri, not_found,
-    pnpr_protocols_disabled, private_if_caller_gated, private_no_cache, publish_package, put_login,
-    pypi, reject_team_mutation, remove_dist_tag, require_artifact_caller, require_resolver_caller,
-    serve_artifact_blob, serve_batch_publish, serve_org_packages, serve_packument, serve_ping,
-    serve_pnpr_handshake, serve_publish_artifact, serve_registry_packument, serve_registry_tarball,
-    serve_registry_version_manifest, serve_resolve, serve_resolve_artifacts,
-    serve_revision_tarball, serve_search, serve_tarball, serve_verify_lockfile,
-    serve_version_manifest, set_dist_tag, staged, tilde_registry, update_packument,
-    upstream_tarball_base,
+    MAX_PUBLISH_BODY_BYTES, StripedLocks, TargetRegistry, addressed_registry, authenticate, batch,
+    caller_scoped, cargo, compute_upstream_cache_namespace, delete_package, delete_session_token,
+    delete_tarball, delete_token_by_key, get_dist_tags, get_org_teams, get_profile,
+    get_team_members, get_token_list, get_whoami, loggable_uri, not_found, pnpr_protocols_disabled,
+    private_no_cache, publish_package, put_login, pypi, reject_team_mutation, remove_dist_tag,
+    require_artifact_caller, require_resolver_caller, serve_artifact_blob, serve_batch_publish,
+    serve_org_packages, serve_packument, serve_ping, serve_pnpr_handshake, serve_publish_artifact,
+    serve_resolve, serve_resolve_artifacts, serve_revision_tarball, serve_search, serve_tarball,
+    serve_verify_lockfile, serve_version_manifest, set_dist_tag, staged, update_packument,
 };
 
 pub(super) fn router_with_auth_and_osv(
@@ -79,9 +78,7 @@ pub(super) fn router_with_auth_and_osv(
             .iter()
             .map(|(name, upstream)| {
                 let client = Upstream::new(name, upstream);
-                let client = if config.registries.ecosystem(name)
-                    == Some(pnpr_registry::Ecosystem::Npm)
-                {
+                let client = if config.registries.ecosystem(name) == Some(Ecosystem::Npm) {
                     client
                 } else {
                     client
@@ -181,10 +178,6 @@ pub(super) fn router_with_auth_and_osv(
                     )),
             );
     }
-    // The npm-registry surface: every packument/tarball read, publish,
-    // unpublish, dist-tag, and search. When the surface is off (no registries
-    // declared, or `--disable-registry`), none of these routes are mounted.
-    // Resolver- and artifacts-only tiers expose no registry surface at all.
     if registry_enabled {
         let npm = npm_registry_routes();
         router = router
@@ -284,579 +277,457 @@ pub(super) fn router_with_auth_and_osv(
 /// credentials (`pnpm login --registry https://<resolver-host>/`) instead of
 /// depending on a registry-serving replica that shares the auth backend.
 ///
-/// Each endpoint also answers under any `/~<prefix>/`, so a client whose
+/// Each endpoint also answers under any `/~<name>/`, so a client whose
 /// registry URL is a registry endpoint can log in against it. The identity
 /// endpoints are global and consult no registry state; a registry-table lookup
 /// would gate nothing while turning the 401-vs-404 split into an existence
 /// oracle for private registry names that the content handlers carefully mask.
 fn account_routes() -> Router<AppState> {
-    Router::new()
-        .route("/-/whoami", get(get_whoami))
-        .route("/{prefix}/-/whoami", get(get_whoami))
-        .route(
-            "/-/user/{user}",
-            put(put_login).route_layer(DefaultBodyLimit::max(MAX_LOGIN_BODY_BYTES)),
-        )
-        .route(
-            "/{prefix}/-/user/{user}",
-            put(put_login).route_layer(DefaultBodyLimit::max(MAX_LOGIN_BODY_BYTES)),
-        )
-        .route("/-/user/token/{token}", delete(delete_session_token))
-        .route("/{prefix}/-/user/token/{token}", delete(delete_session_token))
-        .route("/-/npm/v1/user", get(get_profile))
-        .route("/{prefix}/-/npm/v1/user", get(get_profile))
-        .route("/-/npm/v1/tokens", get(get_token_list))
-        .route("/{prefix}/-/npm/v1/tokens", get(get_token_list))
-        .route("/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key))
-        .route("/{prefix}/-/npm/v1/tokens/token/{key}", delete(delete_token_by_key))
+    let mut router = Router::new();
+    for base in ["", "/~{registry}"] {
+        let path = |tail: &str| format!("{base}{tail}");
+        router = router
+            .route(&path("/-/whoami"), get(get_whoami))
+            .route(
+                &path("/-/user/{user}"),
+                put(put_login).route_layer(DefaultBodyLimit::max(MAX_LOGIN_BODY_BYTES)),
+            )
+            .route(&path("/-/user/token/{token}"), delete(delete_session_token))
+            .route(&path("/-/npm/v1/user"), get(get_profile))
+            .route(&path("/-/npm/v1/tokens"), get(get_token_list))
+            .route(&path("/-/npm/v1/tokens/token/{key}"), delete(delete_token_by_key));
+    }
+    router
 }
 
 /// The npm-registry surface: every packument/tarball read, publish,
 /// unpublish, dist-tag, and search. Mounted only when the registry feature is
 /// on (registries declared and not `--disable-registry`), so resolver- and
 /// artifacts-only tiers expose no registry surface at all.
+///
+/// Every route is registered twice: bare, addressing the default target
+/// through the path-less base, and under `/~<name>/`, addressing one named
+/// registry. [`TargetRegistry`] is what tells a handler which of the two it
+/// was reached through.
 fn npm_registry_routes() -> Router<AppState> {
-    Router::new()
-        // Batch publish: one request carrying many packages' publish
-        // documents. Not part of the standard npm registry API —
-        // `pnpm publish --batch` opts into it explicitly.
-        .route("/-/pnpm/v1/publish", put(serve_batch_publish))
-        // Staged (two-phase) publishing — the `pnpm stage` surface.
-        // Static `-`/`stage` segments take priority over the generic
-        // segment-count routes below, so these never shadow package
-        // reads. Each route has a `/~<name>/`-prefixed twin so a client
-        // whose registry URL is a registry endpoint can stage through it.
-        .route("/-/stage", get(staged::list_staged))
-        .route("/-/stage/package/{name}", post(staged::post_staged_publish))
-        .route("/-/stage/{id}", get(staged::get_staged).delete(staged::reject_staged))
-        .route("/-/stage/{id}/approve", post(staged::approve_staged))
-        .route("/-/stage/{id}/tarball", get(staged::get_staged_tarball))
-        .route("/{prefix}/-/stage", get(staged::list_staged))
-        .route("/{prefix}/-/stage/package/{name}", post(staged::post_staged_publish))
-        .route("/{prefix}/-/stage/{id}", get(staged::get_staged).delete(staged::reject_staged))
-        .route("/{prefix}/-/stage/{id}/approve", post(staged::approve_staged))
-        .route("/{prefix}/-/stage/{id}/tarball", get(staged::get_staged_tarball))
-        .route("/{name}", get(get_packument_unscoped).put(put_one_segment))
-        .route("/{first}/{second}", get(get_two_segments).put(put_two_segments))
-        .route(
-            "/{first}/{second}/{third}",
-            get(get_three_segments).put(put_three_segments).delete(delete_three_segments),
-        )
-        .route("/{scope}/{name}/-/{filename}", get(get_tarball_scoped))
-        .route(
-            "/{a}/{b}/{c}/{d}",
-            get(get_four_segments).put(put_four_segments).delete(delete_four_segments),
-        )
-        .route(
-            "/{a}/{b}/{c}/{d}/{e}",
-            get(get_five_segments).put(put_five_segments).delete(delete_five_segments),
-        )
-        // Scoped tarball delete: `DELETE /@scope/name/-/<basename-version>.tgz/-rev/<rev>`,
-        // plus the registry-addressed dist-tag write and unscoped tarball delete.
-        .route(
-            "/{a}/{b}/{c}/{d}/{e}/{f}",
-            get(get_six_segments).put(put_six_segments).delete(delete_six_segments),
-        )
-        // Registry-addressed scoped tarball delete:
-        // `DELETE /~<name>/@scope/name/-/<file>/-rev/<rev>`
-        .route("/{a}/{b}/{c}/{d}/{e}/{f}/{g}", delete(delete_seven_segments))
-}
-
-// --------------------------------------------------------------------
-// GET handlers — packument, version manifest, tarball.
-// Same overall shape as before, with an access-policy check added
-// up front so protected packages return 401 to anonymous callers.
-// --------------------------------------------------------------------
-
-async fn get_packument_unscoped(
-    State(state): State<AppState>,
-    AuthedCaller(identity): AuthedCaller,
-    headers: HeaderMap,
-    Path(name): Path<String>,
-) -> Response {
-    serve_packument(&state, &identity, &headers, &name).await
-}
-
-async fn get_two_segments(
-    State(state): State<AppState>,
-    AuthedCaller(identity): AuthedCaller,
-    headers: HeaderMap,
-    Path((first, second)): Path<(String, String)>,
-) -> Response {
-    // `/~<name>/<pkg>` — unscoped packument through a registry endpoint. The
-    // tarball base is the client's `/~<name>/` URL so the rewritten URLs stay
-    // canonical for the registry the client actually addressed.
-    if let Some(registry) = tilde_registry(&first) {
-        let base = upstream_tarball_base(&state.inner.config.public_url, registry);
-        return private_no_cache(
-            serve_registry_packument(&state, &identity, &headers, registry, &second, &base).await,
-        );
-    }
-    if first.starts_with('@') {
-        if first.contains('/') {
-            serve_version_manifest(&state, &identity, &first, &second).await
-        } else {
-            let full = format!("{first}/{second}");
-            serve_packument(&state, &identity, &headers, &full).await
-        }
-    } else {
-        serve_version_manifest(&state, &identity, &first, &second).await
-    }
-}
-
-async fn get_three_segments(
-    State(state): State<AppState>,
-    AuthedCaller(identity): AuthedCaller,
-    OriginalUri(uri): OriginalUri,
-    headers: HeaderMap,
-    Path((first, second, third)): Path<(String, String, String)>,
-) -> Response {
-    if first == "-" && second == "v1" && third == "search" {
-        let query = uri.query().unwrap_or("");
-        // Search results are filtered per caller (registry access + per-package
-        // ACL), so they must never land in a shared HTTP cache.
-        return private_no_cache(serve_search(&state, &identity, None, query).await);
-    }
-    if let Some(registry) = tilde_registry(&first) {
-        // The account endpoints (whoami, adduser, logout, profile, tokens)
-        // live on dedicated always-mounted routes; a `/~<name>/-/...` path
-        // that still reaches this handler names no registry content.
-        if second == "-" {
-            return not_found();
-        }
-        let base = upstream_tarball_base(&state.inner.config.public_url, registry);
-        if second.starts_with('@') {
-            // `/~<name>/@scope%2Fname/<version>` — version manifest for an
-            // encoded scoped package through a registry endpoint.
-            if second.contains('/') {
-                return private_no_cache(
-                    serve_registry_version_manifest(
-                        &state, &identity, registry, &second, &third, &base,
-                    )
-                    .await,
-                );
-            }
-            // `/~<name>/@scope/<pkg>` — scoped packument through a registry.
-            let full = format!("{second}/{third}");
-            return private_no_cache(
-                serve_registry_packument(&state, &identity, &headers, registry, &full, &base).await,
+    // Batch publish: one request carrying many packages' publish documents.
+    // Not part of the standard npm registry API — `pnpm publish --batch` opts
+    // into it explicitly, and only against the path-less base.
+    let mut router = Router::new().route("/-/pnpm/v1/publish", put(serve_batch_publish));
+    for base in ["", "/~{registry}"] {
+        let path = |tail: &str| format!("{base}{tail}");
+        router = router
+            // Staged (two-phase) publishing — the `pnpm stage` surface.
+            .route(&path("/-/stage"), get(staged::list_staged))
+            .route(&path("/-/stage/package/{name}"), post(staged::post_staged_publish))
+            .route(&path("/-/stage/{id}"), get(staged::get_staged).delete(staged::reject_staged))
+            .route(&path("/-/stage/{id}/approve"), post(staged::approve_staged))
+            .route(&path("/-/stage/{id}/tarball"), get(staged::get_staged_tarball))
+            .route(&path("/-/v1/search"), get(get_search))
+            .route(&path("/-/tarballs/sha512/{digest}"), get(get_revision_tarball))
+            .route(&path("/-/package/{name}/dist-tags"), get(get_package_dist_tags))
+            .route(
+                &path("/-/package/{name}/dist-tags/{tag}"),
+                put(put_package_dist_tag).delete(delete_package_dist_tag),
+            )
+            .route(&path("/-/org/{scope}/team"), get(get_teams).put(put_team))
+            .route(&path("/-/org/{scope}/package"), get(get_org_package_list))
+            .route(&path("/-/team/{scope}/{team}"), delete(delete_team))
+            .route(
+                &path("/-/team/{scope}/{team}/user"),
+                get(get_team_users).put(put_team_user).delete(delete_team_user),
+            )
+            // Package addresses. npm spells a scoped name either as two
+            // literal segments (`/@scope/name`) or as one percent-encoded
+            // segment (`/@scope%2Fname`), so a path's segment count never says
+            // on its own which resource it names. The `-` and `-rev` markers
+            // do: whatever stands to their left is the package.
+            .route(&path("/{name}"), get(get_packument).put(put_package))
+            .route(
+                &path("/{first}/{second}"),
+                get(get_packument_or_version_manifest).put(put_scoped_package),
+            )
+            .route(&path("/{name}/-/{filename}"), get(get_tarball))
+            .route(
+                &path("/{name}/-rev/{rev}"),
+                put(put_packument_revision).delete(unpublish_package),
+            )
+            .route(&path("/{scope}/{name}/{version}"), get(get_scoped_version_manifest))
+            .route(&path("/{scope}/{name}/-/{filename}"), get(get_scoped_tarball))
+            .route(&path("/{name}/-/{filename}/-rev/{rev}"), delete(unpublish_tarball))
+            .route(
+                &path("/{scope}/{name}/-/{filename}/-rev/{rev}"),
+                delete(unpublish_scoped_tarball),
             );
-        }
-        // `/~<name>/<pkg>/<version-or-tag>` — unscoped version manifest
-        // through a registry endpoint. (The unscoped tarball shape
-        // `/~<name>/<pkg>/-/<file>` is a distinct literal-`-` route.)
-        return private_no_cache(
-            serve_registry_version_manifest(&state, &identity, registry, &second, &third, &base)
-                .await,
-        );
     }
-    if second == "-" {
-        serve_tarball(&state, &identity, &first, &third).await
-    } else if first.starts_with('@') {
-        let full = format!("{first}/{second}");
-        serve_version_manifest(&state, &identity, &full, &third).await
-    } else {
-        not_found()
-    }
+    router
 }
 
-async fn get_tarball_scoped(
+// --------------------------------------------------------------------
+// Path shapes. Each names only the segments its handlers read: the
+// `/~<name>/` registration captures a `registry` segment too, and the
+// `-rev` routes capture a revision token pnpr does not track.
+// --------------------------------------------------------------------
+
+/// A package addressed by a single segment: an unscoped name, or a scoped name
+/// percent-encoded as `@scope%2Fname`.
+#[derive(Deserialize)]
+struct NamePath {
+    name: String,
+}
+
+/// npm's overloaded two-segment address. Which package it names, and which
+/// resource of it, depends on the first segment's shape and on the method, so
+/// neither segment can be given a resource name here.
+#[derive(Deserialize)]
+struct TwoSegments {
+    first: String,
+    second: String,
+}
+
+#[derive(Deserialize)]
+struct ScopedVersionPath {
+    scope: String,
+    name: String,
+    version: String,
+}
+
+#[derive(Deserialize)]
+struct TarballPath {
+    name: String,
+    filename: String,
+}
+
+#[derive(Deserialize)]
+struct ScopedTarballPath {
+    scope: String,
+    name: String,
+    filename: String,
+}
+
+#[derive(Deserialize)]
+struct DistTagPath {
+    name: String,
+    tag: String,
+}
+
+#[derive(Deserialize)]
+struct ScopePath {
+    scope: String,
+}
+
+#[derive(Deserialize)]
+struct TeamPath {
+    scope: String,
+    team: String,
+}
+
+#[derive(Deserialize)]
+struct DigestPath {
+    digest: String,
+}
+
+// --------------------------------------------------------------------
+// Package reads — packument, version manifest, tarball.
+// --------------------------------------------------------------------
+
+/// `GET {base}/{pkg}`.
+async fn get_packument(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((scope, name, filename)): Path<(String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    headers: HeaderMap,
+    Path(path): Path<NamePath>,
 ) -> Response {
-    // `/~<name>/<pkg>/-/<file>` — unscoped tarball through a registry endpoint.
-    if let Some(registry) = tilde_registry(&scope) {
-        return private_no_cache(
-            serve_registry_tarball(&state, &identity, registry, &name, &filename).await,
-        );
+    serve_packument(&state, &identity, &headers, registry.as_deref(), &path.name).await
+}
+
+/// `GET {base}/@{scope}/{pkg}` — a scoped package's packument — or
+/// `GET {base}/{pkg}/{version-or-tag}` — a version manifest for a package
+/// whose name fits one segment.
+async fn get_packument_or_version_manifest(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    headers: HeaderMap,
+    Path(path): Path<TwoSegments>,
+) -> Response {
+    let TwoSegments { first, second } = path;
+    if first.starts_with('@') && !first.contains('/') {
+        let name = format!("{first}/{second}");
+        return serve_packument(&state, &identity, &headers, registry.as_deref(), &name).await;
     }
+    serve_version_manifest(&state, &identity, registry.as_deref(), &first, &second).await
+}
+
+/// `GET {base}/@{scope}/{pkg}/{version-or-tag}` — a scoped package's version
+/// manifest. A first segment that is not a scope names no package.
+async fn get_scoped_version_manifest(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopedVersionPath>,
+) -> Response {
+    let ScopedVersionPath { scope, name, version } = path;
     if !scope.starts_with('@') {
         return not_found();
     }
     let full = format!("{scope}/{name}");
-    serve_tarball(&state, &identity, &full, &filename).await
+    serve_version_manifest(&state, &identity, registry.as_deref(), &full, &version).await
 }
 
-/// 4-segment GET:
-/// * `/-/package/{pkg}/dist-tags` — packument's `dist-tags` object.
-/// * `/-/org/{scope}/team` — the teams of the registry claiming `@scope`.
-/// * `/-/tarballs/sha512/{digest}` — immutable artifact through the default registry.
-/// * `/~<name>/-/v1/search` — search through a registry endpoint.
-/// * `/~<name>/@scope/{pkg}/{version}` — scoped version manifest through a
-///   registry endpoint.
-async fn get_four_segments(
+/// `GET {base}/{pkg}/-/{filename}`.
+async fn get_tarball(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    OriginalUri(uri): OriginalUri,
-    Path((a, b, c, d)): Path<(String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<TarballPath>,
 ) -> Response {
-    if a == "-" && b == "tarballs" && c == "sha512" {
-        let Some(registry) = default_registry_target(&state) else { return not_found() };
-        return serve_revision_tarball(&state, &identity, &registry, &d).await;
-    }
-    if a == "-" && b == "package" && d == "dist-tags" {
-        let response = get_dist_tags(&state, &identity, None, &c).await;
-        return private_if_caller_gated(&state, &c, response);
-    }
-    if a == "-" && b == "org" && d == "team" {
-        return private_no_cache(get_org_teams(&state, &identity, None, &c));
-    }
-    if a == "-" && b == "org" && d == "package" {
-        return private_no_cache(serve_org_packages(&state, &identity, None, &c).await);
-    }
-    if let Some(registry) = tilde_registry(&a) {
-        if b == "-" && c == "v1" && d == "search" {
-            let query = uri.query().unwrap_or("");
-            return private_no_cache(serve_search(&state, &identity, Some(registry), query).await);
-        }
-        if b.starts_with('@') && !b.contains('/') {
-            let full = format!("{b}/{c}");
-            let base = upstream_tarball_base(&state.inner.config.public_url, registry);
-            return private_no_cache(
-                serve_registry_version_manifest(&state, &identity, registry, &full, &d, &base)
-                    .await,
-            );
-        }
-    }
-    not_found()
+    serve_tarball(&state, &identity, registry.as_deref(), &path.name, &path.filename).await
 }
 
-/// 5-segment GET:
-/// * `/-/team/{scope}/{team}/user` — a team's members.
-/// * `/~<name>/@scope/<pkg>/-/<file>` — scoped tarball through a registry
-///   endpoint.
-/// * `/~<name>/-/package/<pkg>/dist-tags` — dist-tags through a registry
-///   endpoint.
-/// * `/~<name>/-/org/{scope}/team` — org teams through a registry endpoint.
-/// * `/~<name>/-/tarballs/sha512/{digest}`: immutable artifact through an addressed registry.
-///
-/// Every other 5-segment GET is a not-found catchall (the route exists so
-/// DELETE/PUT can sit on the same path).
-async fn get_five_segments(
+/// `GET {base}/@{scope}/{pkg}/-/{filename}`.
+async fn get_scoped_tarball(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e)): Path<(String, String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopedTarballPath>,
 ) -> Response {
-    if a == "-" && b == "team" && e == "user" {
-        return private_no_cache(get_team_members(&state, &identity, None, &c, &d));
+    let ScopedTarballPath { scope, name, filename } = path;
+    if !scope.starts_with('@') {
+        return not_found();
     }
-    if let Some(registry) = tilde_registry(&a) {
-        if b == "-" && c == "tarballs" && d == "sha512" {
-            return serve_revision_tarball(&state, &identity, registry, &e).await;
-        }
-        if b.starts_with('@') && d == "-" {
-            let full = format!("{b}/{c}");
-            return private_no_cache(
-                serve_registry_tarball(&state, &identity, registry, &full, &e).await,
-            );
-        }
-        if b == "-" && c == "package" && e == "dist-tags" {
-            return private_no_cache(get_dist_tags(&state, &identity, Some(registry), &d).await);
-        }
-        if b == "-" && c == "org" && e == "team" {
-            return private_no_cache(get_org_teams(&state, &identity, Some(registry), &d));
-        }
-        if b == "-" && c == "org" && e == "package" {
-            return private_no_cache(
-                serve_org_packages(&state, &identity, Some(registry), &d).await,
-            );
-        }
-    }
-    not_found()
+    let full = format!("{scope}/{name}");
+    serve_tarball(&state, &identity, registry.as_deref(), &full, &filename).await
 }
 
-/// 6-segment GET:
-/// * `/~<name>/-/team/{scope}/{team}/user` — a team's members through a
-///   registry endpoint.
-async fn get_six_segments(
+/// `GET {base}/-/tarballs/sha512/{digest}` — an integrity-addressed tarball.
+async fn get_revision_tarball(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<DigestPath>,
 ) -> Response {
-    if let Some(registry) = tilde_registry(&a)
-        && b == "-"
-        && c == "team"
-        && f == "user"
-    {
-        return private_no_cache(get_team_members(&state, &identity, Some(registry), &d, &e));
-    }
-    not_found()
+    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+        return not_found();
+    };
+    serve_revision_tarball(&state, &identity, &target, &path.digest).await
+}
+
+/// `GET {base}/-/v1/search`.
+async fn get_search(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    RawQuery(query): RawQuery,
+) -> Response {
+    let query = query.unwrap_or_default();
+    // Results are filtered per caller (registry access plus per-package ACL),
+    // so they must never land in a shared HTTP cache.
+    private_no_cache(serve_search(&state, &identity, registry.as_deref(), &query).await)
 }
 
 // --------------------------------------------------------------------
-// PUT handlers — adduser, publish, dist-tag write.
+// Package writes — publish, unpublish, dist-tags.
 // --------------------------------------------------------------------
 
-/// `PUT /{name}` — publish an unscoped package.
-async fn put_one_segment(
+/// `PUT {base}/{pkg}`.
+async fn put_package(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path(name): Path<String>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<NamePath>,
     body: axum::body::Bytes,
 ) -> Response {
-    publish_package(&state, &identity, None, &name, body).await
+    publish_package(&state, &identity, registry.as_deref(), &path.name, body).await
 }
 
-/// `PUT /{first}/{second}` — publish a scoped package
-/// (`/@scope/name`), or an unscoped package through a registry endpoint
-/// (`/~<name>/<pkg>`). The `/-/package/{pkg}` shape never lands here
-/// because that's at least 4 segments.
-async fn put_two_segments(
+/// `PUT {base}/@{scope}/{pkg}` — publish a scoped package. A first segment
+/// that is not a scope names no publishable package.
+async fn put_scoped_package(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((first, second)): Path<(String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<TwoSegments>,
     body: axum::body::Bytes,
 ) -> Response {
-    // `PUT /~<name>/<pkg>` — publish an unscoped package through a registry.
-    if let Some(registry) = tilde_registry(&first) {
-        return publish_package(&state, &identity, Some(registry), &second, body).await;
+    let TwoSegments { first, second } = path;
+    if !first.starts_with('@') {
+        return not_found();
     }
-    if first.starts_with('@') {
-        let full = format!("{first}/{second}");
-        return publish_package(&state, &identity, None, &full, body).await;
-    }
-    not_found()
+    let full = format!("{first}/{second}");
+    publish_package(&state, &identity, registry.as_deref(), &full, body).await
 }
 
-/// `PUT /{pkg}/-rev/{rev}` — packument update (partial unpublish).
-async fn put_three_segments(
+/// `PUT {base}/{pkg}/-rev/{rev}` — the full mutated packument, which is how
+/// npm spells a partial unpublish.
+async fn put_packument_revision(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((first, second, third)): Path<(String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<NamePath>,
     body: axum::body::Bytes,
 ) -> Response {
-    // `PUT /~<name>/@scope/<pkg>` — publish a scoped package through a registry.
-    if let Some(registry) = tilde_registry(&first)
-        && second.starts_with('@')
-    {
-        let full = format!("{second}/{third}");
-        return publish_package(&state, &identity, Some(registry), &full, body).await;
-    }
-    if second == "-rev" {
-        // `third` is the opaque revision token the client sent back.
-        // We don't track revisions, so it's only used for routing —
-        // the body is the full mutated packument.
-        let _ = third;
-        return update_packument(&state, &identity, None, &first, &body).await;
-    }
-    not_found()
+    update_packument(&state, &identity, registry.as_deref(), &path.name, &body).await
 }
 
-/// 4-segment PUT:
-/// * `/~<name>/{pkg}/-rev/{rev}` — packument update (partial unpublish)
-///   through a registry endpoint. Scoped packages arrive percent-encoded as a
-///   single `@scope%2Fname` segment, like the path-less 3-segment form.
-async fn put_four_segments(
+/// `DELETE {base}/{pkg}/-rev/{rev}` — remove a whole package
+/// (`pnpm unpublish --force`).
+async fn unpublish_package(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d)): Path<(String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<NamePath>,
+) -> Response {
+    delete_package(&state, &identity, registry.as_deref(), &path.name).await
+}
+
+/// `DELETE {base}/{pkg}/-/{filename}/-rev/{rev}` — remove one version's
+/// tarball, a step of `pnpm unpublish <pkg>@<version>`.
+async fn unpublish_tarball(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<TarballPath>,
+) -> Response {
+    delete_tarball(&state, &identity, registry.as_deref(), &path.name, &path.filename).await
+}
+
+/// `DELETE {base}/@{scope}/{pkg}/-/{filename}/-rev/{rev}` — remove one scoped
+/// version's tarball. The unpublish flow reconstructs this URL from the
+/// packument's `dist.tarball`, which spells a scoped name with a literal
+/// slash.
+async fn unpublish_scoped_tarball(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopedTarballPath>,
+) -> Response {
+    let ScopedTarballPath { scope, name, filename } = path;
+    if !scope.starts_with('@') {
+        return not_found();
+    }
+    let full = format!("{scope}/{name}");
+    delete_tarball(&state, &identity, registry.as_deref(), &full, &filename).await
+}
+
+/// `GET {base}/-/package/{pkg}/dist-tags`.
+async fn get_package_dist_tags(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<NamePath>,
+) -> Response {
+    let response = get_dist_tags(&state, &identity, registry.as_deref(), &path.name).await;
+    caller_scoped(&state, Ecosystem::Npm, registry.as_deref(), Some(&path.name), response)
+}
+
+/// `PUT {base}/-/package/{pkg}/dist-tags/{tag}`.
+async fn put_package_dist_tag(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<DistTagPath>,
     body: axum::body::Bytes,
 ) -> Response {
-    // `PUT /-/org/{scope}/team` — team create; config-managed, rejected.
-    if a == "-" && b == "org" && d == "team" {
-        return reject_team_mutation(&state, &identity, None, &c, "create a team");
-    }
-    if let Some(registry) = tilde_registry(&a)
-        && c == "-rev"
-    {
-        let _ = d; // revision token is unused
-        return update_packument(&state, &identity, Some(registry), &b, &body).await;
-    }
-    not_found()
+    set_dist_tag(&state, &identity, registry.as_deref(), &path.name, &path.tag, &body).await
 }
 
-/// `DELETE /{pkg}/-rev/{rev}` — remove the entire package
-/// (`pnpm unpublish --force`). For scoped packages the URL is
-/// `/@scope%2Fname/-rev/{rev}` and arrives as a single segment after
-/// axum's percent-decoding.
-async fn delete_three_segments(
+/// `DELETE {base}/-/package/{pkg}/dist-tags/{tag}`.
+async fn delete_package_dist_tag(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((first, second, third)): Path<(String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<DistTagPath>,
 ) -> Response {
-    if second == "-rev" {
-        let _ = third;
-        return delete_package(&state, &identity, None, &first).await;
-    }
-    not_found()
+    remove_dist_tag(&state, &identity, registry.as_deref(), &path.name, &path.tag).await
 }
 
-/// 5-segment PUT:
-/// * `/-/package/{pkg}/dist-tags/{tag}` — add/update a dist-tag.
-/// * `/-/team/{scope}/{team}/user` — team member add; config-managed,
-///   rejected.
-/// * `/~<name>/-/org/{scope}/team` — team create through a registry
-///   endpoint; config-managed, rejected.
-async fn put_five_segments(
+// --------------------------------------------------------------------
+// Orgs and teams. Membership is config-managed, so every mutation is
+// rejected with an explanation rather than silently ignored.
+// --------------------------------------------------------------------
+
+/// `GET {base}/-/org/{scope}/team` — the teams of the registry claiming
+/// `scope`.
+async fn get_teams(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e)): Path<(String, String, String, String, String)>,
-    body: axum::body::Bytes,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
 ) -> Response {
-    if a == "-" && b == "package" && d == "dist-tags" {
-        return set_dist_tag(&state, &identity, None, &c, &e, &body).await;
-    }
-    if a == "-" && b == "team" && e == "user" {
-        return reject_team_mutation(&state, &identity, None, &c, "add a team member");
-    }
-    if let Some(registry) = tilde_registry(&a)
-        && b == "-"
-        && c == "org"
-        && e == "team"
-    {
-        return reject_team_mutation(&state, &identity, Some(registry), &d, "create a team");
-    }
-    not_found()
+    private_no_cache(get_org_teams(&state, &identity, registry.as_deref(), &path.scope))
 }
 
-/// 6-segment PUT:
-/// * `/~<name>/-/package/{pkg}/dist-tags/{tag}` — add/update a dist-tag
-///   through a registry endpoint.
-/// * `/~<name>/-/team/{scope}/{team}/user` — team member add through a
-///   registry endpoint; config-managed, rejected.
-async fn put_six_segments(
+/// `GET {base}/-/org/{scope}/package` — the packages of the registry claiming
+/// `scope`.
+async fn get_org_package_list(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
-    body: axum::body::Bytes,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
 ) -> Response {
-    if let Some(registry) = tilde_registry(&a)
-        && b == "-"
-    {
-        if c == "package" && e == "dist-tags" {
-            return set_dist_tag(&state, &identity, Some(registry), &d, &f, &body).await;
-        }
-        if c == "team" && f == "user" {
-            return reject_team_mutation(
-                &state,
-                &identity,
-                Some(registry),
-                &d,
-                "add a team member",
-            );
-        }
-    }
-    not_found()
+    private_no_cache(serve_org_packages(&state, &identity, registry.as_deref(), &path.scope).await)
 }
 
-/// 4-segment DELETE:
-/// * `/-/team/{scope}/{team}` — team destroy; config-managed, rejected.
-/// * `/~<name>/{pkg}/-rev/{rev}` — remove the entire package through a
-///   registry endpoint (scoped packages arrive percent-encoded as one
-///   `@scope%2Fname` segment).
-async fn delete_four_segments(
+/// `PUT {base}/-/org/{scope}/team`.
+async fn put_team(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d)): Path<(String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
 ) -> Response {
-    if a == "-" && b == "team" {
-        let _ = d; // team name — the mutation is rejected regardless
-        return reject_team_mutation(&state, &identity, None, &c, "destroy a team");
-    }
-    if let Some(registry) = tilde_registry(&a)
-        && c == "-rev"
-    {
-        let _ = d; // revision token is unused
-        return delete_package(&state, &identity, Some(registry), &b).await;
-    }
-    not_found()
+    reject_team_mutation(&state, &identity, registry.as_deref(), &path.scope, "create a team")
 }
 
-/// 5-segment DELETE:
-/// * `/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag.
-/// * `/-/team/{scope}/{team}/user` — team member remove; config-managed,
-///   rejected.
-/// * `/~<name>/-/team/{scope}/{team}` — team destroy through a registry
-///   endpoint; config-managed, rejected.
-/// * `/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped tarball
-///   (one step of `pnpm unpublish <pkg>@<version>`).
-async fn delete_five_segments(
+/// `DELETE {base}/-/team/{scope}/{team}`.
+async fn delete_team(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e)): Path<(String, String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
 ) -> Response {
-    if a == "-" && b == "package" && d == "dist-tags" {
-        return remove_dist_tag(&state, &identity, None, &c, &e).await;
-    }
-    if a == "-" && b == "team" && e == "user" {
-        return reject_team_mutation(&state, &identity, None, &c, "remove a team member");
-    }
-    if let Some(registry) = tilde_registry(&a)
-        && b == "-"
-        && c == "team"
-    {
-        let _ = e; // team name — the mutation is rejected regardless
-        return reject_team_mutation(&state, &identity, Some(registry), &d, "destroy a team");
-    }
-    if b == "-" && d == "-rev" {
-        let _ = e; // revision token is unused
-        return delete_tarball(&state, &identity, None, &a, &c).await;
-    }
-    not_found()
+    reject_team_mutation(&state, &identity, registry.as_deref(), &path.scope, "destroy a team")
 }
 
-/// 6-segment DELETE:
-/// * `/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
-///   tarball. The pnpm unpublish flow gets here when the tarball URL
-///   it reconstructs from the packument is the literal-slash scoped
-///   form (`http://host/@scope/name/-/name-1.0.0.tgz`), so the
-///   request lands here unencoded rather than as a 5-seg
-///   `@scope%2Fname` URL.
-/// * `/~<name>/-/package/{pkg}/dist-tags/{tag}` — remove a dist-tag
-///   through a registry endpoint.
-/// * `/~<name>/-/team/{scope}/{team}/user` — team member remove through a
-///   registry endpoint; config-managed, rejected.
-/// * `/~<name>/{pkg}/-/{filename}/-rev/{rev}` — remove an unscoped
-///   tarball through a registry endpoint.
-async fn delete_six_segments(
+/// `GET {base}/-/team/{scope}/{team}/user`.
+async fn get_team_users(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e, f)): Path<(String, String, String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<TeamPath>,
 ) -> Response {
-    if a.starts_with('@') && c == "-" && e == "-rev" {
-        let _ = f; // revision token is unused
-        let full = format!("{a}/{b}");
-        return delete_tarball(&state, &identity, None, &full, &d).await;
-    }
-    if let Some(registry) = tilde_registry(&a) {
-        if b == "-" && c == "package" && e == "dist-tags" {
-            return remove_dist_tag(&state, &identity, Some(registry), &d, &f).await;
-        }
-        if b == "-" && c == "team" && f == "user" {
-            return reject_team_mutation(
-                &state,
-                &identity,
-                Some(registry),
-                &d,
-                "remove a team member",
-            );
-        }
-        if c == "-" && e == "-rev" {
-            let _ = f; // revision token is unused
-            return delete_tarball(&state, &identity, Some(registry), &b, &d).await;
-        }
-    }
-    not_found()
+    private_no_cache(get_team_members(
+        &state,
+        &identity,
+        registry.as_deref(),
+        &path.scope,
+        &path.team,
+    ))
 }
 
-/// 7-segment DELETE:
-/// * `/~<name>/{scope}/{name}/-/{filename}/-rev/{rev}` — remove a scoped
-///   tarball through a registry endpoint (the unencoded literal-slash form the
-///   pnpm unpublish flow reconstructs from the packument's tarball URL).
-async fn delete_seven_segments(
+/// `PUT {base}/-/team/{scope}/{team}/user`.
+async fn put_team_user(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
-    Path((a, b, c, d, e, f, g)): Path<(String, String, String, String, String, String, String)>,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
 ) -> Response {
-    if let Some(registry) = tilde_registry(&a)
-        && b.starts_with('@')
-        && d == "-"
-        && f == "-rev"
-    {
-        let _ = g; // revision token is unused
-        let full = format!("{b}/{c}");
-        return delete_tarball(&state, &identity, Some(registry), &full, &e).await;
-    }
-    not_found()
+    reject_team_mutation(&state, &identity, registry.as_deref(), &path.scope, "add a team member")
+}
+
+/// `DELETE {base}/-/team/{scope}/{team}/user`.
+async fn delete_team_user(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    Path(path): Path<ScopePath>,
+) -> Response {
+    reject_team_mutation(
+        &state,
+        &identity,
+        registry.as_deref(),
+        &path.scope,
+        "remove a team member",
+    )
 }

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -107,13 +107,13 @@ fn parse_staged_list_query(query: &str) -> StagedListQuery {
 }
 
 // ---------------------------------------------------------------------
-// Route handlers. Each is registered both bare and under `/{prefix}`;
+// Route handlers. Each is registered both bare and under `/~{registry}`;
 // `TargetRegistry` reports which form the request arrived on.
 // ---------------------------------------------------------------------
 
 /// Path capture of the staged routes that address one record. Named rather
 /// than a bare `Path<String>` because the prefixed registration captures the
-/// `{prefix}` segment too, which a single-value `Path` would refuse.
+/// `{registry}` segment too, which a single-value `Path` would refuse.
 #[derive(Deserialize)]
 pub(super) struct StageIdPath {
     id: String,

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2145,6 +2145,60 @@ async fn scoped_tarball_filename_is_canonicalized_before_fetch_and_cache() {
     mock.assert_async().await;
 }
 
+/// npm spells a scoped package's name either as two literal path segments or
+/// as one percent-encoded segment, so the same package has several addresses.
+#[tokio::test]
+async fn every_address_of_one_scoped_package_reaches_it() {
+    let mut upstream = mockito::Server::new_async().await;
+    let bytes = b"scoped-address-bytes";
+    let _packument_mock =
+        mock_packument_for_tarball(&mut upstream, "@types/node", "20.0.0", bytes).await;
+    let _tarball_mock = upstream
+        .mock("GET", "/@types/node/-/node-20.0.0.tgz")
+        .with_status(200)
+        .with_body(bytes)
+        .create_async()
+        .await;
+
+    let tmp = TempDir::new().unwrap();
+    let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
+    let get = |path: &str| {
+        let app = app.clone();
+        let path = path.to_string();
+        async move {
+            app.oneshot(Request::get(path.as_str()).body(Body::empty()).unwrap()).await.unwrap()
+        }
+    };
+
+    for path in ["/@types/node", "/@types%2Fnode", "/~npmjs/@types/node", "/~npmjs/@types%2Fnode"] {
+        let response = get(path).await;
+        assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+        assert_eq!(body_json(response.into_body()).await["name"], "@types/node", "GET {path}");
+    }
+
+    for path in [
+        "/@types/node/20.0.0",
+        "/@types%2Fnode/20.0.0",
+        "/~npmjs/@types/node/20.0.0",
+        "/~npmjs/@types%2Fnode/20.0.0",
+    ] {
+        let response = get(path).await;
+        assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+        assert_eq!(body_json(response.into_body()).await["version"], "20.0.0", "GET {path}");
+    }
+
+    for path in [
+        "/@types/node/-/node-20.0.0.tgz",
+        "/@types%2Fnode/-/node-20.0.0.tgz",
+        "/~npmjs/@types/node/-/node-20.0.0.tgz",
+        "/~npmjs/@types%2Fnode/-/node-20.0.0.tgz",
+    ] {
+        let response = get(path).await;
+        assert_eq!(response.status(), StatusCode::OK, "GET {path}");
+        assert_eq!(body_bytes(response.into_body()).await, bytes, "GET {path}");
+    }
+}
+
 #[tokio::test]
 async fn packument_is_refetched_after_ttl_expires() {
     let mut upstream = mockito::Server::new_async().await;
@@ -2978,24 +3032,21 @@ async fn registry_only_serves_registry_and_refuses_resolver_endpoints() {
         }),
     );
 
-    // `/-/pnpr/v0/resolve` and `/-/pnpr/v0/verify-lockfile` are NOT stubbed:
-    // with the resolver disabled they fall through to the registry's
-    // four-segment catch-all (`GET|DELETE /{a}/{b}/{c}/{d}`), which has no
-    // POST handler, so a POST returns 405. Only `/-/pnpr` needs a stub for
-    // clean capability detection.
+    // With the resolver disabled its two endpoints are not mounted, and no
+    // other route claims them.
     let resolve = app
         .clone()
         .oneshot(Request::post("/-/pnpr/v0/resolve").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
-    assert_eq!(resolve.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(resolve.status(), StatusCode::NOT_FOUND);
 
     let verify = app
         .clone()
         .oneshot(Request::post("/-/pnpr/v0/verify-lockfile").body(Body::from("{}")).unwrap())
         .await
         .unwrap();
-    assert_eq!(verify.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(verify.status(), StatusCode::NOT_FOUND);
 
     mock.assert_async().await;
 }
@@ -4894,19 +4945,85 @@ async fn identity_endpoints_are_served_under_any_registry_prefix() {
     }
 }
 
-/// Falling through to the path-less behaviour here would let *any* first
-/// segment reach the account and staging endpoints.
+/// The account and staging endpoints answer under a `/~<name>/` prefix only.
+/// Letting *any* first segment reach them would expose them at as many
+/// addresses as a client cares to invent.
 #[tokio::test]
-async fn a_first_segment_that_is_not_a_tilde_prefix_is_not_found() {
+async fn a_first_segment_that_is_not_a_tilde_prefix_does_not_reach_the_account_endpoints() {
     let tmp = TempDir::new().unwrap();
     let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
     config.auth.htpasswd.max_users = MaxUsers::Unlimited;
     let app = router(config);
 
-    for path in ["/corp/-/whoami", "/~/-/whoami", "/corp/-/npm/v1/tokens", "/~/-/npm/v1/user"] {
+    for path in ["/~/-/whoami", "/corp/-/npm/v1/tokens", "/~/-/npm/v1/user"] {
         let response =
             app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND, "GET {path}");
+    }
+
+    // `/corp/-/whoami` is a well-formed tarball address — package `corp`,
+    // file `whoami` — so it reads through the registry graph instead of
+    // answering as whoami. The configured upstream is unreachable, which is
+    // what a package read of it reports.
+    let tarball_shaped =
+        app.oneshot(Request::get("/corp/-/whoami").body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(tarball_shaped.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+/// The scoped addresses spend two path segments on the package name, so their
+/// first segment has to be a scope. The configured upstream is unreachable, so
+/// a 404 rather than a 503 also shows the request was turned away before any
+/// registry lookup.
+#[tokio::test]
+async fn a_scoped_address_whose_first_segment_is_not_a_scope_is_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+    let app = router(config);
+
+    for (method, path) in [
+        ("GET", "/notascope/widget/1.0.0"),
+        ("GET", "/notascope/widget/-/widget-1.0.0.tgz"),
+        ("GET", "/~npmjs/notascope/widget/1.0.0"),
+        ("GET", "/~npmjs/notascope/widget/-/widget-1.0.0.tgz"),
+        ("PUT", "/notascope/widget"),
+        ("PUT", "/~npmjs/notascope/widget"),
+        ("DELETE", "/notascope/widget/-/widget-1.0.0.tgz/-rev/1"),
+        ("DELETE", "/~npmjs/notascope/widget/-/widget-1.0.0.tgz/-rev/1"),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().method(method).uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{method} {path}");
+    }
+}
+
+/// An address that exists for other methods answers `405`, not the `404` a
+/// route matching only on segment count used to produce.
+#[tokio::test]
+async fn a_method_the_address_does_not_serve_is_method_not_allowed() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+    config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+    let app = router(config);
+
+    for (method, path) in [
+        // `/{name}` reads and publishes.
+        ("DELETE", "/widget"),
+        // `/{name}/-rev/{rev}` updates and unpublishes.
+        ("GET", "/widget/-rev/1"),
+        ("GET", "/~npmjs/widget/-rev/1"),
+        // Search is a read.
+        ("DELETE", "/-/v1/search"),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().method(method).uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED, "{method} {path}");
     }
 }
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Takes the **"Explicit routes for the npm surface"** item off
pnpm/pnpm#14599.

The npm surface dispatched by segment count. Seven catch-all routes
(`/{name}`, `/{first}/{second}`, `/{a}/{b}/{c}`, … up to
`/{a}/{b}/{c}/{d}/{e}/{f}/{g}`) fanned out to handlers that re-derived the
resource from the `-`, `-rev`, `@` and `~` markers — once per arity, and again
per method. Adding an endpoint meant finding the right arity handler and
inserting another `if` into its ladder.

The issue framed this as a compatibility decision: drop the path-less root
alias in favour of `/npm/`, and the npm surface could use explicit routes like
Cargo and Python do. **It turns out no deprecation is needed.** What blocked
explicit routes was the assumption that a route parameter has to own a whole
path segment. matchit 0.8 (what axum 0.8 routes with) matches static text
inside a segment, so the registry prefix can be spelled `/~{registry}` and each
npm URL can be its own route. The path-less base keeps working exactly as it
does today.

The route table now reads as the npm registry API:

```rust
for base in ["", "/~{registry}"] {
    // …
    .route(&path("/-/v1/search"), get(get_search))
    .route(&path("/-/package/{name}/dist-tags"), get(get_package_dist_tags))
    .route(&path("/{name}"), get(get_packument).put(put_package))
    .route(&path("/{name}/-/{filename}"), get(get_tarball))
    .route(&path("/{name}/-rev/{rev}"), put(put_packument_revision).delete(unpublish_package))
    .route(&path("/{scope}/{name}/{version}"), get(get_scoped_version_manifest))
    .route(&path("/{scope}/{name}/-/{filename}"), get(get_scoped_tarball))
    // …
}
```

Each address is registered once, for the default target and for a named
registry, and `TargetRegistry` tells the handler which one it was reached
through. Handlers are named for the resource they serve
(`get_scoped_tarball`, `unpublish_package`, `put_package_dist_tag`) rather
than for how many segments the URL has.

One reading stays in a handler, because npm's URL grammar is genuinely
ambiguous there: a scoped name is either two literal segments (`/@scope/name`)
or one percent-encoded segment (`/@scope%2Fname`), so `/{first}/{second}` is a
scoped packument or a version manifest depending on the first segment's shape.
Everything else is anchored by the `-` and `-rev` markers.

The account, Cargo and Python surfaces move from `/{prefix}` to `/~{registry}`
too, so `TargetRegistry` no longer has to re-parse the `~`, and a first segment
that is not a registry prefix no longer matches a route that only meant to
serve one.

While in here: `serve_packument`, `serve_version_manifest` and `serve_tarball`
now take the addressed registry, which folds away the path-less vs `/~<name>/`
split every call site used to make; and `private_if_caller_gated` folds into
`caller_scoped`, which already did that job for the Cargo and Python surfaces.

### Behaviour changes

Every npm address answers as before — a new test walks all twelve spellings of
one scoped package's packument, version manifest and tarball, on the path-less
base and through a registry endpoint. Two edges move:

- A path no route claims answers `404` instead of falling into an arity
  catch-all. `POST /-/pnpr/v0/resolve` on a registry with the resolver disabled
  was a `405`; it is a `404` now.
- `/{pkg}/-/whoami` reads as the tarball address it is, instead of being
  shadowed by `/{prefix}/-/whoami`. The account endpoints answer under
  `/~<name>/` only.

## Squash Commit Body

```text
The npm surface dispatched by segment count: seven catch-all routes
(`/{a}/{b}/{c}`, `/{a}/{b}/{c}/{d}`, ...) whose handlers re-derived the
resource from `-`, `-rev`, `@` and `~` markers, once per arity and once
more per method. matchit 0.8 matches static text inside a segment, so a
registry prefix can be spelled `/~{registry}` and each npm URL can be its
own route. The path-less base needs no deprecation: what blocked explicit
routes was the assumption that a parameter has to own a whole segment.

Each address is now registered once, for the default target and for a
named registry, and handlers are named for the resource they serve. The
`-` and `-rev` markers anchor the table, so a scoped name spelled as two
literal segments and the same name percent-encoded land on the same
handler. The account, Cargo and Python surfaces move to `/~{registry}`
too, so a first segment that is not a registry prefix no longer reaches
an endpoint that only meant to serve one.

`serve_packument`, `serve_version_manifest` and `serve_tarball` take the
addressed registry, folding away the path-less/`~<name>` split that each
call site used to make, and `private_if_caller_gated` folds into
`caller_scoped`, which already did the same job for the other ecosystems.

A path no route claims now answers 404 rather than reaching an arity
catch-all, and `/{pkg}/-/whoami` reads as the tarball address it is
instead of being shadowed by the account endpoint.

Closes one item of pnpm/pnpm#14599
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E469r6skDjpq2GyNi1nZN6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14610"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791278817&installation_model_id=426870&pr_number=14610&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14610&signature=0d31b4ee59200221f61a67b17b3c50f3b3157b6bae9ef62427a6490380c7482d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added explicit named-registry URL support under `/~<name>/` for npm, Cargo, and PyPI endpoints.
  - Account and staging endpoints now respond only through supported `/~<name>/` addresses.
  - Scoped packages support consistent literal and encoded URL forms.
  - Added publish-protocol support when resolver functionality is disabled.

- **Bug Fixes**
  - Unsupported npm paths now return `404` or `405` as appropriate.
  - Invalid registry addresses no longer reach unrelated endpoints.
  - PyPI uploads now accept declared SHA-256 digests regardless of letter casing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->