### PR TITLE
refactor(pnpr): canonicalize ecosystem package names

### DIFF
--- a/.changeset/calm-cats-canonicalize.md
+++ b/.changeset/calm-cats-canonicalize.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+pnpr now canonicalizes package names consistently for npm, Cargo, and Python registry operations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6193,6 +6193,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "flate2",
+ "pnpr-package-name",
  "semver",
  "serde",
  "serde_json",
@@ -6211,11 +6212,9 @@ dependencies = [
  "pnpm-config-dir",
  "pnpm-env-replace",
  "pnpm-testing-utils",
- "pnpr-cargo",
  "pnpr-error",
  "pnpr-package-name",
  "pnpr-policy",
- "pnpr-pypi",
  "pnpr-registry",
  "reqwest",
  "serde",
@@ -6282,7 +6281,10 @@ dependencies = [
 name = "pnpr-package-name"
 version = "0.0.1"
 dependencies = [
+ "derive_more",
+ "pep508_rs",
  "pnpr-error",
+ "serde",
 ]
 
 [[package]]
@@ -6299,8 +6301,8 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "pep440_rs",
- "pep508_rs",
  "pnpm-network",
+ "pnpr-package-name",
  "regex",
  "serde",
  "serde_json",
@@ -6313,7 +6315,6 @@ dependencies = [
  "indexmap 2.14.0",
  "pnpr-error",
  "pnpr-package-name",
- "serde",
  "wax",
 ]
 

--- a/pnpr/crates/cargo/Cargo.toml
+++ b/pnpr/crates/cargo/Cargo.toml
@@ -11,13 +11,14 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-derive_more = { workspace = true }
-flate2      = { workspace = true }
-semver      = { workspace = true }
-serde       = { workspace = true }
-serde_json  = { workspace = true }
-tar         = { workspace = true }
-toml        = { workspace = true }
+derive_more       = { workspace = true }
+flate2            = { workspace = true }
+pnpr-package-name = { workspace = true }
+semver            = { workspace = true }
+serde             = { workspace = true }
+serde_json        = { workspace = true }
+tar               = { workspace = true }
+toml              = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/cargo/src/lib.rs
+++ b/pnpr/crates/cargo/src/lib.rs
@@ -10,6 +10,8 @@
 //! publish runs before accepting bytes.
 
 use derive_more::{Display, Error};
+use pnpr_package_name::canonicalize_crate_name;
+pub use pnpr_package_name::{CrateNameError, MAX_CRATE_NAME_LEN};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{
@@ -25,45 +27,16 @@ pub const INDEX_PATH: &str = "index";
 /// `/~<name>/api/v1/crates/new`, `/~<name>/api/v1/crates/<crate>/<version>/download`.
 pub const API_PATH: &str = "api/v1/crates";
 
-/// The longest crate name crates.io accepts.
-pub const MAX_CRATE_NAME_LEN: usize = 64;
-
 /// The decompressed size at which a published crate archive is rejected: a
 /// bound on the work a gzip bomb can force onto the archive check.
 pub const MAX_CRATE_ARCHIVE_UNPACKED_BYTES: u64 = 512 * 1024 * 1024;
-
-/// A crate name that no Cargo registry can serve.
-#[derive(Debug, Display, Error, Clone, PartialEq, Eq)]
-pub enum CrateNameError {
-    #[display("crate name must not be empty")]
-    Empty,
-    #[display("crate name {name:?} is longer than {MAX_CRATE_NAME_LEN} characters")]
-    TooLong { name: String },
-    #[display("crate name {name:?} must start with a letter or `_`")]
-    InvalidStart { name: String },
-    #[display("crate name {name:?} may only contain ASCII letters, digits, `-` and `_`")]
-    InvalidCharacter { name: String },
-}
 
 /// Validate a crate name the way crates.io does: ASCII letters, digits, `-`
 /// and `_`, starting with a letter or `_`, at most 64 characters. Every
 /// crate name in a URL, a publish body, or an index entry passes through
 /// here before it is used as a storage path segment.
 pub fn validate_crate_name(name: &str) -> Result<(), CrateNameError> {
-    let mut chars = name.chars();
-    let Some(first) = chars.next() else {
-        return Err(CrateNameError::Empty);
-    };
-    if name.len() > MAX_CRATE_NAME_LEN {
-        return Err(CrateNameError::TooLong { name: name.to_string() });
-    }
-    if !(first.is_ascii_alphabetic() || first == '_') {
-        return Err(CrateNameError::InvalidStart { name: name.to_string() });
-    }
-    if !chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_')) {
-        return Err(CrateNameError::InvalidCharacter { name: name.to_string() });
-    }
-    Ok(())
+    canonicalize_crate_name(name).map(|_| ())
 }
 
 /// The directory part of a crate's sparse-index path, in the name's own

--- a/pnpr/crates/config/Cargo.toml
+++ b/pnpr/crates/config/Cargo.toml
@@ -11,11 +11,9 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-cargo        = { workspace = true }
 pnpr-error        = { workspace = true }
 pnpr-package-name = { workspace = true }
 pnpr-policy       = { workspace = true }
-pnpr-pypi         = { workspace = true }
 pnpr-registry     = { workspace = true }
 pnpm-config-dir   = { workspace = true }
 pnpm-env-replace  = { workspace = true }

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -13,6 +13,7 @@ use object_store::{
 };
 use pnpm_env_replace::{EnvVar, SystemEnv, env_replace_lossy};
 use pnpr_error::{RegistryError, redact_url_credentials};
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::{AccessList, AccessToken, PackageRule, PackageRules};
 use pnpr_registry::{Ecosystem, PackagePattern, Registries, Registry, RegistryConfigError};
 use reqwest::header::HeaderMap;
@@ -1962,23 +1963,19 @@ fn ecosystem_package_keys(
     ecosystem: Ecosystem,
     packages: IndexMap<String, Option<PackageAccess>>,
 ) -> Result<IndexMap<String, Option<PackageAccess>>, RegistryError> {
-    let canonical = |key: &str| -> Result<String, String> {
-        match ecosystem {
-            Ecosystem::Npm => Ok(key.to_string()),
-            Ecosystem::Cargo => pnpr_cargo::validate_crate_name(key)
-                .map(|()| key.to_ascii_lowercase())
-                .map_err(|err| err.to_string()),
-            Ecosystem::Pypi => pnpr_pypi::normalize_name(key).map_err(|err| err.to_string()),
-        }
-    };
     let mut normalized = IndexMap::new();
     for (key, access) in packages {
         let normalized_key = if ecosystem == Ecosystem::Npm || key == "**" {
             key.clone()
         } else {
-            canonical(&key).map_err(|reason| RegistryError::InvalidConfig {
-                reason: format!("{ecosystem} registry {registry:?} `packages:` key: {reason}"),
-            })?
+            CanonicalPackageName::parse(&key, ecosystem)
+                .map(|name| name.as_str().to_string())
+                .map_err(|error| RegistryError::InvalidConfig {
+                    reason: format!(
+                        "{ecosystem} registry {registry:?} `packages:` key: {}",
+                        error.public_message(),
+                    ),
+                })?
         };
         if normalized.contains_key(&normalized_key) {
             return Err(RegistryError::InvalidConfig {

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -64,6 +64,16 @@ pub enum RegistryError {
         name: String,
     },
 
+    #[display("Package name {name:?} is not valid for {ecosystem}: {reason}")]
+    InvalidEcosystemPackageName {
+        #[error(not(source))]
+        name: String,
+        #[error(not(source))]
+        ecosystem: String,
+        #[error(not(source))]
+        reason: String,
+    },
+
     #[display("Tarball filename {filename:?} is not valid for package {package:?}")]
     InvalidTarballName {
         #[error(not(source))]
@@ -318,6 +328,7 @@ impl RegistryError {
             RegistryError::UpstreamUnavailable { .. } => "upstream_unavailable",
             RegistryError::TarballIntegrity { .. } => "tarball_integrity",
             RegistryError::InvalidPackageName { .. } => "invalid_package_name",
+            RegistryError::InvalidEcosystemPackageName { .. } => "invalid_package_name",
             RegistryError::InvalidTarballName { .. } => "invalid_tarball_name",
             RegistryError::InvalidConfig { .. } => "invalid_config",
             RegistryError::NotFound => "not_found",
@@ -415,6 +426,7 @@ impl RegistryError {
             | RegistryError::TarballIntegrity { .. } => StatusCode::BAD_GATEWAY,
             RegistryError::UpstreamUnavailable { .. } => StatusCode::SERVICE_UNAVAILABLE,
             RegistryError::InvalidPackageName { .. }
+            | RegistryError::InvalidEcosystemPackageName { .. }
             | RegistryError::InvalidTarballName { .. }
             | RegistryError::InvalidConfig { .. }
             | RegistryError::InvalidAttachment { .. }

--- a/pnpr/crates/package-name/Cargo.toml
+++ b/pnpr/crates/package-name/Cargo.toml
@@ -11,7 +11,10 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpr-error = { workspace = true }
+pnpr-error  = { workspace = true }
+derive_more = { workspace = true }
+pep508_rs   = { workspace = true }
+serde       = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/package-name/src/lib.rs
+++ b/pnpr/crates/package-name/src/lib.rs
@@ -65,13 +65,21 @@ pub struct CanonicalPackageName {
 
 impl CanonicalPackageName {
     pub fn parse(raw: &str, ecosystem: Ecosystem) -> Result<Self, RegistryError> {
-        let invalid = || RegistryError::InvalidPackageName { name: raw.to_string() };
         let canonical = match ecosystem {
             Ecosystem::Npm => raw.to_string(),
-            Ecosystem::Cargo => canonicalize_crate_name(raw).map_err(|_| invalid())?,
-            Ecosystem::Pypi => canonicalize_python_name(raw).map_err(|_| invalid())?,
+            Ecosystem::Cargo => canonicalize_crate_name(raw)
+                .map_err(|error| invalid_ecosystem_name(raw, ecosystem, error.to_string()))?,
+            Ecosystem::Pypi => canonicalize_python_name(raw)
+                .map_err(|error| invalid_ecosystem_name(raw, ecosystem, error.to_string()))?,
         };
-        Self::parse_canonical(&canonical)
+        Self::parse_canonical(&canonical).map_err(|error| match ecosystem {
+            Ecosystem::Npm => error,
+            Ecosystem::Cargo | Ecosystem::Pypi => invalid_ecosystem_name(
+                raw,
+                ecosystem,
+                "its canonical form is not a safe registry key".to_string(),
+            ),
+        })
     }
 
     fn parse_canonical(raw: &str) -> Result<Self, RegistryError> {
@@ -134,6 +142,14 @@ impl CanonicalPackageName {
             return Err(invalid());
         }
         Ok((self.tarball_name_for_version(version), version.to_string()))
+    }
+}
+
+fn invalid_ecosystem_name(name: &str, ecosystem: Ecosystem, reason: String) -> RegistryError {
+    RegistryError::InvalidEcosystemPackageName {
+        name: name.to_string(),
+        ecosystem: ecosystem.to_string(),
+        reason,
     }
 }
 

--- a/pnpr/crates/package-name/src/lib.rs
+++ b/pnpr/crates/package-name/src/lib.rs
@@ -1,12 +1,61 @@
+use derive_more::{Display, Error};
+use pep508_rs::PackageName as PythonPackageName;
 use pnpr_error::RegistryError;
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
 
-/// The name of a package in any ecosystem — an npm package, a crate, a
-/// Python project — validated to be safe for use as a filesystem path
-/// segment (no traversal, no absolute-path prefixes) and well-formed
-/// enough to send upstream. Callers canonicalize the name for their
-/// ecosystem first; this is what the storage layer keys a package by.
+/// The protocol whose naming rules a registry surface follows.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Ecosystem {
+    #[default]
+    Npm,
+    Cargo,
+    Pypi,
+}
+
+impl Ecosystem {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Ecosystem::Npm => "npm",
+            Ecosystem::Cargo => "cargo",
+            Ecosystem::Pypi => "pypi",
+        }
+    }
+}
+
+impl fmt::Display for Ecosystem {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+pub const MAX_CRATE_NAME_LEN: usize = 64;
+
+#[derive(Debug, Display, Error, Clone, PartialEq, Eq)]
+pub enum CrateNameError {
+    #[display("crate name must not be empty")]
+    Empty,
+    #[display("crate name {name:?} is longer than {MAX_CRATE_NAME_LEN} characters")]
+    TooLong { name: String },
+    #[display("crate name {name:?} must start with a letter or `_`")]
+    InvalidStart { name: String },
+    #[display("crate name {name:?} may only contain ASCII letters, digits, `-` and `_`")]
+    InvalidCharacter { name: String },
+}
+
+#[derive(Debug, Display, Error, Clone, PartialEq, Eq)]
+#[display("{name:?} is not a valid Python project name")]
+pub struct PythonNameError {
+    pub name: String,
+}
+
+/// The canonical name of an npm package, Cargo crate, or Python project.
+/// Construction applies the ecosystem's normalization and validation before
+/// the name can be used as a storage or cache key.
 #[derive(Debug, Clone)]
-pub struct PackageName {
+pub struct CanonicalPackageName {
     raw: String,
     /// The unscoped portion — for `@scope/name` this is `name`, for
     /// `name` this is the whole thing. Used to validate tarball
@@ -14,8 +63,18 @@ pub struct PackageName {
     basename: String,
 }
 
-impl PackageName {
-    pub fn parse(raw: &str) -> Result<Self, RegistryError> {
+impl CanonicalPackageName {
+    pub fn parse(raw: &str, ecosystem: Ecosystem) -> Result<Self, RegistryError> {
+        let invalid = || RegistryError::InvalidPackageName { name: raw.to_string() };
+        let canonical = match ecosystem {
+            Ecosystem::Npm => raw.to_string(),
+            Ecosystem::Cargo => canonicalize_crate_name(raw).map_err(|_| invalid())?,
+            Ecosystem::Pypi => canonicalize_python_name(raw).map_err(|_| invalid())?,
+        };
+        Self::parse_canonical(&canonical)
+    }
+
+    fn parse_canonical(raw: &str) -> Result<Self, RegistryError> {
         let invalid = || RegistryError::InvalidPackageName { name: raw.to_string() };
         if raw.is_empty() || raw.len() > 214 {
             return Err(invalid());
@@ -76,6 +135,37 @@ impl PackageName {
         }
         Ok((self.tarball_name_for_version(version), version.to_string()))
     }
+}
+
+pub fn canonicalize_crate_name(name: &str) -> Result<String, CrateNameError> {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return Err(CrateNameError::Empty);
+    };
+    if name.len() > MAX_CRATE_NAME_LEN {
+        return Err(CrateNameError::TooLong { name: name.to_string() });
+    }
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return Err(CrateNameError::InvalidStart { name: name.to_string() });
+    }
+    if !chars.all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_')) {
+        return Err(CrateNameError::InvalidCharacter { name: name.to_string() });
+    }
+    Ok(name.to_ascii_lowercase())
+}
+
+pub fn canonicalize_python_name(raw: &str) -> Result<String, PythonNameError> {
+    let invalid = || PythonNameError { name: raw.to_string() };
+    let normalized = PythonPackageName::from_str(raw).map_err(|_| invalid())?.as_ref().to_string();
+    let well_formed =
+        normalized.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        }) && normalized.chars().next().is_some_and(|character| character.is_ascii_alphanumeric())
+            && normalized
+                .chars()
+                .next_back()
+                .is_some_and(|character| character.is_ascii_alphanumeric());
+    well_formed.then_some(normalized).ok_or_else(invalid)
 }
 
 // `:` is rejected because on Windows `C:foo` is a drive-relative *prefix*

--- a/pnpr/crates/package-name/src/tests.rs
+++ b/pnpr/crates/package-name/src/tests.rs
@@ -14,6 +14,21 @@ fn canonicalizes_each_ecosystem() {
 }
 
 #[test]
+fn reports_ecosystem_specific_name_errors() {
+    let cargo_error = CanonicalPackageName::parse("9lives", Ecosystem::Cargo).unwrap_err();
+    assert_eq!(
+        cargo_error.public_message(),
+        r#"Package name "9lives" is not valid for cargo: crate name "9lives" must start with a letter or `_`"#,
+    );
+
+    let python_error = CanonicalPackageName::parse("demo package", Ecosystem::Pypi).unwrap_err();
+    assert_eq!(
+        python_error.public_message(),
+        r#"Package name "demo package" is not valid for pypi: "demo package" is not a valid Python project name"#,
+    );
+}
+
+#[test]
 fn accepts_unscoped() {
     let name = CanonicalPackageName::parse("lodash", Ecosystem::Npm).unwrap();
     assert_eq!(name.as_str(), "lodash");

--- a/pnpr/crates/package-name/src/tests.rs
+++ b/pnpr/crates/package-name/src/tests.rs
@@ -1,8 +1,21 @@
-use super::{PackageName, is_safe_path_segment};
+use super::{CanonicalPackageName, Ecosystem, is_safe_path_segment};
+
+#[test]
+fn canonicalizes_each_ecosystem() {
+    assert_eq!(CanonicalPackageName::parse("React", Ecosystem::Npm).unwrap().as_str(), "React");
+    assert_eq!(
+        CanonicalPackageName::parse("Serde_JSON", Ecosystem::Cargo).unwrap().as_str(),
+        "serde_json",
+    );
+    assert_eq!(
+        CanonicalPackageName::parse("Demo.Package_name", Ecosystem::Pypi).unwrap().as_str(),
+        "demo-package-name",
+    );
+}
 
 #[test]
 fn accepts_unscoped() {
-    let name = PackageName::parse("lodash").unwrap();
+    let name = CanonicalPackageName::parse("lodash", Ecosystem::Npm).unwrap();
     assert_eq!(name.as_str(), "lodash");
     assert_eq!(name.tarball_name_for_version("4.17.21"), "lodash-4.17.21.tgz");
     name.parse_tarball_name("lodash-4.17.21.tgz").unwrap();
@@ -10,7 +23,7 @@ fn accepts_unscoped() {
 
 #[test]
 fn accepts_scoped() {
-    let name = PackageName::parse("@types/node").unwrap();
+    let name = CanonicalPackageName::parse("@types/node", Ecosystem::Npm).unwrap();
     assert_eq!(name.as_str(), "@types/node");
     assert_eq!(name.tarball_name_for_version("20.0.0"), "node-20.0.0.tgz");
     name.parse_tarball_name("node-20.0.0.tgz").unwrap();
@@ -18,19 +31,19 @@ fn accepts_scoped() {
 
 #[test]
 fn rejects_traversal() {
-    assert!(PackageName::parse("..").is_err());
-    assert!(PackageName::parse("foo/../bar").is_err());
-    assert!(PackageName::parse("@scope/..").is_err());
+    assert!(CanonicalPackageName::parse("..", Ecosystem::Npm).is_err());
+    assert!(CanonicalPackageName::parse("foo/../bar", Ecosystem::Npm).is_err());
+    assert!(CanonicalPackageName::parse("@scope/..", Ecosystem::Npm).is_err());
 }
 
 #[test]
 fn rejects_dot_prefix() {
-    assert!(PackageName::parse(".hidden").is_err());
+    assert!(CanonicalPackageName::parse(".hidden", Ecosystem::Npm).is_err());
 }
 
 #[test]
 fn rejects_tarball_for_other_package() {
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", Ecosystem::Npm).unwrap();
     assert!(name.parse_tarball_name("bar-1.0.0.tgz").is_err());
     assert!(name.parse_tarball_name("../foo-1.0.0.tgz").is_err());
     assert!(name.parse_tarball_name("foo-1.0.0").is_err());
@@ -44,9 +57,9 @@ fn rejects_tarball_for_other_package() {
 fn rejects_windows_drive_prefixes() {
     assert!(!is_safe_path_segment("C:evil.tgz"));
     assert!(!is_safe_path_segment("c:"));
-    assert!(PackageName::parse("C:foo").is_err());
-    assert!(PackageName::parse("@scope/C:foo").is_err());
-    let name = PackageName::parse("foo").unwrap();
+    assert!(CanonicalPackageName::parse("C:foo", Ecosystem::Npm).is_err());
+    assert!(CanonicalPackageName::parse("@scope/C:foo", Ecosystem::Npm).is_err());
+    let name = CanonicalPackageName::parse("foo", Ecosystem::Npm).unwrap();
     assert!(name.parse_tarball_name("foo-1.0.0:x.tgz").is_err());
 }
 
@@ -56,11 +69,11 @@ fn rejects_windows_drive_prefixes() {
 #[test]
 fn rejects_url_delimiters_and_blanks() {
     for raw in ["foo?bar", "foo#bar", "foo%2fbar", "foo bar", "foo\tbar", "foo\u{7f}bar"] {
-        assert!(PackageName::parse(raw).is_err(), "{raw:?}");
+        assert!(CanonicalPackageName::parse(raw, Ecosystem::Npm).is_err(), "{raw:?}");
         assert!(!is_safe_path_segment(raw), "{raw:?}");
     }
-    assert!(PackageName::parse("@scope/foo?bar").is_err());
-    assert!(PackageName::parse("@sco?pe/foo").is_err());
-    let name = PackageName::parse("foo").unwrap();
+    assert!(CanonicalPackageName::parse("@scope/foo?bar", Ecosystem::Npm).is_err());
+    assert!(CanonicalPackageName::parse("@sco?pe/foo", Ecosystem::Npm).is_err());
+    let name = CanonicalPackageName::parse("foo", Ecosystem::Npm).unwrap();
     assert!(name.parse_tarball_name("foo-1.0.0?x.tgz").is_err());
 }

--- a/pnpr/crates/pnpr/src/resolver/cargo.rs
+++ b/pnpr/crates/pnpr/src/resolver/cargo.rs
@@ -233,14 +233,16 @@ impl IndexFetcher {
     /// holds it fetches and caches the entry while the rest wait and read
     /// what it stored.
     async fn index_file(&self, name: &str) -> Result<String, String> {
-        pnpr_cargo::validate_crate_name(name).map_err(|err| err.to_string())?;
+        let canonical_name =
+            pnpr_package_name::CanonicalPackageName::parse(name, pnpr_registry::Ecosystem::Cargo)
+                .map_err(|err| err.to_string())?;
         let relative_path = pnpr_cargo::sparse_index_path(name);
         let url = format!("{}/{relative_path}", self.registry);
         // The route policy classifies a fetch by the crate it is for, as the
         // Cargo registry surface does, so an upstream's per-crate rules
         // decide the credential and the cache namespace here too. Both
         // surfaces match rules against the lowercased crate name.
-        let canonical_name = name.to_ascii_lowercase();
+        let canonical_name = canonical_name.as_str().to_string();
         let auth = self.auth_for(&canonical_name);
         let cache_path = self.cache_path(&auth, &url, &relative_path);
         if let Some(cached) = self.cached(&cache_path).await {

--- a/pnpr/crates/pnpr/src/resolver/pypi.rs
+++ b/pnpr/crates/pnpr/src/resolver/pypi.rs
@@ -597,7 +597,9 @@ fn index_url(index: &str) -> Result<url::Url, String> {
 /// The PEP 503 spelling of a project's name, which is what the Python
 /// registry surface matches its rules against.
 fn canonical_project_name(name: &pep508_rs::PackageName) -> Result<String, String> {
-    pnpr_pypi::normalize_name(name.as_ref()).map_err(|err| err.to_string())
+    pnpr_package_name::CanonicalPackageName::parse(name.as_ref(), pnpr_registry::Ecosystem::Pypi)
+        .map(|name| name.as_str().to_string())
+        .map_err(|err| err.to_string())
 }
 
 fn within_budget(held: usize) -> bool {

--- a/pnpr/crates/pnpr/src/resolver/wire.rs
+++ b/pnpr/crates/pnpr/src/resolver/wire.rs
@@ -15,7 +15,7 @@ use pnpm_resolving_npm_resolver::ObservedDistStats;
 use pnpm_resolving_resolver_base::PackageVersionGuard;
 
 use pnpr_osv::{OsvIndex, format_advisory_ids};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_route::{RouteClass, RouteContext, sanitize_registry_tarball_url, strip_url_credentials};
 use pnpr_upstream::tarball_basename;
@@ -166,7 +166,7 @@ impl TarballRouter {
 fn tarball_filename(package: &str, version: &str, tarball_url: &str) -> String {
     tarball_basename(tarball_url).map_or_else(
         || {
-            PackageName::parse(package).map_or_else(
+            CanonicalPackageName::parse(package, pnpr_package_name::Ecosystem::Npm).map_or_else(
                 |_| format!("{package}-{version}.tgz"),
                 |name| name.tarball_name_for_version(version),
             )

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -46,7 +46,7 @@ use pnpm_lockfile::TarballRevision;
 use pnpr_auth::{AuthState, UpsertOutcome, identify};
 use pnpr_config::{Config, HostedConfig};
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{ConcreteKind, Ecosystem, Registry, Resolved};
 use pnpr_storage::{
@@ -603,7 +603,7 @@ async fn serve_registry_version_manifest(
     version_or_tag: &str,
     tarball_base: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -835,7 +835,7 @@ async fn load_upstream_packument(
     state: &AppState,
     namespace: &str,
     upstream: &Upstream,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     ttl: Duration,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     if upstream.caches()
@@ -909,7 +909,7 @@ async fn recover_stale_upstream_packument(
     state: &AppState,
     namespace: &str,
     upstream: &Upstream,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     err: RegistryError,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     if !err.is_transient_upstream_error() || !upstream.caches() {
@@ -936,7 +936,7 @@ async fn load_upstream_packument_for(
     state: &AppState,
     identity: &Identity,
     upstream: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     let namespace = upstream_cache_namespace(state, upstream);
     let upstream = authorized_upstream(state, identity, upstream)?;
@@ -954,7 +954,7 @@ async fn load_packument_for_read(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
-    name: &PackageName,
+    name: &CanonicalPackageName,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     let target = match registry {
         Some(registry) => registry.to_string(),
@@ -991,7 +991,7 @@ async fn serve_packument_via_upstream(
     identity: &Identity,
     headers: &HeaderMap,
     upstream: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     tarball_base: &str,
     revision_registry: Option<&str>,
 ) -> Response {
@@ -1026,7 +1026,7 @@ async fn serve_tarball_via_upstream(
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -1268,7 +1268,10 @@ async fn serve_hosted_revision_tarball(
             Err(err) => return private_no_cache(err.into_response()),
         };
         for original in refs {
-            let package = match PackageName::parse(&original.package) {
+            let package = match CanonicalPackageName::parse(
+                &original.package,
+                pnpr_package_name::Ecosystem::Npm,
+            ) {
                 Ok(package) => package,
                 Err(err) => return private_no_cache(err.into_response()),
             };
@@ -1352,7 +1355,7 @@ async fn hosted_revision_refs(
 
 async fn hosted_original_is_current(
     storage: &Storage,
-    package: &PackageName,
+    package: &CanonicalPackageName,
     version: &str,
     digest: &str,
 ) -> Result<bool, RegistryError> {
@@ -1371,7 +1374,7 @@ async fn hosted_original_is_current(
 
 async fn open_hosted_revision_tarball(
     storage: &Storage,
-    package: &PackageName,
+    package: &CanonicalPackageName,
     version: &str,
     digest: &str,
     integrity: &Integrity,
@@ -1458,7 +1461,7 @@ fn original_integrity(dist: &HostedRevisionDist) -> Option<Integrity> {
 async fn cached_upstream_tarball(
     state: &AppState,
     namespace: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     filename: &str,
 ) -> Option<Response> {
     match timed(
@@ -1658,7 +1661,7 @@ async fn serve_registry_packument(
     raw_name: &str,
     tarball_base: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -1711,7 +1714,7 @@ async fn serve_registry_tarball(
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -1806,7 +1809,7 @@ async fn serve_hosted_packument(
     identity: &Identity,
     headers: &HeaderMap,
     source: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     tarball_base: &str,
 ) -> Response {
     let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
@@ -1836,7 +1839,7 @@ async fn serve_hosted_tarball(
     state: &AppState,
     identity: &Identity,
     source: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     filename: &str,
 ) -> Response {
     let org = match hosted_read_namespace(state, identity, source, name.as_str()) {
@@ -1912,7 +1915,7 @@ struct DistBlock {
 
 fn expected_tarball_dist(
     packument: &[u8],
-    name: &PackageName,
+    name: &CanonicalPackageName,
     filename: &str,
 ) -> Result<Option<TarballDist>, RegistryError> {
     let packument: PackumentDists = serde_json::from_slice(packument)?;
@@ -1971,7 +1974,7 @@ fn expected_tarball_dist(
 
 fn tarball_stream_error(
     err: streaming::BlobStreamError,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     filename: &str,
 ) -> RegistryError {
     tarball_stream_error_for_package(err, name.as_str(), filename)
@@ -2492,7 +2495,9 @@ async fn serve_org_packages(
     raw_scope: &str,
 ) -> Response {
     let scope = raw_scope.strip_prefix('@').unwrap_or(raw_scope);
-    if PackageName::parse(&format!("@{scope}/package")).is_err() {
+    if CanonicalPackageName::parse(&format!("@{scope}/package"), pnpr_package_name::Ecosystem::Npm)
+        .is_err()
+    {
         return not_found();
     }
     let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
@@ -2699,7 +2704,7 @@ fn resolve_write_target(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
-    name: &PackageName,
+    name: &CanonicalPackageName,
 ) -> Result<WriteTarget, RegistryError> {
     resolve_write_target_for(state, identity, registry, Ecosystem::Npm, name)
 }
@@ -2710,7 +2715,7 @@ fn resolve_write_target_for(
     identity: &Identity,
     registry: Option<&str>,
     ecosystem: Ecosystem,
-    name: &PackageName,
+    name: &CanonicalPackageName,
 ) -> Result<WriteTarget, RegistryError> {
     match resolve_publish_target_for(state, identity, registry, ecosystem, name.as_str()) {
         PublishTarget::Hosted { source, org } => Ok(WriteTarget { source, org }),
@@ -2746,7 +2751,7 @@ fn wants_abbreviated(headers: &HeaderMap) -> bool {
 /// `application/vnd.npm.install-v1+json` content type. Parse
 /// failures surface as 502 via `RegistryError::Json`.
 fn packument_response(
-    name: &PackageName,
+    name: &CanonicalPackageName,
     bytes: &[u8],
     tarball_base: &str,
     revision_registry: Option<&str>,
@@ -2773,7 +2778,7 @@ fn packument_response(
 
 fn filter_osv_vulnerable_versions(
     packument: &mut Value,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     osv_index: Option<&Arc<pnpr_osv::OsvIndex>>,
 ) {
     let Some(osv_index) = osv_index else { return };
@@ -2819,7 +2824,7 @@ fn filter_osv_vulnerable_versions(
 fn filter_osv_vulnerable_dist_tags(
     tags: &mut Value,
     packument: &Value,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     osv_index: Option<&Arc<pnpr_osv::OsvIndex>>,
 ) {
     let Some(osv_index) = osv_index else { return };
@@ -2863,7 +2868,7 @@ fn resolve_version_or_tag<'a>(packument: &'a Value, version_or_tag: &'a str) -> 
 
 fn ensure_osv_allowed(
     state: &AppState,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     version: &str,
 ) -> Result<(), RegistryError> {
     let Some(osv_index) = state.inner.osv_index.as_ref() else {

--- a/pnpr/crates/pnpr/src/server/batch.rs
+++ b/pnpr/crates/pnpr/src/server/batch.rs
@@ -40,7 +40,7 @@ use axum::{
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use pnpr_cargo::PublishMetadata;
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_pypi::Upload;
 use pnpr_registry::Ecosystem;
 use pnpr_storage::publish::now_iso;
@@ -100,7 +100,7 @@ impl ValidatedEntry {
         }
     }
 
-    fn key(&self) -> &PackageName {
+    fn key(&self) -> &CanonicalPackageName {
         match self {
             ValidatedEntry::Npm(doc, _) => &doc.name,
             ValidatedEntry::Cargo(publication) => publication.key(),
@@ -206,7 +206,7 @@ async fn validate_entry(
                     reason: "every npm entry in `packages` must have a string `name`".to_string(),
                 }
             })?;
-            let name = PackageName::parse(name)?;
+            let name = CanonicalPackageName::parse(name, pnpr_package_name::Ecosystem::Npm)?;
             // The batch endpoint is path-less, so each package routes via the
             // default target; validation resolves that route and checks the
             // resolved hosted registry's publish rule per document.

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -39,10 +39,10 @@ use axum::{
 use pnpr_cargo::{
     CrateDocument, IndexConfig, IndexEntry, PublishMetadata, crate_filename, download_url,
     errors_json, ok_json, parse_index, parse_publish_body, publish_ok_json, sparse_index_path,
-    validate_crate_archive, validate_crate_name,
+    validate_crate_archive,
 };
 use pnpr_error::RegistryError;
-use pnpr_package_name::{PackageName, is_safe_path_segment};
+use pnpr_package_name::{CanonicalPackageName, is_safe_path_segment};
 use pnpr_policy::Identity;
 use pnpr_registry::Ecosystem;
 use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentUpdate};
@@ -89,13 +89,6 @@ fn bad_request(reason: impl Display) -> Response {
     error_response(RegistryError::BadRequest { reason: reason.to_string() })
 }
 
-/// The lowercase cache/storage key of a crate.
-fn crate_key(name: &str) -> Result<PackageName, RegistryError> {
-    validate_crate_name(name)
-        .map_err(|err| RegistryError::BadRequest { reason: err.to_string() })?;
-    PackageName::parse(&name.to_ascii_lowercase())
-}
-
 /// `GET index/config.json`.
 async fn get_index_config(
     State(state): State<AppState>,
@@ -134,19 +127,13 @@ async fn get_index_file(
     let segments: Vec<&str> =
         ["a", "b", "c"].iter().filter_map(|key| params.get(*key).map(String::as_str)).collect();
     let Some(name) = segments.last().copied() else { return not_found() };
-    if validate_crate_name(name).is_err() {
-        return not_found();
-    }
+    let Ok(key) = CanonicalPackageName::parse(name, ECOSYSTEM) else { return not_found() };
     let path = sparse_index_path(name);
     if path != segments.join("/") {
         return not_found();
     }
     let Some(target) = addressed_registry(&state, registry.as_deref()) else {
         return not_found();
-    };
-    let key = match crate_key(name) {
-        Ok(key) => key,
-        Err(err) => return error_response(err),
     };
     let index = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, key.as_str()) {
         RegistrySource::Hosted(source) => {
@@ -171,7 +158,7 @@ async fn load_upstream_index(
     state: &AppState,
     identity: &Identity,
     source: &RegistrySource,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     path: &str,
 ) -> Result<Option<String>, RegistryError> {
     let (upstream, namespace) = upstream_for(state, identity, source, key)?;
@@ -201,15 +188,12 @@ async fn get_download(
     let (Some(name), Some(version)) = (params.get("name"), params.get("version")) else {
         return not_found();
     };
-    if validate_crate_name(name).is_err() || !is_safe_path_segment(version) {
+    let Ok(key) = CanonicalPackageName::parse(name, ECOSYSTEM) else { return not_found() };
+    if !is_safe_path_segment(version) {
         return not_found();
     }
     let Some(target) = addressed_registry(&state, registry.as_deref()) else {
         return not_found();
-    };
-    let key = match crate_key(name) {
-        Ok(key) => key,
-        Err(err) => return error_response(err),
     };
     let response = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, key.as_str()) {
         RegistrySource::Hosted(source) => {
@@ -229,7 +213,7 @@ async fn download_hosted_crate(
     state: &AppState,
     identity: &Identity,
     source: &str,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     version: &str,
 ) -> Result<Response, RegistryError> {
     let document = read_hosted_document::<CrateDocument>(state, identity, source, key)
@@ -247,7 +231,7 @@ async fn download_via_upstream(
     state: &AppState,
     identity: &Identity,
     source: &RegistrySource,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     name: &str,
     version: &str,
 ) -> Response {
@@ -281,7 +265,8 @@ async fn download_via_upstream(
             reason: format!("index entry {name}@{version} has no SHA-256 checksum"),
         });
     };
-    let config_key = PackageName::parse(INDEX_CONFIG_KEY).expect("static key is a safe segment");
+    let config_key = CanonicalPackageName::parse(INDEX_CONFIG_KEY, Ecosystem::Npm)
+        .expect("static key is a safe segment");
     let request = UpstreamDocument {
         name: &config_key,
         relative_path: INDEX_CONFIG_KEY,
@@ -348,7 +333,7 @@ async fn put_publish(
 /// will record it is built. Publishing it is [`Self::publish`] on its own, or
 /// [`Self::stage`] as one package of a cross-ecosystem batch.
 pub(super) struct CratePublication {
-    key: PackageName,
+    key: CanonicalPackageName,
     org: String,
     filename: String,
     entry: IndexEntry,
@@ -372,7 +357,7 @@ pub(super) async fn validate_crate_publish(
 /// so a caller holding an undecoded payload can settle the question before
 /// spending anything on the archive.
 pub(super) struct CrateTarget {
-    key: PackageName,
+    key: CanonicalPackageName,
     org: String,
 }
 
@@ -383,7 +368,7 @@ pub(super) fn authorize_crate_publish(
     metadata: &PublishMetadata,
 ) -> Result<CrateTarget, RegistryError> {
     metadata.validate().map_err(|err| RegistryError::BadRequest { reason: err.to_string() })?;
-    let key = crate_key(&metadata.name)?;
+    let key = CanonicalPackageName::parse(&metadata.name, ECOSYSTEM)?;
     let (source, org) =
         match resolve_publish_target_for(state, identity, registry, ECOSYSTEM, key.as_str()) {
             PublishTarget::Hosted { source, org } => (source, org),
@@ -417,7 +402,7 @@ pub(super) async fn verify_crate_archive(
 }
 
 impl CratePublication {
-    pub(super) fn key(&self) -> &PackageName {
+    pub(super) fn key(&self) -> &CanonicalPackageName {
         &self.key
     }
 
@@ -495,7 +480,7 @@ async fn set_yanked(
     let (Some(name), Some(version)) = (params.get("name"), params.get("version")) else {
         return not_found();
     };
-    let key = match crate_key(name) {
+    let key = match CanonicalPackageName::parse(name, ECOSYSTEM) {
         Ok(key) => key,
         Err(err) => return error_response(err),
     };

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -16,7 +16,7 @@ use super::{
 };
 use pnpr_cargo::{CrateDocument, crate_filename};
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_pypi::ProjectDocument;
 use pnpr_registry::Ecosystem;
@@ -143,7 +143,7 @@ pub(super) async fn read_hosted_document<Document: HostedDocument>(
     state: &AppState,
     identity: &Identity,
     source: &str,
-    key: &PackageName,
+    key: &CanonicalPackageName,
 ) -> Result<Option<Document>, RegistryError> {
     let org = hosted_read_namespace(state, identity, source, key.as_str())?;
     state
@@ -169,7 +169,7 @@ pub(super) async fn read_hosted_document<Document: HostedDocument>(
 pub(super) async fn store_hosted_artifact<Document: HostedDocument + Send>(
     state: &AppState,
     org: &str,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     filename: &str,
     bytes: &[u8],
     refuse: impl Fn(&Document) -> Result<(), RegistryError> + Send + Sync,
@@ -200,7 +200,7 @@ pub(super) async fn store_hosted_artifact<Document: HostedDocument + Send>(
 pub(super) async fn stage_hosted_artifact<Document: HostedDocument + Send>(
     state: &AppState,
     org: &str,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     filename: &str,
     bytes: &[u8],
     refuse: &(impl Fn(&Document) -> Result<(), RegistryError> + Send + Sync),

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -18,7 +18,7 @@ use super::{
 };
 use axum::response::{IntoResponse, Response};
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{Ecosystem, Registry};
 use pnpr_storage::streaming;
@@ -121,7 +121,7 @@ pub(super) async fn serve_hosted_blob(
     state: &AppState,
     identity: &Identity,
     source: &str,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     filename: &str,
 ) -> Result<Response, RegistryError> {
     let org = hosted_read_namespace(state, identity, source, key.as_str())?;
@@ -138,7 +138,7 @@ pub(super) fn upstream_for<'state>(
     state: &'state AppState,
     identity: &Identity,
     source: &RegistrySource,
-    key: &PackageName,
+    key: &CanonicalPackageName,
 ) -> Result<(&'state Upstream, String), RegistryError> {
     let RegistrySource::Upstream(name) = source else {
         return Err(RegistryError::NotFound);
@@ -151,7 +151,7 @@ pub(super) fn upstream_for<'state>(
 /// An upstream metadata document to read through the proxy cache.
 pub(super) struct UpstreamDocument<'request> {
     /// The cache key.
-    pub(super) name: &'request PackageName,
+    pub(super) name: &'request CanonicalPackageName,
     /// The path relative to the upstream's base URL.
     pub(super) relative_path: &'request str,
     pub(super) accept: Option<&'request str>,
@@ -212,7 +212,7 @@ pub(super) async fn serve_upstream_artifact(
     state: &AppState,
     upstream: &Upstream,
     namespace: &str,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     filename: &str,
     url: &str,
     integrity: &Integrity,

--- a/pnpr/crates/pnpr/src/server/package_mutation.rs
+++ b/pnpr/crates/pnpr/src/server/package_mutation.rs
@@ -6,7 +6,7 @@ use axum::{
 use serde_json::{Value, json};
 
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentUpdate, DocumentWrite, publish::now_iso};
 
@@ -33,7 +33,7 @@ pub(super) async fn update_packument(
     raw_name: &str,
     body: &[u8],
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -140,7 +140,7 @@ pub(super) async fn update_packument(
 /// restores). Must hold the package lock so a concurrent publish can't race it.
 fn enforce_published_version_immutability(
     hosted: &Value,
-    name: &PackageName,
+    name: &CanonicalPackageName,
     incoming: &mut Value,
 ) -> Option<RegistryError> {
     // None (no versions to enforce) means "accept", not "error" here.
@@ -234,7 +234,7 @@ fn enforce_published_version_immutability(
 /// [`pnpr_upstream::rewrite_tarball_urls`]: the `dist.tarball` URL's own basename when it has
 /// one, otherwise the version-derived canonical name the rewrite falls back to.
 /// Returns `None` when the manifest carries no string `dist.tarball` to serve.
-fn served_tarball_basename(manifest: &Value, pkg: &PackageName) -> Option<String> {
+fn served_tarball_basename(manifest: &Value, pkg: &CanonicalPackageName) -> Option<String> {
     let url = manifest.get("dist").and_then(|dist| dist.get("tarball")).and_then(Value::as_str)?;
     if let Some(basename) = tarball_basename(url) {
         return Some(basename.to_owned());
@@ -264,7 +264,7 @@ pub(super) async fn delete_package(
     registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -309,7 +309,7 @@ pub(super) async fn delete_tarball(
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -355,7 +355,7 @@ pub(super) async fn get_dist_tags(
     registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -433,7 +433,7 @@ async fn update_dist_tag<Mutate>(
 where
     Mutate: FnMut(&mut serde_json::Map<String, Value>) -> Result<(), RegistryError>,
 {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -11,7 +11,7 @@ use serde_json::{Value, json};
 use ssri::Integrity;
 
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
 use pnpr_registry::{Ecosystem, Registry};
 use pnpr_storage::{
@@ -152,7 +152,7 @@ pub(super) async fn publish_package(
     raw_name: &str,
     body: axum::body::Bytes,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(n) => n,
         Err(err) => return err.into_response(),
     };
@@ -248,7 +248,7 @@ pub(super) async fn serve_batch_publish(
             }
             .into_response();
         };
-        let name = match PackageName::parse(doc_name) {
+        let name = match CanonicalPackageName::parse(doc_name, pnpr_package_name::Ecosystem::Npm) {
             Ok(name) => name,
             Err(err) => return err.into_response(),
         };
@@ -304,7 +304,7 @@ pub(super) async fn serve_batch_publish(
 /// each attachment maps to a canonical disk filename and a
 /// `versions[v].dist` block.
 pub(super) struct ValidatedPublish {
-    pub(super) name: PackageName,
+    pub(super) name: CanonicalPackageName,
     /// The publish body with `_attachments` stripped.
     pub(super) incoming: Value,
     /// One entry per attachment.
@@ -329,7 +329,7 @@ pub(super) async fn validate_publish_doc(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
-    name: PackageName,
+    name: CanonicalPackageName,
     mut incoming: Value,
 ) -> Result<(ValidatedPublish, WriteTarget), RegistryError> {
     // Route the write to its hosted registry first (masking a denied caller
@@ -391,7 +391,7 @@ fn record_publisher(incoming: &mut Value, identity: &Identity) {
 /// [`commit_publishes`] makes it visible. Every surface stages into this, so
 /// one commit can carry packages of more than one ecosystem.
 pub(super) struct StagedPublish {
-    pub(super) name: PackageName,
+    pub(super) name: CanonicalPackageName,
     pub(super) ecosystem: Ecosystem,
     /// The document to record, merged with what the store held when it was
     /// read: a packument, a crate document, a project document.
@@ -538,7 +538,7 @@ pub(super) async fn stage_publish(
 }
 
 fn staged_hosted_original_ref(
-    package: &PackageName,
+    package: &CanonicalPackageName,
     attachment: &PreparedAttachment,
 ) -> Option<JournaledRevisionRef> {
     let integrity: Integrity = attachment.dist.get("integrity")?.as_str()?.parse().ok()?;

--- a/pnpr/crates/pnpr/src/server/pypi.rs
+++ b/pnpr/crates/pnpr/src/server/pypi.rs
@@ -36,13 +36,13 @@ use axum::{
     routing::{get, post},
 };
 use pnpr_error::RegistryError;
-use pnpr_package_name::{PackageName, is_safe_path_segment};
+use pnpr_package_name::{CanonicalPackageName, is_safe_path_segment};
 use pnpr_policy::Identity;
 use pnpr_pypi::{
     DistributionKind, FILES_PATH, HTML_CONTENT_TYPE, JSON_CONTENT_TYPE, ProjectDocument,
-    ProjectFile, SIMPLE_PATH, UPLOAD_PATH, Upload, Yanked, multipart, normalize_name,
-    normalize_version, parse_distribution_filename, parse_upload, render_project_list_html,
-    render_project_list_json, wants_json, wants_versioned_html,
+    ProjectFile, SIMPLE_PATH, UPLOAD_PATH, Upload, Yanked, multipart, normalize_version,
+    parse_distribution_filename, parse_upload, render_project_list_html, render_project_list_json,
+    wants_json, wants_versioned_html,
 };
 use pnpr_registry::Ecosystem;
 use pnpr_storage::publish::now_iso;
@@ -163,7 +163,8 @@ async fn get_project_page(
     Path(params): Path<HashMap<String, String>>,
 ) -> Response {
     let Some(raw_project) = params.get("project") else { return not_found() };
-    let Ok(project) = normalize_name(raw_project) else { return not_found() };
+    let Ok(key) = CanonicalPackageName::parse(raw_project, ECOSYSTEM) else { return not_found() };
+    let project = key.as_str();
     let endpoint = registry_endpoint(&state, ECOSYSTEM, registry.as_deref());
     if project != *raw_project {
         return Response::builder()
@@ -175,16 +176,12 @@ async fn get_project_page(
     let Some(target) = addressed_registry(&state, registry.as_deref()) else {
         return not_found();
     };
-    let key = match PackageName::parse(&project) {
-        Ok(key) => key,
-        Err(err) => return err.into_response(),
-    };
-    let document = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, &project) {
+    let document = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, project) {
         RegistrySource::Hosted(source) => {
             read_hosted_document::<ProjectDocument>(&state, &identity, &source, &key).await
         }
         source @ RegistrySource::Upstream(_) => {
-            load_upstream_page(&state, &identity, &source, &key, &project)
+            load_upstream_page(&state, &identity, &source, &key, project)
                 .await
                 .map(|page| page.map(|(document, _)| document))
         }
@@ -202,7 +199,7 @@ async fn get_project_page(
         Ok(None) => not_found(),
         Err(err) => err.into_response(),
     };
-    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), Some(&project), response)
+    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), Some(project), response)
 }
 
 /// An upstream project's page through the cache, as the parsed document plus
@@ -211,7 +208,7 @@ async fn load_upstream_page(
     state: &AppState,
     identity: &Identity,
     source: &RegistrySource,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     project: &str,
 ) -> Result<Option<(ProjectDocument, url::Url)>, RegistryError> {
     let (upstream, namespace) = upstream_for(state, identity, source, key)?;
@@ -255,18 +252,15 @@ async fn get_file(
     else {
         return not_found();
     };
-    let Ok(project) = normalize_name(raw_project) else { return not_found() };
+    let Ok(key) = CanonicalPackageName::parse(raw_project, ECOSYSTEM) else { return not_found() };
+    let project = key.as_str();
     if !is_safe_path_segment(filename) {
         return not_found();
     }
     let Some(target) = addressed_registry(&state, registry.as_deref()) else {
         return not_found();
     };
-    let key = match PackageName::parse(&project) {
-        Ok(key) => key,
-        Err(err) => return err.into_response(),
-    };
-    let response = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, &project) {
+    let response = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, project) {
         RegistrySource::Hosted(source) => {
             match read_hosted_document::<ProjectDocument>(&state, &identity, &source, &key).await {
                 Ok(Some(document)) if document.file(filename).is_some() => {
@@ -279,11 +273,11 @@ async fn get_file(
             }
         }
         source @ RegistrySource::Upstream(_) => {
-            file_via_upstream(&state, &identity, &source, &key, &project, filename).await
+            file_via_upstream(&state, &identity, &source, &key, project, filename).await
         }
         RegistrySource::Unclaimed | RegistrySource::NotFound => not_found(),
     };
-    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), Some(&project), response)
+    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), Some(project), response)
 }
 
 /// Proxy a file download: bind the request to the page's entry for the
@@ -293,7 +287,7 @@ async fn file_via_upstream(
     state: &AppState,
     identity: &Identity,
     source: &RegistrySource,
-    key: &PackageName,
+    key: &CanonicalPackageName,
     project: &str,
     filename: &str,
 ) -> Response {
@@ -372,7 +366,7 @@ async fn upload_file(
 /// that will record it is built. Publishing it is [`Self::publish`] on its
 /// own, or [`Self::stage`] as one package of a cross-ecosystem batch.
 pub(super) struct PypiPublication {
-    key: PackageName,
+    key: CanonicalPackageName,
     org: String,
     entry: ProjectFile,
     content: Vec<u8>,
@@ -394,7 +388,7 @@ pub(super) async fn validate_upload(
 /// a caller holding an undecoded payload can settle the question before
 /// spending anything on the file.
 pub(super) struct PypiTarget {
-    key: PackageName,
+    key: CanonicalPackageName,
     org: String,
 }
 
@@ -404,7 +398,8 @@ pub(super) fn authorize_upload(
     registry: Option<&str>,
     upload: &Upload,
 ) -> Result<PypiTarget, RegistryError> {
-    let project = normalize_name(&upload.name).map_err(bad_request)?;
+    let key = CanonicalPackageName::parse(&upload.name, ECOSYSTEM)?;
+    let project = key.as_str();
     let version = normalize_version(&upload.version).map_err(bad_request)?;
     let distribution = parse_distribution_filename(&upload.filename).map_err(bad_request)?;
     if distribution.name != project {
@@ -428,15 +423,14 @@ pub(super) fn authorize_upload(
             )));
         }
     }
-    let key = PackageName::parse(&project)?;
     let (source, org) =
-        match resolve_publish_target_for(state, identity, registry, ECOSYSTEM, &project) {
+        match resolve_publish_target_for(state, identity, registry, ECOSYSTEM, project) {
             PublishTarget::Hosted { source, org } => (source, org),
             PublishTarget::Reject(reason) => return Err(RegistryError::BadRequest { reason }),
             PublishTarget::Denied(err) => return Err(err),
             PublishTarget::NotFound => return Err(RegistryError::NotFound),
         };
-    authorize(state, identity, &RegistrySource::Hosted(source), &project, Action::Publish)?;
+    authorize(state, identity, &RegistrySource::Hosted(source), project, Action::Publish)?;
     Ok(PypiTarget { key, org })
 }
 
@@ -468,7 +462,7 @@ pub(super) fn verify_upload(
 }
 
 impl PypiPublication {
-    pub(super) fn key(&self) -> &PackageName {
+    pub(super) fn key(&self) -> &CanonicalPackageName {
         &self.key
     }
 

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -30,7 +30,7 @@ use super::{
     resolve_write_target, stage_publish, validate_publish_doc,
 };
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_search::percent_decode;
 use pnpr_storage::publish::{extract_attachments, now_iso};
 
@@ -194,7 +194,7 @@ async fn serve_staged_publish(
     raw_name: &str,
     body: &axum::body::Bytes,
 ) -> Response {
-    let name = match PackageName::parse(raw_name) {
+    let name = match CanonicalPackageName::parse(raw_name, pnpr_package_name::Ecosystem::Npm) {
         Ok(name) => name,
         Err(err) => return err.into_response(),
     };
@@ -374,7 +374,10 @@ async fn serve_staged_approve(
         Ok(value) => value,
         Err(err) => return RegistryError::Json(err).into_response(),
     };
-    let name = match PackageName::parse(&record.package_name) {
+    let name = match CanonicalPackageName::parse(
+        &record.package_name,
+        pnpr_package_name::Ecosystem::Npm,
+    ) {
         Ok(name) => name,
         Err(err) => return err.into_response(),
     };
@@ -489,7 +492,8 @@ async fn authorize_staged(
     identity: &Identity,
     record: &StagedRecord,
 ) -> Result<(), RegistryError> {
-    let name = PackageName::parse(&record.package_name)?;
+    let name =
+        CanonicalPackageName::parse(&record.package_name, pnpr_package_name::Ecosystem::Npm)?;
     let target = resolve_write_target(state, identity, record.registry.as_deref(), &name)?;
     authorize(
         state,

--- a/pnpr/crates/pnpr/tests/auth_publish.rs
+++ b/pnpr/crates/pnpr/tests/auth_publish.rs
@@ -1201,7 +1201,7 @@ async fn publish_with_failed_attachment_cleans_up_earlier_tmp_files() {
 /// again. This regression test pins that down: if someone reintroduces
 /// a manual `urldecode` (which was previously here and was both
 /// redundant and buggy on literal `%` chars), the `@scope/pkg`
-/// `PackageName::parse` would still pass but a future bug-fix that
+/// `CanonicalPackageName::parse` would still pass but a future bug-fix that
 /// changes the decoder could break percent-encoded scoped paths.
 #[tokio::test]
 async fn dist_tag_set_works_with_url_encoded_scoped_path() {

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -2322,7 +2322,7 @@ async fn invalid_package_name_returns_bad_request() {
     let tmp = TempDir::new().unwrap();
     let app = router(config_for(&upstream.url(), tmp.path().to_path_buf()));
 
-    // `.hidden` trips the dot-prefix rejection in `PackageName::parse`.
+    // `.hidden` trips the dot-prefix rejection in `CanonicalPackageName::parse`.
     let response =
         app.oneshot(Request::get("/.hidden").body(Body::empty()).unwrap()).await.unwrap();
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);

--- a/pnpr/crates/pypi/Cargo.toml
+++ b/pnpr/crates/pypi/Cargo.toml
@@ -11,13 +11,13 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-pnpm-network = { workspace = true }
-derive_more  = { workspace = true }
-pep440_rs    = { workspace = true }
-pep508_rs    = { workspace = true }
-regex        = { workspace = true }
-serde        = { workspace = true }
-serde_json   = { workspace = true }
+pnpm-network      = { workspace = true }
+derive_more       = { workspace = true }
+pnpr-package-name = { workspace = true }
+pep440_rs         = { workspace = true }
+regex             = { workspace = true }
+serde             = { workspace = true }
+serde_json        = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pypi/src/lib.rs
+++ b/pnpr/crates/pypi/src/lib.rs
@@ -12,7 +12,8 @@ pub mod multipart;
 
 use derive_more::{Display, Error};
 use pep440_rs::Version;
-use pep508_rs::PackageName;
+pub use pnpr_package_name::PythonNameError as NameError;
+use pnpr_package_name::canonicalize_python_name;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{collections::BTreeMap, fmt::Write as _, str::FromStr};
@@ -40,25 +41,12 @@ pub const HTML_CONTENT_TYPE: &str = "application/vnd.pypi.simple.v1+html";
 /// `versions`, `size` and `upload-time` keys.
 pub const API_VERSION: &str = "1.1";
 
-/// A project name no Python index can serve.
-#[derive(Debug, Display, Error, Clone, PartialEq, Eq)]
-#[display("{name:?} is not a valid Python project name")]
-pub struct NameError {
-    pub name: String,
-}
-
 /// Normalize a project name the PEP 503 way (lowercase, runs of `-`, `_`
 /// and `.` collapsed to one `-`), rejecting names PEP 508 does not allow.
 /// Every project name in a URL, an upload form, or a filename passes
 /// through here, so `Demo_Pkg`, `demo.pkg` and `demo-pkg` are one project.
 pub fn normalize_name(raw: &str) -> Result<String, NameError> {
-    let invalid = || NameError { name: raw.to_string() };
-    let normalized = PackageName::from_str(raw).map_err(|_| invalid())?.as_ref().to_string();
-    let well_formed =
-        normalized.chars().all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '-')
-            && normalized.chars().next().is_some_and(|ch| ch.is_ascii_alphanumeric())
-            && normalized.chars().next_back().is_some_and(|ch| ch.is_ascii_alphanumeric());
-    well_formed.then_some(normalized).ok_or_else(invalid)
+    canonicalize_python_name(raw)
 }
 
 /// A version string PEP 440 does not allow.

--- a/pnpr/crates/registry/Cargo.toml
+++ b/pnpr/crates/registry/Cargo.toml
@@ -14,7 +14,6 @@ repository.workspace = true
 pnpr-error        = { workspace = true }
 pnpr-package-name = { workspace = true }
 indexmap          = { workspace = true }
-serde             = { workspace = true }
 wax               = { workspace = true }
 
 [lints]

--- a/pnpr/crates/registry/src/lib.rs
+++ b/pnpr/crates/registry/src/lib.rs
@@ -26,41 +26,9 @@
 //! relation is decidable for this deliberately small glob language.
 
 use indexmap::IndexMap;
-use pnpr_package_name::PackageName;
-use serde::{Deserialize, Serialize};
+use pnpr_package_name::CanonicalPackageName;
+pub use pnpr_package_name::Ecosystem;
 use std::fmt;
-
-/// The package ecosystem a concrete registry serves, which decides the wire
-/// protocol spoken at its `/~<name>/` endpoint: the npm registry API, the
-/// Cargo sparse-index and crates API, or the Python Simple Repository API
-/// plus the legacy upload API. A router inherits the one ecosystem all of
-/// its sources share.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Ecosystem {
-    #[default]
-    Npm,
-    Cargo,
-    Pypi,
-}
-
-impl Ecosystem {
-    /// The lowercase YAML spelling of the ecosystem (`npm`, `cargo`, `pypi`).
-    #[must_use]
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Ecosystem::Npm => "npm",
-            Ecosystem::Cargo => "cargo",
-            Ecosystem::Pypi => "pypi",
-        }
-    }
-}
-
-impl fmt::Display for Ecosystem {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
-}
 
 /// A package-name pattern: one member of a concrete registry's declared
 /// namespace.
@@ -105,7 +73,7 @@ impl PackagePattern {
         if let Some(scope) = pattern.strip_prefix('@').and_then(|rest| rest.strip_suffix("/*")) {
             // A single, concrete scope: `@acme/*`. A wildcard inside the
             // scope is an unsupported glob; a scope that request parsing
-            // (`PackageName::parse`) would reject — `@.acme`, `@..`, a
+            // (`CanonicalPackageName::parse`) would reject — `@.acme`, `@..`, a
             // separator — is a claim no valid package name can ever match,
             // so both fail loudly instead of becoming a dead pattern that
             // silently lets the scope land on a later router source.
@@ -123,7 +91,7 @@ impl PackagePattern {
         if pattern.contains('*') {
             return Err(invalid());
         }
-        if PackageName::parse(pattern).is_err() {
+        if CanonicalPackageName::parse(pattern, Ecosystem::Npm).is_err() {
             return Err(RegistryConfigError::ExactPatternNotAName { pattern: pattern.to_string() });
         }
         Ok(PackagePattern::Exact(pattern.to_string()))

--- a/pnpr/crates/registry/src/tests.rs
+++ b/pnpr/crates/registry/src/tests.rs
@@ -65,7 +65,7 @@ fn rejects_exact_pattern_that_is_not_a_package_name() {
     }
 }
 
-/// A `@<scope>/*` pattern whose scope request parsing (`PackageName::parse`)
+/// A `@<scope>/*` pattern whose scope request parsing (`CanonicalPackageName::parse`)
 /// would reject is a claim no valid package name can ever match. It must be a
 /// config error rather than a dead pattern — a mistyped private-scope claim
 /// that never matches would silently let the names it was meant to cover land

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -9,7 +9,7 @@
 //! search returns dozens of fuzzy matches for almost anything.
 
 use pnpr_error::Result;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_storage::Storage;
 use serde_json::{Map, Value, json};
 use std::collections::BTreeMap;
@@ -127,7 +127,10 @@ pub async fn local_search_names(
             continue;
         }
         if matches!(query, SearchText::Maintainer(_)) {
-            let Ok(parsed) = PackageName::parse(&name) else { continue };
+            let Ok(parsed) = CanonicalPackageName::parse(&name, pnpr_package_name::Ecosystem::Npm)
+            else {
+                continue;
+            };
             let Ok(Some(bytes)) = storage.read_hosted_document(&parsed).await else { continue };
             let Ok(packument) = serde_json::from_slice::<Value>(&bytes) else { continue };
             if !packument_has_maintainer(&packument, &needle) {
@@ -142,7 +145,7 @@ pub async fn local_search_names(
 
 pub async fn local_search_entry(storage: &Storage, name: &str) -> Value {
     let entry = async {
-        let parsed = PackageName::parse(name).ok()?;
+        let parsed = CanonicalPackageName::parse(name, pnpr_package_name::Ecosystem::Npm).ok()?;
         let bytes = storage.read_hosted_document(&parsed).await.ok()??;
         let packument = serde_json::from_slice::<Value>(&bytes).ok()?;
         build_search_entry(name, &packument)

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use axum::body::Body;
 use object_store::UpdateVersion;
 use pnpr_error::Result;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use std::{
     fmt::Debug,
     path::{Path, PathBuf},
@@ -22,13 +22,13 @@ use std::{
 /// rename or by upload, and how a namespace maps onto paths or key prefixes.
 #[async_trait]
 pub(crate) trait HostedBackend: Debug + Send + Sync {
-    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>>;
+    async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>>;
 
     /// Read a document together with the token [`Self::write_document_if_current`]
     /// needs to detect a concurrent writer.
     async fn read_document_for_update(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<HostedDocumentForUpdate>>;
 
     /// Write only if the stored document is still at `version`. A backend
@@ -36,21 +36,25 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     /// unconditionally — it serializes writers by another means.
     async fn write_document_if_current(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
         version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite>;
 
     async fn open_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>>;
 
     /// Reserve the local staging path the publish flow decodes into. Always
     /// local: the bytes are verified on the way in, before the backend sees
     /// them.
-    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf>;
+    async fn reserve_blob_tmp(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<PathBuf>;
 
     /// Promote a staged blob to its final home, consuming the tmp file
     /// unless the outcome is [`BlobFinalize::Conflict`] — those bytes stay
@@ -58,13 +62,13 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     async fn finalize_blob(
         &self,
         tmp_path: &Path,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobFinalize>;
 
-    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool>;
+    async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool>;
 
-    async fn remove_package(&self, name: &PackageName) -> Result<bool>;
+    async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool>;
 
     async fn list_package_names(&self) -> Result<Vec<String>>;
 

--- a/pnpr/crates/storage/src/journal.rs
+++ b/pnpr/crates/storage/src/journal.rs
@@ -37,7 +37,7 @@ use crate::{
 };
 use pnpr_config::Config;
 use pnpr_error::{RegistryError, Result};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_registry::Ecosystem;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -116,7 +116,7 @@ pub struct JournaledRevisionRef {
 /// One package of a publish about to be committed, borrowed from the
 /// handler's staged state.
 pub struct JournaledPublish<'publish> {
-    pub name: &'publish PackageName,
+    pub name: &'publish CanonicalPackageName,
     /// Hosted-org storage namespace, or `None` for the flat hosted store.
     pub org: Option<&'publish str>,
     pub ecosystem: Ecosystem,
@@ -133,7 +133,7 @@ pub struct JournaledPublish<'publish> {
 /// One hosted document to bring up to date as a transaction is applied.
 pub struct DocumentMerge<'txn> {
     pub ecosystem: Ecosystem,
-    pub name: &'txn PackageName,
+    pub name: &'txn CanonicalPackageName,
     /// The document as the store holds it, `None` when the package has none.
     pub existing: Option<&'txn [u8]>,
     /// The document the transaction computed when it was sealed.
@@ -385,7 +385,7 @@ impl SealedTxn {
         let outcome = &mut progress.outcome;
         let mut lost_tmp_paths = Vec::new();
         for (index, package) in manifest.packages.iter().enumerate() {
-            let name = PackageName::parse(&package.name)?;
+            let name = CanonicalPackageName::parse(&package.name, package.ecosystem)?;
             // Promote into the package's hosted namespace (or the flat store
             // when it has none), so the commit and a later startup recovery
             // land in exactly the store the publish targeted.

--- a/pnpr/crates/storage/src/journal/tests.rs
+++ b/pnpr/crates/storage/src/journal/tests.rs
@@ -8,7 +8,7 @@ use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use object_store::{ObjectStore, memory::InMemory};
 use pnpr_config::HostedStoreConfig;
 use pnpr_error::{RegistryError, Result};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_registry::Ecosystem;
 use serde_json::json;
 use std::sync::{
@@ -99,7 +99,7 @@ fn npm_package(name: &str) -> PackageId {
 /// A journaled npm publish of `packument` for `name`, with no staged blobs
 /// unless the test adds them.
 fn npm_publish<'publish>(
-    name: &'publish PackageName,
+    name: &'publish CanonicalPackageName,
     packument: &'publish [u8],
     revision_refs: &'publish [JournaledRevisionRef],
 ) -> JournaledPublish<'publish> {
@@ -154,7 +154,7 @@ async fn commit_persists_revision_references() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let packument = serde_json::to_vec(&json!({
         "name": "pkg",
         "versions": {},
@@ -195,7 +195,7 @@ async fn commit_drops_a_version_that_cannot_reserve_a_revision_reference() {
             .await
             .unwrap();
     }
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let packument = serde_json::to_vec(&json!({
         "name": "pkg",
         "versions": {
@@ -251,7 +251,7 @@ async fn commit_only_removes_transaction_owned_references_for_a_dropped_version(
             .await
             .unwrap();
     }
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let packument = serde_json::to_vec(&json!({
         "name": "pkg",
         "versions": { "1.0.0": { "version": "1.0.0" } },
@@ -320,8 +320,10 @@ async fn applying_preserves_a_blob_conflict_across_a_later_package_failure() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let conflicted_name = PackageName::parse("conflicted-pkg").unwrap();
-    let later_name = PackageName::parse("later-pkg").unwrap();
+    let conflicted_name =
+        CanonicalPackageName::parse("conflicted-pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
+    let later_name =
+        CanonicalPackageName::parse("later-pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let filename = "conflicted-pkg-1.0.0.tgz";
 
     let winner = storage.reserve_hosted_blob(&conflicted_name, filename).await.unwrap();
@@ -429,7 +431,7 @@ async fn commit_reports_a_package_whose_merge_recorded_nothing() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
     let entries = [npm_publish(&name, &document, &[])];
     storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
@@ -456,7 +458,7 @@ async fn commit_reports_an_entry_the_retry_found_recorded_by_another_writer() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
     let entries = [npm_publish(&name, &document, &[])];
     storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
@@ -481,8 +483,10 @@ async fn commit_does_not_report_what_its_own_first_attempt_wrote() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let written_name = PackageName::parse("written-pkg").unwrap();
-    let failed_name = PackageName::parse("failed-pkg").unwrap();
+    let written_name =
+        CanonicalPackageName::parse("written-pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
+    let failed_name =
+        CanonicalPackageName::parse("failed-pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let written_document =
         serde_json::to_vec(&json!({ "name": "written-pkg", "versions": {} })).unwrap();
     let failed_document =
@@ -517,7 +521,7 @@ async fn commit_keeps_the_journal_entry_when_the_retry_fails_too() {
         tmp.path().join("cache"),
     )
     .unwrap();
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let document = serde_json::to_vec(&json!({ "name": "pkg", "versions": {} })).unwrap();
     let entries = [npm_publish(&name, &document, &[])];
     storage.publish_journal().commit(&storage, &entries, &NpmDocuments).await.unwrap();
@@ -540,7 +544,7 @@ async fn recovery_applies_a_journal_with_the_alias_manifest_keys() {
     let storage =
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), tmp.path().join("cache"))
             .unwrap();
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let slot = storage.reserve_hosted_blob(&name, "pkg-1.0.0.tgz").await.unwrap();
     fs::write(&slot.tmp_path, b"tarball bytes").await.unwrap();
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -10,7 +10,7 @@ use axum::body::Body;
 use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
 use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
@@ -209,14 +209,18 @@ pub struct BlobWrite {
 #[derive(Debug)]
 pub struct BlobSlot {
     pub tmp_path: PathBuf,
-    name: PackageName,
+    name: CanonicalPackageName,
     filename: String,
 }
 
 impl BlobSlot {
     /// Rebuild a slot from its journaled parts so startup recovery can
     /// re-run [`Storage::finalize_blob_slot`] on it.
-    pub(crate) fn from_parts(tmp_path: PathBuf, name: PackageName, filename: String) -> Self {
+    pub(crate) fn from_parts(
+        tmp_path: PathBuf,
+        name: CanonicalPackageName,
+        filename: String,
+    ) -> Self {
         Self { tmp_path, name, filename }
     }
 
@@ -368,13 +372,13 @@ pub enum DocumentUpdate {
 /// is promoted by rename.
 #[async_trait]
 impl HostedBackend for Store {
-    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         Store::read_document_any_age(self, name).await
     }
 
     async fn read_document_for_update(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<HostedDocumentForUpdate>> {
         Ok(Store::read_document_any_age(self, name).await?.map(|bytes| HostedDocumentForUpdate {
             bytes,
@@ -384,7 +388,7 @@ impl HostedBackend for Store {
 
     async fn write_document_if_current(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
         _version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite> {
@@ -394,7 +398,7 @@ impl HostedBackend for Store {
 
     async fn open_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
         Ok(Store::open_blob(self, name, filename)
@@ -402,25 +406,29 @@ impl HostedBackend for Store {
             .map(|(file, len)| (streaming::stream_file(file), Some(len))))
     }
 
-    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+    async fn reserve_blob_tmp(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<PathBuf> {
         Store::reserve_blob_tmp(self, name, filename).await
     }
 
     async fn finalize_blob(
         &self,
         tmp_path: &Path,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobFinalize> {
         Store::finalize_blob(self, tmp_path, name, filename).await?;
         Ok(BlobFinalize::Written)
     }
 
-    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
         Store::remove_blob(self, name, filename).await
     }
 
-    async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         Store::remove_package(self, name).await
     }
 
@@ -566,20 +574,23 @@ impl Storage {
 
     /// Read the authoritative document for `name`, fresh or stale.
     /// Hosted content has no TTL — it is the source of truth.
-    pub async fn read_hosted_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    pub async fn read_hosted_document(
+        &self,
+        name: &CanonicalPackageName,
+    ) -> Result<Option<Vec<u8>>> {
         self.hosted.read_document(name).await
     }
 
     pub async fn read_hosted_document_for_update(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<HostedDocumentForUpdate>> {
         self.hosted.read_document_for_update(name).await
     }
 
     pub async fn write_hosted_document_if_current(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
         version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite> {
@@ -598,7 +609,7 @@ impl Storage {
     /// stays in one place.
     pub async fn update_hosted_document_with_retry<Build>(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         retries: usize,
         mut build: Build,
     ) -> Result<DocumentUpdate>
@@ -631,7 +642,7 @@ impl Storage {
     /// storage remains operator-controlled rather than an upstream cache.
     pub async fn open_hosted_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
         self.hosted.open_blob(name, filename).await
@@ -643,7 +654,7 @@ impl Storage {
     /// finalize with [`Self::finalize_blob_slot`].
     pub async fn reserve_hosted_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobSlot> {
         let tmp_path = self.hosted.reserve_blob_tmp(name, filename).await?;
@@ -655,7 +666,7 @@ impl Storage {
     /// document back; clearing the proxied mirror too stops
     /// the proxy cache from serving a stale copy of the just-removed
     /// version.
-    pub async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    pub async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
         let hosted = self.hosted.remove_blob(name, filename).await?;
         let cached = self.cached.remove_blob(name, filename).await?;
         Ok(hosted || cached)
@@ -664,7 +675,7 @@ impl Storage {
     /// Remove the package from both stores. Unpublish must purge the
     /// hosted copy *and* any proxied mirror, so a stale cached copy
     /// can't resurface after the package is gone.
-    pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    pub async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         let hosted = self.hosted.remove_package(name).await?;
         let cached = self.cached.remove_package(name).await?;
         Ok(hosted || cached)
@@ -684,7 +695,7 @@ impl Storage {
     pub async fn read_upstream_document(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         ttl: Duration,
     ) -> Result<Option<Vec<u8>>> {
         match self.cached.namespaced(namespace).read_document_entry(name, ttl).await? {
@@ -701,7 +712,7 @@ impl Storage {
     pub async fn read_upstream_document_any(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<Vec<u8>>> {
         // `Duration::MAX` classifies any existing entry as fresh, so its body
         // is returned regardless of age (the stale arm can't be reached here).
@@ -714,7 +725,7 @@ impl Storage {
     pub async fn write_upstream_document(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
     ) -> Result<()> {
         self.cached.namespaced(namespace).write_document(name, bytes).await
@@ -728,7 +739,7 @@ impl Storage {
     pub async fn remove_upstream_package(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<bool> {
         self.cached.namespaced(namespace).remove_package(name).await
     }
@@ -736,7 +747,7 @@ impl Storage {
     pub async fn open_upstream_blob_tmp(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobWrite> {
         self.cached.namespaced(namespace).open_blob_tmp(name, filename).await
@@ -745,7 +756,7 @@ impl Storage {
     pub async fn open_upstream_blob(
         &self,
         namespace: &str,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(fs::File, u64)>> {
         self.cached.namespaced(namespace).open_blob(name, filename).await
@@ -894,7 +905,7 @@ impl Store {
 
     async fn read_document_entry(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         ttl: Duration,
     ) -> Result<Option<CachedDocument>> {
         let path = self.document_path(name);
@@ -915,7 +926,7 @@ impl Store {
         }
     }
 
-    async fn read_document_any_age(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    async fn read_document_any_age(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         let path = self.document_path(name);
         match fs::read(&path).await {
             Ok(bytes) => Ok(Some(bytes)),
@@ -924,14 +935,14 @@ impl Store {
         }
     }
 
-    async fn write_document(&self, name: &PackageName, bytes: &[u8]) -> Result<()> {
+    async fn write_document(&self, name: &CanonicalPackageName, bytes: &[u8]) -> Result<()> {
         let path = self.document_path(name);
         write_atomic(&path, bytes).await
     }
 
     async fn open_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(fs::File, u64)>> {
         let path = self.blob_path(name, filename);
@@ -961,7 +972,11 @@ impl Store {
         Ok(Some((file, len)))
     }
 
-    async fn open_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<BlobWrite> {
+    async fn open_blob_tmp(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<BlobWrite> {
         let final_path = self.blob_path(name, filename);
         self.open_blob_tmp_at(final_path).await
     }
@@ -991,7 +1006,11 @@ impl Store {
     /// Reserve a tmp path in the destination package directory so the
     /// publish flow can write there and [`Self::finalize_blob`] can
     /// rename within the same directory (atomic on POSIX).
-    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+    async fn reserve_blob_tmp(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<PathBuf> {
         let final_path = self.blob_path(name, filename);
         if let Some(parent) = final_path.parent() {
             fs::create_dir_all(parent).await?;
@@ -1002,7 +1021,7 @@ impl Store {
     async fn finalize_blob(
         &self,
         tmp_path: &Path,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<()> {
         let final_path = self.blob_path(name, filename);
@@ -1016,7 +1035,7 @@ impl Store {
     /// Remove the entire package directory. Returns `Ok(false)` if it
     /// didn't exist (treat as a no-op success, matching what verdaccio
     /// does on a duplicate DELETE).
-    async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         let dir = self.package_dir(name);
         match fs::remove_dir_all(&dir).await {
             Ok(()) => Ok(true),
@@ -1029,7 +1048,7 @@ impl Store {
     /// is already gone; the pnpm unpublish flow always issues a DELETE
     /// after the document-update PUT, and a benign 404 here would
     /// surface as a real error to the caller.
-    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
         match fs::remove_file(self.blob_path(name, filename)).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
@@ -1128,15 +1147,15 @@ impl Store {
         }
     }
 
-    fn package_dir(&self, name: &PackageName) -> PathBuf {
+    fn package_dir(&self, name: &CanonicalPackageName) -> PathBuf {
         self.root.join(name.as_str())
     }
 
-    fn document_path(&self, name: &PackageName) -> PathBuf {
+    fn document_path(&self, name: &CanonicalPackageName) -> PathBuf {
         self.package_dir(name).join(DOCUMENT_FILE)
     }
 
-    fn blob_path(&self, name: &PackageName, filename: &str) -> PathBuf {
+    fn blob_path(&self, name: &CanonicalPackageName, filename: &str) -> PathBuf {
         self.package_dir(name).join(filename)
     }
 

--- a/pnpr/crates/storage/src/publish/tests.rs
+++ b/pnpr/crates/storage/src/publish/tests.rs
@@ -3,7 +3,7 @@ use super::{
     merge_manifest, now_iso, sha1_hex_from_integrity_opts, stream_decode_verify_and_write,
 };
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use pnpr_registry::Ecosystem;
 use serde_json::{Value, json};
 use ssri::{Algorithm, IntegrityOpts};
@@ -377,7 +377,7 @@ fn drop_lost_versions_tolerates_a_missing_versions_map() {
 
 #[test]
 fn merging_a_journaled_packument_adds_its_versions_to_the_stored_one() {
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let stored = serde_json::to_vec(&json!({
         "name": "pkg",
         "versions": { "1.0.0": { "version": "1.0.0" } },
@@ -411,7 +411,7 @@ fn merging_a_journaled_packument_adds_its_versions_to_the_stored_one() {
 /// `dist.tarball` URL the packument carries.
 #[test]
 fn merging_a_journaled_packument_drops_the_versions_of_lost_blobs() {
-    let name = PackageName::parse("pkg").unwrap();
+    let name = CanonicalPackageName::parse("pkg", pnpr_package_name::Ecosystem::Npm).unwrap();
     let journaled = serde_json::to_vec(&json!({
         "name": "pkg",
         "versions": {

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -27,7 +27,7 @@ use object_store::{
     path::Path as ObjectPath,
 };
 use pnpr_error::{RegistryError, Result};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use std::{
     io,
     path::{Path, PathBuf},
@@ -98,7 +98,7 @@ impl S3Store {
         }
     }
 
-    pub async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    pub async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         match self.store.get(&self.document_key(name)).await {
             Ok(result) => Ok(Some(result.bytes().await?.to_vec())),
             Err(object_store::Error::NotFound { .. }) => Ok(None),
@@ -108,7 +108,7 @@ impl S3Store {
 
     pub(crate) async fn read_document_for_update(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<S3DocumentForUpdate>> {
         match self.store.get(&self.document_key(name)).await {
             Ok(result) => {
@@ -125,7 +125,7 @@ impl S3Store {
 
     pub(crate) async fn write_document_if_current(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
         version: Option<&UpdateVersion>,
     ) -> Result<bool> {
@@ -157,7 +157,7 @@ impl S3Store {
     /// or upstream.
     pub async fn open_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
         match self.store.get(&self.blob_key(name, filename)).await {
@@ -176,7 +176,11 @@ impl S3Store {
     /// Reserve a local staging path for the publish flow to decode and
     /// verify a blob into; [`Self::upload_blob`] promotes it to
     /// the bucket once the verification passes.
-    pub async fn staging_tmp_path(&self, _name: &PackageName, filename: &str) -> Result<PathBuf> {
+    pub async fn staging_tmp_path(
+        &self,
+        _name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<PathBuf> {
         fs::create_dir_all(&self.staging_dir).await?;
         Ok(crate::unique_tmp_path(&self.staging_dir.join(filename)))
     }
@@ -184,7 +188,7 @@ impl S3Store {
     pub async fn upload_blob(
         &self,
         tmp_path: &Path,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobFinalize> {
         let bytes = fs::read(tmp_path).await?;
@@ -220,7 +224,7 @@ impl S3Store {
         }
     }
 
-    pub async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    pub async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
         match self.store.delete(&self.blob_key(name, filename)).await {
             Ok(()) => Ok(true),
             Err(object_store::Error::NotFound { .. }) => Ok(false),
@@ -228,7 +232,7 @@ impl S3Store {
         }
     }
 
-    pub async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    pub async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         let prefix = ObjectPath::from(format!("{}{}/", self.prefix, name.as_str()));
         let mut listing = self.store.list(Some(&prefix));
         let mut removed = false;
@@ -422,11 +426,11 @@ impl S3Store {
         }
     }
 
-    fn document_key(&self, name: &PackageName) -> ObjectPath {
+    fn document_key(&self, name: &CanonicalPackageName) -> ObjectPath {
         ObjectPath::from(format!("{}{}/{DOCUMENT_FILE}", self.prefix, name.as_str()))
     }
 
-    fn blob_key(&self, name: &PackageName, filename: &str) -> ObjectPath {
+    fn blob_key(&self, name: &CanonicalPackageName, filename: &str) -> ObjectPath {
         ObjectPath::from(format!("{}{}/{filename}", self.prefix, name.as_str()))
     }
 
@@ -491,13 +495,13 @@ mod tests;
 /// by upload rather than rename.
 #[async_trait]
 impl HostedBackend for S3Store {
-    async fn read_document(&self, name: &PackageName) -> Result<Option<Vec<u8>>> {
+    async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         S3Store::read_document(self, name).await
     }
 
     async fn read_document_for_update(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
     ) -> Result<Option<HostedDocumentForUpdate>> {
         Ok(S3Store::read_document_for_update(self, name).await?.map(|document| {
             HostedDocumentForUpdate {
@@ -509,7 +513,7 @@ impl HostedBackend for S3Store {
 
     async fn write_document_if_current(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         bytes: &[u8],
         version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite> {
@@ -526,20 +530,24 @@ impl HostedBackend for S3Store {
 
     async fn open_blob(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
         S3Store::open_blob(self, name, filename).await
     }
 
-    async fn reserve_blob_tmp(&self, name: &PackageName, filename: &str) -> Result<PathBuf> {
+    async fn reserve_blob_tmp(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<PathBuf> {
         self.staging_tmp_path(name, filename).await
     }
 
     async fn finalize_blob(
         &self,
         tmp_path: &Path,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobFinalize> {
         let outcome = self.upload_blob(tmp_path, name, filename).await?;
@@ -552,11 +560,11 @@ impl HostedBackend for S3Store {
         Ok(outcome)
     }
 
-    async fn remove_blob(&self, name: &PackageName, filename: &str) -> Result<bool> {
+    async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
         S3Store::remove_blob(self, name, filename).await
     }
 
-    async fn remove_package(&self, name: &PackageName) -> Result<bool> {
+    async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         S3Store::remove_package(self, name).await
     }
 

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -2,7 +2,7 @@ use super::{Body, ObjectStore, S3Store};
 use crate::HostedRevisionRefWrite;
 use object_store::{ObjectStoreExt, PutPayload, memory::InMemory, path::Path as ObjectPath};
 use pnpr_config::S3Settings;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use std::sync::Arc;
 use tempfile::tempdir;
 
@@ -26,8 +26,9 @@ fn store_with_prefix(prefix: &str) -> (S3Store, tempfile::TempDir) {
     (store, staging)
 }
 
-fn pkg(name: &str) -> PackageName {
-    PackageName::parse(name).expect("valid package name")
+fn pkg(name: &str) -> CanonicalPackageName {
+    CanonicalPackageName::parse(name, pnpr_package_name::Ecosystem::Npm)
+        .expect("valid package name")
 }
 
 async fn collect(body: Body) -> Vec<u8> {
@@ -38,13 +39,13 @@ async fn collect(body: Body) -> Vec<u8> {
 /// the decoded bytes to the reserved local tmp file, then upload.
 /// (Cleaning up the staging file belongs to the `HostedBackend` impl, not
 /// to `upload_blob`, so it stays behind here.)
-async fn upload(store: &S3Store, name: &PackageName, filename: &str, bytes: &[u8]) {
+async fn upload(store: &S3Store, name: &CanonicalPackageName, filename: &str, bytes: &[u8]) {
     let tmp = store.staging_tmp_path(name, filename).await.expect("reserve staging path");
     tokio::fs::write(&tmp, bytes).await.expect("write staging file");
     store.upload_blob(&tmp, name, filename).await.expect("upload");
 }
 
-async fn write_document(store: &S3Store, name: &PackageName, bytes: &[u8]) {
+async fn write_document(store: &S3Store, name: &CanonicalPackageName, bytes: &[u8]) {
     assert!(store.write_document_if_current(name, bytes, None).await.unwrap());
 }
 

--- a/pnpr/crates/storage/src/streaming/tests.rs
+++ b/pnpr/crates/storage/src/streaming/tests.rs
@@ -2,7 +2,7 @@ use super::{BlobStreamError, integrity_checker, parse_integrity, stream_verified
 use crate::Storage;
 use futures_util::StreamExt;
 use pnpr_config::HostedStoreConfig;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use ssri::{Algorithm, Integrity, IntegrityOpts};
 use std::{path::Path, sync::Arc, time::Duration};
 use tempfile::TempDir;
@@ -132,7 +132,7 @@ async fn cancelling_in_flight_response_body_removes_tmp_file() {
     let cache = tmp.path().join("cache");
     let storage =
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let write =
         storage.open_upstream_blob_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 
@@ -164,7 +164,7 @@ async fn oversized_response_is_rejected_and_tmp_is_removed() {
     let cache = tmp.path().join("cache");
     let storage =
         Storage::new(&HostedStoreConfig::Fs, tmp.path().join("hosted"), cache.clone()).unwrap();
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let write =
         storage.open_upstream_blob_tmp("~public/test", &name, "foo-1.0.0.tgz").await.unwrap();
 

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    AsyncWriteExt, BlobWrite, ErrorKind, HostedRevisionRefWrite, HostedStoreConfig,
-    MAX_HOSTED_REVISION_REFS, PackageName, RegistryError, Storage, create_tmp_file_with, fs,
+    AsyncWriteExt, BlobWrite, CanonicalPackageName, ErrorKind, HostedRevisionRefWrite,
+    HostedStoreConfig, MAX_HOSTED_REVISION_REFS, RegistryError, Storage, create_tmp_file_with, fs,
 };
 use tempfile::TempDir;
 
@@ -9,8 +9,8 @@ fn storage_in(tmp: &TempDir) -> Storage {
         .unwrap()
 }
 
-fn pkg(name: &str) -> PackageName {
-    PackageName::parse(name).unwrap()
+fn pkg(name: &str) -> CanonicalPackageName {
+    CanonicalPackageName::parse(name, pnpr_package_name::Ecosystem::Npm).unwrap()
 }
 
 #[test]

--- a/pnpr/crates/upstream/src/lib.rs
+++ b/pnpr/crates/upstream/src/lib.rs
@@ -9,7 +9,7 @@ use pnpm_network::{
 };
 use pnpr_config::{RedactedHeaders, UpstreamConfig};
 use pnpr_error::{RegistryError, Result};
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use reqwest::{
     StatusCode,
     header::{self, HeaderMap, HeaderValue},
@@ -281,7 +281,7 @@ impl Upstream {
     /// network when the circuit breaker is open.
     pub async fn fetch_packument(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         validators: &CacheValidators,
     ) -> Result<PackumentFetch> {
         self.ensure_available()?;
@@ -331,7 +331,7 @@ impl Upstream {
     /// network when the circuit breaker is open.
     pub async fn fetch_tarball_response(
         &self,
-        name: &PackageName,
+        name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<FetchOutcome<ThrottledResponse>> {
         let started = Instant::now();
@@ -614,14 +614,14 @@ async fn read_upstream_error_body(response: reqwest::Response) -> String {
 /// Walks both packument shape (`{ "versions": { v: { dist: ... } } }`)
 /// and single-version manifest shape (`{ dist: ... }` at the top level)
 /// so a single helper covers both endpoints.
-pub fn rewrite_tarball_urls(value: &mut Value, pkg: &PackageName, public_url: &str) {
+pub fn rewrite_tarball_urls(value: &mut Value, pkg: &CanonicalPackageName, public_url: &str) {
     rewrite_tarball_urls_from_registry(value, pkg, None, public_url);
 }
 
 /// Rewrite tarball URLs from an upstream registry, preserving valid revision routes.
 pub fn rewrite_upstream_tarball_urls(
     value: &mut Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     source_registry: &str,
     public_url: &str,
 ) {
@@ -630,7 +630,7 @@ pub fn rewrite_upstream_tarball_urls(
 
 fn rewrite_tarball_urls_from_registry(
     value: &mut Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     source_registry: Option<&str>,
     public_url: &str,
 ) {
@@ -645,7 +645,7 @@ fn rewrite_tarball_urls_from_registry(
 
 fn rewrite_dist_tarball(
     value: &mut Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     source_registry: Option<&str>,
     public_url: &str,
 ) {
@@ -770,7 +770,7 @@ pub fn tarball_basename(url: &str) -> Option<&str> {
 #[must_use]
 pub fn extract_version_manifest(
     packument: &Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     version_or_tag: &str,
     public_url: &str,
 ) -> Option<Value> {
@@ -781,7 +781,7 @@ pub fn extract_version_manifest(
 #[must_use]
 pub fn extract_upstream_version_manifest(
     packument: &Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     version_or_tag: &str,
     source_registry: &str,
     public_url: &str,
@@ -797,7 +797,7 @@ pub fn extract_upstream_version_manifest(
 
 fn extract_version_manifest_from_registry(
     packument: &Value,
-    pkg: &PackageName,
+    pkg: &CanonicalPackageName,
     version_or_tag: &str,
     source_registry: Option<&str>,
     public_url: &str,

--- a/pnpr/crates/upstream/src/tests.rs
+++ b/pnpr/crates/upstream/src/tests.rs
@@ -6,7 +6,7 @@ use super::{
 use chrono::{DateTime, TimeZone, Utc};
 use pnpr_config::UpstreamConfig;
 use pnpr_error::RegistryError;
-use pnpr_package_name::PackageName;
+use pnpr_package_name::CanonicalPackageName;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use serde_json::json;
 use std::time::Duration;
@@ -53,7 +53,7 @@ async fn fetch_packument_forwards_configured_headers() {
         .await;
 
     let upstream = upstream(server.url(), auth_and_custom_headers());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
     assert!(matches!(outcome, PackumentFetch::Modified(_)));
@@ -74,7 +74,7 @@ async fn fetch_tarball_response_forwards_configured_headers() {
         .await;
 
     let upstream = upstream(server.url(), auth_and_custom_headers());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let outcome = upstream.fetch_tarball_response(&name, "foo-1.0.0.tgz").await.unwrap();
 
     assert!(matches!(outcome, FetchOutcome::Ok(_)));
@@ -195,7 +195,7 @@ async fn fetch_packument_sends_no_authorization_when_headers_empty() {
         .await;
 
     let upstream = upstream(server.url(), HeaderMap::new());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
     assert!(matches!(outcome, PackumentFetch::Modified(_)));
@@ -214,7 +214,7 @@ async fn fetch_packument_modified_carries_the_body() {
         .await;
 
     let upstream = upstream(server.url(), HeaderMap::new());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
     let PackumentFetch::Modified(fetched) = outcome else { panic!("expected a body") };
@@ -237,7 +237,7 @@ async fn fetch_packument_replays_validators_and_handles_304() {
         .await;
 
     let upstream = upstream(server.url(), HeaderMap::new());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let validators = CacheValidators {
         etag: Some(r#""abc123""#.to_string()),
         last_modified: Some("Wed, 21 Oct 2015 07:28:00 GMT".to_string()),
@@ -265,7 +265,7 @@ async fn fetch_packument_304_without_validators_is_an_error() {
         .await;
 
     let upstream = upstream(server.url(), HeaderMap::new());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let result = upstream.fetch_packument(&name, &CacheValidators::default()).await;
 
     assert!(result.is_err(), "an unconditional 304 must not be treated as NotModified");
@@ -278,7 +278,7 @@ async fn fetch_packument_maps_404_to_not_found() {
     let mock = server.mock("GET", "/foo").with_status(404).expect(1).create_async().await;
 
     let upstream = upstream(server.url(), HeaderMap::new());
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let outcome = upstream.fetch_packument(&name, &CacheValidators::default()).await.unwrap();
 
     assert!(matches!(outcome, PackumentFetch::NotFound));
@@ -298,7 +298,7 @@ fn rewrites_npm_form_tarball() {
             }
         }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:4873");
     assert_eq!(
         doc["versions"]["1.0.0"]["dist"]["tarball"],
@@ -334,7 +334,7 @@ fn preserves_valid_upstream_revision_route_on_the_public_registry() {
             }
         }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
 
     rewrite_upstream_tarball_urls(
         &mut doc,
@@ -375,7 +375,7 @@ fn drops_invalid_upstream_revision_history_entries() {
             }],
         },
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
 
     rewrite_upstream_tarball_urls(&mut doc, &name, "https://upstream.test/", "http://pnpr.test/");
 
@@ -385,7 +385,7 @@ fn drops_invalid_upstream_revision_history_entries() {
 #[test]
 fn does_not_preserve_an_invalid_upstream_revision_route() {
     let digest = "A".repeat(86);
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     for (revision, tarball) in [
         (json!(0), format!("https://upstream.test/-/tarballs/sha512/{digest}")),
         (json!(2), format!("https://other.test/-/tarballs/sha512/{digest}")),
@@ -425,7 +425,8 @@ fn rewrites_verdaccio_form_tarball_for_scoped() {
             }
         }
     });
-    let name = PackageName::parse("@foo/no-deps").unwrap();
+    let name =
+        CanonicalPackageName::parse("@foo/no-deps", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:9999");
     assert_eq!(
         doc["versions"]["1.0.0"]["dist"]["tarball"],
@@ -448,7 +449,8 @@ fn preserves_non_canonical_tarball_basename() {
             }
         }
     });
-    let name = PackageName::parse("esprima-fb").unwrap();
+    let name =
+        CanonicalPackageName::parse("esprima-fb", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:9999");
     assert_eq!(
         doc["versions"]["3001.1.0-dev-harmony-fb"]["dist"]["tarball"],
@@ -468,7 +470,7 @@ fn rewrites_query_bearing_tarball_to_its_path_basename() {
             }
         }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:9999");
     assert_eq!(
         doc["versions"]["1.0.0"]["dist"]["tarball"],
@@ -490,7 +492,7 @@ fn rewrites_basenameless_tarball_url_to_pnpr_route() {
             }
         }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:9999");
     assert_eq!(
         doc["versions"]["1.0.0"]["dist"]["tarball"],
@@ -511,7 +513,7 @@ fn tarball_basename_strips_query_and_fragment() {
 #[test]
 fn handles_packument_without_versions() {
     let mut doc = json!({ "name": "foo" });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     rewrite_tarball_urls(&mut doc, &name, "http://127.0.0.1:4873");
     assert_eq!(doc, json!({ "name": "foo" }));
 }
@@ -532,7 +534,8 @@ fn extracts_version_by_dist_tag() {
             }
         }
     });
-    let name = PackageName::parse("@foo/no-deps").unwrap();
+    let name =
+        CanonicalPackageName::parse("@foo/no-deps", pnpr_package_name::Ecosystem::Npm).unwrap();
     let manifest = extract_version_manifest(&doc, &name, "latest", "http://reg").unwrap();
     assert_eq!(manifest["version"], "1.0.0");
     assert_eq!(manifest["dist"]["tarball"], "http://reg/@foo/no-deps/-/no-deps-1.0.0.tgz");
@@ -545,7 +548,7 @@ fn extracts_version_by_literal_version() {
         "name": "foo",
         "versions": { "2.0.0": { "version": "2.0.0", "dist": { "tarball": "x/foo-2.0.0.tgz" } } }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     let manifest = extract_version_manifest(&doc, &name, "2.0.0", "http://reg").unwrap();
     assert_eq!(manifest["version"], "2.0.0");
     assert_eq!(manifest["dist"]["tarball"], "http://reg/foo/-/foo-2.0.0.tgz");
@@ -556,7 +559,7 @@ fn extract_returns_none_for_unknown_version() {
     let doc = json!({
         "versions": { "1.0.0": { "dist": { "tarball": "x/foo-1.0.0.tgz" } } }
     });
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     assert!(extract_version_manifest(&doc, &name, "9.9.9", "http://reg").is_none());
     assert!(extract_version_manifest(&doc, &name, "latest", "http://reg").is_none());
 }
@@ -809,7 +812,7 @@ async fn open_circuit_short_circuits_without_hitting_the_upstream() {
     let mock = server.mock("GET", "/foo").with_status(500).expect(1).create_async().await;
 
     let upstream = breaking_upstream(server.url(), 1);
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
 
     let first = upstream.fetch_packument(&name, &CacheValidators::default()).await;
     assert!(matches!(first, Err(RegistryError::UpstreamStatus { status: 500, .. })));
@@ -831,7 +834,7 @@ async fn client_error_status_does_not_open_the_circuit() {
     let mock = server.mock("GET", "/foo").with_status(401).expect(2).create_async().await;
 
     let upstream = breaking_upstream(server.url(), 1);
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
 
     for _ in 0..2 {
         let result = upstream.fetch_packument(&name, &CacheValidators::default()).await;
@@ -1070,7 +1073,7 @@ async fn artifact_and_npm_downloads_hold_permits_after_returning_headers() {
     upstream.client = std::sync::Arc::new(
         pnpm_network::ThrottledClient::new_for_installs().with_max_sockets_per_host(Some(1)),
     );
-    let name = PackageName::parse("foo").unwrap();
+    let name = CanonicalPackageName::parse("foo", pnpr_package_name::Ecosystem::Npm).unwrap();
     for mode in 0..3 {
         let outcome = match mode {
             0 => upstream.fetch_artifact_response(&server.url()).await,


### PR DESCRIPTION
## Summary

- Move ecosystem-aware package-name validation and canonicalization into `pnpr-package-name`.
- Rename the storage and cache key type to `CanonicalPackageName` and require its ecosystem at construction.
- Remove `pnpr-config` dependencies on Cargo and Python protocol crates, and use the canonical constructor in server, resolver, and journal recovery paths.
- Add coverage for npm spelling preservation, Cargo lowercasing, and PEP 503 Python normalization.

Related to pnpm/pnpm#14599.

## Squash Commit Body

```text
Centralize npm, Cargo, and Python package-name validation and normalization in `pnpr-package-name`. Make storage and cache keys canonical by construction, and keep journal recovery keyed by the recorded ecosystem.

This removes protocol-crate dependencies from `pnpr-config` and eliminates duplicate normalization in server and resolver call sites.

Related to pnpm/pnpm#14599.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Codex, GPT-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14617"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791286865&installation_model_id=426870&pr_number=14617&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14617&signature=162e2be876f260afae3e51656824331a0ac54315f4d9df9a1f28e5b2db25bde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Package names are now canonicalized consistently across npm, Cargo, and PyPI operations.
  - Cargo names are normalized to lowercase, while Python project names follow standard PyPI formatting.
  - Registry routing, publishing, downloads, caching, and storage use canonical package names.

- **Bug Fixes**
  - Improved consistency when packages use different capitalization or separator styles.
  - Clearer validation errors are provided for invalid Cargo and PyPI names.

- **Tests**
  - Added coverage for ecosystem-specific canonicalization and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->