### PR TITLE
fix(patching): preserve added and deleted patch paths

### DIFF
--- a/.changeset/fix-patch-commit-file-paths.md
+++ b/.changeset/fix-patch-commit-file-paths.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm patch-commit` now writes valid patch paths for added and deleted files [#14559](https://github.com/pnpm/pnpm/issues/14559).

--- a/pnpm/crates/patching/src/commit.rs
+++ b/pnpm/crates/patching/src/commit.rs
@@ -374,10 +374,12 @@ fn is_diff_path_line(line: &str) -> bool {
 
 fn normalize_diff_path_line(line: &str, folder_a: &str, folder_b: &str) -> String {
     let mut out = line.to_string();
-    for (prefix, folder) in [('a', folder_a), ('b', folder_b)] {
+    for folder in [folder_a, folder_b] {
         let trimmed = folder.trim_matches('/');
-        out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
-        out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
+        for prefix in ['a', 'b'] {
+            out = out.replace(&format!("{prefix}/{trimmed}/"), &format!("{prefix}/"));
+            out = out.replace(&format!("{prefix}{folder}/"), &format!("{prefix}/"));
+        }
         out = out.replace(&format!("{folder}/"), "");
     }
     out

--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -4,6 +4,7 @@ use super::{
     prepare_pkg_files_for_diff_with_fs, remove_existing_temp_dir_with_fs, safe_package_file_path,
     temporary_filtered_dir,
 };
+use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -22,6 +23,44 @@ fn patch_commit_diff_dirs_strips_absolute_temp_paths() {
     assert!(diff.contains("diff --git a/index.js b/index.js"), "diff: {diff}");
     assert!(!diff.contains(&before.path().display().to_string()), "diff: {diff}");
     assert!(!diff.contains(&after.path().display().to_string()), "diff: {diff}");
+}
+
+#[test]
+fn patch_commit_diff_dirs_preserves_deleted_file_paths() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("readme.md"), "package documentation\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+    eprintln!("{diff}");
+    let mut patches = PatchSet::parse(&diff, ParseOptions::gitdiff());
+    let patch = patches.next().expect("deleted file patch").expect("parse generated patch");
+    let FileOperation::Delete(path) = patch.operation().strip_prefix(1) else {
+        panic!("expected a file deletion");
+    };
+
+    assert_eq!(path.as_ref(), "readme.md");
+    assert!(patches.next().is_none(), "expected one file patch");
+}
+
+#[test]
+fn patch_commit_diff_dirs_preserves_created_file_paths() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::create_dir(after.path().join("docs")).unwrap();
+    fs::write(after.path().join("docs/readme.md"), "package documentation\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+    eprintln!("{diff}");
+    let mut patches = PatchSet::parse(&diff, ParseOptions::gitdiff());
+    let patch = patches.next().expect("created file patch").expect("parse generated patch");
+    let FileOperation::Create(path) = patch.operation().strip_prefix(1) else {
+        panic!("expected a file creation");
+    };
+
+    assert_eq!(diff.lines().next(), Some("diff --git a/docs/readme.md b/docs/readme.md"));
+    assert_eq!(path.as_ref(), "docs/readme.md");
+    assert!(patches.next().is_none(), "expected one file patch");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`pnpm patch-commit` now preserves the `a/` and `b/` prefixes when generating patches for added and deleted files. Both prefixes are matched against each diff directory before removing any remaining directory text.

Fixes pnpm/pnpm#14559.

This overlaps with pnpm/pnpm#14621. This PR includes regression tests for a deleted file and a newly created file in a nested directory. The TypeScript v11 implementation already handles both prefix combinations and needs no code change. The separate patch-application problem in pnpm/pnpm#14558 is outside this change.

Local validation at `a3afc80bf1`:

- Both new regression tests failed before the implementation change. All 98 patching tests passed afterward.
- `just ready` passed, including 10,100 Rust tests, with 5 tests skipped by the existing configuration, and workspace-wide Clippy.
- TypeScript compilation and lint, Dylint, rustdoc with warnings denied, TOML formatting, npm wrapper tests, and all commit/push hooks passed.

## Squash Commit Body

```text
Match both git path prefixes against each diff directory. Git uses the
original directory on both sides of a deletion and the edited directory
on both sides of a creation. Pairing each directory with only one prefix
left the other side to the bare-directory replacement, which removed the
slash following the prefix.

Add regression tests using real git diffs and the patch parser. Check the
creation header explicitly because the parser can recover the target
from the +++ marker even when the a/ header is malformed.

The TypeScript v11 implementation already handles both prefixes for each
directory. Patch-application behavior is unchanged.

Fixes pnpm/pnpm#14559.
```

## Checklist

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it. There is overlap with pnpm/pnpm#14621, as noted above.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791315433&installation_model_id=426870&pr_number=14625&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14625&signature=eb8636c60297ae2d518c6c6655bab62a557b6b025e47e814ed13bea55e8d309e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm patch-commit` so patches use valid relative paths for added and deleted files.
  - Improved handling of nested file paths in generated patches.

- **Tests**
  - Added coverage to verify path preservation for deleted files and newly created files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->