### PR TITLE
fix(directory-fetcher): confine a symlinked source directory to its real path

### DIFF
--- a/.changeset/install-symlinked-file-dependencies.md
+++ b/.changeset/install-symlinked-file-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `pnpm setup` failing with `ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE` on Windows [#14618](https://github.com/pnpm/pnpm/issues/14618). A `file:` dependency whose directory is a symlink or junction is now packed from the directory it points at. Files that a symlink inside the package reaches outside that directory are still refused.

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -539,6 +539,31 @@ fn add_accepts_multiple_local_package_selectors() {
     drop(root); // cleanup
 }
 
+/// Covers pnpm/pnpm#14618: `pnpm setup` re-runs from the globally
+/// installed `@pnpm/exe`, whose directory is the symlink pnpm's own
+/// `node_modules` layout puts there.
+#[test]
+fn add_installs_a_local_package_reached_through_a_symlinked_directory() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let real_dir = workspace.join("fixtures/real-local");
+    std::fs::create_dir_all(&real_dir).expect("create local package directory");
+    std::fs::write(
+        real_dir.join("package.json"),
+        serde_json::json!({ "name": "local", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write local package manifest");
+    std::fs::write(real_dir.join("index.js"), "module.exports = 1\n").expect("write index.js");
+    pnpm_fs::symlink_dir(&real_dir, &workspace.join("fixtures/linked-local"))
+        .expect("link the local package directory");
+
+    pacquet.with_args(["add", "file:./fixtures/linked-local"]).assert().success();
+
+    assert_eq!(prod_spec(&workspace, "local"), "file:fixtures/linked-local");
+    assert!(workspace.join("node_modules/local/index.js").is_file());
+
+    drop(root); // cleanup
+}
+
 /// A one-member workspace whose `fixtures/` packages let a `-w` add use
 /// `file:` specs instead of reaching the registry. Returns the member's
 /// directory.

--- a/pnpm/crates/directory-fetcher/src/fetcher.rs
+++ b/pnpm/crates/directory-fetcher/src/fetcher.rs
@@ -23,7 +23,7 @@ use std::{collections::HashMap, path::PathBuf};
 /// - `resolve_symlinks = true` → follow symlinks via `realpath` (used
 ///   when `resolveSymlinksInInjectedDirs` is on).
 /// - `allow_path_escape = false` → reject files whose real path leaves
-///   `directory`.
+///   the real path of `directory`.
 pub struct DirectoryFetcher {
     pub directory: PathBuf,
     pub include_only_package_files: bool,
@@ -48,9 +48,6 @@ pub struct DirectoryFetchOutput {
 
 impl DirectoryFetcher {
     pub fn run(&self) -> Result<DirectoryFetchOutput, DirectoryFetcherError> {
-        if !self.allow_path_escape {
-            walker::reject_linked_confined_root(&self.directory)?;
-        }
         let files_map = if self.include_only_package_files {
             let mut files_map = walker::walk_package_files(&self.directory)?;
             if !self.allow_path_escape {

--- a/pnpm/crates/directory-fetcher/src/fetcher/tests.rs
+++ b/pnpm/crates/directory-fetcher/src/fetcher/tests.rs
@@ -34,27 +34,26 @@ fn confined_all_files_fetcher_rewrites_symlink_sources_to_real_paths() {
 
 #[cfg(any(unix, windows))]
 #[test]
-fn confined_package_files_fetcher_rejects_linked_root() {
+fn confined_package_files_fetcher_packs_a_linked_root() {
     let dir = tempdir().unwrap();
-    let outside = dir.path().join("outside");
-    fs::create_dir_all(&outside).unwrap();
-    fs::write(outside.join("package.json"), r#"{ "name": "x", "version": "0.0.0" }"#).unwrap();
-    fs::write(outside.join("index.js"), "content").unwrap();
+    let real_root = dir.path().join("real-root");
+    fs::create_dir_all(&real_root).unwrap();
+    fs::write(real_root.join("package.json"), r#"{ "name": "x", "version": "0.0.0" }"#).unwrap();
+    fs::write(real_root.join("index.js"), "content").unwrap();
     let root_link = dir.path().join("root-link");
-    pnpm_fs::symlink_dir(&outside, &root_link).unwrap();
+    pnpm_fs::symlink_dir(&real_root, &root_link).unwrap();
 
-    let Err(err) = (DirectoryFetcher {
+    let output = DirectoryFetcher {
         directory: root_link,
         include_only_package_files: true,
         resolve_symlinks: false,
         allow_path_escape: false,
-    })
-    .run() else {
-        panic!("linked root should be rejected before packlist walks it");
-    };
+    }
+    .run()
+    .unwrap();
 
-    assert!(
-        err.to_string().contains("resolves outside source directory"),
-        "unexpected error: {err}",
+    assert_eq!(
+        output.files_map.get("index.js"),
+        Some(&fs::canonicalize(real_root.join("index.js")).unwrap()),
     );
 }

--- a/pnpm/crates/directory-fetcher/src/walker.rs
+++ b/pnpm/crates/directory-fetcher/src/walker.rs
@@ -33,10 +33,6 @@ pub(crate) type FilesMap = HashMap<String, PathBuf>;
 /// Recursive walk of `dir`, skipping `node_modules` at any depth and
 /// dropping entries whose `stat` (or `realpath` under `resolve_symlinks`)
 /// fails with `ENOENT`.
-///
-/// A confined walk descends the root's real path, not the caller's, so
-/// the tree it reads is the one its containment check approved even if
-/// `dir` is a link that gets retargeted mid-walk.
 pub(crate) fn walk_all_files(
     dir: &Path,
     resolve_symlinks: bool,
@@ -45,6 +41,10 @@ pub(crate) fn walk_all_files(
     let mut out = FilesMap::new();
     let mut visited = HashSet::new();
     let confined_root = if allow_path_escape { None } else { Some(canonicalize_path(dir)?) };
+    // Descending the resolved root rather than `dir` keeps the tree
+    // being read the one the containment check approved: retargeting a
+    // linked `dir` mid-walk would otherwise feed entries that are
+    // ordinary files, and so never checked against the root at all.
     let root = confined_root.as_deref().unwrap_or(dir);
     walk_all_inner(root, "", resolve_symlinks, confined_root.as_deref(), &mut visited, &mut out)?;
     Ok(out)

--- a/pnpm/crates/directory-fetcher/src/walker.rs
+++ b/pnpm/crates/directory-fetcher/src/walker.rs
@@ -40,26 +40,9 @@ pub(crate) fn walk_all_files(
 ) -> Result<FilesMap, DirectoryFetcherError> {
     let mut out = FilesMap::new();
     let mut visited = HashSet::new();
-    let confined_root = if allow_path_escape { None } else { Some(confined_root(dir)?) };
+    let confined_root = if allow_path_escape { None } else { Some(canonicalize_path(dir)?) };
     walk_all_inner(dir, "", resolve_symlinks, confined_root.as_deref(), &mut visited, &mut out)?;
     Ok(out)
-}
-
-pub(crate) fn reject_linked_confined_root(dir: &Path) -> Result<(), DirectoryFetcherError> {
-    let metadata = fs::symlink_metadata(dir)
-        .map_err(|source| DirectoryFetcherError::Io { dir: dir.display().to_string(), source })?;
-    if is_linked_entry(&metadata) {
-        return Err(DirectoryFetcherError::PathOutsideDirectory {
-            path: dir.to_path_buf(),
-            directory: dir.to_path_buf(),
-        });
-    }
-    Ok(())
-}
-
-fn confined_root(dir: &Path) -> Result<PathBuf, DirectoryFetcherError> {
-    reject_linked_confined_root(dir)?;
-    canonicalize_path(dir)
 }
 
 fn is_linked_entry(metadata: &Metadata) -> bool {
@@ -249,7 +232,7 @@ pub(crate) fn resolve_paths_in_directory(
     directory: &Path,
     files_map: &mut FilesMap,
 ) -> Result<(), DirectoryFetcherError> {
-    let root = confined_root(directory)?;
+    let root = canonicalize_path(directory)?;
     for path in files_map.values_mut() {
         let original = path.clone();
         let resolved = canonicalize_path(&original)?;

--- a/pnpm/crates/directory-fetcher/src/walker.rs
+++ b/pnpm/crates/directory-fetcher/src/walker.rs
@@ -33,6 +33,10 @@ pub(crate) type FilesMap = HashMap<String, PathBuf>;
 /// Recursive walk of `dir`, skipping `node_modules` at any depth and
 /// dropping entries whose `stat` (or `realpath` under `resolve_symlinks`)
 /// fails with `ENOENT`.
+///
+/// A confined walk descends the root's real path, not the caller's, so
+/// the tree it reads is the one its containment check approved even if
+/// `dir` is a link that gets retargeted mid-walk.
 pub(crate) fn walk_all_files(
     dir: &Path,
     resolve_symlinks: bool,
@@ -41,7 +45,8 @@ pub(crate) fn walk_all_files(
     let mut out = FilesMap::new();
     let mut visited = HashSet::new();
     let confined_root = if allow_path_escape { None } else { Some(canonicalize_path(dir)?) };
-    walk_all_inner(dir, "", resolve_symlinks, confined_root.as_deref(), &mut visited, &mut out)?;
+    let root = confined_root.as_deref().unwrap_or(dir);
+    walk_all_inner(root, "", resolve_symlinks, confined_root.as_deref(), &mut visited, &mut out)?;
     Ok(out)
 }
 

--- a/pnpm/crates/directory-fetcher/src/walker/tests.rs
+++ b/pnpm/crates/directory-fetcher/src/walker/tests.rs
@@ -210,15 +210,33 @@ fn walk_all_files_rejects_nested_junction_escape_when_confined() {
 
 #[cfg(any(unix, windows))]
 #[test]
-fn walk_all_files_rejects_linked_root_when_confined() {
+fn walk_all_files_confines_a_linked_root_to_its_real_path() {
     let dir = tempdir().unwrap();
+    let real_root = dir.path().join("real-root");
+    fs::create_dir_all(&real_root).unwrap();
+    touch(&real_root, "index.js");
+    let root_link = dir.path().join("root-link");
+    pnpm_fs::symlink_dir(&real_root, &root_link).unwrap();
+
+    let out = walk_all_files(&root_link, false, false).unwrap();
+    let expected = BTreeMap::from([("index.js".to_string(), "index.js".to_string())]);
+    assert_eq!(collect_rels(&root_link, out), expected);
+}
+
+#[cfg(any(unix, windows))]
+#[test]
+fn walk_all_files_rejects_escape_from_a_linked_root_when_confined() {
+    let dir = tempdir().unwrap();
+    let real_root = dir.path().join("real-root");
+    fs::create_dir_all(&real_root).unwrap();
     let outside = dir.path().join("outside");
     fs::create_dir_all(&outside).unwrap();
     touch(&outside, "secret.txt");
+    pnpm_fs::symlink_dir(&outside, &real_root.join("outside")).unwrap();
     let root_link = dir.path().join("root-link");
-    pnpm_fs::symlink_dir(&outside, &root_link).unwrap();
+    pnpm_fs::symlink_dir(&real_root, &root_link).unwrap();
 
-    let err = walk_all_files(&root_link, false, false).expect_err("linked root should fail");
+    let err = walk_all_files(&root_link, false, false).expect_err("outside symlink should fail");
     assert!(
         err.to_string().contains("resolves outside source directory"),
         "unexpected error: {err}",

--- a/pnpm/crates/directory-fetcher/src/walker/tests.rs
+++ b/pnpm/crates/directory-fetcher/src/walker/tests.rs
@@ -219,8 +219,9 @@ fn walk_all_files_confines_a_linked_root_to_its_real_path() {
     pnpm_fs::symlink_dir(&real_root, &root_link).unwrap();
 
     let out = walk_all_files(&root_link, false, false).unwrap();
+    let real_root = fs::canonicalize(&real_root).unwrap();
     let expected = BTreeMap::from([("index.js".to_string(), "index.js".to_string())]);
-    assert_eq!(collect_rels(&root_link, out), expected);
+    assert_eq!(collect_rels(&real_root, out), expected);
 }
 
 #[cfg(any(unix, windows))]


### PR DESCRIPTION
## Summary

`pnpm setup` fails on Windows with `ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE`, and the error names the same path twice — once as the path that escaped, once as the source directory it escaped from:

```
Installing pnpm CLI globally from C:\Users\user\AppData\Local\pnpm\global\v11\<hash>\node_modules\@pnpm\exe

Error: ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE
  × adding a new package
  ╰─▶ path C:\...\node_modules\@pnpm\exe resolves outside source directory C:\...\node_modules\@pnpm\exe
```

`setup` installs the CLI with `pnpm add -g file:<directory of the running executable>`. When it is re-run from a pnpm that is already installed globally, that directory is `<global dir>/node_modules/@pnpm/exe` — which pnpm's own `node_modules` layout makes a link into the virtual store. Windows reports the launch path without resolving reparse points, so `current_exe` hands back the link; `/proc/self/exe` resolves it, which is why only Windows hit this.

The directory fetcher's containment pass refused any source directory that was itself a link. It now confines the walk to the directory's real path instead. The guard exists to stop a package from reaching files outside its own tree through a symlink, and a linked root is not such an escape: everything under the real path is still the package the caller named, and a link inside it that leaves that path is rejected exactly as before.

This is not Windows-only in general. On any platform, `pnpm add file:<symlinked dir>` fails on pnpm 12 today and succeeds on pnpm 11 — v11's `@pnpm/directory-fetcher` has no containment pass at all — so this also restores parity. Reproduced and verified on Linux:

```console
$ ln -s real/mypkg linked-mypkg
$ pnpm add file:./linked-mypkg     # before: ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE
+ mypkg file:./linked-mypkg        # after
```

pnpm v11 is not affected, so this is a v12-only fix.

A second commit hardens the confined walk while it is in the area: it canonicalized the root for its containment check but then descended the caller's path, so entries under a link retargeted mid-walk were accepted without being checked against the root that was approved. It now descends the resolved root, so it reads the tree it validated. Packlist mode already canonicalizes and containment-checks every enumerated path, so it is unchanged.

Closes pnpm/pnpm#14618

## Squash Commit Body

```text
`pnpm setup` failed on Windows with
`ERR_PNPM_DIRECTORY_FETCHER_PATH_ESCAPE`, naming the very same path as both
the escaping path and the source directory it escaped.

setup installs the CLI with `pnpm add -g file:<directory of the running
executable>`. Re-run from a pnpm that is already installed globally, that
directory is `<global dir>/node_modules/@pnpm/exe`, which pnpm's own
node_modules layout makes a link into the virtual store. Windows reports the
launch path without resolving reparse points, so `current_exe` hands back the
link; `/proc/self/exe` resolves it, which is why only Windows hit this.

The containment pass refused a source directory that was itself a link.
Confine the walk to the directory's real path instead. The guard exists to
stop a package from reaching files outside its own tree through a symlink,
and a linked root is not such an escape: everything under the real path is
still the package the caller named, and a link inside it that leaves that
path is rejected as before. pnpm v11 has no containment pass at all, so this
also restores parity for every `file:` dependency whose directory is a link,
on all platforms.

Closes pnpm/pnpm#14618
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (v11 has no containment pass, so
  it is not affected.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DZckASmXATGDhrdUPWGnLr


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm setup` failures on Windows when installing local `file:` dependencies through a symlinked or junction directory.
  * Local packages are now correctly packed from the directory their symlink points to.
  * Files that resolve outside the package directory continue to be rejected for safety.

* **Tests**
  * Added coverage for installing local packages reached through symlinked directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->