### PR TITLE
fix(cli): pin engine and runtime installs to the isolated node linker

### DIFF
--- a/.changeset/engine-install-pins-isolated-linker.md
+++ b/.changeset/engine-install-pins-isolated-linker.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed pnpm failing to provision the version pinned in `packageManager` when the project sets `nodeLinker: hoisted` [#14595](https://github.com/pnpm/pnpm/issues/14595). The engine install used the project's linker, so the downloaded pnpm landed in a temporary directory that pnpm deleted before running it. Provisioning a managed Node.js, Deno, or Bun runtime no longer follows a `nodeLinker: hoisted` set in the global config either.
+Fixed pnpm failing to provision the version pinned in `packageManager` when the project sets `nodeLinker: hoisted`. Provisioning a managed Node.js, Deno, or Bun runtime now ignores a `nodeLinker: hoisted` in the global config too [#14595](https://github.com/pnpm/pnpm/issues/14595).

--- a/.changeset/engine-install-pins-isolated-linker.md
+++ b/.changeset/engine-install-pins-isolated-linker.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed pnpm failing to provision the version pinned in `packageManager` when the project sets `nodeLinker: hoisted` [#14595](https://github.com/pnpm/pnpm/issues/14595). The engine install used the project's linker, so the downloaded pnpm landed in a temporary directory that pnpm deleted before running it. Provisioning a managed Node.js, Deno, or Bun runtime no longer follows a `nodeLinker: hoisted` set in the global config either.

--- a/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
+++ b/pnpm/crates/cli/src/cli_args/self_update/install_pnpm.rs
@@ -8,7 +8,7 @@
 
 use crate::{State, cli_args::add::add_package, executable_link::replace_executable};
 use miette::{Context, IntoDiagnostic};
-use pnpm_config::{Config, PackageManagerBootstrap};
+use pnpm_config::{Config, NodeLinker, PackageManagerBootstrap};
 use pnpm_global::{clean_orphaned_install_dirs, create_install_dir, find_global_package};
 use pnpm_graph_hasher::{format_global_virtual_store_path, host_arch, host_libc, host_platform};
 use pnpm_package_is_installable::SupportedArchitectures;
@@ -292,6 +292,11 @@ pub(crate) async fn run_install<Reporter: self::Reporter + 'static>(
     cfg.package_extensions = None;
     cfg.catalogs = None;
     cfg.patched_dependencies = None;
+    // The engine closure is pnpm's own, so the project's linker choice must
+    // not shape its layout: under `hoisted` the engine materializes inside
+    // `install_dir` instead of the global virtual store the caller resolves
+    // its slot from (pnpm/pnpm#14595).
+    cfg.node_linker = NodeLinker::Isolated;
 
     let config: &'static Config = Config::leak(cfg);
     let manifest_path = install_dir.join("package.json");

--- a/pnpm/crates/cli/src/engine_pm/install.rs
+++ b/pnpm/crates/cli/src/engine_pm/install.rs
@@ -353,11 +353,24 @@ fn compute_engine_slot(
 /// Derive the engine's GVS slot from the install's own wrapper symlink. This
 /// is the ground truth after an install, independent of any hash
 /// recomputation.
+///
+/// Errors when the wrapper is a real directory inside `install_dir` rather
+/// than a symlink into the store: `install_dir` is thrown away right after,
+/// so a slot naming it would be gone before the engine is linked.
 fn resolve_slot(install_dir: &Path, package_name: &str) -> miette::Result<PathBuf> {
     let link = package_dir(install_dir, package_name);
     let real = fs::canonicalize(&link)
         .into_diagnostic()
         .wrap_err_with(|| format!("resolve the installed {package_name} at {}", link.display()))?;
+    let install_real = fs::canonicalize(install_dir).into_diagnostic().wrap_err_with(|| {
+        format!("resolve the temporary install directory at {}", install_dir.display())
+    })?;
+    if real.starts_with(&install_real) {
+        return Err(miette::miette!(
+            "the installed {package_name} at {} did not materialize in the global virtual store",
+            real.display()
+        ));
+    }
     slot_from_package_dir(&real, package_name).ok_or_else(|| {
         miette::miette!("could not locate the {package_name} global-virtual-store slot")
     })

--- a/pnpm/crates/cli/src/engine_pm/install.rs
+++ b/pnpm/crates/cli/src/engine_pm/install.rs
@@ -366,9 +366,9 @@ fn resolve_slot(install_dir: &Path, package_name: &str) -> miette::Result<PathBu
         format!("resolve the temporary install directory at {}", install_dir.display())
     })?;
     if real.starts_with(&install_real) {
+        let real_display = real.display();
         return Err(miette::miette!(
-            "the installed {package_name} at {} did not materialize in the global virtual store",
-            real.display()
+            "the installed {package_name} at {real_display} did not materialize in the global virtual store"
         ));
     }
     slot_from_package_dir(&real, package_name).ok_or_else(|| {

--- a/pnpm/crates/cli/src/engine_pm/install/tests.rs
+++ b/pnpm/crates/cli/src/engine_pm/install/tests.rs
@@ -1,4 +1,4 @@
-use super::{link_cached_engine_bins, package_dir, package_manager_engine_config};
+use super::{link_cached_engine_bins, package_dir, package_manager_engine_config, resolve_slot};
 use pnpm_config::Config;
 use pnpm_graph_hasher::{host_arch, host_libc, host_platform};
 use pnpm_store_dir::StoreDir;
@@ -71,6 +71,37 @@ fn package_manager_engine_config_uses_global_store() {
         !engine_config.store_dir.root().starts_with(&project_store_root),
         "engine store must not use project store at {}",
         project_store_root.display(),
+    );
+}
+
+#[test]
+fn slot_resolution_follows_the_wrapper_symlink_into_the_store() {
+    let root = tempfile::TempDir::new().expect("tmp dir");
+    let install_dir = root.path().join("tmp-install");
+    let slot = root.path().join("links").join("@pnpm").join("exe").join("9.3.0").join("hash");
+    let installed_pkg_dir = package_dir(&slot, "@pnpm/exe");
+    fs::create_dir_all(&installed_pkg_dir).expect("create the store package dir");
+    let link = package_dir(&install_dir, "@pnpm/exe");
+    fs::create_dir_all(link.parent().expect("the wrapper scope dir")).expect("create scope dir");
+    pnpm_fs::force_symlink_dir(&installed_pkg_dir, &link).expect("link the wrapper");
+
+    let resolved = resolve_slot(&install_dir, "@pnpm/exe").expect("resolve the slot");
+
+    assert_eq!(resolved, fs::canonicalize(&slot).expect("canonicalize the slot"));
+}
+
+#[test]
+fn slot_resolution_rejects_an_engine_materialized_in_the_install_dir() {
+    let root = tempfile::TempDir::new().expect("tmp dir");
+    let install_dir = root.path().join("tmp-install");
+    fs::create_dir_all(package_dir(&install_dir, "@pnpm/exe")).expect("create the wrapper dir");
+
+    let error = resolve_slot(&install_dir, "@pnpm/exe").expect_err("an install-dir slot");
+
+    let message = format!("{error}");
+    assert!(
+        message.contains("did not materialize in the global virtual store"),
+        "unexpected error: {message}",
     );
 }
 

--- a/pnpm/crates/cli/src/shim_dispatch/runtime_env.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/runtime_env.rs
@@ -3,7 +3,7 @@
 
 use crate::{State, cli_args::add::add_package};
 use miette::{Context, IntoDiagnostic};
-use pnpm_config::{Config, Host};
+use pnpm_config::{Config, Host, NodeLinker};
 use pnpm_crypto_hash::create_hex_hash;
 use pnpm_fs::DirLock;
 use pnpm_package_manifest::DependencyGroup;
@@ -56,6 +56,11 @@ pub(crate) fn trusted_runtime_config(environments_dir: &Path) -> miette::Result<
 /// `supportedArchitectures.libc: [musl]` override on a glibc host would
 /// select an unofficial-builds artifact that the promptless policy's
 /// host-libc check did not account for.
+///
+/// The linker is pinned to isolated for the same reason: a `hoisted`
+/// setting inherited from the environment or the global config would
+/// materialize the runtime inside the environment directory, where
+/// [`managed_runtime_bin`] does not accept it.
 pub(super) fn hardened_install_config(
     config: Config,
     environment_dir: &Path,
@@ -66,6 +71,7 @@ pub(super) fn hardened_install_config(
     install_config.virtual_store_dir = environment_dir.join("node_modules").join(".pnpm");
     install_config.enable_global_virtual_store = true;
     install_config.global_virtual_store_dir = global_virtual_store_dir;
+    install_config.node_linker = NodeLinker::Isolated;
     install_config.workspace_dir = Some(environment_dir.to_path_buf());
     install_config.lockfile = true;
     install_config.frozen_lockfile = Some(false);

--- a/pnpm/crates/cli/src/shim_dispatch/tests.rs
+++ b/pnpm/crates/cli/src/shim_dispatch/tests.rs
@@ -7,11 +7,11 @@ use super::{
         read_shim_target_from_content, small_file_hash,
     },
     is_automatic_runtime, local_bin_path, local_bin_unchanged, manifest_runtime_pin,
-    runtime_env::managed_runtime_bin,
+    runtime_env::{hardened_install_config, managed_runtime_bin},
     trust::{append_trust_decision, read_trust_decision},
     try_dispatch,
 };
-use pnpm_config::ShimPolicy;
+use pnpm_config::{Config, NodeLinker, ShimPolicy};
 use std::{ffi::OsString, fs, path::Path};
 
 fn strings(items: &[&str]) -> Vec<OsString> {
@@ -219,6 +219,22 @@ fn managed_runtime_must_resolve_inside_the_global_store() {
         managed_runtime_bin(root.path().join("state/environment").as_path(), "node", &store),
         None,
     );
+}
+
+/// [`managed_runtime_bin`] only accepts a runtime that resolves into the
+/// global virtual store, which the hoisted linker never writes to.
+#[test]
+fn hardened_runtime_install_pins_the_isolated_linker() {
+    let root = tempfile::tempdir().unwrap();
+    let config = Config { node_linker: NodeLinker::Hoisted, ..Config::default() };
+
+    let install_config = hardened_install_config(
+        config,
+        &root.path().join("environment"),
+        root.path().join("store/links"),
+    );
+
+    assert_eq!(install_config.node_linker, NodeLinker::Isolated);
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/version.rs
+++ b/pnpm/crates/cli/tests/suite/version.rs
@@ -83,6 +83,32 @@ fn version_flag_switches_to_project_package_manager_version() {
     drop((root, mock_instance));
 }
 
+/// The engine is installed into the shared global virtual store and the
+/// directory the install runs from is thrown away. A project that selects
+/// the hoisted linker must not drag the engine into that directory
+/// (pnpm/pnpm#14595).
+#[test]
+fn version_flag_switches_to_the_pinned_version_under_the_hoisted_node_linker() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(workspace.join("package.json"), r#"{"packageManager":"pnpm@9.3.0"}"#)
+        .expect("write package.json");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "nodeLinker: hoisted\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = test_command(pacquet, root.path())
+        .env("PNPM_CONFIG_REGISTRY", mock_instance.url())
+        .args(["--version"])
+        .output()
+        .expect("run pacquet --version");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet --version should succeed");
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "9.3.0\n");
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn child_pnpm_selects_the_version_for_its_own_directory() {
     let CommandTempCwd { pacquet, root, npmrc_info, .. } =


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14595.

With `nodeLinker: hoisted`, provisioning the version pinned in `packageManager` failed on a cold engine cache:

```
Error:   × the installed pnpm wrapper is missing at
  │ <PNPM_HOME>/package-manager-store/v11/tmp/pnpm-engine-10.33.2-<pid>-<nanos>/node_modules/@pnpm/exe
```

Engine provisioning installs into a throwaway directory with the global virtual store enabled, so the engine materializes in `<store>/links/...` and the throwaway directory holds only symlinks into it. `run_install` neutralizes the repo-controlled settings that must not reach the engine install (`overrides`, `packageExtensions`, `catalogs`, `patchedDependencies`, `allowBuilds`, `ignoreScripts`, `workspaceDir`), but it inherited `nodeLinker` from the project. Under the hoisted linker the engine materialized *inside* the throwaway directory, `resolve_slot` walked up from a real directory and returned that directory as the slot, and it was removed before `link_exe_platform_binary` ran.

The fix pins the engine install to the isolated linker. Two further changes go with it:

- `resolve_slot` now refuses a slot that lies inside the throwaway directory, so any remaining case reports what actually happened instead of a missing wrapper.
- The managed-runtime install (`hardened_install_config`) is pinned the same way. Its config is anchored in pnpm's state dir, so no project reaches it, but `PNPM_CONFIG_NODE_LINKER=hoisted` or a `nodeLinker: hoisted` in the global config still did — and `managed_runtime_bin` only accepts a runtime that resolves into the global virtual store, which the hoisted linker never writes to.

pnpm v11 does not provision engines through the global virtual store and is not affected, so this is a v12-only fix.

Verified against the issue's repro with a locally built binary (cold `PNPM_HOME`, `packageManager: pnpm@10.33.2`, `nodeLinker: hoisted`): it now prints `10.33.2`.

Tests: a new e2e test pins `packageManager` alongside `nodeLinker: hoisted` and asserts `pnpm --version` switches to the pinned engine; it fails on the unfixed code with the new `resolve_slot` diagnostic. Unit tests cover both `resolve_slot` outcomes and the pinned linker in `hardened_install_config`.

`dlx::dlx_provisions_a_package_manager_by_name` fails on this machine for an unrelated, pre-existing reason (it picks up the ambient PATH yarn 1.22.19); it fails the same way on a clean `main` here.

## Squash Commit Body

```text
Package-manager engine provisioning installs into a throwaway directory
with the global virtual store enabled, so the engine materializes in
`<store>/links/...` and the throwaway directory holds only symlinks into
it. The install inherited `nodeLinker` from the project, and under
`nodeLinker: hoisted` the engine materialized inside the throwaway
directory instead. The slot derived from that install named the
directory itself, which is removed right after, so linking the wrapper's
native binary failed with a misleading "the installed pnpm wrapper is
missing".

`run_install` already neutralizes the repo-controlled settings that must
not reach the engine install; `node_linker` joins them. `resolve_slot`
now refuses a slot inside the throwaway directory, so any remaining case
says what actually happened. The managed-runtime install is pinned the
same way: `managed_runtime_bin` only accepts a runtime that resolves
into the global virtual store, which the hoisted linker never writes to.

Closes pnpm/pnpm#14595
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791337636&installation_model_id=426870&pr_number=14643&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14643&signature=b6b1cc0efd4fd8f33f0c2ec4acad2c6ecce2659366d849c7d04eeb0394bb65c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed engine installation for projects or global settings using the hoisted node linker.
  - Pinned package manager versions and managed Node.js, Deno, and Bun runtimes now install reliably without being removed before use.
  - Fixed `--version` to correctly switch to and report the configured pinned package manager version with hoisted linker settings.

- **Tests**
  - Added regression coverage for engine installation and version selection across linker configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->