### PR TITLE
fix(config): read the engine pins from the workspace root

### DIFF
--- a/.changeset/engine-pins-follow-the-workspace-root.md
+++ b/.changeset/engine-pins-follow-the-workspace-root.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/config.reader": patch
+"pnpm": patch
+---
+
+pnpm now reads the `packageManager`, `devEngines.packageManager` and runtime pins from the workspace root's `package.json` when `lockfileDir` is set. It read them from the lockfile directory, so a project that moved its lockfile lost the pins it declared [#14633](https://github.com/pnpm/pnpm/issues/14633).

--- a/.changeset/engine-pins-follow-the-workspace-root.md
+++ b/.changeset/engine-pins-follow-the-workspace-root.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-pnpm now reads the `packageManager`, `devEngines.packageManager` and runtime pins from the workspace root's `package.json` when `lockfileDir` is set. It read them from the lockfile directory, so a project that moved its lockfile lost the pins it declared [#14633](https://github.com/pnpm/pnpm/issues/14633).
+pnpm now reads the `packageManager`, `devEngines.packageManager` and runtime pins from the workspace root's `package.json` when `lockfileDir` is set. A project that moved its lockfile lost the pins it declared there [#14633](https://github.com/pnpm/pnpm/issues/14633).

--- a/pnpm11/config/reader/src/Config.ts
+++ b/pnpm11/config/reader/src/Config.ts
@@ -60,6 +60,18 @@ export interface ConfigContext {
   prodOnlySelectedProjectDirs?: ProjectRootDir[]
   rootProjectManifest?: ProjectManifest
   rootProjectManifestDir: string
+  /**
+   * The manifest that declares the engine pins pnpm acts on: the
+   * `packageManager` field, `devEngines.packageManager`, and the runtimes
+   * under `devEngines.runtime` / `engines.runtime`.
+   *
+   * The workspace root's manifest, which is the same object as
+   * `rootProjectManifest` unless `lockfileDir` moved the root project
+   * directory off the workspace root. The pins belong to the workspace the
+   * contributor is working in, not to whichever directory the lockfile was
+   * pointed at.
+   */
+  enginePinManifest?: ProjectManifest
 
   // -- CLI metadata --
   cliOptions: Record<string, any> // eslint-disable-line

--- a/pnpm11/config/reader/src/index.ts
+++ b/pnpm11/config/reader/src/index.ts
@@ -516,13 +516,23 @@ export async function getConfig (opts: {
       if (ignoredPnpmFieldKeys.length > 0) {
         warnings.push(`The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: ${quoteAndJoin(ignoredPnpmFieldKeys.map(k => `pnpm.${k}`))}. See https://pnpm.io/settings for the new home of each setting.`)
       }
-      const wantedPmResult = getWantedPackageManager(pnpmConfig.rootProjectManifest)
+    }
+
+    // `lockfileDir` moves `rootProjectManifestDir` off the workspace root,
+    // and the engine pins stay with the workspace the contributor works in.
+    // Re-read only when the two directories differ.
+    const enginePinManifestDir = pnpmConfig.workspaceDir ?? pnpmConfig.dir
+    pnpmConfig.enginePinManifest = enginePinManifestDir === pnpmConfig.rootProjectManifestDir
+      ? pnpmConfig.rootProjectManifest
+      : await safeReadProjectManifestOnly(enginePinManifestDir) ?? undefined
+    if (pnpmConfig.enginePinManifest != null) {
+      const wantedPmResult = getWantedPackageManager(pnpmConfig.enginePinManifest)
       if (wantedPmResult.pm) {
         pnpmConfig.wantedPackageManager = wantedPmResult.pm
       }
       warnings.push(...wantedPmResult.warnings)
       if (pnpmConfig.nodeVersion == null) {
-        pnpmConfig.nodeVersion = getNodeVersionFromEnginesRuntime(pnpmConfig.rootProjectManifest)
+        pnpmConfig.nodeVersion = getNodeVersionFromEnginesRuntime(pnpmConfig.enginePinManifest)
       }
     }
 
@@ -960,7 +970,7 @@ export async function getConfig (opts: {
   const {
     hooks, finders,
     allProjects, selectedProjectsGraph, allProjectsGraph, prodAllProjectsGraph, prodOnlySelectedProjectDirs,
-    rootProjectManifest, rootProjectManifestDir,
+    rootProjectManifest, rootProjectManifestDir, enginePinManifest,
     cliOptions: ctxCliOptions,
     explicitlySetKeys: ctxExplicitlySetKeys,
     packageManager: ctxPackageManager, wantedPackageManager,
@@ -969,7 +979,7 @@ export async function getConfig (opts: {
   const context: ConfigContext = {
     hooks, finders,
     allProjects, selectedProjectsGraph, allProjectsGraph, prodAllProjectsGraph, prodOnlySelectedProjectDirs,
-    rootProjectManifest, rootProjectManifestDir,
+    rootProjectManifest, rootProjectManifestDir, enginePinManifest,
     cliOptions: ctxCliOptions,
     explicitlySetKeys: ctxExplicitlySetKeys,
     packageManager: ctxPackageManager, wantedPackageManager,
@@ -1556,6 +1566,7 @@ const CONFIG_CONTEXT_KEYS = [
   'prodOnlySelectedProjectDirs',
   'rootProjectManifest',
   'rootProjectManifestDir',
+  'enginePinManifest',
   'cliOptions',
   'explicitlySetKeys',
   'packageManager',

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -393,6 +393,58 @@ test('devEngines.packageManager with explicit onFail is respected (regression gu
   expect(context.wantedPackageManager?.onFail).toBe('error')
 })
 
+test('lockfileDir does not hide the engine pins declared at the workspace root', async () => {
+  prepare({
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '11.0.0',
+        onFail: 'error',
+      },
+      runtime: {
+        name: 'node',
+        version: '20.0.0',
+        onFail: 'error',
+      },
+    },
+  })
+  fs.mkdirSync('lf')
+
+  const { context } = await getConfig({
+    cliOptions: { 'lockfile-dir': 'lf' },
+    packageManager: { name: 'pnpm', version: '11.0.0' },
+  })
+
+  // The lockfile moved, so the root project directory moved with it and
+  // carries no manifest of its own.
+  expect(context.rootProjectManifest).toBeUndefined()
+  // The pins stay with the workspace the contributor works in.
+  expect(context.wantedPackageManager).toMatchObject({
+    name: 'pnpm',
+    version: '11.0.0',
+    onFail: 'error',
+  })
+  expect(context.enginePinManifest?.devEngines?.runtime).toMatchObject({
+    name: 'node',
+    version: '20.0.0',
+  })
+})
+
+test('without lockfileDir the engine pin manifest is the root project manifest itself', async () => {
+  prepare({
+    devEngines: {
+      packageManager: { name: 'pnpm', version: '11.0.0', onFail: 'error' },
+    },
+  })
+
+  const { context } = await getConfig({
+    cliOptions: {},
+    packageManager: { name: 'pnpm', version: '11.0.0' },
+  })
+
+  expect(context.enginePinManifest).toBe(context.rootProjectManifest)
+})
+
 describe('"packageManager" / "devEngines.packageManager" conflict warning', () => {
   const HASH_A = 'sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
   const HASH_B = 'sha512.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'

--- a/pnpm11/config/reader/test/index.ts
+++ b/pnpm11/config/reader/test/index.ts
@@ -415,10 +415,7 @@ test('lockfileDir does not hide the engine pins declared at the workspace root',
     packageManager: { name: 'pnpm', version: '11.0.0' },
   })
 
-  // The lockfile moved, so the root project directory moved with it and
-  // carries no manifest of its own.
   expect(context.rootProjectManifest).toBeUndefined()
-  // The pins stay with the workspace the contributor works in.
   expect(context.wantedPackageManager).toMatchObject({
     name: 'pnpm',
     version: '11.0.0',

--- a/pnpm11/pnpm/src/main.ts
+++ b/pnpm11/pnpm/src/main.ts
@@ -486,7 +486,7 @@ const RUNTIME_DISPLAY_NAMES: Record<RuntimeName, string> = {
 // devEngines.runtime takes precedence over engines.runtime per the iteration
 // order below: the first entry seen for a given runtime wins.
 function getWantedRuntimes (context: ConfigContext): EngineDependency[] {
-  const manifest = context.rootProjectManifest
+  const manifest = context.enginePinManifest
   if (manifest == null) return []
   const result: EngineDependency[] = []
   const seen = new Set<RuntimeName>()

--- a/pnpm11/pnpm/test/packageManagerCheck.test.ts
+++ b/pnpm11/pnpm/test/packageManagerCheck.test.ts
@@ -207,6 +207,24 @@ test('devEngines.runtime with onFail=error should fail on Node.js version mismat
   expect(stderr.toString()).toContain('This project requires Node.js 99999.0.0')
 })
 
+test('devEngines.runtime is still checked when --lockfile-dir moves the root project directory', async () => {
+  prepare({
+    devEngines: {
+      runtime: {
+        name: 'node',
+        version: '99999.0.0',
+        onFail: 'error',
+      },
+    },
+  })
+  fs.mkdirSync('lf')
+
+  const { status, stderr } = execPnpmSync(['install', '--lockfile-dir=lf', '--lockfile-only'])
+
+  expect(status).toBe(1)
+  expect(stderr.toString()).toContain('This project requires Node.js 99999.0.0')
+})
+
 test('devEngines.runtime with onFail=warn should warn on Node.js version mismatch', async () => {
   prepare({
     devEngines: {


### PR DESCRIPTION
## Summary

pnpm v11 reads the package-manager and runtime pins from `rootProjectManifest`, which is rooted at `lockfileDir ?? workspaceDir ?? dir` (`config/reader/src/index.ts`). A project that points the lockfile directory at a directory with no `package.json` of its own therefore loses every pin it declared at the workspace root: no version switch, no runtime check, and nothing recorded under `packageManagerDependencies`.

**Which sources trigger it.** `rootProjectManifestDir` is derived at `index.ts:507`, before the workspace manifest is merged further down. Only the sources read before that point move the root in time to hide the pins: `--lockfile-dir`, the env var, and `.npmrc`. A `lockfileDir:` in `pnpm-workspace.yaml` lands after, so it moves the lockfile but leaves the pins readable. The tests use the flag form for that reason.

pnpm v12 already reads the pins from the workspace root. This aligns v11 with it, which is the direction chosen after the divergence surfaced while fixing pnpm/pnpm#14575 — the pin belongs to the workspace the contributor is working in, not to whichever directory the lockfile was pointed at.

### What moved, and what did not

Only the pins move:

| Read | Rooted at |
| --- | --- |
| `packageManager`, `devEngines.packageManager` | workspace root (**changed**) |
| `devEngines.runtime`, `engines.runtime`, `nodeVersion` | workspace root (**changed**) |
| `rootProjectManifest` itself, the `pnpm` field warning, the `workspaces` warning | root project dir (unchanged) |
| the env lockfile the pin is recorded in | root project dir (unchanged) |

`enginePinManifest` is the same object as `rootProjectManifest` unless `lockfileDir` moved the root, so the common case reads no extra file.

### Trade-off worth a reviewer's eye

If `lockfileDir` points at a directory that *does* have its own `package.json` carrying a pin, that pin is no longer the one pnpm reads; the workspace root's is. That is v12's rule, and aligning means adopting it. Flagging it because it is the one case this changes in the other direction.

### Testing

Two tests in `config/reader/test/index.ts`: the pins survive `--lockfile-dir`, and without it `enginePinManifest` is the very same object as `rootProjectManifest` (so no second read). Full `@pnpm/config.reader` suite: 308 passed, 1 skipped (pre-existing).

One CLI-level test in `pnpm/test/packageManagerCheck.test.ts` covers the wiring the config-reader tests cannot see: they pin `enginePinManifest` itself and pass whether or not `getWantedRuntimes` reads it. Each test was verified by reverting the fix and confirming it fails — the CLI one reports `Expected: 1, Received: 0`, the runtime check silently not firing.

Closes pnpm/pnpm#14633

## Squash Commit Body

```text
`rootProjectManifestDir` is `lockfileDir ?? workspaceDir ?? dir`, and the
package-manager and runtime pins were read from the manifest there. A
project that points `lockfileDir` at a directory with no `package.json`
of its own therefore lost every pin it declared at the workspace root:
no version switch, no runtime check, and nothing recorded under
`packageManagerDependencies`.

The pins now come from the workspace root's manifest, which is what
pnpm 12 already reads them from. Everything else that belongs to the
root project directory stays there, including the env lockfile the pin
is recorded in and the "pnpm field is no longer read" warning.

`enginePinManifest` is the same object as `rootProjectManifest` unless
`lockfileDir` moved the root, so the common case reads no extra file.

Closes pnpm/pnpm#14633
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FPfp4dvqS7Nac4Luy3URJm


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Engine version requirements declared at the workspace root are now honored even when the lockfile is stored in a different directory.
  - Package manager and Node.js runtime checks continue to apply after relocating the lockfile.
- **Tests**
  - Added coverage for engine pin resolution with and without a separate lockfile directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->