### PR TITLE
fix(config): let an .npmrc registry outrank the global _auth file's routes

### DIFF
--- a/.changeset/npmrc-registry-beats-auth-file.md
+++ b/.changeset/npmrc-registry-beats-auth-file.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-A `registry` or `@scope:registry` set in an `.npmrc` now keeps its place when the global `config.yaml` holds an `_auth` credential for another registry. Previously, after a `pnpm login` to one registry, installs in a project whose `.npmrc` pointed at a private registry went to the logged-in registry instead. The credential's inferred route now only fills in a registry that no config file declares [#14614](https://github.com/pnpm/pnpm/issues/14614).
+A `registry` or `@scope:registry` set in an `.npmrc` now wins over the registry a `pnpm login` credential stored in the global `config.yaml` points at. Previously, after logging in to one registry, installs in a project whose `.npmrc` named a private registry went to the logged-in registry instead. They now go to the registry the `.npmrc` names [#14614](https://github.com/pnpm/pnpm/issues/14614).

--- a/.changeset/npmrc-registry-beats-auth-file.md
+++ b/.changeset/npmrc-registry-beats-auth-file.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+A `registry` or `@scope:registry` set in an `.npmrc` now keeps its place when the global `config.yaml` holds an `_auth` credential for another registry. The credential's inferred route only fills in a registry that no config file declares. Previously, after a `pnpm login` to one registry, installs in a project whose `.npmrc` pointed at a private registry went to the logged-in registry instead [#14614](https://github.com/pnpm/pnpm/issues/14614).

--- a/.changeset/npmrc-registry-beats-auth-file.md
+++ b/.changeset/npmrc-registry-beats-auth-file.md
@@ -4,4 +4,4 @@
 "pacquet": patch
 ---
 
-A `registry` or `@scope:registry` set in an `.npmrc` now keeps its place when the global `config.yaml` holds an `_auth` credential for another registry. The credential's inferred route only fills in a registry that no config file declares. Previously, after a `pnpm login` to one registry, installs in a project whose `.npmrc` pointed at a private registry went to the logged-in registry instead [#14614](https://github.com/pnpm/pnpm/issues/14614).
+A `registry` or `@scope:registry` set in an `.npmrc` now keeps its place when the global `config.yaml` holds an `_auth` credential for another registry. Previously, after a `pnpm login` to one registry, installs in a project whose `.npmrc` pointed at a private registry went to the logged-in registry instead. The credential's inferred route now only fills in a registry that no config file declares [#14614](https://github.com/pnpm/pnpm/issues/14614).

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3565,7 +3565,10 @@ impl Config {
             global_settings.apply_proxy_to(&mut bootstrap.proxy, &mut bootstrap.proxy_keys);
         }
 
-        npmrc_auth.apply_registry_and_warn(&mut self);
+        // Collected as each file is applied, since applying it is what makes
+        // a declared route indistinguishable by value from a resolved one.
+        let mut declared_registries = crate::npmrc_auth::DeclaredRegistries::default();
+        npmrc_auth.apply_registry_and_warn(&mut self, &mut declared_registries);
         // Proxy cascade fires unconditionally — even when no `.npmrc`
         // is found — because the env-var fallback is a normalization step
         // on the resolved config, not a function of `.npmrc` presence.
@@ -3609,9 +3612,6 @@ impl Config {
         // resolution must fire only when the user has *not* pinned a
         // path. See [`crate::store_path::resolve_store_dir`].
         let mut store_dir_explicit = false;
-        // Collected as each file is applied, since applying it is what makes
-        // a declared route indistinguishable by value from a resolved one.
-        let mut declared_registries = crate::npmrc_auth::DeclaredRegistries::default();
         if let Some(mut global_settings) = global_settings {
             note_declared_registries(&mut declared_registries, &global_settings);
             virtual_store_dir_explicit |= global_settings.virtual_store_dir.is_some();
@@ -3983,10 +3983,12 @@ fn build_package_manager_bootstrap<Sys: EnvVar>(
     // drop the duplicates this second pass would log.
     trusted_auth.warnings.clear();
     let mut config = Config::default();
-    trusted_auth.apply_registry_and_warn(&mut config);
-    // No config file reaches the bootstrap cascade, so none declares here.
-    trusted_auth
-        .apply_json_env_registries(&mut config, &crate::npmrc_auth::DeclaredRegistries::default());
+    // The trusted `.npmrc` files are the only config files that reach the
+    // bootstrap cascade, so only what they declare holds the `_auth` file's
+    // routes back here.
+    let mut declared_registries = crate::npmrc_auth::DeclaredRegistries::default();
+    trusted_auth.apply_registry_and_warn(&mut config, &mut declared_registries);
+    trusted_auth.apply_json_env_registries(&mut config, &declared_registries);
     trusted_auth.apply_proxy_cascade::<Sys>(&mut config);
     trusted_auth.apply_tls_and_local_address(&mut config);
     trusted_auth.build_auth_headers(&mut config)?;

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -109,8 +109,8 @@ pub(crate) struct NpmrcAuth {
     /// The same routes inferred from the `_auth` of the global config
     /// **file**. That file is the user's own store rather than a mandate —
     /// it is where `pnpm login` puts a credential — so a `registry` or
-    /// `registries` a config file declares outranks these, and they fill in
-    /// only what nothing else declares. See
+    /// `registries` a config file declares, whether an `.npmrc` or a yaml,
+    /// outranks these, and they fill in only what nothing else declares. See
     /// [`Self::apply_json_env_registries`].
     pub json_file_registries: BTreeMap<String, String>,
     /// Raw INI config keys (those for which
@@ -568,11 +568,22 @@ impl NpmrcAuth {
     /// after every other config layer (notably `pnpm-workspace.yaml`)
     /// has had a chance to override `registry`, so default-registry
     /// creds end up keyed at the final URL.
-    pub fn apply_registry_and_warn(&mut self, config: &mut Config) {
+    ///
+    /// The `registry=` and `@scope:registry=` lines the `.npmrc` files
+    /// carried are recorded on `declared` as they are consumed, since
+    /// once written to `config` they are indistinguishable by value from
+    /// the builtin default.
+    pub fn apply_registry_and_warn(
+        &mut self,
+        config: &mut Config,
+        declared: &mut DeclaredRegistries,
+    ) {
         if let Some(registry) = self.registry.take() {
+            declared.registry = true;
             config.registry =
                 if registry.ends_with('/') { registry } else { format!("{registry}/") };
         }
+        declared.scopes.extend(self.scoped_registries.keys().cloned());
         config.registries_by_scope.append(&mut self.scoped_registries);
         for message in std::mem::take(&mut self.warnings) {
             tracing::warn!(target: "pacquet::npmrc", "{message}");
@@ -587,9 +598,8 @@ impl NpmrcAuth {
     /// The file-sourced routes fill in only what a config file has not
     /// declared, which `declared` names: provenance rather than value,
     /// because pinning the registry a lower layer already resolved to is
-    /// still a declaration. A route the `.npmrc` merely resolved is not one,
-    /// so those give way. The environment-sourced routes replace whatever
-    /// they find.
+    /// still a declaration, while the builtin default is not one. The
+    /// environment-sourced routes replace whatever they find.
     pub fn apply_json_env_registries(
         &mut self,
         config: &mut Config,
@@ -851,7 +861,7 @@ impl NpmrcAuth {
     #[cfg(test)]
     pub fn apply_to<Sys: EnvVar>(mut self, config: &mut Config) {
         self.rescope_unscoped("<.npmrc>");
-        self.apply_registry_and_warn(config);
+        self.apply_registry_and_warn(config, &mut DeclaredRegistries::default());
         self.apply_proxy_cascade::<Sys>(config);
         self.apply_tls_and_local_address(config);
         self.build_auth_headers(config).expect("valid credentials in test .npmrc");
@@ -1262,9 +1272,10 @@ fn apply_creds_field(creds: &mut RawCreds, field: &str, value: String) {
     }
 }
 
-/// What the config files declared about registry routing, as opposed to what
-/// the cascade merely resolved to. Collected before each layer is applied,
-/// because applying it is what makes the two indistinguishable by value.
+/// What the config files — the `.npmrc` files as much as the yamls —
+/// declared about registry routing, as opposed to what the cascade merely
+/// resolved to. Collected before each layer is applied, because applying it
+/// is what makes the two indistinguishable by value.
 #[derive(Debug, Default, Clone)]
 pub struct DeclaredRegistries {
     /// Whether any config file named the registry packages resolve from,

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -5,7 +5,7 @@ use pretty_assertions::assert_eq;
 
 use crate::{Config, workspace_yaml::LoadWorkspaceYamlError};
 
-use super::{EnvVar, NpmrcAuth, RawCreds, base64_decode, base64_encode};
+use super::{DeclaredRegistries, EnvVar, NpmrcAuth, RawCreds, base64_decode, base64_encode};
 
 /// Generate a per-test unit struct implementing [`EnvVar`] from a
 /// `&[(&str, &str)]` literal — saves each cascade test from spelling
@@ -652,7 +652,7 @@ fn apply_registry_and_warn_drains_warnings() {
     let mut auth = NpmrcAuth::from_ini::<NoEnv>(ini, Path::new(""));
     assert_eq!(auth.warnings.len(), 1);
     let mut config = Config::new();
-    auth.apply_registry_and_warn(&mut config);
+    auth.apply_registry_and_warn(&mut config, &mut DeclaredRegistries::default());
     assert!(auth.warnings.is_empty(), "warnings should be drained after flush");
 }
 

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4642,8 +4642,6 @@ pub fn a_registries_map_declaring_the_default_beats_the_global_auth_file() {
     assert_eq!(config.registry, "https://declared.example/");
 }
 
-/// Writing a global `config.yaml` whose `_auth` credits `registry` and the
-/// project `.npmrc` `npmrc`, then loading config from that project.
 fn load_with_auth_file_and_npmrc(auth_yaml: &str, npmrc: &str) -> Config {
     fake_env!(load_with_fake_env);
     let xdg = tempdir().expect("xdg tempdir");

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4642,28 +4642,75 @@ pub fn a_registries_map_declaring_the_default_beats_the_global_auth_file() {
     assert_eq!(config.registry, "https://declared.example/");
 }
 
-/// An `.npmrc` route is what the cascade resolved, not what a config file
-/// declared, so the stored credential's route outranks it — as it does in
-/// pnpm's `config.reader`.
+/// Writing a global `config.yaml` whose `_auth` credits `registry` and the
+/// project `.npmrc` `npmrc`, then loading config from that project.
+fn load_with_auth_file_and_npmrc(auth_yaml: &str, npmrc: &str) -> Config {
+    fake_env!(load_with_fake_env);
+    let xdg = tempdir().expect("xdg tempdir");
+    let config_dir = xdg.path().join("pnpm");
+    fs::create_dir_all(&config_dir).expect("create config dir");
+    fs::write(config_dir.join("config.yaml"), auth_yaml).expect("write global config.yaml");
+
+    let project = tempdir().expect("project tempdir");
+    fs::write(project.path().join(".npmrc"), npmrc).expect("write .npmrc");
+    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+
+    load_with_fake_env(project.path())
+}
+
+/// A `registry=` in the project's `.npmrc` declares where packages come from
+/// as plainly as a yaml does, so a credential stored for another registry
+/// must not redirect the install to it (pnpm/pnpm#14614).
 #[test]
-pub fn the_global_auth_file_outranks_an_npmrc_scope_route() {
+pub fn an_npmrc_registry_beats_the_global_auth_file() {
+    let config =
+        load_with_auth_file_and_npmrc(STORED_LOGIN, "registry=http://project-choice.example/\n");
+
+    assert_eq!(config.registry, "http://project-choice.example/");
+    // The credential still reaches the registry it was written for.
+    assert_eq!(
+        config.auth_tokens_by_uri.get("//private.example/").map(String::as_str),
+        Some("stored-token"),
+    );
+}
+
+#[test]
+pub fn an_npmrc_scope_route_beats_the_global_auth_file() {
+    let config =
+        load_with_auth_file_and_npmrc(STORED_LOGIN, "@org:registry=https://from-npmrc.example/\n");
+
+    assert_eq!(
+        config.registries_by_scope.get("@org").map(String::as_str),
+        Some("https://from-npmrc.example/"),
+    );
+    // The default registry is not declared, so the stored credential still routes it.
+    assert_eq!(config.registry, "https://private.example/");
+}
+
+/// The trusted `.npmrc` an `npmrcAuthFile` names reaches the bootstrap
+/// cascade, so its declared registry holds the stored credential's route
+/// back there too.
+#[test]
+pub fn an_npmrc_registry_beats_the_global_auth_file_in_the_bootstrap() {
     fake_env!(load_with_fake_env);
     let xdg = tempdir().expect("xdg tempdir");
     let config_dir = xdg.path().join("pnpm");
     fs::create_dir_all(&config_dir).expect("create config dir");
     fs::write(config_dir.join("config.yaml"), STORED_LOGIN).expect("write global config.yaml");
+    let auth = tempdir().expect("auth tempdir");
+    let auth_file = auth.path().join("custom-npmrc");
+    fs::write(&auth_file, "registry=https://user-choice.example/\n").expect("write auth file");
 
     let project = tempdir().expect("project tempdir");
-    fs::write(project.path().join(".npmrc"), "@org:registry=https://from-npmrc.example/\n")
-        .expect("write .npmrc");
-    set_fake_env(&[("XDG_CONFIG_HOME", xdg.path().to_str().unwrap())]);
+    set_fake_env(&[
+        ("XDG_CONFIG_HOME", xdg.path().to_str().unwrap()),
+        ("PNPM_CONFIG_NPMRC_AUTH_FILE", auth_file.to_str().unwrap()),
+    ]);
 
     let config = load_with_fake_env(project.path());
 
-    assert_eq!(
-        config.registries_by_scope.get("@org").map(String::as_str),
-        Some("https://private.example/"),
-    );
+    assert_eq!(config.registry, "https://user-choice.example/");
+    assert_eq!(config.package_manager_bootstrap.registry, "https://user-choice.example/");
 }
 
 /// The older `registries: { default: … }` spelling names the default

--- a/pnpm/crates/config/src/tests.rs
+++ b/pnpm/crates/config/src/tests.rs
@@ -4662,14 +4662,20 @@ fn load_with_auth_file_and_npmrc(auth_yaml: &str, npmrc: &str) -> Config {
 #[test]
 pub fn an_npmrc_registry_beats_the_global_auth_file() {
     let config =
-        load_with_auth_file_and_npmrc(STORED_LOGIN, "registry=http://project-choice.example/\n");
+        load_with_auth_file_and_npmrc(STORED_LOGIN, "registry=https://project-choice.example/\n");
 
-    assert_eq!(config.registry, "http://project-choice.example/");
-    // The credential still reaches the registry it was written for.
+    assert_eq!(config.registry, "https://project-choice.example/");
+    // The credential still reaches the registry it was written for, and
+    // does not follow the install to the one the `.npmrc` chose.
     assert_eq!(
         config.auth_tokens_by_uri.get("//private.example/").map(String::as_str),
         Some("stored-token"),
     );
+    assert_eq!(
+        config.auth_headers.for_url("https://private.example/is-positive").as_deref(),
+        Some("Bearer stored-token"),
+    );
+    assert_eq!(config.auth_headers.for_url("https://project-choice.example/is-positive"), None);
 }
 
 #[test]
@@ -4683,6 +4689,19 @@ pub fn an_npmrc_scope_route_beats_the_global_auth_file() {
     );
     // The default registry is not declared, so the stored credential still routes it.
     assert_eq!(config.registry, "https://private.example/");
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package("https://private.example/@org%2Fpkg", Some("@org/pkg"))
+            .as_deref(),
+        Some("Bearer stored-org-token"),
+    );
+    assert_eq!(
+        config
+            .auth_headers
+            .for_url_with_package("https://from-npmrc.example/@org%2Fpkg", Some("@org/pkg")),
+        None,
+    );
 }
 
 /// The trusted `.npmrc` an `npmrcAuthFile` names reaches the bootstrap
@@ -4709,6 +4728,12 @@ pub fn an_npmrc_registry_beats_the_global_auth_file_in_the_bootstrap() {
 
     assert_eq!(config.registry, "https://user-choice.example/");
     assert_eq!(config.package_manager_bootstrap.registry, "https://user-choice.example/");
+    let bootstrap_headers = &config.package_manager_bootstrap.auth_headers;
+    assert_eq!(
+        bootstrap_headers.for_url("https://private.example/@pnpm%2Fexe").as_deref(),
+        Some("Bearer stored-token"),
+    );
+    assert_eq!(bootstrap_headers.for_url("https://user-choice.example/@pnpm%2Fexe"), None);
 }
 
 /// The older `registries: { default: … }` spelling names the default

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -399,6 +399,9 @@ export async function getConfig (opts: {
     // reached only through a stored credential is reached the same way when
     // pnpm downloads itself as when it installs.
     ...npmrcResult.jsonAuth.fallbackRegistries,
+    // A `registry=` in a trusted `.npmrc` declares the default registry as
+    // plainly as a yaml does, so it holds the file fallback back here too.
+    ...npmrcResult.trustedDeclaredRegistries,
     ...trustedNetworkConfigs.registries,
     // `_auth` routes apply here too so bootstrap (self-download / version
     // switching) resolves the same way as regular installs.
@@ -587,7 +590,7 @@ export async function getConfig (opts: {
     }
   }
 
-  // Precedence: builtin < .npmrc < `_auth` file < yaml < `_auth` env < CLI. CLI
+  // Precedence: builtin < `_auth` file < .npmrc < yaml < `_auth` env < CLI. CLI
   // `--@scope:registry` / `--registry` already entered `registriesFromNpmrc`
   // via `authConfig`, so they're re-applied last here to avoid being buried
   // by yaml. `cliScopedRegistries` iterates raw `cliOptions` because
@@ -605,8 +608,11 @@ export async function getConfig (opts: {
     ...registriesFromNpmrc,
     // The global config file's `_auth` only fills in what nothing declares:
     // it is where a `pnpm login` stores a credential, and holding one is not
-    // a statement about where packages come from.
+    // a statement about where packages come from. `registriesFromNpmrc`
+    // carries the builtin default as well as what the `.npmrc` files
+    // declared, so only the latter are restated above the fallback.
     ...npmrcResult.jsonAuth.fallbackRegistries,
+    ...npmrcResult.declaredRegistries,
     ...globalYamlRegistries,
     ...workspaceManifestRegistries,
     ...declaredDefault,

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -31,6 +31,14 @@ export interface NpmrcConfigResult {
   warnings: string[]
   /** Parsed `_auth` (env var + global config yaml). See {@link JsonAuthResult}. */
   jsonAuth: JsonAuthResult
+  /**
+   * Scope→URL routes the `.npmrc` files declared through `registry=` and
+   * `@scope:registry=`, keyed like `registriesByScope`. The builtin defaults
+   * are not declarations, so they are absent.
+   */
+  declaredRegistries: Record<string, string>
+  /** The same routes from the non-project `.npmrc` files, for the package-manager bootstrap. */
+  trustedDeclaredRegistries: Record<string, string>
 }
 
 /**
@@ -47,8 +55,8 @@ export interface NpmrcConfigResult {
  *   Merged above workspace yaml but below CLI flags.
  * - `fallbackRegistries` — the same routes inferred from the `_auth` of
  *   the global config **file**. That file is the user's own store rather
- *   than a mandate, so an explicitly declared `registries` / `registry`
- *   outranks it and it only fills in what nothing else declares.
+ *   than a mandate, so a `registries` / `registry` declared in a yaml or
+ *   an `.npmrc` outranks it and it only fills in what nothing else declares.
  */
 export interface JsonAuthResult {
   auth: Record<string, string>
@@ -208,7 +216,27 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
     localPrefix,
     warnings,
     jsonAuth,
+    declaredRegistries: readDeclaredRegistries([userConfig, pnpmAuthConfig, workspaceNpmrc]),
+    trustedDeclaredRegistries: readDeclaredRegistries([userConfig, pnpmAuthConfig]),
   }
+}
+
+/**
+ * The scope→URL routes `sources` declare through `registry=` and
+ * `@scope:registry=`, a later source overriding an earlier one. Whether a
+ * registry was declared is a question about the key, not its value, so one
+ * pinned to the builtin default is declared too.
+ */
+function readDeclaredRegistries (sources: Array<Record<string, unknown>>): Record<string, string> {
+  const registries: Record<string, string> = {}
+  for (const source of sources) {
+    for (const [key, value] of Object.entries(source)) {
+      if (typeof value !== 'string' || !isRegistryKey(key)) continue
+      const scope = key === 'registry' ? 'default' : key.slice(0, -':registry'.length)
+      registries[scope] = normalizeRegistryUrl(value)
+    }
+  }
+  return registries
 }
 
 // Matches `npm_config_//…` and `pnpm_config_//…` env var names. The prefix is

--- a/pnpm11/config/reader/src/loadNpmrcFiles.ts
+++ b/pnpm11/config/reader/src/loadNpmrcFiles.ts
@@ -225,7 +225,8 @@ export function loadNpmrcConfig (opts: LoadNpmrcConfigOpts): NpmrcConfigResult {
  * The scope→URL routes `sources` declare through `registry=` and
  * `@scope:registry=`, a later source overriding an earlier one. Whether a
  * registry was declared is a question about the key, not its value, so one
- * pinned to the builtin default is declared too.
+ * pinned to the builtin default is declared too. A value that is not a
+ * string is not a route and is skipped.
  */
 function readDeclaredRegistries (sources: Array<Record<string, unknown>>): Record<string, string> {
   const registries: Record<string, string> = {}

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -2986,6 +2986,65 @@ test('a scope declared in pnpm-workspace.yaml beats the global _auth file', asyn
   expect(config.registriesByScope['@org']).toBe('https://project-choice.example/')
 })
 
+test('a registry declared in the project .npmrc beats the global _auth file', async () => {
+  prepareEmpty()
+
+  fs.writeFileSync('.npmrc', 'registry=http://project-choice.example/', 'utf8')
+
+  const { config } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://private.example': {
+        '@': { authToken: 'stored-token' },
+      },
+    },
+  })
+
+  expect(config.registry).toBe('http://project-choice.example/')
+  expect(config.registriesByScope.default).toBe('http://project-choice.example/')
+  // The credential still reaches the registry it was written for.
+  expect(config.authConfig['//private.example/:_authToken']).toBe('stored-token')
+})
+
+test('a scope declared in the project .npmrc beats the global _auth file', async () => {
+  prepareEmpty()
+
+  fs.writeFileSync('.npmrc', '@org:registry=https://from-npmrc.example/', 'utf8')
+
+  const { config } = await getConfigWithGlobalYaml({
+    _auth: {
+      'https://private.example': {
+        '@': { authToken: 'stored-token' },
+        '@org': { authToken: 'stored-org-token' },
+      },
+    },
+  })
+
+  expect(config.registriesByScope['@org']).toBe('https://from-npmrc.example/')
+  // Nothing declares the default registry, so the stored credential still routes it.
+  expect(config.registry).toBe('https://private.example/')
+})
+
+test('a registry declared in the user .npmrc beats the global _auth file in the package-manager registries', async () => {
+  prepareEmpty()
+
+  const userNpmrc = path.resolve('user-npmrc')
+  fs.writeFileSync(userNpmrc, 'registry=https://user-choice.example/', 'utf8')
+
+  const { config } = await getConfigWithGlobalYaml(
+    {
+      _auth: {
+        'https://private.example': {
+          '@': { authToken: 'stored-token' },
+        },
+      },
+    },
+    { cliOptions: { 'npmrc-auth-file': userNpmrc } }
+  )
+
+  expect(config.registry).toBe('https://user-choice.example/')
+  expect(config.packageManagerRegistries?.default).toBe('https://user-choice.example/')
+})
+
 test('a registry declared in the global config beats its own _auth file', async () => {
   prepareEmpty()
 


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14614.

A credential stored under `_auth` in the global `config.yaml` also infers a scope→registry route. Since pnpm/pnpm#14268 that route is meant to fill in only what no config file declares, but both readers counted only `pnpm-workspace.yaml` and `config.yaml` as declaring. A `registry=` or `@scope:registry=` in an `.npmrc` therefore gave way, and after a `pnpm login` to npmjs.org, installs in a project whose `.npmrc` named a private registry went to npmjs.org with the npmjs credential attached.

The fix is the same in both stacks: an `.npmrc` route is a declaration too.

```
CLI flags  >  _auth env  >  yaml  >  .npmrc  >  _auth file  >  builtin default
```

**pacquet.** `apply_registry_and_warn` now records the `registry=` and `@scope:registry=` lines it consumes on `DeclaredRegistries`, so the project cascade and the package-manager bootstrap cascade both hold the `_auth` file's routes back behind them. The test that pinned the old ordering (`the_global_auth_file_outranks_an_npmrc_scope_route`) is replaced by tests for the `.npmrc` `registry=`, `@scope:registry=`, and bootstrap cases.

**pnpm v11.** `loadNpmrcConfig` returns the routes the `.npmrc` files declared (`declaredRegistries`, and `trustedDeclaredRegistries` for the bootstrap) and `getConfig` restates them above the `_auth` file's fallback routes. `registriesFromNpmrc` could not serve for this because it also carries the builtin npmjs default, which is not a declaration.

Verified end to end with the issue's repro against a built pacquet: the install now fails trying to reach `http://127.0.0.1:9/`, the registry the project's `.npmrc` names, and `pnpm config get registry` prints it.

Not changed here: the `pnpr_install` suite tests the issue mentions still do not isolate `XDG_CONFIG_HOME`. They pass after this fix on a machine with an `_auth` block in the global config, because their `.npmrc` `registry=` now wins, but isolating the suite from the ambient global config is a separate hardening.

## Squash Commit Body

```text
A credential stored under `_auth` in the global config.yaml infers a
scope-to-registry route, and that route is meant to fill in only what no
config file declares. Both readers counted only `pnpm-workspace.yaml` and
config.yaml as declaring, so a `registry=` or `@scope:registry=` in an
`.npmrc` gave way and installs went to the logged-in registry instead.

pacquet records the `.npmrc` routes on `DeclaredRegistries` as
`apply_registry_and_warn` consumes them, for the project cascade and the
bootstrap cascade alike. The TypeScript reader returns the routes the
`.npmrc` files declared from `loadNpmrcConfig` and restates them above the
file's fallback routes, since `registriesFromNpmrc` also carries the builtin
default and cannot tell the two apart.

Closes https://github.com/pnpm/pnpm/issues/14614
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5-1).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14636"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791328553&installation_model_id=426870&pr_number=14636&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14636&signature=bd7a18d5ff8693e6e0de3ae3f125dc102279b7ceb93dab56976a0a6f276e3aa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `.npmrc` registry settings now take precedence over registry routing inferred from global authentication configuration.
  - Project, user, and trusted authentication `.npmrc` files correctly control default and scoped registry selection.
  - Authentication credentials continue to be routed to their configured registries when explicit registry settings are present.
  - Registry precedence is now consistent across standard configuration loading and package-manager bootstrap.

- **Documentation**
  - Clarified registry precedence and fallback behavior for authentication-based registry configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->