### PR TITLE
fix(cli): record the pinned pnpm when version switching is off

### DIFF
--- a/.changeset/record-the-pin-when-switching-is-off.md
+++ b/.changeset/record-the-pin-when-switching-is-off.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Commands other than `pnpm install` now record the pinned pnpm version in `pnpm-lock.yaml` when package manager version switching is turned off. The install family already recorded it, so the two kept rewriting each other's `packageManagerDependencies` block [#14575](https://github.com/pnpm/pnpm/issues/14575).
+Commands other than `pnpm install` now record the pinned pnpm version in `pnpm-lock.yaml` when package manager version switching is turned off. Alternating an install with any other command rewrote the same `packageManagerDependencies` lines back and forth [#14575](https://github.com/pnpm/pnpm/issues/14575).

--- a/.changeset/record-the-pin-when-switching-is-off.md
+++ b/.changeset/record-the-pin-when-switching-is-off.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Commands other than `pnpm install` now record the pinned pnpm version in `pnpm-lock.yaml` when package manager version switching is turned off. Alternating an install with any other command rewrote the same `packageManagerDependencies` lines back and forth [#14575](https://github.com/pnpm/pnpm/issues/14575).
+pnpm no longer rewrites the `packageManagerDependencies` block of `pnpm-lock.yaml` back and forth when package manager version switching is turned off. `pnpm install` recorded the pinned pnpm version there and commands such as `pnpm list` did not [#14575](https://github.com/pnpm/pnpm/issues/14575).

--- a/.changeset/record-the-pin-when-switching-is-off.md
+++ b/.changeset/record-the-pin-when-switching-is-off.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Commands other than `pnpm install` now record the pinned pnpm version in `pnpm-lock.yaml` when package manager version switching is turned off. The install family already recorded it, so the two kept rewriting each other's `packageManagerDependencies` block [#14575](https://github.com/pnpm/pnpm/issues/14575).

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -256,12 +256,8 @@ fn pre_command_plan_from_input(
         let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
         if on_fail != PmOnFail::Ignore {
             if unmanaged_pin {
-                // Which pnpm runs is the user's choice here, but which one
-                // the lockfile records is still the project's, and the
-                // install family records it from its own pipeline whatever
-                // this setting says. A command that skipped the record would
-                // leave a block the next install rewrites, flipping the
-                // lockfile back and forth (pnpm/pnpm#14575).
+                // The install family records the pin from its own pipeline
+                // whatever this setting says (pnpm/pnpm#14575).
                 if !input.global {
                     package_manager_to_sync = env_lockfile_sync(
                         root_manifest,

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -254,8 +254,24 @@ fn pre_command_plan_from_input(
         // the version and picked the wrong one, so the mismatch is reported
         // rather than switched.
         let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
-        if on_fail != PmOnFail::Ignore && !unmanaged_pin {
-            if switch_wanted && !process_state.executed_by_corepack {
+        if on_fail != PmOnFail::Ignore {
+            if unmanaged_pin {
+                // Which pnpm runs is the user's choice here, but which one
+                // the lockfile records is still the project's, and the
+                // install family records it from its own pipeline whatever
+                // this setting says. A command that skipped the record would
+                // leave a block the next install rewrites, flipping the
+                // lockfile back and forth (pnpm/pnpm#14575).
+                if !input.global {
+                    package_manager_to_sync = env_lockfile_sync(
+                        root_manifest,
+                        &root_dir,
+                        on_fail,
+                        input,
+                        ReadEnvLockfile::NotYet,
+                    )?;
+                }
+            } else if switch_wanted && !process_state.executed_by_corepack {
                 let frozen_lockfile =
                     switch.frozen_lockfile.or(config.frozen_lockfile).unwrap_or(false);
                 if let Some(target) = switch_target(&config, &root_dir, frozen_lockfile)? {

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -334,6 +334,50 @@ fn pre_command_plan_switches_to_the_version_the_pin_resolved_to() {
     assert_eq!(version, "99.0.0");
 }
 
+/// The install family records the pin from its own pipeline whether or not
+/// version switching is on, so every other command has to record it there
+/// too — otherwise the two rewrite each other forever (pnpm/pnpm#14575).
+#[test]
+fn pre_command_plan_records_a_pin_when_version_switching_is_turned_off() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: true, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    let Some(PreCommandPlan::SyncEnvLockfile(sync)) = plan else {
+        panic!("expected an env lockfile sync, got {plan:?}");
+    };
+    assert_eq!(
+        sync.package_manager,
+        PackageManagerToSync {
+            specifier: PNPM_VERSION.to_string(),
+            version: PNPM_VERSION.to_string(),
+        },
+    );
+}
+
+/// A pin the running pnpm cannot satisfy resolves to no version to record,
+/// so turning the switch off never cements one nobody runs.
+#[test]
+fn pre_command_plan_records_nothing_for_an_unsatisfiable_pin_when_switching_is_turned_off() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), "^999.0.0");
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: true, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+}
+
 #[test]
 fn pre_command_plan_records_a_pin_the_pm_on_fail_setting_reactivated() {
     let root = TempDir::new().expect("tmp dir");

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -378,8 +378,6 @@ fn pre_command_plan_records_nothing_for_an_unsatisfiable_pin_when_switching_is_t
     assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
 }
 
-/// `--global` does not act on the project, so it records nothing there
-/// either.
 #[test]
 fn pre_command_plan_records_nothing_for_a_global_command_when_switching_is_turned_off() {
     let root = TempDir::new().expect("tmp dir");

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -378,6 +378,23 @@ fn pre_command_plan_records_nothing_for_an_unsatisfiable_pin_when_switching_is_t
     assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
 }
 
+/// `--global` does not act on the project, so it records nothing there
+/// either.
+#[test]
+fn pre_command_plan_records_nothing_for_a_global_command_when_switching_is_turned_off() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &PreCommandInput { global: true, ..pre_command_input(root.path()) },
+        &ConfigOverrides::default(),
+        SwitchProcessState { package_manager_switch_disabled: true, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+}
+
 #[test]
 fn pre_command_plan_records_a_pin_the_pm_on_fail_setting_reactivated() {
     let root = TempDir::new().expect("tmp dir");

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -370,7 +370,7 @@ fn turning_off_version_management_accepts_a_mismatched_pnpm_pin() {
 /// two rewrite each other forever (pnpm/pnpm#14575).
 #[test]
 fn turning_off_version_management_still_records_the_pinned_package_manager() {
-    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
         CommandTempCwd::init().add_mocked_registry_with_pnpm_version(pnpm_config::PNPM_VERSION);
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
     write_dev_engines_package_manager(
@@ -379,14 +379,16 @@ fn turning_off_version_management_still_records_the_pinned_package_manager() {
         pnpm_config::PNPM_VERSION,
         Some("download"),
     );
-
-    let output = run(
-        pacquet
+    let unmanaged = || {
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&workspace)
+            .without_ambient_pnpm_config()
             .with_env("PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS", "false")
-            .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url()),
-        root.path(),
-        &["list"],
-    );
+            .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+    };
+
+    let output = run(unmanaged(), root.path(), &["list"]);
 
     assert_success(&output);
     let env_lockfile = EnvLockfile::read(&workspace)
@@ -396,9 +398,31 @@ fn turning_off_version_management_still_records_the_pinned_package_manager() {
         .package_manager_dependencies
         .as_ref()
         .expect("packageManagerDependencies should be recorded");
+    assert_eq!(recorded["pnpm"].specifier, pnpm_config::PNPM_VERSION);
     assert_eq!(recorded["pnpm"].version, pnpm_config::PNPM_VERSION);
+    let after_list = env_document(&workspace);
+
+    let output = run(unmanaged(), root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_eq!(
+        env_document(&workspace),
+        after_list,
+        "the install must leave the env document the other command wrote alone",
+    );
 
     drop(mock_instance);
+}
+
+/// The first YAML document of `pnpm-lock.yaml`, which is where the package
+/// manager's own resolutions live.
+fn env_document(workspace: &Path) -> String {
+    fs::read_to_string(workspace.join("pnpm-lock.yaml"))
+        .expect("read pnpm-lock.yaml")
+        .split("\n---\n")
+        .next()
+        .expect("the env document")
+        .to_string()
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -2,8 +2,10 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pnpm_lockfile::EnvLockfile;
 use pnpm_testing_utils::{
-    bin::CommandTempCwd, command_env::CommandTestExt,
+    bin::{AddMockedRegistry, CommandTempCwd},
+    command_env::CommandTestExt,
     diagnostics::assert_diagnostic_contains as assert_contains,
 };
 use std::{
@@ -360,6 +362,43 @@ fn turning_off_version_management_accepts_a_mismatched_pnpm_pin() {
 
     assert_success(&output);
     assert!(!output_text(&output).contains("0.0.0"), "unexpected mention of the pinned version");
+}
+
+/// Turning version management off hands the user which pnpm runs, not which
+/// one the lockfile records: the install family records the pin from its own
+/// pipeline either way, so a read-only command has to record it too, or the
+/// two rewrite each other forever (pnpm/pnpm#14575).
+#[test]
+fn turning_off_version_management_still_records_the_pinned_package_manager() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_pnpm_version(pnpm_config::PNPM_VERSION);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_dev_engines_package_manager(
+        &workspace,
+        "pnpm",
+        pnpm_config::PNPM_VERSION,
+        Some("download"),
+    );
+
+    let output = run(
+        pacquet
+            .with_env("PNPM_CONFIG_MANAGE_PACKAGE_MANAGER_VERSIONS", "false")
+            .with_env("PNPM_CONFIG_REGISTRY", mock_instance.url()),
+        root.path(),
+        &["list"],
+    );
+
+    assert_success(&output);
+    let env_lockfile = EnvLockfile::read(&workspace)
+        .expect("read the written env lockfile")
+        .expect("the env lockfile should have been written");
+    let recorded = env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("packageManagerDependencies should be recorded");
+    assert_eq!(recorded["pnpm"].version, pnpm_config::PNPM_VERSION);
+
+    drop(mock_instance);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -414,8 +414,6 @@ fn turning_off_version_management_still_records_the_pinned_package_manager() {
     drop(mock_instance);
 }
 
-/// The first YAML document of `pnpm-lock.yaml`, which is where the package
-/// manager's own resolutions live.
 fn env_document(workspace: &Path) -> String {
     fs::read_to_string(workspace.join("pnpm-lock.yaml"))
         .expect("read pnpm-lock.yaml")


### PR DESCRIPTION
## Summary

`packageManagerDependencies` reaches `pnpm-lock.yaml` from two places, and they disagreed once package manager version switching was turned off.

- The install family records the pin from its own pipeline (`derive_config_root_and_package_manager_to_sync` → `InstallPipeline::run`), which never consults `manage-package-manager-versions`.
- Every other command records it from the pre-command sync, which was skipped entirely when the pin was "unmanaged" (`switch_wanted && package_manager_switch_disabled`).

That setting is not something users have to opt into for this to bite. A pnpm older than 11.20.0 spawns the pnpm it delegates to with `npm_config_manage_package_manager_versions=false` (to stop the child switching again), and `pnpm with` sets the same four variables. In such a project the old parent writes its own idea of the block, `pnpm list` in the v12 child leaves it alone, and the next `pnpm install` rewrites it — the same ~19 lines flip back and forth forever, so every other command dirties the tree.

Reproduced with the released 12.3.4 driven by pnpm 11.19.0 (whose `--version` reports `12.3.4`, because it delegates — which is why the report reads as one binary disagreeing with itself):

```console
$ pnpm i --lockfile-only && grep -c '@pnpm/exe@' pnpm-lock.yaml
0
$ pnpm list && grep -c '@pnpm/exe@' pnpm-lock.yaml
2
```

The pre-command path now records the pin in the unmanaged case too. The switch itself and the version-mismatch report stay off: which pnpm runs is the user's choice there, which one the lockfile records is not. A pin the running pnpm cannot satisfy still records nothing, and `--global` still records nothing.

This is a pnpm v12 bug only. pnpm v11 has no `manage-package-manager-versions` setting, and its `syncEnvLockfile` runs for every command from one place.

Closes pnpm/pnpm#14575

## Squash Commit Body

```text
`packageManagerDependencies` reached the lockfile from two places that
disagreed. The install family records the pin from its own pipeline
whatever `manage-package-manager-versions` says, while the pre-command
sync every other command runs skipped the record entirely once the
setting was off.

A pnpm older than 11.20.0 turns that setting off for the pnpm it
delegates to, and so does `pnpm with`. In such a project `pnpm list`
left the delegating pnpm's block in place while the next `pnpm install`
rewrote it, flipping the same lines back and forth forever.

The pre-command path now records the pin too. The switch itself and the
version-mismatch report stay off: which pnpm runs is the user's choice
there, which one the lockfile records is not.

Closes pnpm/pnpm#14575
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPfp4dvqS7Nac4Luy3URJm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14626"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791321156&installation_model_id=426870&pr_number=14626&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14626&signature=3d2fb0f0807952d1d10fda0bcc062708ab32f8dda23a7b37cf69917414280a1c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-global commands, including `pnpm list`, now record compatible pinned pnpm versions in the project lockfile when version switching is disabled.
  * Subsequent lockfile-only installs preserve the recorded package manager information and avoid repeated lockfile rewrites.
  * Unsupported version pins remain unrecorded, while global commands continue without lockfile synchronization.
  * This keeps project environment details consistent across supported pnpm commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->