### PR TITLE
fix(cli): wrap the Dependents column of `outdated -r`

### DIFF
--- a/.changeset/outdated-recursive-dependents-column-wraps.md
+++ b/.changeset/outdated-recursive-dependents-column-wraps.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm outdated -r` now wraps the `Dependents` column at 30 columns. A dependency used by many workspace projects listed all of them on one line, which made the table hundreds of columns wide [#14591](https://github.com/pnpm/pnpm/issues/14591).

--- a/pnpm/crates/cli/src/cli_args/outdated.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated.rs
@@ -981,12 +981,20 @@ fn render_json(outdated: &[OutdatedPackage], long: bool) -> String {
         .expect("serialize outdated report to JSON")
 }
 
+/// A dependency shared by every project of a large workspace lists all of
+/// them in one `Dependents` cell, so that column is the only one that can
+/// push the table past any terminal. It wraps at this many columns instead.
+const DEPENDENTS_COLUMN_WIDTH: usize = 30;
+
 fn render_recursive_table(outdated: &[OutdatedInWorkspace], long: bool) -> String {
     if outdated.is_empty() {
         return String::new();
     }
     use tabled::builder::Builder;
-    use tabled::settings::Style;
+    use tabled::settings::object::Columns;
+    use tabled::settings::{Modify, Style, Width};
+
+    const DEPENDENTS_COLUMN: usize = 3;
 
     let mut header: Vec<String> = ["Package", "Current", "Latest", "Dependents"]
         .iter()
@@ -1011,6 +1019,10 @@ fn render_recursive_table(outdated: &[OutdatedInWorkspace], long: bool) -> Strin
     }
     let mut table = builder.build();
     table.with(Style::modern());
+    table.with(
+        Modify::new(Columns::one(DEPENDENTS_COLUMN))
+            .with(Width::wrap(DEPENDENTS_COLUMN_WIDTH).keep_words(true)),
+    );
     table.to_string()
 }
 

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,7 +1,7 @@
 use super::{
     Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
     classify, current_versions_from_importer, render_dependents, render_json, render_latest,
-    render_recursive_json, sort_outdated,
+    render_recursive_json, render_recursive_table, sort_outdated,
 };
 use node_semver::Version;
 use pnpm_lockfile::Lockfile;
@@ -257,6 +257,39 @@ fn dependent_names_are_sanitized_for_terminal_output() {
     };
 
     assert_eq!(render_dependents(&entry), "app[2J");
+}
+
+// Mirrors the `getCellWidth(data, 3, 30)` clamp of pnpm 11's recursive
+// renderer in `pnpm11/deps/inspection/commands/src/outdated/recursive.ts`.
+// A dependency shared by a dozen workspace projects lists all of them in one
+// cell, which sizes the `Dependents` column past any terminal unless the cell
+// wraps.
+#[test]
+fn recursive_table_wraps_the_dependents_column() {
+    let entry = OutdatedInWorkspace {
+        package: pkg("is-odd", "3.0.0", "3.0.1", DependencyGroup::Prod),
+        dependents: (1..=12)
+            .map(|index| DependentProject {
+                name: format!("example-workspace-package-{index:02}"),
+                location: PathBuf::from(format!("packages/pkg-{index:02}")),
+            })
+            .collect(),
+    };
+
+    let table = render_recursive_table(&[entry], false);
+    println!("{table}");
+    assert_borders_aligned(&table);
+
+    let width = border_columns(table.lines().next().expect("top border"))
+        .last()
+        .copied()
+        .expect("box-drawing borders")
+        + 1;
+    assert!(width <= 80, "the table must fit a normal terminal, got {width} columns");
+
+    let dependent_lines =
+        table.lines().filter(|line| line.contains("example-workspace-package-")).count();
+    assert!(dependent_lines > 1, "the dependents cell must wrap onto several lines");
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -291,14 +291,22 @@ fn recursive_table_wraps_the_dependents_column() {
     assert_borders_aligned(&table);
     assert_eq!(last_column_width(&table), DEPENDENTS_COLUMN_WIDTH);
 
-    let dependent_lines =
-        table.lines().filter(|line| line.contains("example-workspace-package-")).count();
-    assert!(dependent_lines > 1, "the dependents cell must wrap onto several lines");
+    let cells = last_column_cells(&table);
+    let (heading, wrapped) = cells.split_first().expect("a heading and one row");
+    assert_eq!(*heading, "Dependents");
+    assert!(wrapped.len() > 1, "the dependents cell must wrap onto several lines");
 
+    let rejoined = wrapped.concat();
     for index in 1..=12 {
         let name = format!("example-workspace-package-{index:02}");
-        assert!(table.contains(&name), "wrapping must not drop {name}");
+        assert!(rejoined.contains(&name), "wrapping must not drop {name}");
     }
+    assert!(rejoined.contains(long_name), "wrapping must not drop {long_name}");
+}
+
+/// Text of each row's rightmost cell, top to bottom, with padding trimmed.
+fn last_column_cells(table: &str) -> Vec<&str> {
+    table.lines().filter_map(|line| line.rsplit('│').nth(1)).map(str::trim).collect()
 }
 
 /// Content width of the table's rightmost column, excluding its border and

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -301,9 +301,8 @@ fn recursive_table_wraps_the_dependents_column() {
     }
 }
 
-/// Content width of the table's rightmost column: the span between the two
-/// rightmost boundaries of the top border, less the boundary itself and the
-/// column's one-space padding on each side.
+/// Content width of the table's rightmost column, excluding its border and
+/// padding.
 fn last_column_width(table: &str) -> usize {
     const PADDING: usize = 2;
     let borders = border_columns(table.lines().next().expect("top border"));

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -304,7 +304,6 @@ fn recursive_table_wraps_the_dependents_column() {
     assert!(rejoined.contains(long_name), "wrapping must not drop {long_name}");
 }
 
-/// Text of each row's rightmost cell, top to bottom, with padding trimmed.
 fn last_column_cells(table: &str) -> Vec<&str> {
     table.lines().filter_map(|line| line.rsplit('│').nth(1)).map(str::trim).collect()
 }

--- a/pnpm/crates/cli/src/cli_args/outdated/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/outdated/tests.rs
@@ -1,7 +1,8 @@
 use super::{
-    Change, DependentProject, OutdatedDependencyOptions, OutdatedInWorkspace, OutdatedPackage,
-    classify, current_versions_from_importer, render_dependents, render_json, render_latest,
-    render_recursive_json, render_recursive_table, sort_outdated,
+    Change, DEPENDENTS_COLUMN_WIDTH, DependentProject, OutdatedDependencyOptions,
+    OutdatedInWorkspace, OutdatedPackage, classify, current_versions_from_importer,
+    render_dependents, render_json, render_latest, render_recursive_json, render_recursive_table,
+    sort_outdated,
 };
 use node_semver::Version;
 use pnpm_lockfile::Lockfile;
@@ -266,6 +267,11 @@ fn dependent_names_are_sanitized_for_terminal_output() {
 // wraps.
 #[test]
 fn recursive_table_wraps_the_dependents_column() {
+    // The last dependent is one unbreakable name longer than the clamp, so the
+    // rendered column lands on exactly `DEPENDENTS_COLUMN_WIDTH` rather than on
+    // whatever width the shorter names happen to pack into.
+    let long_name = "example-workspace-package-with-a-name-past-the-clamp";
+    assert!(long_name.len() > DEPENDENTS_COLUMN_WIDTH);
     let entry = OutdatedInWorkspace {
         package: pkg("is-odd", "3.0.0", "3.0.1", DependencyGroup::Prod),
         dependents: (1..=12)
@@ -273,23 +279,38 @@ fn recursive_table_wraps_the_dependents_column() {
                 name: format!("example-workspace-package-{index:02}"),
                 location: PathBuf::from(format!("packages/pkg-{index:02}")),
             })
+            .chain([DependentProject {
+                name: long_name.to_string(),
+                location: PathBuf::from("packages/pkg-long"),
+            }])
             .collect(),
     };
 
     let table = render_recursive_table(&[entry], false);
     println!("{table}");
     assert_borders_aligned(&table);
-
-    let width = border_columns(table.lines().next().expect("top border"))
-        .last()
-        .copied()
-        .expect("box-drawing borders")
-        + 1;
-    assert!(width <= 80, "the table must fit a normal terminal, got {width} columns");
+    assert_eq!(last_column_width(&table), DEPENDENTS_COLUMN_WIDTH);
 
     let dependent_lines =
         table.lines().filter(|line| line.contains("example-workspace-package-")).count();
     assert!(dependent_lines > 1, "the dependents cell must wrap onto several lines");
+
+    for index in 1..=12 {
+        let name = format!("example-workspace-package-{index:02}");
+        assert!(table.contains(&name), "wrapping must not drop {name}");
+    }
+}
+
+/// Content width of the table's rightmost column: the span between the two
+/// rightmost boundaries of the top border, less the boundary itself and the
+/// column's one-space padding on each side.
+fn last_column_width(table: &str) -> usize {
+    const PADDING: usize = 2;
+    let borders = border_columns(table.lines().next().expect("top border"));
+    let [.., left, right] = borders[..] else {
+        panic!("expected at least two column boundaries in:\n{table}");
+    };
+    right - left - 1 - PADDING
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

`pnpm outdated -r` sized the `Dependents` column to its widest cell. A dependency
used by many workspace projects lists every one of them in a single cell, so the
table came out hundreds of columns wide and each row folded over several visual
lines with interleaved borders. In the reporter's 30-project monorepo the table
was 427 columns; the issue's 12-project repro produces 401.

pnpm 11 clamped that column to 30 columns and wrapped inside the cell
(`getCellWidth(data, 3, 30)` with `wrapWord: true` in
`pnpm11/deps/inspection/commands/src/outdated/recursive.ts`). This restores that
behavior in pnpm v12 by wrapping the `Dependents` column at word boundaries.

pnpm 11 is not affected, so there is no TypeScript change.

Output for the repro in the issue:

```
┌─────────┬─────────┬────────┬────────────────────────────────┐
│ Package │ Current │ Latest │ Dependents                     │
├─────────┼─────────┼────────┼────────────────────────────────┤
│ is-odd  │ 3.0.0   │ 3.0.1  │ example-workspace-package-01,  │
│         │         │        │ example-workspace-package-02,  │
│         │         │        │ example-workspace-package-03,  │
│         │         │        │ …                              │
└─────────┴─────────┴────────┴────────────────────────────────┘
```

Closes pnpm/pnpm#14591

## Squash Commit Body

```text
`pnpm outdated -r` sized the `Dependents` column to its widest cell. In a
workspace where one dependency is used by many projects, that cell lists
every project on one line, so the table came out hundreds of columns wide
and every row folded over several visual lines.

Clamp the column to 30 columns and wrap inside the cell at word
boundaries, matching pnpm 11's `getCellWidth(data, 3, 30)` in
`pnpm11/deps/inspection/commands/src/outdated/recursive.ts`.

`tabled`'s `Width::wrap` only shrinks a column, so a workspace whose
dependents fit under 30 columns still renders exactly as before. The
`ansi` feature is already enabled on `tabled`, so wrapping stays aware of
the SGR escapes the other columns emit. `--format list` and
`--format json` were never affected and are unchanged.

pnpm 11 already clamps this column, so this is a v12-only fix.

Closes pnpm/pnpm#14591
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14639"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791329780&installation_model_id=426870&pr_number=14639&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14639&signature=e019cea18b331e86eb4ea4df8ff0e201ceb41b26c7095f392376e10a5f89e7ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `pnpm outdated -r` table formatting by wrapping the `Dependents` column at 30 columns.
  * Prevented long dependent lists from making tables excessively wide.
  * Preserved complete dependent names, including long names, while wrapping entries across multiple lines.
  * Kept table borders aligned and content readable within typical terminal widths.
  * Improved readability for workspaces with dependencies used by many projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->