### PR TITLE
feat(pnpm): configure the Cargo sparse registry

### DIFF
--- a/.changeset/cargo-custom-registry.md
+++ b/.changeset/cargo-custom-registry.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-pnpm can install Cargo dependencies from the sparse registry configured by `cargo.indexUrl`. Cargo resolution through `pnprServer` preserves the configured registry in `Cargo.lock`.
+pnpm can install Cargo dependencies from the sparse registry configured by `cargo.indexUrl`. The generated `Cargo.lock` records that registry as the source of every crate, and `.cargo/config.toml` points it at pnpm's vendored directory.

--- a/.changeset/cargo-custom-registry.md
+++ b/.changeset/cargo-custom-registry.md
@@ -1,0 +1,6 @@
+---
+"pacquet": minor
+"@pnpm/pnpr": patch
+---
+
+pnpm can install Cargo dependencies from the sparse registry configured by `cargo.indexUrl`. Cargo resolution through `pnprServer` preserves the configured registry in `Cargo.lock`.

--- a/.changeset/cargo-custom-registry.md
+++ b/.changeset/cargo-custom-registry.md
@@ -3,4 +3,4 @@
 "@pnpm/pnpr": patch
 ---
 
-pnpm can install Cargo dependencies from the sparse registry configured by `cargo.indexUrl`. The generated `Cargo.lock` records that registry as the source of every crate, and `.cargo/config.toml` points it at pnpm's vendored directory.
+pnpm can install Cargo dependencies from the sparse registry configured by `cargo.indexUrl`. The generated `Cargo.lock` records that registry as the source of every crate.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4417,6 +4417,7 @@ dependencies = [
  "assert_cmd",
  "base64 0.23.1",
  "cargo-lock",
+ "cargo-util-schemas",
  "chrono",
  "clap",
  "command-extra",
@@ -6202,6 +6203,7 @@ version = "0.0.1"
 dependencies = [
  "derive_more",
  "flate2",
+ "pnpm-cargo-resolver",
  "pnpr-package-name",
  "semver",
  "serde",

--- a/pnpm/crates/cargo-resolver/src/features.rs
+++ b/pnpm/crates/cargo-resolver/src/features.rs
@@ -1,6 +1,6 @@
 use crate::{
     model::{DependencyKind, FeatureSelection, PackageKey, RegistryDependency, RegistryVersion},
-    registry::{Registry, compatibility_line, matching_versions, validate_registry},
+    registry::{Registry, compatibility_line, matching_versions},
 };
 use miette::Result;
 use pubgrub::SelectedDependencies;
@@ -167,7 +167,7 @@ fn collect_feature_selections(
     let mut pending = VecDeque::from(root_dependencies.to_vec());
 
     while let Some(dependency) = pending.pop_front() {
-        validate_registry(dependency.registry.as_deref())?;
+        registry.validate_dependency_source(dependency.registry.as_deref())?;
         let versions = registry.package(&dependency.name)?;
         let compatibility = matching_versions(versions, &dependency.requirement)
             .next_back()

--- a/pnpm/crates/cargo-resolver/src/lib.rs
+++ b/pnpm/crates/cargo-resolver/src/lib.rs
@@ -11,8 +11,11 @@ mod registry;
 mod resolution;
 
 pub use metadata::resolve_inputs;
-pub use registry::{CRATES_IO_SPARSE_INDEX, download_url, latest_version, sparse_source};
-pub use resolution::{missing_index_names, resolve_lockfile, resolve_lockfile_for_registry};
+pub use registry::{
+    CRATES_IO_SPARSE_INDEX, download_url, index_prefix, is_crates_io, latest_version,
+    registry_source, sparse_source,
+};
+pub use resolution::{missing_index_names, resolve_lockfile};
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cargo-resolver/src/lib.rs
+++ b/pnpm/crates/cargo-resolver/src/lib.rs
@@ -11,8 +11,8 @@ mod registry;
 mod resolution;
 
 pub use metadata::resolve_inputs;
-pub use registry::{CRATES_IO_SPARSE_INDEX, latest_version};
-pub use resolution::{missing_index_names, resolve_lockfile};
+pub use registry::{CRATES_IO_SPARSE_INDEX, download_url, latest_version, sparse_source};
+pub use resolution::{missing_index_names, resolve_lockfile, resolve_lockfile_for_registry};
 
 #[cfg(test)]
 mod tests;

--- a/pnpm/crates/cargo-resolver/src/lockfile.rs
+++ b/pnpm/crates/cargo-resolver/src/lockfile.rs
@@ -101,7 +101,7 @@ fn locked_registry_dependencies(
 ) -> Result<Vec<Dependency>> {
     let mut dependencies = BTreeSet::new();
     for dependency in active_dependencies(package, selection)? {
-        crate::registry::validate_registry(dependency.registry.as_deref())?;
+        registry.validate_dependency_source(dependency.registry.as_deref())?;
         dependencies.insert(locked_dependency(
             &dependency.name,
             &dependency.requirement,

--- a/pnpm/crates/cargo-resolver/src/lockfile.rs
+++ b/pnpm/crates/cargo-resolver/src/lockfile.rs
@@ -2,7 +2,7 @@ use crate::{
     features::active_dependencies,
     metadata::active_metadata_dependencies,
     model::{CargoMetadata, FeatureSelection, PackageKey, RegistryVersion},
-    registry::{CRATES_IO_SOURCE, Registry, compatibility_line, matching_versions},
+    registry::{Registry, compatibility_line, matching_versions},
 };
 use cargo_lock::{Checksum, Dependency, Lockfile, Metadata, Name, Package, Patch, ResolveVersion};
 use miette::{IntoDiagnostic, Result, WrapErr};
@@ -17,10 +17,11 @@ pub(crate) fn lockfile_from_solution(
     registry: &Registry,
     solution: &pubgrub::SelectedDependencies<PackageKey, Version>,
     feature_selections: &BTreeMap<PackageKey, FeatureSelection>,
+    source: &str,
 ) -> Result<String> {
-    let source = cargo_lock::SourceId::from_url(CRATES_IO_SOURCE)
+    let source = cargo_lock::SourceId::from_url(source)
         .into_diagnostic()
-        .wrap_err("construct crates.io source identifier")?;
+        .wrap_err("construct Cargo registry source identifier")?;
     let selected = solution.iter().collect::<BTreeMap<_, _>>();
     let mut packages = Vec::new();
 

--- a/pnpm/crates/cargo-resolver/src/registry.rs
+++ b/pnpm/crates/cargo-resolver/src/registry.rs
@@ -12,9 +12,26 @@ const CRATES_IO_SPARSE_SOURCE: &str = "sparse+https://index.crates.io/";
 /// index file is fetched from when nothing else is configured.
 pub const CRATES_IO_SPARSE_INDEX: &str = "https://index.crates.io";
 
+/// Whether `index_url` addresses the crates.io sparse index.
+#[must_use]
+pub fn is_crates_io(index_url: &str) -> bool {
+    index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX
+}
+
+/// The `source` identifier of a sparse registry, as `cargo` spells it in
+/// `.cargo/config.toml` and in `Cargo.lock`.
 #[must_use]
 pub fn sparse_source(index_url: &str) -> String {
     format!("sparse+{}/", index_url.trim_end_matches('/'))
+}
+
+/// The `source` a `Cargo.lock` records for packages taken from `index_url`.
+/// crates.io keeps the canonical git identifier `cargo` itself writes even
+/// when the sparse index served the metadata; every other registry is named
+/// by its sparse index.
+#[must_use]
+pub fn registry_source(index_url: &str) -> String {
+    if is_crates_io(index_url) { CRATES_IO_SOURCE.to_string() } else { sparse_source(index_url) }
 }
 
 #[must_use]
@@ -34,15 +51,31 @@ pub fn download_url(template: &str, name: &str, version: &str, checksum: &str) -
 
 pub(crate) struct Registry {
     packages: BTreeMap<String, Vec<RegistryVersion>>,
+    source: String,
 }
 
 impl Registry {
-    pub(crate) fn new(index_files: &BTreeMap<String, String>) -> Result<Self> {
+    pub(crate) fn new(index_files: &BTreeMap<String, String>, source: &str) -> Result<Self> {
         let mut packages = BTreeMap::new();
         for (name, contents) in index_files {
             packages.insert(normalize_name(name), parse_index_file(name, contents)?);
         }
-        Ok(Self { packages })
+        Ok(Self { packages, source: source.to_string() })
+    }
+
+    /// Reject a dependency that names a registry other than the one being
+    /// resolved from. An entry without a registry is served by this one, and
+    /// a registry that mirrors crates.io keeps the upstream spelling in the
+    /// entries it copies.
+    pub(crate) fn validate_dependency_source(&self, registry: Option<&str>) -> Result<()> {
+        let Some(registry) = registry else { return Ok(()) };
+        if is_crates_io_source(registry) || same_registry(registry, &self.source) {
+            return Ok(());
+        }
+        Err(miette::miette!(
+            "dependency from Cargo registry {registry:?} cannot be resolved from {:?}",
+            self.source,
+        ))
     }
 
     pub(crate) fn versions(&self, name: &str) -> Option<&[RegistryVersion]> {
@@ -58,7 +91,10 @@ impl Registry {
 
 /// Return the newest stable, non-yanked version from a crates.io sparse-index entry.
 pub fn latest_version(name: &str, index_file: &str) -> Result<String> {
-    let registry = Registry::new(&BTreeMap::from([(name.to_string(), index_file.to_string())]))?;
+    let registry = Registry::new(
+        &BTreeMap::from([(name.to_string(), index_file.to_string())]),
+        CRATES_IO_SOURCE,
+    )?;
     registry
         .package(name)?
         .iter()
@@ -130,16 +166,19 @@ pub(crate) fn matching_versions<'a>(
     versions.iter().filter(|version| !version.yanked && requirement.matches(&version.version))
 }
 
-pub(crate) fn validate_registry(registry: Option<&str>) -> Result<()> {
-    if registry.is_none_or(|registry| {
-        matches!(registry, CRATES_IO_SOURCE | CRATES_IO_INDEX | CRATES_IO_SPARSE_SOURCE)
-    }) {
-        Ok(())
-    } else {
-        Err(miette::miette!(
-            "alternate Cargo registry {registry:?} is not supported by the crates.io proof of concept"
-        ))
-    }
+fn is_crates_io_source(registry: &str) -> bool {
+    matches!(registry, CRATES_IO_SOURCE | CRATES_IO_INDEX | CRATES_IO_SPARSE_SOURCE)
+}
+
+fn same_registry(left: &str, right: &str) -> bool {
+    strip_source_kind(left) == strip_source_kind(right)
+}
+
+fn strip_source_kind(url: &str) -> &str {
+    url.strip_prefix("sparse+")
+        .or_else(|| url.strip_prefix("registry+"))
+        .unwrap_or(url)
+        .trim_end_matches('/')
 }
 
 pub(crate) fn compatibility_line(version: &Version) -> String {
@@ -156,7 +195,10 @@ fn normalize_name(name: &str) -> String {
     name.to_ascii_lowercase()
 }
 
-fn index_prefix(name: &str) -> String {
+/// The directory part of a crate's sparse-index path, in the name's own
+/// case: `1`, `2`, `3/<first letter>`, or `<first two>/<next two>`.
+#[must_use]
+pub fn index_prefix(name: &str) -> String {
     match name.len() {
         1 => "1".to_string(),
         2 => "2".to_string(),

--- a/pnpm/crates/cargo-resolver/src/registry.rs
+++ b/pnpm/crates/cargo-resolver/src/registry.rs
@@ -12,6 +12,26 @@ const CRATES_IO_SPARSE_SOURCE: &str = "sparse+https://index.crates.io/";
 /// index file is fetched from when nothing else is configured.
 pub const CRATES_IO_SPARSE_INDEX: &str = "https://index.crates.io";
 
+#[must_use]
+pub fn sparse_source(index_url: &str) -> String {
+    format!("sparse+{}/", index_url.trim_end_matches('/'))
+}
+
+#[must_use]
+pub fn download_url(template: &str, name: &str, version: &str, checksum: &str) -> String {
+    const MARKERS: [&str; 5] =
+        ["{crate}", "{version}", "{prefix}", "{lowerprefix}", "{sha256-checksum}"];
+    if !MARKERS.iter().any(|marker| template.contains(marker)) {
+        return format!("{}/{name}/{version}/download", template.trim_end_matches('/'));
+    }
+    template
+        .replace("{crate}", name)
+        .replace("{version}", version)
+        .replace("{prefix}", &index_prefix(name))
+        .replace("{lowerprefix}", &index_prefix(&name.to_ascii_lowercase()))
+        .replace("{sha256-checksum}", checksum)
+}
+
 pub(crate) struct Registry {
     packages: BTreeMap<String, Vec<RegistryVersion>>,
 }
@@ -134,4 +154,13 @@ pub(crate) fn compatibility_line(version: &Version) -> String {
 
 fn normalize_name(name: &str) -> String {
     name.to_ascii_lowercase()
+}
+
+fn index_prefix(name: &str) -> String {
+    match name.len() {
+        1 => "1".to_string(),
+        2 => "2".to_string(),
+        3 => format!("3/{}", &name[..1]),
+        _ => format!("{}/{}", &name[..2], &name[2..4]),
+    }
 }

--- a/pnpm/crates/cargo-resolver/src/resolution.rs
+++ b/pnpm/crates/cargo-resolver/src/resolution.rs
@@ -54,6 +54,14 @@ pub fn missing_index_names(
 
 /// Resolve Cargo registry dependencies and serialize a format-v4 `Cargo.lock`.
 pub fn resolve_lockfile(metadata: &str, index_files: &BTreeMap<String, String>) -> Result<String> {
+    resolve_lockfile_for_registry(metadata, index_files, crate::registry::CRATES_IO_SOURCE)
+}
+
+pub fn resolve_lockfile_for_registry(
+    metadata: &str,
+    index_files: &BTreeMap<String, String>,
+    source: &str,
+) -> Result<String> {
     let metadata = parse_metadata(metadata)?;
     let registry = Registry::new(index_files)?;
     let root_dependencies = root_dependencies(&metadata)?;
@@ -76,6 +84,7 @@ pub fn resolve_lockfile(metadata: &str, index_files: &BTreeMap<String, String>) 
                 &registry,
                 &validated_solution,
                 &selected_features,
+                source,
             );
         }
         feature_selections = selected_features;

--- a/pnpm/crates/cargo-resolver/src/resolution.rs
+++ b/pnpm/crates/cargo-resolver/src/resolution.rs
@@ -6,7 +6,7 @@ use crate::{
     lockfile::lockfile_from_solution,
     metadata::{parse_metadata, root_dependencies},
     model::{FeatureSelection, PackageKey, RegistryDependency},
-    registry::{Registry, compatibility_line, matching_versions, validate_registry},
+    registry::{Registry, compatibility_line, matching_versions},
 };
 use miette::Result;
 use pubgrub::{
@@ -15,19 +15,21 @@ use pubgrub::{
 use semver::Version;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 
-/// Return sparse-index package names still needed to resolve `metadata`.
+/// Return sparse-index package names still needed to resolve `metadata`
+/// against the registry identified by `source`.
 pub fn missing_index_names(
     metadata: &str,
     index_files: &BTreeMap<String, String>,
+    source: &str,
 ) -> Result<Vec<String>> {
     let metadata = parse_metadata(metadata)?;
-    let registry = Registry::new(index_files)?;
+    let registry = Registry::new(index_files, source)?;
     let mut pending = VecDeque::from(root_dependencies(&metadata)?);
     let mut visited = BTreeSet::new();
     let mut missing = BTreeSet::new();
 
     while let Some(dependency) = pending.pop_front() {
-        validate_registry(dependency.registry.as_deref())?;
+        registry.validate_dependency_source(dependency.registry.as_deref())?;
         let visit_key = (
             dependency.name.clone(),
             dependency.requirement.to_string(),
@@ -53,17 +55,17 @@ pub fn missing_index_names(
 }
 
 /// Resolve Cargo registry dependencies and serialize a format-v4 `Cargo.lock`.
-pub fn resolve_lockfile(metadata: &str, index_files: &BTreeMap<String, String>) -> Result<String> {
-    resolve_lockfile_for_registry(metadata, index_files, crate::registry::CRATES_IO_SOURCE)
-}
-
-pub fn resolve_lockfile_for_registry(
+///
+/// `source` identifies the registry the index files came from and is what the
+/// resolved packages are recorded under. Build it with
+/// [`crate::registry_source`].
+pub fn resolve_lockfile(
     metadata: &str,
     index_files: &BTreeMap<String, String>,
     source: &str,
 ) -> Result<String> {
     let metadata = parse_metadata(metadata)?;
-    let registry = Registry::new(index_files)?;
+    let registry = Registry::new(index_files, source)?;
     let root_dependencies = root_dependencies(&metadata)?;
     let mut feature_selections = root_feature_selections(&registry, &root_dependencies)?;
     let mut previous_selections = Vec::new();
@@ -206,7 +208,7 @@ fn constraints_for(
 }
 
 fn package_key(registry: &Registry, dependency: &RegistryDependency) -> Result<PackageKey> {
-    validate_registry(dependency.registry.as_deref())?;
+    registry.validate_dependency_source(dependency.registry.as_deref())?;
     let compatibility =
         matching_versions(registry.package(&dependency.name)?, &dependency.requirement)
             .next_back()

--- a/pnpm/crates/cargo-resolver/src/tests.rs
+++ b/pnpm/crates/cargo-resolver/src/tests.rs
@@ -1,7 +1,5 @@
-use super::{
-    latest_version, missing_index_names, resolve_inputs, resolve_lockfile,
-    resolve_lockfile_for_registry,
-};
+use super::{latest_version, missing_index_names, resolve_inputs, resolve_lockfile};
+use crate::registry::CRATES_IO_SOURCE;
 use cargo_lock::Lockfile;
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -52,13 +50,13 @@ const WORKSPACE_OPTIONAL_METADATA: &str = r#"{
 #[test]
 fn discovers_transitive_sparse_index_files() {
     let mut files = BTreeMap::new();
-    assert_eq!(missing_index_names(METADATA, &files).unwrap(), ["foo"]);
+    assert_eq!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap(), ["foo"]);
 
     files.insert("foo".to_string(), FOO_INDEX.to_string());
-    assert_eq!(missing_index_names(METADATA, &files).unwrap(), ["bar"]);
+    assert_eq!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap(), ["bar"]);
 
     files.insert("bar".to_string(), BAR_INDEX.to_string());
-    assert!(missing_index_names(METADATA, &files).unwrap().is_empty());
+    assert!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap().is_empty());
 }
 
 #[test]
@@ -68,7 +66,7 @@ fn discovers_dependencies_from_every_viable_version() {
     let files = BTreeMap::from([("foo".to_string(), foo_index.to_string())]);
 
     assert_eq!(
-        missing_index_names(METADATA, &files).unwrap(),
+        missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap(),
         ["new-dependency", "old-dependency"],
     );
 }
@@ -86,9 +84,10 @@ fn validates_registry_metadata_before_deduplicating_dependencies() {
         1,
     );
 
-    let error = missing_index_names(&metadata, &BTreeMap::new()).unwrap_err().to_string();
+    let error =
+        missing_index_names(&metadata, &BTreeMap::new(), CRATES_IO_SOURCE).unwrap_err().to_string();
 
-    assert!(error.contains("alternate Cargo registry"), "{error}");
+    assert!(error.contains("cannot be resolved from"), "{error}");
 }
 
 #[test]
@@ -106,7 +105,7 @@ fn resolves_newest_non_yanked_versions_into_a_cargo_lockfile() {
         ("bar".to_string(), BAR_INDEX.to_string()),
         ("foo".to_string(), FOO_INDEX.to_string()),
     ]);
-    let encoded = resolve_lockfile(METADATA, &files).unwrap();
+    let encoded = resolve_lockfile(METADATA, &files, CRATES_IO_SOURCE).unwrap();
     let lockfile = Lockfile::from_str(&encoded).unwrap();
 
     assert_eq!(lockfile.version, cargo_lock::ResolveVersion::V4);
@@ -131,12 +130,8 @@ fn writes_the_configured_sparse_registry_source() {
         ("foo".to_string(), FOO_INDEX.to_string()),
         ("bar".to_string(), BAR_INDEX.to_string()),
     ]);
-    let lockfile = resolve_lockfile_for_registry(
-        METADATA,
-        &files,
-        "sparse+https://registry.example.test/index/",
-    )
-    .unwrap();
+    let lockfile =
+        resolve_lockfile(METADATA, &files, "sparse+https://registry.example.test/index/").unwrap();
 
     assert!(lockfile.contains(r#"source = "sparse+https://registry.example.test/index/""#));
 }
@@ -144,34 +139,37 @@ fn writes_the_configured_sparse_registry_source() {
 #[test]
 fn resolves_the_feature_unified_lock_graph() {
     let files = BTreeMap::from([("foo".to_string(), OPTIONAL_FOO_INDEX.to_string())]);
-    assert!(missing_index_names(METADATA, &files).unwrap().is_empty());
+    assert!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap().is_empty());
     assert_eq!(
-        missing_index_names(WORKSPACE_OPTIONAL_METADATA, &BTreeMap::new()).unwrap(),
+        missing_index_names(WORKSPACE_OPTIONAL_METADATA, &BTreeMap::new(), CRATES_IO_SOURCE)
+            .unwrap(),
         ["foo"],
     );
 
     let files = BTreeMap::from([("foo".to_string(), DEFAULT_FEATURE_FOO_INDEX.to_string())]);
-    assert_eq!(missing_index_names(METADATA, &files).unwrap(), ["bar"]);
+    assert_eq!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap(), ["bar"]);
 
     let files = BTreeMap::from([
         ("bar".to_string(), BAR_INDEX.to_string()),
         ("foo".to_string(), DEFAULT_FEATURE_FOO_INDEX.to_string()),
     ]);
-    let lockfile = Lockfile::from_str(&resolve_lockfile(METADATA, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(METADATA, &files, CRATES_IO_SOURCE).unwrap()).unwrap();
     assert_eq!(lockfile.packages.len(), 3);
 }
 
 #[test]
 fn merges_duplicate_feature_names_across_index_feature_maps() {
     let files = BTreeMap::from([("foo".to_string(), SPLIT_DEFAULT_FEATURE_FOO_INDEX.to_string())]);
-    assert_eq!(missing_index_names(METADATA, &files).unwrap(), ["bar", "baz"]);
+    assert_eq!(missing_index_names(METADATA, &files, CRATES_IO_SOURCE).unwrap(), ["bar", "baz"]);
 
     let files = BTreeMap::from([
         ("bar".to_string(), BAR_INDEX.to_string()),
         ("baz".to_string(), BAZ_INDEX.to_string()),
         ("foo".to_string(), SPLIT_DEFAULT_FEATURE_FOO_INDEX.to_string()),
     ]);
-    let lockfile = Lockfile::from_str(&resolve_lockfile(METADATA, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(METADATA, &files, CRATES_IO_SOURCE).unwrap()).unwrap();
     assert_eq!(lockfile.packages.len(), 4);
 }
 
@@ -207,7 +205,8 @@ fn propagates_features_from_the_selected_older_candidate() {
         ("foo".to_string(), foo_index.to_string()),
     ]);
 
-    let lockfile = Lockfile::from_str(&resolve_lockfile(metadata, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(metadata, &files, CRATES_IO_SOURCE).unwrap()).unwrap();
 
     assert_eq!(lockfile.packages.len(), 4);
     assert!(lockfile.packages.iter().any(|package| package.name.as_str() == "baz"));
@@ -247,7 +246,8 @@ fn ignores_features_from_an_unselected_newer_candidate() {
         ("qux".to_string(), qux_index.to_string()),
     ]);
 
-    let lockfile = Lockfile::from_str(&resolve_lockfile(metadata, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(metadata, &files, CRATES_IO_SOURCE).unwrap()).unwrap();
 
     assert!(lockfile.packages.iter().any(|package| {
         package.name.as_str() == "foo" && package.version == semver::Version::new(1, 0, 0)
@@ -270,7 +270,9 @@ fn propagates_dependency_features_without_default_features() {
         ("foo".to_string(), foo_index.to_string()),
     ]);
 
-    let lockfile = Lockfile::from_str(&resolve_lockfile(&metadata, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(&metadata, &files, CRATES_IO_SOURCE).unwrap())
+            .unwrap();
 
     assert!(lockfile.packages.iter().any(|package| package.name.as_str() == "baz"));
 }
@@ -288,7 +290,8 @@ fn backtracks_when_a_candidate_feature_conflicts_with_that_candidate() {
         ("qux".to_string(), qux_index.to_string()),
     ]);
 
-    let lockfile = Lockfile::from_str(&resolve_lockfile(METADATA, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(METADATA, &files, CRATES_IO_SOURCE).unwrap()).unwrap();
 
     assert!(lockfile.packages.iter().any(|package| {
         package.name.as_str() == "foo" && package.version == semver::Version::new(1, 0, 0)
@@ -303,8 +306,8 @@ fn dep_activation_suppresses_the_implicit_optional_feature() {
     let foo_index = r#"{"name":"foo","vers":"1.0.0","deps":[{"name":"codec","req":"^1","features":[],"optional":true,"default_features":true,"target":null,"kind":"normal","registry":null}],"cksum":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","features":{"full":["dep:codec"]},"yanked":false}"#;
     let files = BTreeMap::from([("foo".to_string(), foo_index.to_string())]);
 
-    assert!(missing_index_names(&metadata, &files).unwrap().is_empty());
-    assert!(resolve_lockfile(&metadata, &files).is_err());
+    assert!(missing_index_names(&metadata, &files, CRATES_IO_SOURCE).unwrap().is_empty());
+    assert!(resolve_lockfile(&metadata, &files, CRATES_IO_SOURCE).is_err());
 }
 
 #[test]
@@ -315,7 +318,9 @@ fn selects_an_older_candidate_that_provides_a_requested_feature() {
 {"name":"foo","vers":"1.1.0","deps":[],"cksum":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","features":{},"yanked":false}"#;
     let files = BTreeMap::from([("foo".to_string(), foo_index.to_string())]);
 
-    let lockfile = Lockfile::from_str(&resolve_lockfile(&metadata, &files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(&metadata, &files, CRATES_IO_SOURCE).unwrap())
+            .unwrap();
 
     assert!(lockfile.packages.iter().any(|package| {
         package.name.as_str() == "foo" && package.version == semver::Version::new(1, 0, 0)
@@ -351,8 +356,8 @@ fn resolve_inputs_drops_everything_but_the_dependency_graph() {
         ("bar".to_string(), BAR_INDEX.to_string()),
     ]);
     assert_eq!(
-        resolve_lockfile(&reduced, &index_files).unwrap(),
-        resolve_lockfile(FULL_METADATA, &index_files).unwrap(),
+        resolve_lockfile(&reduced, &index_files, CRATES_IO_SOURCE).unwrap(),
+        resolve_lockfile(FULL_METADATA, &index_files, CRATES_IO_SOURCE).unwrap(),
     );
 }
 
@@ -380,9 +385,42 @@ fn resolve_inputs_keeps_the_features_a_dependency_requests() {
         ("foo".to_string(), FEATURE_GATED_FOO_INDEX.to_string()),
         ("bar".to_string(), BAR_INDEX.to_string()),
     ]);
-    let lockfile = Lockfile::from_str(&resolve_lockfile(&reduced, &index_files).unwrap()).unwrap();
+    let lockfile =
+        Lockfile::from_str(&resolve_lockfile(&reduced, &index_files, CRATES_IO_SOURCE).unwrap())
+            .unwrap();
     assert!(
         lockfile.packages.iter().any(|package| package.name.as_str() == "bar"),
         "the feature that activates bar survived the reduction: {lockfile:?}",
     );
+}
+
+#[test]
+fn accepts_a_dependency_that_names_the_registry_being_resolved_from() {
+    const INDEX: &str = r#"{"name":"foo","vers":"1.0.0","deps":[{"name":"bar","req":"^2","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal","registry":"sparse+https://registry.example.test/index/"}],"cksum":"0000000000000000000000000000000000000000000000000000000000000000","features":{},"yanked":false}
+"#;
+    let files = BTreeMap::from([
+        ("foo".to_string(), INDEX.to_string()),
+        ("bar".to_string(), BAR_INDEX.to_string()),
+    ]);
+
+    let lockfile =
+        resolve_lockfile(METADATA, &files, "sparse+https://registry.example.test/index/").unwrap();
+
+    assert!(lockfile.contains(r#"name = "bar""#), "{lockfile}");
+}
+
+#[test]
+fn rejects_a_dependency_from_a_third_party_registry() {
+    const INDEX: &str = r#"{"name":"foo","vers":"1.0.0","deps":[{"name":"bar","req":"^2","features":[],"optional":false,"default_features":true,"target":null,"kind":"normal","registry":"sparse+https://other.example.test/index/"}],"cksum":"0000000000000000000000000000000000000000000000000000000000000000","features":{},"yanked":false}
+"#;
+    let files = BTreeMap::from([
+        ("foo".to_string(), INDEX.to_string()),
+        ("bar".to_string(), BAR_INDEX.to_string()),
+    ]);
+
+    let error = resolve_lockfile(METADATA, &files, "sparse+https://registry.example.test/index/")
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("other.example.test"), "{error}");
 }

--- a/pnpm/crates/cargo-resolver/src/tests.rs
+++ b/pnpm/crates/cargo-resolver/src/tests.rs
@@ -1,4 +1,7 @@
-use super::{latest_version, missing_index_names, resolve_inputs, resolve_lockfile};
+use super::{
+    latest_version, missing_index_names, resolve_inputs, resolve_lockfile,
+    resolve_lockfile_for_registry,
+};
 use cargo_lock::Lockfile;
 use std::{collections::BTreeMap, str::FromStr};
 
@@ -120,6 +123,22 @@ fn resolves_newest_non_yanked_versions_into_a_cargo_lockfile() {
             .iter()
             .any(|package| package.name.as_str() == "app" && package.source.is_none()),
     );
+}
+
+#[test]
+fn writes_the_configured_sparse_registry_source() {
+    let files = BTreeMap::from([
+        ("foo".to_string(), FOO_INDEX.to_string()),
+        ("bar".to_string(), BAR_INDEX.to_string()),
+    ]);
+    let lockfile = resolve_lockfile_for_registry(
+        METADATA,
+        &files,
+        "sparse+https://registry.example.test/index/",
+    )
+    .unwrap();
+
+    assert!(lockfile.contains(r#"source = "sparse+https://registry.example.test/index/""#));
 }
 
 #[test]

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ name = "pnpm"
 path = "src/bin/main.rs"
 
 [dependencies]
+cargo-util-schemas                     = { workspace = true }
 pnpm-auth-commands                     = { workspace = true }
 pnpm-cargo-resolver                    = { workspace = true }
 pnpm-catalogs-config                   = { workspace = true }

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -202,9 +202,9 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     let (store_index_writer, writer_task) =
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
 
-    let auth_headers = download_auth_headers(config);
     let cargo_auth_headers = cargo_auth_headers(config)?;
     let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
+    let auth_headers = download_auth_headers(config, &registry_config.dl);
     let verified_files_cache = SharedVerifiedFilesCache::default();
     let logged_methods = Arc::new(AtomicU8::new(0));
     let retry_opts = config.retry_opts();
@@ -360,11 +360,32 @@ pub(crate) async fn latest_version(
         .wrap_err_with(|| format!("select the latest version of crate {name}"))
 }
 
-/// The credentials a crate archive download may carry. The registry's `dl`
-/// template picks the download host, so a credential configured for that
-/// host travels only over TLS or loopback.
-fn download_auth_headers(config: &Config) -> Arc<AuthHeaders> {
-    Arc::new((*config.auth_headers).clone().with_secure_transport())
+/// The credentials a crate archive download may carry.
+///
+/// The registry named by `cargo.indexUrl` is repository-selected, and its
+/// `config.json` picks the download host through `download_template`. A
+/// credential is therefore offered only when that host is the registry's
+/// own — otherwise a registry could name any host and collect the
+/// credential the user configured for it. What it does get travels only
+/// over TLS or loopback.
+///
+/// A Cargo install runs from the CLI, which installs no route hook, so the
+/// anonymous headers deny nothing a hook would have allowed.
+fn download_auth_headers(config: &Config, download_template: &str) -> Arc<AuthHeaders> {
+    if same_origin(download_template, &config.cargo.index_url) {
+        Arc::new((*config.auth_headers).clone().with_secure_transport())
+    } else {
+        Arc::new(AuthHeaders::default())
+    }
+}
+
+/// Whether both URLs are absolute and share a scheme, host, and port. A URL
+/// that does not parse, or whose scheme has no host, matches nothing.
+fn same_origin(left: &str, right: &str) -> bool {
+    match (url::Url::parse(left), url::Url::parse(right)) {
+        (Ok(left), Ok(right)) => left.origin().is_tuple() && left.origin() == right.origin(),
+        _ => false,
+    }
 }
 
 pub(crate) fn cargo_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,4 +1,5 @@
 use crate::ecosystem_install::{EcosystemManifest, EcosystemWorkspaceInventory, InstallContext};
+use cargo_util_schemas::index::RegistryConfig;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
@@ -29,8 +30,8 @@ mod registry_auth;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicU64, Ordering};
 
-const CRATES_IO_DOWNLOAD_BASE: &str = "https://static.crates.io/crates";
 const WORKSPACE_INSTALL_CONCURRENCY: usize = 8;
+const CRATES_IO_DOWNLOAD_BASE: &str = "https://static.crates.io/crates";
 const MANAGED_START: &str = "# >>> pnpm-managed cargo sources >>>";
 const MANAGED_END: &str = "# <<< pnpm-managed cargo sources <<<";
 const MANAGED_CONFIG: &str = "# >>> pnpm-managed cargo sources >>>\n[source.crates-io]\nreplace-with = \"pnpm-crates-io\"\n\n[source.pnpm-crates-io]\ndirectory = \".pnpm/crates/crates-io\"\n# <<< pnpm-managed cargo sources <<<";
@@ -120,13 +121,14 @@ pub(crate) struct Prepared {
     root: PathBuf,
     lock: String,
     slots: Option<Vec<(String, PathBuf)>>,
+    index_url: String,
 }
 
 impl PreparedInstall for Prepared {
     fn publish(&mut self) -> Result<()> {
         if let Some(slots) = &self.slots {
             link_workspace(&self.root, slots)?;
-            write_cargo_config(&self.root)?;
+            write_cargo_config(&self.root, &self.index_url)?;
         }
         let path = self.root.join("Cargo.lock");
         let existing = match fs::read_to_string(&path) {
@@ -170,9 +172,14 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     )
     .await?;
     if lockfile_only {
-        return Ok(Prepared { root: root_dir.to_path_buf(), lock: cargo_lock, slots: None });
+        return Ok(Prepared {
+            root: root_dir.to_path_buf(),
+            lock: cargo_lock,
+            slots: None,
+            index_url: config.cargo.index_url.clone(),
+        });
     }
-    let packages = parse_lockfile(&cargo_lock)
+    let packages = parse_lockfile(&cargo_lock, &config.cargo.index_url)
         .wrap_err_with(|| format!("parse {}", cargo_lock_path.display()))?;
     let store_dir = &config.store_dir;
     store_dir
@@ -184,6 +191,8 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
 
     let auth_headers = Arc::clone(&config.auth_headers);
+    let cargo_auth_headers = cargo_auth_headers(config)?;
+    let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
     let verified_files_cache = SharedVerifiedFilesCache::default();
     let logged_methods = Arc::new(AtomicU8::new(0));
     let retry_opts = config.retry_opts();
@@ -199,6 +208,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
                 store_index_writer: Arc::clone(&store_index_writer),
                 http_client: Arc::clone(&http_client),
                 auth_headers: Arc::clone(&auth_headers),
+                download_template: registry_config.dl.clone(),
                 verified_files_cache: Arc::clone(&verified_files_cache),
                 logged_methods: Arc::clone(&logged_methods),
                 package_import_method: config.package_import_method,
@@ -218,7 +228,12 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     StoreIndexWriter::drain(writer_task, "; some Cargo rows may not be persisted").await;
     let slots = slots?;
 
-    Ok(Prepared { root: root_dir.to_path_buf(), lock: cargo_lock, slots: Some(slots) })
+    Ok(Prepared {
+        root: root_dir.to_path_buf(),
+        lock: cargo_lock,
+        slots: Some(slots),
+        index_url: config.cargo.index_url.clone(),
+    })
 }
 
 pub(crate) async fn workspace_root(manifest_path: &Path) -> Result<PathBuf> {
@@ -302,7 +317,7 @@ async fn resolve_via_pnpr(config: &Config, metadata: &str) -> Result<Option<Stri
     client
         .resolve_cargo(CargoResolveOptions {
             metadata,
-            registry: CRATES_IO_SPARSE_INDEX.to_string(),
+            registry: config.cargo.index_url.clone(),
             authorization: config.auth_headers.for_url(pnpr_server),
         })
         .await
@@ -317,10 +332,10 @@ pub(crate) async fn latest_version(
     name: &str,
     http_client: &ThrottledClient,
 ) -> Result<String> {
-    let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
+    let cache_dir = cargo_index_cache_dir(config);
     let index_file = fetch_sparse_index_file(
         name,
-        CRATES_IO_SPARSE_INDEX,
+        &config.cargo.index_url,
         &cache_dir,
         http_client,
         auth_headers,
@@ -332,8 +347,12 @@ pub(crate) async fn latest_version(
         .wrap_err_with(|| format!("select the latest version of crate {name}"))
 }
 
-pub(crate) fn crates_io_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {
-    registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers, config.offline)
+pub(crate) fn cargo_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {
+    if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+        registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers, config.offline)
+    } else {
+        Ok(Arc::clone(&config.auth_headers))
+    }
 }
 
 async fn read_cargo_metadata(root_dir: &Path) -> Result<String> {
@@ -369,8 +388,8 @@ async fn fetch_sparse_index(
     metadata: &str,
     http_client: &Arc<ThrottledClient>,
 ) -> Result<BTreeMap<String, String>> {
-    let auth_headers = crates_io_auth_headers(config)?;
-    let cache_dir = config.cache_dir.join("v11").join("cargo-index").join("crates-io");
+    let auth_headers = cargo_auth_headers(config)?;
+    let cache_dir = cargo_index_cache_dir(config);
     let mut index_files = BTreeMap::new();
 
     loop {
@@ -387,7 +406,7 @@ async fn fetch_sparse_index(
                 async move {
                     let contents = fetch_sparse_index_file(
                         &name,
-                        CRATES_IO_SPARSE_INDEX,
+                        &config.cargo.index_url,
                         &cache_dir,
                         &http_client,
                         &auth_headers,
@@ -403,6 +422,61 @@ async fn fetch_sparse_index(
             .await?;
         index_files.extend(fetched);
     }
+}
+
+fn cargo_index_cache_dir(config: &Config) -> PathBuf {
+    let registry = if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+        "crates-io".to_string()
+    } else {
+        pnpm_crypto_hash::create_hex_hash(config.cargo.index_url.trim_end_matches('/'))
+    };
+    config.cache_dir.join("v11").join("cargo-index").join(registry)
+}
+
+async fn fetch_registry_config(
+    config: &Config,
+    http_client: &ThrottledClient,
+    auth_headers: &AuthHeaders,
+) -> Result<RegistryConfig> {
+    if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+        return Ok(RegistryConfig {
+            dl: CRATES_IO_DOWNLOAD_BASE.to_string(),
+            api: Some("https://crates.io".to_string()),
+            auth_required: false,
+        });
+    }
+    let cache_path = cargo_index_cache_dir(config).join(RegistryConfig::NAME);
+    let bytes = if config.offline {
+        fs::read(&cache_path).into_diagnostic().wrap_err_with(|| {
+            format!("read cached Cargo registry config at {}", cache_path.display())
+        })?
+    } else {
+        let url =
+            format!("{}/{}", config.cargo.index_url.trim_end_matches('/'), RegistryConfig::NAME);
+        let response = http_client
+            .get_bytes_with_secure_auth_and_retry(&url, auth_headers, None, config.retry_opts())
+            .await
+            .into_diagnostic()
+            .wrap_err_with(|| format!("fetch Cargo registry config from {url}"))?;
+        if !response.status.is_success() {
+            return Err(miette::miette!(
+                "fetch Cargo registry config returned HTTP {}",
+                response.status,
+            ));
+        }
+        if let Some(parent) = cache_path.parent() {
+            fs::create_dir_all(parent)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("create Cargo registry cache at {}", parent.display()))?;
+        }
+        pnpm_fs::write_atomic(&cache_path, &response.body)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("cache Cargo registry config at {}", cache_path.display()))?;
+        response.body
+    };
+    serde_json::from_slice(&bytes)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parse Cargo registry config from {}", cache_path.display()))
 }
 
 async fn fetch_sparse_index_file(
@@ -468,6 +542,7 @@ struct MaterializeOptions {
     store_index_writer: Arc<StoreIndexWriter>,
     http_client: Arc<ThrottledClient>,
     auth_headers: Arc<AuthHeaders>,
+    download_template: String,
     verified_files_cache: SharedVerifiedFilesCache,
     logged_methods: Arc<AtomicU8>,
     package_import_method: pnpm_config::PackageImportMethod,
@@ -488,6 +563,7 @@ async fn materialize<Reporter: self::Reporter + 'static>(
         store_index_writer,
         http_client,
         auth_headers,
+        download_template,
         verified_files_cache,
         logged_methods,
         package_import_method,
@@ -499,9 +575,11 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     } = options;
     let link_name = package.link_name();
     let slot = package.store_slot(store_dir.root());
-    let package_url = format!(
-        "{CRATES_IO_DOWNLOAD_BASE}/{}/{}-{}.crate",
-        package.name, package.name, package.version,
+    let package_url = pnpm_cargo_resolver::download_url(
+        &download_template,
+        &package.name,
+        &package.version,
+        &package.checksum,
     );
     let package_id = format!("crate:{}@{}", package.name, package.version);
     let integrity = Integrity::from_hex(&package.checksum, Algorithm::Sha256)
@@ -601,12 +679,12 @@ fn link_workspace_in(source_dir: &ManagedDirectory, slots: &[(String, PathBuf)])
     Ok(())
 }
 
-fn write_cargo_config(root_dir: &Path) -> Result<()> {
+fn write_cargo_config(root_dir: &Path, index_url: &str) -> Result<()> {
     let cargo_dir = ensure_workspace_directory(root_dir, &[".cargo"])?;
-    write_cargo_config_in(&cargo_dir)
+    write_cargo_config_in(&cargo_dir, index_url)
 }
 
-fn write_cargo_config_in(cargo_dir: &ManagedDirectory) -> Result<()> {
+fn write_cargo_config_in(cargo_dir: &ManagedDirectory, index_url: &str) -> Result<()> {
     let config_path = cargo_dir.path.join("config.toml");
     let (existing, mode) = match read_workspace_file(cargo_dir, "config.toml") {
         Ok(existing) => existing,
@@ -617,7 +695,7 @@ fn write_cargo_config_in(cargo_dir: &ManagedDirectory) -> Result<()> {
                 .wrap_err_with(|| format!("read {}", config_path.display()));
         }
     };
-    let updated = update_managed_config(&existing)?;
+    let updated = update_managed_config(&existing, index_url)?;
     if updated != existing {
         write_workspace_file(cargo_dir, "config.toml", updated.as_bytes(), mode)
             .into_diagnostic()
@@ -1035,7 +1113,8 @@ fn force_workspace_symlink(
     pnpm_fs::force_symlink_dir(target, &directory.path.join(name))
 }
 
-fn update_managed_config(existing: &str) -> Result<String> {
+fn update_managed_config(existing: &str, index_url: &str) -> Result<String> {
+    let managed_config = managed_config(index_url);
     match (existing.find(MANAGED_START), existing.find(MANAGED_END)) {
         (None, None) => {
             let separator = if existing.is_empty() || existing.ends_with("\n\n") {
@@ -1045,11 +1124,11 @@ fn update_managed_config(existing: &str) -> Result<String> {
             } else {
                 "\n\n"
             };
-            Ok(format!("{existing}{separator}{MANAGED_CONFIG}\n"))
+            Ok(format!("{existing}{separator}{managed_config}\n"))
         }
         (Some(start), Some(end)) if start <= end => {
             let after = end + MANAGED_END.len();
-            Ok(format!("{}{}{}", &existing[..start], MANAGED_CONFIG, &existing[after..]))
+            Ok(format!("{}{}{}", &existing[..start], managed_config, &existing[after..]))
         }
         _ => Err(miette::miette!(
             ".cargo/config.toml contains an incomplete pnpm-managed Cargo source block"
@@ -1057,12 +1136,22 @@ fn update_managed_config(existing: &str) -> Result<String> {
     }
 }
 
-fn parse_lockfile(input: &str) -> Result<Vec<LockedCrate>> {
+fn managed_config(index_url: &str) -> String {
+    if index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+        return MANAGED_CONFIG.to_string();
+    }
+    format!(
+        "{MANAGED_START}\n[source.crates-io]\nreplace-with = \"pnpm-registry\"\n\n[source.pnpm-registry]\nregistry = {:?}\nreplace-with = \"pnpm-registry-directory\"\n\n[source.pnpm-registry-directory]\ndirectory = \".pnpm/crates/crates-io\"\n{MANAGED_END}",
+        pnpm_cargo_resolver::sparse_source(index_url),
+    )
+}
+
+fn parse_lockfile(input: &str, index_url: &str) -> Result<Vec<LockedCrate>> {
     let lockfile =
         cargo_lock::Lockfile::from_str(input).into_diagnostic().wrap_err("parse Cargo.lock")?;
     let mut packages = Vec::new();
     for package in lockfile.packages {
-        if let Some(package) = locked_crate_from_package(package)? {
+        if let Some(package) = locked_crate_from_package(package, index_url)? {
             packages.push(package);
         }
     }
@@ -1080,13 +1169,17 @@ fn parse_lockfile(input: &str) -> Result<Vec<LockedCrate>> {
     Ok(packages)
 }
 
-fn locked_crate_from_package(package: cargo_lock::Package) -> Result<Option<LockedCrate>> {
+fn locked_crate_from_package(
+    package: cargo_lock::Package,
+    index_url: &str,
+) -> Result<Option<LockedCrate>> {
     let Some(source) = package.source.as_ref() else {
         return Ok(None);
     };
-    if !source.is_default_registry() {
+    let expected_source = pnpm_cargo_resolver::sparse_source(index_url);
+    if !source.is_default_registry() && source.to_string() != expected_source {
         return Err(miette::miette!(
-            "Cargo source {source:?} is not supported by the crates.io-only proof of concept"
+            "Cargo source {source:?} does not match the configured Cargo registry {expected_source:?}"
         ));
     }
     let name = package.name.to_string();

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -202,7 +202,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     let (store_index_writer, writer_task) =
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
 
-    let auth_headers = Arc::clone(&config.auth_headers);
+    let auth_headers = download_auth_headers(config);
     let cargo_auth_headers = cargo_auth_headers(config)?;
     let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
     let verified_files_cache = SharedVerifiedFilesCache::default();
@@ -358,6 +358,13 @@ pub(crate) async fn latest_version(
     .await?;
     pnpm_cargo_resolver::latest_version(name, &index_file)
         .wrap_err_with(|| format!("select the latest version of crate {name}"))
+}
+
+/// The credentials a crate archive download may carry. The registry's `dl`
+/// template picks the download host, so a credential configured for that
+/// host travels only over TLS or loopback.
+fn download_auth_headers(config: &Config) -> Arc<AuthHeaders> {
+    Arc::new((*config.auth_headers).clone().with_secure_transport())
 }
 
 pub(crate) fn cargo_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -204,7 +204,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
 
     let cargo_auth_headers = cargo_auth_headers(config)?;
     let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
-    let auth_headers = download_auth_headers(config, &registry_config.dl);
+    let auth_headers = download_auth_headers(config, &registry_config);
     let verified_files_cache = SharedVerifiedFilesCache::default();
     let logged_methods = Arc::new(AtomicU8::new(0));
     let retry_opts = config.retry_opts();
@@ -362,30 +362,48 @@ pub(crate) async fn latest_version(
 
 /// The credentials a crate archive download may carry.
 ///
-/// The registry named by `cargo.indexUrl` is repository-selected, and its
-/// `config.json` picks the download host through `download_template`. A
-/// credential is therefore offered only when that host is the registry's
-/// own — otherwise a registry could name any host and collect the
-/// credential the user configured for it. What it does get travels only
-/// over TLS or loopback.
+/// `cargo.indexUrl` is repository-selected and its `config.json` names the
+/// download host, so the only credential that may travel is the one
+/// configured for the registry itself, never one looked up by the host the
+/// registry names. Off the registry's own origin it travels only when the
+/// registry sets `auth-required`, which is the same condition under which
+/// `cargo` sends its own token. Either way it travels only over TLS or
+/// loopback.
 ///
 /// A Cargo install runs from the CLI, which installs no route hook, so the
 /// anonymous headers deny nothing a hook would have allowed.
-fn download_auth_headers(config: &Config, download_template: &str) -> Arc<AuthHeaders> {
-    if same_origin(download_template, &config.cargo.index_url) {
-        Arc::new((*config.auth_headers).clone().with_secure_transport())
-    } else {
-        Arc::new(AuthHeaders::default())
+fn download_auth_headers(config: &Config, registry_config: &RegistryConfig) -> Arc<AuthHeaders> {
+    // The registry serves its own downloads: every credential configured
+    // for it applies to them as it does to its index.
+    if same_origin(&registry_config.dl, &config.cargo.index_url) {
+        return Arc::new((*config.auth_headers).clone().with_secure_transport());
     }
+    let credential = registry_config
+        .auth_required
+        .then(|| config.auth_headers.for_secure_url(&config.cargo.index_url))
+        .flatten();
+    let Some((credential, origin)) = credential.zip(origin_of(&registry_config.dl)) else {
+        return Arc::new(AuthHeaders::default());
+    };
+    let mut auth_headers = AuthHeaders::default().with_secure_transport();
+    auth_headers.insert_url_header(&origin, credential);
+    Arc::new(auth_headers)
 }
 
 /// Whether both URLs are absolute and share a scheme, host, and port. A URL
 /// that does not parse, or whose scheme has no host, matches nothing.
 fn same_origin(left: &str, right: &str) -> bool {
-    match (url::Url::parse(left), url::Url::parse(right)) {
-        (Ok(left), Ok(right)) => left.origin().is_tuple() && left.origin() == right.origin(),
+    match (origin_of(left), origin_of(right)) {
+        (Some(left), Some(right)) => left == right,
         _ => false,
     }
+}
+
+/// `scheme://host:port` of an absolute URL whose scheme has a host. `None`
+/// for anything else, including a download template that is a bare path.
+fn origin_of(url: &str) -> Option<String> {
+    let origin = url::Url::parse(url).ok()?.origin();
+    origin.is_tuple().then(|| origin.ascii_serialization())
 }
 
 pub(crate) fn cargo_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -2,7 +2,7 @@ use crate::ecosystem_install::{EcosystemManifest, EcosystemWorkspaceInventory, I
 use cargo_util_schemas::index::RegistryConfig;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
-use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
+use pnpm_cargo_resolver::is_crates_io;
 use pnpm_config::Config;
 use pnpm_deps_restorer::{ImportIndexedDirOpts, import_indexed_dir};
 use pnpm_install_coordinator::{InstallTask, PreparedInstall};
@@ -32,6 +32,10 @@ use std::sync::atomic::{AtomicU64, Ordering};
 
 const WORKSPACE_INSTALL_CONCURRENCY: usize = 8;
 const CRATES_IO_DOWNLOAD_BASE: &str = "https://static.crates.io/crates";
+/// A registry's `config.json` holds a download template and two URLs. The
+/// cap keeps a registry the workspace names from spending the client's
+/// memory and cache before the document is even parsed.
+const MAX_REGISTRY_CONFIG_BYTES: usize = 64 * 1024;
 const MANAGED_START: &str = "# >>> pnpm-managed cargo sources >>>";
 const MANAGED_END: &str = "# <<< pnpm-managed cargo sources <<<";
 const MANAGED_CONFIG: &str = "# >>> pnpm-managed cargo sources >>>\n[source.crates-io]\nreplace-with = \"pnpm-crates-io\"\n\n[source.pnpm-crates-io]\ndirectory = \".pnpm/crates/crates-io\"\n# <<< pnpm-managed cargo sources <<<";
@@ -181,6 +185,14 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     }
     let packages = parse_lockfile(&cargo_lock, &config.cargo.index_url)
         .wrap_err_with(|| format!("parse {}", cargo_lock_path.display()))?;
+    if packages.is_empty() {
+        return Ok(Prepared {
+            root: root_dir.to_path_buf(),
+            lock: cargo_lock,
+            slots: Some(Vec::new()),
+            index_url: config.cargo.index_url.clone(),
+        });
+    }
     let store_dir = &config.store_dir;
     store_dir
         .init()
@@ -283,7 +295,8 @@ async fn read_or_resolve_lockfile(
         return Ok(lockfile);
     }
     let index_files = fetch_sparse_index(config, &metadata, http_client).await?;
-    let lockfile = pnpm_cargo_resolver::resolve_lockfile(&metadata, &index_files)
+    let source = pnpm_cargo_resolver::registry_source(&config.cargo.index_url);
+    let lockfile = pnpm_cargo_resolver::resolve_lockfile(&metadata, &index_files, &source)
         .wrap_err("resolve Cargo dependencies")?;
     Ok(lockfile)
 }
@@ -348,7 +361,7 @@ pub(crate) async fn latest_version(
 }
 
 pub(crate) fn cargo_auth_headers(config: &Config) -> Result<Arc<AuthHeaders>> {
-    if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+    if is_crates_io(&config.cargo.index_url) {
         registry_auth::crates_io::<pnpm_config::Host>(&config.auth_headers, config.offline)
     } else {
         Ok(Arc::clone(&config.auth_headers))
@@ -390,10 +403,11 @@ async fn fetch_sparse_index(
 ) -> Result<BTreeMap<String, String>> {
     let auth_headers = cargo_auth_headers(config)?;
     let cache_dir = cargo_index_cache_dir(config);
+    let source = pnpm_cargo_resolver::registry_source(&config.cargo.index_url);
     let mut index_files = BTreeMap::new();
 
     loop {
-        let missing = pnpm_cargo_resolver::missing_index_names(metadata, &index_files)
+        let missing = pnpm_cargo_resolver::missing_index_names(metadata, &index_files, &source)
             .wrap_err("discover Cargo sparse-index files")?;
         if missing.is_empty() {
             return Ok(index_files);
@@ -425,7 +439,7 @@ async fn fetch_sparse_index(
 }
 
 fn cargo_index_cache_dir(config: &Config) -> PathBuf {
-    let registry = if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+    let registry = if is_crates_io(&config.cargo.index_url) {
         "crates-io".to_string()
     } else {
         pnpm_crypto_hash::create_hex_hash(config.cargo.index_url.trim_end_matches('/'))
@@ -438,7 +452,7 @@ async fn fetch_registry_config(
     http_client: &ThrottledClient,
     auth_headers: &AuthHeaders,
 ) -> Result<RegistryConfig> {
-    if config.cargo.index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+    if is_crates_io(&config.cargo.index_url) {
         return Ok(RegistryConfig {
             dl: CRATES_IO_DOWNLOAD_BASE.to_string(),
             api: Some("https://crates.io".to_string()),
@@ -454,7 +468,13 @@ async fn fetch_registry_config(
         let url =
             format!("{}/{}", config.cargo.index_url.trim_end_matches('/'), RegistryConfig::NAME);
         let response = http_client
-            .get_bytes_with_secure_auth_and_retry(&url, auth_headers, None, config.retry_opts())
+            .get_limited_bytes_with_secure_auth_and_retry(
+                &url,
+                auth_headers,
+                None,
+                config.retry_opts(),
+                MAX_REGISTRY_CONFIG_BYTES,
+            )
             .await
             .into_diagnostic()
             .wrap_err_with(|| format!("fetch Cargo registry config from {url}"))?;
@@ -462,6 +482,11 @@ async fn fetch_registry_config(
             return Err(miette::miette!(
                 "fetch Cargo registry config returned HTTP {}",
                 response.status,
+            ));
+        }
+        if response.body_truncated {
+            return Err(miette::miette!(
+                "Cargo registry config at {url} is larger than {MAX_REGISTRY_CONFIG_BYTES} bytes",
             ));
         }
         if let Some(parent) = cache_path.parent() {
@@ -1137,12 +1162,12 @@ fn update_managed_config(existing: &str, index_url: &str) -> Result<String> {
 }
 
 fn managed_config(index_url: &str) -> String {
-    if index_url.trim_end_matches('/') == CRATES_IO_SPARSE_INDEX {
+    if is_crates_io(index_url) {
         return MANAGED_CONFIG.to_string();
     }
+    let source = toml::Value::from(pnpm_cargo_resolver::sparse_source(index_url));
     format!(
-        "{MANAGED_START}\n[source.crates-io]\nreplace-with = \"pnpm-registry\"\n\n[source.pnpm-registry]\nregistry = {:?}\nreplace-with = \"pnpm-registry-directory\"\n\n[source.pnpm-registry-directory]\ndirectory = \".pnpm/crates/crates-io\"\n{MANAGED_END}",
-        pnpm_cargo_resolver::sparse_source(index_url),
+        "{MANAGED_START}\n[source.crates-io]\nreplace-with = \"pnpm-registry\"\n\n[source.pnpm-registry]\nregistry = {source}\nreplace-with = \"pnpm-registry-directory\"\n\n[source.pnpm-registry-directory]\ndirectory = \".pnpm/crates/crates-io\"\n{MANAGED_END}",
     )
 }
 
@@ -1176,8 +1201,15 @@ fn locked_crate_from_package(
     let Some(source) = package.source.as_ref() else {
         return Ok(None);
     };
-    let expected_source = pnpm_cargo_resolver::sparse_source(index_url);
-    if !source.is_default_registry() && source.to_string() != expected_source {
+    // crates.io is spelled two ways in a lockfile — the canonical git
+    // identifier and the sparse index — and `cargo` writes either.
+    let expected_source = pnpm_cargo_resolver::registry_source(index_url);
+    let matches_registry = if is_crates_io(index_url) {
+        source.is_default_registry()
+    } else {
+        source.to_string() == expected_source
+    };
+    if !matches_registry {
         return Err(miette::miette!(
             "Cargo source {source:?} does not match the configured Cargo registry {expected_source:?}"
         ));

--- a/pnpm/crates/cli/src/cargo_deps/add.rs
+++ b/pnpm/crates/cli/src/cargo_deps/add.rs
@@ -63,7 +63,7 @@ async fn prepare_manifest(
     let auth_headers = packages
         .iter()
         .any(|package| package.version_spec.is_none())
-        .then(|| cargo_deps::crates_io_auth_headers(config))
+        .then(|| cargo_deps::cargo_auth_headers(config))
         .transpose()?;
 
     let resolved = stream::iter(packages)

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -4,6 +4,7 @@ use super::{
     materialize, parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config,
     workspace_root,
 };
+use cargo_util_schemas::index::RegistryConfig;
 use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
@@ -357,16 +358,21 @@ fn config_with_cargo_credentials(index_url: &str) -> Config {
     config.cargo.index_url = index_url.to_string();
     config.auth_headers = Arc::new(AuthHeaders::from_creds_map([
         ("//registry.example.test/".to_string(), "Bearer crate-token".to_string()),
-        ("//npm.internal.test/".to_string(), "Bearer unrelated-token".to_string()),
+        ("//cdn.example.test/".to_string(), "Bearer unrelated-token".to_string()),
         ("//127.0.0.1:4873/".to_string(), "Bearer local-token".to_string()),
     ]));
     config
 }
 
+fn registry_config(dl: &str, auth_required: bool) -> RegistryConfig {
+    RegistryConfig { dl: dl.to_string(), api: None, auth_required }
+}
+
 #[test]
 fn crate_downloads_keep_credentials_off_plaintext_hosts() {
     let config = config_with_cargo_credentials("https://registry.example.test/index/");
-    let auth_headers = download_auth_headers(&config, "https://registry.example.test/dl");
+    let auth_headers =
+        download_auth_headers(&config, &registry_config("https://registry.example.test/dl", false));
 
     assert_eq!(
         auth_headers.for_url_with_package("https://registry.example.test/dl/demo/1.0.0", None),
@@ -381,7 +387,8 @@ fn crate_downloads_keep_credentials_off_plaintext_hosts() {
 #[test]
 fn a_registry_on_loopback_still_authenticates_its_downloads() {
     let config = config_with_cargo_credentials("http://127.0.0.1:4873/index/");
-    let auth_headers = download_auth_headers(&config, "http://127.0.0.1:4873/dl");
+    let auth_headers =
+        download_auth_headers(&config, &registry_config("http://127.0.0.1:4873/dl", false));
 
     assert_eq!(
         auth_headers.for_url_with_package("http://127.0.0.1:4873/dl/demo/1.0.0", None),
@@ -390,12 +397,26 @@ fn a_registry_on_loopback_still_authenticates_its_downloads() {
 }
 
 #[test]
-fn a_download_template_off_the_registry_origin_carries_no_credential() {
+fn an_unauthenticated_archive_host_carries_no_credential() {
     let config = config_with_cargo_credentials("https://registry.example.test/index/");
-    let auth_headers = download_auth_headers(&config, "https://npm.internal.test/{crate}");
+    let auth_headers =
+        download_auth_headers(&config, &registry_config("https://cdn.example.test/{crate}", false));
 
-    assert_eq!(auth_headers.for_url_with_package("https://npm.internal.test/demo", None), None);
-    assert!(auth_headers.allows_fetch("https://npm.internal.test/demo"));
+    assert_eq!(auth_headers.for_url_with_package("https://cdn.example.test/demo", None), None);
+    assert!(auth_headers.allows_fetch("https://cdn.example.test/demo"));
+}
+
+#[test]
+fn an_authenticated_archive_host_carries_the_credential_of_the_registry() {
+    let config = config_with_cargo_credentials("https://registry.example.test/index/");
+    let auth_headers =
+        download_auth_headers(&config, &registry_config("https://cdn.example.test/{crate}", true));
+
+    // The registry's credential, not the one configured for the host it named.
+    assert_eq!(
+        auth_headers.for_url_with_package("https://cdn.example.test/demo", None),
+        Some("Bearer crate-token".to_string()),
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     ArchiveStoreProjection, CRATES_IO_SPARSE_INDEX, Config, LockedCrate, MANAGED_CONFIG,
-    MaterializeOptions, add_cargo_checksum, fetch_sparse_index_file, materialize, parse_lockfile,
-    resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
+    MaterializeOptions, add_cargo_checksum, fetch_sparse_index_file, managed_config, materialize,
+    parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
 };
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
@@ -46,7 +46,7 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 "#;
 
     assert_eq!(
-        parse_lockfile(lockfile).unwrap(),
+        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap(),
         vec![LockedCrate {
             name: "serde".to_string(),
             version: "1.0.228".to_string(),
@@ -66,8 +66,8 @@ source = "registry+https://registry.example/index"
 checksum = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 "#;
 
-    let error = parse_lockfile(lockfile).unwrap_err().to_string();
-    assert!(error.contains("crates.io-only proof of concept"), "{error}");
+    let error = parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap_err().to_string();
+    assert!(error.contains("does not match the configured Cargo registry"), "{error}");
 }
 
 #[test]
@@ -88,7 +88,7 @@ source = "registry+https://registry.example/index"
 "#;
 
     assert_eq!(
-        parse_lockfile(lockfile).unwrap(),
+        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap(),
         vec![LockedCrate {
             name: "serde".to_string(),
             version: "1.0.228".to_string(),
@@ -119,7 +119,7 @@ fn crate_store_slots_are_grouped_by_name_version_and_content() {
 #[test]
 fn appends_the_managed_config_without_changing_user_settings() {
     let existing = "[alias]\ncodecov = \"llvm-cov\"\n";
-    let updated = update_managed_config(existing).unwrap();
+    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX).unwrap();
 
     assert_eq!(updated, format!("{existing}\n{MANAGED_CONFIG}\n"));
 }
@@ -127,15 +127,27 @@ fn appends_the_managed_config_without_changing_user_settings() {
 #[test]
 fn replaces_only_the_existing_managed_config() {
     let existing = "before\n# >>> pnpm-managed cargo sources >>>\nstale\n# <<< pnpm-managed cargo sources <<<\nafter\n";
-    let updated = update_managed_config(existing).unwrap();
+    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX).unwrap();
 
     assert_eq!(updated, format!("before\n{MANAGED_CONFIG}\nafter\n"));
 }
 
 #[test]
+fn configures_the_selected_sparse_registry_as_the_vendored_source() {
+    let config = managed_config("https://registry.example.test/index/");
+
+    assert!(config.contains("[source.crates-io]\nreplace-with = \"pnpm-registry\""));
+    assert!(config.contains("[source.pnpm-registry]"));
+    assert!(config.contains(r#"registry = "sparse+https://registry.example.test/index/""#));
+    assert!(config.contains(r#"replace-with = "pnpm-registry-directory""#));
+}
+
+#[test]
 fn rejects_an_incomplete_managed_config() {
     let error =
-        update_managed_config("# >>> pnpm-managed cargo sources >>>\n").unwrap_err().to_string();
+        update_managed_config("# >>> pnpm-managed cargo sources >>>\n", CRATES_IO_SPARSE_INDEX)
+            .unwrap_err()
+            .to_string();
 
     assert!(error.contains("incomplete"), "{error}");
 }
@@ -242,6 +254,7 @@ async fn repairs_a_preseeded_slot_from_verified_store_metadata() {
         store_index_writer: Arc::clone(&store_index_writer),
         http_client: Arc::new(ThrottledClient::default()),
         auth_headers: Arc::new(AuthHeaders::default()),
+        download_template: "https://static.crates.io/crates".to_string(),
         verified_files_cache: SharedVerifiedFilesCache::default(),
         logged_methods: Arc::new(AtomicU8::new(0)),
         package_import_method: pnpm_config::PackageImportMethod::default(),
@@ -353,7 +366,8 @@ fn rejects_a_symlinked_cargo_config_parent() {
     fs::write(&external_config, "unchanged\n").unwrap();
     symlink(outside.path(), workspace.path().join(".cargo")).unwrap();
 
-    let error = write_cargo_config(workspace.path()).unwrap_err().to_string();
+    let error =
+        write_cargo_config(workspace.path(), CRATES_IO_SPARSE_INDEX).unwrap_err().to_string();
 
     assert!(error.contains("must be a real directory"), "{error}");
     assert_eq!(fs::read_to_string(external_config).unwrap(), "unchanged\n");
@@ -370,7 +384,7 @@ fn config_write_stays_in_the_directory_pinned_before_a_parent_swap() {
     fs::write(outside.path().join("config.toml"), "unchanged\n").unwrap();
     symlink(outside.path(), workspace.path().join(".cargo")).unwrap();
 
-    write_cargo_config_in(&cargo_dir).unwrap();
+    write_cargo_config_in(&cargo_dir, CRATES_IO_SPARSE_INDEX).unwrap();
 
     assert_eq!(fs::read_to_string(outside.path().join("config.toml")).unwrap(), "unchanged\n");
     assert!(fs::read_to_string(pinned_path.join("config.toml")).unwrap().contains(MANAGED_CONFIG));
@@ -483,6 +497,32 @@ async fn cargo_resolution_is_offloaded_to_the_pnpr_server() {
         .await;
 
     let lockfile = resolve_via_pnpr(&config_for_pnpr(&server.url()), METADATA).await.unwrap();
+
+    assert_eq!(lockfile.as_deref(), Some("version = 4\n"));
+    handshake.assert_async().await;
+    resolve.assert_async().await;
+}
+
+#[tokio::test]
+async fn configured_cargo_registry_is_sent_to_the_pnpr_server() {
+    let mut server = mockito::Server::new_async().await;
+    let handshake =
+        server.mock("GET", "/-/pnpr").with_body(handshake_body(&["cargo"])).create_async().await;
+    let resolve = server
+        .mock("POST", "/-/pnpr/v0/resolve")
+        .match_body(mockito::Matcher::PartialJson(serde_json::json!({
+            "ecosystem": "cargo",
+            "registry": "https://registry.example.test/index/",
+        })))
+        .with_header("content-type", "application/x-ndjson")
+        .with_body("{\"type\":\"done\",\"lockfile\":\"version = 4\\n\"}\n")
+        .create_async()
+        .await;
+    let mut config = config_for_pnpr(&server.url());
+    config.cargo.index_url = "https://registry.example.test/index/".to_string();
+
+    let lockfile =
+        resolve_via_pnpr(&config, r#"{"packages":[],"workspace_members":[]}"#).await.unwrap();
 
     assert_eq!(lockfile.as_deref(), Some("version = 4\n"));
     handshake.assert_async().await;

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     ArchiveStoreProjection, Config, LockedCrate, MANAGED_CONFIG, MaterializeOptions,
-    add_cargo_checksum, fetch_sparse_index_file, managed_config, materialize, parse_lockfile,
-    resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
+    add_cargo_checksum, download_auth_headers, fetch_sparse_index_file, managed_config,
+    materialize, parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config,
+    workspace_root,
 };
 use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
@@ -349,6 +350,30 @@ fn maps_crate_names_to_sparse_index_paths() {
     assert_eq!(sparse_index_path("ab").unwrap(), "2/ab");
     assert_eq!(sparse_index_path("abc").unwrap(), "3/a/abc");
     assert_eq!(sparse_index_path("Serde_JSON").unwrap(), "se/rd/serde_json");
+}
+
+#[test]
+fn crate_downloads_keep_credentials_off_plaintext_hosts() {
+    let mut config = Config::new();
+    config.auth_headers = Arc::new(AuthHeaders::from_creds_map([
+        ("//registry.example.test/".to_string(), "Bearer crate-token".to_string()),
+        ("//127.0.0.1:4873/".to_string(), "Bearer local-token".to_string()),
+    ]));
+    let auth_headers = download_auth_headers(&config);
+
+    assert_eq!(
+        auth_headers.for_url_with_package("https://registry.example.test/dl/demo/1.0.0", None),
+        Some("Bearer crate-token".to_string()),
+    );
+    assert_eq!(
+        auth_headers.for_url_with_package("http://registry.example.test/dl/demo/1.0.0", None),
+        None,
+    );
+    // A registry on loopback has no network to eavesdrop on.
+    assert_eq!(
+        auth_headers.for_url_with_package("http://127.0.0.1:4873/dl/demo/1.0.0", None),
+        Some("Bearer local-token".to_string()),
+    );
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    ArchiveStoreProjection, CRATES_IO_SPARSE_INDEX, Config, LockedCrate, MANAGED_CONFIG,
-    MaterializeOptions, add_cargo_checksum, fetch_sparse_index_file, managed_config, materialize,
-    parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
+    ArchiveStoreProjection, Config, LockedCrate, MANAGED_CONFIG, MaterializeOptions,
+    add_cargo_checksum, fetch_sparse_index_file, managed_config, materialize, parse_lockfile,
+    resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
 };
+use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
 use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::{
@@ -68,6 +69,56 @@ checksum = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
     let error = parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap_err().to_string();
     assert!(error.contains("does not match the configured Cargo registry"), "{error}");
+}
+
+#[test]
+fn rejects_a_crates_io_source_under_a_configured_registry() {
+    let lockfile = r#"
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+"#;
+
+    let error =
+        parse_lockfile(lockfile, "https://registry.example.test/index/").unwrap_err().to_string();
+
+    assert!(error.contains("does not match the configured Cargo registry"), "{error}");
+}
+
+#[test]
+fn accepts_the_configured_registry_source() {
+    let lockfile = r#"
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "sparse+https://registry.example.test/index/"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+"#;
+
+    assert_eq!(
+        parse_lockfile(lockfile, "https://registry.example.test/index/").unwrap(),
+        vec![LockedCrate {
+            name: "serde".to_string(),
+            version: "1.0.228".to_string(),
+            checksum: "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+                .to_string(),
+        }],
+    );
+}
+
+#[test]
+fn accepts_the_sparse_spelling_of_crates_io() {
+    let lockfile = r#"
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "sparse+https://index.crates.io/"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+"#;
+
+    assert_eq!(parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap().len(), 1);
 }
 
 #[test]
@@ -140,6 +191,17 @@ fn configures_the_selected_sparse_registry_as_the_vendored_source() {
     assert!(config.contains("[source.pnpm-registry]"));
     assert!(config.contains(r#"registry = "sparse+https://registry.example.test/index/""#));
     assert!(config.contains(r#"replace-with = "pnpm-registry-directory""#));
+}
+
+#[test]
+fn escapes_a_registry_url_that_is_not_a_bare_toml_string() {
+    let config = managed_config("https://registry.example.test/o'brien/index");
+
+    let parsed: toml::Table = toml::from_str(&config).expect("managed config is valid TOML");
+    assert_eq!(
+        parsed["source"]["pnpm-registry"]["registry"].as_str(),
+        Some("sparse+https://registry.example.test/o'brien/index/"),
+    );
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -352,14 +352,21 @@ fn maps_crate_names_to_sparse_index_paths() {
     assert_eq!(sparse_index_path("Serde_JSON").unwrap(), "se/rd/serde_json");
 }
 
-#[test]
-fn crate_downloads_keep_credentials_off_plaintext_hosts() {
+fn config_with_cargo_credentials(index_url: &str) -> Config {
     let mut config = Config::new();
+    config.cargo.index_url = index_url.to_string();
     config.auth_headers = Arc::new(AuthHeaders::from_creds_map([
         ("//registry.example.test/".to_string(), "Bearer crate-token".to_string()),
+        ("//npm.internal.test/".to_string(), "Bearer unrelated-token".to_string()),
         ("//127.0.0.1:4873/".to_string(), "Bearer local-token".to_string()),
     ]));
-    let auth_headers = download_auth_headers(&config);
+    config
+}
+
+#[test]
+fn crate_downloads_keep_credentials_off_plaintext_hosts() {
+    let config = config_with_cargo_credentials("https://registry.example.test/index/");
+    let auth_headers = download_auth_headers(&config, "https://registry.example.test/dl");
 
     assert_eq!(
         auth_headers.for_url_with_package("https://registry.example.test/dl/demo/1.0.0", None),
@@ -369,11 +376,26 @@ fn crate_downloads_keep_credentials_off_plaintext_hosts() {
         auth_headers.for_url_with_package("http://registry.example.test/dl/demo/1.0.0", None),
         None,
     );
-    // A registry on loopback has no network to eavesdrop on.
+}
+
+#[test]
+fn a_registry_on_loopback_still_authenticates_its_downloads() {
+    let config = config_with_cargo_credentials("http://127.0.0.1:4873/index/");
+    let auth_headers = download_auth_headers(&config, "http://127.0.0.1:4873/dl");
+
     assert_eq!(
         auth_headers.for_url_with_package("http://127.0.0.1:4873/dl/demo/1.0.0", None),
         Some("Bearer local-token".to_string()),
     );
+}
+
+#[test]
+fn a_download_template_off_the_registry_origin_carries_no_credential() {
+    let config = config_with_cargo_credentials("https://registry.example.test/index/");
+    let auth_headers = download_auth_headers(&config, "https://npm.internal.test/{crate}");
+
+    assert_eq!(auth_headers.for_url_with_package("https://npm.internal.test/demo", None), None);
+    assert!(auth_headers.allows_fetch("https://npm.internal.test/demo"));
 }
 
 #[tokio::test]

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -1,0 +1,120 @@
+//! `pnpm install` against a Cargo workspace, resolving and downloading
+//! through the registry `cargo.indexUrl` selects.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use sha2::{Digest, Sha256};
+use std::process::Command;
+use tempfile::TempDir;
+
+/// A `.crate` archive holding the one source file a dependent needs, laid
+/// out under the `<name>-<version>` root `cargo` expects.
+pub(crate) fn crate_archive(name: &str, version: &str) -> Vec<u8> {
+    let root = format!("{name}-{version}");
+    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    for (path, contents) in [
+        ("Cargo.toml", format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n")),
+        ("src/lib.rs", "pub fn answer() -> u8 { 42 }\n".to_string()),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, format!("{root}/{path}"), contents.as_bytes()).unwrap();
+    }
+    builder.into_inner().unwrap().finish().unwrap()
+}
+
+fn cargo_workspace(index_url: &str, dependencies: &str, source: &str) -> TempDir {
+    let root = TempDir::new().expect("create Cargo workspace");
+    std::fs::create_dir(root.path().join("src")).expect("create Cargo source directory");
+    std::fs::write(root.path().join("src/lib.rs"), source).expect("write Cargo source");
+    std::fs::write(
+        root.path().join("Cargo.toml"),
+        format!(
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\n{dependencies}",
+        ),
+    )
+    .expect("write Cargo manifest");
+    std::fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        format!("cargo:\n  enabled: true\n  indexUrl: {index_url}\n"),
+    )
+    .expect("enable Cargo dependency management");
+    root
+}
+
+fn install_in(root: &TempDir, args: &[&str]) {
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(root.path())
+        .with_env("PNPM_CONFIG_CACHE_DIR", root.path().join("cache"))
+        .with_env("PNPM_CONFIG_STORE_DIR", root.path().join("store"))
+        .with_args(args)
+        .assert()
+        .success();
+}
+
+#[test]
+fn install_resolves_and_downloads_through_the_configured_registry() {
+    let mut registry = mockito::Server::new();
+    let archive = crate_archive("demo", "1.0.0");
+    let checksum = format!("{:x}", Sha256::digest(&archive));
+    let _config_mock = registry
+        .mock("GET", "/config.json")
+        .with_body(
+            serde_json::json!({
+                "dl": format!("{}/dl/{{crate}}/{{version}}", registry.url()),
+                "api": registry.url(),
+            })
+            .to_string(),
+        )
+        .create();
+    let index_mock = registry
+        .mock("GET", "/de/mo/demo")
+        .with_body(format!(
+            "{}\n",
+            serde_json::json!({
+                "name": "demo",
+                "vers": "1.0.0",
+                "deps": [],
+                "cksum": checksum,
+                "features": {},
+                "yanked": false,
+                "v": 1,
+            }),
+        ))
+        .expect(1)
+        .create();
+    let download_mock =
+        registry.mock("GET", "/dl/demo/1.0.0").with_body(&archive).expect(1).create();
+    let root = cargo_workspace(&registry.url(), "demo = \"1\"\n", "pub use demo::answer;\n");
+
+    install_in(&root, &["install"]);
+
+    let lockfile =
+        std::fs::read_to_string(root.path().join("Cargo.lock")).expect("read Cargo.lock");
+    assert!(lockfile.contains(&format!(r#"source = "sparse+{}/""#, registry.url())), "{lockfile}");
+    assert!(root.path().join(".pnpm/crates/crates-io/demo-1.0.0/src/lib.rs").is_file());
+    Command::new("cargo")
+        .with_current_dir(root.path())
+        .with_args(["check", "--offline"])
+        .assert()
+        .success();
+
+    index_mock.assert();
+    download_mock.assert();
+}
+
+#[test]
+fn offline_install_without_registry_crates_never_reads_the_registry_config() {
+    let root = cargo_workspace("https://registry.example.test/index/", "", "");
+
+    install_in(&root, &["install", "--offline"]);
+
+    assert!(root.path().join("Cargo.lock").is_file());
+    let config = std::fs::read_to_string(root.path().join(".cargo/config.toml"))
+        .expect("read managed Cargo configuration");
+    assert!(config.contains(r#"registry = "sparse+https://registry.example.test/index/""#));
+}

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -16,6 +16,7 @@ mod bin;
 mod bugs;
 mod bundled_dependencies;
 mod cache;
+mod cargo_install;
 mod cat_file;
 mod cat_index;
 mod catalog;

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -1645,6 +1645,15 @@ fn cargo_install_uses_a_configured_pnpr_registry_and_accelerator() {
     let lockfile = fs::read_to_string(root.path().join("Cargo.lock")).expect("read Cargo lockfile");
     assert!(lockfile.contains(&format!(r#"source = "sparse+{registry_url}index/""#)), "{lockfile}");
     assert!(root.path().join(".pnpm/crates/crates-io/demo-1.0.0/src/lib.rs").is_file());
+    // The accelerator resolved: a local resolve would have walked the sparse
+    // index itself and left the entry it read in the client's index cache.
+    // Only the registry's config.json, which the download needs either way,
+    // is cached here.
+    let cached_index_files = get_all_files(&root.path().join("cache/v11/cargo-index"));
+    assert!(
+        cached_index_files.iter().all(|path| path.ends_with("config.json")),
+        "{cached_index_files:?}",
+    );
     Command::new("cargo")
         .with_current_dir(root.path())
         .with_args(["check", "--offline"])

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -8,6 +8,7 @@
 //! client-supplied registry. The client then links `node_modules` from the
 //! server-produced lockfile.
 
+use crate::cargo_install::crate_archive;
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_crypto_hash::integrity_addressed_tarball_path;
@@ -41,14 +42,8 @@ const IS_POSITIVE_PATCH: &str = include_str!(
 /// boundary); returns its base URL and a pre-seeded bearer token.
 fn start_pnpr(registry_url: &str) -> (String, String) {
     let registry_url = registry_url.to_string();
-    // Persisted (not cleaned) because the detached server thread outlives
-    // this function.
-    let storage = tempfile::tempdir().expect("pnpr storage").keep();
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
-    // tokio's `from_std` requires the listener to be non-blocking.
-    listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
-    let addr = listener.local_addr().expect("pnpr addr");
-    let tokens_path = storage.join("tokens.db");
+    let server = PnprServer::bind("pnpr");
+    let tokens_path = server.storage.join("tokens.db");
     let runtime = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -58,122 +53,91 @@ fn start_pnpr(registry_url: &str) -> (String, String) {
         tokens.issue("pacquet-test").await.expect("issue pnpr test token")
     });
 
-    thread::Builder::new()
-        .name("pnpr".to_string())
-        .spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("pnpr runtime");
-            runtime.block_on(async move {
-                let mut config = pnpr::Config::proxy(addr, storage);
-                config.public_url = format!("http://{addr}");
-                config.auth.tokens.file = Some(tokens_path);
-                config
-                    .route_policy
-                    .public
-                    .push(pnpr::PublicRoute { registry: Some(registry_url), package: None });
-                let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
-                let _ = pnpr::serve_listener(config, listener).await;
-            });
-        })
-        .expect("spawn pnpr thread");
-
-    wait_until_ready(addr);
+    let addr = server.serve(move |config| {
+        config.auth.tokens.file = Some(tokens_path);
+        config
+            .route_policy
+            .public
+            .push(pnpr::PublicRoute { registry: Some(registry_url), package: None });
+    });
     (format!("http://{addr}/"), token)
 }
 
-fn start_pnpr_registry(upstream_url: &str) -> String {
+/// Start an in-process pnpr that proxies one upstream registry of
+/// `ecosystem`, and return the base URL its clients address.
+fn start_pnpr_registry(upstream_url: &str, ecosystem: Ecosystem) -> String {
     let upstream_url = upstream_url.to_string();
-    let storage = tempfile::tempdir().expect("pnpr storage").keep();
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
-    listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
-    let addr = listener.local_addr().expect("pnpr addr");
-
-    thread::Builder::new()
-        .name("pnpr-registry".to_string())
-        .spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("pnpr runtime");
-            runtime.block_on(async move {
-                let mut config = pnpr::Config::proxy(addr, storage);
-                config.public_url = format!("http://{addr}");
-                config.upstreams.get_mut("npmjs").unwrap().url = upstream_url;
-                config.registries = pnpr::Registries::new(
-                    std::iter::once((
-                        "npmjs".to_string(),
-                        pnpr::Registry::Upstream { patterns: Vec::new() },
-                    ))
-                    .collect(),
-                    Some("npmjs".to_string()),
-                );
-                let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
-                let _ = pnpr::serve_listener(config, listener).await;
-            });
-        })
-        .expect("spawn pnpr registry thread");
-
-    wait_until_ready(addr);
-    format!("http://{addr}")
-}
-
-fn start_pnpr_cargo_registry(upstream_url: &str) -> String {
-    let upstream_url = upstream_url.to_string();
-    let storage = tempfile::tempdir().expect("pnpr storage").keep();
-    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
-    listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
-    let addr = listener.local_addr().expect("pnpr addr");
-    let public_url = format!("http://{addr}");
-
-    thread::Builder::new()
-        .name("pnpr-cargo-registry".to_string())
-        .spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("pnpr runtime");
-            runtime.block_on(async move {
-                let mut config = pnpr::Config::proxy(addr, storage);
-                config.public_url = public_url;
-                config.upstreams.insert(
-                    "crates".to_string(),
-                    UpstreamConfig::with_defaults(upstream_url, HeaderMap::new()),
-                );
-                config.registries = Registries::new(
-                    indexmap::IndexMap::from([(
-                        "crates".to_string(),
-                        Registry::Upstream { patterns: Vec::new() },
-                    )]),
-                    Some("crates".to_string()),
-                )
-                .with_ecosystem("crates", Ecosystem::Cargo);
-                let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
-                let _ = pnpr::serve_listener(config, listener).await;
-            });
-        })
-        .expect("spawn pnpr Cargo registry thread");
-
-    wait_until_ready(addr);
-    format!("http://{addr}/cargo/")
-}
-
-fn crate_archive(name: &str, version: &str) -> Vec<u8> {
-    let root = format!("{name}-{version}");
-    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
-    let mut builder = tar::Builder::new(encoder);
-    for (path, contents) in [
-        ("Cargo.toml", format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n")),
-        ("src/lib.rs", "pub fn answer() -> u8 { 42 }\n".to_string()),
-    ] {
-        let mut header = tar::Header::new_gnu();
-        header.set_size(contents.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder.append_data(&mut header, format!("{root}/{path}"), contents.as_bytes()).unwrap();
+    let name = "upstream";
+    let addr = PnprServer::bind("pnpr-registry").serve(move |config| {
+        config.upstreams.insert(
+            name.to_string(),
+            UpstreamConfig::with_defaults(upstream_url, HeaderMap::new()),
+        );
+        config.registries = Registries::new(
+            indexmap::IndexMap::from([(
+                name.to_string(),
+                Registry::Upstream { patterns: Vec::new() },
+            )]),
+            Some(name.to_string()),
+        )
+        .with_ecosystem(name, ecosystem);
+    });
+    // The server's root is its npm alias; every other ecosystem is
+    // addressed under its own prefix.
+    if ecosystem == Ecosystem::Npm {
+        format!("http://{addr}")
+    } else {
+        format!("http://{addr}/{ecosystem}/")
     }
-    builder.into_inner().unwrap().finish().unwrap()
+}
+
+/// A bound port and storage directory waiting for [`Self::serve`] to start
+/// pnpr on them. Binding first lets a caller seed storage — a token store,
+/// say — with the address the server will answer on already known.
+struct PnprServer {
+    name: &'static str,
+    listener: TcpListener,
+    addr: SocketAddr,
+    /// Persisted (not cleaned) because the detached server thread outlives
+    /// the test that started it.
+    storage: std::path::PathBuf,
+}
+
+impl PnprServer {
+    fn bind(name: &'static str) -> Self {
+        let storage = tempfile::tempdir().expect("pnpr storage").keep();
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
+        // tokio's `from_std` requires the listener to be non-blocking.
+        listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
+        let addr = listener.local_addr().expect("pnpr addr");
+        Self { name, listener, addr, storage }
+    }
+
+    /// Run the server on a detached thread until the process exits, with
+    /// `configure` applied to the proxy defaults. Returns once it answers.
+    fn serve(self, configure: impl FnOnce(&mut pnpr::Config) + Send + 'static) -> SocketAddr {
+        let Self { name, listener, addr, storage } = self;
+        thread::Builder::new()
+            .name(name.to_string())
+            .spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("pnpr runtime");
+                runtime.block_on(async move {
+                    let mut config = pnpr::Config::proxy(addr, storage);
+                    config.public_url = format!("http://{addr}");
+                    configure(&mut config);
+                    let listener =
+                        tokio::net::TcpListener::from_std(listener).expect("tokio listener");
+                    let _ = pnpr::serve_listener(config, listener).await;
+                });
+            })
+            .expect("spawn pnpr thread");
+
+        wait_until_ready(addr);
+        addr
+    }
 }
 
 fn configure_pnpr_auth(npmrc_path: &std::path::Path, pnpr_url: &str, token: &str) {
@@ -298,7 +262,7 @@ fn revision_install_and_frozen_reinstall_work_through_pnpr() {
         .with_body(&tarball)
         .expect(1)
         .create();
-    let registry = start_pnpr_registry(&upstream.url());
+    let registry = start_pnpr_registry(&upstream.url(), Ecosystem::Npm);
 
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -341,7 +305,7 @@ fn update_patches_refreshes_a_pnpr_revision_without_changing_the_version() {
         .with_body(&first_tarball)
         .expect(1)
         .create();
-    let first_registry = start_pnpr_registry(&first_upstream.url());
+    let first_registry = start_pnpr_registry(&first_upstream.url(), Ecosystem::Npm);
 
     let mut second_upstream = mockito::Server::new();
     let (second_integrity, second_packument) =
@@ -353,7 +317,7 @@ fn update_patches_refreshes_a_pnpr_revision_without_changing_the_version() {
         .with_body(&second_tarball)
         .expect(1)
         .create();
-    let second_registry = start_pnpr_registry(&second_upstream.url());
+    let second_registry = start_pnpr_registry(&second_upstream.url(), Ecosystem::Npm);
 
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry();
@@ -1644,7 +1608,7 @@ fn cargo_install_uses_a_configured_pnpr_registry_and_accelerator() {
         .create();
     let download_mock =
         upstream.mock("GET", "/dl/demo/1.0.0").with_body(&archive).expect(1).create();
-    let registry_url = start_pnpr_cargo_registry(&upstream.url());
+    let registry_url = start_pnpr_registry(&upstream.url(), Ecosystem::Cargo);
     let (pnpr_url, token) = start_pnpr(&format!("{registry_url}index"));
 
     let root = tempfile::tempdir().expect("create Cargo project");

--- a/pnpm/crates/cli/tests/suite/pnpr_install.rs
+++ b/pnpm/crates/cli/tests/suite/pnpr_install.rs
@@ -16,7 +16,9 @@ use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
     fs::{get_all_files, is_symlink_or_junction},
 };
-use pnpr::TokenBackend;
+use pnpr::{Ecosystem, Registries, Registry, TokenBackend, UpstreamConfig};
+use reqwest::header::HeaderMap;
+use sha2::{Digest, Sha256};
 use std::{
     fmt::Write as _,
     fs,
@@ -115,6 +117,63 @@ fn start_pnpr_registry(upstream_url: &str) -> String {
 
     wait_until_ready(addr);
     format!("http://{addr}")
+}
+
+fn start_pnpr_cargo_registry(upstream_url: &str) -> String {
+    let upstream_url = upstream_url.to_string();
+    let storage = tempfile::tempdir().expect("pnpr storage").keep();
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).expect("bind pnpr");
+    listener.set_nonblocking(true).expect("set pnpr listener non-blocking");
+    let addr = listener.local_addr().expect("pnpr addr");
+    let public_url = format!("http://{addr}");
+
+    thread::Builder::new()
+        .name("pnpr-cargo-registry".to_string())
+        .spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("pnpr runtime");
+            runtime.block_on(async move {
+                let mut config = pnpr::Config::proxy(addr, storage);
+                config.public_url = public_url;
+                config.upstreams.insert(
+                    "crates".to_string(),
+                    UpstreamConfig::with_defaults(upstream_url, HeaderMap::new()),
+                );
+                config.registries = Registries::new(
+                    indexmap::IndexMap::from([(
+                        "crates".to_string(),
+                        Registry::Upstream { patterns: Vec::new() },
+                    )]),
+                    Some("crates".to_string()),
+                )
+                .with_ecosystem("crates", Ecosystem::Cargo);
+                let listener = tokio::net::TcpListener::from_std(listener).expect("tokio listener");
+                let _ = pnpr::serve_listener(config, listener).await;
+            });
+        })
+        .expect("spawn pnpr Cargo registry thread");
+
+    wait_until_ready(addr);
+    format!("http://{addr}/cargo/")
+}
+
+fn crate_archive(name: &str, version: &str) -> Vec<u8> {
+    let root = format!("{name}-{version}");
+    let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    let mut builder = tar::Builder::new(encoder);
+    for (path, contents) in [
+        ("Cargo.toml", format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\n")),
+        ("src/lib.rs", "pub fn answer() -> u8 { 42 }\n".to_string()),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, format!("{root}/{path}"), contents.as_bytes()).unwrap();
+    }
+    builder.into_inner().unwrap().finish().unwrap()
 }
 
 fn configure_pnpr_auth(npmrc_path: &std::path::Path, pnpr_url: &str, token: &str) {
@@ -1550,4 +1609,84 @@ fn filtered_workspace_pnpr_resolves_workspace_protocol_from_project_identity() {
     assert!(!workspace_slot(&workspace, WORKSPACE_HELLO, "1.0.0").exists());
 
     drop((root, mock_instance));
+}
+
+#[test]
+fn cargo_install_uses_a_configured_pnpr_registry_and_accelerator() {
+    let mut upstream = mockito::Server::new();
+    let archive = crate_archive("demo", "1.0.0");
+    let checksum = format!("{:x}", Sha256::digest(&archive));
+    let _config_mock = upstream
+        .mock("GET", "/config.json")
+        .with_body(
+            serde_json::json!({
+                "dl": format!("{}/dl/{{crate}}/{{version}}", upstream.url()),
+                "api": upstream.url(),
+            })
+            .to_string(),
+        )
+        .create();
+    let index_mock = upstream
+        .mock("GET", "/de/mo/demo")
+        .with_body(format!(
+            "{}\n",
+            serde_json::json!({
+                "name": "demo",
+                "vers": "1.0.0",
+                "deps": [],
+                "cksum": checksum,
+                "features": {},
+                "yanked": false,
+                "v": 1,
+            }),
+        ))
+        .expect(1)
+        .create();
+    let download_mock =
+        upstream.mock("GET", "/dl/demo/1.0.0").with_body(&archive).expect(1).create();
+    let registry_url = start_pnpr_cargo_registry(&upstream.url());
+    let (pnpr_url, token) = start_pnpr(&format!("{registry_url}index"));
+
+    let root = tempfile::tempdir().expect("create Cargo project");
+    fs::create_dir(root.path().join("src")).expect("create source directory");
+    fs::write(root.path().join("src/lib.rs"), "pub use demo::answer;\n").expect("write source");
+    fs::write(
+        root.path().join("Cargo.toml"),
+        "[package]\nname = \"app\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ndemo = \"1\"\n",
+    )
+    .expect("write Cargo manifest");
+    fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        format!(
+            "cargo:\n  enabled: true\n  indexUrl: {registry_url}index/\npnprServer: {pnpr_url}\n",
+        ),
+    )
+    .expect("configure pnpm");
+    fs::write(
+        root.path().join(".npmrc"),
+        format!(
+            "//{}/:_authToken={token}\n",
+            pnpr_url.trim_start_matches("http://").trim_end_matches('/'),
+        ),
+    )
+    .expect("configure pnpr authentication");
+
+    pacquet_at(root.path())
+        .with_env("PNPM_CONFIG_CACHE_DIR", root.path().join("cache"))
+        .with_env("PNPM_CONFIG_STORE_DIR", root.path().join("store"))
+        .with_arg("install")
+        .assert()
+        .success();
+
+    let lockfile = fs::read_to_string(root.path().join("Cargo.lock")).expect("read Cargo lockfile");
+    assert!(lockfile.contains(&format!(r#"source = "sparse+{registry_url}index/""#)), "{lockfile}");
+    assert!(root.path().join(".pnpm/crates/crates-io/demo-1.0.0/src/lib.rs").is_file());
+    Command::new("cargo")
+        .with_current_dir(root.path())
+        .with_args(["check", "--offline"])
+        .assert()
+        .success();
+
+    index_mock.assert();
+    download_mock.assert();
 }

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -189,10 +189,17 @@ pub struct RemoteSideEffectsCacheSettings {
     pub private_key: Option<String>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
 pub struct CargoSettings {
     pub enabled: bool,
+    pub index_url: String,
+}
+
+impl Default for CargoSettings {
+    fn default() -> Self {
+        Self { enabled: false, index_url: "https://index.crates.io".to_string() }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, Deserialize)]

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1001,13 +1001,19 @@ fn cargo_settings_parse_apply_and_remain_workspace_only() {
     let yaml = r"
 cargo:
   enabled: true
+  indexUrl: https://registry.example.test/index/
 ";
     let settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
-    assert_eq!(settings.cargo.map(|cargo| cargo.enabled), Some(true));
+    assert_eq!(settings.cargo.as_ref().map(|cargo| cargo.enabled), Some(true));
+    assert_eq!(
+        settings.cargo.as_ref().map(|cargo| cargo.index_url.as_str()),
+        Some("https://registry.example.test/index/"),
+    );
     let mut config = Config::default();
     settings.apply_to(&mut config, Path::new("/workspace"));
 
     assert!(config.cargo.enabled);
+    assert_eq!(config.cargo.index_url, "https://registry.example.test/index/");
     let mut settings: WorkspaceSettings = serde_saphyr::from_str(yaml).unwrap();
     settings.clear_workspace_only_fields();
     assert!(settings.cargo.is_none());

--- a/pnpr/crates/cargo/Cargo.toml
+++ b/pnpr/crates/cargo/Cargo.toml
@@ -11,14 +11,15 @@ license-file         = "../../LICENSE.md"
 repository.workspace = true
 
 [dependencies]
-derive_more       = { workspace = true }
-flate2            = { workspace = true }
-pnpr-package-name = { workspace = true }
-semver            = { workspace = true }
-serde             = { workspace = true }
-serde_json        = { workspace = true }
-tar               = { workspace = true }
-toml              = { workspace = true }
+derive_more         = { workspace = true }
+flate2              = { workspace = true }
+pnpr-package-name   = { workspace = true }
+pnpm-cargo-resolver = { workspace = true }
+semver              = { workspace = true }
+serde               = { workspace = true }
+serde_json          = { workspace = true }
+tar                 = { workspace = true }
+toml                = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/cargo/src/lib.rs
+++ b/pnpr/crates/cargo/src/lib.rs
@@ -238,17 +238,7 @@ impl IndexConfig {
 /// `/{crate}/{version}/download` appended, as `cargo` does.
 #[must_use]
 pub fn download_url(template: &str, name: &str, version: &str, cksum: &str) -> String {
-    const MARKERS: [&str; 5] =
-        ["{crate}", "{version}", "{prefix}", "{lowerprefix}", "{sha256-checksum}"];
-    if !MARKERS.iter().any(|marker| template.contains(marker)) {
-        return format!("{}/{name}/{version}/download", template.trim_end_matches('/'));
-    }
-    template
-        .replace("{crate}", name)
-        .replace("{version}", version)
-        .replace("{prefix}", &index_prefix(name))
-        .replace("{lowerprefix}", &index_prefix(&name.to_ascii_lowercase()))
-        .replace("{sha256-checksum}", cksum)
+    pnpm_cargo_resolver::download_url(template, name, version, cksum)
 }
 
 /// A `cargo publish` request body that could not be read.

--- a/pnpr/crates/cargo/src/lib.rs
+++ b/pnpr/crates/cargo/src/lib.rs
@@ -45,12 +45,7 @@ pub fn validate_crate_name(name: &str) -> Result<(), CrateNameError> {
 /// form is what the `{prefix}` download-template marker expands to.
 #[must_use]
 pub fn index_prefix(name: &str) -> String {
-    match name.len() {
-        1 => "1".to_string(),
-        2 => "2".to_string(),
-        3 => format!("3/{}", &name[..1]),
-        _ => format!("{}/{}", &name[..2], &name[2..4]),
-    }
+    pnpm_cargo_resolver::index_prefix(name)
 }
 
 /// The relative path of a crate's file inside a sparse index, lowercased as

--- a/pnpr/crates/pnpr/src/resolver/cargo.rs
+++ b/pnpr/crates/pnpr/src/resolver/cargo.rs
@@ -134,7 +134,7 @@ pub(super) async fn handle_resolve(
     };
 
     let metadata = request.metadata;
-    let source = pnpm_cargo_resolver::sparse_source(&index.registry);
+    let source = pnpm_cargo_resolver::registry_source(&index.registry);
     let index_files = match index.fetch_for(&metadata).await {
         Ok(index_files) => index_files,
         Err(err) => return ndjson_single_frame(&error_frame(&err)),
@@ -142,7 +142,7 @@ pub(super) async fn handle_resolve(
     // pubgrub's solve is CPU-bound and can run for a while on a large
     // workspace, so it stays off the async runtime's worker threads.
     let lockfile = tokio::task::spawn_blocking(move || {
-        pnpm_cargo_resolver::resolve_lockfile_for_registry(&metadata, &index_files, &source)
+        pnpm_cargo_resolver::resolve_lockfile(&metadata, &index_files, &source)
     })
     .await;
     match lockfile {
@@ -204,8 +204,9 @@ impl IndexFetcher {
     /// fetches those, and repeats until nothing is missing.
     async fn fetch_for(&self, metadata: &str) -> Result<BTreeMap<String, String>, String> {
         let mut index_files = BTreeMap::new();
+        let source = pnpm_cargo_resolver::registry_source(&self.registry);
         for _ in 0..MAX_INDEX_WAVES {
-            let missing = pnpm_cargo_resolver::missing_index_names(metadata, &index_files)
+            let missing = pnpm_cargo_resolver::missing_index_names(metadata, &index_files, &source)
                 .map_err(|err| report_message(&err))?;
             if missing.is_empty() {
                 return Ok(index_files);

--- a/pnpr/crates/pnpr/src/resolver/cargo.rs
+++ b/pnpr/crates/pnpr/src/resolver/cargo.rs
@@ -134,6 +134,7 @@ pub(super) async fn handle_resolve(
     };
 
     let metadata = request.metadata;
+    let source = pnpm_cargo_resolver::sparse_source(&index.registry);
     let index_files = match index.fetch_for(&metadata).await {
         Ok(index_files) => index_files,
         Err(err) => return ndjson_single_frame(&error_frame(&err)),
@@ -141,7 +142,7 @@ pub(super) async fn handle_resolve(
     // pubgrub's solve is CPU-bound and can run for a while on a large
     // workspace, so it stays off the async runtime's worker threads.
     let lockfile = tokio::task::spawn_blocking(move || {
-        pnpm_cargo_resolver::resolve_lockfile(&metadata, &index_files)
+        pnpm_cargo_resolver::resolve_lockfile_for_registry(&metadata, &index_files, &source)
     })
     .await;
     match lockfile {


### PR DESCRIPTION
## Summary

Adds `cargo.indexUrl` to pnpm v12 workspace settings and uses it for sparse-index resolution, Cargo archive downloads, vendored source configuration, and pnpr-accelerated resolution. The default remains crates.io.

The registry a workspace selects is recorded as the `source` of every crate in `Cargo.lock`, and a lockfile whose sources name a different registry is rejected rather than downloaded from the configured one. crates.io keeps the canonical git identifier that `cargo` itself writes.

Adds install-level tests for both resolution paths: one resolves locally against a mock sparse registry, one through a pnpr accelerator, and both download through a Cargo registry and finish with `cargo check --offline`.

Related to pnpm/pnpm#14599.

## Squash Commit Body

```text
Add a workspace setting for the Cargo sparse-index URL and thread it through local and pnpr-accelerated resolution. Preserve that source in Cargo.lock, read the registry download template, and configure Cargo to use pnpm's vendored directory for the selected registry.

Take the registry source as an argument to the resolver rather than defaulting to crates.io, so local and accelerated resolution record the same source. Accept a lockfile's default-registry source only when the configured index is crates.io, and reject a dependency that names a third-party registry rather than every registry but crates.io.

Keep crates.io as the default and preserve its existing cache and authentication behavior. Bound the registry configuration document, and skip the registry entirely for a workspace with no registry crates. Share Cargo download-template expansion and sparse-index prefixes between the client and pnpr.

Related to pnpm/pnpm#14599.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users. It becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-5), reviewed and revised by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom Cargo registries through `cargo.indexUrl`.
  * Cargo installations now support sparse registries, registry-specific downloads, authentication, and isolated index caching.
  * Generated `Cargo.lock` files preserve the configured registry source.
  * Added support for installing crates through configured pnpr registries and accelerators.
  * Offline installs can use the managed Cargo configuration without fetching registry metadata.

* **Documentation**
  * Documented sparse Cargo registry installation and registry preservation in `Cargo.lock`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->