### PR TITLE
test(executor): cover the emulator quoting branch off Windows

### DIFF
--- a/pnpm/crates/executor/src/run_script.rs
+++ b/pnpm/crates/executor/src/run_script.rs
@@ -241,9 +241,6 @@ fn run_piped(
 
 /// Whether `cmd` will parse the script. The shell emulator is a POSIX
 /// shell on every platform, so only a native Windows run reaches `cmd`.
-///
-/// `windows` is a parameter rather than a `cfg!` so that both answers stay
-/// reachable from a test on any host.
 fn parsed_by_windows_shell(windows: bool, shell_emulator: bool) -> bool {
     windows && !shell_emulator
 }

--- a/pnpm/crates/executor/src/run_script.rs
+++ b/pnpm/crates/executor/src/run_script.rs
@@ -111,7 +111,11 @@ pub struct RunScript<'a> {
 /// Run a single user script in the foreground, sending its output where
 /// [`RunScript::output`] says.
 pub fn run_script(opts: &RunScript<'_>) -> Result<ScriptExit, RunScriptError> {
-    let command = build_command(opts.script, opts.args, opts.shell_emulator);
+    let command = build_command(
+        opts.script,
+        opts.args,
+        parsed_by_windows_shell(cfg!(windows), opts.shell_emulator),
+    );
 
     // The `scriptShell` value is validated even when the emulator will
     // run the script, matching pnpm's `runLifecycleHook`, which rejects a
@@ -235,13 +239,22 @@ fn run_piped(
         .map_err(|source| RunScriptError::Wait { script: command.to_string(), source })
 }
 
-/// Append shell-quoted `args` to `script`: POSIX quoting for the shell
-/// emulator and Unix shells, and per-argument JSON quoting for native Windows shells.
-fn build_command(script: &str, args: &[String], shell_emulator: bool) -> String {
+/// Whether `cmd` will parse the script. The shell emulator is a POSIX
+/// shell on every platform, so only a native Windows run reaches `cmd`.
+///
+/// `windows` is a parameter rather than a `cfg!` so that both answers stay
+/// reachable from a test on any host.
+fn parsed_by_windows_shell(windows: bool, shell_emulator: bool) -> bool {
+    windows && !shell_emulator
+}
+
+/// Append shell-quoted `args` to `script`: per-argument JSON quoting when
+/// `cmd` will parse them, and `shlex`-style POSIX quoting otherwise.
+fn build_command(script: &str, args: &[String], windows_shell: bool) -> String {
     if args.is_empty() {
         return script.to_string();
     }
-    let quoted = if cfg!(windows) && !shell_emulator {
+    let quoted = if windows_shell {
         args.iter().map(|arg| Value::String(arg.clone()).to_string()).collect::<Vec<_>>().join(" ")
     } else {
         args.iter().map(|arg| posix_quote(arg)).collect::<Vec<_>>().join(" ")

--- a/pnpm/crates/executor/src/run_script/tests.rs
+++ b/pnpm/crates/executor/src/run_script/tests.rs
@@ -38,8 +38,10 @@ fn build_command_appends_posix_quoted_args() {
 
 #[test]
 fn build_command_appends_json_quoted_args_for_the_windows_shell() {
-    let args = [r"C:\dir\".to_string(), "needs quoting".to_string()];
-    assert_eq!(build_command("echo", &args, true), r#"echo "C:\\dir\\" "needs quoting""#);
+    let args =
+        [r"C:\dir\".to_string(), String::new(), r#"a"b"#.to_string(), "line\nbreak".to_string()];
+    let expected = r#"echo "C:\\dir\\" "" "a\"b" "line\nbreak""#;
+    assert_eq!(build_command("echo", &args, true), expected);
 }
 
 #[test]

--- a/pnpm/crates/executor/src/run_script/tests.rs
+++ b/pnpm/crates/executor/src/run_script/tests.rs
@@ -1,4 +1,6 @@
-use super::{RunScript, ScriptOutput, build_command, posix_quote, run_script};
+use super::{
+    RunScript, ScriptOutput, build_command, parsed_by_windows_shell, posix_quote, run_script,
+};
 use crate::{extend_path::ScriptsPrependNodePath, script_exit::ScriptExit};
 use std::{collections::HashMap, fs, path::Path};
 use tempfile::tempdir;
@@ -23,16 +25,29 @@ fn posix_quote_escapes_embedded_single_quotes() {
 
 #[test]
 fn build_command_without_args_returns_script_unchanged() {
-    for shell_emulator in [false, true] {
-        assert_eq!(build_command("tsc --build", &[], shell_emulator), "tsc --build");
+    for windows_shell in [false, true] {
+        assert_eq!(build_command("tsc --build", &[], windows_shell), "tsc --build");
     }
 }
 
 #[test]
-#[cfg_attr(target_os = "windows", ignore = "asserts POSIX quoting; Windows uses JSON.stringify")]
-fn build_command_appends_quoted_args() {
+fn build_command_appends_posix_quoted_args() {
     let args = ["plain".to_string(), "needs quoting".to_string()];
     assert_eq!(build_command("echo", &args, false), "echo plain 'needs quoting'");
+}
+
+#[test]
+fn build_command_appends_json_quoted_args_for_the_windows_shell() {
+    let args = [r"C:\dir\".to_string(), "needs quoting".to_string()];
+    assert_eq!(build_command("echo", &args, true), r#"echo "C:\\dir\\" "needs quoting""#);
+}
+
+#[test]
+fn only_a_native_windows_run_is_parsed_by_the_windows_shell() {
+    assert!(parsed_by_windows_shell(true, false));
+    assert!(!parsed_by_windows_shell(true, true));
+    assert!(!parsed_by_windows_shell(false, false));
+    assert!(!parsed_by_windows_shell(false, true));
 }
 
 fn manifest() -> serde_json::Value {

--- a/pnpm11/exec/lifecycle/test/argQuoting.ts
+++ b/pnpm11/exec/lifecycle/test/argQuoting.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { expect, jest, test } from '@jest/globals'
+import { fixtures } from '@pnpm/test-fixtures'
+
+jest.unstable_mockModule('is-windows', () => ({ default: () => true }))
+
+const { runLifecycleHook } = await import('../lib/index.js')
+
+const f = fixtures(path.join(import.meta.dirname, 'fixtures'))
+const rootModulesDir = path.join(import.meta.dirname, '..', 'node_modules')
+
+// The emulator is a POSIX shell on every platform, so a Windows host must
+// still get shlex quoting rather than the JSON quoting `cmd` needs. Mocking
+// `is-windows` is what keeps this branch reachable off Windows.
+test('runLifecycleHook() quotes arguments for the emulator rather than for cmd on Windows', async () => {
+  const pkgRoot = f.prepare('escape-args')
+  const { default: pkg } = await import(path.join(pkgRoot, 'package.json'))
+  const args = [
+    'C:\\Program Files\\tool\\',
+    '',
+    'a"b',
+    '$PNPM_QUOTING_TEST',
+    'line\nbreak',
+  ]
+
+  await runLifecycleHook('echo', pkg, {
+    args,
+    depPath: '/escape-args/1.0.0',
+    extraEnv: { PNPM_QUOTING_TEST: 'expanded' },
+    pkgRoot,
+    rootModulesDir,
+    shellEmulator: true,
+    unsafePerm: true,
+  })
+
+  const recorded = JSON.parse(await fs.promises.readFile(path.join(pkgRoot, 'output.json'), 'utf8'))
+  expect(recorded).toStrictEqual(args)
+})

--- a/pnpm11/exec/lifecycle/test/argQuoting.ts
+++ b/pnpm11/exec/lifecycle/test/argQuoting.ts
@@ -11,9 +11,8 @@ const { runLifecycleHook } = await import('../lib/index.js')
 const f = fixtures(path.join(import.meta.dirname, 'fixtures'))
 const rootModulesDir = path.join(import.meta.dirname, '..', 'node_modules')
 
-// The emulator is a POSIX shell on every platform, so a Windows host must
-// still get shlex quoting rather than the JSON quoting `cmd` needs. Mocking
-// `is-windows` is what keeps this branch reachable off Windows.
+// `is-windows` is mocked because the branch under test is otherwise
+// reachable only from a Windows host.
 test('runLifecycleHook() quotes arguments for the emulator rather than for cmd on Windows', async () => {
   const pkgRoot = f.prepare('escape-args')
   const { default: pkg } = await import(path.join(pkgRoot, 'package.json'))

--- a/pnpm11/exec/lifecycle/test/argQuoting.ts
+++ b/pnpm11/exec/lifecycle/test/argQuoting.ts
@@ -20,6 +20,7 @@ test('runLifecycleHook() quotes arguments for the emulator rather than for cmd o
     'C:\\Program Files\\tool\\',
     '',
     'a"b',
+    "it's",
     '$PNPM_QUOTING_TEST',
     'line\nbreak',
   ]


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14576, which fixed argument quoting under `shellEmulator`. That fix landed with a blind spot: the rule it establishes was only observable on Windows.

Both stacks decided the quoting style with a platform check that is constant for a given run — `cfg!(windows) && !shell_emulator` in Rust, `isWindows() && !opts.shellEmulator` in TypeScript. On Linux and macOS the left operand is always false, so no test on those hosts can tell the fixed expression from the broken one. Coverage of the actual regression rested entirely on Windows CI, and the one Rust unit test that asserted quoting was `#[cfg_attr(target_os = "windows", ignore)]` — skipped on the only platform where the bug lived. The Windows JSON branch had no unit test at all.

This PR makes the rule assertable everywhere. No behavior changes.

- `parsed_by_windows_shell(windows, shell_emulator)` takes the platform as a value; `run_script` passes `cfg!(windows)`. `build_command` now receives the shell family to quote for rather than the emulator flag.
- Both quoting branches and all four combinations of the rule are asserted on any host. The `ignore` attribute is gone, and the JSON branch gains its first coverage off Windows, including a trailing-backslash path.
- A new lifecycle test mocks `is-windows` so `runLifecycleHook` takes the Windows path on any host, then asserts the arguments survive the emulator round trip.

Each new assertion was confirmed to fail when its half of the rule is removed: dropping `!shell_emulator` from `parsed_by_windows_shell` reddens the Rust test on Linux, and dropping `&& !opts.shellEmulator` from `runLifecycleHook` reddens the TypeScript test on Linux. Before this PR, neither sabotage was detectable off Windows.

No changeset: this is test coverage plus an internal refactor, with no user-visible change.

## Squash Commit Body

```text
The rule that the shell emulator takes POSIX quoting on every platform was
only observable on Windows. Both stacks gated it behind a platform check
that is constant for a given run, so a Linux or macOS job could not tell
`windows && !shell_emulator` from `windows` alone.

Take the platform as a value in `parsed_by_windows_shell` and give
`build_command` the shell family it should quote for. Both quoting branches
and the emulator rule are now asserted on any host, which also retires the
`build_command` case that was ignored on Windows and leaves the JSON branch
covered for the first time off Windows.

Mock `is-windows` in a lifecycle test so the same rule is exercised through
`runLifecycleHook` on any host. Each assertion was confirmed to fail when
its half of the rule is removed.

Related to pnpm/pnpm#14548
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W75WqCcKRyds5HpiWapYpQ

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14623"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791306156&installation_model_id=426870&pr_number=14623&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14623&signature=b5c640fc7ce7bc0665e0947e977924349c548b24ac9cb632d0274408389305b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument quoting for lifecycle scripts running through Windows shells or shell emulators.
  * Preserved special characters, including backslashes, quotes, empty values, environment-variable syntax, and line breaks.
  * Applied quoting consistently according to the shell parsing the command.
  * Improved consistency between native Windows execution and shell-emulated execution, reducing the risk of altered script arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->