### PR TITLE
fix(pipeline): reject incomplete input hashes

### DIFF
--- a/.changeset/pipeline-input-hashing.md
+++ b/.changeset/pipeline-input-hashing.md
@@ -2,4 +2,6 @@
 "pacquet": patch
 ---
 
-`pnpm pipeline` now reports unreadable inputs and non-UTF-8 filenames when computing task cache keys. These inputs were silently omitted, which could reuse stale results. Unix filenames containing backslashes are now hashed as literal paths.
+`pnpm pipeline` now reports unreadable inputs and non-UTF-8 filenames when computing task cache keys. Unix filenames containing backslashes are now hashed as literal paths.
+
+Projects containing Git submodules and tasks depending on them bypass caching and still execute.

--- a/.changeset/pipeline-input-hashing.md
+++ b/.changeset/pipeline-input-hashing.md
@@ -2,6 +2,6 @@
 "pacquet": patch
 ---
 
-`pnpm pipeline` now reports unreadable inputs and non-UTF-8 filenames when computing task cache keys. Unix filenames containing backslashes are now hashed as literal paths.
+`pnpm pipeline` now reports symlinked inputs, unreadable files, and non-UTF-8 filenames when computing task cache keys. Unix filenames containing backslashes are now hashed as literal paths.
 
 Projects containing Git submodules and tasks depending on them bypass caching and still execute.

--- a/.changeset/pipeline-input-hashing.md
+++ b/.changeset/pipeline-input-hashing.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm pipeline` now reports unreadable inputs and non-UTF-8 filenames when computing task cache keys. These inputs were silently omitted, which could reuse stale results. Unix filenames containing backslashes are now hashed as literal paths.

--- a/.changeset/pipeline-input-hashing.md
+++ b/.changeset/pipeline-input-hashing.md
@@ -4,4 +4,4 @@
 
 `pnpm pipeline` now rejects symlinked inputs when computing task cache keys. Unreadable input files now produce an error. Non-UTF-8 input filenames now produce an error. Unix filenames containing backslashes are now hashed as literal paths.
 
-Projects containing Git submodules and tasks depending on them bypass caching and still execute.
+Projects inside or containing Git submodules and tasks depending on them bypass caching and still execute.

--- a/.changeset/pipeline-input-hashing.md
+++ b/.changeset/pipeline-input-hashing.md
@@ -2,6 +2,6 @@
 "pacquet": patch
 ---
 
-`pnpm pipeline` now reports symlinked inputs, unreadable files, and non-UTF-8 filenames when computing task cache keys. Unix filenames containing backslashes are now hashed as literal paths.
+`pnpm pipeline` now rejects symlinked inputs when computing task cache keys. Unreadable input files now produce an error. Non-UTF-8 input filenames now produce an error. Unix filenames containing backslashes are now hashed as literal paths.
 
 Projects containing Git submodules and tasks depending on them bypass caching and still execute.

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -337,7 +337,7 @@ pub fn run_pipeline(
             config,
             invocation,
             cache: &cache,
-            task_key: &task_keys[&key],
+            task_key: task_keys[&key].as_deref(),
             init_cwd: &init_cwd,
             base_extra_env: &base_extra_env,
             emit,
@@ -615,14 +615,21 @@ fn compute_task_keys(
     graph: &ProjectGraph<GraphPkg<'_>>,
     cache: &TaskCache,
     config: &Config,
-) -> miette::Result<HashMap<TaskKey, String>> {
-    let mut keys: HashMap<TaskKey, String> = HashMap::with_capacity(task_graph.len());
+) -> miette::Result<HashMap<TaskKey, Option<String>>> {
+    let mut keys: HashMap<TaskKey, Option<String>> = HashMap::with_capacity(task_graph.len());
     for key in sequenced_tasks {
         let node = &task_graph[key];
         let manifest = graph[node.project.as_path()].package.project.manifest.value();
         let script_bodies = task_script_bodies(node, manifest, config.enable_pre_post_scripts);
-        let mut dependency_keys: Vec<&str> =
-            node.dependencies.iter().map(|dependency| keys[dependency].as_str()).collect();
+        let Some(mut dependency_keys) = node
+            .dependencies
+            .iter()
+            .map(|dependency| keys[dependency].as_deref())
+            .collect::<Option<Vec<&str>>>()
+        else {
+            keys.insert(key.clone(), None);
+            continue;
+        };
         dependency_keys.sort_unstable();
         let task_key = cache.compute_task_key(&cache::TaskKeyInputs {
             node,
@@ -672,7 +679,7 @@ struct RunTaskOptions<'a, 'graph> {
     config: &'a Config,
     invocation: &'a PipelineInvocation,
     cache: &'a TaskCache,
-    task_key: &'a str,
+    task_key: Option<&'a str>,
     init_cwd: &'a Path,
     base_extra_env: &'a HashMap<String, String>,
     emit: fn(&LogEvent),
@@ -697,11 +704,13 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     } = *options;
     let root = node.project.as_path();
     let settings = config.tasks.get(&node.task_name);
-    let cacheable = task_cacheable(invocation, settings);
+    let cache_key = task_key.filter(|_| task_cacheable(invocation, settings));
     let start = Instant::now();
     report.task_started(summary_key, task_key);
 
-    if cacheable && let Some(stored) = cache.lookup(task_key) {
+    if let Some(cache_key) = cache_key
+        && let Some(stored) = cache.lookup(cache_key)
+    {
         match cache.restore(&stored, root, summary_key) {
             Ok(()) => {
                 capture::replay(&stored.scripts, root, emit);
@@ -736,11 +745,11 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
     let execution = execute_task_with_cargo_cache(options, settings)?;
     let duration = start.elapsed().as_secs_f64() * 1e3;
     if execution.status == Status::Passed
-        && cacheable
+        && let Some(cache_key) = cache_key
         && let Some(captured) = execution.captured
     {
         let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
-        if let Err(error) = cache.store(task_key, root, summary_key, outputs, captured) {
+        if let Err(error) = cache.store(cache_key, root, summary_key, outputs, captured) {
             emit(&LogEvent::Pnpm(PnpmLog {
                 level: LogLevel::Warn,
                 message: format!("{summary_key}: failed to store the task in the cache: {error}"),
@@ -748,7 +757,8 @@ fn run_pipeline_task(options: &RunTaskOptions<'_, '_>) -> miette::Result<Executi
             }));
         }
     }
-    let disposition = if cacheable { CacheDisposition::Miss } else { CacheDisposition::Bypass };
+    let disposition =
+        if cache_key.is_some() { CacheDisposition::Miss } else { CacheDisposition::Bypass };
     report.task_finished(summary_key, execution.status, disposition, duration);
     Ok(ExecutionStatus {
         status: execution.status,
@@ -774,7 +784,7 @@ fn execute_task_with_cargo_cache(
     );
     let cargo_cacheable =
         !invocation.no_cache && settings.is_some_and(|settings| settings.cache != Some(false));
-    let snapshot = if cargo_cacheable {
+    let snapshot = if cargo_cacheable && let Some(task_key) = task_key {
         match cargo_cache::snapshot_entry(&config.cache_dir, root, task_key, &environment) {
             Ok(snapshot) => Some(snapshot),
             Err(error) => {
@@ -805,6 +815,7 @@ fn execute_task_with_cargo_cache(
     let execution =
         execute_task_scripts(&RunTaskOptions { base_extra_env: &extra_env, ..*options })?;
     if execution.status == Status::Passed
+        && let Some(task_key) = task_key
         && let Some((entry, key, local_packages)) = &snapshot
     {
         match cargo_cache::snapshot_entry(&config.cache_dir, root, task_key, &environment) {
@@ -855,7 +866,8 @@ fn execute_task_scripts(options: &RunTaskOptions<'_, '_>) -> miette::Result<Task
     let manifest = &graph[root].package.project.manifest;
 
     let extra_env = task_environment(config, root, base_extra_env);
-    let capture_output = task_cacheable(invocation, config.tasks.get(&node.task_name));
+    let capture_output =
+        options.task_key.is_some() && task_cacheable(invocation, config.tasks.get(&node.task_name));
     let root_str = root.to_string_lossy().into_owned();
     let mut status = Status::Passed;
     let mut message = None;

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -10,6 +10,7 @@ use super::{
     capture::CapturedScript,
     paths::{check_ancestors, validate_relative_path},
 };
+use miette::IntoDiagnostic;
 use pnpm_config::TaskSettings;
 use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file, create_short_hash};
 use pnpm_workspace_task_scheduler::TaskNode;
@@ -459,6 +460,7 @@ impl TaskCache {
                         && fs::symlink_metadata(&absolute)
                             .is_err_and(|error| error.kind() == io::ErrorKind::NotFound) =>
                 {
+                    check_ancestors(project, Path::new(rel_path)).into_diagnostic()?;
                     continue;
                 }
                 Err(error) => {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -452,6 +452,7 @@ impl TaskCache {
             if rel_path == "node_modules" || rel_path.starts_with("node_modules/") {
                 continue;
             }
+            check_ancestors(project, Path::new(rel_path)).into_diagnostic()?;
             let absolute = project.join(rel_path);
             let hash = match create_hex_hash_from_file(&absolute) {
                 Ok(hash) => hash,
@@ -460,7 +461,6 @@ impl TaskCache {
                         && fs::symlink_metadata(&absolute)
                             .is_err_and(|error| error.kind() == io::ErrorKind::NotFound) =>
                 {
-                    check_ancestors(project, Path::new(rel_path)).into_diagnostic()?;
                     continue;
                 }
                 Err(error) => {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -431,16 +431,32 @@ impl TaskCache {
             if rel_path.is_empty() {
                 continue;
             }
-            let rel_path = String::from_utf8_lossy(rel_path).replace('\\', "/");
+            let rel_path = std::str::from_utf8(rel_path).map_err(|error| {
+                let display_path = String::from_utf8_lossy(rel_path);
+                miette::miette!(
+                    "non-UTF-8 cache input path {display_path:?} in {project_display}: {error}",
+                )
+            })?;
             if rel_path == "node_modules" || rel_path.starts_with("node_modules/") {
                 continue;
             }
-            // A tracked file deleted from the working tree contributes
-            // nothing; the deletion shows up as the file's absence.
-            let Ok(hash) = create_hex_hash_from_file(&project.join(&rel_path)) else {
-                continue;
+            let absolute = project.join(rel_path);
+            let hash = match create_hex_hash_from_file(&absolute) {
+                Ok(hash) => hash,
+                Err(error)
+                    if error.kind() == io::ErrorKind::NotFound
+                        && fs::symlink_metadata(&absolute)
+                            .is_err_and(|error| error.kind() == io::ErrorKind::NotFound) =>
+                {
+                    continue;
+                }
+                Err(error) => {
+                    return Err(miette::miette!(
+                        "hashing cache input {rel_path:?} in {project_display}: {error}",
+                    ));
+                }
             };
-            files.push(HashedFile { rel_path, hash });
+            files.push(HashedFile { rel_path: rel_path.to_string(), hash });
         }
         files.sort_by(|left, right| left.rel_path.cmp(&right.rel_path));
         let files = Arc::new(files);

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -418,6 +418,13 @@ impl TaskCache {
         {
             return Ok(files.as_ref().map(Arc::clone));
         }
+        if has_gitlinks(project)? {
+            self.project_files
+                .lock()
+                .expect("project-files lock is not poisoned")
+                .insert(project.to_path_buf(), None);
+            return Ok(None);
+        }
         let project_display = project.display();
         let output = Command::new("git")
             .args(["ls-files", "-z", "--cached", "--others", "--exclude-standard"])
@@ -448,13 +455,6 @@ impl TaskCache {
             let absolute = project.join(rel_path);
             let hash = match create_hex_hash_from_file(&absolute) {
                 Ok(hash) => hash,
-                Err(_) if is_gitlink(project, rel_path)? => {
-                    self.project_files
-                        .lock()
-                        .expect("project-files lock is not poisoned")
-                        .insert(project.to_path_buf(), None);
-                    return Ok(None);
-                }
                 Err(error)
                     if error.kind() == io::ErrorKind::NotFound
                         && fs::symlink_metadata(&absolute)
@@ -548,10 +548,10 @@ fn compile_globs_owned(patterns: &[String]) -> miette::Result<Vec<Glob<'static>>
 #[cfg(test)]
 mod tests;
 
-fn is_gitlink(project: &Path, relative: &str) -> miette::Result<bool> {
+fn has_gitlinks(project: &Path) -> miette::Result<bool> {
     let project_display = project.display();
     let output = Command::new("git")
-        .args(["--literal-pathspecs", "ls-files", "--stage", "-z", "--", relative])
+        .args(["ls-files", "--stage", "-z"])
         .current_dir(project)
         .output()
         .map_err(|error| {

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -60,8 +60,11 @@ pub struct TaskCache {
     /// Per-project tracked-file hashes, shared by every task of the
     /// project: enumeration and hashing run once, per-task input specs
     /// filter the shared list.
-    project_files: Mutex<HashMap<PathBuf, Arc<Vec<HashedFile>>>>,
+    project_files: Mutex<HashMap<PathBuf, ProjectInputHashes>>,
 }
+
+/// Submodule inputs have no complete hash list and require cache bypass.
+type ProjectInputHashes = Option<Arc<Vec<HashedFile>>>;
 
 #[derive(Debug)]
 struct HashedFile {
@@ -123,7 +126,7 @@ impl TaskCache {
 
     /// The task's cache key: `pnpm-pipeline-task:v0` over the components
     /// the RFC names, NUL-separated and hashed.
-    pub fn compute_task_key(&self, inputs: &TaskKeyInputs<'_>) -> miette::Result<String> {
+    pub fn compute_task_key(&self, inputs: &TaskKeyInputs<'_>) -> miette::Result<Option<String>> {
         let TaskKeyInputs { node, settings, dependency_keys, script_bodies, environment } = *inputs;
         let project_rel = self.project_rel(&node.project);
         let mut components: Vec<String> = vec![
@@ -142,13 +145,14 @@ impl TaskCache {
             let value = environment.get(name).cloned().or_else(|| env::var(name).ok());
             components.push(format!("env:{name}={value:?}"));
         }
-        for file in self.input_files(node, settings)?.iter() {
+        let Some(files) = self.input_files(node, settings)? else { return Ok(None) };
+        for file in files.iter() {
             components.push(format!("file:{}={}", file.rel_path, file.hash));
         }
         for dependency_key in dependency_keys {
             components.push(format!("dep:{dependency_key}"));
         }
-        Ok(create_hex_hash(&components.join("\0")))
+        Ok(Some(create_hex_hash(&components.join("\0"))))
     }
 
     pub fn lookup(&self, key: &str) -> Option<StoredTask> {
@@ -376,8 +380,8 @@ impl TaskCache {
         &self,
         node: &TaskNode,
         settings: Option<&TaskSettings>,
-    ) -> miette::Result<Arc<Vec<HashedFile>>> {
-        let all = self.hashed_project_files(&node.project)?;
+    ) -> miette::Result<ProjectInputHashes> {
+        let Some(all) = self.hashed_project_files(&node.project)? else { return Ok(None) };
         let outputs = settings.and_then(|settings| settings.outputs.as_deref()).unwrap_or_default();
         let inputs = settings.and_then(|settings| settings.inputs.as_deref());
         let output_globs = compile_globs(outputs)?;
@@ -404,14 +408,14 @@ impl TaskCache {
             })
             .map(|file| HashedFile { rel_path: file.rel_path.clone(), hash: file.hash.clone() })
             .collect();
-        Ok(Arc::new(filtered))
+        Ok(Some(Arc::new(filtered)))
     }
 
-    fn hashed_project_files(&self, project: &Path) -> miette::Result<Arc<Vec<HashedFile>>> {
+    fn hashed_project_files(&self, project: &Path) -> miette::Result<ProjectInputHashes> {
         if let Some(files) =
             self.project_files.lock().expect("project-files lock is not poisoned").get(project)
         {
-            return Ok(Arc::clone(files));
+            return Ok(files.as_ref().map(Arc::clone));
         }
         let project_display = project.display();
         let output = Command::new("git")
@@ -443,6 +447,13 @@ impl TaskCache {
             let absolute = project.join(rel_path);
             let hash = match create_hex_hash_from_file(&absolute) {
                 Ok(hash) => hash,
+                Err(_) if is_gitlink(project, rel_path)? => {
+                    self.project_files
+                        .lock()
+                        .expect("project-files lock is not poisoned")
+                        .insert(project.to_path_buf(), None);
+                    return Ok(None);
+                }
                 Err(error)
                     if error.kind() == io::ErrorKind::NotFound
                         && fs::symlink_metadata(&absolute)
@@ -463,8 +474,8 @@ impl TaskCache {
         self.project_files
             .lock()
             .expect("project-files lock is not poisoned")
-            .insert(project.to_path_buf(), Arc::clone(&files));
-        Ok(files)
+            .insert(project.to_path_buf(), Some(Arc::clone(&files)));
+        Ok(Some(files))
     }
 }
 
@@ -534,3 +545,19 @@ fn compile_globs_owned(patterns: &[String]) -> miette::Result<Vec<Glob<'static>>
 
 #[cfg(test)]
 mod tests;
+
+fn is_gitlink(project: &Path, relative: &str) -> miette::Result<bool> {
+    let project_display = project.display();
+    let output = Command::new("git")
+        .args(["--literal-pathspecs", "ls-files", "--stage", "-z", "--", relative])
+        .current_dir(project)
+        .output()
+        .map_err(|error| {
+            miette::miette!("reading Git input metadata in {project_display}: {error}")
+        })?;
+    if !output.status.success() {
+        let error = String::from_utf8_lossy(&output.stderr);
+        return Err(miette::miette!("reading Git input metadata in {project_display}: {error}"));
+    }
+    Ok(output.stdout.split(|byte| *byte == 0).any(|entry| entry.starts_with(b"160000 ")))
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -418,7 +418,7 @@ impl TaskCache {
         {
             return Ok(files.as_ref().map(Arc::clone));
         }
-        if has_gitlinks(project)? {
+        if has_submodule_inputs(project)? {
             self.project_files
                 .lock()
                 .expect("project-files lock is not poisoned")
@@ -548,18 +548,24 @@ fn compile_globs_owned(patterns: &[String]) -> miette::Result<Vec<Glob<'static>>
 #[cfg(test)]
 mod tests;
 
-fn has_gitlinks(project: &Path) -> miette::Result<bool> {
+fn has_submodule_inputs(project: &Path) -> miette::Result<bool> {
+    let superproject =
+        git_input_metadata(project, &["rev-parse", "--show-superproject-working-tree"])?;
+    if superproject.iter().any(|byte| !byte.is_ascii_whitespace()) {
+        return Ok(true);
+    }
+    let index = git_input_metadata(project, &["ls-files", "--stage", "-z"])?;
+    Ok(index.split(|byte| *byte == 0).any(|entry| entry.starts_with(b"160000 ")))
+}
+
+fn git_input_metadata(project: &Path, args: &[&str]) -> miette::Result<Vec<u8>> {
     let project_display = project.display();
-    let output = Command::new("git")
-        .args(["ls-files", "--stage", "-z"])
-        .current_dir(project)
-        .output()
-        .map_err(|error| {
-            miette::miette!("reading Git input metadata in {project_display}: {error}")
-        })?;
+    let output = Command::new("git").args(args).current_dir(project).output().map_err(|error| {
+        miette::miette!("reading Git input metadata in {project_display}: {error}")
+    })?;
     if !output.status.success() {
         let error = String::from_utf8_lossy(&output.stderr);
         return Err(miette::miette!("reading Git input metadata in {project_display}: {error}"));
     }
-    Ok(output.stdout.split(|byte| *byte == 0).any(|entry| entry.starts_with(b"160000 ")))
+    Ok(output.stdout)
 }

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -176,7 +176,7 @@ fn hashing_inputs_preserves_deleted_tracked_files() {
     let (root, _repo, cache) = setup_input_cache();
     let project = root.path().join("inputs-src");
     fs::remove_file(project.join("input")).unwrap();
-    let files = cache.hashed_project_files(&project).unwrap();
+    let files = cache.hashed_project_files(&project).unwrap().unwrap();
     assert!(files.is_empty(), "deleted tracked input must be absent: {files:?}");
 }
 
@@ -195,13 +195,24 @@ fn hashing_inputs_reports_read_errors() {
     );
 }
 
-#[cfg(unix)]
 #[test]
 fn hashing_inputs_rejects_non_utf8_names() {
-    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
     let (root, _repo, cache) = setup_input_cache();
     let project = root.path().join("inputs-src");
-    fs::write(project.join(OsStr::from_bytes(b"invalid-\xff")), "source").unwrap();
+    let blob = assert_cmd::Command::new("git")
+        .current_dir(&project)
+        .args(["rev-parse", "HEAD:input"])
+        .assert()
+        .success();
+    let blob = String::from_utf8_lossy(&blob.get_output().stdout);
+    let mut record = format!("100644 {}\tinvalid-", blob.trim()).into_bytes();
+    record.extend_from_slice(b"\xff\0");
+    assert_cmd::Command::new("git")
+        .current_dir(&project)
+        .args(["update-index", "-z", "--index-info"])
+        .write_stdin(record)
+        .assert()
+        .success();
     let error = cache.hashed_project_files(&project).unwrap_err().to_string();
     assert!(error.contains("non-UTF-8") && error.contains("invalid-"), "{error}");
     assert!(error.contains(&project.display().to_string()), "{error}");
@@ -214,7 +225,7 @@ fn hashing_inputs_keeps_literal_backslashes_distinct_from_separators() {
     let project = root.path().join("inputs-src");
     repo.write_file("src/input", "nested source");
     fs::write(project.join(r"src\input"), "literal source").unwrap();
-    let files = cache.hashed_project_files(&project).unwrap();
+    let files = cache.hashed_project_files(&project).unwrap().unwrap();
     for relative in ["src/input", r"src\input"] {
         let file =
             files.iter().find(|file| file.rel_path == relative).expect("each filename is retained");

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -257,3 +257,35 @@ fn hashing_inputs_rejects_dangling_parent_symlinks() {
     let error = cache.hashed_project_files(&project).unwrap_err().to_string();
     assert!(error.contains("symlink") && error.contains("dir"), "{error}");
 }
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_valid_leaf_symlinks() {
+    let (root, _repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    let outside = root.path().join("outside-input");
+    fs::write(&outside, "external source").unwrap();
+    std::os::unix::fs::symlink(&outside, project.join("linked-input")).unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("symlink") && error.contains("linked-input"), "{error}");
+    assert!(cache.project_files.lock().unwrap().is_empty(), "unsafe inputs must not be cached");
+}
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_valid_parent_symlinks() {
+    let (root, repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    repo.write_file("dir/input", "source");
+    let _ = repo.commit("nested input");
+    repo.write_file(".gitignore", "dir\n");
+    fs::remove_file(project.join("dir/input")).unwrap();
+    fs::remove_dir(project.join("dir")).unwrap();
+    let outside = root.path().join("outside");
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("input"), "external source").unwrap();
+    std::os::unix::fs::symlink(&outside, project.join("dir")).unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("symlink") && error.contains("dir"), "{error}");
+    assert!(cache.project_files.lock().unwrap().is_empty(), "unsafe inputs must not be cached");
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -1,6 +1,7 @@
 use super::{RecordedFile, TaskCache, collect_output_files};
 #[cfg(unix)]
 use pnpm_crypto_hash::create_hex_hash_from_file;
+use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::fs;
 
 fn setup() -> (tempfile::TempDir, tempfile::TempDir, TaskCache) {
@@ -158,4 +159,75 @@ fn symlinked_project_roots_are_rejected() {
     let stored = cache.lookup("abcdef").unwrap();
     assert!(cache.restore(&stored, &link, "build").is_err());
     assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "built");
+}
+
+fn setup_input_cache() -> (tempfile::TempDir, GitRepoFixture, TaskCache) {
+    let root = tempfile::tempdir().unwrap();
+    let repo = GitRepoFixture::init(root.path(), "inputs");
+    repo.write_file("input", "source");
+    let _ = repo.commit("initial input");
+    let cache =
+        TaskCache::open(&root.path().join("cache"), &root.path().join("inputs-src")).unwrap();
+    (root, repo, cache)
+}
+
+#[test]
+fn hashing_inputs_preserves_deleted_tracked_files() {
+    let (root, _repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    fs::remove_file(project.join("input")).unwrap();
+    let files = cache.hashed_project_files(&project).unwrap();
+    assert!(files.is_empty(), "deleted tracked input must be absent: {files:?}");
+}
+
+#[test]
+fn hashing_inputs_reports_read_errors() {
+    let (root, _repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    fs::remove_file(project.join("input")).unwrap();
+    fs::create_dir(project.join("input")).unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("hashing cache input"), "{error}");
+    assert!(error.contains("input") && error.contains(&project.display().to_string()), "{error}");
+    assert!(
+        cache.project_files.lock().unwrap().is_empty(),
+        "failed enumeration must not be cached",
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_non_utf8_names() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
+    let (root, _repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    fs::write(project.join(OsStr::from_bytes(b"invalid-\xff")), "source").unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("non-UTF-8") && error.contains("invalid-"), "{error}");
+    assert!(error.contains(&project.display().to_string()), "{error}");
+}
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_keeps_literal_backslashes_distinct_from_separators() {
+    let (root, repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    repo.write_file("src/input", "nested source");
+    fs::write(project.join(r"src\input"), "literal source").unwrap();
+    let files = cache.hashed_project_files(&project).unwrap();
+    for relative in ["src/input", r"src\input"] {
+        let file =
+            files.iter().find(|file| file.rel_path == relative).expect("each filename is retained");
+        assert_eq!(file.hash, create_hex_hash_from_file(&project.join(relative)).unwrap());
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_dangling_symlinks() {
+    let (root, _repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    std::os::unix::fs::symlink("missing", project.join("linked-input")).unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("linked-input"), "{error}");
 }

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -242,3 +242,18 @@ fn hashing_inputs_rejects_dangling_symlinks() {
     let error = cache.hashed_project_files(&project).unwrap_err().to_string();
     assert!(error.contains("linked-input"), "{error}");
 }
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_dangling_parent_symlinks() {
+    let (root, repo, cache) = setup_input_cache();
+    let project = root.path().join("inputs-src");
+    repo.write_file("dir/input", "source");
+    let _ = repo.commit("nested input");
+    repo.write_file(".gitignore", "dir\n");
+    fs::remove_file(project.join("dir/input")).unwrap();
+    fs::remove_dir(project.join("dir")).unwrap();
+    std::os::unix::fs::symlink("missing", project.join("dir")).unwrap();
+    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
+    assert!(error.contains("symlink") && error.contains("dir"), "{error}");
+}

--- a/pnpm/crates/cli/src/cli_args/pipeline/report.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/report.rs
@@ -73,7 +73,7 @@ impl RunReport {
         })
     }
 
-    pub fn task_started(&self, task: &str, key: &str) {
+    pub fn task_started(&self, task: &str, key: Option<&str>) {
         self.push(json!({
             "event": "taskStarted",
             "task": task,
@@ -118,10 +118,10 @@ impl RunReport {
     pub fn finish(
         &self,
         statuses: &IndexMap<String, ExecutionStatus>,
-        task_keys: &HashMap<TaskKey, String>,
+        task_keys: &HashMap<TaskKey, Option<String>>,
         workspace_root: &Path,
     ) {
-        let keys: IndexMap<String, &String> =
+        let keys: IndexMap<String, &Option<String>> =
             task_keys.iter().map(|(task, key)| (format_task(task, workspace_root), key)).collect();
         *self.summary.lock().expect("summary lock is not poisoned") = json!({
             "runId": self.run_id,

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -193,6 +193,7 @@ fn submodule_projects_and_their_dependents_bypass_task_caching() {
         repo.write_file(&format!("packages/{name}/package.json"), &manifest.to_string());
     }
     repo.write_file("packages/independent/input", "independent");
+    repo.write_file("packages/producer/a-unreadable-input", "source");
     Command::new("git")
         .current_dir(&workspace)
         .args([
@@ -208,6 +209,8 @@ fn submodule_projects_and_their_dependents_bypass_task_caching() {
         .assert()
         .success();
     let _ = repo.commit("workspace with submodule");
+    fs::remove_file(workspace.join("packages/producer/a-unreadable-input")).unwrap();
+    fs::create_dir(workspace.join("packages/producer/a-unreadable-input")).unwrap();
     let command = || {
         let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
         command

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -165,3 +165,81 @@ fn dry_run_prints_the_graph_without_executing_workspace_code() {
         assert!(!project.path().join(path).exists(), "dry-run must not create {path}");
     }
 }
+
+#[test]
+fn submodule_projects_and_their_dependents_bypass_task_caching() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "workspace");
+    let module = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "module");
+    module.write_file("input", "one");
+    let _ = module.commit("initial submodule");
+    let workspace = root.path().join("workspace-src");
+    repo.write_file("package.json", r#"{"private":true}"#);
+    repo.write_file(".gitignore", "node_modules/\n**/out/\n**/runs\n");
+    repo.write_file("pnpm-workspace.yaml", "packages: ['packages/*']\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: ['^build']\n    outputs: ['out/**']\n");
+    for (name, input) in [
+        ("producer", "vendor/input"),
+        ("consumer", "../producer/out/result"),
+        ("independent", "input"),
+    ] {
+        let script = format!(
+            r#"node -e "const fs=require('fs');fs.mkdirSync('out',{{recursive:true}});fs.writeFileSync('out/result',fs.existsSync('{input}')?fs.readFileSync('{input}'):'absent');fs.appendFileSync('runs','x')""#,
+        );
+        let mut manifest =
+            serde_json::json!({"name":name,"version":"1.0.0","scripts":{"build":script}});
+        if name == "consumer" {
+            manifest["dependencies"] = serde_json::json!({"producer":"workspace:*"});
+        }
+        repo.write_file(&format!("packages/{name}/package.json"), &manifest.to_string());
+    }
+    repo.write_file("packages/independent/input", "independent");
+    Command::new("git")
+        .current_dir(&workspace)
+        .args([
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-b",
+            "main",
+            &module.file_url(),
+            "packages/producer/vendor",
+        ])
+        .assert()
+        .success();
+    let _ = repo.commit("workspace with submodule");
+    let command = || {
+        let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
+        command
+            .current_dir(&workspace)
+            .env("XDG_CACHE_HOME", root.path().join("cache"))
+            .env("XDG_CONFIG_HOME", root.path().join("config"));
+        command
+    };
+    command().arg("install").assert().success();
+    for (index, value) in ["one", "two", "two", "absent", "absent"].into_iter().enumerate() {
+        if index == 4 {
+            fs::remove_dir(workspace.join("packages/producer/vendor")).unwrap();
+        } else if value == "absent" {
+            Command::new("git")
+                .current_dir(&workspace)
+                .args(["submodule", "deinit", "-f", "--", "packages/producer/vendor"])
+                .assert()
+                .success();
+        } else {
+            fs::write(workspace.join("packages/producer/vendor/input"), value).unwrap();
+        }
+        command().args(["pipeline", "--full"]).assert().success();
+        for name in ["producer", "consumer"] {
+            assert_eq!(
+                fs::read_to_string(workspace.join(format!("packages/{name}/out/result"))).unwrap(),
+                value,
+            );
+            assert_eq!(
+                fs::read_to_string(workspace.join(format!("packages/{name}/runs"))).unwrap(),
+                "x".repeat(index + 1),
+            );
+        }
+        assert_eq!(fs::read_to_string(workspace.join("packages/independent/runs")).unwrap(), "x");
+    }
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -246,3 +246,62 @@ fn submodule_projects_and_their_dependents_bypass_task_caching() {
         assert_eq!(fs::read_to_string(workspace.join("packages/independent/runs")).unwrap(), "x");
     }
 }
+
+#[test]
+fn projects_rooted_in_submodules_bypass_task_caching() {
+    let root = tempfile::tempdir().unwrap();
+    let repo = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "workspace");
+    let module = pnpm_testing_utils::git_repo::GitRepoFixture::init(root.path(), "module");
+    let script = r#"node -e "const fs=require('fs');fs.mkdirSync('out',{recursive:true});fs.writeFileSync('out/result',fs.readFileSync('input'));fs.appendFileSync('runs','x')""#;
+    module.write_file(
+        "package.json",
+        &serde_json::json!({"name":"producer","version":"1.0.0","scripts":{"build":script}})
+            .to_string(),
+    );
+    module.write_file(".gitignore", "out/\nruns\nnode_modules/\n");
+    module.write_file("input", "one");
+    let _ = module.commit("initial submodule package");
+    repo.write_file("package.json", r#"{"private":true}"#);
+    repo.write_file(".gitignore", "node_modules/\n**/out/\n**/runs\n");
+    repo.write_file("pnpm-workspace.yaml", "packages: ['packages/*']\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: ['^build']\n    outputs: ['out/**']\n");
+    repo.write_file("packages/consumer/package.json", &serde_json::json!({"name":"consumer","version":"1.0.0","dependencies":{"producer":"workspace:*"},"scripts":{"build":script.replace("'input'", "'../producer/out/result'")}}).to_string());
+    let workspace = root.path().join("workspace-src");
+    Command::new("git")
+        .current_dir(&workspace)
+        .args([
+            "-c",
+            "protocol.file.allow=always",
+            "submodule",
+            "add",
+            "-b",
+            "main",
+            &module.file_url(),
+            "packages/producer",
+        ])
+        .assert()
+        .success();
+    let _ = repo.commit("workspace with submodule package");
+    let command = || {
+        let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
+        command
+            .current_dir(&workspace)
+            .env("XDG_CACHE_HOME", root.path().join("cache"))
+            .env("XDG_CONFIG_HOME", root.path().join("config"));
+        command
+    };
+    command().arg("install").assert().success();
+    for (index, value) in ["one", "one", "two", "two"].into_iter().enumerate() {
+        fs::write(workspace.join("packages/producer/input"), value).unwrap();
+        command().args(["pipeline", "--full"]).assert().success();
+        for name in ["producer", "consumer"] {
+            assert_eq!(
+                fs::read_to_string(workspace.join(format!("packages/{name}/out/result"))).unwrap(),
+                value,
+            );
+            assert_eq!(
+                fs::read_to_string(workspace.join(format!("packages/{name}/runs"))).unwrap(),
+                "x".repeat(index + 1),
+            );
+        }
+    }
+}

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -86,6 +86,11 @@ for this implementation.
 
 ## Pipeline execution and reporting
 
+Projects with Git submodule inputs and tasks depending on them bypass task
+and Cargo snapshot caching. Their scripts still run, including when the
+submodule contains local edits or has not been initialized. Their run reports
+record a null task key.
+
 Completed-task log capture is limited to 1 MiB per task. Tasks with larger logs
 still stream their output, but their completed result is not cached. Cargo tasks
 and tasks with caching disabled do not capture logs in memory.

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -86,7 +86,8 @@ for this implementation.
 
 ## Pipeline execution and reporting
 
-Projects with Git submodule inputs and tasks depending on them bypass task
+Projects inside Git submodules, projects with submodule inputs, and tasks
+depending on them bypass task
 and Cargo snapshot caching. Their scripts still run, including when the
 submodule contains local edits or has not been initialized. Their run reports
 record a null task key.

--- a/pnpm/scripts/pipeline-cargo-cache.md
+++ b/pnpm/scripts/pipeline-cargo-cache.md
@@ -91,6 +91,8 @@ and Cargo snapshot caching. Their scripts still run, including when the
 submodule contains local edits or has not been initialized. Their run reports
 record a null task key.
 
+Task input hashing rejects symlinks, including symlinked parent directories.
+
 Completed-task log capture is limited to 1 MiB per task. Tasks with larger logs
 still stream their output, but their completed result is not cached. Cargo tasks
 and tasks with caching disabled do not capture logs in memory.


### PR DESCRIPTION
## Summary

`pnpm pipeline` could reuse a task result after an input read failed: hashing silently omitted the file and produced a key from the remaining inputs. Invalid UTF-8 filenames were decoded lossily, and literal Unix backslashes were rewritten as directory separators.

Report these input errors before generating task keys, preserve literal filenames, and omit only paths confirmed absent from the working tree. Symlinks in the file or any parent directory are rejected before file contents are read, whether their target exists or is missing. Errors include the project and the relative input path.

Projects inside Git submodules and projects containing submodules bypass task and Cargo snapshot caching while their tasks still run. Enclosing-superproject and gitlink metadata are checked before hashing ordinary inputs, so bypass does not depend on their order. The bypass propagates to dependent tasks, including pass-through nodes, and is represented by null task keys in run reports. Independent tasks remain cacheable. We do not key submodule contents only by the pinned commit, which would miss local edits.

This addresses the first item of https://github.com/pnpm/pnpm/issues/14632 and follows https://github.com/pnpm/pnpm/pull/14233. Related input-enumeration work remains tracked in https://github.com/pnpm/pnpm/issues/14279. The affected pipeline cache exists only in Rust pnpm v12.

Validation: five input-hashing regressions cover read errors, non-UTF-8 names, literal backslashes, dangling symlinks, and deleted tracked files. Four failed against the previous implementation; all five pass with the fix. A real-submodule integration test checks clean and edited contents, repeated execution, deinitialized and removed submodule directories, an earlier-sorting unreadable file, dependent-task execution, and independent cache hits. Additional regressions reject valid external file and parent-directory symlinks before storing input hashes. A second integration regression covers a package rooted in a submodule and its dependent across repeated runs and local edits. All 41 pipeline tests pass. Full repository checks and strict Dylint passed with isolated developer configuration.

## Squash Commit Body

```text
Reject incomplete pipeline task-input enumeration before generating a cache
key. Preserve Git's path spelling and reject non-UTF-8 filenames instead of
hashing a lossy or separator-rewritten path.

Propagate file-read failures with the project and relative path. Only omit
NotFound inputs when symlink metadata confirms the input itself is absent;
a dangling symlink must not be treated as a deleted tracked file.

Recognize Git submodules before hashing and bypass both cache tiers for
their projects and dependent tasks. Keep independent tasks cacheable and
record a null key for bypassed tasks.

Add real-filesystem regressions for each case and preserve deletion behavior.
This affects the Rust-only pipeline cache.

Related to pnpm/pnpm#14632 and pnpm/pnpm#14279.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14635"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791328445&installation_model_id=426870&pr_number=14635&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14635&signature=ab1a843cddbe111e3bdb953a3caba7e0c1fd8cef3de8b353366b8f470cbd49df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm pipeline` now reports unreadable inputs and invalid filename encoding errors during task cache-key computation instead of silently ignoring them.
  * Missing files continue to be skipped when confirmed absent.
  * Unix filenames containing backslashes are hashed as literal paths, preserving their identity.
  * Symlinked inputs, including symlinked parent directories, are rejected during hashing.
  * Projects inside or containing Git submodules, and dependent tasks, bypass task and Cargo snapshot caching while still executing.
  * Run reports show a null task key when caching is bypassed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

