### PR TITLE
docs(changeset): link the lockfileDir entry to its own issue

### DIFF
--- a/.changeset/record-the-pin-in-one-place.md
+++ b/.changeset/record-the-pin-in-one-place.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-pnpm now records the pinned pnpm version in the lockfile the project actually uses when `lockfileDir` is set. It wrote the pin into a second `pnpm-lock.yaml` at the workspace root, and the real lockfile never carried it [#14575](https://github.com/pnpm/pnpm/issues/14575).
+pnpm now records the pinned pnpm version in the lockfile the project actually uses when `lockfileDir` is set. It wrote the pin into a second `pnpm-lock.yaml` at the workspace root, and the real lockfile never carried it [#14633](https://github.com/pnpm/pnpm/issues/14633).


### PR DESCRIPTION
## Summary

The changeset added in pnpm/pnpm#14627 describes the `lockfileDir` bug but links pnpm/pnpm#14575, which is the version-switching bug it happened to ship alongside. A reader following the link from the release note lands on an unrelated report.

pnpm/pnpm#14633 now records the `lockfileDir` bug on its own, so the entry links that instead. Changeset text is otherwise unchanged.

Closes pnpm/pnpm#14633

## Squash Commit Body

```text
The entry describes the `lockfileDir` bug but linked the issue for the
version-switching bug it shipped alongside, so the release note pointed
readers at an unrelated report.

Closes pnpm/pnpm#14633
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPfp4dvqS7Nac4Luy3URJm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14634"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791328166&installation_model_id=426870&pr_number=14634&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14634&signature=6f889dbe4078bbb5df89d55bbed9979fc693a7543e2da80b0aa0a94db3ff74d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed lockfile metadata so the pinned pnpm version is recorded in the lockfile used by the project when a custom lockfile directory is configured.
- **Documentation**
  - Updated the changelog to reference the correct issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->