### PR TITLE
feat(pnpr): add oci registry maintenance

### DIFF
--- a/.changeset/oci-registry-operations.md
+++ b/.changeset/oci-registry-operations.md
@@ -1,0 +1,7 @@
+---
+"@pnpm/pnpr": minor
+---
+
+pnpr can resume OCI uploads across replicas when using S3 storage. Abandoned shared upload sessions expire at startup after 24 hours of inactivity.
+
+`pnpr oci-gc --registry <name>` collects old, unreferenced image blobs while registry writers are stopped. Use `--dry-run` to preview the cleanup.

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -188,6 +188,13 @@ pub enum RegistryError {
         packages: String,
     },
 
+    #[display("Upload {id:?} changed; query its offset before retrying")]
+    #[from(skip)]
+    BlobUploadConflict {
+        #[error(not(source))]
+        id: String,
+    },
+
     #[display("Hosted document for package {package:?} changed while writing")]
     #[from(skip)]
     DocumentWriteConflict {
@@ -340,6 +347,7 @@ impl RegistryError {
             RegistryError::VersionAlreadyPublished { .. } => "version_already_published",
             RegistryError::ArtifactAlreadyPublished { .. } => "artifact_already_published",
             RegistryError::PublishNotRecorded { .. } => "publish_not_recorded",
+            RegistryError::BlobUploadConflict { .. } => "blob_upload_conflict",
             RegistryError::DocumentWriteConflict { .. } => "document_write_conflict",
             RegistryError::RevisionReferenceLimit { .. } => "revision_reference_limit",
             RegistryError::RevisionReferenceWriteConflict { .. } => {
@@ -434,6 +442,7 @@ impl RegistryError {
             RegistryError::VersionAlreadyPublished { .. }
             | RegistryError::ArtifactAlreadyPublished { .. }
             | RegistryError::PublishNotRecorded { .. }
+            | RegistryError::BlobUploadConflict { .. }
             | RegistryError::DocumentWriteConflict { .. }
             | RegistryError::RevisionReferenceLimit { .. }
             | RegistryError::RevisionReferenceWriteConflict { .. } => StatusCode::CONFLICT,

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -337,7 +337,10 @@ streams the accepted chunks to local scratch for digest verification, then
 streams large blobs back to S3 in 8 MiB parts. Allow scratch space for concurrent
 requests and completed layers. Concurrent changes to one session are rejected;
 clients can query its current offset and retry. A session accepts up to 10,000
-nonempty chunks.
+nonempty chunks. Completion freezes the chunk list and digest before promotion.
+If promotion fails, retry completion with that digest and an empty request body.
+Frozen sessions reject further chunks and cancellation, and expire after 24 hours
+of inactivity.
 
 Startup removes upload sessions idle for more than 24 hours, including their
 accepted chunks. Run a rolling restart periodically if abandoned uploads need

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -365,7 +365,8 @@ Collection keeps untagged manifests, the children of retained indexes, and their
 config and layer blobs. Removing a tag alone does not make its image collectible.
 Missing or corrupt retained manifests stop collection before any blobs are
 deleted. The inventory includes unpublished repositories and nested repository
-names. Online `DELETE` of individual blobs remains unsupported because a manifest
+names. Collection streams the inventory into a temporary SQLite database, so
+local temporary storage must have room for the inventory metadata. Online `DELETE` of individual blobs remains unsupported because a manifest
 publish could race the reference check; use offline collection to delete safely.
 
 

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -330,6 +330,45 @@ docker pull pnpr.example.com/acme/app:1.0
 skopeo copy docker://pnpr.example.com/acme/app:1.0 oci:./app:1.0
 ```
 
+With S3 storage, upload sessions and their accepted chunks live in the bucket.
+A client can continue an upload on another replica with the same storage prefix
+and registry configuration. Each request stores only its new chunk. Completion
+streams the accepted chunks to local scratch for digest verification, then
+streams large blobs back to S3 in 8 MiB parts. Allow scratch space for concurrent
+requests and completed layers. Concurrent changes to one session are rejected;
+clients can query its current offset and retry. A session accepts up to 10,000
+nonempty chunks.
+
+Startup removes upload sessions idle for more than 24 hours, including their
+accepted chunks. Run a rolling restart periodically if abandoned uploads need
+reclaiming on a long-running deployment. Configure the bucket's lifecycle policy
+to abort incomplete multipart uploads as well, since a process killed during a
+multipart request cannot send its abort request. Filesystem storage keeps upload
+sessions local and requires requests for a session to reach the same instance.
+
+To reclaim old blobs that no retained manifest references, stop **every writer**
+sharing the store and run:
+
+```sh
+pnpr -c config.yaml oci-gc --registry images --dry-run
+pnpr -c config.yaml oci-gc --registry images
+```
+
+Use the concrete hosted OCI registry's config name for `--registry`. The command
+recovers the local publish journal before scanning. Recover journals on every
+replica's scratch volume before collecting shared storage. Keep writers stopped
+for the entire scan and deletion. `--dry-run` reports candidates without deleting
+them. `--min-age-secs` defaults to 86400, preserving recent uploads for interrupted
+pushes to resume. Set it to zero to collect all unreferenced blobs.
+
+Collection keeps untagged manifests, the children of retained indexes, and their
+config and layer blobs. Removing a tag alone does not make its image collectible.
+Missing or corrupt retained manifests stop collection before any blobs are
+deleted. The inventory includes unpublished repositories and nested repository
+names. Online `DELETE` of individual blobs remains unsupported because a manifest
+publish could race the reference check; use offline collection to delete safely.
+
+
 `GET /v2/` answers `401` with a `Basic` challenge to an anonymous caller even
 where reads are open. A client settles its authentication scheme on that one
 response, so a `200` would leave it with no way to authenticate a later push.

--- a/pnpr/crates/pnpr/src/lib.rs
+++ b/pnpr/crates/pnpr/src/lib.rs
@@ -7,6 +7,8 @@
 //!
 //! See <https://github.com/pnpm/pnpm> for the parent project.
 
+pub mod oci_maintenance;
+
 mod resolver;
 mod server;
 

--- a/pnpr/crates/pnpr/src/main.rs
+++ b/pnpr/crates/pnpr/src/main.rs
@@ -6,6 +6,9 @@ use tracing_subscriber::EnvFilter;
 #[derive(Debug, Parser)]
 #[command(name = "pnpr", version, about = "pnpm-compatible npm registry server")]
 struct Args {
+    #[command(subcommand)]
+    command: Option<Command>,
+
     /// Path to a verdaccio-shaped YAML config (storage, upstreams,
     /// packages, log). When omitted, the global `config.yaml` in
     /// pnpr's config dir (pnpm's config-dir rules, under `pnpr`) is
@@ -71,6 +74,22 @@ struct Args {
     disable_artifacts: bool,
 }
 
+#[derive(Debug, clap::Subcommand)]
+enum Command {
+    /// Collect old, unreferenced image blobs. Stop all registry writers first.
+    OciGc {
+        /// Concrete hosted OCI registry from the config.
+        #[arg(long)]
+        registry: String,
+        /// Report reclaimable blobs without deleting them.
+        #[arg(long)]
+        dry_run: bool,
+        /// Minimum blob age to reclaim, in seconds.
+        #[arg(long, default_value_t = 86400)]
+        min_age_secs: u64,
+    },
+}
+
 impl Args {
     fn feature_overrides(&self) -> pnpr::FeatureOverrides {
         pnpr::FeatureOverrides {
@@ -132,6 +151,19 @@ async fn main() -> miette::Result<()> {
     // enforced that at least one surface stays enabled.
     init_logging(&config.logs);
     log_config_source(&source);
+    if let Some(Command::OciGc { registry, dry_run, min_age_secs }) = args.command {
+        pnpr::recover_publish_journal(&config).await.map_err(|err| redacted_report(&err))?;
+        let (blobs, bytes) = pnpr::oci_maintenance::collect_oci_blobs(
+            &config,
+            &registry,
+            Duration::from_secs(min_age_secs),
+            dry_run,
+        )
+        .await
+        .map_err(|err| redacted_report(&err))?;
+        tracing::info!(blobs, bytes, dry_run, "OCI collection completed");
+        return Ok(());
+    }
     serve(config).await.map_err(|err| redacted_report(&err))
 }
 

--- a/pnpr/crates/pnpr/src/oci_maintenance.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance.rs
@@ -2,13 +2,12 @@
 //! stopped, including other replicas, throughout the scan and deletion.
 
 use crate::{Config, Ecosystem, RegistryError, Result};
+use futures_util::TryStreamExt;
 use pnpr_oci::{Digest, ImageDocument, Manifest, media_type};
 use pnpr_package_name::CanonicalPackageName;
-use pnpr_storage::{HostedBlobFile, Storage};
-use std::{
-    collections::{BTreeMap, HashSet},
-    time::Duration,
-};
+use pnpr_storage::Storage;
+use rusqlite::{Connection, OptionalExtension, params};
+use std::{collections::HashSet, time::Duration};
 
 /// Reclaim unreferenced OCI blobs in one hosted registry.
 ///
@@ -52,34 +51,81 @@ async fn collect(
     dry_run: bool,
     excluded: &HashSet<&str>,
 ) -> Result<(usize, u64)> {
-    let mut repositories: BTreeMap<String, Vec<HostedBlobFile>> = BTreeMap::new();
-    for file in storage.hosted_blob_files().await? {
+    let temporary = tempfile::NamedTempFile::new()?;
+    let inventory = Connection::open(temporary.path())?;
+    inventory.execute_batch(
+        "PRAGMA journal_mode=OFF;
+         CREATE TABLE repositories (name TEXT PRIMARY KEY);
+         CREATE TABLE blobs (
+             repository TEXT, filename TEXT, size INTEGER, old INTEGER,
+             keep INTEGER DEFAULT 0, UNIQUE(repository, filename)
+         );
+         BEGIN;",
+    )?;
+    let mut files = storage.hosted_blob_files();
+    while let Some(file) = files.try_next().await? {
         if file.path.split('/').next().is_some_and(|part| excluded.contains(part)) {
             continue;
         }
         let Some((repository, filename)) = file.path.rsplit_once('/') else { continue };
-        if filename_digest(filename).is_none() {
+        if CanonicalPackageName::parse(repository, Ecosystem::Oci).is_err() {
             continue;
         }
-        repositories.entry(repository.to_string()).or_default().push(file);
-    }
-    let mut candidates = Vec::new();
-    for (repository, files) in repositories {
-        let Ok(name) = CanonicalPackageName::parse(&repository, Ecosystem::Oci) else { continue };
-        let reachable = referenced_blobs(storage, &name).await?;
-        for file in files {
-            let filename = file.path.rsplit('/').next().expect("inventory entry has a filename");
-            if !reachable.contains(filename)
-                && file.modified.elapsed().unwrap_or_default() >= min_age
-            {
-                candidates.push((name.clone(), filename.to_string(), file.size));
-            }
+        if filename != "package.json" && filename_digest(filename).is_none() {
+            continue;
         }
+        inventory.execute("INSERT OR IGNORE INTO repositories VALUES (?)", [repository])?;
+        if filename == "package.json" {
+            continue;
+        }
+        let size = i64::try_from(file.size).map_err(|_| RegistryError::BadRequest {
+            reason: format!("blob {} is too large to inventory", file.path),
+        })?;
+        inventory.execute(
+            "INSERT INTO blobs (repository, filename, size, old) VALUES (?, ?, ?, ?)",
+            params![
+                repository,
+                filename,
+                size,
+                file.modified.elapsed().unwrap_or_default() >= min_age
+            ],
+        )?;
     }
+    inventory.execute_batch("COMMIT;")?;
+    inventory.execute_batch("BEGIN;")?;
+    let mut previous = String::new();
+    while let Some(repository) = inventory
+        .query_row(
+            "SELECT name FROM repositories WHERE name > ? ORDER BY name LIMIT 1",
+            [&previous],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+    {
+        let name = CanonicalPackageName::parse(&repository, Ecosystem::Oci)?;
+        let reachable = referenced_blobs(storage, &name).await?;
+        for filename in reachable {
+            inventory.execute(
+                "UPDATE blobs SET keep = 1 WHERE repository = ? AND filename = ?",
+                params![repository, filename],
+            )?;
+        }
+        previous = repository;
+    }
+    inventory.execute_batch("COMMIT;")?;
     let mut removed = 0;
     let mut bytes = 0;
-    for (name, filename, size) in candidates {
-        if dry_run || storage.remove_blob(&name, &filename).await? {
+    let mut cursor = 0i64;
+    loop {
+        let candidate = inventory.query_row(
+            "SELECT rowid, repository, filename, size FROM blobs WHERE rowid > ? AND old = 1 AND keep = 0 ORDER BY rowid LIMIT 1",
+            [cursor], |row| Ok((row.get::<_, i64>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?, row.get::<_, i64>(3)?)),
+        ).optional()?;
+        let Some((row, repository, filename, size)) = candidate else { break };
+        cursor = row;
+        let size = u64::try_from(size).expect("inventory only records nonnegative blob sizes");
+        let name = CanonicalPackageName::parse(&repository, Ecosystem::Oci)?;
+        if dry_run || storage.remove_hosted_blob(&name, &filename).await? {
             tracing::info!(
                 repository = name.as_str(),
                 blob = filename,

--- a/pnpr/crates/pnpr/src/oci_maintenance.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance.rs
@@ -1,0 +1,149 @@
+//! Offline OCI blob reclamation. All writers sharing the store must be
+//! stopped, including other replicas, throughout the scan and deletion.
+
+use crate::{Config, Ecosystem, RegistryError, Result};
+use pnpr_oci::{Digest, ImageDocument, Manifest, media_type};
+use pnpr_package_name::CanonicalPackageName;
+use pnpr_storage::{HostedBlobFile, Storage};
+use std::{
+    collections::{BTreeMap, HashSet},
+    time::Duration,
+};
+
+/// Reclaim unreferenced OCI blobs in one hosted registry.
+///
+/// Stop every writer sharing this store before calling this function. Recover
+/// publish journals first, including those on other replicas' scratch volumes.
+/// `dry_run` reports candidates without removing them. Blobs newer than
+/// `min_age` are retained so an interrupted push can resume after maintenance.
+pub async fn collect_oci_blobs(
+    config: &Config,
+    registry: &str,
+    min_age: Duration,
+    dry_run: bool,
+) -> Result<(usize, u64)> {
+    if config.registries.ecosystem(registry) != Some(Ecosystem::Oci) {
+        return Err(RegistryError::BadRequest {
+            reason: format!("{registry:?} is not a concrete OCI registry"),
+        });
+    }
+    let hosted = config.hosted.get(registry).ok_or_else(|| RegistryError::BadRequest {
+        reason: format!("{registry:?} is not a hosted registry"),
+    })?;
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?
+            .for_hosted(&hosted.org);
+    let excluded: HashSet<&str> = if hosted.org.is_empty() {
+        config
+            .hosted
+            .values()
+            .map(|hosted| hosted.org.as_str())
+            .filter(|org| !org.is_empty())
+            .collect()
+    } else {
+        HashSet::new()
+    };
+    collect(&storage, min_age, dry_run, &excluded).await
+}
+
+async fn collect(
+    storage: &Storage,
+    min_age: Duration,
+    dry_run: bool,
+    excluded: &HashSet<&str>,
+) -> Result<(usize, u64)> {
+    let mut repositories: BTreeMap<String, Vec<HostedBlobFile>> = BTreeMap::new();
+    for file in storage.hosted_blob_files().await? {
+        if file.path.split('/').next().is_some_and(|part| excluded.contains(part)) {
+            continue;
+        }
+        let Some((repository, filename)) = file.path.rsplit_once('/') else { continue };
+        if filename_digest(filename).is_none() {
+            continue;
+        }
+        repositories.entry(repository.to_string()).or_default().push(file);
+    }
+    let mut candidates = Vec::new();
+    for (repository, files) in repositories {
+        let Ok(name) = CanonicalPackageName::parse(&repository, Ecosystem::Oci) else { continue };
+        let reachable = referenced_blobs(storage, &name).await?;
+        for file in files {
+            let filename = file.path.rsplit('/').next().expect("inventory entry has a filename");
+            if !reachable.contains(filename)
+                && file.modified.elapsed().unwrap_or_default() >= min_age
+            {
+                candidates.push((name.clone(), filename.to_string(), file.size));
+            }
+        }
+    }
+    let mut removed = 0;
+    let mut bytes = 0;
+    for (name, filename, size) in candidates {
+        if dry_run || storage.remove_blob(&name, &filename).await? {
+            tracing::info!(
+                repository = name.as_str(),
+                blob = filename,
+                size,
+                dry_run,
+                "unreferenced OCI blob",
+            );
+            removed += 1;
+            bytes += size;
+        }
+    }
+    Ok((removed, bytes))
+}
+
+fn filename_digest(filename: &str) -> Option<Digest> {
+    Digest::parse(&format!("sha256:{}", filename.strip_prefix("sha256-")?)).ok()
+}
+
+async fn referenced_blobs(
+    storage: &Storage,
+    name: &CanonicalPackageName,
+) -> Result<HashSet<String>> {
+    let Some(bytes) = storage.read_hosted_document(name).await? else { return Ok(HashSet::new()) };
+    let document = ImageDocument::parse(&bytes)?;
+    let mut pending: Vec<(Digest, Option<String>)> = document
+        .manifests()
+        .iter()
+        .map(|entry| (entry.digest.clone(), Some(entry.media_type.clone())))
+        .collect();
+    let mut visited = HashSet::new();
+    let mut reachable = HashSet::new();
+    while let Some((digest, content_type)) = pending.pop() {
+        if !visited.insert(digest.clone()) {
+            continue;
+        }
+        let filename = digest.blob_filename();
+        reachable.insert(filename.clone());
+        let invalid = |reason: String| RegistryError::BadRequest {
+            reason: format!("cannot collect {}/{filename}: {reason}", name.as_str()),
+        };
+        let (body, _) = storage
+            .open_hosted_blob(name, &filename)
+            .await?
+            .ok_or_else(|| invalid("retained manifest is missing".into()))?;
+        let bytes = axum::body::to_bytes(body, 4 * 1024 * 1024)
+            .await
+            .map_err(|error| invalid(error.to_string()))?;
+        if Digest::of(&bytes) != digest {
+            return Err(invalid("manifest digest mismatch".into()));
+        }
+        let manifest = Manifest::parse(&bytes, content_type.as_deref())
+            .map_err(|error| invalid(error.to_string()))?;
+        for reference in manifest.references() {
+            reachable.insert(reference.digest.blob_filename());
+            if media_type::is_index(manifest.media_type()) {
+                let content_type = reference.media_type.clone().or_else(|| {
+                    document.manifest(&reference.digest).map(|entry| entry.media_type.clone())
+                });
+                pending.push((reference.digest.clone(), content_type));
+            }
+        }
+    }
+    Ok(reachable)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
@@ -1,4 +1,5 @@
 use super::{collect, referenced_blobs};
+use crate::RegistryError;
 use pnpr_config::HostedStoreConfig;
 use pnpr_oci::{Digest, ImageDocument, ManifestEntry, media_type};
 use pnpr_package_name::{CanonicalPackageName, Ecosystem};
@@ -79,12 +80,18 @@ async fn corrupt_or_missing_manifests_prevent_deletion() {
     let orphan = blob(&storage, &name("aaa"), b"orphan").await;
     let path = temp.path().join("store/acme/app").join(manifest.blob_filename());
     tokio::fs::write(&path, b"corrupt").await.unwrap();
-    assert!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.is_err());
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    assert!(
+        matches!(error, RegistryError::BadRequest { reason } if reason.contains("manifest digest mismatch")),
+    );
     assert!(
         storage.open_hosted_blob(&name("aaa"), &orphan.blob_filename()).await.unwrap().is_some(),
     );
     tokio::fs::remove_file(path).await.unwrap();
-    assert!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.is_err());
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    assert!(
+        matches!(error, RegistryError::BadRequest { reason } if reason.contains("retained manifest is missing")),
+    );
 }
 
 #[tokio::test]
@@ -150,4 +157,58 @@ async fn collection_uses_the_stored_media_type_for_header_only_manifests() {
         referenced_blobs(&storage, &repository).await.unwrap(),
         HashSet::from([digest.blob_filename(), layer.blob_filename()]),
     );
+}
+
+#[tokio::test]
+async fn a_document_without_any_blob_files_still_blocks_collection_when_corrupt() {
+    let (_temp, storage) = setup();
+    let repository = name("empty");
+    let mut document = ImageDocument::new(repository.as_str());
+    document.insert_manifest(ManifestEntry {
+        digest: Digest::of(b"missing"),
+        size: 7,
+        media_type: media_type::OCI_IMAGE_MANIFEST.into(),
+    });
+    storage
+        .write_hosted_document_if_current(&repository, &document.to_bytes(), None)
+        .await
+        .unwrap();
+    let orphan = blob(&storage, &name("aaa"), b"orphan").await;
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    assert!(
+        matches!(error, RegistryError::BadRequest { reason } if reason.contains("retained manifest is missing")),
+    );
+    assert!(
+        storage.open_hosted_blob(&name("aaa"), &orphan.blob_filename()).await.unwrap().is_some(),
+    );
+}
+
+#[tokio::test]
+async fn collection_streams_an_object_store_inventory() {
+    let temp = TempDir::new().unwrap();
+    let config = HostedStoreConfig::ObjectStore {
+        store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+        prefix: "images/".into(),
+    };
+    let storage =
+        Storage::new(&config, temp.path().join("store"), temp.path().join("cache")).unwrap();
+    let repository = name("acme/app");
+    retained_image(&storage, &repository).await;
+    blob(&storage, &name("acme/app/nested"), b"orphan").await;
+    assert_eq!(collect(&storage, Duration::ZERO, true, &HashSet::new()).await.unwrap(), (1, 6));
+    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (1, 6));
+    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (0, 0));
+}
+
+#[tokio::test]
+async fn collection_does_not_remove_a_matching_blob_from_the_shared_cache() {
+    let (temp, storage) = setup();
+    let hosted = storage.for_hosted("images");
+    let repository = name("acme/app");
+    let digest = blob(&hosted, &repository, b"orphan").await;
+    let cache = temp.path().join("cache/acme/app").join(digest.blob_filename());
+    tokio::fs::create_dir_all(cache.parent().unwrap()).await.unwrap();
+    tokio::fs::write(&cache, b"cached").await.unwrap();
+    assert_eq!(collect(&hosted, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (1, 6));
+    assert_eq!(tokio::fs::read(cache).await.unwrap(), b"cached");
 }

--- a/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
@@ -1,0 +1,153 @@
+use super::{collect, referenced_blobs};
+use pnpr_config::HostedStoreConfig;
+use pnpr_oci::{Digest, ImageDocument, ManifestEntry, media_type};
+use pnpr_package_name::{CanonicalPackageName, Ecosystem};
+use pnpr_storage::Storage;
+use serde_json::json;
+use std::{collections::HashSet, time::Duration};
+use tempfile::TempDir;
+
+fn setup() -> (TempDir, Storage) {
+    let temp = TempDir::new().unwrap();
+    let storage =
+        Storage::new(&HostedStoreConfig::Fs, temp.path().join("store"), temp.path().join("cache"))
+            .unwrap();
+    (temp, storage)
+}
+
+fn name(repository: &str) -> CanonicalPackageName {
+    CanonicalPackageName::parse(repository, Ecosystem::Oci).unwrap()
+}
+
+async fn blob(storage: &Storage, repository: &CanonicalPackageName, bytes: &[u8]) -> Digest {
+    let digest = Digest::of(bytes);
+    let slot = storage.reserve_hosted_blob(repository, &digest.blob_filename()).await.unwrap();
+    tokio::fs::write(&slot.tmp_path, bytes).await.unwrap();
+    storage.finalize_blob_slot(slot).await.unwrap();
+    digest
+}
+
+async fn retained_image(storage: &Storage, repository: &CanonicalPackageName) -> (Digest, Digest) {
+    let layer = blob(storage, repository, b"layer").await;
+    let bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2, "mediaType": media_type::OCI_IMAGE_MANIFEST,
+        "config": {"digest": layer, "size": 5}, "layers": [],
+    }))
+    .unwrap();
+    let manifest = blob(storage, repository, &bytes).await;
+    let mut document = ImageDocument::new(repository.as_str());
+    document.insert_manifest(ManifestEntry {
+        digest: manifest.clone(),
+        size: bytes.len() as u64,
+        media_type: media_type::OCI_IMAGE_MANIFEST.into(),
+    });
+    storage.write_hosted_document_if_current(repository, &document.to_bytes(), None).await.unwrap();
+    (manifest, layer)
+}
+
+#[tokio::test]
+async fn collection_keeps_untagged_manifests_and_layers_and_finds_nested_orphans() {
+    let (_temp, storage) = setup();
+    let repository = name("acme/app");
+    let (manifest, layer) = retained_image(&storage, &repository).await;
+    blob(&storage, &repository, b"orphan").await;
+    let nested = name("acme/app/tool");
+    let nested_orphan = blob(&storage, &nested, b"nested orphan").await;
+    assert_eq!(
+        collect(&storage, Duration::from_hours(24), false, &HashSet::new()).await.unwrap(),
+        (0, 0),
+    );
+    assert_eq!(collect(&storage, Duration::ZERO, true, &HashSet::new()).await.unwrap(), (2, 19));
+    assert!(
+        storage.open_hosted_blob(&nested, &nested_orphan.blob_filename()).await.unwrap().is_some(),
+    );
+    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (2, 19));
+    assert!(
+        storage.open_hosted_blob(&repository, &manifest.blob_filename()).await.unwrap().is_some(),
+    );
+    assert!(storage.open_hosted_blob(&repository, &layer.blob_filename()).await.unwrap().is_some());
+    assert!(
+        storage.open_hosted_blob(&nested, &nested_orphan.blob_filename()).await.unwrap().is_none(),
+    );
+}
+
+#[tokio::test]
+async fn corrupt_or_missing_manifests_prevent_deletion() {
+    let (temp, storage) = setup();
+    let repository = name("acme/app");
+    let (manifest, _) = retained_image(&storage, &repository).await;
+    let orphan = blob(&storage, &name("aaa"), b"orphan").await;
+    let path = temp.path().join("store/acme/app").join(manifest.blob_filename());
+    tokio::fs::write(&path, b"corrupt").await.unwrap();
+    assert!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.is_err());
+    assert!(
+        storage.open_hosted_blob(&name("aaa"), &orphan.blob_filename()).await.unwrap().is_some(),
+    );
+    tokio::fs::remove_file(path).await.unwrap();
+    assert!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.is_err());
+}
+
+#[tokio::test]
+async fn index_keeps_children_removed_from_the_document_and_their_layers() {
+    let (_temp, storage) = setup();
+    let repository = name("acme/app");
+    let (child, layer) = retained_image(&storage, &repository).await;
+    let bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2, "mediaType": media_type::OCI_IMAGE_INDEX,
+        "manifests": [{"digest": child, "size": 0}],
+    }))
+    .unwrap();
+    let index = blob(&storage, &repository, &bytes).await;
+    let mut document = ImageDocument::new(repository.as_str());
+    document.insert_manifest(ManifestEntry {
+        digest: index.clone(),
+        size: bytes.len() as u64,
+        media_type: media_type::OCI_IMAGE_INDEX.into(),
+    });
+    storage
+        .write_hosted_document_if_current(&repository, &document.to_bytes(), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        referenced_blobs(&storage, &repository).await.unwrap(),
+        HashSet::from([index.blob_filename(), child.blob_filename(), layer.blob_filename()]),
+    );
+    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (0, 0));
+}
+
+#[tokio::test]
+async fn flat_registry_collection_excludes_other_namespaces() {
+    let (_temp, storage) = setup();
+    blob(&storage, &name("other/app"), b"private").await;
+    blob(&storage, &name("app"), b"orphan").await;
+    assert_eq!(
+        collect(&storage, Duration::ZERO, false, &HashSet::from(["other"])).await.unwrap(),
+        (1, 6),
+    );
+}
+
+#[tokio::test]
+async fn collection_uses_the_stored_media_type_for_header_only_manifests() {
+    let (_temp, storage) = setup();
+    let repository = name("app");
+    let layer = blob(&storage, &repository, b"layer").await;
+    let bytes = serde_json::to_vec(&json!({
+        "schemaVersion": 2, "config": {"digest": layer, "size": 5}, "layers": [],
+    }))
+    .unwrap();
+    let digest = blob(&storage, &repository, &bytes).await;
+    let mut document = ImageDocument::new(repository.as_str());
+    document.insert_manifest(ManifestEntry {
+        digest: digest.clone(),
+        size: bytes.len() as u64,
+        media_type: media_type::OCI_IMAGE_MANIFEST.into(),
+    });
+    storage
+        .write_hosted_document_if_current(&repository, &document.to_bytes(), None)
+        .await
+        .unwrap();
+    assert_eq!(
+        referenced_blobs(&storage, &repository).await.unwrap(),
+        HashSet::from([digest.blob_filename(), layer.blob_filename()]),
+    );
+}

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -267,9 +267,8 @@ async fn sweep_abandoned_uploads(config: &Config) -> pnpr_error::Result<()> {
     }
     let storage =
         Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
-    // Uploads are namespaced with the hosted store they will land in, so each
-    // organization keeps its own; the object-store backend stages them all in
-    // one scratch root, where sweeping it once covers every organization.
+    // Shared sessions live in their hosted namespace. Local scratch can be
+    // shared by those namespaces and is safe to sweep more than once.
     let mut namespaces: Vec<&str> =
         config.hosted.values().map(|hosted| hosted.org.as_str()).collect();
     namespaces.push("");

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -773,9 +773,11 @@ impl Refusal {
 /// the error chose.
 impl From<RegistryError> for Refusal {
     fn from(err: RegistryError) -> Self {
+        let upload_conflict = matches!(err, RegistryError::BlobUploadConflict { .. });
         let message = err.public_message();
         let status = err.into_response().status();
         let code = match status {
+            StatusCode::CONFLICT if upload_conflict => ErrorCode::BlobUploadInvalid,
             StatusCode::UNAUTHORIZED => ErrorCode::Unauthorized,
             StatusCode::FORBIDDEN => ErrorCode::Denied,
             StatusCode::NOT_FOUND => ErrorCode::NameUnknown,
@@ -948,8 +950,10 @@ async fn append_body(storage: &Storage, upload: &BlobUpload, body: Body) -> Resu
     let mut writer = upload.append().await?;
     let mut stream = body.into_data_stream();
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk
-            .map_err(|_| Refusal::new(ErrorCode::BlobUploadInvalid, "upload stream ended early"))?;
+        let Ok(chunk) = chunk else {
+            writer.finish().await?;
+            return Err(Refusal::new(ErrorCode::BlobUploadInvalid, "upload stream ended early"));
+        };
         let Some(next) = advance_within_ceiling(written, chunk.len()) else {
             let _ = storage.abort_blob_upload(upload.id()).await;
             return Err(Refusal::new(
@@ -987,6 +991,7 @@ fn upload_lock_key(id: &str) -> String {
 
 /// Hash a finished upload without holding it in memory.
 async fn hash_upload(upload: &BlobUpload) -> Result<Digest, RegistryError> {
+    upload.materialize().await?;
     let mut file = tokio::fs::File::open(upload.path()).await.map_err(RegistryError::Io)?;
     let mut hasher = Sha256::new();
     let mut buffer = vec![0u8; HASH_CHUNK];

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -678,13 +678,10 @@ impl Request {
             }
             Err(err) => return registry_error(err),
         }
-        let slot = match storage.stage_uploaded_blob(upload, key, &digest.blob_filename()).await {
-            Ok(slot) => slot,
-            Err(err) => return registry_error(err),
-        };
-        match storage.finalize_blob_slot(slot).await {
-            // A blob is its bytes, so another writer winning the slot means
-            // the content is already there, which is what the client wanted.
+        match storage.finalize_uploaded_blob(upload, key, &digest.blob_filename()).await {
+            Ok(pnpr_storage::BlobFinalize::Conflict) => {
+                error(ErrorCode::DigestInvalid, "stored blob conflicts with the uploaded content")
+            }
             Ok(_) => created(&format!("{}/{}/blobs/{digest}", self.base, key.as_str()), &digest),
             Err(err) => registry_error(err),
         }

--- a/pnpr/crates/pnpr/src/tests.rs
+++ b/pnpr/crates/pnpr/src/tests.rs
@@ -166,3 +166,24 @@ fn startup_error_report_redacts_dsn_credentials() {
     assert!(!report.contains("admin"));
     assert!(!report.contains("secret"));
 }
+
+#[test]
+fn oci_gc_requires_a_registry_and_parses_maintenance_options() {
+    let _env = scrubbed_env();
+    assert!(Args::try_parse_from(["pnpr", "oci-gc"]).is_err());
+    let args = Args::try_parse_from([
+        "pnpr",
+        "-c",
+        "registry.yaml",
+        "oci-gc",
+        "--registry",
+        "images",
+        "--dry-run",
+        "--min-age-secs",
+        "0",
+    ])
+    .unwrap();
+    assert!(
+        matches!(args.command, Some(super::Command::OciGc { registry, dry_run: true, min_age_secs: 0 }) if registry == "images"),
+    );
+}

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -924,3 +924,76 @@ async fn a_chunk_that_ends_early_leaves_the_prefix_to_resume_from() {
     let response = app.clone().oneshot(request).await.unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 }
+
+#[tokio::test]
+async fn s3_upload_moves_between_replicas_and_keeps_an_interrupted_chunks_prefix() {
+    let first_disk = TempDir::new().unwrap();
+    let second_disk = TempDir::new().unwrap();
+    let objects: std::sync::Arc<dyn object_store::ObjectStore> =
+        std::sync::Arc::new(object_store::memory::InMemory::new());
+    let auth_state = AuthState::in_memory();
+    let replica = |disk: &TempDir| {
+        let mut config = oci_config(disk.path().to_path_buf(), "$all");
+        config.hosted_store = pnpr::HostedStoreConfig::ObjectStore {
+            store: std::sync::Arc::clone(&objects),
+            prefix: "shared/".into(),
+        };
+        router_with_auth(config, auth_state.clone())
+    };
+    let first = replica(&first_disk);
+    let second = replica(&second_disk);
+    let auth = basic(&token(&first).await);
+    let response = first
+        .clone()
+        .oneshot(
+            Request::post("/v2/acme/app/blobs/uploads/")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from("hello "))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let location = response.headers()[header::LOCATION].to_str().unwrap().to_string();
+    let torn = futures_util::stream::iter([
+        Ok(axum::body::Bytes::from_static(b"wor")),
+        Err(std::io::Error::other("disconnected")),
+    ]);
+    let response = second
+        .clone()
+        .oneshot(
+            Request::patch(&location)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from_stream(torn))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response = first
+        .clone()
+        .oneshot(
+            Request::get(&location)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.headers()[header::RANGE], "0-8");
+    let digest = digest_of(b"hello world");
+    let response = first
+        .clone()
+        .oneshot(
+            Request::put(format!("{location}?digest={digest}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from("ld"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let response = get(&second, &format!("/v2/acme/app/blobs/{digest}")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(body_bytes(response.into_body()).await, b"hello world");
+}

--- a/pnpr/crates/storage/Cargo.toml
+++ b/pnpr/crates/storage/Cargo.toml
@@ -28,6 +28,7 @@ serde             = { workspace = true }
 serde_json        = { workspace = true }
 ssri              = { workspace = true }
 tokio             = { workspace = true }
+tempfile          = { workspace = true }
 tracing           = { workspace = true }
 
 [dev-dependencies]

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -74,7 +74,8 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
 
     async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool>;
 
-    async fn list_blob_files(&self) -> Result<Vec<crate::HostedBlobFile>>;
+    fn list_blob_files(&self)
+    -> futures_util::stream::BoxStream<'_, Result<crate::HostedBlobFile>>;
 
     async fn list_package_names(&self) -> Result<Vec<String>>;
 

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -22,6 +22,10 @@ use std::{
 /// rename or by upload, and how a namespace maps onto paths or key prefixes.
 #[async_trait]
 pub(crate) trait HostedBackend: Debug + Send + Sync {
+    fn upload_store(&self) -> Option<crate::upload::RemoteUploadStore> {
+        None
+    }
+
     async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>>;
 
     /// Read a document together with the token [`Self::write_document_if_current`]
@@ -69,6 +73,8 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool>;
 
     async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool>;
+
+    async fn list_blob_files(&self) -> Result<Vec<crate::HostedBlobFile>>;
 
     async fn list_package_names(&self) -> Result<Vec<String>>;
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -360,6 +360,14 @@ pub struct Storage {
     cached: Store,
 }
 
+/// A file in the hosted namespace, for offline maintenance.
+#[derive(Debug)]
+pub struct HostedBlobFile {
+    pub path: String,
+    pub modified: SystemTime,
+    pub size: u64,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DocumentWrite {
     Written,
@@ -439,6 +447,41 @@ impl HostedBackend for Store {
 
     async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         Store::remove_package(self, name).await
+    }
+
+    async fn list_blob_files(&self) -> Result<Vec<HostedBlobFile>> {
+        let mut pending = vec![self.root.clone()];
+        let mut files = Vec::new();
+        while let Some(directory) = pending.pop() {
+            let mut entries = match fs::read_dir(&directory).await {
+                Ok(entries) => entries,
+                Err(error) if error.kind() == ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            while let Some(entry) = entries.next_entry().await? {
+                if entry.file_name().to_string_lossy().starts_with('.') {
+                    continue;
+                }
+                let kind = entry.file_type().await?;
+                if kind.is_dir() {
+                    pending.push(entry.path());
+                } else if kind.is_file() {
+                    let metadata = entry.metadata().await?;
+                    let path = entry
+                        .path()
+                        .strip_prefix(&self.root)
+                        .expect("entry is below the store root")
+                        .to_string_lossy()
+                        .replace('\\', "/");
+                    files.push(HostedBlobFile {
+                        path,
+                        modified: metadata.modified()?,
+                        size: metadata.len(),
+                    });
+                }
+            }
+        }
+        Ok(files)
     }
 
     async fn list_package_names(&self) -> Result<Vec<String>> {
@@ -522,6 +565,12 @@ impl Storage {
             )),
         };
         Ok(Self { hosted, cached })
+    }
+
+    /// Inventory all regular files, including repositories with no document
+    /// and repositories nested below another. Only for offline maintenance.
+    pub async fn hosted_blob_files(&self) -> Result<Vec<HostedBlobFile>> {
+        self.hosted.list_blob_files().await
     }
 
     /// The hosted package names, used by the local search scan (which

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -8,6 +8,10 @@ pub mod upload;
 use crate::s3::S3Store;
 use async_trait::async_trait;
 use axum::body::Body;
+use futures_util::{
+    StreamExt,
+    stream::{self, BoxStream},
+};
 use pnpm_crypto_hash::integrity_addressed_tarball_integrity;
 use pnpr_config::{HostedStoreConfig, build_s3_store, normalize_key_prefix};
 use pnpr_error::{RegistryError, Result};
@@ -449,39 +453,49 @@ impl HostedBackend for Store {
         Store::remove_package(self, name).await
     }
 
-    async fn list_blob_files(&self) -> Result<Vec<HostedBlobFile>> {
-        let mut pending = vec![self.root.clone()];
-        let mut files = Vec::new();
-        while let Some(directory) = pending.pop() {
-            let mut entries = match fs::read_dir(&directory).await {
-                Ok(entries) => entries,
-                Err(error) if error.kind() == ErrorKind::NotFound => continue,
-                Err(error) => return Err(error.into()),
-            };
-            while let Some(entry) = entries.next_entry().await? {
-                if entry.file_name().to_string_lossy().starts_with('.') {
-                    continue;
+    fn list_blob_files(&self) -> BoxStream<'_, Result<HostedBlobFile>> {
+        let root = &self.root;
+        stream::try_unfold(
+            (true, Vec::<fs::ReadDir>::new()),
+            move |(first, mut directories)| async move {
+                if first {
+                    match fs::read_dir(root).await {
+                        Ok(entries) => directories.push(entries),
+                        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+                        Err(error) => return Err(RegistryError::Io(error)),
+                    }
                 }
-                let kind = entry.file_type().await?;
-                if kind.is_dir() {
-                    pending.push(entry.path());
-                } else if kind.is_file() {
-                    let metadata = entry.metadata().await?;
-                    let path = entry
-                        .path()
-                        .strip_prefix(&self.root)
-                        .expect("entry is below the store root")
-                        .to_string_lossy()
-                        .replace('\\', "/");
-                    files.push(HostedBlobFile {
-                        path,
-                        modified: metadata.modified()?,
-                        size: metadata.len(),
-                    });
+                while let Some(entries) = directories.last_mut() {
+                    let Some(entry) = entries.next_entry().await? else {
+                        directories.pop();
+                        continue;
+                    };
+                    if entry.file_name().to_string_lossy().starts_with('.') {
+                        continue;
+                    }
+                    let kind = entry.file_type().await?;
+                    if kind.is_dir() {
+                        directories.push(fs::read_dir(entry.path()).await?);
+                    } else if kind.is_file() {
+                        let metadata = entry.metadata().await?;
+                        let path = entry
+                            .path()
+                            .strip_prefix(root)
+                            .expect("entry is below the store root")
+                            .to_string_lossy()
+                            .replace('\\', "/");
+                        let file = HostedBlobFile {
+                            path,
+                            modified: metadata.modified()?,
+                            size: metadata.len(),
+                        };
+                        return Ok(Some((file, (false, directories))));
+                    }
                 }
-            }
-        }
-        Ok(files)
+                Ok(None)
+            },
+        )
+        .boxed()
     }
 
     async fn list_package_names(&self) -> Result<Vec<String>> {
@@ -569,8 +583,9 @@ impl Storage {
 
     /// Inventory all regular files, including repositories with no document
     /// and repositories nested below another. Only for offline maintenance.
-    pub async fn hosted_blob_files(&self) -> Result<Vec<HostedBlobFile>> {
-        self.hosted.list_blob_files().await
+    #[must_use]
+    pub fn hosted_blob_files(&self) -> BoxStream<'_, Result<HostedBlobFile>> {
+        self.hosted.list_blob_files()
     }
 
     /// The hosted package names, used by the local search scan (which
@@ -723,13 +738,22 @@ impl Storage {
         Ok(BlobSlot { tmp_path, name: name.clone(), filename: filename.to_string() })
     }
 
+    /// Remove a hosted blob without changing any proxy-cache namespace.
+    pub async fn remove_hosted_blob(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<bool> {
+        self.hosted.remove_blob(name, filename).await
+    }
+
     /// Remove a single blob from both stores. The
     /// partial-unpublish flow calls this after PUT'ing the modified
     /// document back; clearing the proxied mirror too stops
     /// the proxy cache from serving a stale copy of the just-removed
     /// version.
     pub async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
-        let hosted = self.hosted.remove_blob(name, filename).await?;
+        let hosted = self.remove_hosted_blob(name, filename).await?;
         let cached = self.cached.remove_blob(name, filename).await?;
         Ok(hosted || cached)
     }

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -649,23 +649,28 @@ impl HostedBackend for S3Store {
         S3Store::remove_package(self, name).await
     }
 
-    async fn list_blob_files(&self) -> Result<Vec<crate::HostedBlobFile>> {
+    fn list_blob_files(
+        &self,
+    ) -> futures_util::stream::BoxStream<'_, Result<crate::HostedBlobFile>> {
         let prefix = ObjectPath::from(self.prefix.trim_end_matches('/'));
-        let mut listing = self.store.list(Some(&prefix));
-        let mut files = Vec::new();
-        while let Some(meta) = listing.next().await {
-            let meta = meta?;
-            let Some(path) = meta.location.as_ref().strip_prefix(&self.prefix) else { continue };
-            if path.split('/').any(|part| part.starts_with('.')) {
-                continue;
-            }
-            files.push(crate::HostedBlobFile {
-                path: path.to_string(),
-                modified: meta.last_modified.into(),
-                size: meta.size,
-            });
-        }
-        Ok(files)
+        self.store
+            .list(Some(&prefix))
+            .filter_map(move |result| async move {
+                let meta = match result {
+                    Ok(meta) => meta,
+                    Err(error) => return Some(Err(error.into())),
+                };
+                let path = meta.location.as_ref().strip_prefix(&self.prefix)?;
+                if path.split('/').any(|part| part.starts_with('.')) {
+                    return None;
+                }
+                Some(Ok(crate::HostedBlobFile {
+                    path: path.to_string(),
+                    modified: meta.last_modified.into(),
+                    size: meta.size,
+                }))
+            })
+            .boxed()
     }
 
     async fn list_package_names(&self) -> Result<Vec<String>> {

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -83,7 +83,17 @@ pub(crate) struct S3DocumentForUpdate {
 const STAGING_SUBDIR: &str = "pnpr-hosted-staging";
 
 /// Send `tmp_path` as parts and complete the upload.
-async fn send_parts(tmp_path: &Path, upload: &mut dyn MultipartUpload) -> Result<()> {
+pub(crate) async fn send_parts(tmp_path: &Path, upload: &mut dyn MultipartUpload) -> Result<()> {
+    let result = stream_parts(tmp_path, upload).await;
+    if result.is_err()
+        && let Err(error) = upload.abort().await
+    {
+        tracing::warn!(%error, "failed to abort multipart upload");
+    }
+    result
+}
+
+async fn stream_parts(tmp_path: &Path, upload: &mut dyn MultipartUpload) -> Result<()> {
     let mut file = fs::File::open(tmp_path).await?;
     let mut part = vec![0u8; MULTIPART_PART_BYTES];
     loop {
@@ -283,17 +293,8 @@ impl S3Store {
         key: &ObjectPath,
     ) -> Result<BlobFinalize> {
         let mut upload = self.store.put_multipart(key).await?;
-        match send_parts(tmp_path, upload.as_mut()).await {
-            Ok(()) => Ok(BlobFinalize::Written),
-            Err(err) => {
-                // The parts already sent are stored, and billed, until the
-                // upload they belong to ends. Nothing else knows this one
-                // exists, so a push failing partway would leave them for the
-                // provider's own expiry rule to find.
-                let _ = upload.abort().await;
-                Err(err)
-            }
-        }
+        send_parts(tmp_path, upload.as_mut()).await?;
+        Ok(BlobFinalize::Written)
     }
 
     pub async fn remove_blob(&self, name: &CanonicalPackageName, filename: &str) -> Result<bool> {
@@ -567,6 +568,14 @@ mod tests;
 /// by upload rather than rename.
 #[async_trait]
 impl HostedBackend for S3Store {
+    fn upload_store(&self) -> Option<crate::upload::RemoteUploadStore> {
+        Some(crate::upload::RemoteUploadStore::new(
+            Arc::clone(&self.store),
+            &self.prefix,
+            self.cache_root.join(crate::upload::UPLOADS_DIR),
+        ))
+    }
+
     async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         S3Store::read_document(self, name).await
     }
@@ -638,6 +647,25 @@ impl HostedBackend for S3Store {
 
     async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
         S3Store::remove_package(self, name).await
+    }
+
+    async fn list_blob_files(&self) -> Result<Vec<crate::HostedBlobFile>> {
+        let prefix = ObjectPath::from(self.prefix.trim_end_matches('/'));
+        let mut listing = self.store.list(Some(&prefix));
+        let mut files = Vec::new();
+        while let Some(meta) = listing.next().await {
+            let meta = meta?;
+            let Some(path) = meta.location.as_ref().strip_prefix(&self.prefix) else { continue };
+            if path.split('/').any(|part| part.starts_with('.')) {
+                continue;
+            }
+            files.push(crate::HostedBlobFile {
+                path: path.to_string(),
+                modified: meta.last_modified.into(),
+                size: meta.size,
+            });
+        }
+        Ok(files)
     }
 
     async fn list_package_names(&self) -> Result<Vec<String>> {

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -367,3 +367,79 @@ fn prefix_normalizes() {
     assert_eq!(normalized(Some("packages")), "packages/");
     assert_eq!(normalized(Some("/packages/")), "packages/");
 }
+
+#[derive(Debug, Default)]
+struct RecordedMultipart {
+    sizes: Vec<usize>,
+    fail_part: bool,
+    completed: bool,
+    aborted: bool,
+}
+
+#[async_trait::async_trait]
+impl object_store::MultipartUpload for RecordedMultipart {
+    fn put_part(&mut self, data: PutPayload) -> object_store::UploadPart {
+        self.sizes.push(data.content_length());
+        let fail = self.fail_part;
+        Box::pin(async move {
+            if fail {
+                return Err(object_store::Error::Generic {
+                    store: "test",
+                    source: std::io::Error::other("part failed").into(),
+                });
+            }
+            Ok(())
+        })
+    }
+
+    async fn complete(&mut self) -> object_store::Result<object_store::PutResult> {
+        self.completed = true;
+        Ok(object_store::PutResult {
+            e_tag: None,
+            version: None,
+            extensions: axum::http::Extensions::default(),
+        })
+    }
+
+    async fn abort(&mut self) -> object_store::Result<()> {
+        self.aborted = true;
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn multipart_streams_large_files_in_bounded_parts_and_aborts_failures() {
+    let temp = tempfile::NamedTempFile::new().unwrap();
+    let size = super::MAX_SINGLE_PUT_BYTES + 1;
+    temp.as_file().set_len(size).unwrap();
+    let mut upload = RecordedMultipart::default();
+    super::send_parts(temp.path(), &mut upload).await.unwrap();
+    assert!(upload.completed);
+    assert!(!upload.aborted);
+    assert_eq!(upload.sizes.iter().sum::<usize>() as u64, size);
+    assert_eq!(upload.sizes.last(), Some(&1));
+    assert!(
+        upload.sizes[..upload.sizes.len() - 1]
+            .iter()
+            .all(|size| *size == super::MULTIPART_PART_BYTES),
+    );
+    let mut failed = RecordedMultipart { fail_part: true, ..Default::default() };
+    assert!(super::send_parts(temp.path(), &mut failed).await.is_err());
+    assert!(failed.aborted);
+    assert!(!failed.completed);
+}
+
+#[tokio::test]
+async fn maintenance_inventory_includes_nested_and_unmanifested_repositories() {
+    let (store, _staging) = store_with_prefix("images");
+    let parent =
+        CanonicalPackageName::parse("acme/app", pnpr_package_name::Ecosystem::Oci).unwrap();
+    let child =
+        CanonicalPackageName::parse("acme/app/tool", pnpr_package_name::Ecosystem::Oci).unwrap();
+    upload(&store, &parent, "sha256-parent", b"parent").await;
+    upload(&store, &child, "sha256-child", b"child").await;
+    write_document(&store, &parent, b"{}").await;
+    let files = crate::HostedBackend::list_blob_files(&store).await.unwrap();
+    assert_eq!(files.len(), 3);
+    assert!(files.iter().any(|file| file.path == "acme/app/tool/sha256-child"));
+}

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -1,5 +1,6 @@
 use super::{Body, ObjectStore, S3Store};
 use crate::HostedRevisionRefWrite;
+use futures_util::TryStreamExt;
 use object_store::{ObjectStoreExt, PutPayload, memory::InMemory, path::Path as ObjectPath};
 use pnpr_config::S3Settings;
 use pnpr_package_name::CanonicalPackageName;
@@ -439,7 +440,8 @@ async fn maintenance_inventory_includes_nested_and_unmanifested_repositories() {
     upload(&store, &parent, "sha256-parent", b"parent").await;
     upload(&store, &child, "sha256-child", b"child").await;
     write_document(&store, &parent, b"{}").await;
-    let files = crate::HostedBackend::list_blob_files(&store).await.unwrap();
+    let files =
+        crate::HostedBackend::list_blob_files(&store).try_collect::<Vec<_>>().await.unwrap();
     assert_eq!(files.len(), 3);
     assert!(files.iter().any(|file| file.path == "acme/app/tool/sha256-child"));
 }

--- a/pnpr/crates/storage/src/upload.rs
+++ b/pnpr/crates/storage/src/upload.rs
@@ -1,18 +1,18 @@
 //! Resumable blob uploads.
 //!
-//! A blob whose bytes arrive across several requests cannot be held in
-//! memory between them, so an upload is a local file the client appends to
-//! and an id that names it. Only when the client finishes and the bytes hash
-//! to what it promised does the file become a hosted blob.
-//!
-//! The file lives beside the publish journal in the backend's local scratch
-//! root, so an S3-backed registry stages here too and the eventual promotion
-//! is one rename or one upload rather than a second copy through memory.
+//! Filesystem uploads append to a local file. Object-store uploads commit
+//! immutable chunks through a conditional session record, so any replica can
+//! resume at the accepted offset. Completion materializes the bytes locally
+//! for digest verification before promotion to a hosted blob.
+
+mod remote;
+
+pub(crate) use remote::RemoteUploadStore;
 
 use crate::{BlobSlot, Storage};
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::CanonicalPackageName;
-use std::{fmt::Write as _, path::PathBuf, time::Duration};
+use std::{fmt::Write as _, path::PathBuf, sync::Arc, time::Duration};
 use tokio::{
     fs,
     io::{AsyncWriteExt, ErrorKind},
@@ -40,6 +40,8 @@ pub const UPLOAD_MAX_AGE: Duration = Duration::from_hours(24);
 pub struct BlobUpload {
     id: String,
     path: PathBuf,
+    remote: Option<Arc<remote::RemoteUpload>>,
+    _temp: Option<Arc<tempfile::TempPath>>,
 }
 
 impl BlobUpload {
@@ -52,6 +54,9 @@ impl BlobUpload {
     /// How many bytes have been accepted so far, which is where the next
     /// chunk must start.
     pub async fn offset(&self) -> Result<u64> {
+        if let Some(remote) = &self.remote {
+            return Ok(remote.offset().await);
+        }
         match fs::metadata(&self.path).await {
             Ok(metadata) => Ok(metadata.len()),
             Err(error) if error.kind() == ErrorKind::NotFound => Ok(0),
@@ -59,11 +64,19 @@ impl BlobUpload {
         }
     }
 
-    /// Where the accumulated bytes are, for a caller that needs to read them
-    /// back without holding them in memory.
+    /// Local path for digest verification. Call [`Self::materialize`] before
+    /// reading an object-store upload.
     #[must_use]
     pub fn path(&self) -> &std::path::Path {
         &self.path
+    }
+
+    /// Materialize accepted chunks for digest verification and promotion.
+    pub async fn materialize(&self) -> Result<()> {
+        if let Some(remote) = &self.remote {
+            remote.materialize(&self.path).await?;
+        }
+        Ok(())
     }
 
     /// The filename of this upload's repository record.
@@ -74,19 +87,23 @@ impl BlobUpload {
     /// Open the upload for appending. Held for one request, so a chunk is
     /// written with one open rather than one per buffer.
     pub async fn append(&self) -> Result<BlobUploadWriter> {
+        if let Some(remote) = &self.remote {
+            return remote.append().await;
+        }
         let file = fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.path)
             .await
             .map_err(RegistryError::Io)?;
-        Ok(BlobUploadWriter { file })
+        Ok(BlobUploadWriter { file, remote: None })
     }
 }
 
 /// The append handle for one request's worth of an upload.
 pub struct BlobUploadWriter {
     file: fs::File,
+    remote: Option<remote::RemoteChunk>,
 }
 
 impl BlobUploadWriter {
@@ -97,13 +114,21 @@ impl BlobUploadWriter {
     /// Flush to disk and report the upload's new length.
     pub async fn finish(self) -> Result<u64> {
         self.file.sync_all().await.map_err(RegistryError::Io)?;
-        self.file.metadata().await.map(|metadata| metadata.len()).map_err(RegistryError::Io)
+        let size = self.file.metadata().await.map_err(RegistryError::Io)?.len();
+        drop(self.file);
+        if let Some(chunk) = self.remote {
+            return chunk.commit(size).await;
+        }
+        Ok(size)
     }
 }
 
 impl Storage {
     /// Start an upload for `repository` and give it an unguessable id.
     pub async fn begin_blob_upload(&self, repository: &CanonicalPackageName) -> Result<BlobUpload> {
+        if let Some(remote) = self.hosted.upload_store() {
+            return remote.begin(repository).await;
+        }
         let root = self.uploads_root();
         fs::create_dir_all(&root).await.map_err(RegistryError::Io)?;
         let id = generate_upload_id();
@@ -119,7 +144,7 @@ impl Storage {
         fs::write(root.join(repository_record(&id)), self.upload_owner(repository))
             .await
             .map_err(RegistryError::Io)?;
-        Ok(BlobUpload { id, path })
+        Ok(BlobUpload { id, path, remote: None, _temp: None })
     }
 
     /// Reopen an upload of `repository` by id.
@@ -136,6 +161,9 @@ impl Storage {
         if !is_upload_id(id) {
             return Ok(None);
         }
+        if let Some(remote) = self.hosted.upload_store() {
+            return remote.open(repository, id).await;
+        }
         let root = self.uploads_root();
         let held = match fs::read_to_string(root.join(repository_record(id))).await {
             Ok(held) => held,
@@ -147,7 +175,7 @@ impl Storage {
         }
         let path = root.join(id);
         match fs::metadata(&path).await {
-            Ok(_) => Ok(Some(BlobUpload { id: id.to_string(), path })),
+            Ok(_) => Ok(Some(BlobUpload { id: id.to_string(), path, remote: None, _temp: None })),
             Err(error) if error.kind() == ErrorKind::NotFound => Ok(None),
             Err(error) => Err(RegistryError::Io(error)),
         }
@@ -157,6 +185,9 @@ impl Storage {
     pub async fn abort_blob_upload(&self, id: &str) -> Result<bool> {
         if !is_upload_id(id) {
             return Ok(false);
+        }
+        if let Some(remote) = self.hosted.upload_store() {
+            return remote.abort(id).await;
         }
         let root = self.uploads_root();
         let _ = fs::remove_file(root.join(repository_record(id))).await;
@@ -170,18 +201,21 @@ impl Storage {
     /// Move a finished upload into a hosted blob slot, ready for
     /// [`Storage::finalize_blob_slot`].
     ///
-    /// The upload is consumed on success, where its bytes become the slot's.
-    /// It is left where it was on failure, so a caller can retry or abort it
-    /// rather than lose bytes a client already sent.
+    /// Consumes the upload on success. Object-store sessions must still match
+    /// the version that was verified; concurrent appends refuse promotion.
     pub async fn stage_uploaded_blob(
         &self,
         upload: BlobUpload,
         name: &CanonicalPackageName,
         filename: &str,
     ) -> Result<BlobSlot> {
+        upload.materialize().await?;
         let slot = self.reserve_hosted_blob(name, filename).await?;
         if let Some(parent) = slot.tmp_path.parent() {
             fs::create_dir_all(parent).await.map_err(RegistryError::Io)?;
+        }
+        if let Some(remote) = &upload.remote {
+            remote.close().await?;
         }
         // Both paths are under the backend's local scratch root, so this is a
         // rename rather than a copy through memory. A cross-device staging
@@ -200,13 +234,17 @@ impl Storage {
     /// left behind. An upload still being written has just been appended to,
     /// so its age is its idle time rather than its lifetime.
     pub async fn sweep_blob_uploads(&self, max_age: Duration) -> Result<usize> {
+        let remote_swept = match self.hosted.upload_store() {
+            Some(remote) => remote.sweep(max_age).await?,
+            None => 0,
+        };
         let root = self.uploads_root();
         let mut entries = match fs::read_dir(&root).await {
             Ok(entries) => entries,
-            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(0),
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(remote_swept),
             Err(error) => return Err(RegistryError::Io(error)),
         };
-        let mut swept = 0;
+        let mut swept = remote_swept;
         while let Some(entry) = entries.next_entry().await.map_err(RegistryError::Io)? {
             let name = entry.file_name();
             let name = name.to_string_lossy();

--- a/pnpr/crates/storage/src/upload.rs
+++ b/pnpr/crates/storage/src/upload.rs
@@ -9,7 +9,7 @@ mod remote;
 
 pub(crate) use remote::RemoteUploadStore;
 
-use crate::{BlobSlot, Storage};
+use crate::{BlobFinalize, BlobSlot, Storage};
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::CanonicalPackageName;
 use std::{fmt::Write as _, path::PathBuf, sync::Arc, time::Duration};
@@ -198,12 +198,31 @@ impl Storage {
         }
     }
 
+    /// Promote verified bytes before closing their shared upload session.
+    /// A failed promotion leaves accepted remote chunks available for retry.
+    pub async fn finalize_uploaded_blob(
+        &self,
+        upload: BlobUpload,
+        name: &CanonicalPackageName,
+        filename: &str,
+    ) -> Result<BlobFinalize> {
+        let remote = upload.remote.clone();
+        let slot = self.stage_uploaded_blob(upload, name, filename).await?;
+        let _temp = tempfile::TempPath::try_from_path(slot.tmp_path.clone())?;
+        let outcome = self.finalize_blob_slot(slot).await?;
+        if outcome != BlobFinalize::Conflict
+            && let Some(remote) = remote
+        {
+            remote.close().await?;
+        }
+        Ok(outcome)
+    }
+
     /// Move a finished upload into a hosted blob slot, ready for
     /// [`Storage::finalize_blob_slot`].
     ///
-    /// Consumes the upload on success. Object-store sessions must still match
-    /// the version that was verified; concurrent appends refuse promotion.
-    pub async fn stage_uploaded_blob(
+    /// Shared sessions remain open until their bytes have been promoted.
+    async fn stage_uploaded_blob(
         &self,
         upload: BlobUpload,
         name: &CanonicalPackageName,
@@ -213,9 +232,6 @@ impl Storage {
         let slot = self.reserve_hosted_blob(name, filename).await?;
         if let Some(parent) = slot.tmp_path.parent() {
             fs::create_dir_all(parent).await.map_err(RegistryError::Io)?;
-        }
-        if let Some(remote) = &upload.remote {
-            remote.close().await?;
         }
         // Both paths are under the backend's local scratch root, so this is a
         // rename rather than a copy through memory. A cross-device staging

--- a/pnpr/crates/storage/src/upload.rs
+++ b/pnpr/crates/storage/src/upload.rs
@@ -209,11 +209,15 @@ impl Storage {
         let remote = upload.remote.clone();
         let slot = self.stage_uploaded_blob(upload, name, filename).await?;
         let _temp = tempfile::TempPath::try_from_path(slot.tmp_path.clone())?;
+        if let Some(remote) = &remote {
+            remote.prepare_completion(filename).await?;
+        }
         let outcome = self.finalize_blob_slot(slot).await?;
         if outcome != BlobFinalize::Conflict
             && let Some(remote) = remote
+            && let Err(error) = remote.close().await
         {
-            remote.close().await?;
+            tracing::warn!(error = %error.log_message(), "promoted upload awaits session cleanup");
         }
         Ok(outcome)
     }
@@ -221,7 +225,7 @@ impl Storage {
     /// Move a finished upload into a hosted blob slot, ready for
     /// [`Storage::finalize_blob_slot`].
     ///
-    /// Shared sessions remain open until their bytes have been promoted.
+    /// Shared chunks remain available until their bytes have been promoted.
     async fn stage_uploaded_blob(
         &self,
         upload: BlobUpload,

--- a/pnpr/crates/storage/src/upload/remote.rs
+++ b/pnpr/crates/storage/src/upload/remote.rs
@@ -1,0 +1,290 @@
+use super::{BlobUpload, BlobUploadWriter, generate_upload_id, is_upload_id};
+use crate::s3::send_parts;
+use futures_util::StreamExt;
+use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, UpdateVersion, path::Path};
+use pnpr_error::{RegistryError, Result};
+use pnpr_package_name::CanonicalPackageName;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+use tempfile::TempPath;
+use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
+
+const MAX_CHUNKS: usize = 10_000;
+
+#[derive(Debug, Clone)]
+pub(crate) struct RemoteUploadStore {
+    store: Arc<dyn ObjectStore>,
+    prefix: String,
+    scratch: PathBuf,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct UploadRecord {
+    repository: String,
+    chunks: Vec<String>,
+    size: u64,
+    closed: bool,
+}
+
+#[derive(Debug)]
+struct VersionedRecord {
+    record: UploadRecord,
+    version: UpdateVersion,
+}
+
+#[derive(Debug)]
+pub(super) struct RemoteUpload {
+    backend: RemoteUploadStore,
+    id: String,
+    state: Mutex<VersionedRecord>,
+}
+
+pub(super) struct RemoteChunk {
+    upload: Arc<RemoteUpload>,
+    snapshot: UploadRecord,
+    version: UpdateVersion,
+    path: TempPath,
+}
+
+impl RemoteUploadStore {
+    pub(crate) fn new(store: Arc<dyn ObjectStore>, prefix: &str, scratch: PathBuf) -> Self {
+        Self { store, prefix: format!("{prefix}.pnpr-uploads/"), scratch }
+    }
+
+    fn key(&self, id: &str, object: &str) -> Path {
+        Path::from(format!("{}{id}/{object}", self.prefix))
+    }
+
+    async fn read(&self, id: &str) -> Result<Option<VersionedRecord>> {
+        let result = match self.store.get(&self.key(id, "session.json")).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let version = UpdateVersion {
+            e_tag: result.meta.e_tag.clone(),
+            version: result.meta.version.clone(),
+        };
+        let record: UploadRecord = serde_json::from_slice(&result.bytes().await?)?;
+        if record.chunks.len() > MAX_CHUNKS || record.chunks.iter().any(|id| !is_upload_id(id)) {
+            return Err(RegistryError::Internal { reason: "invalid upload chunk list".into() });
+        }
+        Ok(Some(VersionedRecord { record, version }))
+    }
+
+    async fn write(&self, id: &str, record: &UploadRecord, mode: PutMode) -> Result<UpdateVersion> {
+        let result = self
+            .store
+            .put_opts(
+                &self.key(id, "session.json"),
+                serde_json::to_vec(record)?.into(),
+                PutOptions { mode, ..Default::default() },
+            )
+            .await
+            .map_err(|error| match error {
+                object_store::Error::Precondition { .. }
+                | object_store::Error::AlreadyExists { .. }
+                | object_store::Error::NotFound { .. } => {
+                    RegistryError::BlobUploadConflict { id: id.to_string() }
+                }
+                error => error.into(),
+            })?;
+        Ok(UpdateVersion { e_tag: result.e_tag, version: result.version })
+    }
+
+    async fn temp(&self) -> Result<TempPath> {
+        fs::create_dir_all(&self.scratch).await?;
+        Ok(tempfile::NamedTempFile::new_in(&self.scratch)?.into_temp_path())
+    }
+
+    async fn handle(&self, id: &str, state: VersionedRecord) -> Result<BlobUpload> {
+        let temp = Arc::new(self.temp().await?);
+        Ok(BlobUpload {
+            id: id.to_string(),
+            path: temp.to_path_buf(),
+            remote: Some(Arc::new(RemoteUpload {
+                backend: self.clone(),
+                id: id.to_string(),
+                state: Mutex::new(state),
+            })),
+            _temp: Some(temp),
+        })
+    }
+
+    pub(super) async fn begin(&self, repository: &CanonicalPackageName) -> Result<BlobUpload> {
+        let id = generate_upload_id();
+        let record = UploadRecord {
+            repository: repository.as_str().to_string(),
+            chunks: Vec::new(),
+            size: 0,
+            closed: false,
+        };
+        let version = self.write(&id, &record, PutMode::Create).await?;
+        self.handle(&id, VersionedRecord { record, version }).await
+    }
+
+    pub(super) async fn open(
+        &self,
+        repository: &CanonicalPackageName,
+        id: &str,
+    ) -> Result<Option<BlobUpload>> {
+        let Some(state) = self.read(id).await? else { return Ok(None) };
+        if state.record.closed || state.record.repository != repository.as_str() {
+            return Ok(None);
+        }
+        self.handle(id, state).await.map(Some)
+    }
+
+    pub(super) async fn abort(&self, id: &str) -> Result<bool> {
+        let Some(mut state) = self.read(id).await? else { return Ok(false) };
+        if state.record.closed {
+            return Ok(false);
+        }
+        state.record.closed = true;
+        self.write(id, &state.record, PutMode::Update(state.version)).await?;
+        self.remove_chunks(id, &state.record).await?;
+        Ok(true)
+    }
+
+    async fn remove_chunks(&self, id: &str, record: &UploadRecord) -> Result<()> {
+        for chunk in &record.chunks {
+            self.remove(&self.key(id, chunk)).await?;
+        }
+        Ok(())
+    }
+
+    async fn remove(&self, path: &Path) -> Result<()> {
+        match self.store.delete(path).await {
+            Ok(()) | Err(object_store::Error::NotFound { .. }) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) async fn sweep(&self, max_age: Duration) -> Result<usize> {
+        let mut listing = self.store.list(Some(&Path::from(self.prefix.clone())));
+        let mut swept = 0;
+        let mut live_sessions = HashSet::new();
+        while let Some(meta) = listing.next().await {
+            let meta = meta?;
+            let Some(relative) = meta.location.as_ref().strip_prefix(&self.prefix) else {
+                continue;
+            };
+            let Some((id, object)) = relative.split_once('/') else { continue };
+            if !is_upload_id(id) {
+                continue;
+            }
+            let age = std::time::SystemTime::from(meta.last_modified).elapsed().unwrap_or_default();
+            if age <= max_age || (object != "session.json" && live_sessions.contains(id)) {
+                continue;
+            }
+            let Some(mut state) = self.read(id).await? else {
+                self.remove(&meta.location).await?;
+                continue;
+            };
+            if object == "session.json" {
+                // The listing may predate a successful append. Compare the
+                // listed version, never a freshly read version, when expiring it.
+                state.record.closed = true;
+                let version = UpdateVersion { e_tag: meta.e_tag, version: meta.version };
+                match self.write(id, &state.record, PutMode::Update(version)).await {
+                    Ok(_) => {}
+                    Err(RegistryError::BlobUploadConflict { .. }) => continue,
+                    Err(error) => return Err(error),
+                }
+                live_sessions.remove(id);
+                self.remove_chunks(id, &state.record).await?;
+                self.remove(&meta.location).await?;
+                swept += 1;
+            } else if state.record.closed {
+                self.remove(&meta.location).await?;
+            } else {
+                live_sessions.insert(id.to_string());
+            }
+        }
+        Ok(swept)
+    }
+}
+
+impl RemoteUpload {
+    pub(super) async fn offset(&self) -> u64 {
+        self.state.lock().await.record.size
+    }
+
+    pub(super) async fn append(self: &Arc<Self>) -> Result<BlobUploadWriter> {
+        let state = self.state.lock().await;
+        let path = self.backend.temp().await?;
+        let file = fs::OpenOptions::new().write(true).open(&path).await?;
+        Ok(BlobUploadWriter {
+            file,
+            remote: Some(RemoteChunk {
+                upload: Arc::clone(self),
+                snapshot: state.record.clone(),
+                version: state.version.clone(),
+                path,
+            }),
+        })
+    }
+
+    pub(super) async fn materialize(&self, path: &std::path::Path) -> Result<()> {
+        let state = self.state.lock().await;
+        if fs::metadata(path).await?.len() == state.record.size {
+            return Ok(());
+        }
+        let mut file = fs::File::create(path).await?;
+        for chunk in &state.record.chunks {
+            let mut stream =
+                self.backend.store.get(&self.backend.key(&self.id, chunk)).await?.into_stream();
+            while let Some(bytes) = stream.next().await {
+                file.write_all(&bytes?).await?;
+            }
+        }
+        file.sync_all().await?;
+        Ok(())
+    }
+
+    pub(super) async fn close(&self) -> Result<()> {
+        let mut state = self.state.lock().await;
+        let mut record = state.record.clone();
+        record.closed = true;
+        let version =
+            self.backend.write(&self.id, &record, PutMode::Update(state.version.clone())).await?;
+        *state = VersionedRecord { record, version };
+        if let Err(error) = self.backend.remove_chunks(&self.id, &state.record).await {
+            tracing::warn!(%error, upload = self.id, "completed upload chunks await expiry cleanup");
+        }
+        Ok(())
+    }
+}
+
+impl RemoteChunk {
+    pub(super) async fn commit(mut self, size: u64) -> Result<u64> {
+        if size == 0 {
+            return Ok(self.snapshot.size);
+        }
+        if self.snapshot.chunks.len() == MAX_CHUNKS {
+            return Err(RegistryError::BadRequest { reason: "upload has too many chunks".into() });
+        }
+        let chunk = generate_upload_id();
+        let key = self.upload.backend.key(&self.upload.id, &chunk);
+        let mut multipart = self.upload.backend.store.put_multipart(&key).await?;
+        send_parts(&self.path, multipart.as_mut()).await?;
+        self.snapshot.chunks.push(chunk);
+        self.snapshot.size =
+            self.snapshot.size.checked_add(size).ok_or_else(|| RegistryError::BadRequest {
+                reason: "upload size overflow".into(),
+            })?;
+        // An uncertain write may have committed. Leave its chunk until session
+        // expiry, when no append can make the chunk reachable anymore.
+        let version = self
+            .upload
+            .backend
+            .write(&self.upload.id, &self.snapshot, PutMode::Update(self.version))
+            .await?;
+        let offset = self.snapshot.size;
+        *self.upload.state.lock().await = VersionedRecord { record: self.snapshot, version };
+        Ok(offset)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/storage/src/upload/remote.rs
+++ b/pnpr/crates/storage/src/upload/remote.rs
@@ -5,7 +5,12 @@ use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, UpdateVersi
 use pnpr_error::{RegistryError, Result};
 use pnpr_package_name::CanonicalPackageName;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, path::PathBuf, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+    sync::Arc,
+    time::Duration,
+};
 use tempfile::TempPath;
 use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
 
@@ -142,13 +147,19 @@ impl RemoteUploadStore {
         }
         state.record.closed = true;
         self.write(id, &state.record, PutMode::Update(state.version)).await?;
-        self.remove_chunks(id, &state.record).await?;
+        self.remove_chunks(id).await?;
         Ok(true)
     }
 
-    async fn remove_chunks(&self, id: &str, record: &UploadRecord) -> Result<()> {
-        for chunk in &record.chunks {
-            self.remove(&self.key(id, chunk)).await?;
+    async fn remove_chunks(&self, id: &str) -> Result<()> {
+        let prefix = Path::from(format!("{}{id}/", self.prefix));
+        let mut listing = self.store.list(Some(&prefix));
+        let session = self.key(id, "session.json");
+        while let Some(meta) = listing.next().await {
+            let meta = meta?;
+            if meta.location != session {
+                self.remove(&meta.location).await?;
+            }
         }
         Ok(())
     }
@@ -163,7 +174,8 @@ impl RemoteUploadStore {
     pub(super) async fn sweep(&self, max_age: Duration) -> Result<usize> {
         let mut listing = self.store.list(Some(&Path::from(self.prefix.clone())));
         let mut swept = 0;
-        let mut live_sessions = HashSet::new();
+        let mut sessions = HashMap::new();
+        let mut unreadable = HashSet::new();
         while let Some(meta) = listing.next().await {
             let meta = meta?;
             let Some(relative) = meta.location.as_ref().strip_prefix(&self.prefix) else {
@@ -174,10 +186,27 @@ impl RemoteUploadStore {
                 continue;
             }
             let age = std::time::SystemTime::from(meta.last_modified).elapsed().unwrap_or_default();
-            if age <= max_age || (object != "session.json" && live_sessions.contains(id)) {
+            if age <= max_age || unreadable.contains(id) {
                 continue;
             }
-            let Some(mut state) = self.read(id).await? else {
+            if object != "session.json"
+                && let Some(live) = sessions.get(id)
+            {
+                if !live {
+                    self.remove(&meta.location).await?;
+                }
+                continue;
+            }
+            let state = match self.read(id).await {
+                Ok(state) => state,
+                Err(error) => {
+                    tracing::warn!(error = %error.log_message(), upload = id, "skipping unreadable upload session");
+                    unreadable.insert(id.to_string());
+                    continue;
+                }
+            };
+            let Some(mut state) = state else {
+                sessions.insert(id.to_string(), false);
                 self.remove(&meta.location).await?;
                 continue;
             };
@@ -191,14 +220,15 @@ impl RemoteUploadStore {
                     Err(RegistryError::BlobUploadConflict { .. }) => continue,
                     Err(error) => return Err(error),
                 }
-                live_sessions.remove(id);
-                self.remove_chunks(id, &state.record).await?;
+                sessions.insert(id.to_string(), false);
+                self.remove_chunks(id).await?;
                 self.remove(&meta.location).await?;
                 swept += 1;
-            } else if state.record.closed {
-                self.remove(&meta.location).await?;
             } else {
-                live_sessions.insert(id.to_string());
+                sessions.insert(id.to_string(), !state.record.closed);
+                if state.record.closed {
+                    self.remove(&meta.location).await?;
+                }
             }
         }
         Ok(swept)
@@ -249,7 +279,7 @@ impl RemoteUpload {
         let version =
             self.backend.write(&self.id, &record, PutMode::Update(state.version.clone())).await?;
         *state = VersionedRecord { record, version };
-        if let Err(error) = self.backend.remove_chunks(&self.id, &state.record).await {
+        if let Err(error) = self.backend.remove_chunks(&self.id).await {
             tracing::warn!(%error, upload = self.id, "completed upload chunks await expiry cleanup");
         }
         Ok(())
@@ -259,6 +289,12 @@ impl RemoteUpload {
 impl RemoteChunk {
     pub(super) async fn commit(mut self, size: u64) -> Result<u64> {
         if size == 0 {
+            let current = self.upload.backend.read(&self.upload.id).await?;
+            if current
+                .is_none_or(|current| current.record.closed || current.version != self.version)
+            {
+                return Err(RegistryError::BlobUploadConflict { id: self.upload.id.clone() });
+            }
             return Ok(self.snapshot.size);
         }
         if self.snapshot.chunks.len() == MAX_CHUNKS {

--- a/pnpr/crates/storage/src/upload/remote.rs
+++ b/pnpr/crates/storage/src/upload/remote.rs
@@ -29,6 +29,8 @@ struct UploadRecord {
     chunks: Vec<String>,
     size: u64,
     closed: bool,
+    #[serde(default)]
+    completion: Option<String>,
 }
 
 #[derive(Debug)]
@@ -123,6 +125,7 @@ impl RemoteUploadStore {
             chunks: Vec::new(),
             size: 0,
             closed: false,
+            completion: None,
         };
         let version = self.write(&id, &record, PutMode::Create).await?;
         self.handle(&id, VersionedRecord { record, version }).await
@@ -144,6 +147,9 @@ impl RemoteUploadStore {
         let Some(mut state) = self.read(id).await? else { return Ok(false) };
         if state.record.closed {
             return Ok(false);
+        }
+        if state.record.completion.is_some() {
+            return Err(RegistryError::BlobUploadConflict { id: id.to_string() });
         }
         state.record.closed = true;
         self.write(id, &state.record, PutMode::Update(state.version)).await?;
@@ -272,6 +278,23 @@ impl RemoteUpload {
         Ok(())
     }
 
+    /// Freeze the verified chunk list before promotion. A retry can promote the
+    /// same digest after a crash or failed object-store write.
+    pub(super) async fn prepare_completion(&self, filename: &str) -> Result<()> {
+        let mut state = self.state.lock().await;
+        if state.record.closed
+            || state.record.completion.as_deref().is_some_and(|value| value != filename)
+        {
+            return Err(RegistryError::BlobUploadConflict { id: self.id.clone() });
+        }
+        let mut record = state.record.clone();
+        record.completion = Some(filename.to_string());
+        let version =
+            self.backend.write(&self.id, &record, PutMode::Update(state.version.clone())).await?;
+        *state = VersionedRecord { record, version };
+        Ok(())
+    }
+
     pub(super) async fn close(&self) -> Result<()> {
         let mut state = self.state.lock().await;
         let mut record = state.record.clone();
@@ -296,6 +319,9 @@ impl RemoteChunk {
                 return Err(RegistryError::BlobUploadConflict { id: self.upload.id.clone() });
             }
             return Ok(self.snapshot.size);
+        }
+        if self.snapshot.closed || self.snapshot.completion.is_some() {
+            return Err(RegistryError::BlobUploadConflict { id: self.upload.id.clone() });
         }
         if self.snapshot.chunks.len() == MAX_CHUNKS {
             return Err(RegistryError::BadRequest { reason: "upload has too many chunks".into() });

--- a/pnpr/crates/storage/src/upload/remote/tests.rs
+++ b/pnpr/crates/storage/src/upload/remote/tests.rs
@@ -11,6 +11,7 @@ async fn a_full_chunk_list_still_accepts_an_empty_completion_request() {
         repository: "app".into(),
         chunks: vec!["b".repeat(32); MAX_CHUNKS],
         size: 0,
+        completion: None,
         closed: false,
     };
     let version = backend.write(&id, &record, PutMode::Create).await.unwrap();
@@ -29,8 +30,13 @@ async fn expiry_removes_unrecorded_chunks_even_when_they_are_listed_first() {
     let disk = tempfile::TempDir::new().unwrap();
     let backend = RemoteUploadStore::new(Arc::new(InMemory::new()), "", disk.path().into());
     let id = "a".repeat(32);
-    let record =
-        UploadRecord { repository: "app".into(), chunks: Vec::new(), size: 0, closed: false };
+    let record = UploadRecord {
+        repository: "app".into(),
+        chunks: Vec::new(),
+        size: 0,
+        completion: None,
+        closed: false,
+    };
     backend.write(&id, &record, PutMode::Create).await.unwrap();
     backend.store.put(&backend.key(&id, &"b".repeat(32)), b"orphan".to_vec().into()).await.unwrap();
     assert_eq!(backend.sweep(std::time::Duration::ZERO).await.unwrap(), 1);
@@ -54,8 +60,13 @@ async fn unreadable_sessions_do_not_prevent_other_uploads_from_expiring() {
         .put(&backend.key(&unreadable, &"b".repeat(32)), b"keep".to_vec().into())
         .await
         .unwrap();
-    let record =
-        UploadRecord { repository: "app".into(), chunks: Vec::new(), size: 0, closed: false };
+    let record = UploadRecord {
+        repository: "app".into(),
+        chunks: Vec::new(),
+        size: 0,
+        completion: None,
+        closed: false,
+    };
     backend.write(&expired, &record, PutMode::Create).await.unwrap();
     assert_eq!(backend.sweep(std::time::Duration::ZERO).await.unwrap(), 1);
     assert!(backend.read(&expired).await.unwrap().is_none());

--- a/pnpr/crates/storage/src/upload/remote/tests.rs
+++ b/pnpr/crates/storage/src/upload/remote/tests.rs
@@ -1,0 +1,23 @@
+use super::{MAX_CHUNKS, RemoteUploadStore, UploadRecord, VersionedRecord};
+use object_store::{PutMode, memory::InMemory};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn a_full_chunk_list_still_accepts_an_empty_completion_request() {
+    let disk = tempfile::TempDir::new().unwrap();
+    let backend = RemoteUploadStore::new(Arc::new(InMemory::new()), "", disk.path().into());
+    let id = "a".repeat(32);
+    let record = UploadRecord {
+        repository: "app".into(),
+        chunks: vec!["b".repeat(32); MAX_CHUNKS],
+        size: 0,
+        closed: false,
+    };
+    let version = backend.write(&id, &record, PutMode::Create).await.unwrap();
+    let upload = backend.handle(&id, VersionedRecord { record, version }).await.unwrap();
+    assert_eq!(upload.append().await.unwrap().finish().await.unwrap(), 0);
+    let mut writer = upload.append().await.unwrap();
+    writer.write_all(b"overflow").await.unwrap();
+    assert!(writer.finish().await.is_err());
+    assert_eq!(upload.offset().await.unwrap(), 0);
+}

--- a/pnpr/crates/storage/src/upload/remote/tests.rs
+++ b/pnpr/crates/storage/src/upload/remote/tests.rs
@@ -21,3 +21,55 @@ async fn a_full_chunk_list_still_accepts_an_empty_completion_request() {
     assert!(writer.finish().await.is_err());
     assert_eq!(upload.offset().await.unwrap(), 0);
 }
+
+#[tokio::test]
+async fn expiry_removes_unrecorded_chunks_even_when_they_are_listed_first() {
+    use futures_util::TryStreamExt;
+    use object_store::ObjectStoreExt;
+    let disk = tempfile::TempDir::new().unwrap();
+    let backend = RemoteUploadStore::new(Arc::new(InMemory::new()), "", disk.path().into());
+    let id = "a".repeat(32);
+    let record =
+        UploadRecord { repository: "app".into(), chunks: Vec::new(), size: 0, closed: false };
+    backend.write(&id, &record, PutMode::Create).await.unwrap();
+    backend.store.put(&backend.key(&id, &"b".repeat(32)), b"orphan".to_vec().into()).await.unwrap();
+    assert_eq!(backend.sweep(std::time::Duration::ZERO).await.unwrap(), 1);
+    assert!(backend.store.list(None).try_collect::<Vec<_>>().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn unreadable_sessions_do_not_prevent_other_uploads_from_expiring() {
+    use object_store::ObjectStoreExt;
+    let disk = tempfile::TempDir::new().unwrap();
+    let backend = RemoteUploadStore::new(Arc::new(InMemory::new()), "", disk.path().into());
+    let unreadable = "a".repeat(32);
+    let expired = "c".repeat(32);
+    backend
+        .store
+        .put(&backend.key(&unreadable, "session.json"), b"corrupt".to_vec().into())
+        .await
+        .unwrap();
+    backend
+        .store
+        .put(&backend.key(&unreadable, &"b".repeat(32)), b"keep".to_vec().into())
+        .await
+        .unwrap();
+    let record =
+        UploadRecord { repository: "app".into(), chunks: Vec::new(), size: 0, closed: false };
+    backend.write(&expired, &record, PutMode::Create).await.unwrap();
+    assert_eq!(backend.sweep(std::time::Duration::ZERO).await.unwrap(), 1);
+    assert!(backend.read(&expired).await.unwrap().is_none());
+    assert_eq!(
+        backend
+            .store
+            .get(&backend.key(&unreadable, "session.json"))
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap()
+            .as_ref(),
+        b"corrupt",
+    );
+    assert!(backend.store.head(&backend.key(&unreadable, &"b".repeat(32))).await.is_ok());
+}

--- a/pnpr/crates/storage/src/upload/tests.rs
+++ b/pnpr/crates/storage/src/upload/tests.rs
@@ -306,8 +306,7 @@ async fn s3_upload_resumes_on_another_replica_and_survives_loss_of_scratch() {
     assert_eq!(writer.finish().await.unwrap(), 11);
     resumed.materialize().await.unwrap();
     assert_eq!(tokio::fs::read(resumed.path()).await.unwrap(), b"hello world");
-    let slot = second.stage_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
-    second.finalize_blob_slot(slot).await.unwrap();
+    second.finalize_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
     assert_eq!(
         second.open_hosted_blob(&repository, "sha256-test").await.unwrap().unwrap().1,
         Some(11),
@@ -327,7 +326,7 @@ async fn s3_concurrent_append_and_stale_completion_cannot_overwrite_accepted_byt
     loser.write_all(b"loser").await.unwrap();
     winner.finish().await.unwrap();
     assert!(loser.finish().await.is_err());
-    assert!(second.stage_uploaded_blob(stale, &repository, "sha256-stale").await.is_err());
+    assert!(second.finalize_uploaded_blob(stale, &repository, "sha256-stale").await.is_err());
     let resumed = second.open_blob_upload(&repository, original.id()).await.unwrap().unwrap();
     resumed.materialize().await.unwrap();
     assert_eq!(tokio::fs::read(resumed.path()).await.unwrap(), b"winner");
@@ -354,4 +353,62 @@ async fn s3_sessions_are_repository_and_namespace_bound_and_expire() {
     stale.write_all(b"too late").await.unwrap();
     assert!(stale.finish().await.is_err());
     assert_eq!(second.sweep_blob_uploads(Duration::ZERO).await.unwrap(), 0);
+}
+
+#[tokio::test]
+async fn failed_promotion_keeps_shared_chunks_available_for_retry() {
+    let (first, second, _first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    let id = upload.id().to_string();
+    let mut writer = upload.append().await.unwrap();
+    writer.write_all(b"accepted").await.unwrap();
+    writer.finish().await.unwrap();
+    let slot = first.stage_uploaded_blob(upload, &repository, "sha256-test").await.unwrap();
+    tokio::fs::remove_file(&slot.tmp_path).await.unwrap();
+    assert!(first.finalize_blob_slot(slot).await.is_err());
+    let resumed = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    assert_eq!(resumed.offset().await.unwrap(), 8);
+    second.finalize_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
+    assert!(first.open_blob_upload(&repository, &id).await.unwrap().is_none());
+    let (body, _) = first.open_hosted_blob(&repository, "sha256-test").await.unwrap().unwrap();
+    assert_eq!(axum::body::to_bytes(body, 100).await.unwrap().as_ref(), b"accepted");
+}
+
+#[tokio::test]
+async fn empty_shared_chunks_reject_a_concurrently_changed_session() {
+    let (first, second, _first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    let resumed = second.open_blob_upload(&repository, upload.id()).await.unwrap().unwrap();
+    let empty = upload.append().await.unwrap();
+    let mut writer = resumed.append().await.unwrap();
+    writer.write_all(b"new bytes").await.unwrap();
+    writer.finish().await.unwrap();
+    assert!(matches!(
+        empty.finish().await,
+        Err(pnpr_error::RegistryError::BlobUploadConflict { .. })
+    ));
+}
+
+#[tokio::test]
+async fn conflicting_blob_promotion_does_not_consume_the_shared_upload() {
+    let (first, second, _first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let slot = first.reserve_hosted_blob(&repository, "sha256-test").await.unwrap();
+    tokio::fs::write(&slot.tmp_path, b"conflicting").await.unwrap();
+    first.finalize_blob_slot(slot).await.unwrap();
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    let id = upload.id().to_string();
+    let mut writer = upload.append().await.unwrap();
+    writer.write_all(b"accepted").await.unwrap();
+    writer.finish().await.unwrap();
+    assert_eq!(
+        first.finalize_uploaded_blob(upload, &repository, "sha256-test").await.unwrap(),
+        BlobFinalize::Conflict,
+    );
+    let resumed = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    assert_eq!(resumed.offset().await.unwrap(), 8);
+    first.remove_blob(&repository, "sha256-test").await.unwrap();
+    second.finalize_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
 }

--- a/pnpr/crates/storage/src/upload/tests.rs
+++ b/pnpr/crates/storage/src/upload/tests.rs
@@ -327,6 +327,7 @@ async fn s3_concurrent_append_and_stale_completion_cannot_overwrite_accepted_byt
     winner.finish().await.unwrap();
     assert!(loser.finish().await.is_err());
     assert!(second.finalize_uploaded_blob(stale, &repository, "sha256-stale").await.is_err());
+    assert!(second.open_hosted_blob(&repository, "sha256-stale").await.unwrap().is_none());
     let resumed = second.open_blob_upload(&repository, original.id()).await.unwrap().unwrap();
     resumed.materialize().await.unwrap();
     assert_eq!(tokio::fs::read(resumed.path()).await.unwrap(), b"winner");
@@ -364,6 +365,7 @@ async fn failed_promotion_keeps_shared_chunks_available_for_retry() {
     let mut writer = upload.append().await.unwrap();
     writer.write_all(b"accepted").await.unwrap();
     writer.finish().await.unwrap();
+    upload.remote.as_ref().unwrap().prepare_completion("sha256-test").await.unwrap();
     let slot = first.stage_uploaded_blob(upload, &repository, "sha256-test").await.unwrap();
     tokio::fs::remove_file(&slot.tmp_path).await.unwrap();
     assert!(first.finalize_blob_slot(slot).await.is_err());
@@ -411,4 +413,34 @@ async fn conflicting_blob_promotion_does_not_consume_the_shared_upload() {
     assert_eq!(resumed.offset().await.unwrap(), 8);
     first.remove_blob(&repository, "sha256-test").await.unwrap();
     second.finalize_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
+}
+
+#[tokio::test]
+async fn prepared_completion_freezes_chunks_and_survives_replica_loss() {
+    let (first, second, first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    let id = upload.id().to_string();
+    let mut writer = upload.append().await.unwrap();
+    writer.write_all(b"accepted").await.unwrap();
+    writer.finish().await.unwrap();
+    let stale = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    let mut stale_writer = stale.append().await.unwrap();
+    stale_writer.write_all(b"racing").await.unwrap();
+    upload.remote.as_ref().unwrap().prepare_completion("sha256-test").await.unwrap();
+    assert!(stale_writer.finish().await.is_err());
+    assert!(second.abort_blob_upload(&id).await.is_err());
+    drop(upload);
+    drop(first_disk);
+    let resumed = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    let mut writer = resumed.append().await.unwrap();
+    writer.write_all(b"extra").await.unwrap();
+    assert!(writer.finish().await.is_err());
+    assert_eq!(resumed.append().await.unwrap().finish().await.unwrap(), 8);
+    assert!(second.finalize_uploaded_blob(resumed, &repository, "sha256-other").await.is_err());
+    assert!(second.open_hosted_blob(&repository, "sha256-other").await.unwrap().is_none());
+    let resumed = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    second.finalize_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
+    let (body, _) = second.open_hosted_blob(&repository, "sha256-test").await.unwrap().unwrap();
+    assert_eq!(axum::body::to_bytes(body, 100).await.unwrap().as_ref(), b"accepted");
 }

--- a/pnpr/crates/storage/src/upload/tests.rs
+++ b/pnpr/crates/storage/src/upload/tests.rs
@@ -271,3 +271,87 @@ fn uploads_left(tmp: &TempDir) -> Vec<std::ffi::OsString> {
         .map(|entry| entry.unwrap().file_name())
         .collect()
 }
+
+fn replicas() -> (Storage, Storage, TempDir, TempDir) {
+    let first = TempDir::new().unwrap();
+    let second = TempDir::new().unwrap();
+    let objects: std::sync::Arc<dyn object_store::ObjectStore> =
+        std::sync::Arc::new(object_store::memory::InMemory::new());
+    let storage = |temp: &TempDir| Storage {
+        hosted: std::sync::Arc::new(crate::s3::S3Store::new(
+            std::sync::Arc::clone(&objects),
+            "images/".into(),
+            temp.path().join("scratch"),
+        )),
+        cached: crate::Store::new(temp.path().join("cache")),
+    };
+    (storage(&first), storage(&second), first, second)
+}
+
+#[tokio::test]
+async fn s3_upload_resumes_on_another_replica_and_survives_loss_of_scratch() {
+    let (first, second, first_disk, _second_disk) = replicas();
+    let repository = image("acme/app");
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    let id = upload.id().to_string();
+    let mut writer = upload.append().await.unwrap();
+    writer.write_all(b"hello ").await.unwrap();
+    writer.finish().await.unwrap();
+    drop(upload);
+    drop(first_disk);
+    let resumed = second.open_blob_upload(&repository, &id).await.unwrap().unwrap();
+    assert_eq!(resumed.offset().await.unwrap(), 6);
+    let mut writer = resumed.append().await.unwrap();
+    writer.write_all(b"world").await.unwrap();
+    assert_eq!(writer.finish().await.unwrap(), 11);
+    resumed.materialize().await.unwrap();
+    assert_eq!(tokio::fs::read(resumed.path()).await.unwrap(), b"hello world");
+    let slot = second.stage_uploaded_blob(resumed, &repository, "sha256-test").await.unwrap();
+    second.finalize_blob_slot(slot).await.unwrap();
+    assert_eq!(
+        second.open_hosted_blob(&repository, "sha256-test").await.unwrap().unwrap().1,
+        Some(11),
+    );
+    assert!(second.open_blob_upload(&repository, &id).await.unwrap().is_none());
+}
+
+#[tokio::test]
+async fn s3_concurrent_append_and_stale_completion_cannot_overwrite_accepted_bytes() {
+    let (first, second, _first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let original = first.begin_blob_upload(&repository).await.unwrap();
+    let stale = second.open_blob_upload(&repository, original.id()).await.unwrap().unwrap();
+    let mut winner = original.append().await.unwrap();
+    let mut loser = stale.append().await.unwrap();
+    winner.write_all(b"winner").await.unwrap();
+    loser.write_all(b"loser").await.unwrap();
+    winner.finish().await.unwrap();
+    assert!(loser.finish().await.is_err());
+    assert!(second.stage_uploaded_blob(stale, &repository, "sha256-stale").await.is_err());
+    let resumed = second.open_blob_upload(&repository, original.id()).await.unwrap().unwrap();
+    resumed.materialize().await.unwrap();
+    assert_eq!(tokio::fs::read(resumed.path()).await.unwrap(), b"winner");
+}
+
+#[tokio::test]
+async fn s3_sessions_are_repository_and_namespace_bound_and_expire() {
+    let (first, second, _first_disk, _second_disk) = replicas();
+    let repository = image("app");
+    let upload = first.begin_blob_upload(&repository).await.unwrap();
+    assert!(second.open_blob_upload(&image("other"), upload.id()).await.unwrap().is_none());
+    assert!(
+        second
+            .for_hosted("other")
+            .open_blob_upload(&repository, upload.id())
+            .await
+            .unwrap()
+            .is_none(),
+    );
+    assert_eq!(second.sweep_blob_uploads(Duration::from_hours(24)).await.unwrap(), 0);
+    assert_eq!(second.sweep_blob_uploads(Duration::ZERO).await.unwrap(), 1);
+    assert!(first.open_blob_upload(&repository, upload.id()).await.unwrap().is_none());
+    let mut stale = upload.append().await.unwrap();
+    stale.write_all(b"too late").await.unwrap();
+    assert!(stale.finish().await.is_err());
+    assert_eq!(second.sweep_blob_uploads(Duration::ZERO).await.unwrap(), 0);
+}


### PR DESCRIPTION
## Summary

Address the four items in the "Correctness and operations" section of https://github.com/pnpm/pnpm/issues/14630:

- Add `pnpr oci-gc --registry <name>` for offline collection of old, unreferenced blobs, with an age threshold and dry run. Walk every retained manifest and index child, including untagged images, and stop before deleting anything if a retained manifest is missing or corrupt. The maintenance inventory also finds nested, unpublished, and document-only repositories. Inventory and deletion candidates are spooled to temporary SQLite storage.
- Store S3 upload sessions and immutable request chunks in the shared bucket. A subsequent request can reach another replica, and conditional session updates reject concurrent appends or stale completion. Interrupted request bodies retain their accepted prefix. Completion freezes the chunk list and digest before promotion, and failed promotion remains retryable on another replica.
- Extend startup expiry to shared sessions and their chunks. The existing local startup expiry remains in place.
- Reuse the existing multipart blob sender for upload chunks, centralize abort cleanup, and test that a large file is sent in bounded parts and failed multipart requests are aborted.

Collection requires all writers sharing the store to be stopped and all replica publish journals recovered. Online blob `DELETE` remains unsupported because reference walking alone cannot serialize deletion against concurrent manifest publication. Other sections of the issue and the catalog endpoint's listing behavior remain outside this PR.

Validation: workspace checks and Clippy, 10,600 passing Rust tests, custom Rust lints, and rustdoc checks. The tests include the OCI HTTP integration suite and both storage backends.

## Squash Commit Body

```text
Add offline OCI blob collection and shared upload sessions for S3-backed
registries. These changes address the correctness and operations section
of pnpm/pnpm#14630.

Use immutable objects for request chunks and compare-and-set writes for
the session record. Only a successfully recorded chunk advances the
accepted offset. Completion assembles the chunks on local scratch for
digest verification, then uses the existing multipart blob path. Losing
a replica's scratch no longer loses an accepted upload. Conditionally freeze
the accepted chunks and digest before promotion, keeping failed promotion
retryable with the same digest. After promotion, session cleanup is best
effort; cleanup failures do not turn a committed blob into a failed response.
Closing or expiring a session invalidates stale writers before chunk deletion.

Keep garbage collection offline so no publisher can introduce a new
reference between the mark and delete phases. Walk retained manifests
and index children rather than tags alone, and validate their integrity
before deleting any candidate. Inventory blob files separately from the
request-path package listing to include unpublished, document-only, and nested
image repositories without making catalog requests enumerate blob populations.
Stream the inventory into temporary SQLite storage so a large registry does
not require its complete file listing and candidate set in memory.

Startup expiry and large-blob multipart transfer were already present
in the initial OCI implementation. Extend expiry to shared sessions and
reuse and test multipart cleanup for both promotion and session chunks.

Related to pnpm/pnpm#14630. This affects pnpr only; there is no pnpm CLI
implementation to mirror.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] Added a changeset for the published pnpr wrapper.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - OCI uploads using S3 storage can resume across replicas.
  - Added `oci-gc` to reclaim old, unreferenced image blobs, with preview and minimum-age options.
  - Abandoned shared upload sessions expire after 24 hours of inactivity.

- **Bug Fixes**
  - Improved interrupted upload recovery, conflict handling, and preservation of uploaded data.
  - OCI garbage collection now protects blobs referenced by retained images and avoids affecting shared proxy cache content.

- **Documentation**
  - Added guidance for S3-backed uploads, session cleanup, and OCI garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->