### PR TITLE
refactor(cli): record the package manager pin from one place

### DIFF
--- a/.changeset/record-the-pin-in-one-place.md
+++ b/.changeset/record-the-pin-in-one-place.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+pnpm now records the pinned pnpm version in the lockfile the project actually uses when `lockfileDir` is set. It wrote the pin into a second `pnpm-lock.yaml` at the workspace root, and the real lockfile never carried it [#14575](https://github.com/pnpm/pnpm/issues/14575).

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -237,15 +237,11 @@ fn install_with_update_check<'a>(
         // monomorphized install futures would otherwise each reserve
         // their full size in this frame.
         {
-            // CLI overrides for `offline` / `prefer_offline` live
-            // alongside `--frozen-lockfile`: they upgrade an
-            // unset / `false` yaml value to `true`, but cannot
-            // turn an explicit yaml `true` back off. Matches
-            // pnpm's CLI semantics — the flags are "enable", not
-            // a toggle. Applied here (between `config()` and
-            // `State::init`) while the loaded `Config` is still
-            // mutable through `Config::leak`'s
-            // `&'static mut Config` return.
+            // Applied between `config()` and `State::init`, while
+            // the loaded `Config` is still mutable through
+            // `Config::leak`'s `&'static mut Config` return. How
+            // each `--flag` / `--no-flag` pair beats the configured
+            // value is `resolve_bool_override`'s contract.
             let cfg = config()?;
             let recursive_sort = cfg.sort;
             args.lockfile_dir.apply_to(cfg, dir);

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -19,8 +19,7 @@ use super::{
     patch_remove::PatchRemoveArgs,
     pipelines::{
         AddPipeline, DedupePipeline, DeployPipeline, InstallPipeline, PrunePipeline,
-        RemovePipeline, UpdatePipeline, apply_install_cli_config,
-        derive_config_root_and_package_manager_to_sync,
+        RemovePipeline, UpdatePipeline, apply_install_cli_config, derive_config_root,
     },
     prune::PruneArgs,
     rebuild::RebuildArgs,
@@ -89,9 +88,8 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
         }
         args.lockfile_dir.apply_to(cfg, dir);
         args.apply_cli_config(cfg);
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
         // `allowBuilds` is persisted to `pnpm-workspace.yaml`, which stays
         // at the workspace root even when `lockfileDir` moved the config
         // root elsewhere.
@@ -102,7 +100,6 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
             args,
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix: dir.to_path_buf(),
             manifest_path: manifest_path.to_path_buf(),
             recursive_sort,
@@ -143,14 +140,12 @@ pub(super) fn update<'a>(ctx: &RunCtx<'a>, args: UpdateArgs) -> miette::Result<C
         let recursive_sort = cfg.sort;
         args.lockfile_dir.apply_to(cfg, dir);
         args.apply_cli_config(cfg);
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = UpdatePipeline {
             args,
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix: dir.to_path_buf(),
             manifest_path: manifest_path.to_path_buf(),
             recursive_sort,
@@ -191,14 +186,12 @@ pub(super) fn remove<'a>(ctx: &RunCtx<'a>, args: RemoveArgs) -> miette::Result<C
         let cfg = config()?;
         let recursive_sort = cfg.sort;
         args.lockfile_dir.apply_to(cfg, dir);
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = RemovePipeline {
             args,
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix: dir.to_path_buf(),
             manifest_path: manifest_path.to_path_buf(),
             recursive_sort,
@@ -266,9 +259,8 @@ fn install_with_update_check<'a>(
             // `pnpm-workspace.yaml` is found), falling back to `--dir`
             // for a single-package repo. Owned so it doesn't hold a
             // borrow of `cfg` across the `&mut` `updateConfig` pass.
-            let (config_root, package_manager_to_sync) =
-                derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                    .wrap_err("derive workspace root and package manager policy")?;
+            let config_root = derive_config_root(cfg, dir, reporter)
+                .wrap_err("derive workspace root and package manager policy")?;
             let update_check = match update_check_policy {
                 UpdateCheckPolicy::Run => update_notifier::spawn(cfg, reporter_emit(reporter)),
                 UpdateCheckPolicy::Skip => None,
@@ -285,7 +277,6 @@ fn install_with_update_check<'a>(
                 args,
                 cfg,
                 config_root,
-                package_manager_to_sync,
                 prefix: dir.to_path_buf(),
                 manifest_path: manifest_path.to_path_buf(),
                 recursive_sort,
@@ -370,10 +361,9 @@ pub(super) fn deploy<'a>(ctx: &RunCtx<'a>, args: DeployArgs) -> miette::Result<C
         {
             let cfg = config()?;
             apply_install_cli_config(cfg, &args.install_args);
-            let (config_root, package_manager_to_sync) =
-                derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                    .wrap_err("derive workspace root and package manager policy")?;
-            let pipeline = DeployPipeline { args, cfg, config_root, package_manager_to_sync };
+            let config_root = derive_config_root(cfg, dir, reporter)
+                .wrap_err("derive workspace root and package manager policy")?;
+            let pipeline = DeployPipeline { args, cfg, config_root };
             match reporter {
                 ReporterType::Default | ReporterType::AppendOnly => {
                     Box::pin(pipeline.run::<DefaultReporter>(dir)).await?;
@@ -398,16 +388,10 @@ pub(super) fn dedupe<'a>(ctx: &RunCtx<'a>, args: DedupeArgs) -> miette::Result<C
     Ok(Box::pin(async move {
         let cfg = config()?;
         args.apply_cli_config(cfg);
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
-        let dedupe = DedupePipeline {
-            args,
-            cfg,
-            config_root,
-            package_manager_to_sync,
-            manifest_path: manifest_path.to_path_buf(),
-        };
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
+        let dedupe =
+            DedupePipeline { args, cfg, config_root, manifest_path: manifest_path.to_path_buf() };
         match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
                 Box::pin(dedupe.run::<DefaultReporter>()).await?;
@@ -426,16 +410,10 @@ pub(super) fn prune<'a>(ctx: &RunCtx<'a>, args: PruneArgs) -> miette::Result<Com
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
-        let pipeline = PrunePipeline {
-            args,
-            cfg,
-            config_root,
-            package_manager_to_sync,
-            manifest_path: manifest_path.to_path_buf(),
-        };
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
+        let pipeline =
+            PrunePipeline { args, cfg, config_root, manifest_path: manifest_path.to_path_buf() };
         match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
                 Box::pin(pipeline.run::<DefaultReporter>()).await?;
@@ -516,14 +494,12 @@ pub(super) fn unlink<'a>(ctx: &RunCtx<'a>, args: UnlinkArgs) -> miette::Result<C
         // selection and per-project lockfiles apply. The reinstall forces a
         // fresh resolution so the removed `link:` overrides re-resolve from
         // the registry.
-        let (config_root, package_manager_to_sync) =
-            derive_config_root_and_package_manager_to_sync(cfg, dir, reporter)
-                .wrap_err("derive workspace root and package manager policy")?;
+        let config_root = derive_config_root(cfg, dir, reporter)
+            .wrap_err("derive workspace root and package manager policy")?;
         let pipeline = InstallPipeline {
             args: InstallArgs::for_reresolving_install(),
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix: dir.to_path_buf(),
             manifest_path: manifest_path.to_path_buf(),
             recursive_sort,

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -3,8 +3,7 @@ use crate::{
     cli_args::{
         legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, lockfile_dir::LockfileDirArg,
         override_version_references::warn_deprecated_override_version_references,
-        package_manager::package_manager_needs_recording, pipelines::InstallFamilySelection,
-        recursive::discover_workspace_projects,
+        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
     },
 };
@@ -417,14 +416,6 @@ impl InstallArgs {
         let Ok(manifest) = pnpm_package_manifest::PackageManifest::from_path(manifest_path) else {
             return false;
         };
-        // The pin reaches the lockfile from the install pipeline, which this
-        // short-circuit returns before. This manifest is the root one unless
-        // a workspace or `lockfileDir` put the root elsewhere, in which case
-        // the check reads that one.
-        let root_manifest = (config_root == dir).then(|| manifest.value());
-        if package_manager_needs_recording(&config_root, config.pm_on_fail, root_manifest) {
-            return false;
-        }
         let node_linker = self.node_linker.map_or(config.node_linker, NodeLinkerArg::into_config);
         let Some(up_to_date) = install_already_up_to_date(&UpToDateFastPathCheck {
             config,

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -1,7 +1,5 @@
 use miette::IntoDiagnostic;
 use pnpm_config::{PNPM_VERSION, PmOnFail};
-use pnpm_env_installer::is_package_manager_resolved;
-use pnpm_lockfile::EnvLockfile;
 use pnpm_package_manifest::{
     package_manager_spec::{
         dev_engines_package_managers, is_version_request, split_spec, version_without_build,
@@ -67,45 +65,6 @@ pub(crate) fn package_manager_to_sync(
     version_satisfies(PNPM_VERSION, wanted_version).then(|| PackageManagerToSync {
         specifier: wanted_version.to_string(),
         version: PNPM_VERSION.to_string(),
-    })
-}
-
-/// Whether the pnpm version the manifest at `root_dir` pins still has to be
-/// recorded in the env lockfile there. The install family records it from
-/// its own pipeline, so an install that short-circuits before the pipeline
-/// has to give up its fast path — a plain install would otherwise keep
-/// reporting success while leaving every `--frozen-lockfile` run failing on
-/// the unwritten entry.
-///
-/// `root_manifest` is that manifest when the caller already holds it, so a
-/// fast path does not read the same file twice.
-///
-/// A manifest that cannot be read answers `false`: the full install path
-/// reports that, and a fast path is not where it should surface.
-pub(crate) fn package_manager_needs_recording(
-    root_dir: &Path,
-    on_fail: Option<PmOnFail>,
-    root_manifest: Option<&Value>,
-) -> bool {
-    let read;
-    let manifest = if let Some(manifest) = root_manifest {
-        manifest
-    } else {
-        let Ok(Some(manifest)) = read_manifest_json(&root_dir.join("package.json")) else {
-            return false;
-        };
-        read = manifest;
-        &read
-    };
-    let Some(package_manager) = package_manager_to_sync(manifest, root_dir, on_fail) else {
-        return false;
-    };
-    !EnvLockfile::read(root_dir).ok().flatten().is_some_and(|env_lockfile| {
-        is_package_manager_resolved(
-            &env_lockfile,
-            &package_manager.specifier,
-            &package_manager.version,
-        )
     })
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -3,7 +3,7 @@ use super::{
     dedupe::{self, DedupeArgs},
     deploy::DeployArgs,
     install::{InstallArgs, resolve_bool_override},
-    package_manager::{PackageManagerToSync, package_manager_to_sync, read_manifest_json},
+    package_manager::read_manifest_json,
     prune::PruneArgs,
     recursive::{
         AutoExcludeRoot, discover_workspace_projects, filtered_projects_dependencies,
@@ -345,7 +345,6 @@ pub(crate) struct InstallPipeline {
     pub(crate) args: InstallArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
     pub(crate) recursive_sort: bool,
@@ -359,26 +358,13 @@ impl InstallPipeline {
             args,
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix,
             manifest_path,
             recursive_sort,
             require_lockfile,
             frozen_lockfile,
         } = self;
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                frozen_lockfile,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        config_deps::prepare::<Reporter>(cfg, &config_root, frozen_lockfile).await?;
         // Built ahead of project discovery so a run that is certain to
         // read the wanted lockfile parses it on a background thread
         // while discovery walks the workspace. Certain means the fast
@@ -543,7 +529,6 @@ pub(crate) struct AddPipeline {
     pub(crate) args: AddArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
     pub(crate) recursive_sort: bool,
@@ -560,26 +545,13 @@ impl AddPipeline {
             args,
             cfg,
             config_root,
-            package_manager_to_sync,
             prefix,
             manifest_path,
             recursive_sort,
             config_dependencies,
             package_specifier_plan,
         } = self;
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         if !package_specifier_plan.ecosystem_packages.is_empty() {
             return run_add_with_ecosystems::<Reporter>(
                 args,
@@ -715,7 +687,6 @@ pub(crate) struct UpdatePipeline {
     pub(crate) args: UpdateArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
     pub(crate) recursive_sort: bool,
@@ -723,28 +694,8 @@ pub(crate) struct UpdatePipeline {
 
 impl UpdatePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let UpdatePipeline {
-            args,
-            cfg,
-            config_root,
-            package_manager_to_sync,
-            prefix,
-            manifest_path,
-            recursive_sort,
-        } = self;
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let UpdatePipeline { args, cfg, config_root, prefix, manifest_path, recursive_sort } = self;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         let plan = select_install_family_plan::<Reporter>(
             cfg,
             &prefix,
@@ -824,7 +775,6 @@ pub(crate) struct RemovePipeline {
     pub(crate) args: RemoveArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
     pub(crate) recursive_sort: bool,
@@ -832,28 +782,8 @@ pub(crate) struct RemovePipeline {
 
 impl RemovePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let RemovePipeline {
-            args,
-            cfg,
-            config_root,
-            package_manager_to_sync,
-            prefix,
-            manifest_path,
-            recursive_sort,
-        } = self;
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let RemovePipeline { args, cfg, config_root, prefix, manifest_path, recursive_sort } = self;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         let plan = select_install_family_plan::<Reporter>(
             cfg,
             &prefix,
@@ -908,7 +838,6 @@ pub(crate) struct DeployPipeline {
     pub(crate) args: DeployArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
 }
 
 impl DeployPipeline {
@@ -916,20 +845,8 @@ impl DeployPipeline {
         self,
         dir_ref: &Path,
     ) -> miette::Result<()> {
-        let DeployPipeline { args, cfg, config_root, package_manager_to_sync } = self;
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        let DeployPipeline { args, cfg, config_root } = self;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         let cfg: &'static Config = cfg;
         Box::pin(args.run::<Reporter>(cfg, dir_ref)).await
     }
@@ -979,11 +896,11 @@ async fn run_dedicated_lockfile_workspace_install<Reporter: self::Reporter + 'st
 
 /// Shared workspace-root and package-manager policy derivation used by the
 /// install, dedupe, and prune dispatch paths.
-pub(crate) fn derive_config_root_and_package_manager_to_sync(
+pub(crate) fn derive_config_root(
     cfg: &Config,
     dir_ref: &Path,
     reporter: ReporterType,
-) -> miette::Result<(PathBuf, Option<PackageManagerToSync>)> {
+) -> miette::Result<PathBuf> {
     let config_root = cfg.root_project_manifest_dir(dir_ref).to_path_buf();
     let root_manifest = read_manifest_json(&config_root.join("package.json"))
         .wrap_err("read package manager policy")?;
@@ -993,10 +910,7 @@ pub(crate) fn derive_config_root_and_package_manager_to_sync(
     warn_ignored_pnpm_manifest_fields(root_manifest.as_ref());
     warn_deprecated_override_version_references(cfg, reporter_emit(reporter));
     warn_unmatched_registry_options(cfg);
-    let package_manager_to_sync = root_manifest
-        .as_ref()
-        .and_then(|manifest| package_manager_to_sync(manifest, &config_root, cfg.pm_on_fail));
-    Ok((config_root, package_manager_to_sync))
+    Ok(config_root)
 }
 
 pub(crate) fn apply_install_cli_config(cfg: &mut Config, args: &InstallArgs) {
@@ -1049,14 +963,12 @@ pub(crate) struct DedupePipeline {
     pub(crate) args: DedupeArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) manifest_path: PathBuf,
 }
 
 impl DedupePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let DedupePipeline { args, cfg, config_root, package_manager_to_sync, manifest_path } =
-            self;
+        let DedupePipeline { args, cfg, config_root, manifest_path } = self;
 
         let lockfile_path = config_root.join(cfg.wanted_lockfile_name());
 
@@ -1067,19 +979,7 @@ impl DedupePipeline {
         let guard =
             args.check.then(|| dedupe::LockfileGuard::new(existing.clone(), &lockfile_path));
 
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         let cfg: &'static Config = cfg;
         let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
         Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path)).await
@@ -1098,27 +998,14 @@ pub(crate) struct PrunePipeline {
     pub(crate) args: PruneArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
-    pub(crate) package_manager_to_sync: Option<PackageManagerToSync>,
     pub(crate) manifest_path: PathBuf,
 }
 
 impl PrunePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let PrunePipeline { args, cfg, config_root, package_manager_to_sync, manifest_path } = self;
+        let PrunePipeline { args, cfg, config_root, manifest_path } = self;
 
-        if let Some(pm) = package_manager_to_sync.as_ref() {
-            config_deps::sync_package_manager_dependencies(
-                cfg,
-                &config_root,
-                &pm.specifier,
-                &pm.version,
-                false,
-                false,
-            )
-            .await?;
-        }
-        config_deps::install_config_deps::<Reporter>(cfg, &config_root, false).await?;
-        config_deps::run_update_config_hooks::<Reporter>(cfg, &config_root).await?;
+        config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
         // Validate path containment AFTER hooks: updateConfig can mutate
         // modules_dir / virtual_store_dir via WorkspaceSettings::apply_to,
         // so the check must use the final (post-hook) config values.

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -65,7 +65,6 @@ pub(crate) fn pre_command_plan(
             global: is_global(&args.command),
             skip_pm_handling: should_skip_pm_handling(&args.command),
             check_runtimes: true,
-            syncs_env_lockfile_in_pipeline: syncs_env_lockfile_in_pipeline(&args.command),
             emit: reporter_emit(args.reporter),
             key_issues: key_issue_reporting(&args.command),
         },
@@ -88,9 +87,6 @@ pub(crate) fn pre_command_plan_for_version_flag(
             global: false,
             skip_pm_handling: false,
             check_runtimes: false,
-            // No install pipeline runs behind `--version`, so nothing else
-            // would record the pin.
-            syncs_env_lockfile_in_pipeline: false,
             emit: DefaultReporter::emit,
             // Printing the version must work in a project whose
             // `pnpm-workspace.yaml` is broken, like the runtime checks above.
@@ -110,14 +106,10 @@ pub(crate) async fn execute_plan(
     match plan {
         PreCommandPlan::Switch(plan) => execute_switch(plan, child_argv).await,
         PreCommandPlan::SyncEnvLockfile(sync) => {
-            let EnvLockfileSync { config, root_dir, package_manager } = sync;
-            // The install family syncs the pin in its own pipeline, with the
-            // `--frozen-lockfile` flag layered in; every other command reaches
-            // here, where only the `frozenLockfile` setting can forbid the write.
-            let frozen_lockfile = config.frozen_lockfile.unwrap_or(false);
+            let EnvLockfileSync { config, env_root, package_manager, frozen_lockfile } = sync;
             config_deps::sync_package_manager_dependencies(
                 &config,
-                &root_dir,
+                &env_root,
                 &package_manager.specifier,
                 &package_manager.version,
                 frozen_lockfile,
@@ -232,9 +224,21 @@ fn pre_command_plan_from_input(
     if let Some(state_dir) = switch.state_dir.as_deref() {
         apply_state_dir_override::<Host>(&mut config, state_dir, &dir);
     }
+    // `--lockfile-dir` moves the lockfile the pin is recorded in, and
+    // `--offline` governs how that record is resolved. Both are install-family
+    // flags, and the record below is made for every command.
+    if let Some(lockfile_dir) = switch.lockfile_dir.as_deref() {
+        config.pin_lockfile_dir(&dir.join(lockfile_dir));
+    }
+    if let Some(offline) = switch.offline {
+        config.offline = offline || config.offline;
+    }
 
-    let root_dir = config.workspace_dir.clone().unwrap_or_else(|| dir.clone());
-    let manifest = read_manifest_json(&root_dir.join("package.json"))?;
+    let roots = PinRoots {
+        manifest: config.workspace_dir.clone().unwrap_or_else(|| dir.clone()),
+        env: config.root_project_manifest_dir(&dir).to_path_buf(),
+    };
+    let manifest = read_manifest_json(&roots.manifest.join("package.json"))?;
 
     let wanted_pm = manifest.as_ref().and_then(wanted_package_manager);
     let running_matches_pin = wanted_pm.as_ref().is_some_and(|pm| {
@@ -256,21 +260,17 @@ fn pre_command_plan_from_input(
         let unmanaged_pin = switch_wanted && process_state.package_manager_switch_disabled;
         if on_fail != PmOnFail::Ignore {
             if unmanaged_pin {
-                // The install family records the pin from its own pipeline
-                // whatever this setting says (pnpm/pnpm#14575).
+                // Which pnpm runs is the user's choice here; which one the
+                // lockfile records is still the project's, and a frozen
+                // install has to find it there (pnpm/pnpm#14575).
                 if !input.global {
-                    package_manager_to_sync = env_lockfile_sync(
-                        root_manifest,
-                        &root_dir,
-                        on_fail,
-                        input,
-                        ReadEnvLockfile::NotYet,
-                    )?;
+                    package_manager_to_sync =
+                        env_lockfile_sync(root_manifest, &roots, on_fail, ReadEnvLockfile::NotYet)?;
                 }
             } else if switch_wanted && !process_state.executed_by_corepack {
                 let frozen_lockfile =
                     switch.frozen_lockfile.or(config.frozen_lockfile).unwrap_or(false);
-                if let Some(target) = switch_target(&config, &root_dir, frozen_lockfile)? {
+                if let Some(target) = switch_target(&config, &roots, frozen_lockfile)? {
                     if target.switches_away_from_the_running_pnpm() {
                         return Ok(Some(PreCommandPlan::Switch(SwitchPlan { config, target })));
                     }
@@ -280,9 +280,8 @@ fn pre_command_plan_from_input(
                     // have written on its way to the wanted version.
                     package_manager_to_sync = env_lockfile_sync(
                         root_manifest,
-                        &root_dir,
+                        &roots,
                         on_fail,
-                        input,
                         match &target.source {
                             SwitchSource::LockedEnv { env, .. } => ReadEnvLockfile::Already(env),
                             SwitchSource::Resolve { .. } => ReadEnvLockfile::NotYet,
@@ -296,13 +295,8 @@ fn pre_command_plan_from_input(
                 );
             } else {
                 check_package_manager(&pm, on_fail, process_state, input.emit)?;
-                package_manager_to_sync = env_lockfile_sync(
-                    root_manifest,
-                    &root_dir,
-                    on_fail,
-                    input,
-                    ReadEnvLockfile::NotYet,
-                )?;
+                package_manager_to_sync =
+                    env_lockfile_sync(root_manifest, &roots, on_fail, ReadEnvLockfile::NotYet)?;
             }
         }
     }
@@ -323,31 +317,31 @@ fn pre_command_plan_from_input(
         check_runtimes(manifest, &config, input.emit)?;
     }
     Ok(package_manager_to_sync.map(|package_manager| {
-        PreCommandPlan::SyncEnvLockfile(EnvLockfileSync { config, root_dir, package_manager })
+        let frozen_lockfile = switch.frozen_lockfile.or(config.frozen_lockfile).unwrap_or(false);
+        PreCommandPlan::SyncEnvLockfile(EnvLockfileSync {
+            config,
+            env_root: roots.env,
+            package_manager,
+            frozen_lockfile,
+        })
     }))
 }
 
 /// pnpm's `syncEnvLockfile`: the pnpm version a project pins is recorded in
-/// the env lockfile's `packageManagerDependencies` by every command, not only
-/// by the install family, so the entry is the same whichever command a
-/// contributor happens to run first.
+/// the env lockfile's `packageManagerDependencies` here, for every command,
+/// so the entry is the same whichever command a contributor happens to run
+/// first.
 ///
-/// `None` when the project doesn't pin a persisting pnpm version, when the
-/// lockfile already records one that satisfies the pin, or when the command's
-/// own pipeline syncs it — the install family passes its `frozen-lockfile`
-/// value to the sync, and a frozen install must fail on an out-of-date
-/// `packageManagerDependencies` rather than have it repaired here first.
+/// `None` when the project doesn't pin a persisting pnpm version, or when the
+/// lockfile already records one that satisfies the pin.
 fn env_lockfile_sync(
     root_manifest: &Value,
-    root_dir: &Path,
+    roots: &PinRoots,
     on_fail: PmOnFail,
-    input: &PreCommandInput,
     read_lockfile: ReadEnvLockfile<'_>,
 ) -> miette::Result<Option<PackageManagerToSync>> {
-    if input.syncs_env_lockfile_in_pipeline {
-        return Ok(None);
-    }
-    let Some(package_manager) = package_manager_to_sync(root_manifest, root_dir, Some(on_fail))
+    let Some(package_manager) =
+        package_manager_to_sync(root_manifest, &roots.manifest, Some(on_fail))
     else {
         return Ok(None);
     };
@@ -355,7 +349,7 @@ fn env_lockfile_sync(
     let env_lockfile = match read_lockfile {
         ReadEnvLockfile::Already(env_lockfile) => Some(env_lockfile),
         ReadEnvLockfile::NotYet => {
-            read = read_env_lockfile(root_dir)?;
+            read = read_env_lockfile(&roots.env)?;
             read.as_ref()
         }
     };
@@ -589,7 +583,6 @@ struct PreCommandInput {
     global: bool,
     skip_pm_handling: bool,
     check_runtimes: bool,
-    syncs_env_lockfile_in_pipeline: bool,
     emit: fn(&LogEvent),
     key_issues: KeyIssueReporting,
 }
@@ -627,22 +620,6 @@ fn key_issue_reporting(command: &CliCommand) -> KeyIssueReporting {
 /// the commands whose dispatch calls
 /// `pipelines::derive_config_root_and_package_manager_to_sync`.
 /// See [`env_lockfile_sync`].
-fn syncs_env_lockfile_in_pipeline(command: &CliCommand) -> bool {
-    matches!(
-        command,
-        CliCommand::Add(_)
-            | CliCommand::Ci(_)
-            | CliCommand::Dedupe(_)
-            | CliCommand::Deploy(_)
-            | CliCommand::Install(_)
-            | CliCommand::InstallTest(_)
-            | CliCommand::Prune(_)
-            | CliCommand::Remove(_)
-            | CliCommand::Unlink(_)
-            | CliCommand::Update(_),
-    )
-}
-
 /// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command line.
 /// Only the install family carries the flags, and `pnpm ci` is a frozen
 /// install whether or not they were typed.
@@ -652,6 +629,43 @@ fn frozen_lockfile_flag(command: &CliCommand) -> Option<bool> {
         CliCommand::InstallTest(args) => args.install_args.frozen_lockfile_flag(),
         CliCommand::Ci(_) => Some(true),
         _ => None,
+    }
+}
+
+/// `--lockfile-dir` as typed on the command line. The env lockfile is the
+/// first document of `pnpm-lock.yaml`, so it follows the flag that moves
+/// that file.
+fn lockfile_dir_flag(command: &CliCommand) -> Option<PathBuf> {
+    let lockfile_dir = match command {
+        CliCommand::Add(args) => &args.lockfile_dir,
+        CliCommand::Ci(args) => &args.install_args.lockfile_dir,
+        CliCommand::Install(args) => &args.lockfile_dir,
+        CliCommand::InstallTest(args) => &args.install_args.lockfile_dir,
+        CliCommand::Remove(args) => &args.lockfile_dir,
+        CliCommand::Update(args) => &args.lockfile_dir,
+        _ => return None,
+    };
+    lockfile_dir.lockfile_dir.clone()
+}
+
+/// `--offline` / `--no-offline` as typed on the command line. The flags
+/// only turn the setting on, matching [`apply_install_cli_config`].
+///
+/// [`apply_install_cli_config`]: super::pipelines::apply_install_cli_config
+fn offline_flag(command: &CliCommand) -> Option<bool> {
+    let (offline, no_offline) = match command {
+        CliCommand::Ci(args) => (args.install_args.offline, args.install_args.no_offline),
+        CliCommand::Dedupe(args) => (args.offline, args.no_offline),
+        CliCommand::Install(args) => (args.offline, args.no_offline),
+        CliCommand::InstallTest(args) => (args.install_args.offline, args.install_args.no_offline),
+        _ => return None,
+    };
+    if offline {
+        Some(true)
+    } else if no_offline {
+        Some(false)
+    } else {
+        None
     }
 }
 
@@ -682,10 +696,10 @@ fn is_global(command: &CliCommand) -> bool {
 
 fn switch_target(
     config: &Config,
-    root_dir: &Path,
+    roots: &PinRoots,
     frozen_lockfile: bool,
 ) -> miette::Result<Option<SwitchTarget>> {
-    let Some(manifest) = read_manifest_json(&root_dir.join("package.json"))? else {
+    let Some(manifest) = read_manifest_json(&roots.manifest.join("package.json"))? else {
         return Ok(None);
     };
     let Some(mut pm) = wanted_package_manager(&manifest) else {
@@ -705,7 +719,7 @@ fn switch_target(
 
     let persist_lockfile = should_persist_package_manager_lockfile(&pm);
     if persist_lockfile
-        && let Some(env) = read_env_lockfile(root_dir)?
+        && let Some(env) = read_env_lockfile(&roots.env)?
         && let Some(version) = locked_package_manager_version(&env, &spec)?
     {
         if assert_package_manager_lockfile_uses_registry_resolutions(&env).is_ok() {
@@ -722,7 +736,7 @@ fn switch_target(
         return Ok(Some(SwitchTarget {
             spec,
             source: SwitchSource::Resolve {
-                env_root: root_dir.to_path_buf(),
+                env_root: roots.env.clone(),
                 frozen_lockfile,
                 force_resync: true,
                 locked_version: Some(version),
@@ -734,7 +748,7 @@ fn switch_target(
     // is pnpm's own state rather than the project's — a frozen lockfile has
     // nothing to say about it.
     let (env_root, frozen_lockfile) = if persist_lockfile {
-        (root_dir.to_path_buf(), frozen_lockfile)
+        (roots.env.clone(), frozen_lockfile)
     } else {
         let global_pkg_dir = config.global_pkg_dir.clone().ok_or_else(|| {
             miette::miette!(
@@ -1022,6 +1036,17 @@ impl SwitchTarget {
     }
 }
 
+/// The two directories the package-manager pin is read from and written to.
+///
+/// They differ when `lockfileDir` moves `pnpm-lock.yaml` off the workspace
+/// root: the manifest declaring the pin stays at the workspace root, while
+/// the env lockfile is the first document of the lockfile and follows it.
+#[derive(Debug, Clone)]
+struct PinRoots {
+    manifest: PathBuf,
+    env: PathBuf,
+}
+
 #[derive(Debug)]
 pub(crate) struct SwitchPlan {
     config: Config,
@@ -1038,8 +1063,12 @@ pub(crate) enum PreCommandPlan {
 #[derive(Debug)]
 pub(crate) struct EnvLockfileSync {
     config: Config,
-    root_dir: PathBuf,
+    /// Where the env lockfile is written: the lockfile's directory, which
+    /// `--lockfile-dir` and the `lockfileDir` setting move away from the
+    /// workspace root.
+    env_root: PathBuf,
     package_manager: PackageManagerToSync,
+    frozen_lockfile: bool,
 }
 
 #[derive(Debug)]
@@ -1075,6 +1104,11 @@ struct SwitchInput {
     /// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command
     /// line. `None` leaves the `frozenLockfile` setting to answer.
     frozen_lockfile: Option<bool>,
+    /// `--lockfile-dir` as typed on the command line, which moves the env
+    /// lockfile with the lockfile it is the first document of.
+    lockfile_dir: Option<PathBuf>,
+    /// `--offline` / `--no-offline` as typed on the command line.
+    offline: Option<bool>,
     color: Option<ColorMode>,
 }
 
@@ -1086,6 +1120,8 @@ impl SwitchInput {
             npmrc_auth_file: args.npmrc_auth_file.clone(),
             command: Some(command_name(&args.command).to_string()),
             frozen_lockfile: frozen_lockfile_flag(&args.command),
+            lockfile_dir: lockfile_dir_flag(&args.command),
+            offline: offline_flag(&args.command),
             color: args.color.or_else(|| args.no_color.then_some(ColorMode::Never)),
         }
     }
@@ -1098,6 +1134,8 @@ impl SwitchInput {
             npmrc_auth_file: None,
             command: None,
             frozen_lockfile: None,
+            lockfile_dir: None,
+            offline: None,
             color: None,
         };
         let mut index = 1;

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -12,6 +12,8 @@ mod system_runtime_version;
 use super::{
     cli_command::{CliArgs, CliCommand},
     config::{ConfigLocation, ConfigSubcommand},
+    install::{InstallArgs, resolve_bool_override},
+    lockfile_dir::LockfileDirArg,
     package_manager::{
         PACKAGE_MANAGER_SWITCH_ENV_VARS, PackageManagerToSync, WantedPackageManager,
         package_manager_to_sync, read_manifest_json, should_persist_package_manager_lockfile,
@@ -227,12 +229,7 @@ fn pre_command_plan_from_input(
     // `--lockfile-dir` moves the lockfile the pin is recorded in, and
     // `--offline` governs how that record is resolved. Both are install-family
     // flags, and the record below is made for every command.
-    if let Some(lockfile_dir) = switch.lockfile_dir.as_deref() {
-        config.pin_lockfile_dir(&dir.join(lockfile_dir));
-    }
-    if let Some(offline) = switch.offline {
-        config.offline = offline || config.offline;
-    }
+    switch.pin_flags.apply_to(&mut config, &dir);
 
     let roots = PinRoots {
         manifest: config.workspace_dir.clone().unwrap_or_else(|| dir.clone()),
@@ -632,37 +629,82 @@ fn frozen_lockfile_flag(command: &CliCommand) -> Option<bool> {
     }
 }
 
-/// `--lockfile-dir` as typed on the command line. The env lockfile is the
-/// first document of `pnpm-lock.yaml`, so it follows the flag that moves
-/// that file.
-fn lockfile_dir_flag(command: &CliCommand) -> Option<PathBuf> {
-    let lockfile_dir = match command {
-        CliCommand::Add(args) => &args.lockfile_dir,
-        CliCommand::Ci(args) => &args.install_args.lockfile_dir,
-        CliCommand::Install(args) => &args.lockfile_dir,
-        CliCommand::InstallTest(args) => &args.install_args.lockfile_dir,
-        CliCommand::Remove(args) => &args.lockfile_dir,
-        CliCommand::Update(args) => &args.lockfile_dir,
-        _ => return None,
-    };
-    lockfile_dir.lockfile_dir.clone()
+/// The install-family options the pin record reads, as typed on the command
+/// line.
+///
+/// One list, because a command that grows one of these flags has to be added
+/// in one place — `pin_flags_cover_every_command_declaring_them` fails when
+/// it is not.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct PinFlags {
+    /// `--lockfile-dir`, which moves the lockfile the pin is recorded in.
+    lockfile_dir: Option<PathBuf>,
+    /// `--offline` / `--no-offline`, which decide whether the record may be
+    /// resolved over the network.
+    offline: Option<bool>,
+    /// `--prefer-offline` / `--no-prefer-offline`, which decide whether the
+    /// resolution reaches for the cache first.
+    prefer_offline: Option<bool>,
 }
 
-/// `--offline` / `--no-offline` as typed on the command line. The flags
-/// only turn the setting on, matching [`apply_install_cli_config`].
-///
-/// [`apply_install_cli_config`]: super::pipelines::apply_install_cli_config
-fn offline_flag(command: &CliCommand) -> Option<bool> {
-    let (offline, no_offline) = match command {
-        CliCommand::Ci(args) => (args.install_args.offline, args.install_args.no_offline),
-        CliCommand::Dedupe(args) => (args.offline, args.no_offline),
-        CliCommand::Install(args) => (args.offline, args.no_offline),
-        CliCommand::InstallTest(args) => (args.install_args.offline, args.install_args.no_offline),
-        _ => return None,
-    };
-    if offline {
+impl PinFlags {
+    fn of(command: &CliCommand) -> Self {
+        match command {
+            CliCommand::Add(args) => Self::of_lockfile_dir(&args.lockfile_dir),
+            CliCommand::Ci(args) => Self::of_install(&args.install_args),
+            CliCommand::Dedupe(args) => Self {
+                lockfile_dir: None,
+                offline: typed_flag(args.offline, args.no_offline),
+                prefer_offline: typed_flag(args.prefer_offline, args.no_prefer_offline),
+            },
+            CliCommand::Deploy(args) => Self::of_install(&args.install_args),
+            CliCommand::Install(args) => Self::of_install(args),
+            CliCommand::InstallTest(args) => Self::of_install(&args.install_args),
+            CliCommand::Remove(args) => Self::of_lockfile_dir(&args.lockfile_dir),
+            CliCommand::Update(args) => Self::of_lockfile_dir(&args.lockfile_dir),
+            _ => Self::default(),
+        }
+    }
+
+    fn of_install(args: &InstallArgs) -> Self {
+        Self {
+            lockfile_dir: args.lockfile_dir.lockfile_dir.clone(),
+            offline: typed_flag(args.offline, args.no_offline),
+            prefer_offline: typed_flag(args.prefer_offline, args.no_prefer_offline),
+        }
+    }
+
+    fn of_lockfile_dir(lockfile_dir: &LockfileDirArg) -> Self {
+        Self { lockfile_dir: lockfile_dir.lockfile_dir.clone(), ..Self::default() }
+    }
+
+    /// Layer the flags onto `config` with the precedence
+    /// [`resolve_bool_override`] gives a `--flag` / `--no-flag` pair, so
+    /// `--no-offline` clears a configured `offline` here exactly as it does
+    /// for an install.
+    fn apply_to(&self, config: &mut Config, dir: &Path) {
+        if let Some(lockfile_dir) = self.lockfile_dir.as_deref() {
+            config.pin_lockfile_dir(&dir.join(lockfile_dir));
+        }
+        config.offline = resolve_bool_override(
+            self.offline == Some(true),
+            self.offline == Some(false),
+            config.offline,
+        );
+        config.prefer_offline = resolve_bool_override(
+            self.prefer_offline == Some(true),
+            self.prefer_offline == Some(false),
+            config.prefer_offline,
+        );
+    }
+}
+
+/// A `--flag` / `--no-flag` pair as typed on the command line, or `None`
+/// when neither spelling was.
+fn typed_flag(on: bool, off: bool) -> Option<bool> {
+    if on {
         Some(true)
-    } else if no_offline {
+    } else if off {
         Some(false)
     } else {
         None
@@ -1104,11 +1146,8 @@ struct SwitchInput {
     /// `--frozen-lockfile` / `--no-frozen-lockfile` as typed on the command
     /// line. `None` leaves the `frozenLockfile` setting to answer.
     frozen_lockfile: Option<bool>,
-    /// `--lockfile-dir` as typed on the command line, which moves the env
-    /// lockfile with the lockfile it is the first document of.
-    lockfile_dir: Option<PathBuf>,
-    /// `--offline` / `--no-offline` as typed on the command line.
-    offline: Option<bool>,
+    /// The install-family options the pin record reads.
+    pin_flags: PinFlags,
     color: Option<ColorMode>,
 }
 
@@ -1120,8 +1159,7 @@ impl SwitchInput {
             npmrc_auth_file: args.npmrc_auth_file.clone(),
             command: Some(command_name(&args.command).to_string()),
             frozen_lockfile: frozen_lockfile_flag(&args.command),
-            lockfile_dir: lockfile_dir_flag(&args.command),
-            offline: offline_flag(&args.command),
+            pin_flags: PinFlags::of(&args.command),
             color: args.color.or_else(|| args.no_color.then_some(ColorMode::Never)),
         }
     }
@@ -1134,8 +1172,7 @@ impl SwitchInput {
             npmrc_auth_file: None,
             command: None,
             frozen_lockfile: None,
-            lockfile_dir: None,
-            offline: None,
+            pin_flags: PinFlags::default(),
             color: None,
         };
         let mut index = 1;

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    CliArgs, CliCommand, KeyIssueReporting, PackageManagerToSync, PreCommandInput, PreCommandPlan,
-    SwitchInput, SwitchProcessState, SwitchSource, frozen_lockfile_flag,
+    CliArgs, CliCommand, KeyIssueReporting, PackageManagerToSync, PinRoots, PreCommandInput,
+    PreCommandPlan, SwitchInput, SwitchProcessState, SwitchSource, frozen_lockfile_flag,
     pre_command_plan_from_input, switch_target,
 };
 use crate::{boolean_negations::with_boolean_negations, config_overrides::ConfigOverrides};
@@ -256,19 +256,31 @@ fn pre_command_plan_records_a_pin_that_only_warns() {
     );
 }
 
+/// The install family records the pin here like every other command, so
+/// there is one writer and no command list to keep in step with it.
 #[test]
-fn pre_command_plan_leaves_the_env_lockfile_sync_to_the_install_pipeline() {
+fn pre_command_plan_records_the_pin_for_the_install_family_too() {
     let root = TempDir::new().expect("tmp dir");
     write_dev_engine_manifest(root.path(), PNPM_VERSION);
 
-    let plan = pre_command_plan_from_input(
-        &PreCommandInput { syncs_env_lockfile_in_pipeline: true, ..pre_command_input(root.path()) },
-        &ConfigOverrides::default(),
-        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
-    )
-    .expect("pre-command plan");
+    for command in ["install", "add", "ci", "update", "remove", "dedupe", "prune", "unlink"] {
+        let mut input = pre_command_input(root.path());
+        input.switch.command = Some(command.to_string());
+        let plan = pre_command_plan_from_input(
+            &input,
+            &ConfigOverrides::default(),
+            SwitchProcessState {
+                package_manager_switch_disabled: false,
+                executed_by_corepack: false,
+            },
+        )
+        .expect("pre-command plan");
 
-    assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
+        assert!(
+            matches!(plan, Some(PreCommandPlan::SyncEnvLockfile(_))),
+            "expected an env lockfile sync for {command}, got {plan:?}",
+        );
+    }
 }
 
 #[test]
@@ -433,6 +445,10 @@ fn pre_command_plan_does_not_record_a_pin_the_pm_on_fail_setting_turned_off() {
     assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
 }
 
+fn pin_roots(dir: &Path) -> PinRoots {
+    PinRoots { manifest: dir.to_path_buf(), env: dir.to_path_buf() }
+}
+
 fn config_overrides(argv: &[&str]) -> ConfigOverrides {
     ConfigOverrides::extract(argv.iter().copied().map(OsString::from)).0
 }
@@ -445,12 +461,13 @@ fn pre_command_input(dir: &Path) -> PreCommandInput {
             npmrc_auth_file: None,
             command: Some("run".to_string()),
             frozen_lockfile: None,
+            lockfile_dir: None,
+            offline: None,
             color: None,
         },
         global: false,
         skip_pm_handling: false,
         check_runtimes: true,
-        syncs_env_lockfile_in_pipeline: false,
         emit: SilentReporter::emit,
         key_issues: KeyIssueReporting::Enforce,
     }
@@ -497,8 +514,9 @@ snapshots:
 ",
     );
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     assert_eq!(target.spec, "^11.0.0-rc.5");
     let SwitchSource::LockedEnv { version, .. } = target.source else {
@@ -513,8 +531,9 @@ fn switch_target_accepts_peer_suffixed_package_manager_lockfile() {
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_PEER_SUFFIX);
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     let SwitchSource::LockedEnv { version, .. } = target.source else {
         panic!("expected locked env target");
@@ -528,8 +547,9 @@ fn switch_target_accepts_v12_lockfile_without_legacy_wrapper_entry() {
     write_manifest(root.path(), r#"{"packageManager":"pnpm@99.0.0"}"#);
     write_lockfile(root.path(), LOCKED_99_0_0);
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     let SwitchSource::LockedEnv { version, .. } = target.source else {
         panic!("expected locked env target");
@@ -543,8 +563,9 @@ fn switch_target_discards_package_manager_lockfile_resolution_with_non_integrity
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_TARBALL_RESOLUTION);
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     let SwitchSource::Resolve {
         env_root,
@@ -565,8 +586,9 @@ fn switch_target_discards_package_manager_lockfile_dependency_with_non_registry_
     write_dev_engine_manifest(root.path(), "9.3.0");
     write_lockfile(root.path(), LOCKED_9_3_0_WITH_FILE_DEP_PATH);
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     let SwitchSource::Resolve {
         env_root,
@@ -587,8 +609,9 @@ fn switch_target_reresolves_when_locked_version_no_longer_satisfies_range() {
     write_dev_engine_manifest(root.path(), ">=9.1.2 <9.1.4");
     write_lockfile(root.path(), LOCKED_9_1_1);
 
-    let target =
-        switch_target(&Config::default(), root.path(), false).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false)
+        .expect("target")
+        .expect("switch");
 
     assert_eq!(target.spec, ">=9.1.2 <9.1.4");
     let SwitchSource::Resolve {
@@ -611,7 +634,7 @@ fn switch_target_uses_global_env_for_legacy_package_manager_field() {
 
     let target = switch_target(
         &Config { global_pkg_dir: Some(global_pkg_dir.clone()), ..Config::default() },
-        root.path(),
+        &pin_roots(root.path()),
         false,
     )
     .expect("target")
@@ -641,7 +664,7 @@ fn switch_target_respects_pm_on_fail_ignore() {
             global_pkg_dir: Some(root.path().join("pnpm-home").join("global")),
             ..Config::default()
         },
-        root.path(),
+        &pin_roots(root.path()),
         false,
     )
     .expect("target");
@@ -655,8 +678,9 @@ fn switch_target_refuses_to_record_a_persisting_pin_under_frozen_lockfile() {
     write_dev_engine_manifest(root.path(), ">=9.1.2 <9.1.4");
     write_lockfile(root.path(), LOCKED_9_1_1);
 
-    let target =
-        switch_target(&Config::default(), root.path(), true).expect("target").expect("switch");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), true)
+        .expect("target")
+        .expect("switch");
 
     let SwitchSource::Resolve {
         env_root,
@@ -678,7 +702,7 @@ fn switch_target_leaves_the_global_env_writable_under_frozen_lockfile() {
 
     let target = switch_target(
         &Config { global_pkg_dir: Some(global_pkg_dir.clone()), ..Config::default() },
-        root.path(),
+        &pin_roots(root.path()),
         true,
     )
     .expect("target")
@@ -704,7 +728,7 @@ fn switch_target_does_not_switch_dev_engine_without_download() {
         r#"{"devEngines":{"packageManager":{"name":"pnpm","version":"9.3.0","onFail":"error"}}}"#,
     );
 
-    let target = switch_target(&Config::default(), root.path(), false).expect("target");
+    let target = switch_target(&Config::default(), &pin_roots(root.path()), false).expect("target");
 
     assert!(target.is_none(), "unexpected switch target: {target:?}");
 }

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    CliArgs, CliCommand, KeyIssueReporting, PackageManagerToSync, PinRoots, PreCommandInput,
-    PreCommandPlan, SwitchInput, SwitchProcessState, SwitchSource, frozen_lockfile_flag,
-    pre_command_plan_from_input, switch_target,
+    CliArgs, CliCommand, KeyIssueReporting, PackageManagerToSync, PinFlags, PinRoots,
+    PreCommandInput, PreCommandPlan, SwitchInput, SwitchProcessState, SwitchSource,
+    frozen_lockfile_flag, pre_command_plan_from_input, switch_target,
 };
 use crate::{boolean_negations::with_boolean_negations, config_overrides::ConfigOverrides};
 use clap::{CommandFactory, FromArgMatches};
@@ -461,8 +461,7 @@ fn pre_command_input(dir: &Path) -> PreCommandInput {
             npmrc_auth_file: None,
             command: Some("run".to_string()),
             frozen_lockfile: None,
-            lockfile_dir: None,
-            offline: None,
+            pin_flags: PinFlags::default(),
             color: None,
         },
         global: false,
@@ -745,6 +744,89 @@ fn the_switch_reads_frozen_lockfile_from_the_command_line() {
     // Only the install family carries the flag; every other command leaves the
     // `frozenLockfile` setting to answer on its own.
     assert_eq!(flag_of(&["pnpm", "run", "build"]), None);
+}
+
+/// The pin record reads `--lockfile-dir` and `--offline` straight from the
+/// command line, so a command that grows either flag and is not added to
+/// [`PinFlags::of`] would silently record against the wrong directory or go
+/// to the network. Ask clap which commands declare them rather than trusting
+/// a second hand-written list.
+#[test]
+fn pin_flags_cover_every_command_declaring_them() {
+    for subcommand in super::super::grammar().get_subcommands() {
+        let name = subcommand.get_name();
+        // A command that skips the package-manager checks records no pin, so
+        // neither flag reaches a write for it.
+        if super::should_skip_command_name(name) {
+            continue;
+        }
+        let declares =
+            |long: &str| subcommand.get_arguments().any(|arg| arg.get_long() == Some(long));
+        if declares("lockfile-dir") {
+            let flags = PinFlags::of(&parse_with_positional(name, &["--lockfile-dir", "lf"]));
+            assert_eq!(
+                flags.lockfile_dir.as_deref(),
+                Some(Path::new("lf")),
+                "`pnpm {name}` accepts --lockfile-dir but PinFlags::of ignores it",
+            );
+        }
+        if declares("offline") {
+            let flags = PinFlags::of(&parse_with_positional(name, &["--offline"]));
+            assert_eq!(
+                flags.offline,
+                Some(true),
+                "`pnpm {name}` accepts --offline but PinFlags::of ignores it",
+            );
+        }
+        if declares("prefer-offline") {
+            let flags = PinFlags::of(&parse_with_positional(name, &["--prefer-offline"]));
+            assert_eq!(
+                flags.prefer_offline,
+                Some(true),
+                "`pnpm {name}` accepts --prefer-offline but PinFlags::of ignores it",
+            );
+        }
+    }
+}
+
+/// The pair overrides the configured value in both directions, the
+/// precedence `resolve_bool_override` gives every install-family boolean. An
+/// `offline` that only ever turned on would send `--no-offline` to the
+/// network's opposite.
+#[test]
+fn a_negated_flag_clears_a_configured_value() {
+    let cases = [
+        (PinFlags::default(), true, true),
+        (PinFlags::default(), false, false),
+        (PinFlags { offline: Some(false), ..PinFlags::default() }, true, false),
+        (PinFlags { offline: Some(true), ..PinFlags::default() }, false, true),
+    ];
+    for (flags, configured, expected) in cases {
+        let mut config = Config { offline: configured, ..Config::default() };
+        flags.apply_to(&mut config, Path::new("/tmp"));
+        assert_eq!(
+            config.offline, expected,
+            "offline {:?} over a configured {configured}",
+            flags.offline,
+        );
+    }
+}
+
+/// Parse `pnpm <name> <args>`, adding a placeholder positional for the
+/// commands that require one.
+fn parse_with_positional(name: &str, args: &[&str]) -> CliCommand {
+    let mut argv = vec!["pnpm", name];
+    argv.extend_from_slice(args);
+    let parse = |argv: &[&str]| {
+        with_boolean_negations(CliArgs::command())
+            .try_get_matches_from(argv)
+            .and_then(|matches| CliArgs::from_arg_matches(&matches))
+            .map(|args| args.command)
+    };
+    parse(&argv).unwrap_or_else(|_| {
+        argv.push("placeholder");
+        parse(&argv).unwrap_or_else(|error| panic!("parse `pnpm {name}`: {error}"))
+    })
 }
 
 fn parse_command(argv: &[&str]) -> CliCommand {

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -53,6 +53,25 @@ pub async fn install_config_deps<Reporter: self::Reporter>(
     resolve_and_install::<Reporter>(config, config_dependencies, root_dir, frozen_lockfile).await
 }
 
+/// Install the project's `configDependencies` and run their `updateConfig`
+/// hooks — the pair every install-family pipeline opens with.
+///
+/// Both happen before the pipeline builds its state: the env lockfile must
+/// land at the top of `pnpm-lock.yaml` before the wanted lockfile is read,
+/// and `updateConfig` must mutate `config` before the install reads it.
+///
+/// The package-manager pin is recorded earlier, by the pre-command checks,
+/// for every command rather than only for this family.
+pub async fn prepare<Reporter: self::Reporter>(
+    config: &mut Config,
+    root_dir: &Path,
+    frozen_lockfile: bool,
+) -> Result<()> {
+    install_config_deps::<Reporter>(config, root_dir, frozen_lockfile).await?;
+    run_update_config_hooks::<Reporter>(config, root_dir).await?;
+    Ok(())
+}
+
 /// Resolve pnpm's own engine dependencies into the env lockfile's
 /// `packageManagerDependencies` block before the wanted lockfile is
 /// loaded. `force_resync` discards recorded entries and re-resolves them

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -423,6 +423,46 @@ fn env_document(workspace: &Path) -> String {
         .to_string()
 }
 
+/// `lockfileDir` moves `pnpm-lock.yaml`, and the recorded pin is the first
+/// document of that file, so it moves with it. Recording it at the
+/// workspace root instead would leave a second lockfile there, and the one
+/// the install reads would never carry the pin.
+#[test]
+fn a_pinned_package_manager_is_recorded_in_the_lockfile_directory() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_pnpm_version(pnpm_config::PNPM_VERSION);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let lockfile_dir = workspace.join("lf");
+    fs::create_dir_all(&lockfile_dir).expect("create the lockfile directory");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "lockfileDir: ./lf\n")
+        .expect("write the workspace manifest");
+    write_dev_engines_package_manager(
+        &workspace,
+        "pnpm",
+        pnpm_config::PNPM_VERSION,
+        Some("download"),
+    );
+
+    let output =
+        run(pacquet.with_env("PNPM_CONFIG_REGISTRY", mock_instance.url()), root.path(), &["list"]);
+
+    assert_success(&output);
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "the workspace root should carry no lockfile of its own",
+    );
+    let env_lockfile = EnvLockfile::read(&lockfile_dir)
+        .expect("read the written env lockfile")
+        .expect("the env lockfile should have been written beside the lockfile");
+    let recorded = env_lockfile.importers[EnvLockfile::ROOT_IMPORTER_KEY]
+        .package_manager_dependencies
+        .as_ref()
+        .expect("packageManagerDependencies should be recorded");
+    assert_eq!(recorded["pnpm"].version, pnpm_config::PNPM_VERSION);
+
+    drop(mock_instance);
+}
+
 #[test]
 fn a_global_command_warns_instead_of_failing_the_package_manager_check() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();


### PR DESCRIPTION
## Summary

Follow-up to pnpm/pnpm#14626, which is merged; this PR rebases onto it and is the refactor alone.

While fixing pnpm/pnpm#14575 it turned out `packageManagerDependencies` reached the lockfile from **eight** call sites, not two: the pre-command checks for most commands, plus an identical three-call prologue copy-pasted into each of the seven install-family pipelines. A hand-maintained list of ten command variants (`syncs_env_lockfile_in_pipeline`) decided which side owned the write. That list is what let pnpm/pnpm#14575 exist, and the two sides also disagreed about *what* and *where* they wrote.

The pre-command checks now record the pin for every command. The list and the seven copies are gone; the pipelines keep only the config-dependency pair they all share, behind `config_deps::prepare`.

### Two bugs fell out of the merge

Both confirmed on released 12.3.4 before anything was changed, so neither comes from pnpm/pnpm#14626.

| Case | Before | After |
| --- | --- | --- |
| `lockfileDir` is set | The pin is written to a stray `pnpm-lock.yaml` at the workspace root, and the lockfile the install actually reads never carries it | Written once, in the lockfile directory |
| `pnpm unlink` with nothing to unlink | Returns before its pipeline, so the pin is never recorded | Recorded |

The `lockfileDir` one is the more serious of the two. `pre_command` derived its root from `workspace_dir` alone while the pipelines used `root_project_manifest_dir` (which honours `lockfileDir`), so the two wrote to different files. `PinRoots` now separates them: the manifest declaring the pin is read at the workspace root, the env lockfile follows the lockfile.

### Behaviour parity, checked rather than assumed

`--frozen-lockfile` has a history of regressions in this block (pnpm/pnpm#14009, pnpm/pnpm#14124, pnpm/pnpm#14129, pnpm/pnpm#14132), so it was the risk to clear. Pre- and post-refactor binaries on an out-of-date `packageManagerDependencies`:

```
[pre]  --frozen-lockfile exit=1  err=ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE  (lockfile untouched)
[post] --frozen-lockfile exit=1  err=ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE  (lockfile untouched)
```

The `frozenLockfile` setting still blocks the write identically.

The install family used to layer `--lockfile-dir` and `--offline` onto its config before recording, so both now reach the pre-command config; without that, moving the write would have silently dropped them. `--frozen-lockfile` as typed reaches the write for the first time, where that path previously saw only the `frozenLockfile` setting.

The install fast path no longer gives itself up so the pipeline can record the pin, since the record has already happened by the time it runs.

Net −62 lines. All 3318 `pnpm-cli` tests pass; the new `lockfileDir` end-to-end test was verified to fail with the two-root change reverted.

## Squash Commit Body

```text
`packageManagerDependencies` reached the lockfile from eight call sites:
the pre-command checks for most commands, and a copy-pasted prologue in
each of the seven install-family pipelines. A hand-maintained list of
command variants decided which of the two owned the write, and the two
did not agree on what they wrote.

The pre-command checks now record the pin for every command, so the list
and the pipeline copies are gone. The seven pipelines keep only the
config-dependency pair they all share, behind `config_deps::prepare`.

The install family used to layer `--lockfile-dir` and `--offline` onto
its config before recording, so both now reach the pre-command config
too. `--frozen-lockfile` as typed reaches the write for the first time;
it previously only saw the `frozenLockfile` setting there.

Two bugs fall out of the merge. The pre-command path derived its root
from `workspace_dir` alone while the pipelines used `lockfileDir`, so a
project setting one recorded the pin in a stray lockfile at the
workspace root and never in the lockfile the install reads; the write
now follows the lockfile while the manifest is still read from the
workspace root. And `pnpm unlink` returns before its pipeline when there
is nothing to unlink, which used to skip the record entirely.

The install fast path no longer has to give itself up to let the
pipeline record the pin, since the record already happened by then.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPfp4dvqS7Nac4Luy3URJm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed package manager pin recording when `lockfileDir` is configured. Pins are now written alongside the configured lockfile instead of creating an incorrect second lockfile at the workspace root.
  * Ensured package manager pins are recorded consistently across install, update, remove, deploy, dedupe, prune, unlink, and related commands.
  * Improved offline and prefer-offline command-line overrides, including support for explicitly clearing configured values.
* **Tests**
  * Added coverage verifying pinned package manager versions are stored alongside the configured lockfile.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->