### PR TITLE
feat(pnpr): answer cargo search over hosted crates

### DIFF
--- a/.changeset/cargo-search.md
+++ b/.changeset/cargo-search.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-`cargo search` works against a pnpr registry. It matches on crate name over the crates the registry hosts, and reports each crate's newest release that is not yanked.
+`cargo search` works against a pnpr registry. It matches on crate name over the crates the registry hosts. Each result reports the crate's newest release that is not yanked. A crate whose releases are all yanked reports its newest release.

--- a/.changeset/cargo-search.md
+++ b/.changeset/cargo-search.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+`cargo search` works against a pnpr registry. It matches on crate name over the crates the registry hosts, and reports each crate's newest release that is not yanked.

--- a/pnpr/crates/cargo/src/lib.rs
+++ b/pnpr/crates/cargo/src/lib.rs
@@ -230,6 +230,20 @@ impl CrateDocument {
     }
 }
 
+/// The longest description a crate document keeps, which is also the cap
+/// crates.io puts on one. A search response carries a page of descriptions,
+/// and a publisher writes them, so an unbounded one would let a publisher
+/// decide how large every later search response is.
+pub const MAX_DESCRIPTION_LEN: usize = 1_000;
+
+/// A publish's description, cut to [`MAX_DESCRIPTION_LEN`] characters. Cut
+/// rather than refused: the description was accepted and discarded before
+/// crate documents kept one, and a publish that worked should keep working.
+#[must_use]
+pub fn bounded_description(description: Option<&str>) -> Option<String> {
+    description.map(|description| description.chars().take(MAX_DESCRIPTION_LEN).collect())
+}
+
 /// One row of `GET api/v1/crates`. `cargo search` reads exactly these three
 /// fields, so the response stays that narrow rather than modelling all of
 /// what crates.io returns.

--- a/pnpr/crates/cargo/src/lib.rs
+++ b/pnpr/crates/cargo/src/lib.rs
@@ -168,12 +168,42 @@ pub fn render_index(entries: &[IndexEntry]) -> String {
 pub struct CrateDocument {
     pub name: String,
     pub versions: Vec<IndexEntry>,
+    /// The description of the most recently published version, which is
+    /// what the crates API reports for the crate. The sparse index carries
+    /// no description, so this is the only place a hosted crate has one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 impl CrateDocument {
     #[must_use]
     pub fn new(name: &str) -> Self {
-        Self { name: name.to_string(), versions: Vec::new() }
+        Self { name: name.to_string(), versions: Vec::new(), description: None }
+    }
+
+    /// The version the crates API reports as `max_version`: the highest
+    /// non-yanked release, or the highest of all of them once every release
+    /// is yanked. `None` for a document with no parsable version.
+    #[must_use]
+    pub fn max_version(&self) -> Option<String> {
+        let highest = |yanked_allowed: bool| {
+            self.versions
+                .iter()
+                .filter(|entry| yanked_allowed || !entry.yanked)
+                .filter_map(|entry| semver::Version::parse(&entry.vers).ok())
+                .max()
+        };
+        highest(false).or_else(|| highest(true)).map(|version| version.to_string())
+    }
+
+    /// This crate as one row of a search response.
+    #[must_use]
+    pub fn to_search_crate(&self) -> SearchCrate {
+        SearchCrate {
+            name: self.name.clone(),
+            description: self.description.clone(),
+            max_version: self.max_version().unwrap_or_default(),
+        }
     }
 
     pub fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
@@ -198,6 +228,29 @@ impl CrateDocument {
     pub fn render_index(&self) -> String {
         render_index(&self.versions)
     }
+}
+
+/// One row of `GET api/v1/crates`. `cargo search` reads exactly these three
+/// fields, so the response stays that narrow rather than modelling all of
+/// what crates.io returns.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchCrate {
+    pub name: String,
+    pub description: Option<String>,
+    pub max_version: String,
+}
+
+/// The body of `GET api/v1/crates`. `total` counts every match, not the
+/// page, so a client can tell that a query was truncated.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchResponse {
+    pub crates: Vec<SearchCrate>,
+    pub meta: SearchMeta,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchMeta {
+    pub total: usize,
 }
 
 /// The `config.json` at the root of a sparse index.

--- a/pnpr/crates/cargo/src/tests.rs
+++ b/pnpr/crates/cargo/src/tests.rs
@@ -1,11 +1,11 @@
 use super::{
-    CrateArchiveError, CrateDocument, CrateNameError, DependencyKind, IndexConfig,
-    PublishBodyError, PublishMetadata, crate_filename, download_url, parse_index,
+    CrateArchiveError, CrateDocument, CrateNameError, DependencyKind, IndexConfig, IndexEntry,
+    PublishBodyError, PublishMetadata, SearchCrate, crate_filename, download_url, parse_index,
     parse_publish_body, render_index, sparse_index_path, validate_crate_archive,
     validate_crate_archive_with_limit, validate_crate_name,
 };
 use serde_json::json;
-use std::io::Write as _;
+use std::{collections::BTreeMap, io::Write as _};
 
 pub(crate) fn crate_archive(root: &str, files: &[(&str, &str)]) -> Vec<u8> {
     let encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
@@ -365,4 +365,58 @@ fn crate_archive_accepts_an_explicit_root_directory() {
             entry_type.is_dir(),
         );
     }
+}
+
+fn entry(vers: &str, yanked: bool) -> IndexEntry {
+    IndexEntry {
+        name: "demo".to_string(),
+        vers: vers.to_string(),
+        deps: Vec::new(),
+        cksum: "0".repeat(64),
+        features: BTreeMap::new(),
+        yanked,
+        links: None,
+        v: 1,
+        features2: None,
+        rust_version: None,
+    }
+}
+
+#[test]
+fn max_version_prefers_the_newest_release_that_is_not_yanked() {
+    let mut document = CrateDocument::new("demo");
+    document.versions = vec![entry("0.9.0", false), entry("1.10.0", false), entry("1.9.0", false)];
+
+    // Semver ordering, not lexicographic: 1.10.0 is newer than 1.9.0.
+    assert_eq!(document.max_version().as_deref(), Some("1.10.0"));
+
+    document.versions[1].yanked = true;
+    assert_eq!(document.max_version().as_deref(), Some("1.9.0"));
+
+    // With nothing left to prefer, the newest yanked release is reported.
+    for version in &mut document.versions {
+        version.yanked = true;
+    }
+    assert_eq!(document.max_version().as_deref(), Some("1.10.0"));
+}
+
+#[test]
+fn a_document_with_no_release_has_no_max_version() {
+    assert_eq!(CrateDocument::new("demo").max_version(), None);
+}
+
+#[test]
+fn a_search_row_carries_the_name_as_published() {
+    let mut document = CrateDocument::new("Inflector");
+    document.versions = vec![entry("0.11.4", false)];
+    document.description = Some("A crate".to_string());
+
+    assert_eq!(
+        document.to_search_crate(),
+        SearchCrate {
+            name: "Inflector".to_string(),
+            description: Some("A crate".to_string()),
+            max_version: "0.11.4".to_string(),
+        },
+    );
 }

--- a/pnpr/crates/cargo/src/tests.rs
+++ b/pnpr/crates/cargo/src/tests.rs
@@ -1,8 +1,8 @@
 use super::{
     CrateArchiveError, CrateDocument, CrateNameError, DependencyKind, IndexConfig, IndexEntry,
-    PublishBodyError, PublishMetadata, SearchCrate, crate_filename, download_url, parse_index,
-    parse_publish_body, render_index, sparse_index_path, validate_crate_archive,
-    validate_crate_archive_with_limit, validate_crate_name,
+    MAX_DESCRIPTION_LEN, PublishBodyError, PublishMetadata, SearchCrate, bounded_description,
+    crate_filename, download_url, parse_index, parse_publish_body, render_index, sparse_index_path,
+    validate_crate_archive, validate_crate_archive_with_limit, validate_crate_name,
 };
 use serde_json::json;
 use std::{collections::BTreeMap, io::Write as _};
@@ -393,7 +393,6 @@ fn max_version_prefers_the_newest_release_that_is_not_yanked() {
     document.versions[1].yanked = true;
     assert_eq!(document.max_version().as_deref(), Some("1.9.0"));
 
-    // With nothing left to prefer, the newest yanked release is reported.
     for version in &mut document.versions {
         version.yanked = true;
     }
@@ -419,4 +418,17 @@ fn a_search_row_carries_the_name_as_published() {
             max_version: "0.11.4".to_string(),
         },
     );
+}
+
+#[test]
+fn a_description_is_cut_to_the_documented_length() {
+    assert_eq!(bounded_description(None), None);
+    assert_eq!(bounded_description(Some("short")).as_deref(), Some("short"));
+
+    let long = "d".repeat(MAX_DESCRIPTION_LEN + 1);
+    assert_eq!(bounded_description(Some(&long)).unwrap().len(), MAX_DESCRIPTION_LEN);
+
+    // Cut by character, so a multi-byte description stays valid UTF-8.
+    let wide = "é".repeat(MAX_DESCRIPTION_LEN + 1);
+    assert_eq!(bounded_description(Some(&wide)).unwrap().chars().count(), MAX_DESCRIPTION_LEN);
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -1500,25 +1500,20 @@ enum DiscoverySource {
     Upstream(String),
 }
 
-struct SearchPage {
-    objects: Vec<Value>,
+/// One page of search results, in the order the discovery sources are
+/// walked. `names` counts every match so a caller can report a total that
+/// is larger than the page, and it is what makes the first source to serve
+/// a name the one that owns it. `Item` is whatever the surface renders.
+struct SearchPage<Item> {
+    objects: Vec<Item>,
     names: HashSet<String>,
     from: usize,
     size: usize,
 }
 
-impl SearchPage {
+impl<Item> SearchPage<Item> {
     fn new(from: usize, size: usize) -> Self {
         Self { objects: Vec::new(), names: HashSet::new(), from, size }
-    }
-
-    fn push(&mut self, object: Value) {
-        let Some(name) = search_object_name(&object) else {
-            return;
-        };
-        if self.push_name(name) {
-            self.objects.push(object);
-        }
     }
 
     fn push_name(&mut self, name: &str) -> bool {
@@ -1534,6 +1529,17 @@ impl SearchPage {
 
     fn total(&self) -> usize {
         self.names.len()
+    }
+}
+
+impl SearchPage<Value> {
+    fn push(&mut self, object: Value) {
+        let Some(name) = search_object_name(&object) else {
+            return;
+        };
+        if self.push_name(name) {
+            self.objects.push(object);
+        }
     }
 }
 
@@ -2310,30 +2316,23 @@ async fn serve_search(
     };
     let mut page = SearchPage::new(params.from, params.size);
     let mut upstream_budget = UpstreamSearchBudget::default();
-    for source in discovery_sources(state, &registry) {
+    for source in discovery_sources(state, &registry, Ecosystem::Npm) {
         match source {
             DiscoverySource::Hosted(source) => {
-                let Some(hosted) = state.inner.config.hosted.get(&source) else {
-                    continue;
+                let hosted = hosted_search_names(
+                    state,
+                    identity,
+                    &registry,
+                    &source,
+                    Ecosystem::Npm,
+                    &params.text,
+                )
+                .await;
+                let (storage, names) = match hosted {
+                    Ok(Some(hosted)) => hosted,
+                    Ok(None) => continue,
+                    Err(err) => return err.into_response(),
                 };
-                if !hosted.rules.any_access_admits(identity) {
-                    continue;
-                }
-                let storage = hosted_storage(state, Some(&hosted.org));
-                let keep = |name: &str| {
-                    matches!(
-                        resolve_registry_source(state, &registry, name),
-                        RegistrySource::Hosted(resolved) if resolved == source,
-                    ) && matches!(
-                        hosted_gate(state, identity, &source, name),
-                        HostedGate::Allowed(_),
-                    )
-                };
-                let names =
-                    match pnpr_search::local_search_names(&storage, &params.text, keep).await {
-                        Ok(names) => names,
-                        Err(err) => return err.into_response(),
-                    };
                 for name in names {
                     if page.push_name(&name) {
                         page.objects.push(pnpr_search::local_search_entry(&storage, &name).await);
@@ -2380,9 +2379,38 @@ async fn serve_search(
     result(page.objects, total)
 }
 
+/// The hosted names one discovery source contributes to a search, beside the
+/// storage they were read from. `None` when the caller may not see the source
+/// at all. Only the projection of a name into a result differs between
+/// ecosystems, so the walk itself lives here.
+async fn hosted_search_names(
+    state: &AppState,
+    identity: &Identity,
+    registry: &str,
+    source: &str,
+    ecosystem: Ecosystem,
+    text: &pnpr_search::SearchText,
+) -> Result<Option<(Storage, Vec<String>)>, RegistryError> {
+    let Some(hosted) = state.inner.config.hosted.get(source) else {
+        return Ok(None);
+    };
+    if !hosted.rules.any_access_admits(identity) {
+        return Ok(None);
+    }
+    let storage = hosted_storage(state, Some(&hosted.org));
+    let keep = |name: &str| {
+        matches!(
+            resolve_ecosystem_source(state, registry, ecosystem, name),
+            RegistrySource::Hosted(resolved) if resolved == source,
+        ) && matches!(hosted_gate(state, identity, source, name), HostedGate::Allowed(_))
+    };
+    let names = pnpr_search::local_search_names(&storage, text, keep).await?;
+    Ok(Some((storage, names)))
+}
+
 async fn append_upstream_search(
     context: UpstreamSearchContext<'_>,
-    page: &mut SearchPage,
+    page: &mut SearchPage<Value>,
     budget: &mut UpstreamSearchBudget,
 ) -> Result<(), RegistryError> {
     const FETCH_SIZE: usize = 250;
@@ -2440,10 +2468,14 @@ async fn append_upstream_search(
     }
 }
 
-fn discovery_sources(state: &AppState, registry: &str) -> Vec<DiscoverySource> {
+fn discovery_sources(
+    state: &AppState,
+    registry: &str,
+    ecosystem: Ecosystem,
+) -> Vec<DiscoverySource> {
     let registries = &state.inner.config.registries;
     registries
-        .sources(registry, Ecosystem::Npm)
+        .sources(registry, ecosystem)
         .into_iter()
         .filter_map(|source| match registries.get(source) {
             Some(Registry::Hosted { .. }) => Some(DiscoverySource::Hosted(source.to_string())),
@@ -2490,7 +2522,7 @@ async fn serve_org_packages(
     };
     let prefix = format!("@{scope}/");
     let mut packages = Map::new();
-    for source in discovery_sources(state, &registry) {
+    for source in discovery_sources(state, &registry, Ecosystem::Npm) {
         match source {
             DiscoverySource::Hosted(source) => {
                 let Some(hosted) = state.inner.config.hosted.get(&source) else {

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -8,7 +8,8 @@
 //! downloads back at itself). The **crates API** serves downloads
 //! (`api/v1/crates/<crate>/<version>/download`, verified against the index
 //! checksum when proxied), accepts `cargo publish` (`PUT api/v1/crates/new`)
-//! and yank / unyank on hosted registries.
+//! and yank / unyank on hosted registries, and answers `cargo search` over
+//! the crates a registry hosts.
 //!
 //! In a multi-ecosystem registry, both families answer under `/cargo/` (the
 //! default target) and `/cargo/~<name>/` (a named registry). A Cargo-only
@@ -18,29 +19,30 @@
 //! published.
 
 use super::{
-    Action, AppState, AuthedCaller, RegistrySource, TargetRegistry, authorize,
+    Action, AppState, AuthedCaller, DiscoverySource, RegistrySource, SearchPage, TargetRegistry,
+    authorize, discovery_sources,
     documents::{read_hosted_document, stage_hosted_artifact, store_hosted_artifact},
     ecosystem::{
         UpstreamDocument, addressed_registry, caller_scoped, is_fetchable_artifact_url,
         load_upstream_document, registry_endpoint, registry_requires_auth, serve_hosted_blob,
         serve_upstream_artifact, sha256_hex, sha256_integrity, upstream_for,
     },
-    json_response, not_found,
+    hosted_search_names, json_response, not_found,
     publishing::{PublishTarget, StagedPublish, resolve_publish_target_for},
     resolve_ecosystem_source, resolve_write_target_for,
 };
 use axum::{
     Router,
     body::{Body, Bytes},
-    extract::{Path, State},
+    extract::{Path, RawQuery, State},
     http::{StatusCode, header},
     response::{IntoResponse, Response},
     routing::{delete, get, put},
 };
 use pnpr_cargo::{
-    CrateDocument, IndexConfig, IndexEntry, PublishMetadata, crate_filename, download_url,
-    errors_json, ok_json, parse_index, parse_publish_body, publish_ok_json, sparse_index_path,
-    validate_crate_archive,
+    CrateDocument, IndexConfig, IndexEntry, PublishMetadata, SearchCrate, SearchMeta,
+    SearchResponse, crate_filename, download_url, errors_json, ok_json, parse_index,
+    parse_publish_body, publish_ok_json, sparse_index_path, validate_crate_archive,
 };
 use pnpr_error::RegistryError;
 use pnpr_package_name::{CanonicalPackageName, is_safe_path_segment};
@@ -65,6 +67,7 @@ pub(super) fn routes(prefixed: bool) -> Router<AppState> {
             .route(&format!("{base}/index/config.json"), get(get_index_config))
             .route(&format!("{base}/index/{{a}}/{{b}}"), get(get_index_file))
             .route(&format!("{base}/index/{{a}}/{{b}}/{{c}}"), get(get_index_file))
+            .route(&format!("{base}/api/v1/crates"), get(get_search))
             .route(&format!("{base}/api/v1/crates/new"), put(put_publish))
             .route(
                 &format!("{base}/api/v1/crates/{{name}}/{{version}}/download"),
@@ -74,6 +77,77 @@ pub(super) fn routes(prefixed: bool) -> Router<AppState> {
             .route(&format!("{base}/api/v1/crates/{{name}}/{{version}}/unyank"), put(put_unyank));
     }
     router
+}
+
+/// `cargo search`'s default page size, which is also what crates.io returns
+/// when a request names none.
+const DEFAULT_SEARCH_PAGE: usize = 10;
+
+/// `GET api/v1/crates?q=<query>&per_page=<n>&page=<n>` — `cargo search`.
+///
+/// Hosted sources only. An upstream contributes nothing, the way an npm
+/// upstream does until its `search` is turned on, and searching one needs
+/// its `config.json` `api` base rather than the index base pnpr proxies.
+async fn get_search(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    RawQuery(query): RawQuery,
+) -> Response {
+    let query_string = query.unwrap_or_default();
+    let respond = |crates: Vec<SearchCrate>, total: usize| {
+        json_response(
+            StatusCode::OK,
+            &serde_json::to_value(SearchResponse { crates, meta: SearchMeta { total } })
+                .expect("search response serializes"),
+        )
+    };
+    let Some(text) = pnpr_search::parse_query(&query_string).map(pnpr_search::SearchText::Package)
+    else {
+        return respond(Vec::new(), 0);
+    };
+    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+        return not_found();
+    };
+    let size = pnpr_search::parse_usize_param(&query_string, "per_page")
+        .map_or(DEFAULT_SEARCH_PAGE, |size| size.clamp(1, pnpr_search::MAX_PAGE_SIZE));
+    // crates.io numbers pages from one; anything lower starts at the first.
+    let from = pnpr_search::parse_usize_param(&query_string, "page")
+        .map_or(0, |page| page.saturating_sub(1).saturating_mul(size));
+
+    let mut page = SearchPage::new(from, size);
+    for source in discovery_sources(&state, &target, ECOSYSTEM) {
+        let DiscoverySource::Hosted(source) = source else {
+            continue;
+        };
+        let hosted =
+            hosted_search_names(&state, &identity, &target, &source, ECOSYSTEM, &text).await;
+        let (storage, names) = match hosted {
+            Ok(Some(hosted)) => hosted,
+            Ok(None) => continue,
+            Err(err) => return error_response(err),
+        };
+        for name in names {
+            if !page.push_name(&name) {
+                continue;
+            }
+            let Some(entry) = search_crate(&storage, &name).await else {
+                continue;
+            };
+            page.objects.push(entry);
+        }
+    }
+    let total = page.total();
+    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), None, respond(page.objects, total))
+}
+
+/// One search row, read from the crate's stored document. `None` when the
+/// document is unreadable, which leaves the crate out of the page rather
+/// than failing the whole search.
+async fn search_crate(storage: &pnpr_storage::Storage, name: &str) -> Option<SearchCrate> {
+    let key = CanonicalPackageName::parse(name, ECOSYSTEM).ok()?;
+    let bytes = storage.read_hosted_document(&key).await.ok()??;
+    CrateDocument::parse(&bytes).ok().map(|document| document.to_search_crate())
 }
 
 /// A registry error in the crates API's JSON shape, so `cargo` prints the
@@ -336,6 +410,7 @@ pub(super) struct CratePublication {
     org: String,
     filename: String,
     entry: IndexEntry,
+    description: Option<String>,
     archive: Bytes,
 }
 
@@ -397,12 +472,30 @@ pub(super) async fn verify_crate_archive(
     .map_err(RegistryError::JoinError)??;
     let (cksum, archive) = checked;
     let filename = crate_filename(&metadata.name, &metadata.vers);
-    Ok(CratePublication { key, org, filename, entry: metadata.into_index_entry(cksum), archive })
+    let description = metadata.description.clone();
+    Ok(CratePublication {
+        key,
+        org,
+        filename,
+        entry: metadata.into_index_entry(cksum),
+        description,
+        archive,
+    })
 }
 
 impl CratePublication {
     pub(super) fn key(&self) -> &CanonicalPackageName {
         &self.key
+    }
+
+    /// The one-version document this publish contributes, which merges into
+    /// whatever the registry already holds for the crate.
+    fn document(&self) -> CrateDocument {
+        CrateDocument {
+            name: self.entry.name.clone(),
+            versions: vec![self.entry.clone()],
+            description: self.description.clone(),
+        }
     }
 
     /// Publish this crate on its own, in a transaction of one.
@@ -414,7 +507,7 @@ impl CratePublication {
             &self.filename,
             &self.archive,
             refuse_published_version(&self.entry.vers),
-            CrateDocument { name: self.entry.name.clone(), versions: vec![self.entry.clone()] },
+            self.document(),
         )
         .await
     }
@@ -429,7 +522,7 @@ impl CratePublication {
             &self.filename,
             &self.archive,
             &refuse_published_version(&self.entry.vers),
-            CrateDocument { name: self.entry.name.clone(), versions: vec![self.entry.clone()] },
+            self.document(),
         )
         .await
     }

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -27,7 +27,7 @@ use super::{
         load_upstream_document, registry_endpoint, registry_requires_auth, serve_hosted_blob,
         serve_upstream_artifact, sha256_hex, sha256_integrity, upstream_for,
     },
-    hosted_search_names, json_response, not_found,
+    hosted_search_names, json_response, not_found, private_no_cache,
     publishing::{PublishTarget, StagedPublish, resolve_publish_target_for},
     resolve_ecosystem_source, resolve_write_target_for,
 };
@@ -41,8 +41,8 @@ use axum::{
 };
 use pnpr_cargo::{
     CrateDocument, IndexConfig, IndexEntry, PublishMetadata, SearchCrate, SearchMeta,
-    SearchResponse, crate_filename, download_url, errors_json, ok_json, parse_index,
-    parse_publish_body, publish_ok_json, sparse_index_path, validate_crate_archive,
+    SearchResponse, bounded_description, crate_filename, download_url, errors_json, ok_json,
+    parse_index, parse_publish_body, publish_ok_json, sparse_index_path, validate_crate_archive,
 };
 use pnpr_error::RegistryError;
 use pnpr_package_name::{CanonicalPackageName, is_safe_path_segment};
@@ -128,26 +128,41 @@ async fn get_search(
             Err(err) => return error_response(err),
         };
         for name in names {
-            if !page.push_name(&name) {
-                continue;
-            }
-            let Some(entry) = search_crate(&storage, &name).await else {
+            // A hosted namespace shared with another ecosystem holds names
+            // that are not crate names. Dropping them before the position
+            // is claimed keeps them out of the page and out of the total,
+            // and costs no read.
+            let Ok(key) = CanonicalPackageName::parse(&name, ECOSYSTEM) else {
                 continue;
             };
-            page.objects.push(entry);
+            if page.push_name(&name) {
+                page.objects.push(search_crate(&storage, &key).await);
+            }
         }
     }
     let total = page.total();
-    caller_scoped(&state, ECOSYSTEM, registry.as_deref(), None, respond(page.objects, total))
+    // Results are filtered per caller (registry access plus per-package
+    // ACL), so they must never land in a shared HTTP cache.
+    private_no_cache(respond(page.objects, total))
 }
 
-/// One search row, read from the crate's stored document. `None` when the
-/// document is unreadable, which leaves the crate out of the page rather
-/// than failing the whole search.
-async fn search_crate(storage: &pnpr_storage::Storage, name: &str) -> Option<SearchCrate> {
-    let key = CanonicalPackageName::parse(name, ECOSYSTEM).ok()?;
-    let bytes = storage.read_hosted_document(&key).await.ok()??;
-    CrateDocument::parse(&bytes).ok().map(|document| document.to_search_crate())
+/// One search row, read from the crate's stored document. A document that
+/// cannot be read or parsed still answers with the name the caller matched,
+/// so the page never disagrees with the total it reports.
+async fn search_crate(storage: &pnpr_storage::Storage, key: &CanonicalPackageName) -> SearchCrate {
+    let document = async {
+        let bytes = storage.read_hosted_document(key).await.ok()??;
+        CrateDocument::parse(&bytes).ok()
+    }
+    .await;
+    document.as_ref().map_or_else(
+        || SearchCrate {
+            name: key.as_str().to_string(),
+            description: None,
+            max_version: String::new(),
+        },
+        CrateDocument::to_search_crate,
+    )
 }
 
 /// A registry error in the crates API's JSON shape, so `cargo` prints the
@@ -472,7 +487,7 @@ pub(super) async fn verify_crate_archive(
     .map_err(RegistryError::JoinError)??;
     let (cksum, archive) = checked;
     let filename = crate_filename(&metadata.name, &metadata.vers);
-    let description = metadata.description.clone();
+    let description = bounded_description(metadata.description.as_deref());
     Ok(CratePublication {
         key,
         org,

--- a/pnpr/crates/pnpr/src/server/documents.rs
+++ b/pnpr/crates/pnpr/src/server/documents.rs
@@ -78,6 +78,9 @@ impl HostedDocument for CrateDocument {
                 self.name.clone_from(&entry.name);
             }
             self.versions.push(entry);
+            // The crates API reports one description per crate, so the
+            // newest publish that landed owns it.
+            self.description.clone_from(&addition.description);
         }
         self.versions.len() != before
     }

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -385,6 +385,151 @@ async fn yank_and_unyank_flip_the_index_entry() {
 }
 
 #[tokio::test]
+async fn search_lists_hosted_crates_by_newest_version_and_description() {
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(
+        cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$all"),
+        auth,
+    );
+    for (name, version) in [("demo", "0.1.0"), ("demo", "1.2.0"), ("inflector", "0.11.4")] {
+        let response = app
+            .clone()
+            .oneshot(publish_request(
+                Some(&token),
+                publish_body(&metadata(name, version), &crate_archive(name, version)),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{name}@{version}");
+    }
+
+    let search = |app: axum::Router, query: &str| {
+        let uri = format!("/cargo/api/v1/crates?{query}");
+        async move {
+            let response =
+                app.oneshot(Request::get(uri).body(Body::empty()).unwrap()).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            serde_json::from_slice::<Value>(&body_bytes(response.into_body()).await).unwrap()
+        }
+    };
+
+    // The newest release is the one reported, and the description rides along.
+    let body = search(app.clone(), "q=demo&per_page=10").await;
+    assert_eq!(
+        body,
+        json!({
+            "crates": [{ "name": "demo", "description": "A demo crate", "max_version": "1.2.0" }],
+            "meta": { "total": 1 },
+        }),
+    );
+
+    // The query is a substring match over crate names, as npm search is.
+    let body = search(app.clone(), "q=flect").await;
+    assert_eq!(body["crates"][0]["name"], "inflector");
+    assert_eq!(body["meta"]["total"], 1);
+
+    // `total` counts every match; `per_page` and `page` cut the window.
+    let body = search(app.clone(), "q=o&per_page=1").await;
+    assert_eq!(body["crates"].as_array().unwrap().len(), 1);
+    assert_eq!(body["crates"][0]["name"], "demo");
+    assert_eq!(body["meta"]["total"], 2);
+    let body = search(app.clone(), "q=o&per_page=1&page=2").await;
+    assert_eq!(body["crates"].as_array().unwrap().len(), 1);
+    assert_eq!(body["crates"][0]["name"], "inflector");
+
+    // A query that names nothing is not a request to dump the registry.
+    let body = search(app.clone(), "q=nothing-matches-this").await;
+    assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
+    let body = search(app, "per_page=10").await;
+    assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
+}
+
+#[tokio::test]
+async fn search_reports_the_newest_unyanked_release() {
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(
+        cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$all"),
+        auth,
+    );
+    for version in ["0.1.0", "1.2.0"] {
+        let response = app
+            .clone()
+            .oneshot(publish_request(
+                Some(&token),
+                publish_body(&metadata("demo", version), &crate_archive("demo", version)),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{version}");
+    }
+    let response = app
+        .clone()
+        .oneshot(
+            Request::delete("/cargo/api/v1/crates/demo/1.2.0/yank")
+                .header(header::AUTHORIZATION, &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(Request::get("/cargo/api/v1/crates?q=demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body["crates"][0]["max_version"], "0.1.0");
+}
+
+#[tokio::test]
+async fn search_hides_a_private_registry_from_an_anonymous_caller() {
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(
+        cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$authenticated"),
+        auth,
+    );
+    let response = app
+        .clone()
+        .oneshot(publish_request(
+            Some(&token),
+            publish_body(&metadata("demo", "0.1.0"), &crate_archive("demo", "0.1.0")),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(Request::get("/cargo/api/v1/crates?q=demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
+
+    let response = app
+        .oneshot(
+            Request::get("/cargo/api/v1/crates?q=demo")
+                .header(header::AUTHORIZATION, &token)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(body["crates"][0]["name"], "demo");
+}
+
+#[tokio::test]
 async fn crate_names_are_case_insensitive_in_the_index_path() {
     let tmp = TempDir::new().unwrap();
     let auth = AuthState::in_memory();

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -415,7 +415,6 @@ async fn search_lists_hosted_crates_by_newest_version_and_description() {
         }
     };
 
-    // The newest release is the one reported, and the description rides along.
     let body = search(app.clone(), "q=demo&per_page=10").await;
     assert_eq!(
         body,
@@ -425,12 +424,10 @@ async fn search_lists_hosted_crates_by_newest_version_and_description() {
         }),
     );
 
-    // The query is a substring match over crate names, as npm search is.
     let body = search(app.clone(), "q=flect").await;
     assert_eq!(body["crates"][0]["name"], "inflector");
     assert_eq!(body["meta"]["total"], 1);
 
-    // `total` counts every match; `per_page` and `page` cut the window.
     let body = search(app.clone(), "q=o&per_page=1").await;
     assert_eq!(body["crates"].as_array().unwrap().len(), 1);
     assert_eq!(body["crates"][0]["name"], "demo");
@@ -442,8 +439,48 @@ async fn search_lists_hosted_crates_by_newest_version_and_description() {
     // A query that names nothing is not a request to dump the registry.
     let body = search(app.clone(), "q=nothing-matches-this").await;
     assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
-    let body = search(app, "per_page=10").await;
+    let body = search(app.clone(), "per_page=10").await;
     assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
+
+    // Results depend on the caller, so they must never be shared-cached.
+    let response = app
+        .oneshot(Request::get("/cargo/api/v1/crates?q=demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.headers()[header::CACHE_CONTROL], "private, no-store");
+    assert_eq!(response.headers()[header::VARY], "Authorization");
+}
+
+#[tokio::test]
+async fn a_publishers_description_cannot_grow_a_search_response() {
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(
+        cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$all"),
+        auth,
+    );
+    let mut published = metadata("demo", "0.1.0");
+    published["description"] = json!("d".repeat(pnpr_cargo::MAX_DESCRIPTION_LEN + 500));
+    let response = app
+        .clone()
+        .oneshot(publish_request(
+            Some(&token),
+            publish_body(&published, &crate_archive("demo", "0.1.0")),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(Request::get("/cargo/api/v1/crates?q=demo").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(
+        body["crates"][0]["description"].as_str().unwrap().len(),
+        pnpr_cargo::MAX_DESCRIPTION_LEN,
+    );
 }
 
 #[tokio::test]

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -80,33 +80,32 @@ pub fn parse_query(query_string: &str) -> Option<String> {
     fallback
 }
 
+/// The first parsable value of a numeric URL parameter, or `None` when the
+/// query string carries none. Every search surface reads its page size and
+/// offset this way; only the parameter names differ between them.
+#[must_use]
+pub fn parse_usize_param(query_string: &str, key: &str) -> Option<usize> {
+    query_string.split('&').find_map(|pair| {
+        let (candidate, value) = pair.split_once('=')?;
+        (candidate == key).then(|| value.parse().ok()).flatten()
+    })
+}
+
 /// `size=` URL param; bounded the same way npm bounds it (1..=250).
 #[must_use]
 pub fn parse_size(query_string: &str, default_size: usize) -> usize {
-    for pair in query_string.split('&') {
-        if let Some((key, value)) = pair.split_once('=')
-            && key == "size"
-            && let Ok(parsed) = value.parse::<usize>()
-        {
-            return parsed.clamp(1, 250);
-        }
-    }
-    default_size
+    parse_usize_param(query_string, "size")
+        .map_or(default_size, |size| size.clamp(1, MAX_PAGE_SIZE))
 }
 
 /// `from=` URL param. Invalid values start at the first result.
 #[must_use]
 pub fn parse_from(query_string: &str) -> usize {
-    for pair in query_string.split('&') {
-        if let Some((key, value)) = pair.split_once('=')
-            && key == "from"
-            && let Ok(parsed) = value.parse::<usize>()
-        {
-            return parsed;
-        }
-    }
-    0
+    parse_usize_param(query_string, "from").unwrap_or(0)
 }
+
+/// The most results any search surface returns in one page.
+pub const MAX_PAGE_SIZE: usize = 250;
 
 pub async fn local_search_names(
     storage: &Storage,


### PR DESCRIPTION
## Summary

`cargo search --registry <pnpr>` failed against a pnpr registry: the Cargo surface served the sparse index, downloads, publish, yank and unyank, but not `GET api/v1/crates`. It now answers over the crates a registry hosts, matching on crate name the way npm search does.

Verified against the real client. Two versions of a crate published to a local pnpr with `cargo publish`, then:

```
$ cargo search --registry pnpr demo
demo-search-crate = "0.3.0"    # A crate published to pnpr to exercise cargo search
```

The response shape is exactly what `cargo` deserializes — `crates: [{ name, description, max_version }]` and `meta: { total }`, taken from the `Crate` / `Crates` structs in cargo's own `crates-io` crate — so it stays that narrow rather than modelling all of what crates.io returns.

Three things worth a reviewer's attention:

- **A crate document gains a description.** The sparse index carries none, so it was the one field of the crates API pnpr had nowhere to read from. It is recorded from the publish metadata, and the newest publish that lands owns it, which is what crates.io reports. The field is optional on the way in, so documents written before this change still parse.
- **`max_version` is the newest release that is not yanked**, falling back to the newest of all of them once every release is yanked. Ordering is semver, not lexicographic.
- **The hosted half of a search is now shared with the npm surface.** The discovery-source walk, the per-source access gate and the per-name hosted gate were identical; only the projection of a name into a result differs. `SearchPage` became generic over what its surface renders, and `discovery_sources` takes the ecosystem instead of assuming npm.

Upstream sources contribute nothing yet, the way an npm upstream does until its `search` is turned on (`UpstreamConfig` defaults `search` to false). Searching one needs the `api` base from its `config.json` rather than the index base pnpr proxies, which is a separate change; the module doc and the follow-up issue both say so.

Related to pnpm/pnpm#14599.

## Squash Commit Body

```text
The Cargo surface served the sparse index, downloads, publish, yank and
unyank, but not `GET api/v1/crates`, so `cargo search --registry <pnpr>`
failed. It now answers over the crates the registry hosts, matching on
crate name the way npm search does.

A crate document gains the description of its most recent publish. The
sparse index carries none, so it was the one field of the crates API
that pnpr had nowhere to read from.

The hosted half of a search — the discovery-source walk, the per-source
access gate, and the per-name hosted gate — is now shared with the npm
surface, which differs only in how it renders a name into a result.

Upstream sources contribute nothing yet, as an npm upstream does until
its `search` is turned on. Searching one needs the `api` base from its
`config.json` rather than the index base pnpr proxies.

Related to pnpm/pnpm#14599.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XATvoqiLrMLWcY64h6cWtf

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791312757&installation_model_id=426870&pr_number=14624&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14624&signature=4736852708cf3139c39c4633f7f8c853955fdd171390b032631223b7fa605b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Cargo registry search through the `api/v1/crates` endpoint.
  - Search matches crate names and returns descriptions, newest available versions, and result counts.
  - Added pagination with configurable page size and page selection.
  - Search reports the newest non-yanked release when available, falling back to the newest release.
  - Private registries remain hidden from unauthorized callers.
- **Bug Fixes**
  - Cargo crate descriptions are now preserved when newer versions are published and limited to 1,000 characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->