### PR TITLE
feat(pnpr): complete oci protocol surface

### DIFF
--- a/.changeset/pnpr-oci-protocol-surface.md
+++ b/.changeset/pnpr-oci-protocol-surface.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+pnpr now supports ranged OCI blob downloads, cross-repository blob mounts, and the OCI referrers API. Tag and repository listings support pagination with `n` and `last` [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-protocol-surface.md
+++ b/.changeset/pnpr-oci-protocol-surface.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr now supports ranged OCI blob downloads, cross-repository blob mounts, and the OCI referrers API. Tag and repository listings support pagination with `n` and `last` [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).
+pnpr now supports ranged OCI blob downloads. Cross-repository blob mounts reuse layers from readable repositories. The OCI referrers API lists artifacts attached to an image. Tag and repository listings support pagination with `n` and `last` [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/pnpr/crates/oci/src/document.rs
+++ b/pnpr/crates/oci/src/document.rs
@@ -1,9 +1,6 @@
 use crate::Digest;
 use serde::{Deserialize, Serialize};
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, HashSet},
-};
+use std::{cmp::Ordering, collections::HashSet};
 
 /// One manifest the repository holds, keyed by the digest of its bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -12,7 +9,7 @@ pub struct ManifestEntry {
     pub digest: Digest,
     pub media_type: String,
     pub size: u64,
-    /// Absent on documents written before referrer metadata was indexed.
+    /// Missing metadata is populated from the manifest during referrer discovery.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub referrer: Option<ReferrerMetadata>,
 }
@@ -24,9 +21,7 @@ pub struct ReferrerMetadata {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject: Option<Digest>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub artifact_type: Option<String>,
-    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
-    pub annotations: BTreeMap<String, String>,
+    pub artifact_type_digest: Option<Digest>,
 }
 
 /// One tag and the manifest it currently names.

--- a/pnpr/crates/oci/src/document.rs
+++ b/pnpr/crates/oci/src/document.rs
@@ -1,6 +1,9 @@
 use crate::Digest;
 use serde::{Deserialize, Serialize};
-use std::{cmp::Ordering, collections::HashSet};
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, HashSet},
+};
 
 /// One manifest the repository holds, keyed by the digest of its bytes.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -9,6 +12,21 @@ pub struct ManifestEntry {
     pub digest: Digest,
     pub media_type: String,
     pub size: u64,
+    /// Absent on documents written before referrer metadata was indexed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub referrer: Option<ReferrerMetadata>,
+}
+
+/// Metadata used to discover artifacts attached to a subject manifest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReferrerMetadata {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<Digest>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_type: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub annotations: BTreeMap<String, String>,
 }
 
 /// One tag and the manifest it currently names.

--- a/pnpr/crates/oci/src/lib.rs
+++ b/pnpr/crates/oci/src/lib.rs
@@ -18,7 +18,7 @@ mod error_body;
 mod manifest;
 
 pub use digest::{Digest, DigestError};
-pub use document::{ImageDocument, ManifestEntry, TagEntry};
+pub use document::{ImageDocument, ManifestEntry, ReferrerMetadata, TagEntry};
 pub use error_body::{ErrorBody, ErrorCode};
 pub use manifest::{Descriptor, Manifest, ManifestError};
 

--- a/pnpr/crates/oci/src/manifest.rs
+++ b/pnpr/crates/oci/src/manifest.rs
@@ -1,6 +1,7 @@
 use crate::{Digest, media_type};
 use derive_more::{Display, Error};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 /// The schema every manifest pnpr accepts declares. Docker's schema 1 is a
 /// different document with signatures instead of a config, and is long
@@ -44,6 +45,12 @@ pub struct Manifest {
     layers: Vec<Descriptor>,
     #[serde(default)]
     manifests: Vec<Descriptor>,
+    #[serde(default)]
+    subject: Option<Descriptor>,
+    #[serde(default)]
+    artifact_type: Option<String>,
+    #[serde(default)]
+    annotations: BTreeMap<String, String>,
 }
 
 impl Manifest {
@@ -77,6 +84,25 @@ impl Manifest {
     #[must_use]
     pub fn media_type(&self) -> &str {
         self.media_type.as_deref().unwrap_or(media_type::DEFAULT_MANIFEST)
+    }
+
+    #[must_use]
+    pub fn referrer_metadata(&self) -> crate::ReferrerMetadata {
+        let artifact_type = self
+            .artifact_type
+            .as_deref()
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                (!media_type::is_index(self.media_type()))
+                    .then(|| self.config.as_ref().and_then(|config| config.media_type.as_deref()))
+                    .flatten()
+            })
+            .map(ToString::to_string);
+        crate::ReferrerMetadata {
+            subject: self.subject.as_ref().map(|subject| subject.digest.clone()),
+            artifact_type,
+            annotations: self.annotations.clone(),
+        }
     }
 
     /// Every digest that must already be in the store for this manifest to

--- a/pnpr/crates/oci/src/manifest.rs
+++ b/pnpr/crates/oci/src/manifest.rs
@@ -18,6 +18,8 @@ pub enum ManifestError {
     UnsupportedMediaType { media_type: String },
     #[display("an image manifest must carry a config descriptor")]
     MissingConfig,
+    #[display("an image referrer must carry artifactType or a config mediaType")]
+    MissingArtifactType,
 }
 
 /// One reference from a manifest to bytes the registry must already hold.
@@ -76,6 +78,12 @@ impl Manifest {
         if !media_type::is_index(media_type) && manifest.config.is_none() {
             return Err(ManifestError::MissingConfig);
         }
+        if manifest.subject.is_some()
+            && !media_type::is_index(manifest.media_type())
+            && manifest.artifact_type().is_none()
+        {
+            return Err(ManifestError::MissingArtifactType);
+        }
         Ok(manifest)
     }
 
@@ -88,21 +96,32 @@ impl Manifest {
 
     #[must_use]
     pub fn referrer_metadata(&self) -> crate::ReferrerMetadata {
-        let artifact_type = self
-            .artifact_type
-            .as_deref()
-            .filter(|value| !value.is_empty())
-            .or_else(|| {
-                (!media_type::is_index(self.media_type()))
-                    .then(|| self.config.as_ref().and_then(|config| config.media_type.as_deref()))
-                    .flatten()
-            })
-            .map(ToString::to_string);
-        crate::ReferrerMetadata {
-            subject: self.subject.as_ref().map(|subject| subject.digest.clone()),
-            artifact_type,
-            annotations: self.annotations.clone(),
-        }
+        let subject = self.subject.as_ref().map(|subject| subject.digest.clone());
+        let artifact_type_digest = subject
+            .as_ref()
+            .and_then(|_| self.artifact_type())
+            .map(|value| Digest::of(value.as_bytes()));
+        crate::ReferrerMetadata { subject, artifact_type_digest }
+    }
+
+    /// An image without an artifact type uses its config media type. An index
+    /// has no fallback artifact type.
+    #[must_use]
+    pub fn artifact_type(&self) -> Option<&str> {
+        self.artifact_type.as_deref().filter(|value| !value.is_empty()).or_else(|| {
+            if media_type::is_index(self.media_type()) {
+                return None;
+            }
+            self.config
+                .as_ref()
+                .and_then(|config| config.media_type.as_deref())
+                .filter(|value| !value.is_empty())
+        })
+    }
+
+    #[must_use]
+    pub fn annotations(&self) -> &BTreeMap<String, String> {
+        &self.annotations
     }
 
     /// Every digest that must already be in the store for this manifest to

--- a/pnpr/crates/oci/src/tests.rs
+++ b/pnpr/crates/oci/src/tests.rs
@@ -311,6 +311,10 @@ fn an_image_referrer_requires_an_artifact_type_or_config_media_type() {
             manifest["artifactType"] = "application/example.signature".into();
             let parsed = Manifest::parse(&serde_json::to_vec(&manifest).unwrap(), None).unwrap();
             assert_eq!(parsed.artifact_type(), Some("application/example.signature"));
+            assert!(manifest.as_object_mut().unwrap().remove("artifactType").is_some());
+            manifest["config"]["mediaType"] = "application/example.config".into();
+            let parsed = Manifest::parse(&serde_json::to_vec(&manifest).unwrap(), None).unwrap();
+            assert_eq!(parsed.artifact_type(), Some("application/example.config"));
         }
     }
 }

--- a/pnpr/crates/oci/src/tests.rs
+++ b/pnpr/crates/oci/src/tests.rs
@@ -7,6 +7,7 @@ fn digest_of(body: &str) -> Digest {
 
 fn entry(body: &str) -> ManifestEntry {
     ManifestEntry {
+        referrer: None,
         digest: digest_of(body),
         media_type: media_type::OCI_IMAGE_MANIFEST.to_string(),
         size: body.len() as u64,

--- a/pnpr/crates/oci/src/tests.rs
+++ b/pnpr/crates/oci/src/tests.rs
@@ -289,3 +289,28 @@ fn deserializing_directly_sorts_as_parsing_does() {
     assert!(document.manifest(&digest_of("one")).is_some());
     assert_eq!(document.tag_names(), ["alpha", "zeta"]);
 }
+
+#[test]
+fn an_image_referrer_requires_an_artifact_type_or_config_media_type() {
+    for artifact_type in [None, Some("")] {
+        for config_media_type in [None, Some("")] {
+            let mut manifest = serde_json::json!({
+                "schemaVersion": 2,
+                "mediaType": media_type::OCI_IMAGE_MANIFEST,
+                "config": { "digest": digest_of("config"), "size": 6 },
+                "subject": { "digest": digest_of("subject"), "size": 7 },
+            });
+            if let Some(artifact_type) = artifact_type {
+                manifest["artifactType"] = artifact_type.into();
+            }
+            if let Some(config_media_type) = config_media_type {
+                manifest["config"]["mediaType"] = config_media_type.into();
+            }
+            let result = Manifest::parse(&serde_json::to_vec(&manifest).unwrap(), None);
+            assert!(matches!(result, Err(crate::ManifestError::MissingArtifactType)));
+            manifest["artifactType"] = "application/example.signature".into();
+            let parsed = Manifest::parse(&serde_json::to_vec(&manifest).unwrap(), None).unwrap();
+            assert_eq!(parsed.artifact_type(), Some("application/example.signature"));
+        }
+    }
+}

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -388,10 +388,29 @@ leaves nothing behind. A blob no manifest references is invisible rather than
 half-published, which also means unreferenced blobs accumulate until they are
 collected.
 
-Not yet served: proxying an upstream image registry, the referrers API,
-cross-repository blob mounts, and ranged blob downloads. Deleting a manifest
-or a blob needs a registry whose `unpublish` rule admits the caller, which the
-per-registry default does not.
+Blob downloads accept a single HTTP byte range on filesystem and S3 storage,
+including open-ended and suffix ranges. Responses include `Accept-Ranges` and
+an ETag. `If-Range` resumes a matching blob or returns the full blob when its
+validator does not match. Unsupported or malformed ranges are ignored.
+
+Cross-repository blob mounts reuse a layer from a repository the caller may
+read. The caller also needs permission to publish to the destination. A missing
+or inaccessible source starts an ordinary upload. Mounts stream through local
+scratch for digest verification; they do not require the client to resend the layer.
+
+`GET /v2/<name>/referrers/<digest>` returns an OCI image index of manifests and
+indexes attached to that subject. It supports the `artifactType` filter and
+includes annotations. A push acknowledges its subject with `OCI-Subject`.
+Existing manifests are indexed when their repository's referrers are first
+queried. Removing a manifest removes its referrer entry; removing a tag keeps it.
+
+`tags/list` and `_catalog` accept `n` and `last` for pagination and return a
+`Link` header when another page is available. `last` is an exclusive lexical
+cursor. `n=0` returns an empty list without a continuation link.
+
+Proxying an upstream image registry and online blob deletion are not yet served.
+Deleting a manifest needs a registry whose `unpublish` rule admits the caller,
+which the per-registry default does not.
 
 ## License
 

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -401,8 +401,10 @@ scratch for digest verification; they do not require the client to resend the la
 `GET /v2/<name>/referrers/<digest>` returns an OCI image index of manifests and
 indexes attached to that subject. It supports the `artifactType` filter and
 includes annotations. A push acknowledges its subject with `OCI-Subject`.
-Existing manifests are indexed when their repository's referrers are first
-queried. Removing a manifest removes its referrer entry; removing a tag keeps it.
+Follow the `Link` header to collect all pages, even when a filtered page is empty.
+Each page reads at most 32 manifests and 8 MiB of manifest content. Existing
+manifests are indexed incrementally as those pages are queried. Removing a
+manifest removes its referrer entry; removing a tag keeps it.
 
 `tags/list` and `_catalog` accept `n` and `last` for pagination and return a
 `Link` header when another page is available. `last` is an exclusive lexical

--- a/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
@@ -38,6 +38,7 @@ async fn retained_image(storage: &Storage, repository: &CanonicalPackageName) ->
     let manifest = blob(storage, repository, &bytes).await;
     let mut document = ImageDocument::new(repository.as_str());
     document.insert_manifest(ManifestEntry {
+        referrer: None,
         digest: manifest.clone(),
         size: bytes.len() as u64,
         media_type: media_type::OCI_IMAGE_MANIFEST.into(),
@@ -107,6 +108,7 @@ async fn index_keeps_children_removed_from_the_document_and_their_layers() {
     let index = blob(&storage, &repository, &bytes).await;
     let mut document = ImageDocument::new(repository.as_str());
     document.insert_manifest(ManifestEntry {
+        referrer: None,
         digest: index.clone(),
         size: bytes.len() as u64,
         media_type: media_type::OCI_IMAGE_INDEX.into(),
@@ -145,6 +147,7 @@ async fn collection_uses_the_stored_media_type_for_header_only_manifests() {
     let digest = blob(&storage, &repository, &bytes).await;
     let mut document = ImageDocument::new(repository.as_str());
     document.insert_manifest(ManifestEntry {
+        referrer: None,
         digest: digest.clone(),
         size: bytes.len() as u64,
         media_type: media_type::OCI_IMAGE_MANIFEST.into(),
@@ -165,6 +168,7 @@ async fn a_document_without_any_blob_files_still_blocks_collection_when_corrupt(
     let repository = name("empty");
     let mut document = ImageDocument::new(repository.as_str());
     document.insert_manifest(ManifestEntry {
+        referrer: None,
         digest: Digest::of(b"missing"),
         size: 7,
         media_type: media_type::OCI_IMAGE_MANIFEST.into(),

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -129,6 +129,7 @@ struct AppInner {
     /// two concurrent writers to the same package on this instance can't
     /// lose each other's changes.
     package_locks: StripedLocks,
+    referrer_migration_locks: StripedLocks,
     /// Lazily-built engine backing the `/-/pnpr/v0/resolve` endpoint. Built on
     /// first such request so servers that never receive one pay nothing.
     resolver: std::sync::OnceLock<crate::resolver::Resolver>,

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -10,9 +10,12 @@ mod publishing;
 mod pypi;
 mod routing;
 mod staged;
+mod striped_locks;
 
 #[cfg(test)]
 mod tests;
+
+pub(crate) use self::striped_locks::StripedLocks;
 
 use self::{
     authentication::{Action, AuthedCaller, authenticate, authorize},
@@ -142,55 +145,6 @@ struct AppInner {
 struct HostedOriginalRef {
     package: String,
     version: String,
-}
-
-/// A fixed stripe set bounds lock memory while serializing writers for the
-/// same logical resource. Hash collisions only reduce concurrency.
-///
-/// This guards concurrency **within one instance**. Across replicas
-/// sharing one hosted store, the same race needs a conditional write
-/// (S3 `If-Match` / `ETag`); that is the cross-replica half tracked in
-/// [pnpm/pnpm#12199](https://github.com/pnpm/pnpm/issues/12199).
-pub(crate) struct StripedLocks {
-    stripes: Box<[tokio::sync::Mutex<()>]>,
-}
-
-impl StripedLocks {
-    /// Number of stripes. 64 keeps false sharing between distinct resources
-    /// rare while staying tiny in memory.
-    const STRIPES: usize = 64;
-
-    pub(crate) fn new() -> Self {
-        let stripes = (0..Self::STRIPES).map(|_| tokio::sync::Mutex::new(())).collect();
-        Self { stripes }
-    }
-
-    /// Lock the stripe owning `name`, held until the returned guard is dropped.
-    pub(crate) async fn lock(&self, name: &str) -> tokio::sync::MutexGuard<'_, ()> {
-        self.stripes[self.stripe_index(name)].lock().await
-    }
-
-    /// Lock the stripes owning every name in `names`, held until the
-    /// returned guards are dropped. Stripes are locked in ascending
-    /// index order (duplicates collapsed), so two overlapping
-    /// batch publishes — or a batch publish racing a single-package
-    /// publish — can't deadlock on lock order.
-    async fn lock_many(&self, names: &[&str]) -> Vec<tokio::sync::MutexGuard<'_, ()>> {
-        let mut indices: Vec<usize> = names.iter().map(|name| self.stripe_index(name)).collect();
-        indices.sort_unstable();
-        indices.dedup();
-        let mut guards = Vec::with_capacity(indices.len());
-        for index in indices {
-            guards.push(self.stripes[index].lock().await);
-        }
-        guards
-    }
-
-    fn stripe_index(&self, name: &str) -> usize {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        std::hash::Hash::hash(name, &mut hasher);
-        std::hash::Hasher::finish(&hasher) as usize % self.stripes.len()
-    }
 }
 
 /// Build the axum [`Router`] with in-memory auth state. Convenient

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -347,6 +347,9 @@ impl Request {
             } else {
                 entry.referrer.as_ref()
             };
+            if migration_guard.is_some() && indexed_metadata.is_some() && additions.is_empty() {
+                drop(migration_guard.take());
+            }
             let needs_read = indexed_metadata.is_none_or(|metadata| {
                 metadata.subject.as_ref() == Some(&digest)
                     && artifact_type_digest
@@ -360,7 +363,8 @@ impl Request {
                     break;
                 }
                 if indexed_metadata.is_none() && migration_guard.is_none() {
-                    migration_guard = Some(self.state.inner.package_locks.lock(key.as_str()).await);
+                    migration_guard =
+                        Some(self.state.inner.referrer_migration_locks.lock(key.as_str()).await);
                     current_document = match storage.read_hosted_document(&key).await {
                         Ok(Some(bytes)) => match ImageDocument::parse(&bytes) {
                             Ok(document) => Some(document),
@@ -420,6 +424,7 @@ impl Request {
             entries.next();
         }
         if !additions.is_empty() {
+            let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
             let outcome = storage
                 .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
                     let Some(bytes) = existing else { return Ok(None) };

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -72,6 +72,9 @@ const MAX_MANIFEST_REFERENCES: usize = 4096;
 /// How much of a blob is hashed per read when verifying a finished upload.
 const HASH_CHUNK: usize = 64 * 1024;
 
+const MAX_REFERRER_READS: usize = 32;
+const MAX_REFERRER_READ_BYTES: u64 = 8 * 1024 * 1024;
+
 const DOCKER_CONTENT_DIGEST: &str = "docker-content-digest";
 const DOCKER_UPLOAD_UUID: &str = "docker-upload-uuid";
 const API_VERSION_HEADER: &str = "docker-distribution-api-version";
@@ -215,12 +218,8 @@ struct Request {
 }
 
 impl Request {
-    fn paginate<Item: AsRef<str>>(
-        &self,
-        items: &mut Vec<Item>,
-        endpoint: &str,
-    ) -> Result<Option<String>, Refusal> {
-        let count = query_param(Some(&self.query), "n")
+    fn page_size(&self) -> Result<Option<usize>, Refusal> {
+        query_param(Some(&self.query), "n")
             .map(|value| {
                 if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
                     return Err(Refusal::new(
@@ -232,7 +231,15 @@ impl Request {
                     .parse::<usize>()
                     .map_err(|_| Refusal::new(ErrorCode::NameInvalid, "n is too large"))
             })
-            .transpose()?;
+            .transpose()
+    }
+
+    fn paginate<Item: AsRef<str>>(
+        &self,
+        items: &mut Vec<Item>,
+        endpoint: &str,
+    ) -> Result<Option<String>, Refusal> {
+        let count = self.page_size()?;
         if let Some(last) = query_param(Some(&self.query), "last") {
             items.retain(|item| item.as_ref() > last.as_str());
         }
@@ -294,6 +301,11 @@ impl Request {
         let Ok(digest) = Digest::parse(digest) else {
             return error(ErrorCode::DigestInvalid, "not a supported digest");
         };
+        let Ok(last) =
+            query_param(Some(&self.query), "last").map(|value| Digest::parse(&value)).transpose()
+        else {
+            return error(ErrorCode::DigestInvalid, "last must be a supported digest");
+        };
         let (key, source) = match self.hosted_source(name) {
             Ok(found) => found,
             Err(refusal) => return refusal.respond(),
@@ -303,6 +315,8 @@ impl Request {
             Err(err) => return registry_error(err),
         };
         let storage = self.state.inner.storage.for_hosted(&org);
+        let _guard =
+            self.state.inner.package_locks.lock(&format!("oci-referrers:{}", key.as_str())).await;
         let document =
             match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
                 .await
@@ -310,31 +324,85 @@ impl Request {
                 Ok(document) => document.unwrap_or_else(|| ImageDocument::new(key.as_str())),
                 Err(err) => return registry_error(err),
             };
-        let document = match self.backfill_referrers(&storage, &key, document).await {
-            Ok(document) => document,
-            Err(err) => return registry_error(err),
-        };
         let artifact_type = query_param(Some(&self.query), "artifactType");
-        let manifests: Vec<_> = document
-            .manifests()
-            .iter()
-            .filter_map(|entry| {
-                let metadata = entry.referrer.as_ref()?;
-                if metadata.subject.as_ref() != Some(&digest)
-                    || artifact_type
+        let artifact_type_digest = artifact_type.as_ref().map(|value| Digest::of(value.as_bytes()));
+        let start = document.manifests().partition_point(|entry| {
+            last.as_ref().is_some_and(|last| entry.digest.hex() <= last.hex())
+        });
+        let mut entries = document.manifests()[start..].iter().peekable();
+        let mut additions = Vec::new();
+        let mut referrers = Vec::new();
+        let mut inspected = 0;
+        let mut read_bytes = 0;
+        let mut response_bytes = 128;
+        let mut cursor = None;
+        while let Some(&entry) = entries.peek() {
+            let needs_read = entry.referrer.as_ref().is_none_or(|metadata| {
+                metadata.subject.as_ref() == Some(&digest)
+                    && artifact_type_digest
                         .as_ref()
-                        .is_some_and(|filter| metadata.artifact_type.as_ref() != Some(filter))
+                        .is_none_or(|filter| metadata.artifact_type_digest.as_ref() == Some(filter))
+            });
+            if needs_read {
+                if inspected >= MAX_REFERRER_READS
+                    || (inspected > 0 && read_bytes + entry.size > MAX_REFERRER_READ_BYTES)
                 {
-                    return None;
+                    break;
                 }
-                Some(ReferrerDescriptor {
-                    media_type: &entry.media_type,
-                    digest: &entry.digest,
-                    size: entry.size,
-                    artifact_type: metadata.artifact_type.as_deref(),
-                    annotations: &metadata.annotations,
-                })
-            })
+                let bytes = match read_manifest_bytes(&storage, &key, &entry.digest.blob_filename())
+                    .await
+                {
+                    Ok(Some(bytes)) => bytes,
+                    Ok(None) => {
+                        return error(
+                            ErrorCode::ManifestUnknown,
+                            "a referenced manifest is missing",
+                        );
+                    }
+                    Err(err) => return registry_error(err),
+                };
+                inspected += 1;
+                read_bytes += bytes.len() as u64;
+                let manifest = match Manifest::parse(&bytes, Some(&entry.media_type)) {
+                    Ok(manifest) => manifest,
+                    Err(err) => {
+                        return registry_error(RegistryError::Internal { reason: err.to_string() });
+                    }
+                };
+                let metadata = manifest.referrer_metadata();
+                let matches = metadata.subject.as_ref() == Some(&digest)
+                    && artifact_type
+                        .as_deref()
+                        .is_none_or(|filter| manifest.artifact_type() == Some(filter));
+                if entry.referrer.is_none() {
+                    let mut addition = entry.clone();
+                    addition.referrer = Some(metadata);
+                    additions.push(addition);
+                }
+                if matches {
+                    let descriptor_bytes =
+                        match serde_json::to_vec(&ReferrerDescriptor::new(entry, &manifest)) {
+                            Ok(bytes) => bytes.len() + 1,
+                            Err(err) => return registry_error(err.into()),
+                        };
+                    if !referrers.is_empty()
+                        && response_bytes + descriptor_bytes > MAX_MANIFEST_BYTES
+                    {
+                        break;
+                    }
+                    response_bytes += descriptor_bytes;
+                    referrers.push((entry, manifest));
+                }
+            }
+            cursor = Some(&entry.digest);
+            entries.next();
+        }
+        if let Err(err) = self.persist_referrer_metadata(&storage, &key, &additions).await {
+            return registry_error(err);
+        }
+        let manifests = referrers
+            .iter()
+            .map(|(entry, manifest)| ReferrerDescriptor::new(entry, manifest))
             .collect();
         let mut response = json(
             StatusCode::OK,
@@ -344,30 +412,36 @@ impl Request {
         if artifact_type.is_some() {
             insert_header(&mut response, "oci-filters-applied", "artifactType");
         }
+        if entries.peek().is_some()
+            && let Some(cursor) = cursor
+        {
+            let mut query = url::form_urlencoded::Serializer::new(String::new());
+            query.append_pair("last", &cursor.to_string());
+            if let Some(artifact_type) = artifact_type {
+                query.append_pair("artifactType", &artifact_type);
+            }
+            insert_header(
+                &mut response,
+                "link",
+                &format!(
+                    r#"<{}/{}/referrers/{digest}?{}>; rel="next""#,
+                    self.base,
+                    key.as_str(),
+                    query.finish(),
+                ),
+            );
+        }
         self.caller_scoped(Some(key.as_str()), response)
     }
 
-    async fn backfill_referrers(
+    async fn persist_referrer_metadata(
         &self,
         storage: &Storage,
         key: &CanonicalPackageName,
-        mut document: ImageDocument,
-    ) -> Result<ImageDocument, RegistryError> {
-        let mut additions = Vec::new();
-        for entry in document.manifests().iter().filter(|entry| entry.referrer.is_none()) {
-            let bytes = read_manifest_bytes(storage, key, &entry.digest.blob_filename())
-                .await?
-                .ok_or_else(|| RegistryError::Internal {
-                    reason: format!("missing OCI manifest {} in {}", entry.digest, key.as_str()),
-                })?;
-            let manifest = Manifest::parse(&bytes, Some(&entry.media_type))
-                .map_err(|err| RegistryError::Internal { reason: err.to_string() })?;
-            let mut entry = entry.clone();
-            entry.referrer = Some(manifest.referrer_metadata());
-            additions.push(entry);
-        }
+        additions: &[ManifestEntry],
+    ) -> Result<(), RegistryError> {
         if additions.is_empty() {
-            return Ok(document);
+            return Ok(());
         }
         let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
         storage
@@ -375,7 +449,7 @@ impl Request {
                 let Some(bytes) = existing else { return Ok(None) };
                 let mut current = ImageDocument::parse(bytes)?;
                 let mut changed = false;
-                for entry in &additions {
+                for entry in additions {
                     if current.manifest(&entry.digest).is_some_and(|held| held.referrer.is_none()) {
                         current.insert_manifest(entry.clone());
                         changed = true;
@@ -384,10 +458,7 @@ impl Request {
                 Ok(changed.then(|| current.to_bytes()))
             })
             .await?;
-        for entry in additions {
-            document.insert_manifest(entry);
-        }
-        Ok(document)
+        Ok(())
     }
 
     /// `GET /v2/_catalog` — the repository names this caller may read.
@@ -398,6 +469,17 @@ impl Request {
         let Some(target) = addressed_registry(&self.state, self.registry.as_deref()) else {
             return error(ErrorCode::NameUnknown, "no registry is addressed here");
         };
+        match self.page_size() {
+            Ok(Some(0)) => {
+                return private_no_cache(json(
+                    StatusCode::OK,
+                    &Catalog { repositories: Vec::new() },
+                ));
+            }
+            Ok(_) => {}
+            Err(refusal) => return refusal.respond(),
+        }
+        let last = query_param(Some(&self.query), "last");
         let mut repositories = Vec::new();
         for source in hosted_sources(&self.state, &target, ECOSYSTEM) {
             let Some(hosted) = self.state.inner.config.hosted.get(&source) else { continue };
@@ -408,14 +490,15 @@ impl Request {
             };
             // A listing may only name what this caller could have fetched.
             repositories.extend(names.into_iter().filter(|name| {
-                authorize(
-                    &self.state,
-                    &self.identity,
-                    &RegistrySource::Hosted(source.clone()),
-                    name,
-                    Action::Access,
-                )
-                .is_ok()
+                last.as_ref().is_none_or(|last| name > last)
+                    && authorize(
+                        &self.state,
+                        &self.identity,
+                        &RegistrySource::Hosted(source.clone()),
+                        name,
+                        Action::Access,
+                    )
+                    .is_ok()
             }));
         }
         repositories.sort();
@@ -1012,6 +1095,18 @@ struct ReferrerDescriptor<'listing> {
     artifact_type: Option<&'listing str>,
     #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     annotations: &'listing std::collections::BTreeMap<String, String>,
+}
+
+impl<'listing> ReferrerDescriptor<'listing> {
+    fn new(entry: &'listing ManifestEntry, manifest: &'listing Manifest) -> Self {
+        Self {
+            media_type: &entry.media_type,
+            digest: &entry.digest,
+            size: entry.size,
+            artifact_type: manifest.artifact_type(),
+            annotations: manifest.annotations(),
+        }
+    }
 }
 
 fn insert_header(response: &mut Response, name: &'static str, value: &str) {

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -315,8 +315,6 @@ impl Request {
             Err(err) => return registry_error(err),
         };
         let storage = self.state.inner.storage.for_hosted(&org);
-        let _guard =
-            self.state.inner.package_locks.lock(&format!("oci-referrers:{}", key.as_str())).await;
         let document =
             match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
                 .await
@@ -336,8 +334,20 @@ impl Request {
         let mut read_bytes = 0;
         let mut response_bytes = 128;
         let mut cursor = None;
+        let mut migration_guard = None;
+        let mut current_document: Option<ImageDocument> = None;
         while let Some(&entry) = entries.peek() {
-            let needs_read = entry.referrer.as_ref().is_none_or(|metadata| {
+            let indexed_metadata = if let Some(current) = &current_document {
+                let Some(current_entry) = current.manifest(&entry.digest) else {
+                    cursor = Some(&entry.digest);
+                    entries.next();
+                    continue;
+                };
+                current_entry.referrer.as_ref()
+            } else {
+                entry.referrer.as_ref()
+            };
+            let needs_read = indexed_metadata.is_none_or(|metadata| {
                 metadata.subject.as_ref() == Some(&digest)
                     && artifact_type_digest
                         .as_ref()
@@ -348,6 +358,18 @@ impl Request {
                     || (inspected > 0 && read_bytes + entry.size > MAX_REFERRER_READ_BYTES)
                 {
                     break;
+                }
+                if indexed_metadata.is_none() && migration_guard.is_none() {
+                    migration_guard = Some(self.state.inner.package_locks.lock(key.as_str()).await);
+                    current_document = match storage.read_hosted_document(&key).await {
+                        Ok(Some(bytes)) => match ImageDocument::parse(&bytes) {
+                            Ok(document) => Some(document),
+                            Err(err) => return registry_error(err.into()),
+                        },
+                        Ok(None) => Some(ImageDocument::new(key.as_str())),
+                        Err(err) => return registry_error(err),
+                    };
+                    continue;
                 }
                 let bytes = match read_manifest_bytes(&storage, &key, &entry.digest.blob_filename())
                     .await
@@ -374,7 +396,7 @@ impl Request {
                     && artifact_type
                         .as_deref()
                         .is_none_or(|filter| manifest.artifact_type() == Some(filter));
-                if entry.referrer.is_none() {
+                if indexed_metadata.is_none() {
                     let mut addition = entry.clone();
                     addition.referrer = Some(metadata);
                     additions.push(addition);
@@ -397,9 +419,29 @@ impl Request {
             cursor = Some(&entry.digest);
             entries.next();
         }
-        if let Err(err) = self.persist_referrer_metadata(&storage, &key, &additions).await {
-            return registry_error(err);
+        if !additions.is_empty() {
+            let outcome = storage
+                .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
+                    let Some(bytes) = existing else { return Ok(None) };
+                    let mut current = ImageDocument::parse(bytes)?;
+                    let mut changed = false;
+                    for entry in &additions {
+                        if current
+                            .manifest(&entry.digest)
+                            .is_some_and(|held| held.referrer.is_none())
+                        {
+                            current.insert_manifest(entry.clone());
+                            changed = true;
+                        }
+                    }
+                    Ok(changed.then(|| current.to_bytes()))
+                })
+                .await;
+            if let Err(err) = outcome {
+                return registry_error(err);
+            }
         }
+        drop(migration_guard);
         let manifests = referrers
             .iter()
             .map(|(entry, manifest)| ReferrerDescriptor::new(entry, manifest))
@@ -432,33 +474,6 @@ impl Request {
             );
         }
         self.caller_scoped(Some(key.as_str()), response)
-    }
-
-    async fn persist_referrer_metadata(
-        &self,
-        storage: &Storage,
-        key: &CanonicalPackageName,
-        additions: &[ManifestEntry],
-    ) -> Result<(), RegistryError> {
-        if additions.is_empty() {
-            return Ok(());
-        }
-        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
-        storage
-            .update_hosted_document_with_retry(key, DOCUMENT_WRITE_RETRIES, |existing| {
-                let Some(bytes) = existing else { return Ok(None) };
-                let mut current = ImageDocument::parse(bytes)?;
-                let mut changed = false;
-                for entry in additions {
-                    if current.manifest(&entry.digest).is_some_and(|held| held.referrer.is_none()) {
-                        current.insert_manifest(entry.clone());
-                        changed = true;
-                    }
-                }
-                Ok(changed.then(|| current.to_bytes()))
-            })
-            .await?;
-        Ok(())
     }
 
     /// `GET /v2/_catalog` — the repository names this caller may read.

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -145,9 +145,11 @@ async fn dispatch(
         base: api_base(uri.path(), tail),
         method: parts.method,
         digest: query_param(uri.query(), "digest"),
+        query: uri.query().unwrap_or_default().to_string(),
         headers: parts.headers,
     };
     match endpoint {
+        Endpoint::Referrers { name, digest } => request.referrers(&name, &digest).await,
         Endpoint::Catalog => request.catalog().await,
         Endpoint::Tags { name } => request.tags(&name).await,
         Endpoint::Manifest { name, reference } => request.manifest(&name, &reference, body).await,
@@ -160,6 +162,7 @@ async fn dispatch(
 /// Which endpoint a captured path tail addresses.
 enum Endpoint {
     Catalog,
+    Referrers { name: String, digest: String },
     Tags { name: String },
     Manifest { name: String, reference: String },
     Blob { name: String, digest: String },
@@ -187,6 +190,9 @@ fn parse_endpoint(tail: &str) -> Option<Endpoint> {
         [.., "manifests", reference] => {
             Some(Endpoint::Manifest { name: name(last - 2)?, reference: (*reference).to_string() })
         }
+        [.., "referrers", digest] => {
+            Some(Endpoint::Referrers { name: name(last - 2)?, digest: (*digest).to_string() })
+        }
         [.., "blobs", digest] => {
             Some(Endpoint::Blob { name: name(last - 2)?, digest: (*digest).to_string() })
         }
@@ -204,10 +210,186 @@ struct Request {
     method: Method,
     /// The `?digest=` a client completes an upload with.
     digest: Option<String>,
+    query: String,
     headers: HeaderMap,
 }
 
 impl Request {
+    fn paginate<Item: AsRef<str>>(
+        &self,
+        items: &mut Vec<Item>,
+        endpoint: &str,
+    ) -> Result<Option<String>, Refusal> {
+        let count = query_param(Some(&self.query), "n")
+            .map(|value| {
+                if value.is_empty() || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+                    return Err(Refusal::new(
+                        ErrorCode::NameInvalid,
+                        "n must be a non-negative integer",
+                    ));
+                }
+                value
+                    .parse::<usize>()
+                    .map_err(|_| Refusal::new(ErrorCode::NameInvalid, "n is too large"))
+            })
+            .transpose()?;
+        if let Some(last) = query_param(Some(&self.query), "last") {
+            items.retain(|item| item.as_ref() > last.as_str());
+        }
+        let Some(count) = count else { return Ok(None) };
+        let more = items.len() > count;
+        items.truncate(count);
+        Ok(if more && let Some(last) = items.last() {
+            let query = url::form_urlencoded::Serializer::new(String::new())
+                .append_pair("n", &count.to_string())
+                .append_pair("last", last.as_ref())
+                .finish();
+            Some(format!(r#"<{}/{endpoint}?{query}>; rel="next""#, self.base))
+        } else {
+            None
+        })
+    }
+
+    async fn mount_blob(
+        &self,
+        destination: &Storage,
+        key: &CanonicalPackageName,
+        mount: &str,
+        from: &str,
+    ) -> Result<Option<Response>, RegistryError> {
+        let Ok(digest) = Digest::parse(mount) else { return Ok(None) };
+        let Ok((source_key, source)) = self.hosted_source(from) else { return Ok(None) };
+        let source_org = match hosted_read_namespace(
+            &self.state,
+            &self.identity,
+            &source,
+            source_key.as_str(),
+        ) {
+            Ok(org) => org,
+            Err(
+                RegistryError::Unauthenticated { .. }
+                | RegistryError::Forbidden { .. }
+                | RegistryError::NotFound,
+            ) => return Ok(None),
+            Err(err) => return Err(err),
+        };
+        let source_storage = self.state.inner.storage.for_hosted(&source_org);
+        let Some((body, _)) =
+            source_storage.open_hosted_blob(&source_key, &digest.blob_filename()).await?
+        else {
+            return Ok(None);
+        };
+        let upload = destination.begin_blob_upload(key).await?;
+        if let Err(refusal) = append_body(destination, &upload, body).await {
+            destination.abort_blob_upload(upload.id()).await?;
+            return Ok(Some(refusal.respond()));
+        }
+        Ok(Some(self.finish_upload(destination, upload, key, mount).await))
+    }
+
+    async fn referrers(&self, name: &str, digest: &str) -> Response {
+        if self.method != Method::GET {
+            return method_not_allowed();
+        }
+        let Ok(digest) = Digest::parse(digest) else {
+            return error(ErrorCode::DigestInvalid, "not a supported digest");
+        };
+        let (key, source) = match self.hosted_source(name) {
+            Ok(found) => found,
+            Err(refusal) => return refusal.respond(),
+        };
+        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
+            Ok(org) => org,
+            Err(err) => return registry_error(err),
+        };
+        let storage = self.state.inner.storage.for_hosted(&org);
+        let document =
+            match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
+                .await
+            {
+                Ok(document) => document.unwrap_or_else(|| ImageDocument::new(key.as_str())),
+                Err(err) => return registry_error(err),
+            };
+        let document = match self.backfill_referrers(&storage, &key, document).await {
+            Ok(document) => document,
+            Err(err) => return registry_error(err),
+        };
+        let artifact_type = query_param(Some(&self.query), "artifactType");
+        let manifests: Vec<_> = document
+            .manifests()
+            .iter()
+            .filter_map(|entry| {
+                let metadata = entry.referrer.as_ref()?;
+                if metadata.subject.as_ref() != Some(&digest)
+                    || artifact_type
+                        .as_ref()
+                        .is_some_and(|filter| metadata.artifact_type.as_ref() != Some(filter))
+                {
+                    return None;
+                }
+                Some(ReferrerDescriptor {
+                    media_type: &entry.media_type,
+                    digest: &entry.digest,
+                    size: entry.size,
+                    artifact_type: metadata.artifact_type.as_deref(),
+                    annotations: &metadata.annotations,
+                })
+            })
+            .collect();
+        let mut response = json(
+            StatusCode::OK,
+            &Referrers { schema_version: 2, media_type: media_type::OCI_IMAGE_INDEX, manifests },
+        );
+        insert_header(&mut response, "content-type", media_type::OCI_IMAGE_INDEX);
+        if artifact_type.is_some() {
+            insert_header(&mut response, "oci-filters-applied", "artifactType");
+        }
+        self.caller_scoped(Some(key.as_str()), response)
+    }
+
+    async fn backfill_referrers(
+        &self,
+        storage: &Storage,
+        key: &CanonicalPackageName,
+        mut document: ImageDocument,
+    ) -> Result<ImageDocument, RegistryError> {
+        let mut additions = Vec::new();
+        for entry in document.manifests().iter().filter(|entry| entry.referrer.is_none()) {
+            let bytes = read_manifest_bytes(storage, key, &entry.digest.blob_filename())
+                .await?
+                .ok_or_else(|| RegistryError::Internal {
+                    reason: format!("missing OCI manifest {} in {}", entry.digest, key.as_str()),
+                })?;
+            let manifest = Manifest::parse(&bytes, Some(&entry.media_type))
+                .map_err(|err| RegistryError::Internal { reason: err.to_string() })?;
+            let mut entry = entry.clone();
+            entry.referrer = Some(manifest.referrer_metadata());
+            additions.push(entry);
+        }
+        if additions.is_empty() {
+            return Ok(document);
+        }
+        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
+        storage
+            .update_hosted_document_with_retry(key, DOCUMENT_WRITE_RETRIES, |existing| {
+                let Some(bytes) = existing else { return Ok(None) };
+                let mut current = ImageDocument::parse(bytes)?;
+                let mut changed = false;
+                for entry in &additions {
+                    if current.manifest(&entry.digest).is_some_and(|held| held.referrer.is_none()) {
+                        current.insert_manifest(entry.clone());
+                        changed = true;
+                    }
+                }
+                Ok(changed.then(|| current.to_bytes()))
+            })
+            .await?;
+        for entry in additions {
+            document.insert_manifest(entry);
+        }
+        Ok(document)
+    }
+
     /// `GET /v2/_catalog` — the repository names this caller may read.
     async fn catalog(&self) -> Response {
         if self.method != Method::GET {
@@ -220,7 +402,10 @@ impl Request {
         for source in hosted_sources(&self.state, &target, ECOSYSTEM) {
             let Some(hosted) = self.state.inner.config.hosted.get(&source) else { continue };
             let storage = self.state.inner.storage.for_hosted(&hosted.org);
-            let Ok(names) = storage.hosted_package_names().await else { continue };
+            let names = match storage.hosted_package_names().await {
+                Ok(names) => names,
+                Err(err) => return registry_error(err),
+            };
             // A listing may only name what this caller could have fetched.
             repositories.extend(names.into_iter().filter(|name| {
                 authorize(
@@ -237,7 +422,15 @@ impl Request {
         repositories.dedup();
         // The listing is built from what this caller may read, so it is
         // caller-specific whichever registry it came through.
-        private_no_cache(json(StatusCode::OK, &Catalog { repositories }))
+        let link = match self.paginate(&mut repositories, "_catalog") {
+            Ok(link) => link,
+            Err(refusal) => return refusal.respond(),
+        };
+        let mut response = json(StatusCode::OK, &Catalog { repositories });
+        if let Some(link) = link {
+            insert_header(&mut response, "link", &link);
+        }
+        private_no_cache(response)
     }
 
     /// `GET /v2/<name>/tags/list`.
@@ -253,10 +446,19 @@ impl Request {
             match read_hosted_document::<ImageDocument>(&self.state, &self.identity, &source, &key)
                 .await
             {
-                Ok(Some(document)) => json(
-                    StatusCode::OK,
-                    &TagList { name: key.as_str(), tags: document.tag_names() },
-                ),
+                Ok(Some(document)) => {
+                    let mut tags = document.tag_names();
+                    let link =
+                        match self.paginate(&mut tags, &format!("{}/tags/list", key.as_str())) {
+                            Ok(link) => link,
+                            Err(refusal) => return refusal.respond(),
+                        };
+                    let mut response = json(StatusCode::OK, &TagList { name: key.as_str(), tags });
+                    if let Some(link) = link {
+                        insert_header(&mut response, "link", &link);
+                    }
+                    response
+                }
                 Ok(None) => unknown_repository(name).respond(),
                 Err(err) => registry_error(err),
             };
@@ -388,11 +590,14 @@ impl Request {
             }
         }
 
+        let referrer = manifest.referrer_metadata();
+        let subject = referrer.subject.clone();
         let mut addition = ImageDocument::new(key.as_str());
         addition.insert_manifest(ManifestEntry {
             digest: digest.clone(),
             media_type: manifest.media_type().to_string(),
             size: bytes.len() as u64,
+            referrer: Some(referrer),
         });
         if Digest::parse(reference).is_err() {
             if !is_valid_tag(reference) {
@@ -439,7 +644,12 @@ impl Request {
         .await
         {
             Ok(()) => {
-                created(&format!("{}/{}/manifests/{digest}", self.base, key.as_str()), &digest)
+                let mut response =
+                    created(&format!("{}/{}/manifests/{digest}", self.base, key.as_str()), &digest);
+                if let Some(subject) = subject {
+                    insert_header(&mut response, "oci-subject", &subject.to_string());
+                }
+                response
             }
             Err(err) => registry_error(err),
         }
@@ -463,6 +673,7 @@ impl Request {
             return unknown_repository(name).respond();
         };
         let storage = self.state.inner.storage.for_hosted(&hosted.org);
+        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
         let outcome = storage
             .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
                 let Some(bytes) = existing else { return Ok(None) };
@@ -509,6 +720,47 @@ impl Request {
             Err(err) => return registry_error(err),
         };
         let storage = self.state.inner.storage.for_hosted(&org);
+        let etag = format!(r#""{digest}""#);
+        if self.method == Method::GET
+            && self.headers.get(header::IF_RANGE).is_none_or(|value| value == etag.as_str())
+            && self.headers.get_all(header::RANGE).iter().count() == 1
+            && let Some(range) = self
+                .headers
+                .get(header::RANGE)
+                .and_then(|value| value.to_str().ok())
+                .and_then(parse_download_range)
+        {
+            let response =
+                match storage.open_hosted_blob_range(&key, &digest.blob_filename(), &range).await {
+                    Ok(Some(pnpr_storage::RangedBlob::Read { body, range, size })) => {
+                        Response::builder()
+                            .status(StatusCode::PARTIAL_CONTENT)
+                            .header(header::CONTENT_TYPE, "application/octet-stream")
+                            .header(header::CONTENT_LENGTH, range.end - range.start)
+                            .header(
+                                header::CONTENT_RANGE,
+                                format!("bytes {}-{}/{size}", range.start, range.end - 1),
+                            )
+                            .header(header::ACCEPT_RANGES, "bytes")
+                            .header(header::ETAG, &etag)
+                            .header(DOCKER_CONTENT_DIGEST, digest.to_string())
+                            .body(body)
+                            .unwrap_or_else(|_| server_error())
+                    }
+                    Ok(Some(pnpr_storage::RangedBlob::Unsatisfiable { size })) => {
+                        let mut response = respond(
+                            StatusCode::RANGE_NOT_SATISFIABLE,
+                            ErrorCode::SizeInvalid,
+                            "range is outside the blob",
+                        );
+                        insert_header(&mut response, "content-range", &format!("bytes */{size}"));
+                        response
+                    }
+                    Ok(None) => return error(ErrorCode::BlobUnknown, "no such blob"),
+                    Err(err) => return registry_error(err),
+                };
+            return self.caller_scoped(Some(key.as_str()), response);
+        }
         let (body, size) = match storage.open_hosted_blob(&key, &digest.blob_filename()).await {
             Ok(Some(blob)) => blob,
             Ok(None) => return error(ErrorCode::BlobUnknown, "no such blob"),
@@ -516,6 +768,8 @@ impl Request {
         };
         let mut response = Response::builder()
             .status(StatusCode::OK)
+            .header(header::ACCEPT_RANGES, "bytes")
+            .header(header::ETAG, etag)
             .header(header::CONTENT_TYPE, "application/octet-stream")
             .header(DOCKER_CONTENT_DIGEST, digest.to_string());
         if let Some(size) = size {
@@ -537,6 +791,15 @@ impl Request {
             Err(refusal) => return refusal.respond(),
         };
         let storage = self.state.inner.storage.for_hosted(&org);
+        if let (Some(mount), Some(from)) =
+            (query_param(Some(&self.query), "mount"), query_param(Some(&self.query), "from"))
+        {
+            match self.mount_blob(&storage, &key, &mount, &from).await {
+                Ok(Some(response)) => return response,
+                Ok(None) => {}
+                Err(err) => return registry_error(err),
+            }
+        }
         let upload = match storage.begin_blob_upload(&key).await {
             Ok(upload) => upload,
             Err(err) => return registry_error(err),
@@ -545,8 +808,6 @@ impl Request {
             let _ = storage.abort_blob_upload(upload.id()).await;
             return refusal.respond();
         }
-        // A cross-repository mount is optional: handing back a fresh upload is
-        // the spec's own fallback, and the client re-sends the bytes.
         match self.digest.as_deref() {
             Some(digest) => self.finish_upload(&storage, upload, &key, digest).await,
             None => self.upload_progress(&key, &upload).await,
@@ -731,6 +992,59 @@ impl Request {
             PublishTarget::NotFound => Err(unknown_repository(name)),
         }
     }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Referrers<'listing> {
+    schema_version: u64,
+    media_type: &'listing str,
+    manifests: Vec<ReferrerDescriptor<'listing>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReferrerDescriptor<'listing> {
+    media_type: &'listing str,
+    digest: &'listing Digest,
+    size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifact_type: Option<&'listing str>,
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    annotations: &'listing std::collections::BTreeMap<String, String>,
+}
+
+fn insert_header(response: &mut Response, name: &'static str, value: &str) {
+    let value = HeaderValue::from_str(value).expect("generated OCI response header is valid");
+    response.headers_mut().insert(name, value);
+}
+
+fn parse_download_range(value: &str) -> Option<pnpr_storage::GetRange> {
+    let (unit, bounds) = value.trim().split_once('=')?;
+    if !unit.eq_ignore_ascii_case("bytes") {
+        return None;
+    }
+    let (start, end) = bounds.split_once('-')?;
+    let number = |value: &str| {
+        (!value.is_empty() && value.bytes().all(|byte| byte.is_ascii_digit()))
+            .then(|| value.parse::<u64>().ok())
+            .flatten()
+    };
+    if start.is_empty() {
+        return number(end).map(pnpr_storage::GetRange::Suffix);
+    }
+    let start = number(start)?;
+    if end.is_empty() {
+        return Some(pnpr_storage::GetRange::Offset(start));
+    }
+    let end = number(end)?;
+    if start > end {
+        return None;
+    }
+    Some(match end.checked_add(1) {
+        Some(end) => pnpr_storage::GetRange::Bounded(start..end),
+        None => pnpr_storage::GetRange::Offset(start),
+    })
 }
 
 #[derive(Serialize)]

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -113,6 +113,7 @@ pub(super) fn router_with_auth_and_osv(
             config,
             auth,
             package_locks: StripedLocks::new(),
+            referrer_migration_locks: StripedLocks::new(),
             resolver: std::sync::OnceLock::new(),
             osv_index,
         }),

--- a/pnpr/crates/pnpr/src/server/striped_locks.rs
+++ b/pnpr/crates/pnpr/src/server/striped_locks.rs
@@ -1,0 +1,48 @@
+/// A fixed stripe set bounds lock memory while serializing writers for the
+/// same logical resource. Hash collisions only reduce concurrency.
+///
+/// This guards concurrency **within one instance**. Across replicas
+/// sharing one hosted store, the same race needs a conditional write
+/// (S3 `If-Match` / `ETag`); that is the cross-replica half tracked in
+/// [pnpm/pnpm#12199](https://github.com/pnpm/pnpm/issues/12199).
+pub(crate) struct StripedLocks {
+    stripes: Box<[tokio::sync::Mutex<()>]>,
+}
+
+impl StripedLocks {
+    /// Number of stripes. 64 keeps false sharing between distinct resources
+    /// rare while staying tiny in memory.
+    const STRIPES: usize = 64;
+
+    pub(crate) fn new() -> Self {
+        let stripes = (0..Self::STRIPES).map(|_| tokio::sync::Mutex::new(())).collect();
+        Self { stripes }
+    }
+
+    /// Lock the stripe owning `name`, held until the returned guard is dropped.
+    pub(crate) async fn lock(&self, name: &str) -> tokio::sync::MutexGuard<'_, ()> {
+        self.stripes[self.stripe_index(name)].lock().await
+    }
+
+    /// Lock the stripes owning every name in `names`, held until the
+    /// returned guards are dropped. Stripes are locked in ascending
+    /// index order (duplicates collapsed), so two overlapping
+    /// batch publishes — or a batch publish racing a single-package
+    /// publish — can't deadlock on lock order.
+    pub(crate) async fn lock_many(&self, names: &[&str]) -> Vec<tokio::sync::MutexGuard<'_, ()>> {
+        let mut indices: Vec<usize> = names.iter().map(|name| self.stripe_index(name)).collect();
+        indices.sort_unstable();
+        indices.dedup();
+        let mut guards = Vec::with_capacity(indices.len());
+        for index in indices {
+            guards.push(self.stripes[index].lock().await);
+        }
+        guards
+    }
+
+    pub(crate) fn stripe_index(&self, name: &str) -> usize {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        std::hash::Hash::hash(name, &mut hasher);
+        std::hash::Hasher::finish(&hasher) as usize % self.stripes.len()
+    }
+}

--- a/pnpr/crates/pnpr/tests/common/pausing_store.rs
+++ b/pnpr/crates/pnpr/tests/common/pausing_store.rs
@@ -1,0 +1,94 @@
+use async_trait::async_trait;
+use futures_util::stream::BoxStream;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, memory::InMemory, path::Path,
+};
+use std::{fmt, sync::Mutex};
+use tokio::sync::Notify;
+
+#[derive(Debug, Default)]
+pub struct PausingStore {
+    inner: InMemory,
+    filename: Mutex<Option<String>>,
+    pub started: Notify,
+    pub resume: Notify,
+}
+
+impl PausingStore {
+    pub fn pause(&self, filename: String) {
+        *self.filename.lock().unwrap() = Some(filename);
+    }
+}
+
+impl fmt::Display for PausingStore {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("pausing object store")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for PausingStore {
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        let pause = {
+            let mut filename = self.filename.lock().unwrap();
+            let pause = filename
+                .as_ref()
+                .is_some_and(|filename| location.filename() == Some(filename.as_str()));
+            if pause {
+                *filename = None;
+            }
+            pause
+        };
+        if pause {
+            self.started.notify_one();
+            self.resume.notified().await;
+        }
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        options: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(location, payload, options).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        options: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, options).await
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, object_store::Result<Path>>,
+    ) -> BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+}

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -997,3 +997,411 @@ async fn s3_upload_moves_between_replicas_and_keeps_an_interrupted_chunks_prefix
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(body_bytes(response.into_body()).await, b"hello world");
 }
+
+#[tokio::test]
+async fn protocol_surface_on_filesystem() {
+    let tmp = TempDir::new().unwrap();
+    check_protocol_surface(app_allowing_deletes(&tmp)).await;
+}
+
+#[tokio::test]
+async fn protocol_surface_on_object_store() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.hosted_store = pnpr::HostedStoreConfig::ObjectStore {
+        store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+        prefix: "protocol/".into(),
+    };
+    let hosted = config.hosted.get_mut("images").unwrap();
+    hosted.rules = std::mem::take(&mut hosted.rules)
+        .with_default_unpublish(AccessList::from_tokens(["$authenticated"]));
+    check_protocol_surface(router_with_auth(config, AuthState::in_memory())).await;
+}
+
+async fn check_protocol_surface(app: Router) {
+    let auth = basic(&token(&app).await);
+    let digest = push_blob(&app, &auth, "acme/source", b"0123456789").await;
+    let blob_path = format!("/v2/acme/source/blobs/{digest}");
+    for (range, expected, content_range) in [
+        ("bytes=2-5", "2345", "bytes 2-5/10"),
+        ("bytes=7-", "789", "bytes 7-9/10"),
+        ("bytes=-3", "789", "bytes 7-9/10"),
+        ("bytes=7-999", "789", "bytes 7-9/10"),
+        ("bytes=-99", "0123456789", "bytes 0-9/10"),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(&blob_path).header(header::RANGE, range).body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::PARTIAL_CONTENT, "{range}");
+        assert_eq!(response.headers()[header::CONTENT_RANGE], content_range);
+        assert_eq!(response.headers()[header::CONTENT_LENGTH], expected.len().to_string());
+        assert_eq!(response.headers()[header::ACCEPT_RANGES], "bytes");
+        assert_eq!(body_bytes(response.into_body()).await, expected.as_bytes());
+    }
+    for range in ["bytes=10-", "bytes=-0", "bytes=99-100"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(&blob_path).header(header::RANGE, range).body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE, "{range}");
+        assert_eq!(response.headers()[header::CONTENT_RANGE], "bytes */10");
+    }
+    for range in ["items=1-2", "bytes=1-2,4-5", "bytes=9-1", "bytes=+1-2"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(&blob_path).header(header::RANGE, range).body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{range}");
+        assert_eq!(body_bytes(response.into_body()).await, b"0123456789");
+    }
+    for (validator, status) in [
+        (format!(r#""{digest}""#), StatusCode::PARTIAL_CONTENT),
+        (r#""other""#.into(), StatusCode::OK),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(&blob_path)
+                    .header(header::RANGE, "bytes=7-")
+                    .header(header::IF_RANGE, validator)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), status);
+    }
+    let response = app
+        .clone()
+        .oneshot(
+            Request::head(&blob_path)
+                .header(header::RANGE, "bytes=7-")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[header::CONTENT_LENGTH], "10");
+    assert!(body_bytes(response.into_body()).await.is_empty());
+    let empty = push_blob(&app, &auth, "acme/source", b"").await;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(format!("/v2/acme/source/blobs/{empty}"))
+                .header(header::RANGE, "bytes=0-")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::RANGE_NOT_SATISFIABLE);
+    assert_eq!(response.headers()[header::CONTENT_RANGE], "bytes */0");
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!(
+                "/v2/acme/destination/blobs/uploads/?mount={digest}&from=acme%2Fsource",
+            ))
+            .header(header::AUTHORIZATION, &auth)
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let location = response.headers()[header::LOCATION].to_str().unwrap();
+    assert_eq!(location, format!("/v2/acme/destination/blobs/{digest}"));
+    assert_eq!(body_bytes(get(&app, location).await.into_body()).await, b"0123456789");
+    for from in ["acme/missing", "library/upstream"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::post(format!(
+                    "/v2/acme/destination/blobs/uploads/?mount={digest}&from={from}",
+                ))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(response.headers()[header::LOCATION].to_str().unwrap().contains("/uploads/"));
+    }
+
+    for tag in ["a", "c", "e"] {
+        push_image(&app, &auth, "acme/pages", tag).await;
+    }
+    push_image(&app, &auth, "acme/zebra", "latest").await;
+    let response = get(&app, "/v2/acme/pages/tags/list?n=2").await;
+    let link = response.headers()[header::LINK].to_str().unwrap().to_string();
+    assert_eq!(link, r#"</v2/acme/pages/tags/list?n=2&last=c>; rel="next""#);
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["tags"], json!(["a", "c"]));
+    let response = get(&app, "/v2/acme/pages/tags/list?n=2&last=c").await;
+    assert!(!response.headers().contains_key(header::LINK));
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["tags"], json!(["e"]));
+    let response = get(&app, "/v2/acme/pages/tags/list?last=b").await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["tags"], json!(["c", "e"]));
+    for endpoint in ["acme/pages/tags/list", "_catalog"] {
+        let response = get(&app, &format!("/v2/{endpoint}?n=0")).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(!response.headers().contains_key(header::LINK));
+        let payload: Value =
+            serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        let field = if endpoint == "_catalog" { "repositories" } else { "tags" };
+        assert_eq!(payload[field], json!([]));
+        for invalid in ["-1", "oops", "184467440737095516160", ""] {
+            assert_eq!(
+                get(&app, &format!("/v2/{endpoint}?n={invalid}")).await.status(),
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    }
+    let response = get(&app, "/oci/~images/v2/_catalog?n=1").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(
+        response.headers()[header::LINK]
+            .to_str()
+            .unwrap()
+            .starts_with("</oci/~images/v2/_catalog?"),
+    );
+    let response = get(&app, "/v2/_catalog?n=1&last=acme%2Fpages").await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["repositories"], json!(["acme/zebra"]));
+
+    let subject = digest_of(b"not pushed yet");
+    let path = format!("/v2/acme/artifacts/referrers/{subject}");
+    let response = get(&app, &path).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["manifests"], json!([]));
+    let config = push_blob(&app, &auth, "acme/artifacts", b"{}").await;
+    let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_MANIFEST,
+        "config": { "digest": config, "size": 2, "mediaType": "application/example.signature" },
+        "layers": [], "subject": { "digest": subject, "size": 42 },
+        "annotations": { "example.key": "value" } });
+    let bytes = serde_json::to_vec(&manifest).unwrap();
+    let referrer = digest_of(&bytes);
+    for tag in ["signature", "another-tag"] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::put(format!("/v2/acme/artifacts/manifests/{tag}"))
+                    .header(header::AUTHORIZATION, &auth)
+                    .body(Body::from(bytes.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        assert_eq!(response.headers()["oci-subject"], subject);
+    }
+    let response = get(&app, &format!("{path}?artifactType=application%2Fexample.signature")).await;
+    assert_eq!(response.headers()[header::CONTENT_TYPE], pnpr_oci::media_type::OCI_IMAGE_INDEX);
+    assert_eq!(response.headers()["oci-filters-applied"], "artifactType");
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["schemaVersion"], 2);
+    assert_eq!(
+        payload["manifests"],
+        json!([{ "mediaType": pnpr_oci::media_type::OCI_IMAGE_MANIFEST,
+        "digest": referrer, "size": bytes.len(), "artifactType": "application/example.signature",
+        "annotations": { "example.key": "value" } }]),
+    );
+    let response = get(&app, &format!("{path}?artifactType=other")).await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["manifests"], json!([]));
+    let response = app
+        .clone()
+        .oneshot(
+            Request::delete("/v2/acme/artifacts/manifests/signature")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let response = get(&app, &path).await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["manifests"].as_array().unwrap().len(), 1);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::delete(format!("/v2/acme/artifacts/manifests/{referrer}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let response = get(&app, &path).await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["manifests"], json!([]));
+    assert_eq!(
+        get(&app, "/v2/acme/artifacts/referrers/invalid").await.status(),
+        StatusCode::BAD_REQUEST,
+    );
+}
+
+#[tokio::test]
+async fn mounts_and_discovery_respect_source_read_permissions() {
+    let tmp = TempDir::new().unwrap();
+    let auth_state = AuthState::in_memory();
+    let setup = router_with_auth(oci_config(tmp.path().to_path_buf(), "$all"), auth_state.clone());
+    let auth = basic(&token(&setup).await);
+    let digest = push_blob(&setup, &auth, "acme/secret", b"secret layer").await;
+    push_image(&setup, &auth, "acme/secret", "latest").await;
+    push_image(&setup, &auth, "acme/public", "latest").await;
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.hosted.get_mut("images").unwrap().rules = PackageRules::new(
+        vec![PackageRule {
+            pattern: PackagePattern::parse("acme/secret", Ecosystem::Oci).unwrap(),
+            access: Some(AccessList::from_tokens(["bob"])),
+            publish: Some(AccessList::from_tokens(["$authenticated"])),
+            unpublish: None,
+        }],
+        Some(AccessList::from_tokens(["$all"])),
+    );
+    let app = router_with_auth(config, auth_state);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!(
+                "/v2/acme/public/blobs/uploads/?mount={digest}&from=acme/secret",
+            ))
+            .header(header::AUTHORIZATION, &auth)
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(
+        get(&app, &format!("/v2/acme/public/blobs/{digest}")).await.status(),
+        StatusCode::NOT_FOUND,
+    );
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!(
+                "/v2/acme/public/blobs/uploads/?mount={digest}&from=acme/secret",
+            ))
+            .body(Body::empty())
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    for path in [
+        format!("/v2/acme/secret/referrers/{digest}"),
+        "/v2/acme/secret/tags/list?n=1".into(),
+        format!("/v2/acme/secret/blobs/{digest}"),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(path)
+                    .header(header::AUTHORIZATION, &auth)
+                    .header(header::RANGE, "bytes=0-1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+    let response = get(&app, "/v2/_catalog?n=1").await;
+    assert!(!response.headers().contains_key(header::LINK));
+    assert_eq!(response.headers()[header::CACHE_CONTROL], "private, no-store");
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["repositories"], json!(["acme/public"]));
+}
+
+#[tokio::test]
+async fn referrers_backfill_preexisting_manifests_on_both_backends() {
+    for hosted_store in [
+        pnpr::HostedStoreConfig::Fs,
+        pnpr::HostedStoreConfig::ObjectStore {
+            store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+            prefix: "legacy/".into(),
+        },
+    ] {
+        let tmp = TempDir::new().unwrap();
+        let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+        config.hosted_store = hosted_store;
+        let storage = pnpr_storage::Storage::new(
+            &config.hosted_store,
+            config.storage.clone(),
+            config.cache_storage.clone(),
+        )
+        .unwrap()
+        .for_hosted("images");
+        let app = router_with_auth(config, AuthState::in_memory());
+        let auth = basic(&token(&app).await);
+        let subject = digest_of(b"subject");
+        let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_INDEX,
+            "manifests": [], "subject": { "digest": subject, "size": 7 }, "artifactType": "application/example.sbom" });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::put("/v2/acme/legacy/manifests/sbom")
+                    .header(header::AUTHORIZATION, &auth)
+                    .body(Body::from(manifest.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let key =
+            pnpr_package_name::CanonicalPackageName::parse("acme/legacy", Ecosystem::Oci).unwrap();
+        let mut document: Value =
+            serde_json::from_slice(&storage.read_hosted_document(&key).await.unwrap().unwrap())
+                .unwrap();
+        for entry in document["manifests"].as_array_mut().unwrap() {
+            entry.as_object_mut().unwrap().remove("referrer");
+        }
+        storage
+            .update_hosted_document_with_retry(&key, 1, |_| {
+                Ok(Some(serde_json::to_vec(&document).unwrap()))
+            })
+            .await
+            .unwrap();
+        let response = get(&app, &format!("/v2/acme/legacy/referrers/{subject}")).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let payload: Value =
+            serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        assert_eq!(payload["manifests"].as_array().unwrap().len(), 1);
+        assert_eq!(payload["manifests"][0]["artifactType"], "application/example.sbom");
+        let document = pnpr_oci::ImageDocument::parse(
+            &storage.read_hosted_document(&key).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            document.manifests()[0]
+                .referrer
+                .as_ref()
+                .unwrap()
+                .subject
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            subject,
+        );
+    }
+}

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -1354,13 +1354,14 @@ async fn referrers_backfill_preexisting_manifests_on_both_backends() {
         .for_hosted("images");
         let app = router_with_auth(config, AuthState::in_memory());
         let auth = basic(&token(&app).await);
+        let repository = repository_with_colliding_lock_keys();
         let subject = digest_of(b"subject");
         let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_INDEX,
             "manifests": [], "subject": { "digest": subject, "size": 7 }, "artifactType": "application/example.sbom" });
         let response = app
             .clone()
             .oneshot(
-                Request::put("/v2/acme/legacy/manifests/sbom")
+                Request::put(format!("/v2/{repository}/manifests/sbom"))
                     .header(header::AUTHORIZATION, &auth)
                     .body(Body::from(manifest.to_string()))
                     .unwrap(),
@@ -1369,7 +1370,7 @@ async fn referrers_backfill_preexisting_manifests_on_both_backends() {
             .unwrap();
         assert_eq!(response.status(), StatusCode::CREATED);
         let key =
-            pnpr_package_name::CanonicalPackageName::parse("acme/legacy", Ecosystem::Oci).unwrap();
+            pnpr_package_name::CanonicalPackageName::parse(&repository, Ecosystem::Oci).unwrap();
         let mut document: Value =
             serde_json::from_slice(&storage.read_hosted_document(&key).await.unwrap().unwrap())
                 .unwrap();
@@ -1380,7 +1381,12 @@ async fn referrers_backfill_preexisting_manifests_on_both_backends() {
             })
             .await
             .unwrap();
-        let response = get(&app, &format!("/v2/acme/legacy/referrers/{subject}")).await;
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            get(&app, &format!("/v2/{repository}/referrers/{subject}")),
+        )
+        .await
+        .expect("migration must not acquire the same stripe twice");
         assert_eq!(response.status(), StatusCode::OK);
         let payload: Value =
             serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
@@ -1584,4 +1590,20 @@ fn strip_referrer_metadata(document: &mut Value, expected_count: usize) {
             "the stored entry must carry referrer metadata before stripping it",
         );
     }
+}
+
+fn repository_with_colliding_lock_keys() -> String {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+    };
+    let stripe = |key: &str| {
+        let mut hasher = DefaultHasher::new();
+        key.hash(&mut hasher);
+        hasher.finish() % 64
+    };
+    (0..4096)
+        .map(|index| format!("acme/lock-collision-{index}"))
+        .find(|name| stripe(name) == stripe(&format!("oci-referrers:{name}")))
+        .expect("a repository whose lock keys collide")
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -11,6 +11,9 @@
 )]
 mod common;
 
+#[path = "common/pausing_store.rs"]
+mod pausing_store;
+
 use axum::{
     Router,
     body::Body,
@@ -1606,4 +1609,88 @@ fn repository_with_colliding_lock_keys() -> String {
         .map(|index| format!("acme/lock-collision-{index}"))
         .find(|name| stripe(name) == stripe(&format!("oci-referrers:{name}")))
         .expect("a repository whose lock keys collide")
+}
+
+#[tokio::test]
+async fn referrer_migration_does_not_block_writers_or_restore_deleted_manifests() {
+    let tmp = TempDir::new().unwrap();
+    let objects = std::sync::Arc::new(pausing_store::PausingStore::default());
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.hosted_store = pnpr::HostedStoreConfig::ObjectStore {
+        store: std::sync::Arc::<pausing_store::PausingStore>::clone(&objects),
+        prefix: "migration/".into(),
+    };
+    let hosted = config.hosted.get_mut("images").unwrap();
+    hosted.rules = std::mem::take(&mut hosted.rules)
+        .with_default_unpublish(AccessList::from_tokens(["$authenticated"]));
+    let storage = pnpr_storage::Storage::new(
+        &config.hosted_store,
+        config.storage.clone(),
+        config.cache_storage.clone(),
+    )
+    .unwrap()
+    .for_hosted("images");
+    let app = router_with_auth(config, AuthState::in_memory());
+    let auth = basic(&token(&app).await);
+    let subject = digest_of(b"subject");
+    let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_INDEX,
+        "manifests": [], "subject": { "digest": subject, "size": 7 } })
+    .to_string();
+    let digest = pnpr_oci::Digest::of(manifest.as_bytes());
+    let response = app
+        .clone()
+        .oneshot(
+            Request::put("/v2/acme/migration/manifests/sbom")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from(manifest))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let key =
+        pnpr_package_name::CanonicalPackageName::parse("acme/migration", Ecosystem::Oci).unwrap();
+    let mut document: Value =
+        serde_json::from_slice(&storage.read_hosted_document(&key).await.unwrap().unwrap())
+            .unwrap();
+    strip_referrer_metadata(&mut document, 1);
+    storage
+        .update_hosted_document_with_retry(&key, 1, |_| {
+            Ok(Some(serde_json::to_vec(&document).unwrap()))
+        })
+        .await
+        .unwrap();
+    objects.pause(digest.blob_filename());
+    let reader = app.clone();
+    let path = format!("/v2/acme/migration/referrers/{subject}");
+    let read = tokio::spawn(async move { get(&reader, &path).await });
+    tokio::time::timeout(std::time::Duration::from_secs(5), objects.started.notified())
+        .await
+        .unwrap();
+    let update = async {
+        let published = push_image(&app, &auth, "acme/migration", "fresh").await;
+        let deleted = app
+            .clone()
+            .oneshot(
+                Request::delete(format!("/v2/acme/migration/manifests/{digest}"))
+                    .header(header::AUTHORIZATION, &auth)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(deleted.status(), StatusCode::ACCEPTED);
+        published
+    };
+    let published = tokio::time::timeout(std::time::Duration::from_secs(5), update).await;
+    objects.resume.notify_one();
+    let published = published.expect("manifest reads must not hold the package writer lock");
+    let response =
+        tokio::time::timeout(std::time::Duration::from_secs(5), read).await.unwrap().unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let document =
+        pnpr_oci::ImageDocument::parse(&storage.read_hosted_document(&key).await.unwrap().unwrap())
+            .unwrap();
+    assert!(document.manifest(&digest).is_none());
+    assert_eq!(document.resolve("fresh").unwrap().digest.to_string(), published);
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -1373,9 +1373,7 @@ async fn referrers_backfill_preexisting_manifests_on_both_backends() {
         let mut document: Value =
             serde_json::from_slice(&storage.read_hosted_document(&key).await.unwrap().unwrap())
                 .unwrap();
-        for entry in document["manifests"].as_array_mut().unwrap() {
-            entry.as_object_mut().unwrap().remove("referrer");
-        }
+        strip_referrer_metadata(&mut document, 1);
         storage
             .update_hosted_document_with_retry(&key, 1, |_| {
                 Ok(Some(serde_json::to_vec(&document).unwrap()))
@@ -1402,6 +1400,188 @@ async fn referrers_backfill_preexisting_manifests_on_both_backends() {
                 .unwrap()
                 .to_string(),
             subject,
+        );
+    }
+}
+
+#[tokio::test]
+async fn referrer_pages_bound_migration_and_keep_filter_and_registry() {
+    for hosted_store in [
+        pnpr::HostedStoreConfig::Fs,
+        pnpr::HostedStoreConfig::ObjectStore {
+            store: std::sync::Arc::new(object_store::memory::InMemory::new()),
+            prefix: "pages/".into(),
+        },
+    ] {
+        let tmp = TempDir::new().unwrap();
+        let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+        config.hosted_store = hosted_store;
+        let storage = pnpr_storage::Storage::new(
+            &config.hosted_store,
+            config.storage.clone(),
+            config.cache_storage.clone(),
+        )
+        .unwrap()
+        .for_hosted("images");
+        let app = router_with_auth(config, AuthState::in_memory());
+        let auth = basic(&token(&app).await);
+        let subject = digest_of(b"subject");
+        let mut expected = Vec::new();
+        for index in 0..35 {
+            let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_INDEX,
+                "manifests": [], "subject": { "digest": subject, "size": 7 },
+                "artifactType": "application/example+json", "annotations": { "index": index.to_string() } }).to_string();
+            expected.push(digest_of(manifest.as_bytes()));
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::put(format!("/v2/acme/paged/manifests/referrer-{index}"))
+                        .header(header::AUTHORIZATION, &auth)
+                        .body(Body::from(manifest))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::CREATED);
+        }
+        let key =
+            pnpr_package_name::CanonicalPackageName::parse("acme/paged", Ecosystem::Oci).unwrap();
+        let mut document: Value =
+            serde_json::from_slice(&storage.read_hosted_document(&key).await.unwrap().unwrap())
+                .unwrap();
+        strip_referrer_metadata(&mut document, 35);
+        storage
+            .update_hosted_document_with_retry(&key, 1, |_| {
+                Ok(Some(serde_json::to_vec(&document).unwrap()))
+            })
+            .await
+            .unwrap();
+        let path = format!("/oci/~images/v2/acme/paged/referrers/{subject}?artifactType=absent");
+        let response = get(&app, &path).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers().contains_key(header::LINK));
+        let payload: Value =
+            serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        assert_eq!(payload["manifests"], json!([]));
+        let document = pnpr_oci::ImageDocument::parse(
+            &storage.read_hosted_document(&key).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            document.manifests().iter().filter(|entry| entry.referrer.is_some()).count(),
+            32,
+        );
+        let first = get(&app, &path);
+        let second = get(&app, &path);
+        let responses: [_; 2] = tokio::join!(first, second).into();
+        for response in responses {
+            assert_eq!(response.status(), StatusCode::OK);
+            assert!(!response.headers().contains_key(header::LINK));
+        }
+        let document = pnpr_oci::ImageDocument::parse(
+            &storage.read_hosted_document(&key).await.unwrap().unwrap(),
+        )
+        .unwrap();
+        assert!(document.manifests().iter().all(|entry| entry.referrer.is_some()));
+        let mut path = format!(
+            "/oci/~images/v2/acme/paged/referrers/{subject}?artifactType=application%2Fexample%2Bjson",
+        );
+        let mut received = Vec::new();
+        let mut pages = 0;
+        loop {
+            let response = get(&app, &path).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()["oci-filters-applied"], "artifactType");
+            let next = response.headers().get(header::LINK).map(|link| {
+                let link = link.to_str().unwrap();
+                assert!(link.contains("artifactType=application%2Fexample%2Bjson"));
+                assert!(link.starts_with("</oci/~images/v2/"));
+                link.strip_prefix('<').unwrap().split_once('>').unwrap().0.to_string()
+            });
+            let payload: Value =
+                serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+            received.extend(
+                payload["manifests"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .map(|entry| entry["digest"].as_str().unwrap().to_string()),
+            );
+            pages += 1;
+            assert!(pages <= 2);
+            let Some(next) = next else { break };
+            path = next;
+        }
+        expected.sort();
+        assert_eq!(received, expected);
+        assert_eq!(pages, 2);
+    }
+}
+
+#[tokio::test]
+async fn large_referrer_annotations_stay_out_of_repository_documents() {
+    let tmp = TempDir::new().unwrap();
+    let config = oci_config(tmp.path().to_path_buf(), "$all");
+    let storage = pnpr_storage::Storage::new(
+        &config.hosted_store,
+        config.storage.clone(),
+        config.cache_storage.clone(),
+    )
+    .unwrap()
+    .for_hosted("images");
+    let app = router_with_auth(config, AuthState::in_memory());
+    let auth = basic(&token(&app).await);
+    let subject = digest_of(b"subject");
+    for index in 0..3 {
+        let manifest = json!({ "schemaVersion": 2, "mediaType": pnpr_oci::media_type::OCI_IMAGE_INDEX,
+            "manifests": [], "subject": { "digest": subject, "size": 7 },
+            "annotations": { "large": "a".repeat(2 * 1024 * 1024), "index": index.to_string() } });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::put(format!("/v2/acme/large/manifests/referrer-{index}"))
+                    .header(header::AUTHORIZATION, &auth)
+                    .body(Body::from(manifest.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+    }
+    let key = pnpr_package_name::CanonicalPackageName::parse("acme/large", Ecosystem::Oci).unwrap();
+    let document = storage.read_hosted_document(&key).await.unwrap().unwrap();
+    assert!(document.len() < 2048, "annotations must not inflate ordinary repository reads");
+    let mut path = format!("/v2/acme/large/referrers/{subject}");
+    let mut count = 0;
+    loop {
+        let response = get(&app, &path).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let next = response.headers().get(header::LINK).map(|link| {
+            link.to_str().unwrap().strip_prefix('<').unwrap().split_once('>').unwrap().0.to_string()
+        });
+        let bytes = body_bytes(response.into_body()).await;
+        assert!(bytes.len() <= 4 * 1024 * 1024);
+        let payload: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(payload["manifests"].as_array().unwrap().len(), 1);
+        assert_eq!(
+            payload["manifests"][0]["annotations"]["large"].as_str().unwrap().len(),
+            2 * 1024 * 1024,
+        );
+        count += 1;
+        assert!(count <= 3);
+        let Some(next) = next else { break };
+        path = next;
+    }
+    assert_eq!(count, 3);
+}
+
+fn strip_referrer_metadata(document: &mut Value, expected_count: usize) {
+    let entries = document["manifests"].as_array_mut().unwrap();
+    assert_eq!(entries.len(), expected_count, "the pushed manifests are stored");
+    for entry in entries {
+        assert!(
+            entry.as_object_mut().unwrap().remove("referrer").is_some(),
+            "the stored entry must carry referrer metadata before stripping it",
         );
     }
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -14,6 +14,10 @@ mod common;
 #[path = "common/pausing_store.rs"]
 mod pausing_store;
 
+#[path = "../src/server/striped_locks.rs"]
+#[allow(dead_code, reason = "the collision fixture uses the production stripe mapping")]
+mod striped_locks;
+
 use axum::{
     Router,
     body::Body,
@@ -1596,18 +1600,12 @@ fn strip_referrer_metadata(document: &mut Value, expected_count: usize) {
 }
 
 fn repository_with_colliding_lock_keys() -> String {
-    use std::{
-        collections::hash_map::DefaultHasher,
-        hash::{Hash, Hasher},
-    };
-    let stripe = |key: &str| {
-        let mut hasher = DefaultHasher::new();
-        key.hash(&mut hasher);
-        hasher.finish() % 64
-    };
+    let locks = striped_locks::StripedLocks::new();
     (0..4096)
         .map(|index| format!("acme/lock-collision-{index}"))
-        .find(|name| stripe(name) == stripe(&format!("oci-referrers:{name}")))
+        .find(|name| {
+            locks.stripe_index(name) == locks.stripe_index(&format!("oci-referrers:{name}"))
+        })
         .expect("a repository whose lock keys collide")
 }
 

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -51,6 +51,13 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>>;
 
+    async fn open_blob_range(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+        range: &object_store::GetRange,
+    ) -> Result<Option<crate::RangedBlob>>;
+
     /// Reserve the local staging path the publish flow decodes into. Always
     /// local: the bytes are verified on the way in, before the backend sees
     /// them.

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -5,6 +5,8 @@ mod s3;
 pub mod streaming;
 pub mod upload;
 
+pub use object_store::GetRange;
+
 use crate::s3::S3Store;
 use async_trait::async_trait;
 use axum::body::Body;
@@ -29,7 +31,7 @@ use std::{
 };
 use tokio::{
     fs,
-    io::{AsyncSeekExt, AsyncWriteExt},
+    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
 };
 
 pub(crate) use self::backend::HostedBackend;
@@ -364,6 +366,12 @@ pub struct Storage {
     cached: Store,
 }
 
+/// A partial blob read, including the full size needed for HTTP range headers.
+pub enum RangedBlob {
+    Read { body: Body, range: std::ops::Range<u64>, size: u64 },
+    Unsatisfiable { size: u64 },
+}
+
 /// A file in the hosted namespace, for offline maintenance.
 #[derive(Debug)]
 pub struct HostedBlobFile {
@@ -425,6 +433,26 @@ impl HostedBackend for Store {
         Ok(Store::open_blob(self, name, filename)
             .await?
             .map(|(file, len)| (streaming::stream_file(file), Some(len))))
+    }
+
+    async fn open_blob_range(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+        range: &GetRange,
+    ) -> Result<Option<RangedBlob>> {
+        let Some((mut file, size)) = Store::open_blob(self, name, filename).await? else {
+            return Ok(None);
+        };
+        let Ok(range) = range.as_range(size) else {
+            return Ok(Some(RangedBlob::Unsatisfiable { size }));
+        };
+        if range.is_empty() {
+            return Ok(Some(RangedBlob::Unsatisfiable { size }));
+        }
+        file.seek(SeekFrom::Start(range.start)).await?;
+        let body = streaming::stream_file(file.take(range.end - range.start));
+        Ok(Some(RangedBlob::Read { body, range, size }))
     }
 
     async fn reserve_blob_tmp(
@@ -723,6 +751,16 @@ impl Storage {
         filename: &str,
     ) -> Result<Option<(Body, Option<u64>)>> {
         self.hosted.open_blob(name, filename).await
+    }
+
+    /// Open only the requested bytes, without reading the preceding content.
+    pub async fn open_hosted_blob_range(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+        range: &GetRange,
+    ) -> Result<Option<RangedBlob>> {
+        self.hosted.open_blob_range(name, filename, range).await
     }
 
     /// Reserve a staging slot for a blob this server hosts. The

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -617,6 +617,39 @@ impl HostedBackend for S3Store {
         S3Store::open_blob(self, name, filename).await
     }
 
+    async fn open_blob_range(
+        &self,
+        name: &CanonicalPackageName,
+        filename: &str,
+        requested: &object_store::GetRange,
+    ) -> Result<Option<crate::RangedBlob>> {
+        let key = self.blob_key(name, filename);
+        let meta = match self.store.head(&key).await {
+            Ok(meta) => meta,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        let size = meta.size;
+        let Ok(range) = requested.as_range(size) else {
+            return Ok(Some(crate::RangedBlob::Unsatisfiable { size }));
+        };
+        if range.is_empty() {
+            return Ok(Some(crate::RangedBlob::Unsatisfiable { size }));
+        }
+        let options = object_store::GetOptions {
+            range: Some(object_store::GetRange::Bounded(range.clone())),
+            if_match: meta.e_tag,
+            ..Default::default()
+        };
+        let result = match self.store.get_opts(&key, options).await {
+            Ok(result) => result,
+            Err(object_store::Error::NotFound { .. }) => return Ok(None),
+            Err(err) => return Err(err.into()),
+        };
+        let body = Body::from_stream(result.into_stream());
+        Ok(Some(crate::RangedBlob::Read { body, range, size }))
+    }
+
     async fn reserve_blob_tmp(
         &self,
         name: &CanonicalPackageName,

--- a/pnpr/crates/storage/src/streaming.rs
+++ b/pnpr/crates/storage/src/streaming.rs
@@ -234,7 +234,7 @@ async fn download_verified(
 
 /// Stream a cached file as a response body. Caller is responsible for
 /// setting `Content-Length` (from the file metadata it already read).
-pub fn stream_file(file: File) -> Body {
+pub fn stream_file(file: impl tokio::io::AsyncRead + Unpin + Send + 'static) -> Body {
     // Carry the `File` through the unfold *state* (not as a closure
     // capture) so each step owns it, reads, and hands it back. An
     // `FnMut` closure can't move the file across iterations on its


### PR DESCRIPTION
## Summary

Complete the four "Protocol surface" items in https://github.com/pnpm/pnpm/issues/14630 for pnpr's hosted OCI registry:

- Resume blob downloads with single byte ranges on filesystem and S3 storage, including suffix ranges and `If-Range`.
- Mount blobs across repositories after checking destination publish permission and source read permission. Missing or inaccessible sources fall back to an upload session.
- Discover subject-linked manifests and indexes through the OCI referrers API, with artifact type filtering, annotations, bounded pages, and support for manifests pushed before the API existed.
- Paginate tags and the catalog using `n`, `last`, and continuation links, including named registry routes.

Validation: workspace type checking, all 10,608 tests, and Clippy passed, along with TypeScript compile/lint, Rust documentation checks, and Dylint. OCI endpoint tests cover both filesystem and object storage.

## Squash Commit Body

```text
Add the remaining hosted OCI protocol endpoints tracked in pnpm/pnpm#14630.

Ranged reads seek on the filesystem and use conditional ranged object-store
requests on S3. Keep full reads for HEAD, mismatched If-Range validators,
and unsupported or malformed ranges.

Mounts resolve the source through the normal hosted read gate and the target
through the publish gate. Reuse the streamed upload and digest verification
path, including bounded S3 transfers. This avoids sending the layer again
from the client, while still using server scratch space and copying its bytes.

Reject image referrers without an artifact type or config media type.

Persist only subjects and artifact-type hashes in the journaled repository
document. Read annotations from matching manifests on bounded referrers pages,
with at most 32 manifest reads and 8 MiB of manifest content per request.
Backfill older entries incrementally as pages are queried. Coordinate migration
with a separate lock table when a page encounters unindexed metadata. Hold the
package writer lock only for the conditional metadata merge, so blob reads do
not stall publishers. Fully indexed pages do not acquire migration locks.
Preserve concurrent document changes and serialize
deletion with metadata updates on the filesystem backend. Referrer discovery
follows retained manifests, so deleting tags keeps referrers and deleting
manifests removes them.

Exclude catalog names before the cursor before authorizing candidates, then
apply page sizes to the authorized results. Preserve the addressed API base in
continuation links. Zero-sized catalog pages skip enumeration. General catalog
pages still use the existing full storage listing because filesystem traversal
is unordered; this change adds protocol pagination, not a repository index.

Related to pnpm/pnpm#14630. This affects pnpr only; the pnpm CLIs are unchanged.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] Added a changeset for the published pnpr package.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCI ranged blob downloads with range validation and response headers.
  * Added cross-repository blob mounting during uploads.
  * Added OCI referrer discovery, filtering, pagination, and subject metadata.
  * Added pagination for tag and repository listings.
  * Improved concurrent registry operations during referrer metadata processing.
* **Documentation**
  * Documented supported OCI registry capabilities, referrer pagination, and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->