### PR TITLE
fix(network): ignore CA material that carries no certificate

### DIFF
--- a/.changeset/ignore-unreadable-ca-certificates.md
+++ b/.changeset/ignore-unreadable-ca-certificates.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer fails with `Invalid CA certificate` when a `ca` or `cafile` setting carries something pnpm cannot read as a certificate. The unreadable certificate is ignored and the readable ones around it still apply. A `cert` or `key` setting with a blank value now reads as unset [#14646](https://github.com/pnpm/pnpm/issues/14646).
+`pnpm install` failed with `Invalid CA certificate` when a `ca` or `cafile` setting carried something pnpm could not read as a certificate. The unreadable certificate is now ignored and the readable ones around it still apply. A `cert` or `key` setting with a blank value now reads as unset [#14646](https://github.com/pnpm/pnpm/issues/14646).

--- a/.changeset/ignore-unreadable-ca-certificates.md
+++ b/.changeset/ignore-unreadable-ca-certificates.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer fails with `Invalid CA certificate` when a `ca` or `cafile` setting carries something pnpm cannot read as a certificate. The unreadable entry is ignored, the way pnpm 11 ignores it [#14646](https://github.com/pnpm/pnpm/issues/14646). A `cert` or `key` setting with a blank value now reads as unset.

--- a/.changeset/ignore-unreadable-ca-certificates.md
+++ b/.changeset/ignore-unreadable-ca-certificates.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer fails with `Invalid CA certificate` when a `ca` or `cafile` setting carries something pnpm cannot read as a certificate. The unreadable entry is ignored, the way pnpm 11 ignores it [#14646](https://github.com/pnpm/pnpm/issues/14646). A `cert` or `key` setting with a blank value now reads as unset.
+`pnpm install` no longer fails with `Invalid CA certificate` when a `ca` or `cafile` setting carries something pnpm cannot read as a certificate. The unreadable certificate is ignored and the readable ones around it still apply. A `cert` or `key` setting with a blank value now reads as unset [#14646](https://github.com/pnpm/pnpm/issues/14646).

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -983,9 +983,9 @@ fn load_cafile(path: &Path) -> Vec<String> {
     //   from each chunk and re-appended on the map side.
     // - Filter on `chunk.trim().is_empty()` — drops the trailing
     //   empty chunk produced when the file ends with a delimiter,
-    //   but *keeps* a trailing non-empty (malformed) chunk so
-    //   downstream `Certificate::from_pem` surfaces the parse error
-    //   instead of pacquet silently dropping the entry.
+    //   but *keeps* a trailing non-empty (malformed) chunk, which is
+    //   what pnpm's `readCAFileSync` produces too. The network layer
+    //   drops whatever carries no certificate.
     // - `trim_start()` (not full `trim`) — any trailing whitespace
     //   inside the chunk before the appended delimiter is preserved.
     //   It doesn't matter to a PEM parser but does matter for

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -1194,8 +1194,7 @@ fn cafile_trailing_garbage_is_preserved_for_downstream_parser() {
 
 // Regression for <https://github.com/pnpm/pnpm/issues/14646>: a `ca=`
 // whose `${VAR}` never resolved reaches the client builder as an empty
-// entry, and building the client there failed the whole install with
-// `Invalid CA certificate (entry 0)`.
+// entry, which the builder ignores.
 #[test]
 fn ca_with_an_unresolved_placeholder_still_builds_a_client() {
     let auth = NpmrcAuth::from_ini::<NoEnv>("ca=${CORP_CA}\n", Path::new(""));

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -1166,9 +1166,9 @@ fn cafile_reads_and_splits_into_per_cert_pems() {
 
 #[test]
 fn cafile_trailing_garbage_is_preserved_for_downstream_parser() {
-    // Silently dropping the trailing chunk would mask a truncated cert
-    // bundle and leave the user wondering why their CA list is
-    // shorter than expected.
+    // The split matches pnpm's `readCAFileSync`, which keeps the
+    // trailing chunk of a truncated bundle. The network layer is what
+    // decides an entry carries no certificate.
     use std::io::Write;
     let tmp = tempfile::NamedTempFile::new().expect("create tempfile");
     let bundle = format!("{TEST_CA_PEM}\ngarbage-not-a-cert");
@@ -1190,6 +1190,25 @@ fn cafile_trailing_garbage_is_preserved_for_downstream_parser() {
         "delimiter was not re-appended to garbage entry: {:?}",
         config.tls.ca[1],
     );
+}
+
+// Regression for <https://github.com/pnpm/pnpm/issues/14646>: a `ca=`
+// whose `${VAR}` never resolved reaches the client builder as an empty
+// entry, and building the client there failed the whole install with
+// `Invalid CA certificate (entry 0)`.
+#[test]
+fn ca_with_an_unresolved_placeholder_still_builds_a_client() {
+    let auth = NpmrcAuth::from_ini::<NoEnv>("ca=${CORP_CA}\n", Path::new(""));
+    let mut config = Config::new();
+    auth.apply_to::<NoEnv>(&mut config);
+    assert_eq!(config.tls.ca, vec![String::new()], "tls.ca={:?}", config.tls.ca);
+    pnpm_network::ThrottledClient::for_installs(
+        &config.proxy,
+        &config.tls,
+        &config.tls_by_uri,
+        &config.network_settings(),
+    )
+    .expect("an unresolved `ca` placeholder is ignored, not fatal");
 }
 
 #[test]

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -23,7 +23,6 @@ pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{
     RetryOpts, retry_async, send_with_retry, send_with_retry_at_priority, should_retry_status,
 };
-use tls::drop_blank;
 pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use priority_semaphore::{Permit, PrioritySemaphore};
@@ -1095,14 +1094,31 @@ fn load_node_extra_ca_certs() -> Vec<Certificate> {
 
 /// The certificates carried by one PEM buffer.
 ///
-/// Material the TLS backend cannot read yields an empty list. Node
-/// ignores such an entry rather than refusing to open a TLS context,
-/// so pnpm 11 installs fine with an empty, truncated, or
-/// `${VAR}`-unresolved `ca=` value; pacquet drops the same entry
+/// Material the TLS backend cannot read is skipped rather than
+/// rejected. Node ignores such material instead of refusing to open a
+/// TLS context, so pnpm 11 installs fine with an empty, truncated, or
+/// `${VAR}`-unresolved `ca=` value; pacquet drops the same material
 /// instead of failing the client build (pnpm/pnpm#14646).
+///
+/// `Certificate::from_pem_bundle` reads the buffer as a unit and fails
+/// it whole, so one corrupt block in a bundle would take the roots
+/// around it down with it. Falling back to a block-by-block read keeps
+/// every certificate that is readable on its own.
 fn parse_ca_bundle(pem: &[u8]) -> Vec<Certificate> {
-    Certificate::from_pem_bundle(pem).unwrap_or_default()
+    if let Ok(certs) = Certificate::from_pem_bundle(pem) {
+        return certs;
+    }
+    String::from_utf8_lossy(pem)
+        .split_inclusive(END_CERTIFICATE)
+        .filter_map(|block| Certificate::from_pem_bundle(block.as_bytes()).ok())
+        .flatten()
+        .collect()
 }
+
+/// The PEM armor that closes a certificate. Splitting a bundle on it
+/// is how pnpm's own `cafile` reader delimits one certificate from the
+/// next.
+const END_CERTIFICATE: &str = "-----END CERTIFICATE-----";
 
 /// Build the effective [`TlsConfig`] for a per-registry override:
 /// each scoped field (`ca`, `cert`, `key`) replaces its top-level
@@ -1148,16 +1164,8 @@ fn apply_tls(
     mut builder: reqwest::ClientBuilder,
     tls: &TlsConfig,
 ) -> Result<reqwest::ClientBuilder, TlsError> {
-    for (index, pem) in tls.ca.iter().enumerate() {
-        let certs = parse_ca_bundle(pem.as_bytes());
-        if certs.is_empty() {
-            tracing::warn!(
-                target: "pacquet::tls",
-                index,
-                "ignoring a `ca` entry that carries no readable certificate",
-            );
-        }
-        for cert in certs {
+    for pem in &tls.ca {
+        for cert in parse_ca_bundle(pem.as_bytes()) {
             builder = builder.add_root_certificate(cert);
         }
     }
@@ -1193,6 +1201,19 @@ fn apply_tls(
         builder = builder.local_address(addr);
     }
     Ok(builder)
+}
+
+/// `None` for a PEM slot that is empty or all whitespace.
+///
+/// A blank setting is how an unset one looks: a `cert=` line a config
+/// generator wrote out with nothing after it, or a `key=${CORP_KEY}`
+/// whose variable never resolved. pnpm tests these fields for
+/// truthiness before handing them to undici, so a blank one never
+/// reaches Node's TLS layer; pacquet drops it at the same point rather
+/// than pair it with its counterpart and fail the install on the
+/// identity rustls then rejects (pnpm/pnpm#14646).
+fn drop_blank(pem: Option<&str>) -> Option<&str> {
+    pem.filter(|pem| !pem.trim().is_empty())
 }
 
 /// Error surface of [`ThrottledClient::for_installs`]. Wraps either a

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -23,6 +23,7 @@ pub use proxy::{NoProxySetting, ProxyConfig, ProxyError};
 pub use retry::{
     RetryOpts, retry_async, send_with_retry, send_with_retry_at_priority, should_retry_status,
 };
+use tls::drop_blank;
 pub use tls::{PerRegistryTls, RegistryTls, TlsConfig, TlsError};
 
 use priority_semaphore::{Permit, PrioritySemaphore};
@@ -1089,21 +1090,20 @@ fn load_node_extra_ca_certs() -> Vec<Certificate> {
     let Ok(bytes) = std::fs::read(&path) else {
         return Vec::new();
     };
-    Certificate::from_pem_bundle(&bytes).unwrap_or_default()
+    parse_ca_bundle(&bytes)
 }
 
-/// Apply [`TlsConfig`] onto a [`reqwest::ClientBuilder`]: register each
-/// CA, install the client identity, set `danger_accept_invalid_certs`
-/// when `strict_ssl: false`, and pin the outbound interface. Returns
-/// the modified builder unchanged when every field is `None` / empty —
-/// matching pnpm's "TLS-unset is default-TLS" semantics.
+/// The certificates carried by one PEM buffer.
 ///
-/// `strict_ssl` defaults to `true` here (`unwrap_or(true)`) rather than
-/// in the config layer because that's where pnpm applies the same
-/// default — see the "Defaults" section of [`TlsConfig`]. Failures from
-/// PEM parsing surface as [`TlsError::InvalidCa`] /
-/// [`TlsError::InvalidClientIdentity`] and bubble through
-/// [`ForInstallsError`].
+/// Material the TLS backend cannot read yields an empty list. Node
+/// ignores such an entry rather than refusing to open a TLS context,
+/// so pnpm 11 installs fine with an empty, truncated, or
+/// `${VAR}`-unresolved `ca=` value; pacquet drops the same entry
+/// instead of failing the client build (pnpm/pnpm#14646).
+fn parse_ca_bundle(pem: &[u8]) -> Vec<Certificate> {
+    Certificate::from_pem_bundle(pem).unwrap_or_default()
+}
+
 /// Build the effective [`TlsConfig`] for a per-registry override:
 /// each scoped field (`ca`, `cert`, `key`) replaces its top-level
 /// counterpart field-by-field; `strict_ssl` and `local_address`
@@ -1115,7 +1115,7 @@ fn load_node_extra_ca_certs() -> Vec<Certificate> {
 /// the top-level `ca` is a `Vec<String>` (the `cafile` loader split).
 /// When the override has a `ca`, the effective top-level CA list is
 /// *replaced* (not merged) by a one-element list with the scoped PEM
-/// blob — which `Certificate::from_pem` handles fine since it accepts
+/// blob — which [`parse_ca_bundle`] handles fine since it accepts
 /// multi-cert PEM buffers.
 fn merge_tls(top: &TlsConfig, override_: &RegistryTls) -> TlsConfig {
     TlsConfig {
@@ -1130,48 +1130,40 @@ fn merge_tls(top: &TlsConfig, override_: &RegistryTls) -> TlsConfig {
     }
 }
 
-/// Lightweight syntactic check that `pem` contains at least one
-/// `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` armor
-/// pair. Catches the "user pasted garbage instead of PEM" case
-/// without parsing the base64 body — rustls's
-/// `Certificate::from_pem` stores the bytes verbatim and validates
-/// lazily, so without this guard a malformed CA would silently slip
-/// through and the install would proceed against an unknown trust
-/// root. A stricter parse (base64 decode + DER validation) is left
-/// to rustls itself when the connection is actually made.
-fn looks_like_pem_cert(pem: &str) -> bool {
-    let begin = pem.find("-----BEGIN CERTIFICATE-----");
-    let end = pem.rfind("-----END CERTIFICATE-----");
-    matches!((begin, end), (Some(b), Some(e)) if b < e)
-}
-
+/// Apply [`TlsConfig`] onto a [`reqwest::ClientBuilder`]: register each
+/// CA, install the client identity, set `danger_accept_invalid_certs`
+/// when `strict_ssl: false`, and pin the outbound interface. Returns
+/// the modified builder unchanged when every field is `None` / empty —
+/// matching pnpm's "TLS-unset is default-TLS" semantics.
+///
+/// `strict_ssl` defaults to `true` here (`unwrap_or(true)`) rather than
+/// in the config layer because that's where pnpm applies the same
+/// default — see the "Defaults" section of [`TlsConfig`]. A `cert` /
+/// `key` pair rustls rejects surfaces as
+/// [`TlsError::InvalidClientIdentity`] and bubbles through
+/// [`ForInstallsError`], the way Node throws from
+/// `tls.createSecureContext`. Unreadable `ca` material is dropped
+/// instead — see [`parse_ca_bundle`].
 fn apply_tls(
     mut builder: reqwest::ClientBuilder,
     tls: &TlsConfig,
 ) -> Result<reqwest::ClientBuilder, TlsError> {
     for (index, pem) in tls.ca.iter().enumerate() {
-        // Validate the PEM armor *before* handing to reqwest.
-        // Reqwest's rustls backend stores the bytes verbatim and
-        // parses lazily at `Client::build()` time — a garbage CA
-        // entry would otherwise be silently dropped and the install
-        // would proceed against an unknown trust root. The eager
-        // check catches the no-armor case (the common "user
-        // pasted a path instead of PEM contents" failure) and lets
-        // the malformed-CA error point at the specific entry in
-        // the list.
-        if !looks_like_pem_cert(pem) {
-            return Err(TlsError::InvalidCa {
+        let certs = parse_ca_bundle(pem.as_bytes());
+        if certs.is_empty() {
+            tracing::warn!(
+                target: "pacquet::tls",
                 index,
-                reason: "missing `-----BEGIN CERTIFICATE-----` / `-----END CERTIFICATE-----` \
-                         armor"
-                    .to_string(),
-            });
+                "ignoring a `ca` entry that carries no readable certificate",
+            );
         }
-        let cert = Certificate::from_pem(pem.as_bytes())
-            .map_err(|source| TlsError::InvalidCa { index, reason: source.to_string() })?;
-        builder = builder.add_root_certificate(cert);
+        for cert in certs {
+            builder = builder.add_root_certificate(cert);
+        }
     }
-    if let (Some(cert), Some(key)) = (tls.cert.as_deref(), tls.key.as_deref()) {
+    let cert = drop_blank(tls.cert.as_deref());
+    let key = drop_blank(tls.key.as_deref());
+    if let (Some(cert), Some(key)) = (cert, key) {
         // reqwest's `Identity::from_pem` (gated on the `rustls`
         // feature pacquet builds with) takes a single PEM buffer
         // containing *both* the certificate and the private key, in

--- a/pnpm/crates/network/src/lib.rs
+++ b/pnpm/crates/network/src/lib.rs
@@ -477,9 +477,10 @@ impl ThrottledClient {
     ///   Basic-auth user/password halves embedded in the proxy URL
     ///   are percent-decoded before being forwarded as the
     ///   `Proxy-Authorization` header.
-    /// * **TLS.** Each PEM in [`TlsConfig::ca`] is added as a trusted
-    ///   root via `reqwest::Certificate::from_pem`. When both
-    ///   [`TlsConfig::cert`] and [`TlsConfig::key`] are set, they are
+    /// * **TLS.** Every certificate read out of [`TlsConfig::ca`] is
+    ///   added as a trusted root; material the TLS backend cannot read
+    ///   is skipped. When both [`TlsConfig::cert`] and
+    ///   [`TlsConfig::key`] are set and neither is blank, they are
     ///   concatenated and passed to `Identity::from_pem` (rustls
     ///   single-buffer form). rustls accepts PKCS#1, PKCS#8, and EC
     ///   private keys — the same surface Node's `tls` exposes.
@@ -495,10 +496,8 @@ impl ThrottledClient {
     /// Returns [`ProxyError::InvalidProxy`] when either configured
     /// proxy URL fails to parse even after the auto-`http://` prefix
     /// retry (the `ERR_PNPM_INVALID_PROXY` code), or [`TlsError`] when
-    /// any CA or client identity PEM is malformed.
-    /// pnpm does not define `ERR_PNPM_INVALID_CA` / similar codes —
-    /// see [`TlsError`] for why pacquet still surfaces the failure
-    /// eagerly rather than at request time.
+    /// the client identity PEM is malformed. Unreadable CA material is
+    /// not an error — see [`TlsError`] for where that line sits.
     pub fn for_installs(
         proxy: &ProxyConfig,
         tls: &TlsConfig,

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -822,9 +822,8 @@ fn for_installs_with_multiple_ca_pems_builds() {
 }
 
 // Regression for <https://github.com/pnpm/pnpm/issues/14646>: an
-// unreadable `ca` entry took the whole install down with
-// `Invalid CA certificate (entry 0)`, while pnpm 11 installs fine
-// because Node ignores CA material it cannot parse.
+// unreadable `ca` entry contributes no trust anchor and the client
+// still builds, the way Node ignores CA material it cannot parse.
 #[test]
 fn for_installs_ignores_ca_entries_that_carry_no_certificate() {
     let unreadable = ["", "${CORP_CA}", "not a pem certificate"];

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -821,27 +821,28 @@ fn for_installs_with_multiple_ca_pems_builds() {
     .expect("multiple CA PEMs build");
 }
 
+// Regression for <https://github.com/pnpm/pnpm/issues/14646>: an
+// unreadable `ca` entry took the whole install down with
+// `Invalid CA certificate (entry 0)`, while pnpm 11 installs fine
+// because Node ignores CA material it cannot parse.
 #[test]
-fn for_installs_with_invalid_ca_pem_errors_with_index() {
-    // First entry valid, second malformed — the index in the error
-    // must point at the broken one so users with a multi-cert
-    // `cafile` can find which entry failed.
+fn for_installs_ignores_ca_entries_that_carry_no_certificate() {
     let tls = TlsConfig {
-        ca: vec![TEST_CA_PEM.to_string(), "not a pem certificate".to_string()],
+        ca: vec![
+            String::new(),
+            "${CORP_CA}".to_string(),
+            "not a pem certificate".to_string(),
+            TEST_CA_PEM.to_string(),
+        ],
         ..TlsConfig::default()
     };
-    let err = ThrottledClient::for_installs(
+    ThrottledClient::for_installs(
         &ProxyConfig::default(),
         &tls,
         &PerRegistryTls::default(),
         &NetworkSettings::default(),
     )
-    .expect_err("invalid CA must error");
-    eprintln!("err={err:?}");
-    match err {
-        ForInstallsError::Tls(super::TlsError::InvalidCa { index, .. }) => assert_eq!(index, 1),
-        other => panic!("expected Tls(InvalidCa {{ index: 1 }}), got {other:?}"),
-    }
+    .expect("unreadable CA entries are dropped, not fatal");
 }
 
 #[test]
@@ -1082,11 +1083,9 @@ fn for_installs_does_not_retain_per_registry_tls_material() {
 }
 
 #[test]
-fn for_installs_per_registry_invalid_ca_errors() {
-    // A malformed per-registry CA must surface as `InvalidCa` at
-    // build time, same as the top-level path. The `index` in the
-    // error indexes into the merged CA list — which is exactly the
-    // one-element vec carrying the scoped PEM, so `index == 0`.
+fn for_installs_ignores_a_per_registry_ca_that_carries_no_certificate() {
+    // Same tolerance as the top-level path: the override contributes
+    // no trust anchor and the client still builds.
     use crate::RegistryTls;
     use std::collections::HashMap;
     let mut map = HashMap::new();
@@ -1095,17 +1094,33 @@ fn for_installs_per_registry_invalid_ca_errors() {
         RegistryTls { ca: Some("not a pem".to_string()), ..RegistryTls::default() },
     );
     let per_registry = PerRegistryTls::from_map(map);
-    let err = ThrottledClient::for_installs(
+    ThrottledClient::for_installs(
         &ProxyConfig::default(),
         &TlsConfig::default(),
         &per_registry,
         &NetworkSettings::default(),
     )
-    .expect_err("must error");
-    eprintln!("err={err:?}");
-    let is_invalid_ca =
-        matches!(err, ForInstallsError::Tls(super::TlsError::InvalidCa { index: 0, .. }));
-    assert!(is_invalid_ca, "err={err:?}: expected Tls(InvalidCa {{ index: 0 }})");
+    .expect("unreadable per-registry CA is dropped, not fatal");
+}
+
+#[test]
+fn for_installs_ignores_a_blank_client_identity() {
+    // `cert=` / `key=` lines with nothing after them read as unset to
+    // pnpm, which checks them for truthiness before handing them to
+    // undici. Pairing a blank `cert` with a real `key` must not build
+    // an identity rustls then rejects.
+    let tls = TlsConfig {
+        cert: Some("   ".to_string()),
+        key: Some(TEST_CLIENT_PKCS1_KEY.to_string()),
+        ..TlsConfig::default()
+    };
+    ThrottledClient::for_installs(
+        &ProxyConfig::default(),
+        &tls,
+        &PerRegistryTls::default(),
+        &NetworkSettings::default(),
+    )
+    .expect("a blank cert leaves the identity unset");
 }
 
 #[tokio::test]

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -827,18 +827,19 @@ fn for_installs_with_multiple_ca_pems_builds() {
 // because Node ignores CA material it cannot parse.
 #[test]
 fn for_installs_ignores_ca_entries_that_carry_no_certificate() {
-    let tls = TlsConfig {
-        ca: vec![
-            String::new(),
-            "${CORP_CA}".to_string(),
-            "not a pem certificate".to_string(),
-            TEST_CA_PEM.to_string(),
-        ],
-        ..TlsConfig::default()
-    };
+    let unreadable = ["", "${CORP_CA}", "not a pem certificate"];
+    for pem in unreadable {
+        assert!(super::parse_ca_bundle(pem.as_bytes()).is_empty(), "{pem:?} parsed as a cert");
+    }
+    let mut ca: Vec<String> = unreadable.iter().map(|pem| (*pem).to_string()).collect();
+    ca.push(TEST_CA_PEM.to_string());
+    // The valid entry must still reach the trust store — dropping it
+    // alongside its unreadable neighbours would break the install a
+    // different way.
+    assert_eq!(ca.iter().flat_map(|pem| super::parse_ca_bundle(pem.as_bytes())).count(), 1);
     ThrottledClient::for_installs(
         &ProxyConfig::default(),
-        &tls,
+        &TlsConfig { ca, ..TlsConfig::default() },
         &PerRegistryTls::default(),
         &NetworkSettings::default(),
     )
@@ -1101,6 +1102,35 @@ fn for_installs_ignores_a_per_registry_ca_that_carries_no_certificate() {
         &NetworkSettings::default(),
     )
     .expect("unreadable per-registry CA is dropped, not fatal");
+}
+
+#[test]
+fn a_blank_scoped_cert_shadows_the_top_level_identity() {
+    // pnpm spreads the per-registry entry over the top-level one, so a
+    // blank `//reg/:cert=` overrides rather than falls back. Letting
+    // it fall back would pair the top-level certificate with the
+    // scoped key and send an identity the user never configured for
+    // that registry.
+    use crate::RegistryTls;
+    let top = TlsConfig {
+        cert: Some(TEST_CLIENT_PKCS1_CERT.to_string()),
+        key: Some(TEST_CLIENT_PKCS1_KEY.to_string()),
+        ..TlsConfig::default()
+    };
+    let scoped = RegistryTls { cert: Some(String::new()), ..RegistryTls::default() };
+    assert_eq!(super::merge_tls(&top, &scoped).cert.as_deref(), Some(""));
+}
+
+#[test]
+fn a_corrupt_block_does_not_discard_the_rest_of_a_ca_bundle() {
+    // A per-registry `:ca` / `:cafile` arrives as one buffer, so a
+    // single corrupt block must not cost the registry every custom
+    // root in it.
+    const CORRUPT: &str = "-----BEGIN CERTIFICATE-----\nnot-base64!!!\n-----END CERTIFICATE-----";
+    let bundle = format!("{TEST_CA_PEM}\n{CORRUPT}\n{TEST_CA_PEM}\n");
+    assert_eq!(super::parse_ca_bundle(bundle.as_bytes()).len(), 2);
+    assert_eq!(super::parse_ca_bundle(CORRUPT.as_bytes()).len(), 0);
+    assert_eq!(super::parse_ca_bundle(TEST_CA_PEM.as_bytes()).len(), 1);
 }
 
 #[test]

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -49,7 +49,8 @@ pub struct TlsConfig {
     /// `ca` key (inline PEM, possibly multiple via array shape) or by
     /// reading `cafile` (which gets split on
     /// `-----END CERTIFICATE-----`). `cafile`-not-found is silently
-    /// treated as unset.
+    /// treated as unset, and so is an entry that carries no readable
+    /// certificate.
     pub ca: Vec<String>,
 
     /// PEM-encoded client certificate, when client-cert auth is
@@ -86,23 +87,20 @@ pub struct TlsConfig {
 /// Build-time error returned by [`crate::ThrottledClient::for_installs`]
 /// when configured TLS material is invalid.
 ///
-/// pnpm does not define `ERR_PNPM_INVALID_CA` / `ERR_PNPM_INVALID_CERT`
-/// / `ERR_PNPM_INVALID_KEY` error codes — invalid PEM surfaces as raw
-/// `tls.connect` errors at request time.
-/// Pacquet validates eagerly because reqwest's `Certificate::from_pem`
-/// / `Identity::from_pem` return errors up-front and pushing that to
-/// per-request time would silently degrade every install behind a
-/// broken `ca`. Diagnostic messages are plain prose; no code
-/// attribute is emitted so reviewers can see at a glance that this is
-/// a pacquet-only diagnostic, not a pnpm error code.
+/// pnpm does not define `ERR_PNPM_INVALID_CERT` / `ERR_PNPM_INVALID_KEY`
+/// error codes — invalid PEM surfaces as a raw `tls.createSecureContext`
+/// throw. Pacquet reports the same failure up-front because reqwest's
+/// `Identity::from_pem` returns the error there. Diagnostic messages
+/// are plain prose; no code attribute is emitted so reviewers can see
+/// at a glance that this is a pacquet-only diagnostic, not a pnpm
+/// error code.
+///
+/// A `ca` entry is not part of this surface: Node ignores CA material
+/// it cannot read, so pacquet drops the entry rather than fail the
+/// install (pnpm/pnpm#14646).
 #[derive(Debug, derive_more::Display, derive_more::Error, miette::Diagnostic)]
 #[non_exhaustive]
 pub enum TlsError {
-    /// `Certificate::from_pem` rejected one of the `ca` entries.
-    /// `index` is the 0-based position within the resolved CA list.
-    #[display("Invalid CA certificate (entry {index}): {reason}")]
-    InvalidCa { index: usize, reason: String },
-
     /// `Identity::from_pem` rejected the concatenated `cert` +
     /// `key` PEM pair. Rustls accepts PKCS#1, PKCS#8, and EC keys —
     /// landing here means the bytes aren't a valid PEM in any of
@@ -181,14 +179,41 @@ impl RegistryTls {
     pub fn is_empty(&self) -> bool {
         self.ca.is_none() && self.cert.is_none() && self.key.is_none()
     }
+
+    /// Unset every field that is set but blank, so it falls back to
+    /// the top-level value rather than overriding it with nothing.
+    #[must_use]
+    fn without_blank_fields(self) -> Self {
+        RegistryTls {
+            ca: drop_blank(self.ca),
+            cert: drop_blank(self.cert),
+            key: drop_blank(self.key),
+        }
+    }
+}
+
+/// `None` for a PEM slot that is empty or all whitespace.
+///
+/// A blank TLS setting is how an unset one looks: a `cert=` line a
+/// config generator wrote out with nothing after it, or a
+/// `ca=${CORP_CA}` whose variable never resolved. pnpm tests these
+/// fields for truthiness before handing them to undici, so a blank one
+/// never reaches Node's TLS layer; pacquet drops it at the same point
+/// rather than fail the install on it (pnpm/pnpm#14646).
+pub(crate) fn drop_blank<Pem: AsRef<str>>(pem: Option<Pem>) -> Option<Pem> {
+    pem.filter(|pem| !pem.as_ref().trim().is_empty())
 }
 
 impl PerRegistryTls {
-    /// Build from a nerf-darted → [`RegistryTls`] map. Drops empty
-    /// entries.
+    /// Build from a nerf-darted → [`RegistryTls`] map. Drops blank
+    /// fields and then the entries left with nothing to override.
     #[must_use]
     pub fn from_map(by_uri: HashMap<String, RegistryTls>) -> Self {
-        let by_uri: HashMap<_, _> = by_uri.into_iter().filter(|(_, v)| !v.is_empty()).collect();
+        let by_uri: HashMap<_, _> = by_uri
+            .into_iter()
+            .map(|(uri, tls)| (uri, tls.without_blank_fields()))
+            .filter(|(_, tls)| !tls.is_empty())
+            .collect();
         PerRegistryTls { by_uri: PerRegistryMap::from_map(by_uri) }
     }
 

--- a/pnpm/crates/network/src/tls.rs
+++ b/pnpm/crates/network/src/tls.rs
@@ -179,41 +179,14 @@ impl RegistryTls {
     pub fn is_empty(&self) -> bool {
         self.ca.is_none() && self.cert.is_none() && self.key.is_none()
     }
-
-    /// Unset every field that is set but blank, so it falls back to
-    /// the top-level value rather than overriding it with nothing.
-    #[must_use]
-    fn without_blank_fields(self) -> Self {
-        RegistryTls {
-            ca: drop_blank(self.ca),
-            cert: drop_blank(self.cert),
-            key: drop_blank(self.key),
-        }
-    }
-}
-
-/// `None` for a PEM slot that is empty or all whitespace.
-///
-/// A blank TLS setting is how an unset one looks: a `cert=` line a
-/// config generator wrote out with nothing after it, or a
-/// `ca=${CORP_CA}` whose variable never resolved. pnpm tests these
-/// fields for truthiness before handing them to undici, so a blank one
-/// never reaches Node's TLS layer; pacquet drops it at the same point
-/// rather than fail the install on it (pnpm/pnpm#14646).
-pub(crate) fn drop_blank<Pem: AsRef<str>>(pem: Option<Pem>) -> Option<Pem> {
-    pem.filter(|pem| !pem.as_ref().trim().is_empty())
 }
 
 impl PerRegistryTls {
-    /// Build from a nerf-darted → [`RegistryTls`] map. Drops blank
-    /// fields and then the entries left with nothing to override.
+    /// Build from a nerf-darted → [`RegistryTls`] map. Drops empty
+    /// entries.
     #[must_use]
     pub fn from_map(by_uri: HashMap<String, RegistryTls>) -> Self {
-        let by_uri: HashMap<_, _> = by_uri
-            .into_iter()
-            .map(|(uri, tls)| (uri, tls.without_blank_fields()))
-            .filter(|(_, tls)| !tls.is_empty())
-            .collect();
+        let by_uri: HashMap<_, _> = by_uri.into_iter().filter(|(_, v)| !v.is_empty()).collect();
         PerRegistryTls { by_uri: PerRegistryMap::from_map(by_uri) }
     }
 

--- a/pnpm/crates/network/src/tls/tests.rs
+++ b/pnpm/crates/network/src/tls/tests.rs
@@ -42,14 +42,6 @@ fn tls_config_clone_round_trip() {
 }
 
 #[test]
-fn tls_error_invalid_ca_includes_index_in_display() {
-    let err = TlsError::InvalidCa { index: 3, reason: "bad pem".into() };
-    let rendered = err.to_string();
-    assert!(rendered.contains("entry 3"), "expected `entry 3` in {rendered}");
-    assert!(rendered.contains("bad pem"), "expected reason in {rendered}");
-}
-
-#[test]
 fn tls_error_invalid_client_identity_includes_reason_in_display() {
     let err = TlsError::InvalidClientIdentity { reason: "garbage key".into() };
     let rendered = err.to_string();


### PR DESCRIPTION
## Summary

`pnpm install` on pnpm 12 aborted with `Invalid CA certificate (entry 0)` whenever a `ca` or `cafile` setting resolved to something that is not a readable certificate. `apply_tls` checked each entry for `-----BEGIN CERTIFICATE-----` armor and returned `TlsError::InvalidCa` when it was missing, so a blank `ca=`, a `ca=${VAR}` whose variable never resolved (the `.npmrc` parser substitutes `""` and warns), or a truncated bundle took the whole install down.

Node does not behave that way, which is why the same config installs on pnpm 11: `tls.createSecureContext({ca: ['garbage']})` returns a context that simply trusts nothing extra. Each `ca` entry is now parsed with `Certificate::from_pem_bundle`, and whatever it yields is added; an entry that yields nothing contributes no trust anchor. Dropping a root can only make verification stricter, so this fails closed, and `pnpm-network`'s `NODE_EXTRA_CA_CERTS` loader already tolerated the same input the same way.

`from_pem_bundle` reads a buffer as a unit and fails it whole, so a per-registry `:ca` / `:cafile` blob pairing a working private root with one corrupt block would lose every root in it. When the bundle as a whole is rejected, the entry is re-read block by block and each certificate that parses on its own is kept.

A blank `cert` or `key` now reads as unset. pnpm tests those fields for truthiness before handing them to undici, so a blank one never reaches Node, while pacquet paired it with its counterpart and let rustls reject the identity. This happens where the identity is assembled, not at the config layer: pnpm 11 stores a scoped `//reg/:cert=` verbatim (`getNetworkConfigs.ts`) and merges with `{ ...opts, ...sslConfig }` (`dispatcher.ts`), so a blank scoped field shadows its top-level counterpart rather than falling back to it. Per-registry overrides keep that shadowing, and the identity simply goes unset instead of mixing a scoped half with a top-level half.

A `cert` / `key` pair that is present but invalid still errors, because Node throws there too.

pnpm 11 is not affected: it hands the values straight to Node, which ignores unusable CA material, so no TypeScript change is needed.

Closes pnpm/pnpm#14646

## Squash Commit Body

```text
`pnpm install` aborted with `Invalid CA certificate (entry 0)` whenever
a `ca` or `cafile` setting resolved to something that is not a readable
certificate. The armor check in `apply_tls` refused the entry outright,
so a blank `ca=`, a `ca=${VAR}` whose variable never resolved, or a
truncated bundle took the whole install down.

Node ignores CA material it cannot parse, which is why the same config
installs on pnpm 11: `tls.createSecureContext` accepts a garbage `ca`
and simply trusts nothing extra. Parse each entry with
`Certificate::from_pem_bundle` and add whatever it yields, so an
unusable entry contributes no trust anchor instead of failing the
client build. Dropping a root can only make verification stricter, so
this fails closed. `from_pem_bundle` fails a buffer whole, so an entry
it rejects is re-read block by block and every certificate that is
readable on its own is kept.

A blank `cert` / `key` now reads as unset for the same reason: pnpm
tests those fields for truthiness before handing them to undici, so a
blank one never reaches Node, while pacquet paired it with its
counterpart and let rustls reject the identity. The drop happens where
the identity is assembled, so a blank per-registry field keeps
shadowing its top-level counterpart the way pnpm's spread merge does,
rather than pairing a scoped half with a top-level half.

A `cert` / `key` pair that is present but invalid still errors, since
Node throws there too.

Closes pnpm/pnpm#14646
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01USadyvDcut1PyBp8sdfgK7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` now continues when certificate authority entries are empty, unreadable, malformed, or unresolved.
  * Invalid CA entries are ignored while readable certificates in the same bundle continue to be used.
  * Blank client certificate and key settings are treated as unset.
  * Blank per-registry certificate settings correctly override inherited values.
  * Valid TLS configurations continue to work, while invalid client identity data remains reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->