### PR TITLE
fix(cli): bring back `pnpm add --workspace`

### DIFF
--- a/.changeset/add-workspace-flag.md
+++ b/.changeset/add-workspace-flag.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm add --workspace` is supported again. It saves the named packages under the `workspace:` protocol and links them from the workspace, and it fails when no workspace project provides one of them [#14602](https://github.com/pnpm/pnpm/issues/14602).
+`pnpm add --workspace <pkg>` works again. It saves the package under the `workspace:` protocol and links it from the workspace. It fails when no workspace project provides the package. pnpm v12 had rejected the flag as an unknown argument [#14602](https://github.com/pnpm/pnpm/issues/14602).

--- a/.changeset/add-workspace-flag.md
+++ b/.changeset/add-workspace-flag.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm add --workspace` is supported again. It saves the named packages under the `workspace:` protocol and links them from the workspace, and it fails when no workspace project provides one of them [#14602](https://github.com/pnpm/pnpm/issues/14602).

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -100,6 +100,7 @@ pub mod view;
 pub mod whoami;
 pub mod why;
 pub mod with;
+mod workspace_option;
 
 pub(crate) mod cli_command;
 mod dispatch;

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -334,7 +334,12 @@ impl AddArgs {
         config_dependencies: Option<BTreeMap<String, String>>,
     ) -> miette::Result<()> {
         let workspace_packages = self.workspace_link_targets(state.config)?;
-        self.run_with_link_targets::<Reporter>(state, config_dependencies, workspace_packages).await
+        self.run_with_link_targets::<Reporter>(
+            state,
+            config_dependencies,
+            workspace_packages.as_ref(),
+        )
+        .await
     }
 
     /// [`Self::run`] with the `--workspace` link targets already indexed
@@ -344,7 +349,7 @@ impl AddArgs {
         self,
         state: State,
         config_dependencies: Option<BTreeMap<String, String>>,
-        workspace_packages: Option<WorkspacePackages>,
+        workspace_packages: Option<&WorkspacePackages>,
     ) -> miette::Result<()> {
         // `--config` routes to the configurational-dependency path
         // instead of the regular `package.json` add: resolve + install
@@ -391,7 +396,7 @@ impl AddArgs {
             pins.report::<Reporter>();
             return Ok(());
         }
-        let package_names = match &workspace_packages {
+        let package_names = match workspace_packages {
             Some(workspace_packages) => workspace_selectors(&pins.remaining, workspace_packages)?,
             None => pins.remaining.clone(),
         };

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -333,6 +333,19 @@ impl AddArgs {
         state: State,
         config_dependencies: Option<BTreeMap<String, String>>,
     ) -> miette::Result<()> {
+        let workspace_packages = self.workspace_link_targets(state.config)?;
+        self.run_with_link_targets::<Reporter>(state, config_dependencies, workspace_packages).await
+    }
+
+    /// [`Self::run`] with the `--workspace` link targets already indexed
+    /// (see [`Self::workspace_link_targets`]), so a plan that runs the add
+    /// once per project walks the workspace once.
+    pub(crate) async fn run_with_link_targets<Reporter: self::Reporter + 'static>(
+        self,
+        state: State,
+        config_dependencies: Option<BTreeMap<String, String>>,
+        workspace_packages: Option<WorkspacePackages>,
+    ) -> miette::Result<()> {
         // `--config` routes to the configurational-dependency path
         // instead of the regular `package.json` add: resolve + install
         // into `.pnpm-config`, then record the clean specifiers in
@@ -371,7 +384,6 @@ impl AddArgs {
             .or_else(|| self.save_catalog.then(|| "default".to_string()))
             .or_else(|| state.config.save_catalog_name.clone());
 
-        let workspace_packages = self.workspace_link_targets(state.config)?;
         let mut state = state;
         let pins = record_package_manager_pins(&mut state, &self.package_names).await?;
         if pins.remaining.is_empty() {
@@ -531,7 +543,10 @@ impl AddArgs {
     /// The workspace packages `--workspace` links the added dependencies
     /// to, indexed by name and version. `Ok(None)` means the flag was not
     /// passed.
-    fn workspace_link_targets(&self, config: &Config) -> miette::Result<Option<WorkspacePackages>> {
+    pub(crate) fn workspace_link_targets(
+        &self,
+        config: &Config,
+    ) -> miette::Result<Option<WorkspacePackages>> {
         workspace_link_root(self.workspace, config.workspace_dir.as_deref())?
             .map(|workspace_root| {
                 recursive::discover_workspace_projects(workspace_root, config).map(

--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -3,7 +3,8 @@ use crate::{
     cargo_manifest::CargoDependencyKind,
     cli_args::{
         install::resolve_bool_override, lockfile_dir::LockfileDirArg,
-        pipelines::InstallFamilySelection, supported_architectures::SupportedArchitecturesArgs,
+        pipelines::InstallFamilySelection, recursive,
+        supported_architectures::SupportedArchitecturesArgs, workspace_option::workspace_link_root,
     },
     config_deps,
     engine_pm::{
@@ -18,11 +19,12 @@ use clap::Args;
 use derive_more::{Display, Error};
 use miette::{Context, Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
-use pnpm_package_manager::{Add, parse_allow_build_selector};
+use pnpm_package_manager::{Add, build_workspace_packages_map, parse_allow_build_selector};
 use pnpm_package_manifest::DependencyGroup;
 use pnpm_registry::RangeSpecStyle;
 use pnpm_reporter::{LogEvent, LogLevel, PnpmLog, Reporter};
 use pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency;
+use pnpm_resolving_resolver_base::WorkspacePackages;
 use pnpm_workspace_manifest_writer::set_allow_builds;
 use std::{
     collections::BTreeMap,
@@ -202,6 +204,11 @@ pub struct AddArgs {
     /// Add the package as a configuration dependency.
     #[clap(long = "config")]
     pub config: bool,
+    /// Only add the dependency if a workspace project provides it. The
+    /// dependency is saved under the `workspace:` protocol and linked to
+    /// that project.
+    #[clap(long)]
+    pub workspace: bool,
     /// Package names allowed to run lifecycle (build) scripts during this
     /// install, appended to `allowBuilds`. Prefix a name with `!` to deny
     /// its scripts instead. May be repeated.
@@ -364,6 +371,7 @@ impl AddArgs {
             .or_else(|| self.save_catalog.then(|| "default".to_string()))
             .or_else(|| state.config.save_catalog_name.clone());
 
+        let workspace_packages = self.workspace_link_targets(state.config)?;
         let mut state = state;
         let pins = record_package_manager_pins(&mut state, &self.package_names).await?;
         if pins.remaining.is_empty() {
@@ -371,7 +379,10 @@ impl AddArgs {
             pins.report::<Reporter>();
             return Ok(());
         }
-        let package_names = pins.remaining.clone();
+        let package_names = match &workspace_packages {
+            Some(workspace_packages) => workspace_selectors(&pins.remaining, workspace_packages)?,
+            None => pins.remaining.clone(),
+        };
 
         let range_spec_style = self.range_spec_style(state.config);
         let dependency_options =
@@ -409,6 +420,14 @@ impl AddArgs {
         {
             return Err(AddError::PackageManagerInSelection { request: request.clone() }.into());
         }
+        let package_names =
+            match workspace_link_root(self.workspace, state.config.workspace_dir.as_deref())? {
+                Some(_) => workspace_selectors(
+                    &self.package_names,
+                    &build_workspace_packages_map(Some(&selection.projects)).unwrap_or_default(),
+                )?,
+                None => self.package_names.clone(),
+            };
         let supported_architectures =
             self.supported_architectures.apply_to(state.config.supported_architectures.clone());
         let save_catalog_name = self
@@ -447,7 +466,7 @@ impl AddArgs {
             lockfile,
             lockfile_path: Some(&lockfile_path),
             dependency_groups,
-            package_names: &self.package_names,
+            package_names: &package_names,
             range_spec_style,
             save_catalog_name,
             resolved_packages,
@@ -484,6 +503,7 @@ impl AddArgs {
                 "`pnpm add --lockfile-only` cannot be combined with --global."
             ));
         }
+        workspace_link_root(self.workspace, None)?;
         let supported_architectures =
             self.supported_architectures.apply_to(config.supported_architectures.clone());
         let range_spec_style = self.range_spec_style(config);
@@ -507,6 +527,51 @@ impl AddArgs {
             self.save_prefix.as_deref().or(config.save_prefix.as_deref()),
         )
     }
+
+    /// The workspace packages `--workspace` links the added dependencies
+    /// to, indexed by name and version. `Ok(None)` means the flag was not
+    /// passed.
+    fn workspace_link_targets(&self, config: &Config) -> miette::Result<Option<WorkspacePackages>> {
+        workspace_link_root(self.workspace, config.workspace_dir.as_deref())?
+            .map(|workspace_root| {
+                recursive::discover_workspace_projects(workspace_root, config).map(
+                    |(projects, _)| {
+                        build_workspace_packages_map(Some(&projects)).unwrap_or_default()
+                    },
+                )
+            })
+            .transpose()
+    }
+}
+
+/// The `workspace:` requests `--workspace` resolves in place of the
+/// selectors the user typed: `foo` becomes `foo@workspace:*`, `foo@^1`
+/// becomes `foo@workspace:^1`, and an explicit `workspace:` range is kept.
+///
+/// `--workspace` asks to link packages the workspace has, so a selector
+/// naming one it does not have is an error rather than a registry
+/// fallback.
+fn workspace_selectors(
+    selectors: &[String],
+    workspace_packages: &WorkspacePackages,
+) -> Result<Vec<String>, AddError> {
+    selectors
+        .iter()
+        .map(|selector| {
+            let parsed = parse_wanted_dependency(selector);
+            let Some(name) = parsed.alias else {
+                return Err(AddError::NoPkgNameInSpec { selector: selector.clone() });
+            };
+            if !workspace_packages.contains_key(&name) {
+                return Err(AddError::WorkspacePackageNotFound { name });
+            }
+            Ok(match parsed.bare_specifier {
+                None => format!("{name}@workspace:*"),
+                Some(range) if range.starts_with("workspace:") => selector.clone(),
+                Some(range) => format!("{name}@workspace:{range}"),
+            })
+        })
+        .collect()
 }
 
 /// Honor `--allow-build`: reject any package the root project explicitly
@@ -573,6 +638,24 @@ pub enum AddError {
     PackageManagerInSelection {
         #[error(not(source))]
         request: String,
+    },
+
+    /// A `--workspace` selector named a package that no workspace project
+    /// publishes.
+    #[display(r#""{name}" not found in the workspace"#)]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND))]
+    WorkspacePackageNotFound {
+        #[error(not(source))]
+        name: String,
+    },
+
+    /// A `--workspace` selector carried no package name to look up in the
+    /// workspace, such as a bare path or URL.
+    #[display(r#"Cannot update/install from workspace through "{selector}""#)]
+    #[diagnostic(code(ERR_PNPM_NO_PKG_NAME_IN_SPEC))]
+    NoPkgNameInSpec {
+        #[error(not(source))]
+        selector: String,
     },
 }
 

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -245,6 +245,6 @@ fn workspace_selectors_reject_a_selector_without_a_package_name() {
 
     assert!(
         matches!(&err, AddError::NoPkgNameInSpec { selector } if selector == "./local-dir"),
-        "{err}"
+        "{err}",
     );
 }

--- a/pnpm/crates/cli/src/cli_args/add/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/add/tests.rs
@@ -1,4 +1,4 @@
-use super::{AddDependencyOptions, apply_allow_build};
+use super::{AddDependencyOptions, AddError, apply_allow_build, workspace_selectors};
 use crate::cargo_manifest::CargoDependencyKind;
 use pnpm_config::Config;
 use pnpm_package_manifest::DependencyGroup;
@@ -210,4 +210,41 @@ fn save_build_rejects_mixed_packages_and_conflicting_cargo_targets() {
     ] {
         assert!(options.cargo_dependency_kind(false).is_err());
     }
+}
+
+fn workspace_packages(names: &[&str]) -> pnpm_resolving_resolver_base::WorkspacePackages {
+    names.iter().map(|name| (name.to_string(), std::collections::BTreeMap::default())).collect()
+}
+
+#[test]
+fn workspace_selectors_request_the_workspace_copy_of_each_package() {
+    let packages = workspace_packages(&["foo", "@scope/bar", "baz"]);
+    let selectors = ["foo", "@scope/bar@^1.0.0", "baz@workspace:~"].map(str::to_string);
+
+    let rewritten = workspace_selectors(&selectors, &packages).expect("every selector rewrites");
+
+    assert_eq!(rewritten, ["foo@workspace:*", "@scope/bar@workspace:^1.0.0", "baz@workspace:~"]);
+}
+
+#[test]
+fn workspace_selectors_reject_a_package_outside_the_workspace() {
+    let packages = workspace_packages(&["foo"]);
+
+    let err = workspace_selectors(&["foo".to_string(), "bar@1".to_string()], &packages)
+        .expect_err("bar is not in the workspace");
+
+    assert!(matches!(&err, AddError::WorkspacePackageNotFound { name } if name == "bar"), "{err}");
+}
+
+#[test]
+fn workspace_selectors_reject_a_selector_without_a_package_name() {
+    let packages = workspace_packages(&["foo"]);
+
+    let err = workspace_selectors(&["./local-dir".to_string()], &packages)
+        .expect_err("a path carries no package name");
+
+    assert!(
+        matches!(&err, AddError::NoPkgNameInSpec { selector } if selector == "./local-dir"),
+        "{err}"
+    );
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -30,6 +30,7 @@ use super::{
     unlink::UnlinkArgs,
     update::UpdateArgs,
     update_notifier,
+    workspace_option::workspace_link_root,
 };
 use crate::{State, package_specifier::PackageSpecifierPlan};
 use miette::Context;
@@ -42,6 +43,15 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     let package_specifier_plan = PackageSpecifierPlan::parse(&args.package_names)?;
     if args.dependency_options.save_build() && !package_specifier_plan.has_cargo() {
         return Err(miette::miette!("--save-build requires at least one crate: dependency"));
+    }
+    if args.workspace && (package_specifier_plan.has_cargo() || package_specifier_plan.has_python())
+    {
+        return Err(miette::miette!(
+            "--workspace cannot be combined with crate: or pypi: dependencies"
+        ));
+    }
+    if args.workspace && args.config {
+        return Err(miette::miette!("`pnpm add --config` cannot be combined with --workspace."));
     }
     if args.global {
         if package_specifier_plan.has_cargo() {
@@ -83,6 +93,9 @@ pub(super) fn add<'a>(ctx: &RunCtx<'a>, args: AddArgs) -> miette::Result<Command
     let config = ctx.config;
     Ok(Box::pin(async move {
         let cfg = config()?;
+        // Before `apply_allow_build` persists anything: a `--workspace` add
+        // that cannot run must leave `pnpm-workspace.yaml` untouched.
+        workspace_link_root(args.workspace, cfg.workspace_dir.as_deref())?;
         let recursive_sort = cfg.sort;
         if config_dependencies.is_none() {
             args.check_workspace_root(cfg, dir)?;

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -608,13 +608,20 @@ impl AddPipeline {
             InstallFamilyPlan::PerProject(project_dependencies) => {
                 // Dedicated per-project lockfiles: add the packages to each
                 // selected project independently.
+                let workspace_packages = args.workspace_link_targets(cfg)?;
                 DedicatedProjectRuns {
                     config: cfg,
                     project_dependencies,
                     require_lockfile: false,
                     http_client: None,
                 }
-                .run(|state| Box::pin(args.clone().run::<Reporter>(state, None)))
+                .run(|state| {
+                    Box::pin(args.clone().run_with_link_targets::<Reporter>(
+                        state,
+                        None,
+                        workspace_packages.clone(),
+                    ))
+                })
                 .await
             }
             InstallFamilyPlan::Shared(selection) => {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -619,7 +619,7 @@ impl AddPipeline {
                     Box::pin(args.clone().run_with_link_targets::<Reporter>(
                         state,
                         None,
-                        workspace_packages.clone(),
+                        workspace_packages.as_ref(),
                     ))
                 })
                 .await

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -7,6 +7,7 @@ use crate::{
         recursive,
         supported_architectures::SupportedArchitecturesArgs,
         update_interactive::{InteractiveUpdateOptions, UpdatePrompt},
+        workspace_option::{WorkspaceOptionError, workspace_link_root},
     },
     github_actions,
 };
@@ -163,20 +164,6 @@ pub struct UpdateArgs {
 
     #[clap(skip)]
     pub(crate) prompt: UpdatePrompt,
-}
-
-/// The option combinations `--workspace` rejects, checked before any
-/// resolution happens on every dispatch path — plain, selected, and
-/// global (whose global directory is never a workspace).
-#[derive(Debug, Display, Error, Diagnostic)]
-enum WorkspaceUpdateError {
-    #[display("Cannot use --latest with --workspace simultaneously")]
-    #[diagnostic(code(ERR_PNPM_BAD_OPTIONS))]
-    LatestWithWorkspace,
-
-    #[display("--workspace can only be used inside a workspace")]
-    #[diagnostic(code(ERR_PNPM_WORKSPACE_OPTION_OUTSIDE_WORKSPACE))]
-    OutsideWorkspace,
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]
@@ -515,13 +502,10 @@ impl UpdateArgs {
         &self,
         workspace_root: Option<&'root Path>,
     ) -> miette::Result<Option<&'root Path>> {
-        if !self.workspace {
-            return Ok(None);
+        if self.workspace && self.latest {
+            return Err(WorkspaceOptionError::LatestWithWorkspace.into());
         }
-        if self.latest {
-            return Err(WorkspaceUpdateError::LatestWithWorkspace.into());
-        }
-        workspace_root.ok_or_else(|| WorkspaceUpdateError::OutsideWorkspace.into()).map(Some)
+        workspace_link_root(self.workspace, workspace_root)
     }
 
     fn check_patches_options(&self) -> miette::Result<()> {

--- a/pnpm/crates/cli/src/cli_args/workspace_option.rs
+++ b/pnpm/crates/cli/src/cli_args/workspace_option.rs
@@ -1,14 +1,9 @@
-//! The `--workspace` flag `pnpm add` and `pnpm update` share: both link
-//! the named dependencies to their workspace copies, so both reject the
-//! same invocations.
+//! The `--workspace` flag shared by `pnpm add` and `pnpm update`.
 
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::path::Path;
 
-/// The invocations `--workspace` rejects, checked before any resolution
-/// happens on every dispatch path — plain, selected, and global (whose
-/// global directory is never a workspace).
 #[derive(Debug, Display, Error, Diagnostic)]
 pub(crate) enum WorkspaceOptionError {
     #[display("Cannot use --latest with --workspace simultaneously")]
@@ -20,8 +15,8 @@ pub(crate) enum WorkspaceOptionError {
     OutsideWorkspace,
 }
 
-/// The workspace root a `--workspace` run reads its link targets from.
-/// `Ok(None)` means the flag was not passed.
+/// The workspace root `--workspace` links from; `Ok(None)` when the flag
+/// was not passed.
 pub(crate) fn workspace_link_root(
     requested: bool,
     workspace_root: Option<&Path>,

--- a/pnpm/crates/cli/src/cli_args/workspace_option.rs
+++ b/pnpm/crates/cli/src/cli_args/workspace_option.rs
@@ -1,0 +1,33 @@
+//! The `--workspace` flag `pnpm add` and `pnpm update` share: both link
+//! the named dependencies to their workspace copies, so both reject the
+//! same invocations.
+
+use derive_more::{Display, Error};
+use miette::Diagnostic;
+use std::path::Path;
+
+/// The invocations `--workspace` rejects, checked before any resolution
+/// happens on every dispatch path — plain, selected, and global (whose
+/// global directory is never a workspace).
+#[derive(Debug, Display, Error, Diagnostic)]
+pub(crate) enum WorkspaceOptionError {
+    #[display("Cannot use --latest with --workspace simultaneously")]
+    #[diagnostic(code(ERR_PNPM_BAD_OPTIONS))]
+    LatestWithWorkspace,
+
+    #[display("--workspace can only be used inside a workspace")]
+    #[diagnostic(code(ERR_PNPM_WORKSPACE_OPTION_OUTSIDE_WORKSPACE))]
+    OutsideWorkspace,
+}
+
+/// The workspace root a `--workspace` run reads its link targets from.
+/// `Ok(None)` means the flag was not passed.
+pub(crate) fn workspace_link_root(
+    requested: bool,
+    workspace_root: Option<&Path>,
+) -> miette::Result<Option<&Path>> {
+    if !requested {
+        return Ok(None);
+    }
+    workspace_root.ok_or_else(|| WorkspaceOptionError::OutsideWorkspace.into()).map(Some)
+}

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1967,29 +1967,42 @@ mod workspace_flag {
         drop(root);
     }
 
-    /// A recursive add rewrites the selectors once and saves them into
-    /// every selected project.
+    /// A recursive add saves the rewritten selectors into every selected
+    /// project, whether the workspace shares one lockfile or each project
+    /// keeps its own.
     #[test]
     fn links_the_workspace_package_into_every_recursively_selected_project() {
-        let (root, app_dir) = workspace("");
-        let workspace_dir = app_dir.parent().and_then(Path::parent).expect("workspace root");
-        let second_app_dir = workspace_dir.join("packages/app2");
-        std::fs::create_dir_all(&second_app_dir).expect("create second app dir");
-        write_json(
-            &second_app_dir.join("package.json"),
-            &serde_json::json!({ "name": "ws-app-2", "version": "1.0.0" }),
-        );
+        for shared_workspace_lockfile in [true, false] {
+            let (root, app_dir) =
+                workspace(&format!("sharedWorkspaceLockfile: {shared_workspace_lockfile}\n"));
+            let workspace_dir = app_dir.parent().and_then(Path::parent).expect("workspace root");
+            let second_app_dir = workspace_dir.join("packages/app2");
+            std::fs::create_dir_all(&second_app_dir).expect("create second app dir");
+            write_json(
+                &second_app_dir.join("package.json"),
+                &serde_json::json!({ "name": "ws-app-2", "version": "1.0.0" }),
+            );
 
-        Command::cargo_bin("pnpm")
-            .expect("find the pnpm binary")
-            .with_current_dir(workspace_dir)
-            .with_args(["-r", "--filter", "ws-app*", "add", "--workspace", LIB, "--lockfile-only"])
-            .assert()
-            .success();
+            Command::cargo_bin("pnpm")
+                .expect("find the pnpm binary")
+                .with_current_dir(workspace_dir)
+                .with_args([
+                    "-r",
+                    "--filter",
+                    "ws-app*",
+                    "add",
+                    "--workspace",
+                    LIB,
+                    "--lockfile-only",
+                ])
+                .assert()
+                .success();
 
-        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:*"));
-        assert_eq!(saved_spec(&second_app_dir, LIB).as_deref(), Some("workspace:*"));
-        drop(root);
+            eprintln!("sharedWorkspaceLockfile={shared_workspace_lockfile}");
+            assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:*"));
+            assert_eq!(saved_spec(&second_app_dir, LIB).as_deref(), Some("workspace:*"));
+            drop(root);
+        }
     }
 
     #[test]

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1872,9 +1872,6 @@ mod aliasless_selectors {
     }
 }
 
-/// `pnpm add --workspace`: the added packages are linked from the
-/// workspace instead of resolved from the registry.
-///
 /// Covers <https://github.com/pnpm/pnpm/issues/14602>.
 mod workspace_flag {
     use super::{Path, PathBuf, TempDir, saved_spec, workspace_with_lib, write_json};
@@ -1986,6 +1983,35 @@ mod workspace_flag {
         drop(root);
     }
 
+    /// Rejected before the add touches anything, so `--allow-build`
+    /// is not persisted to `pnpm-workspace.yaml` by a run that fails.
+    #[test]
+    fn is_rejected_with_config_dependencies_and_ecosystem_selectors() {
+        let (root, app_dir) = workspace("");
+        let workspace_dir = app_dir.parent().and_then(Path::parent).expect("workspace root");
+        let yaml_path = workspace_dir.join("pnpm-workspace.yaml");
+        let yaml_before = std::fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+
+        assert_add_fails(
+            &app_dir,
+            &["--workspace", "--config", LIB, "--allow-build", "esbuild"],
+            "cannot be combined with --workspace",
+        );
+        assert_add_fails(
+            &app_dir,
+            &["--workspace", "crate:serde", "--allow-build", "esbuild"],
+            "--workspace cannot be combined with crate: or pypi: dependencies",
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&yaml_path).expect("reread pnpm-workspace.yaml"),
+            yaml_before,
+        );
+        drop(root);
+    }
+
+    /// Rejected before `--allow-build` is persisted, like the other
+    /// `--workspace` invocations that cannot run.
     #[test]
     fn is_rejected_outside_a_workspace() {
         let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
@@ -1996,10 +2022,14 @@ mod workspace_flag {
 
         assert_add_fails(
             &workspace,
-            &["--workspace", LIB],
+            &["--workspace", LIB, "--allow-build", "esbuild"],
             "--workspace can only be used inside a workspace",
         );
 
+        assert!(
+            !workspace.join("pnpm-workspace.yaml").exists(),
+            "a rejected add must not persist --allow-build",
+        );
         drop(root);
     }
 }

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1540,8 +1540,11 @@ fn a_bare_workspace_add_uses_the_local_package_and_saved_protocol_setting() {
     for (setting, expected) in
         [(None, "workspace:^"), (Some("true"), "workspace:^1.2.3"), (Some("false"), "^1.2.3")]
     {
-        let (root, app_dir) =
-            workspace_with_lib(setting, &[(LIB, "1.2.3")], "packages/app/package.json");
+        let (root, app_dir) = workspace_with_lib(
+            &linking_settings(setting),
+            &[(LIB, "1.2.3")],
+            "packages/app/package.json",
+        );
         add_in(&app_dir, LIB);
 
         assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some(expected));
@@ -1562,8 +1565,11 @@ fn an_aliased_workspace_add_keeps_naming_its_target() {
         (None, "workspace:@pnpm.e2e/ws-target@^"),
         (Some("true"), "workspace:@pnpm.e2e/ws-target@^1.2.3"),
     ] {
-        let (root, app_dir) =
-            workspace_with_lib(setting, &[(TARGET, "1.2.3")], "packages/app/package.json");
+        let (root, app_dir) = workspace_with_lib(
+            &linking_settings(setting),
+            &[(TARGET, "1.2.3")],
+            "packages/app/package.json",
+        );
         add_in(&app_dir, &format!("myalias@workspace:{TARGET}@^1.0.0"));
 
         assert_eq!(saved_spec(&app_dir, "myalias").as_deref(), Some(expected));
@@ -1580,7 +1586,7 @@ fn an_aliased_workspace_add_keeps_naming_its_target() {
 fn the_pinned_form_picks_the_highest_workspace_version_by_semver() {
     const LIB: &str = "@pnpm.e2e/ws-multi";
     let (root, app_dir) = workspace_with_lib(
-        Some("true"),
+        &linking_settings(Some("true")),
         &[(LIB, "9.0.0"), (LIB, "10.0.0")],
         "packages/app/package.json",
     );
@@ -1599,8 +1605,11 @@ fn the_env_var_drives_the_saved_workspace_range() {
     for (value, expected) in
         [("true", "workspace:^1.2.3"), ("rolling", "workspace:^"), ("false", "workspace:^1.2.3")]
     {
-        let (root, app_dir) =
-            workspace_with_lib(None, &[(LIB, "1.2.3")], "packages/app/package.json");
+        let (root, app_dir) = workspace_with_lib(
+            &linking_settings(None),
+            &[(LIB, "1.2.3")],
+            "packages/app/package.json",
+        );
         Command::cargo_bin("pnpm")
             .expect("find the pnpm binary")
             .with_current_dir(&app_dir)
@@ -1615,21 +1624,28 @@ fn the_env_var_drives_the_saved_workspace_range() {
     }
 }
 
+/// The `pnpm-workspace.yaml` settings for a linking workspace:
+/// `linkWorkspacePackages: true` plus the given `saveWorkspaceProtocol`.
+fn linking_settings(save_workspace_protocol: Option<&str>) -> String {
+    let protocol_line = save_workspace_protocol
+        .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
+        .unwrap_or_default();
+    format!("linkWorkspacePackages: true\n{protocol_line}")
+}
+
 /// Scaffold a workspace whose `packages/*` hold `libs` (one directory
 /// per entry, so the same name may appear at several versions) plus an
-/// `app` member. Returns the temp root and the app's directory.
+/// `app` member, with `settings` appended to its `pnpm-workspace.yaml`.
+/// Returns the temp root and the app's directory.
 fn workspace_with_lib(
-    save_workspace_protocol: Option<&str>,
+    settings: &str,
     libs: &[(&str, &str)],
     app_manifest_path: &str,
 ) -> (TempDir, PathBuf) {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
-    let protocol_line = save_workspace_protocol
-        .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))
-        .unwrap_or_default();
     std::fs::write(
         workspace.join("pnpm-workspace.yaml"),
-        format!("{HERMETIC_STORE_YAML}packages:\n  - packages/*\nlinkWorkspacePackages: true\n{protocol_line}"),
+        format!("{HERMETIC_STORE_YAML}packages:\n  - packages/*\n{settings}"),
     )
     .expect("write workspace yaml");
     write_json(&workspace.join("package.json"), &serde_json::json!({ "name": "root" }));
@@ -1853,5 +1869,137 @@ mod aliasless_selectors {
         );
 
         drop((root, npmrc_info));
+    }
+}
+
+/// `pnpm add --workspace`: the added packages are linked from the
+/// workspace instead of resolved from the registry.
+///
+/// Covers <https://github.com/pnpm/pnpm/issues/14602>.
+mod workspace_flag {
+    use super::{Path, PathBuf, TempDir, saved_spec, workspace_with_lib, write_json};
+    use assert_cmd::prelude::*;
+    use command_extra::CommandExtra;
+    use pnpm_testing_utils::bin::CommandTempCwd;
+    use pretty_assertions::assert_eq;
+    use std::process::Command;
+
+    const LIB: &str = "@pnpm.e2e/ws-flag-lib";
+
+    fn workspace(settings: &str) -> (TempDir, PathBuf) {
+        workspace_with_lib(settings, &[(LIB, "2.0.0")], "packages/app/package.json")
+    }
+
+    fn pnpm_add(dir: &Path, args: &[&str]) -> Command {
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(dir)
+            .with_arg("add")
+            .with_args(args)
+    }
+
+    fn assert_add_fails(dir: &Path, args: &[&str], needle: &str) {
+        let output = pnpm_add(dir, args).output().expect("run pnpm add");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        eprintln!("STDERR:\n{stderr}");
+        assert!(!output.status.success(), "`pnpm add {}` should fail", args.join(" "));
+        assert!(stderr.contains(needle), "stderr did not mention {needle:?}");
+    }
+
+    /// The default settings never link a bare name to the workspace, so
+    /// without the flag this add would go to the registry.
+    #[test]
+    fn links_the_workspace_package_under_the_rolling_protocol() {
+        let (root, app_dir) = workspace("");
+
+        pnpm_add(&app_dir, &["--workspace", LIB]).assert().success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:*"));
+        let linked = app_dir.join("node_modules").join(LIB).join("package.json");
+        assert!(linked.exists(), "{} should be linked into the app", linked.display());
+        drop(root);
+    }
+
+    #[test]
+    fn writes_the_version_when_linking_and_the_protocol_are_off() {
+        let (root, app_dir) =
+            workspace("linkWorkspacePackages: false\nsaveWorkspaceProtocol: false\n");
+
+        pnpm_add(&app_dir, &["--workspace", LIB, "--lockfile-only"]).assert().success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:^2.0.0"));
+        drop(root);
+    }
+
+    #[test]
+    fn writes_the_version_when_linking_is_on_and_the_protocol_is_off() {
+        let (root, app_dir) =
+            workspace("linkWorkspacePackages: true\nsaveWorkspaceProtocol: false\n");
+
+        pnpm_add(&app_dir, &["--workspace", LIB, "--lockfile-only"]).assert().success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:^2.0.0"));
+        drop(root);
+    }
+
+    #[test]
+    fn keeps_the_typed_range_operator() {
+        let (root, app_dir) = workspace("");
+
+        pnpm_add(&app_dir, &["--workspace", &format!("{LIB}@~2.0.0"), "--lockfile-only"])
+            .assert()
+            .success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:~"));
+        drop(root);
+    }
+
+    /// A filtered add resolves the selectors against the selected
+    /// workspace's projects rather than the project the command runs in.
+    #[test]
+    fn links_the_workspace_package_into_a_filtered_project() {
+        let (root, app_dir) = workspace("");
+        let workspace_dir = app_dir.parent().and_then(Path::parent).expect("workspace root");
+
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(workspace_dir)
+            .with_args(["--filter", "ws-app", "add", "--workspace", LIB, "--lockfile-only"])
+            .assert()
+            .success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:*"));
+        drop(root);
+    }
+
+    #[test]
+    fn rejects_a_package_no_workspace_project_provides() {
+        let (root, app_dir) = workspace("");
+
+        assert_add_fails(
+            &app_dir,
+            &["--workspace", "@pnpm.e2e/not-in-workspace"],
+            r#""@pnpm.e2e/not-in-workspace" not found in the workspace"#,
+        );
+
+        assert_eq!(saved_spec(&app_dir, "@pnpm.e2e/not-in-workspace"), None);
+        drop(root);
+    }
+
+    #[test]
+    fn is_rejected_outside_a_workspace() {
+        let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+        write_json(
+            &workspace.join("package.json"),
+            &serde_json::json!({ "name": "standalone", "version": "1.0.0" }),
+        );
+
+        assert_add_fails(
+            &workspace,
+            &["--workspace", LIB],
+            "--workspace can only be used inside a workspace",
+        );
+
+        drop(root);
     }
 }

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1624,8 +1624,6 @@ fn the_env_var_drives_the_saved_workspace_range() {
     }
 }
 
-/// The `pnpm-workspace.yaml` settings for a linking workspace:
-/// `linkWorkspacePackages: true` plus the given `saveWorkspaceProtocol`.
 fn linking_settings(save_workspace_protocol: Option<&str>) -> String {
     let protocol_line = save_workspace_protocol
         .map(|setting| format!("saveWorkspaceProtocol: {setting}\n"))

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1967,9 +1967,6 @@ mod workspace_flag {
         drop(root);
     }
 
-    /// A recursive add saves the rewritten selectors into every selected
-    /// project, whether the workspace shares one lockfile or each project
-    /// keeps its own.
     #[test]
     fn links_the_workspace_package_into_every_recursively_selected_project() {
         for shared_workspace_lockfile in [true, false] {
@@ -2033,11 +2030,13 @@ mod workspace_flag {
             &["--workspace", "--config", LIB, "--allow-build", "esbuild"],
             "cannot be combined with --workspace",
         );
-        assert_add_fails(
-            &app_dir,
-            &["--workspace", "crate:serde", "--allow-build", "esbuild"],
-            "--workspace cannot be combined with crate: or pypi: dependencies",
-        );
+        for ecosystem_selector in ["crate:serde", "pypi:requests"] {
+            assert_add_fails(
+                &app_dir,
+                &["--workspace", ecosystem_selector, "--allow-build", "esbuild"],
+                "--workspace cannot be combined with crate: or pypi: dependencies",
+            );
+        }
 
         assert_eq!(
             std::fs::read_to_string(&yaml_path).expect("reread pnpm-workspace.yaml"),

--- a/pnpm/crates/cli/tests/suite/add.rs
+++ b/pnpm/crates/cli/tests/suite/add.rs
@@ -1969,6 +1969,31 @@ mod workspace_flag {
         drop(root);
     }
 
+    /// A recursive add rewrites the selectors once and saves them into
+    /// every selected project.
+    #[test]
+    fn links_the_workspace_package_into_every_recursively_selected_project() {
+        let (root, app_dir) = workspace("");
+        let workspace_dir = app_dir.parent().and_then(Path::parent).expect("workspace root");
+        let second_app_dir = workspace_dir.join("packages/app2");
+        std::fs::create_dir_all(&second_app_dir).expect("create second app dir");
+        write_json(
+            &second_app_dir.join("package.json"),
+            &serde_json::json!({ "name": "ws-app-2", "version": "1.0.0" }),
+        );
+
+        Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(workspace_dir)
+            .with_args(["-r", "--filter", "ws-app*", "add", "--workspace", LIB, "--lockfile-only"])
+            .assert()
+            .success();
+
+        assert_eq!(saved_spec(&app_dir, LIB).as_deref(), Some("workspace:*"));
+        assert_eq!(saved_spec(&second_app_dir, LIB).as_deref(), Some("workspace:*"));
+        drop(root);
+    }
+
     #[test]
     fn rejects_a_package_no_workspace_project_provides() {
         let (root, app_dir) = workspace("");


### PR DESCRIPTION
## Summary

pnpm v12 dropped the `--workspace` flag of `pnpm add`, so the documented `pnpm add --workspace <pkg>` (https://pnpm.io/cli/add#--workspace) failed as an unknown argument. This PR brings the flag back to pacquet with pnpm v11's behavior:

- The selectors are rewritten to `workspace:` requests before the add runs: `foo` becomes `foo@workspace:*`, `foo@^1` becomes `foo@workspace:^1`, and an explicit `workspace:` range is kept. The regular add pipeline then renders the saved specifier per `saveWorkspaceProtocol` (so `workspace:*` under the default `rolling`, `workspace:^2.0.0` under `true`/`false`), exactly as `pnpm add foo@workspace:*` already did.
- `ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND` (`"<name>" not found in the workspace`) when no workspace project provides a named package.
- `ERR_PNPM_WORKSPACE_OPTION_OUTSIDE_WORKSPACE` (`--workspace can only be used inside a workspace`) outside a workspace, `--global` included. This check runs in the add dispatch before `--allow-build` is persisted, so a rejected add leaves `pnpm-workspace.yaml` untouched.
- `ERR_PNPM_NO_PKG_NAME_IN_SPEC` for a selector that carries no package name (a bare path or URL).
- `--workspace` combined with `--config` or with `crate:`/`pypi:` selectors is rejected up front instead of being silently ignored.

The flag works on every add path: the single project, dedicated per-project lockfiles (the workspace is indexed once and shared by every selected project's run), and a filtered/recursive selection (which resolves against the selection's projects).

`pnpm update --workspace` already defined the outside-workspace and `--latest` errors; they move to a shared `cli_args/workspace_option` module so both commands report the same codes and messages.

pnpm v11 is unaffected, so there is no TypeScript change. The pnpm.io docs already document the flag for `pnpm add`, so no doc change is needed either.

Fixes pnpm/pnpm#14602

## Squash Commit Body

```text
pnpm v12 dropped the `--workspace` flag of `pnpm add`, so the documented
`pnpm add --workspace <pkg>` failed as an unknown argument. The flag now
rewrites each selector to a `workspace:` request (`foo` -> `foo@workspace:*`,
`foo@^1` -> `foo@workspace:^1`, an explicit `workspace:` range is kept) and
hands it to the regular add pipeline, which already renders the saved
specifier per `saveWorkspaceProtocol`. It fails with
ERR_PNPM_WORKSPACE_PACKAGE_NOT_FOUND when no workspace project provides a
named package, with ERR_PNPM_WORKSPACE_OPTION_OUTSIDE_WORKSPACE outside a
workspace (the global directory included), and with
ERR_PNPM_NO_PKG_NAME_IN_SPEC for a selector without a package name, matching
pnpm v11.

The outside-workspace check runs in the add dispatch ahead of
`apply_allow_build`, so a rejected add persists nothing, and `--workspace`
is rejected together with `--config` and with `crate:`/`pypi:` selectors
instead of being silently ignored on those paths.

With dedicated per-project lockfiles the add runs once per selected
project; the `--workspace` link targets are built once in the pipeline and
handed to each run instead of every run walking the workspace again.

The `--workspace` errors `pnpm update` already defined move to a shared
`workspace_option` module so both commands report the same codes and
messages.

Fixes pnpm/pnpm#14602
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-fable-5-1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `pnpm add --workspace <pkg>` to resolve package selectors to workspace-linked dependencies.
  - Supports package versions and ranges while preserving existing `workspace:` selectors.
  - Supports filtered and recursive project selections.

- **Bug Fixes**
  - Added clear errors for unavailable packages, invalid selectors, incompatible options, and use outside a workspace.
  - Prevents configuration changes when workspace operations cannot proceed.

- **Tests**
  - Expanded coverage for workspace linking, filtering, recursive selection, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->