### PR TITLE
fix(patching): keep prefixes on added and deleted files, and apply preimage-less deletions

### DIFF
--- a/.changeset/patch-commit-deleted-file-paths.md
+++ b/.changeset/patch-commit-deleted-file-paths.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm patch-commit` now writes a valid `diff --git a/<file> b/<file>` header for a file deleted in the edit directory. The `b/` prefix lost its slash, so the next `pnpm install` failed with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).

--- a/.changeset/patch-commit-deleted-file-paths.md
+++ b/.changeset/patch-commit-deleted-file-paths.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm patch-commit` now writes a valid `diff --git a/<file> b/<file>` header for a file deleted in the edit directory. The `b/` prefix lost its slash, so the next `pnpm install` failed with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).
+`pnpm patch-commit` now writes a valid patch when a file is deleted in the edit directory. Previously the next `pnpm install` failed with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).

--- a/.changeset/patch-commit-deleted-file-paths.md
+++ b/.changeset/patch-commit-deleted-file-paths.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm patch-commit` now writes a valid patch when a file is deleted in the edit directory. Previously the next `pnpm install` failed with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).
+`pnpm patch-commit` now writes a valid patch when a file is added to or deleted from the edit directory. `pnpm install` now applies a patch that deletes a file without listing its contents, including patches written by pnpm 11. Deleting a file made the next install fail with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).

--- a/.changeset/patch-commit-deleted-file-paths.md
+++ b/.changeset/patch-commit-deleted-file-paths.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm patch-commit` now writes a valid patch when a file is added to or deleted from the edit directory. `pnpm install` now applies a patch that deletes a file without listing its contents, including patches written by pnpm 11. Deleting a file made the next install fail with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).
+`pnpm patch-commit` now writes a valid patch when a file is added to or deleted from the edit directory. `pnpm install` now applies patches that delete a file without listing its contents. Deleting a file made the next install fail with `ERR_PNPM_INVALID_PATCH` [#14559](https://github.com/pnpm/pnpm/issues/14559).

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -773,6 +773,41 @@ fn patch_commit_exact_version_writes_patch_and_reinstalls() {
 }
 
 #[test]
+fn patch_commit_writes_an_applicable_patch_for_a_deleted_file() {
+    let (root, workspace, npmrc_info) = setup_installed();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+    let edit_dir = workspace.join("node_modules/.pnpm_patches/is-positive@1.0.0");
+    fs::remove_file(edit_dir.join("readme.md")).expect("delete readme.md");
+
+    pacquet(
+        &workspace,
+        ["patch-commit", edit_dir.to_str().expect("utf8 edit dir"), "--reporter=silent"],
+    )
+    .assert()
+    .success();
+
+    let patch =
+        fs::read_to_string(workspace.join("patches/is-positive@1.0.0.patch")).expect("patch file");
+    eprintln!("PATCH:\n{patch}");
+    assert!(patch.contains("diff --git a/readme.md b/readme.md\n"), "patch: {patch}");
+    assert!(
+        !workspace.join("node_modules/is-positive/readme.md").exists(),
+        "the reinstall should have dropped readme.md",
+    );
+
+    // Re-running `patch` applies the committed patch to a fresh copy of the package, so it fails
+    // when the generated patch cannot be parsed or applied.
+    fs::remove_dir_all(&edit_dir).expect("remove edit dir");
+    pacquet(&workspace, ["patch", "is-positive@1.0.0", "--reporter=silent"]).assert().success();
+
+    assert!(!edit_dir.join("readme.md").exists(), "readme.md should stay deleted");
+
+    drop((root, mock_instance));
+}
+
+#[test]
 fn patch_commit_bare_name_writes_apply_to_all_key() {
     let (root, workspace, npmrc_info) = setup_installed();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;

--- a/pnpm/crates/patching/src/apply.rs
+++ b/pnpm/crates/patching/src/apply.rs
@@ -247,11 +247,21 @@ fn apply_one_file(
         }
         FileOperation::Delete(path) => {
             let target = resolve_target(Path::new(path.as_ref()))?;
-            // Validate that the existing file matches the patch
-            // before unlinking — a stale or wrong-target patch
-            // would otherwise silently delete the wrong file.
-            // diffy::apply on a delete patch produces the empty
-            // string when every hunk matches.
+            let text_patch = file_patch
+                .patch()
+                .as_text()
+                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+            // A delete block that carries hunks is validated against the
+            // file on disk before unlinking — a stale or wrong-target
+            // patch would otherwise silently delete the wrong file.
+            // diffy::apply on such a patch produces the empty string
+            // when every hunk matches.
+            //
+            // `git diff --irreversible-delete`, which `pnpm patch` and
+            // `pnpm patch-commit` run, writes the header of a deleted
+            // file without its preimage. There are no hunks to check
+            // then, so the file is unlinked on the header alone, as
+            // pnpm 11 does for every deletion.
             //
             // Lossy UTF-8 decoding for the same reason as the
             // `Modify` branch above: match the patch-file reader
@@ -260,29 +270,33 @@ fn apply_one_file(
             // Idempotency: a missing target means the file was
             // already removed by an earlier apply of the same
             // patch — treat as no-op.
-            let bytes = match fs::read(&target) {
-                Ok(b) => b,
-                Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
-                Err(source) => {
-                    return Err(failed(format!("read {}: {source}", target.display())));
+            if !text_patch.hunks().is_empty() {
+                let bytes = match fs::read(&target) {
+                    Ok(b) => b,
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
+                    Err(source) => {
+                        return Err(failed(format!("read {}: {source}", target.display())));
+                    }
+                };
+                let original = String::from_utf8_lossy(&bytes).into_owned();
+                let after = tolerant::apply(&original, text_patch).map_err(|message| {
+                    failed(format!("apply to {}: {message}", target.display()))
+                })?;
+                if !after.is_empty() {
+                    return Err(failed(format!(
+                        "delete patch left {} non-empty after apply ({} bytes remain)",
+                        target.display(),
+                        after.len(),
+                    )));
                 }
-            };
-            let original = String::from_utf8_lossy(&bytes).into_owned();
-            let text_patch = file_patch
-                .patch()
-                .as_text()
-                .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
-            let after = tolerant::apply(&original, text_patch)
-                .map_err(|message| failed(format!("apply to {}: {message}", target.display())))?;
-            if !after.is_empty() {
-                return Err(failed(format!(
-                    "delete patch left {} non-empty after apply ({} bytes remain)",
-                    target.display(),
-                    after.len(),
-                )));
             }
-            fs::remove_file(&target)
-                .map_err(|source| failed(format!("delete {}: {source}", target.display())))?;
+            match fs::remove_file(&target) {
+                Ok(()) => {}
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(failed(format!("delete {}: {source}", target.display())));
+                }
+            }
         }
         FileOperation::Rename { .. } | FileOperation::Copy { .. } => {
             return Err(failed(

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -527,6 +527,44 @@ deleted file mode 100644
     assert!(!target.exists(), "deleted target must be gone");
 }
 
+/// `git diff --irreversible-delete`, which `pnpm patch-commit` runs,
+/// writes the header of a deleted file without its preimage.
+#[test]
+fn applies_delete_that_carries_no_preimage() {
+    let patched = tempdir().unwrap();
+    let target = patched.path().join("to-delete.txt");
+    fs::write(&target, "going away\n").unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        text_block_fnl! {
+            "diff --git a/to-delete.txt b/to-delete.txt"
+            "deleted file mode 100644"
+            "index 8993..0000"
+        },
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    assert!(!target.exists(), "deleted target must be gone");
+}
+
+#[test]
+fn delete_that_carries_no_preimage_on_an_already_deleted_file_is_noop() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(
+        patch_dir.path(),
+        text_block_fnl! {
+            "diff --git a/to-delete.txt b/to-delete.txt"
+            "deleted file mode 100644"
+            "index 8993..0000"
+        },
+    );
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    assert!(!patched.path().join("to-delete.txt").exists());
+}
+
 #[cfg(unix)]
 #[test]
 fn read_patch_file_surfaces_non_not_found_error() {

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -374,10 +374,17 @@ fn is_diff_path_line(line: &str) -> bool {
 
 fn normalize_diff_path_line(line: &str, folder_a: &str, folder_b: &str) -> String {
     let mut out = line.to_string();
-    for (prefix, folder) in [('a', folder_a), ('b', folder_b)] {
-        let trimmed = folder.trim_matches('/');
-        out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
-        out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
+    // `git diff --no-index --irreversible-delete` names both sides of a deleted file after the
+    // source folder, so each prefix has to be matched against both folders before the bare
+    // folder fallback runs, otherwise that fallback also consumes the `/` of the `b/` prefix.
+    for prefix in ['a', 'b'] {
+        for folder in [folder_a, folder_b] {
+            let trimmed = folder.trim_matches('/');
+            out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
+            out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
+        }
+    }
+    for folder in [folder_a, folder_b] {
         out = out.replace(&format!("{folder}/"), "");
     }
     out

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -374,12 +374,13 @@ fn is_diff_path_line(line: &str) -> bool {
 
 fn normalize_diff_path_line(line: &str, folder_a: &str, folder_b: &str) -> String {
     let mut out = line.to_string();
-    // `git diff --no-index --irreversible-delete` names both sides of a deleted file after the
-    // source folder, so each prefix has to be matched against both folders before the bare
-    // folder fallback runs, otherwise that fallback also consumes the `/` of the `b/` prefix.
-    for prefix in ['a', 'b'] {
-        for folder in [folder_a, folder_b] {
-            let trimmed = folder.trim_matches('/');
+    // `git diff --no-index` names both sides of an added or a deleted file after the single
+    // folder that holds it, so each prefix has to be matched against both folders. Leaving one
+    // of them to the bare folder fallback below would strip the `/` of its prefix along with
+    // the folder.
+    for folder in [folder_a, folder_b] {
+        let trimmed = folder.trim_matches('/');
+        for prefix in ['a', 'b'] {
             out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
             out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
         }

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -276,6 +276,41 @@ index 123..456 100644
 }
 
 #[test]
+fn patch_commit_diff_dirs_strips_temp_paths_from_deleted_files() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("index.js"), "module.exports = true\n").unwrap();
+    fs::write(after.path().join("index.js"), "module.exports = true\n").unwrap();
+    fs::write(before.path().join("readme.md"), "# readme\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/readme.md b/readme.md\n"), "diff: {diff}");
+    assert!(diff.contains("deleted file mode 100644\n"), "diff: {diff}");
+    assert!(!diff.contains(&before.path().display().to_string()), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_normalization_keeps_dst_prefix_of_deleted_files() {
+    let diff = "\
+diff --git a/tmp/before/readme.md b/tmp/before/readme.md
+deleted file mode 100644
+index 123..000
+";
+
+    let normalized = normalize_diff_output(diff, "/tmp/before", "/tmp/after");
+
+    assert_eq!(
+        normalized,
+        "\
+diff --git a/readme.md b/readme.md
+deleted file mode 100644
+index 123..000
+"
+    );
+}
+
+#[test]
 fn patch_commit_diff_dirs_reports_git_errors() {
     let tmp = tempdir().expect("temp dir");
 

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -300,14 +300,14 @@ index 123..000
 
     let normalized = normalize_diff_output(diff, "/tmp/before", "/tmp/after");
 
-    assert_eq!(
-        normalized,
-        "\
+    let expected = "\
 diff --git a/readme.md b/readme.md
 deleted file mode 100644
 index 123..000
-"
-    );
+";
+    eprintln!("normalized:\n{normalized}");
+    eprintln!("expected:\n{expected}");
+    assert_eq!(normalized, expected);
 }
 
 #[test]

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -311,6 +311,46 @@ index 123..000
 }
 
 #[test]
+fn patch_commit_diff_dirs_strips_temp_paths_from_added_files() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("index.js"), "module.exports = true\n").unwrap();
+    fs::write(after.path().join("index.js"), "module.exports = true\n").unwrap();
+    fs::write(after.path().join("added.txt"), "added\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert!(diff.contains("diff --git a/added.txt b/added.txt\n"), "diff: {diff}");
+    assert!(diff.contains("new file mode 100644\n"), "diff: {diff}");
+    assert!(diff.contains("+++ b/added.txt\n"), "diff: {diff}");
+    assert!(!diff.contains(&after.path().display().to_string()), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_normalization_keeps_src_prefix_of_added_files() {
+    let diff = "\
+diff --git a/tmp/after/added.txt b/tmp/after/added.txt
+new file mode 100644
+index 000..123
+--- /dev/null
++++ b/tmp/after/added.txt
+";
+
+    let normalized = normalize_diff_output(diff, "/tmp/before", "/tmp/after");
+
+    let expected = "\
+diff --git a/added.txt b/added.txt
+new file mode 100644
+index 000..123
+--- /dev/null
++++ b/added.txt
+";
+    eprintln!("normalized:\n{normalized}");
+    eprintln!("expected:\n{expected}");
+    assert_eq!(normalized, expected);
+}
+
+#[test]
 fn patch_commit_diff_dirs_reports_git_errors() {
     let tmp = tempdir().expect("temp dir");
 


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14559.

Deleting a file in the `pnpm patch` edit directory and running `pnpm patch-commit` produced a header of the form `diff --git a/readme.md breadme.md`, and the next `pnpm install` rejected the patch with `ERR_PNPM_INVALID_PATCH … invalid diff --git path`. Two separate defects sit behind that report; both are fixed here.

**1. The generated header.** `git diff --no-index` names both sides of a deleted file after the source folder, and both sides of an added file after the destination folder. `normalize_diff_path_line` matched the `a/` prefix only against the source folder and the `b/` prefix only against the destination folder, so one side of every added and every deleted file fell through to the bare-folder fallback `replace("<folder>/", "")`, which also consumed the `/` after the prefix. The fix matches every prefix against both folders before the fallback runs. The fallback itself is kept.

**2. Applying the resulting patch.** `patch-commit` runs `git diff --irreversible-delete`, which writes the header of a deleted file without its preimage. The applier required a delete patch's hunks to empty the file before unlinking it, so with the header fixed the patch that `patch-commit` had just written then failed to install with `ERR_PNPM_PATCH_FAILED: delete patch left … non-empty after apply`. A delete block that carries hunks is still verified against the file on disk; one without hunks now unlinks on the header alone, which is what pnpm 11 does for every deletion. This also lets pnpm 12 apply deletion patches written by pnpm 11.

pnpm v11 is affected by neither defect, so only `pnpm/` is changed.

## Squash Commit Body

```text
`git diff --no-index` names both sides of a deleted file after the source
folder and both sides of an added file after the destination folder.
`normalize_diff_path_line` only matched the `a/` prefix against the source
folder and the `b/` prefix against the destination folder, so one side of
every added and deleted file fell through to the bare-folder fallback, which
also removed the `/` following the prefix. The header became
`diff --git a/x bx`, and the next `pnpm install` rejected the patch with
`ERR_PNPM_INVALID_PATCH`. Match every prefix against both folders before
running the fallback.

`patch-commit` runs `git diff --irreversible-delete`, which writes the header
of a deleted file without its preimage. The applier required a delete patch's
hunks to empty the file before unlinking it, so the patch `patch-commit` had
just written failed to install with `ERR_PNPM_PATCH_FAILED`. A delete block
that carries hunks is still verified against the file on disk; one without
hunks now unlinks on the header alone, as pnpm 11 does for every deletion.

pnpm v11 is affected by neither defect.

Fixes pnpm/pnpm#14559
```

## Tests

`crates/patching/src/commit/tests.rs`:

- `patch_commit_diff_dirs_strips_temp_paths_from_deleted_files` and `..._from_added_files` run the real `git diff` through `diff_folders` on temp dirs and assert the headers are `diff --git a/<file> b/<file>`.
- `patch_commit_diff_normalization_keeps_dst_prefix_of_deleted_files` and `..._keeps_src_prefix_of_added_files` feed the headers directly to `normalize_diff_output`.

`crates/patching/src/apply/tests.rs`:

- `applies_delete_that_carries_no_preimage` and `delete_that_carries_no_preimage_on_an_already_deleted_file_is_noop` cover the header-only delete block. The existing tests that refuse a stale or partial delete still hold, since those patches carry hunks.

`crates/cli/tests/suite/patch.rs`:

- `patch_commit_writes_an_applicable_patch_for_a_deleted_file` walks the whole reported scenario: `pnpm patch`, delete a file, `pnpm patch-commit`, then re-run `pnpm patch` so the committed patch is parsed and applied to a fresh copy of the package.

Every one of these fails on `main`, and each was checked against its own fix reverted. `cargo test -p pnpm-patching` (103 tests), `cargo test -p pnpm-cli --test suite patch::` (51 tests), `cargo test -p pnpm-deps-restorer` (468 tests), `cargo fmt --check`, `cargo clippy --deny warnings` and `cargo dylint` are clean locally.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (OpenCode, claude-fable-5-1), operating on behalf of the account owner. The change was compiled, tested and linted locally as described above.

Reviewed, extended and rebased by an agent (Claude Code, claude-opus-5).
<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791292144&installation_model_id=426870&pr_number=14621&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14621&signature=4de254a106b833a3b8d2862eeb94053403d1d58c1714d4b5879956268fe8e845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm patch-commit` handling for files added or deleted during patch editing.
  * Generated patches now preserve valid relative paths and file metadata for added and deleted files.
  * Fixed `pnpm install` applying patches that delete files without included file contents.
  * Applying an already-applied deletion patch now completes successfully without errors.
  * Improved patch path normalization to prevent installation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
