### PR TITLE
fix(cli): resolve the working directory to the local prefix

### DIFF
--- a/.changeset/local-prefix-resolution.md
+++ b/.changeset/local-prefix-resolution.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Commands run from a subdirectory that has no `package.json` of its own now act on the nearest ancestor directory that has one, as they do on pnpm 11. `pnpm bin` printed a `node_modules/.bin` path under the current directory, which does not exist, so tools spawning executables out of it failed [#14622](https://github.com/pnpm/pnpm/issues/14622). `pnpm init` still creates its `package.json` in the current directory.

--- a/.changeset/local-prefix-resolution.md
+++ b/.changeset/local-prefix-resolution.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Commands run from a subdirectory that has no `package.json` of its own now act on the nearest ancestor directory that has one, as they do on pnpm 11. `pnpm bin` printed a `node_modules/.bin` path under the current directory, which does not exist, so tools spawning executables out of it failed [#14622](https://github.com/pnpm/pnpm/issues/14622). `pnpm init` still creates its `package.json` in the current directory.
+Commands run from a subdirectory of a project now act on the nearest ancestor directory that has a manifest, as they do on pnpm 11. `pnpm bin` printed a `node_modules/.bin` path under the current directory, which does not exist [#14622](https://github.com/pnpm/pnpm/issues/14622). `pnpm init` still creates its `package.json` in the current directory, and `pnpm exec` still runs its command there.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -131,6 +131,15 @@ pub struct CliArgs {
     #[clap(short = 'C', long, alias = "prefix", default_value = ".", global = true)]
     pub dir: PathBuf,
 
+    /// Whether `--dir` came from the command line rather than from its
+    /// default. pnpm keeps that distinction: a `--dir` it was given is
+    /// taken as is, while the default resolves to the local prefix
+    /// ([`Self::apply_local_prefix`]) and `init` scaffolds in the process
+    /// cwd. `clap` cannot report it through a derived field, so the entry
+    /// point fills it in from the parsed matches.
+    #[clap(skip)]
+    pub dir_from_command_line: bool,
+
     /// Directory in which the package store is created. Relative paths
     /// are resolved from the workspace root, or from `--dir` outside a
     /// workspace.
@@ -411,6 +420,26 @@ impl CliArgs {
         }
     }
 
+    /// Resolve a `--dir` the command line did not give to pnpm's local
+    /// prefix: the nearest ancestor of the process cwd that holds a
+    /// manifest, a `node_modules`, or a `pnpm-workspace.yaml`. pnpm's
+    /// `config.dir` is that prefix, so a command run from a plain
+    /// subdirectory of a project acts on the project rather than on the
+    /// subdirectory. Call before anything reads `--dir`.
+    ///
+    /// A cwd that cannot be read leaves `--dir` at its default, which the
+    /// canonicalization in [`Self::run`] then reports on.
+    pub fn apply_local_prefix(&mut self) -> miette::Result<()> {
+        if self.dir_from_command_line {
+            return Ok(());
+        }
+        let Ok(cwd) = std::env::current_dir() else {
+            return Ok(());
+        };
+        self.dir = super::prefix::find_local_prefix(&cwd)?;
+        Ok(())
+    }
+
     /// Apply `--workspace-root` / `-w`: point `--dir` at the workspace
     /// root so the command runs on the root project. Call after
     /// [`Self::promote_recursive_for_filter`] and before anything reads
@@ -442,6 +471,9 @@ impl CliArgs {
             .map_err(WorkspaceRootError::FindWorkspaceDir)?
             .ok_or(WorkspaceRootError::NotInWorkspace)?;
         self.dir = workspace_dir;
+        // pnpm's parser writes the workspace root into `cliOptions.dir`, so
+        // `-w` also decides where `init` scaffolds.
+        self.dir_from_command_line = true;
         Ok(())
     }
 

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -133,10 +133,10 @@ pub struct CliArgs {
 
     /// Whether `--dir` came from the command line rather than from its
     /// default. pnpm keeps that distinction: a `--dir` it was given is
-    /// taken as is, while the default resolves to the local prefix
-    /// ([`Self::apply_local_prefix`]) and `init` scaffolds in the process
-    /// cwd. `clap` cannot report it through a derived field, so the entry
-    /// point fills it in from the parsed matches.
+    /// taken as is, while the default resolves to the local prefix and
+    /// `init` scaffolds in the process cwd. `clap` cannot report it
+    /// through a derived field, so the entry point fills it in from the
+    /// parsed matches.
     #[clap(skip)]
     pub dir_from_command_line: bool,
 

--- a/pnpm/crates/cli/src/cli_args/dispatch.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch.rs
@@ -39,6 +39,11 @@ pub(crate) type CommandFuture<'a, Output = ()> =
 /// [`super::approve_builds::ApproveBuildsArgs::prepare`] already consumes.
 pub(crate) struct RunCtx<'a> {
     pub(crate) dir: &'a Path,
+    /// The `--dir` as the command line gave it, or the process cwd when it
+    /// gave none — pnpm's `cliOptions.dir ?? process.cwd()`. `init`
+    /// scaffolds here and a non-recursive `exec` runs here, rather than at
+    /// the local prefix [`Self::dir`] resolves to.
+    pub(crate) cli_dir: &'a Path,
     pub(crate) manifest_path: &'a Path,
     pub(crate) reporter: ReporterType,
     pub(crate) recursive: bool,
@@ -199,6 +204,7 @@ impl CliArgs {
         let CliArgs {
             command,
             dir,
+            dir_from_command_line,
             store_dir,
             state_dir,
             npmrc_auth_file,
@@ -253,6 +259,11 @@ impl CliArgs {
         let dir = dunce::canonicalize(&dir)
             .into_diagnostic()
             .wrap_err_with(|| format!("canonicalizing the `--dir` argument: {}", dir.display()))?;
+        let cli_dir = if dir_from_command_line {
+            dir.clone()
+        } else {
+            std::env::current_dir().and_then(dunce::canonicalize).unwrap_or_else(|_| dir.clone())
+        };
         let started_at = now_millis();
         let is_install_family = matches!(
             &command,
@@ -443,6 +454,7 @@ impl CliArgs {
 
         let ctx = RunCtx {
             dir: &dir,
+            cli_dir: &cli_dir,
             manifest_path: &manifest_path,
             reporter,
             recursive,

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -18,6 +18,7 @@ use pnpm_package_manifest::{InitAuthor, InitOptions, PackageManifest};
 pub(super) fn init<'a>(ctx: &RunCtx<'a>, args: &InitArgs) -> miette::Result<CommandFuture<'a>> {
     let config: &Config = (ctx.config)()?;
     let es_module = args.effective_init_type(config) == InitType::Module;
+    let manifest_path = ctx.cli_dir.join("package.json");
     // `config_self_update`, so a repo-controlled `pnpm-workspace.yaml` cannot
     // relax the release-age and trust policies governing the version pnpm
     // ends up downloading. A manifest that is already there skips the lookup
@@ -25,12 +26,11 @@ pub(super) fn init<'a>(ctx: &RunCtx<'a>, args: &InitArgs) -> miette::Result<Comm
     // `pnpm init` should not wait on a registry to report an error it can
     // already see.
     let pin_config: Option<&Config> =
-        if args.pins_pnpm(config, ctx.dir) && !ctx.manifest_path.exists() {
+        if args.pins_pnpm(config, ctx.cli_dir) && !manifest_path.exists() {
             Some((ctx.config_self_update)()?)
         } else {
             None
         };
-    let manifest_path = ctx.manifest_path;
     Ok(Box::pin(async move {
         let pinned_pnpm_version = match pin_config {
             Some(pin_config) => Some(super::init::version_to_pin(pin_config).await),
@@ -47,7 +47,7 @@ pub(super) fn init<'a>(ctx: &RunCtx<'a>, args: &InitArgs) -> miette::Result<Comm
             license: config.init_license.as_deref(),
             version: config.init_version.as_deref(),
         };
-        PackageManifest::init(manifest_path, options).wrap_err("initialize package.json")
+        PackageManifest::init(&manifest_path, options).wrap_err("initialize package.json")
     }))
 }
 
@@ -134,6 +134,11 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
     let config = (ctx.config)()?;
     let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
+    // A non-recursive `exec` runs the command where the user stands, so
+    // `pnpm exec` from a plain subdirectory of a project acts on that
+    // subdirectory. Only the config and dependency check behind it come
+    // from the project.
+    let cli_dir = ctx.cli_dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
     Ok(Box::pin(async move {
@@ -143,7 +148,7 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
         if recursive {
             args.run_recursive(config, dir, reporter).await
         } else {
-            args.run(dir, config, reporter)
+            args.run(cli_dir, config, reporter)
         }
     }))
 }

--- a/pnpm/crates/cli/src/cli_args/dispatch_script.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_script.rs
@@ -1,6 +1,6 @@
 use super::{
     dispatch::{CommandFuture, RunCtx, apply_update_config},
-    exec::ExecArgs,
+    exec::{ExecArgs, ExecDirs},
     init::InitArgs,
     pkg::PkgArgs,
     restart::RestartArgs,
@@ -116,6 +116,7 @@ pub(super) fn fallback<'a>(
     let config = (ctx.config)()?;
     let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
+    let cli_dir = ctx.cli_dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
     Ok(Box::pin(async move {
@@ -125,7 +126,7 @@ pub(super) fn fallback<'a>(
         if recursive {
             args.run_recursive(config, dir, reporter)
         } else {
-            args.run_fallback(dir, config, reporter)
+            args.run_fallback(ExecDirs { run: cli_dir, project: dir }, config, reporter)
         }
     }))
 }
@@ -134,10 +135,6 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
     let config = (ctx.config)()?;
     let cli_options = RecursiveCliOptions::from_ctx(ctx);
     let dir = ctx.dir;
-    // A non-recursive `exec` runs the command where the user stands, so
-    // `pnpm exec` from a plain subdirectory of a project acts on that
-    // subdirectory. Only the config and dependency check behind it come
-    // from the project.
     let cli_dir = ctx.cli_dir;
     let reporter = ctx.reporter;
     let recursive = ctx.recursive;
@@ -148,7 +145,7 @@ pub(super) fn exec<'a>(ctx: &RunCtx<'a>, args: ExecArgs) -> miette::Result<Comma
         if recursive {
             args.run_recursive(config, dir, reporter).await
         } else {
-            args.run(cli_dir, config, reporter)
+            args.run(ExecDirs { run: cli_dir, project: dir }, config, reporter)
         }
     }))
 }

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -96,17 +96,43 @@ impl From<BadPathDir> for ExecError {
     }
 }
 
+/// Where an exec'd command runs, and which project it belongs to.
+///
+/// The two differ when the command line gave no `--dir` and the process
+/// cwd is a plain subdirectory of the project: pnpm runs the command
+/// where the user stands, while the dependencies, executables, and
+/// manifest it gets are the project's.
+#[derive(Clone, Copy)]
+pub struct ExecDirs<'a> {
+    pub run: &'a Path,
+    pub project: &'a Path,
+}
+
+impl<'a> ExecDirs<'a> {
+    /// The command runs in the project directory itself, as a recursive
+    /// `exec` does for every project it selects.
+    pub fn same(dir: &'a Path) -> Self {
+        ExecDirs { run: dir, project: dir }
+    }
+}
+
 impl ExecArgs {
-    /// Execute the subcommand in `dir` (the project / working directory).
+    /// Execute the subcommand in `dirs.run`, against the project at
+    /// `dirs.project`.
     ///
     /// On a non-zero child exit code this terminates the process with the
     /// same code via [`std::process::exit`], matching pnpm's exec, which
     /// returns `{ exitCode }` and lets the CLI exit with it.
-    pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
+    pub fn run(
+        self,
+        dirs: ExecDirs<'_>,
+        config: &Config,
+        reporter: ReporterType,
+    ) -> miette::Result<()> {
         let command = prepare_command(self.command)?;
-        super::verify_deps::verify_deps_before_run(dir, config, reporter)?;
+        super::verify_deps::verify_deps_before_run(dirs.project, config, reporter)?;
         let status =
-            spawn_in_dir(&command, dir, config, self.shell_mode, ScriptOutput::Inherit, None)?;
+            spawn_in_dir(&command, dirs, config, self.shell_mode, ScriptOutput::Inherit, None)?;
         if !status.success() {
             // Propagate the child's exit code. A signal-terminated child
             // has no code; fall back to 1, matching pnpm's `exitCode ?? 1`.
@@ -158,13 +184,13 @@ fn prepare_command(mut command: Vec<String>) -> Result<Vec<String>, ExecError> {
 /// the terminal.
 pub(super) fn spawn_in_dir(
     command: &[String],
-    dir: &Path,
+    dirs: ExecDirs<'_>,
     config: &Config,
     shell_mode: bool,
     output: ScriptOutput<'_>,
     process_tracker: Option<&ProcessTracker>,
 ) -> Result<ExitStatus, ExecError> {
-    let mut cmd = command_in_dir(command, dir, config, shell_mode)?;
+    let mut cmd = command_in_dir(command, dirs, config, shell_mode)?;
     let ScriptOutput::Streamed { dep_path, emit } = output else {
         let mut child = spawn_child(&mut cmd, process_tracker)
             .map_err(|source| ExecError::Spawn { command: command[0].clone(), source })?;
@@ -172,7 +198,7 @@ pub(super) fn spawn_in_dir(
             .wait()
             .map_err(|source| ExecError::Spawn { command: command[0].clone(), source });
     };
-    let wd = dir.to_string_lossy();
+    let wd = dirs.run.to_string_lossy();
     let streamed = StreamedScript { dep_path, stage: EXEC_STAGE, wd: &wd, emit };
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
     let mut child = spawn_child(&mut cmd, process_tracker)
@@ -186,15 +212,21 @@ pub(super) fn spawn_in_dir(
 
 fn command_in_dir(
     command: &[String],
-    dir: &Path,
+    dirs: ExecDirs<'_>,
     config: &Config,
     shell_mode: bool,
 ) -> Result<Command, ExecError> {
+    let ExecDirs { run: dir, project } = dirs;
     // Prepend `./node_modules/.bin` (resolved against the project
-    // directory) and then the `extraBinPaths`.
-    let mut prepend = Vec::with_capacity(1 + config.extra_bin_paths.len());
+    // directory) and then the `extraBinPaths`. pnpm prepends the whole
+    // ancestor chain of `node_modules/.bin` directories, of which the
+    // project's is the one that holds the installed executables.
+    let mut prepend = Vec::with_capacity(2 + config.extra_bin_paths.len());
     prepend.push(dir.join("node_modules").join(".bin"));
-    prepend.extend(crate::python::execution_paths(config, dir).iter().cloned());
+    if project != dir {
+        prepend.push(project.join("node_modules").join(".bin"));
+    }
+    prepend.extend(crate::python::execution_paths(config, project).iter().cloned());
     let path = prepend_dirs_to_path(&prepend)?;
 
     let mut cmd = if shell_mode {
@@ -232,14 +264,14 @@ fn command_in_dir(
     cmd.env("npm_config_user_agent", &config.user_agent);
     // Same recursion-guard stamp as the lifecycle env builder.
     cmd.env(pnpm_executor::VERIFY_DEPS_BEFORE_RUN_ENV, "false");
-    if let Some(name) = read_package_name(dir) {
+    if let Some(name) = read_package_name(project) {
         cmd.env("PNPM_PACKAGE_NAME", name);
     }
     let mut node_options = configured_node_options(config);
-    if let Some(pnp_path) = pnp_path_for_execution(config, dir) {
+    if let Some(pnp_path) = pnp_path_for_execution(config, project) {
         node_options = Some(make_node_require_option(&pnp_path, node_options.as_deref()));
     }
-    if let Some(package_map_path) = package_map_path_for_execution(config, dir) {
+    if let Some(package_map_path) = package_map_path_for_execution(config, project) {
         node_options =
             Some(make_node_package_map_option(&package_map_path, node_options.as_deref()));
     }

--- a/pnpm/crates/cli/src/cli_args/exec/recursive.rs
+++ b/pnpm/crates/cli/src/cli_args/exec/recursive.rs
@@ -11,7 +11,7 @@
 //! `--reverse` runs the reverse graph, and `--parallel` starts every
 //! project concurrently.
 
-use super::{ExecArgs, ExecError, prepare_command, read_package_name, spawn_in_dir};
+use super::{ExecArgs, ExecDirs, ExecError, prepare_command, read_package_name, spawn_in_dir};
 use crate::cli_args::{
     recursive::{
         AutoExcludeRoot, ExecutionStatus, Status, count_failures, discover_workspace_projects,
@@ -221,8 +221,14 @@ pub async fn exec_recursive(
         let start = Instant::now();
         let dep_path = project_dep_path(root, dir, show_prefix);
         let output = project_output(dep_path.as_deref(), emit);
-        let outcome =
-            spawn_in_dir(&command, root, config, args.shell_mode, output, process_tracker.as_ref());
+        let outcome = spawn_in_dir(
+            &command,
+            ExecDirs::same(root),
+            config,
+            args.shell_mode,
+            output,
+            process_tracker.as_ref(),
+        );
         let execution = project_execution(start, outcome);
         let mut result = result.lock().expect("summary lock is not poisoned");
         let entry = &mut result[&prefix];

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -1165,10 +1165,21 @@ impl SwitchInput {
         }
     }
 
+    /// The `--dir` a command line without one resolves to, matching
+    /// [`CliArgs::apply_local_prefix`]. Degrades to `.` — the caller
+    /// canonicalizes it, and a cwd it cannot resolve is not the
+    /// version check's to report.
+    fn local_prefix_or_cwd() -> PathBuf {
+        std::env::current_dir()
+            .ok()
+            .and_then(|cwd| super::prefix::find_local_prefix(&cwd).ok())
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+
     fn from_version_argv(argv: &[OsString]) -> Self {
         let global_options = ArgTable::top_level(super::grammar());
         let mut input = Self {
-            dir: PathBuf::from("."),
+            dir: Self::local_prefix_or_cwd(),
             state_dir: None,
             npmrc_auth_file: None,
             command: None,

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -1165,10 +1165,10 @@ impl SwitchInput {
         }
     }
 
-    /// The `--dir` a command line without one resolves to, matching
-    /// [`CliArgs::apply_local_prefix`]. Degrades to `.` — the caller
-    /// canonicalizes it, and a cwd it cannot resolve is not the
-    /// version check's to report.
+    /// The `--dir` a command line without one resolves to.
+    ///
+    /// Degrades to `.`, which the caller canonicalizes: a cwd that cannot
+    /// be resolved fails there, with the path it was given.
     fn local_prefix_or_cwd() -> PathBuf {
         std::env::current_dir()
             .ok()

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -19,8 +19,10 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
     struct Case {
         name: &'static str,
         argv: &'static [&'static str],
-        /// The `--dir` the scan is expected to find, or `None` when the
-        /// command line carries none and it falls back to the local prefix.
+        /// The `--dir` the scan is expected to find. `None` asserts
+        /// nothing: the command line carries none, and the default it
+        /// falls back to is covered by the CLI tests that run in a real
+        /// project.
         dir: Option<&'static str>,
         npmrc_auth_file: Option<&'static str>,
         command: Option<&'static str>,
@@ -96,8 +98,9 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
         let argv = case.argv.iter().copied().map(OsString::from).collect::<Vec<_>>();
         let input = SwitchInput::from_version_argv(&argv);
 
-        let expected_dir = case.dir.map_or_else(SwitchInput::local_prefix_or_cwd, PathBuf::from);
-        assert_eq!(input.dir, expected_dir, "case: {}", case.name);
+        if let Some(dir) = case.dir {
+            assert_eq!(input.dir, PathBuf::from(dir), "case: {}", case.name);
+        }
         assert_eq!(
             input.npmrc_auth_file,
             case.npmrc_auth_file.map(PathBuf::from),

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -19,7 +19,9 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
     struct Case {
         name: &'static str,
         argv: &'static [&'static str],
-        dir: &'static str,
+        /// The `--dir` the scan is expected to find, or `None` when the
+        /// command line carries none and it falls back to the local prefix.
+        dir: Option<&'static str>,
         npmrc_auth_file: Option<&'static str>,
         command: Option<&'static str>,
     }
@@ -28,63 +30,63 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
         Case {
             name: "separate long dir and equals auth file",
             argv: &["pnpm", "--dir", "/tmp/project", "--npmrc-auth-file=auth.ini", "--version"],
-            dir: "/tmp/project",
+            dir: Some("/tmp/project"),
             npmrc_auth_file: Some("auth.ini"),
             command: None,
         },
         Case {
             name: "short dir",
             argv: &["pnpm", "-C", "/tmp/short-dir", "--version"],
-            dir: "/tmp/short-dir",
+            dir: Some("/tmp/short-dir"),
             npmrc_auth_file: None,
             command: None,
         },
         Case {
             name: "equals dir and userconfig alias",
             argv: &["pnpm", "--dir=/tmp/equals-dir", "--userconfig", "user.ini", "--version"],
-            dir: "/tmp/equals-dir",
+            dir: Some("/tmp/equals-dir"),
             npmrc_auth_file: Some("user.ini"),
             command: None,
         },
         Case {
             name: "prefix alias of dir",
             argv: &["pnpm", "--prefix", "/tmp/prefix-dir", "--version"],
-            dir: "/tmp/prefix-dir",
+            dir: Some("/tmp/prefix-dir"),
             npmrc_auth_file: None,
             command: None,
         },
         Case {
             name: "equals prefix alias of dir",
             argv: &["pnpm", "--prefix=/tmp/equals-prefix", "--version"],
-            dir: "/tmp/equals-prefix",
+            dir: Some("/tmp/equals-prefix"),
             npmrc_auth_file: None,
             command: None,
         },
         Case {
             name: "separator stops command detection",
             argv: &["pnpm", "--dir=/tmp/separator", "--", "run"],
-            dir: "/tmp/separator",
+            dir: Some("/tmp/separator"),
             npmrc_auth_file: None,
             command: None,
         },
         Case {
             name: "value-taking global option is skipped",
             argv: &["pnpm", "--filter", "pkg", "--reporter", "append-only", "install"],
-            dir: ".",
+            dir: None,
             npmrc_auth_file: None,
             command: Some("install"),
         },
         Case {
             name: "store directory value is not mistaken for the command",
             argv: &["pnpm", "--store", "/tmp/store", "--prefix", "/tmp/scanned", "--version"],
-            dir: "/tmp/scanned",
+            dir: Some("/tmp/scanned"),
             npmrc_auth_file: None,
             command: None,
         },
         Case {
             name: "canonical store directory value is not mistaken for the command",
             argv: &["pnpm", "--store-dir", "/tmp/store", "--dir", "/tmp/scanned", "--version"],
-            dir: "/tmp/scanned",
+            dir: Some("/tmp/scanned"),
             npmrc_auth_file: None,
             command: None,
         },
@@ -94,7 +96,8 @@ fn version_argv_reads_dir_auth_file_and_command_forms() {
         let argv = case.argv.iter().copied().map(OsString::from).collect::<Vec<_>>();
         let input = SwitchInput::from_version_argv(&argv);
 
-        assert_eq!(input.dir, PathBuf::from(case.dir), "case: {}", case.name);
+        let expected_dir = case.dir.map_or_else(SwitchInput::local_prefix_or_cwd, PathBuf::from);
+        assert_eq!(input.dir, expected_dir, "case: {}", case.name);
         assert_eq!(
             input.npmrc_auth_file,
             case.npmrc_auth_file.map(PathBuf::from),

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use super::global::GlobalError;
 
-/// Print the current package prefix — the nearest directory containing a
-/// `package.json`, `node_modules`, or `pnpm-workspace.yaml`.
+/// Print the current package prefix — the nearest directory holding a
+/// project, as [`find_local_prefix`] resolves it.
 #[derive(Debug, Args)]
 pub struct PrefixArgs {
     /// Print the global prefix
@@ -25,8 +25,14 @@ pub enum PrefixError {
     Io { path: PathBuf, source: std::io::Error },
 }
 
-/// Find the nearest directory containing package.json, `node_modules`, etc.
-/// Port of findLocalPrefix from pnpm.
+/// Find the nearest ancestor of `start_dir` that holds a project: a
+/// manifest, a `node_modules`, or a `pnpm-workspace.yaml`. `start_dir`
+/// itself counts, and a `start_dir` no ancestor qualifies for is its own
+/// prefix.
+///
+/// Port of pnpm's `findLocalPrefix`, widened by the manifests pnpm v12
+/// manages beyond `package.json` — a Cargo or Python package without a
+/// `package.json` is a project too.
 pub fn find_local_prefix(start_dir: &Path) -> miette::Result<PathBuf> {
     let mut name = start_dir.to_path_buf();
 
@@ -43,8 +49,15 @@ pub fn find_local_prefix(start_dir: &Path) -> miette::Result<PathBuf> {
 
 fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
     let mut current = name.to_path_buf();
-    let targets =
-        ["node_modules", "package.json", "package.json5", "package.yaml", "pnpm-workspace.yaml"];
+    let targets = [
+        "node_modules",
+        "package.json",
+        "package.json5",
+        "package.yaml",
+        "pnpm-workspace.yaml",
+        "Cargo.toml",
+        "pyproject.toml",
+    ];
 
     loop {
         for target in &targets {
@@ -52,9 +65,13 @@ fn find_prefix_up(name: &Path, original: &Path) -> miette::Result<PathBuf> {
             match target_path.try_exists() {
                 Ok(true) => return Ok(current),
                 Ok(false) => continue,
-                Err(e) => {
+                // A directory that cannot be read only aborts the walk when
+                // it is the one the caller named. Above it, an unreadable
+                // ancestor means the walk found nothing, matching pnpm.
+                Err(e) if current == original => {
                     return Err(PrefixError::Io { path: target_path, source: e }.into());
                 }
+                Err(_) => return Ok(original.to_path_buf()),
             }
         }
 

--- a/pnpm/crates/cli/src/cli_args/prefix.rs
+++ b/pnpm/crates/cli/src/cli_args/prefix.rs
@@ -6,8 +6,8 @@ use std::path::{Path, PathBuf};
 
 use super::global::GlobalError;
 
-/// Print the current package prefix — the nearest directory holding a
-/// project, as [`find_local_prefix`] resolves it.
+/// Print the current package prefix — the nearest ancestor directory
+/// that holds a project.
 #[derive(Debug, Args)]
 pub struct PrefixArgs {
     /// Print the global prefix

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -1,5 +1,5 @@
 use super::{
-    exec::ExecArgs,
+    exec::{ExecArgs, ExecDirs},
     reporter::{ReporterType, reporter_emit},
 };
 use clap::Args;
@@ -172,25 +172,28 @@ impl RunArgs {
     /// meaningful for the recursive path (see [`Self::run_recursive`])
     /// and are ignored here.
     pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
-        self.run_inner(dir, config, reporter, false)
+        self.run_inner(ExecDirs::same(dir), config, reporter, false)
     }
 
+    /// Like [`Self::run`], but a name that matches no script is handed to
+    /// `exec`, which runs it in `dirs.run`.
     pub fn run_fallback(
         self,
-        dir: &Path,
+        dirs: ExecDirs<'_>,
         config: &Config,
         reporter: ReporterType,
     ) -> miette::Result<()> {
-        self.run_inner(dir, config, reporter, true)
+        self.run_inner(dirs, config, reporter, true)
     }
 
     fn run_inner(
         self,
-        dir: &Path,
+        dirs: ExecDirs<'_>,
         config: &Config,
         reporter: ReporterType,
         fallback_to_exec: bool,
     ) -> miette::Result<()> {
+        let dir = dirs.project;
         // Before the dependency verification: an unsupported flag must
         // fail before anything can trigger an install or a prompt.
         if self.dry_run {
@@ -214,7 +217,7 @@ impl RunArgs {
             Err(ReadProjectManifestOnlyError::NoImporterManifestFound { .. })
                 if fallback_to_exec =>
             {
-                return exec_fallback(script_name, args, dir, config, reporter);
+                return exec_fallback(script_name, args, dirs, config, reporter);
             }
             Err(err) => return Err(RunError::Manifest(err).into()),
         };
@@ -233,7 +236,7 @@ impl RunArgs {
                 return Ok(());
             }
             if fallback_to_exec {
-                return exec_fallback(script_name, args, dir, config, reporter);
+                return exec_fallback(script_name, args, dirs, config, reporter);
             }
             return Err(RunError::NoScript {
                 script: script_name.clone(),
@@ -385,7 +388,7 @@ impl RunArgs {
 fn exec_fallback(
     script_name: &str,
     args: &[String],
-    dir: &Path,
+    dirs: ExecDirs<'_>,
     config: &Config,
     reporter: ReporterType,
 ) -> miette::Result<()> {
@@ -399,7 +402,7 @@ fn exec_fallback(
         reverse: false,
         parallel: false,
     }
-    .run(dir, config, reporter)
+    .run(dirs, config, reporter)
 }
 
 /// Shared inputs for running a script, threaded through

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -132,10 +132,11 @@ fn run_cli() -> miette::Result<()> {
     // A command whose arguments begin at a `--` would otherwise lose it to
     // clap's escape handling. See `leading_separator`.
     let argv = leading_separator::preserve_leading_separator(argv);
-    let mut args = match command
-        .try_get_matches_from(argv.clone())
-        .and_then(|matches| CliArgs::from_arg_matches(&matches))
-    {
+    let mut args = match command.try_get_matches_from(argv.clone()).and_then(|matches| {
+        let dir_from_command_line =
+            matches.value_source("dir") == Some(clap::parser::ValueSource::CommandLine);
+        CliArgs::from_arg_matches(&matches).map(|args| CliArgs { dir_from_command_line, ..args })
+    }) {
         Ok(args) => args,
         // pnpm prints the bare version, not clap's "pnpm <version>" rendering.
         Err(err) if err.kind() == clap::error::ErrorKind::DisplayVersion => {
@@ -158,6 +159,7 @@ fn run_cli() -> miette::Result<()> {
     }
     args.apply_parallel_run_options();
     args.promote_recursive_for_filter();
+    args.apply_local_prefix()?;
     args.apply_workspace_root()?;
     args.promote_recursive_by_default();
     args.configure_reporter();

--- a/pnpm/crates/cli/tests/suite/bin.rs
+++ b/pnpm/crates/cli/tests/suite/bin.rs
@@ -18,6 +18,8 @@ fn canonicalize(path: &Path) -> PathBuf {
 #[test]
 fn bin_prints_the_local_node_modules_bin_dir() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "root-pkg" }"#)
+        .expect("write package.json");
 
     let output = pacquet.with_args(["bin"]).output().expect("run pacquet bin");
     dbg!(&output);
@@ -154,10 +156,40 @@ fn bin_global_writes_warnings_to_stderr_so_stdout_stays_a_clean_path() {
     drop(root);
 }
 
-/// Differential parity: from a workspace subdirectory pnpm's `bin` prints the
-/// cwd's `node_modules/.bin` (its `config.dir` is the cwd, not the workspace
-/// root). pacquet must match byte-for-byte. Windows-skipped because it spawns
-/// the external `pnpm` shim (see the `ignore` reason).
+/// A directory that is only a subdirectory of a project — no manifest, no
+/// `node_modules` of its own — is not where the project's executables live,
+/// so `bin` prints the project's. Regression test for
+/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622), where the
+/// printed path did not exist and tools spawning executables out of it
+/// failed with `ENOENT`.
+#[test]
+fn bin_prints_the_project_bin_dir_from_a_plain_subdir() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "root-pkg" }"#)
+        .expect("write package.json");
+    let subdir = workspace.join("src/utils");
+    fs::create_dir_all(&subdir).expect("create the subdirectory");
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&subdir)
+        .with_args(["bin"])
+        .output()
+        .expect("run pacquet bin in the subdir");
+    dbg!(&output);
+    assert!(output.status.success(), "pacquet bin should succeed in the subdir");
+
+    let expected =
+        format!("{}\n", canonicalize(&workspace).join("node_modules").join(".bin").display());
+    assert_eq!(String::from_utf8_lossy(&output.stdout), expected);
+
+    drop(root);
+}
+
+/// Differential parity from a workspace member, whose own `package.json`
+/// makes it the local prefix `bin` prints for. pacquet must match pnpm
+/// byte-for-byte. Windows-skipped because it spawns the external `pnpm`
+/// shim (see the `ignore` reason).
 #[test]
 #[cfg_attr(
     target_os = "windows",

--- a/pnpm/crates/cli/tests/suite/bin.rs
+++ b/pnpm/crates/cli/tests/suite/bin.rs
@@ -156,12 +156,10 @@ fn bin_global_writes_warnings_to_stderr_so_stdout_stays_a_clean_path() {
     drop(root);
 }
 
-/// A directory that is only a subdirectory of a project — no manifest, no
-/// `node_modules` of its own — is not where the project's executables live,
-/// so `bin` prints the project's. Regression test for
-/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622), where the
-/// printed path did not exist and tools spawning executables out of it
-/// failed with `ENOENT`.
+/// Regression test for
+/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622): the path
+/// printed under the subdirectory does not exist, so tools spawning
+/// executables out of it failed with `ENOENT`.
 #[test]
 fn bin_prints_the_project_bin_dir_from_a_plain_subdir() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm/crates/cli/tests/suite/exec.rs
+++ b/pnpm/crates/cli/tests/suite/exec.rs
@@ -173,6 +173,37 @@ fn exec_runs_binary_from_node_modules_bin() {
     drop(root);
 }
 
+/// From a plain subdirectory of a project the command runs where the user
+/// stands, while the executable comes from the project — pnpm's `exec`
+/// takes its working directory from `cliOptions.dir ?? process.cwd()` and
+/// its `PATH` from the project.
+#[cfg(unix)]
+#[test]
+fn exec_runs_in_the_cwd_with_the_projects_binaries() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "outer" }"#)
+        .expect("write package.json");
+    let bin_dir = workspace.join("node_modules").join(".bin");
+    fs::create_dir_all(&bin_dir).expect("create node_modules/.bin");
+    let marker_path = workspace.join("cwd.txt");
+    write_executable(
+        &bin_dir.join("record-cwd"),
+        &format!("#!/bin/sh\npwd > \"{}\"\n", marker_path.display()),
+    );
+    let subdir = workspace.join("src/utils");
+    fs::create_dir_all(&subdir).expect("create the subdirectory");
+
+    pacquet.with_current_dir(&subdir).with_args(["exec", "record-cwd"]).assert().success();
+
+    let recorded = fs::read_to_string(&marker_path).expect("read the recorded cwd");
+    assert_eq!(
+        dunce::canonicalize(recorded.trim()).expect("canonicalize the recorded cwd"),
+        dunce::canonicalize(&subdir).expect("canonicalize the subdirectory"),
+    );
+
+    drop(root);
+}
+
 /// Arguments after the command name flow through to the spawned binary.
 #[cfg(unix)]
 #[test]

--- a/pnpm/crates/cli/tests/suite/init.rs
+++ b/pnpm/crates/cli/tests/suite/init.rs
@@ -195,6 +195,29 @@ fn a_new_workspace_member_is_not_pinned() {
     drop(root);
 }
 
+/// Every other command run from a plain subdirectory of a project acts on
+/// the project, but `init` scaffolds where the user stands — otherwise
+/// there would be no way to start a package inside an existing one.
+#[test]
+fn init_scaffolds_in_the_cwd_inside_an_existing_project() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), r#"{ "name": "outer" }"#)
+        .expect("write the outer package.json");
+    let subdir = workspace.join("packages/inner");
+    fs::create_dir_all(&subdir).expect("create the subdirectory");
+
+    pacquet
+        .with_current_dir(&subdir)
+        .with_args(["init", "--no-init-package-manager"])
+        .assert()
+        .success();
+
+    let manifest = fs::read_to_string(subdir.join("package.json")).expect("read package.json");
+    assert!(manifest.contains(r#""name": "inner""#), "{manifest}");
+
+    drop(root);
+}
+
 fn assert_unpinned(dir: &Path) {
     let manifest = fs::read_to_string(dir.join("package.json")).expect("read from package.json");
     assert!(!manifest.contains("devEngines"), "{manifest}");

--- a/pnpm/crates/cli/tests/suite/prefix.rs
+++ b/pnpm/crates/cli/tests/suite/prefix.rs
@@ -140,3 +140,36 @@ fn prefix_resolves_from_a_workspace_subdir() {
 
     drop(root);
 }
+
+/// pnpm v12 manages Cargo and Python packages, whose members carry no
+/// `package.json`, so their manifests bound the prefix walk too. Without
+/// this a `pnpm add crate:...` from such a member would edit the manifest
+/// of whatever directory above it holds a `package.json`.
+#[test]
+fn prefix_stops_at_an_ecosystem_manifest() {
+    for (manifest, contents) in [
+        ("Cargo.toml", "[package]\nname = \"member\"\nversion = \"0.1.0\"\n"),
+        ("pyproject.toml", "[project]\nname = 'member'\nversion = '1.0'\n"),
+    ] {
+        let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+        fs::write(workspace.join("package.json"), r#"{ "name": "outer" }"#)
+            .expect("write the outer package.json");
+        let member = workspace.join("member");
+        fs::create_dir_all(&member).expect("create the member dir");
+        fs::write(member.join(manifest), contents).expect("write the ecosystem manifest");
+
+        let output = Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&member)
+            .with_args(["prefix"])
+            .output()
+            .expect("run pacquet prefix in the member");
+        dbg!(&output);
+        assert!(output.status.success(), "pacquet prefix should succeed in the {manifest} member");
+
+        let expected = format!("{}\n", canonicalize(&member).display());
+        assert_eq!(String::from_utf8_lossy(&output.stdout), expected, "manifest: {manifest}");
+
+        drop(root);
+    }
+}

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -44,10 +44,9 @@ fn run_executes_declared_script() {
     drop(root);
 }
 
-/// A subdirectory with no `package.json` of its own is part of the project
-/// above it, so a script run from there is the project's, and runs at the
-/// project root. Same local-prefix resolution as
-/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622).
+/// The same local-prefix resolution as
+/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622), which
+/// `pnpm bin` reported.
 #[cfg(unix)]
 #[test]
 fn run_from_a_plain_subdir_runs_the_projects_script() {

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -44,6 +44,33 @@ fn run_executes_declared_script() {
     drop(root);
 }
 
+/// A subdirectory with no `package.json` of its own is part of the project
+/// above it, so a script run from there is the project's, and runs at the
+/// project root. Same local-prefix resolution as
+/// [pnpm/pnpm#14622](https://github.com/pnpm/pnpm/issues/14622).
+#[cfg(unix)]
+#[test]
+fn run_from_a_plain_subdir_runs_the_projects_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let marker_path = workspace.join("marker.txt");
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": {
+            "touch-marker": format!(r#"touch "{}""#, marker_path.display()),
+        },
+    })
+    .to_string();
+    fs::write(workspace.join("package.json"), manifest).expect("write package.json");
+    let subdir = workspace.join("src/utils");
+    fs::create_dir_all(&subdir).expect("create the subdirectory");
+
+    pacquet.with_current_dir(&subdir).with_args(["run", "touch-marker"]).assert().success();
+    assert!(marker_path.exists(), "script should have created the marker file");
+
+    drop(root);
+}
+
 /// Positional arguments after the script name flow through to the
 /// spawned shell verbatim, joined by spaces. Mirrors
 /// `pnpm run <script> -- <args>` minus the npm `--` separator

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -51,13 +51,12 @@ fn run_executes_declared_script() {
 #[test]
 fn run_from_a_plain_subdir_runs_the_projects_script() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
-    let marker_path = workspace.join("marker.txt");
+    // A relative marker, so where the file lands pins the working
+    // directory the script ran in.
     let manifest = json!({
         "name": "test",
         "version": "0.0.0",
-        "scripts": {
-            "touch-marker": format!(r#"touch "{}""#, marker_path.display()),
-        },
+        "scripts": { "touch-marker": "touch marker.txt" },
     })
     .to_string();
     fs::write(workspace.join("package.json"), manifest).expect("write package.json");
@@ -65,7 +64,8 @@ fn run_from_a_plain_subdir_runs_the_projects_script() {
     fs::create_dir_all(&subdir).expect("create the subdirectory");
 
     pacquet.with_current_dir(&subdir).with_args(["run", "touch-marker"]).assert().success();
-    assert!(marker_path.exists(), "script should have created the marker file");
+    assert!(workspace.join("marker.txt").exists(), "the script should have run in the project");
+    assert!(!subdir.join("marker.txt").exists(), "the script should not have run in the subdir");
 
     drop(root);
 }

--- a/pnpm/crates/cli/tests/suite/view.rs
+++ b/pnpm/crates/cli/tests/suite/view.rs
@@ -691,7 +691,9 @@ fn searches_upward_for_manifest() {
         .expect("write package.json");
     let nested = workspace.join("a").join("b");
     fs::create_dir_all(&nested).expect("create nested dir");
-    write_registry_npmrc(&nested, &format!("{}/", server.url()));
+    // The `.npmrc` belongs next to the manifest: a command run from a plain
+    // subdirectory reads its configuration from the project above it too.
+    write_registry_npmrc(&workspace, &format!("{}/", server.url()));
     let mock = serve(&mut server, "/is-negative", &is_negative_body());
     let auth_file = empty_auth_file(root.path());
 

--- a/pnpm/crates/cli/tests/suite/view.rs
+++ b/pnpm/crates/cli/tests/suite/view.rs
@@ -691,8 +691,6 @@ fn searches_upward_for_manifest() {
         .expect("write package.json");
     let nested = workspace.join("a").join("b");
     fs::create_dir_all(&nested).expect("create nested dir");
-    // The `.npmrc` belongs next to the manifest: a command run from a plain
-    // subdirectory reads its configuration from the project above it too.
     write_registry_npmrc(&workspace, &format!("{}/", server.url()));
     let mock = serve(&mut server, "/is-negative", &is_negative_body());
     let auth_file = empty_auth_file(root.path());


### PR DESCRIPTION
## Summary

`pnpm bin` run from a subdirectory of a project printed `<cwd>/node_modules/.bin`, a path that does not exist, so tools spawning executables out of it failed with `ENOENT`. Closes pnpm/pnpm#14622.

The root cause is the working directory itself, as the issue reports: pacquet defaults `--dir` to the process cwd, while pnpm resolves `config.dir` from npm's `localPrefix` — the nearest ancestor directory that holds a project. `pnpm bin` was the reported symptom; `pnpm root` printed the same non-existent `node_modules`, and `pnpm run` from such a subdirectory reported `ERR_PNPM_NO_IMPORTER_MANIFEST_FOUND` where pnpm 11 runs the project's script. So the fix is at `--dir` rather than in the `bin` handler.

A `--dir` given on the command line is still taken as is. The two places pnpm anchors at `cliOptions.dir ?? process.cwd()` instead of at `config.dir` keep the cwd: `init` scaffolds its `package.json` where the user stands (otherwise there would be no way to start a package inside an existing one), and a non-recursive `exec` runs the command there. An `exec` therefore has two directories now, which `ExecDirs` carries: the command's working directory is the cwd, while its dependency check, `node_modules/.bin`, manifest name, and Node.js execution paths are the project's. So `pnpm exec depcheck` from a plain subdirectory runs in that subdirectory and finds the project's `depcheck`, as it does on pnpm 11.

The prefix walk also stops at a `Cargo.toml` or a `pyproject.toml`, the manifests pnpm v12 manages beyond `package.json`. Without them, a Cargo workspace member that has no `package.json` resolves to the workspace root above it and `pnpm add crate:...` edits the wrong manifest.

Verified against the issue's repro, with pnpm 11 for comparison:

```
$ mkdir -p /tmp/pnpm-bin-repro/sub && cd /tmp/pnpm-bin-repro
$ echo '{"name":"repro"}' > package.json && cd sub

# before
$ pnpm bin
/private/tmp/pnpm-bin-repro/sub/node_modules/.bin

# after (and what pnpm 11 prints)
$ pnpm bin
/private/tmp/pnpm-bin-repro/node_modules/.bin
```

This is a v12-only bug; pnpm 11 is correct here, so there is no TypeScript counterpart.

## Squash Commit Body

```text
`--dir` defaulted to the process cwd, while pnpm resolves `config.dir`
from npm's `localPrefix`: the nearest ancestor directory that holds a
project. Run from a plain subdirectory of a project, `pnpm bin` therefore
printed a `node_modules/.bin` path that does not exist, `pnpm root` the
matching `node_modules`, and `pnpm run` reported no manifest at all.

A `--dir` given on the command line is still taken as is, and so are the
two commands pnpm anchors at `cliOptions.dir ?? process.cwd()` instead of
at `config.dir`: `init` scaffolds its `package.json` where the user
stands, and a non-recursive `exec` runs the command there. `ExecDirs`
carries the two directories an `exec` now has, so the dependency check,
the `node_modules/.bin` entry, the manifest name, and the Node.js
execution paths stay the project's while the child's working directory
is the cwd.

The prefix walk also stops at a `Cargo.toml` or a `pyproject.toml`, the
manifests pnpm v12 manages beyond `package.json`. Without them a Cargo
workspace member that has no `package.json` would resolve to the
workspace root above it, and `pnpm add crate:...` would edit the wrong
manifest.

An unreadable ancestor no longer aborts the walk, matching pnpm, which
only propagates the error when the directory it was handed is the
unreadable one.

Closes pnpm/pnpm#14622
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Commands run from plain subdirectories now resolve the nearest parent project.
  - `bin` reports the correct project-level executable directory.
  - Scripts and `exec` commands run from the user’s current directory while using the parent project’s dependencies and configuration.
  - Prefix resolution stops at Cargo and Python project manifests.

- **New Features**
  - `init` creates a new `package.json` in the directory where it is run, including inside an existing project.

- **Tests**
  - Added coverage for subdirectory execution, prefix resolution, executable paths, and initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->