### PR TITLE
feat(pnpr): finish oci registry follow-ups

### DIFF
--- a/.changeset/pnpr-abort-invalid-blob-streams.md
+++ b/.changeset/pnpr-abort-invalid-blob-streams.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+pnpr aborts proxied blob downloads when their contents fail integrity verification. Invalid blobs remain excluded from the cache.

--- a/.changeset/pnpr-oci-batch-publish.md
+++ b/.changeset/pnpr-oci-batch-publish.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+OCI manifests can be published alongside packages through `PUT /-/pnpr/v0/publish`. Upload their layers before submitting the batch [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-blob-deletion.md
+++ b/.changeset/pnpr-oci-blob-deletion.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Authorized users can delete unreferenced OCI blobs. Blobs reachable from retained manifests remain protected during concurrent publishes [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-pull-through.md
+++ b/.changeset/pnpr-oci-pull-through.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+pnpr can cache image pulls from Docker Hub and GHCR. Upstream authentication supports repository-scoped Bearer tokens, and cached images are verified by digest [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-pull-through.md
+++ b/.changeset/pnpr-oci-pull-through.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr can cache image pulls from Docker Hub and GHCR. Upstream authentication supports repository-scoped Bearer tokens, and cached images are verified by digest [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).
+pnpr can cache image pulls from Docker Hub and GHCR. Upstream authentication supports repository-scoped Bearer tokens. Cached images are verified by digest [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-pull-through.md
+++ b/.changeset/pnpr-oci-pull-through.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr can cache image pulls from Docker Hub and GHCR. Upstream authentication supports repository-scoped Bearer tokens. Cached images are verified by digest [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).
+pnpr can cache image pulls from Docker Hub and GHCR. Upstream authentication supports repository-scoped Bearer tokens. pnpr verifies cached images by digest [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-scoped-tokens.md
+++ b/.changeset/pnpr-oci-scoped-tokens.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Set `oci.bearerAuth: true` to use short-lived, repository-scoped credentials with container clients [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/pnpr-oci-size-limits.md
+++ b/.changeset/pnpr-oci-size-limits.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+OCI blob and manifest size limits are configurable with `oci.maxBlobBytes` and `oci.maxManifestBytes` [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).

--- a/.changeset/serve-container-images.md
+++ b/.changeset/serve-container-images.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": minor
 ---
 
-pnpr now serves container images. Declare a registry with `ecosystem: oci`. Push to it with `docker`, `podman`, or `skopeo`. The distribution API answers at `/v2/` on the host root. An image keeps its own name, with no registry key in the path. Sign in with `docker login`, using a pnpr token as the password. Proxying an upstream image registry is not supported yet.
+pnpr now serves container images. Declare a registry with `ecosystem: oci`. Push to it with `docker`, `podman`, or `skopeo`. The distribution API answers at `/v2/` on the host root. An image keeps its own name, with no registry key in the path. Sign in with `docker login`, using a pnpr token as the password.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6120,6 +6120,7 @@ dependencies = [
  "mockito",
  "node-semver",
  "object_store",
+ "p256",
  "pep440_rs",
  "pep508_rs",
  "pipe-trait",

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -70,6 +70,8 @@ pub struct Config {
     /// Cross-origin browser access. Empty by default, so pnpr emits no CORS
     /// response headers unless an operator explicitly names trusted origins.
     pub cors: CorsConfig,
+    /// OCI authentication and size limits.
+    pub oci: OciConfig,
     /// Directory under which authoritative packuments and tarballs
     /// live: packages published to this server and the content served
     /// in static mode. This is the source of truth — it is never
@@ -154,6 +156,25 @@ pub struct Config {
     /// namespace and an access policy gating its packages. The only registry kind
     /// that accepts writes.
     pub hosted: IndexMap<String, HostedConfig>,
+}
+
+/// Authentication and byte limits for the OCI distribution surface.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, rename_all = "camelCase", deny_unknown_fields)]
+pub struct OciConfig {
+    pub bearer_auth: bool,
+    pub max_blob_bytes: u64,
+    pub max_manifest_bytes: usize,
+}
+
+impl Default for OciConfig {
+    fn default() -> Self {
+        Self {
+            bearer_auth: false,
+            max_blob_bytes: 10 * 1024 * 1024 * 1024,
+            max_manifest_bytes: 4 * 1024 * 1024,
+        }
+    }
 }
 
 /// A resolved hosted registry: the `org` namespace it serves and its
@@ -1024,6 +1045,8 @@ struct ConfigFile {
     /// when this block is absent or its allowlist is empty.
     #[serde(default)]
     cors: CorsFile,
+    #[serde(default)]
+    oci: OciConfig,
     /// pnpr-only block: store the hosted (published) packages in an
     /// S3-compatible object store instead of `storage`. Absent on a
     /// stock verdaccio config (silently ignored there).
@@ -1360,6 +1383,7 @@ impl Config {
             listen,
             public_url: format!("http://{listen}"),
             cors: CorsConfig::default(),
+            oci: OciConfig::default(),
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams,
@@ -1411,6 +1435,7 @@ impl Config {
             listen,
             public_url: format!("http://{listen}"),
             cors: CorsConfig::default(),
+            oci: OciConfig::default(),
             cache_storage: default_cache_dir(&storage),
             storage,
             upstreams: IndexMap::new(),
@@ -1618,6 +1643,11 @@ impl Config {
         }
         let file: ConfigFile = serde_saphyr::from_str(&substituted)
             .map_err(|err| RegistryError::InvalidConfig { reason: err.to_string() })?;
+        if file.oci.max_blob_bytes == 0 || file.oci.max_manifest_bytes == 0 {
+            return Err(RegistryError::InvalidConfig {
+                reason: "oci size limits must be greater than zero".to_string(),
+            });
+        }
         let storage = resolve_relative(&file.storage, base_dir);
         let cache_storage = file
             .cache
@@ -1695,6 +1725,7 @@ impl Config {
             listen,
             public_url,
             cors,
+            oci: file.oci,
             storage,
             cache_storage,
             upstreams,

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -2757,3 +2757,32 @@ registries:
     let err = Config::from_yaml_str(bad_key, Path::new("/x"), listen(), None).unwrap_err();
     assert!(err.to_string().contains(r#"oci registry "images" `packages:` key"#), "{err}");
 }
+
+#[test]
+fn oci_limits_are_positive_and_preserve_defaults() {
+    let config = Config::from_yaml_str(
+        "oci: {maxBlobBytes: 123, maxManifestBytes: 456, bearerAuth: true}",
+        Path::new("/config"),
+        listen(),
+        None,
+    )
+    .unwrap();
+    assert_eq!(config.oci.max_blob_bytes, 123);
+    assert_eq!(config.oci.max_manifest_bytes, 456);
+    assert!(config.oci.bearer_auth);
+    let config = Config::from_yaml_str("{}", Path::new("/config"), listen(), None).unwrap();
+    assert_eq!(config.oci.max_blob_bytes, 10 * 1024 * 1024 * 1024);
+    assert_eq!(config.oci.max_manifest_bytes, 4 * 1024 * 1024);
+    assert!(!config.oci.bearer_auth);
+    for yaml in [
+        "oci: {maxBlobBytes: 0}",
+        "oci: {maxManifestBytes: 0}",
+        "oci: {maxBlobBytes: -1}",
+        "oci: {maxManifestByte: 1}",
+    ] {
+        assert!(
+            Config::from_yaml_str(yaml, Path::new("/config"), listen(), None).is_err(),
+            "{yaml}",
+        );
+    }
+}

--- a/pnpr/crates/oci/src/document.rs
+++ b/pnpr/crates/oci/src/document.rs
@@ -65,14 +65,19 @@ struct StoredImageDocument {
     manifests: Vec<ManifestEntry>,
     #[serde(default)]
     tags: Vec<TagEntry>,
+    #[serde(default)]
+    generation: u64,
+    #[serde(default)]
+    deleting_blob: Option<Digest>,
 }
 
 impl From<StoredImageDocument> for ImageDocument {
     fn from(stored: StoredImageDocument) -> Self {
-        let StoredImageDocument { name, mut manifests, mut tags } = stored;
+        let StoredImageDocument { name, mut manifests, mut tags, generation, deleting_blob } =
+            stored;
         manifests.sort_by(|left, right| left.digest.hex().cmp(right.digest.hex()));
         tags.sort_by(|left, right| left.tag.cmp(&right.tag));
-        Self { name, manifests, tags }
+        Self { name, manifests, tags, generation, deleting_blob }
     }
 }
 
@@ -94,6 +99,12 @@ pub struct ImageDocument {
     manifests: Vec<ManifestEntry>,
     #[serde(default)]
     tags: Vec<TagEntry>,
+    /// Fences journaled publishes prepared before an explicit blob deletion.
+    #[serde(default)]
+    pub generation: u64,
+    /// Blocks new publishes until the deletion completes or offline collection recovers it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deleting_blob: Option<Digest>,
 }
 
 impl ImageDocument {
@@ -200,6 +211,9 @@ impl ImageDocument {
     /// the two documents arrive in, which is what lets a journaled write be
     /// replayed after the one that superseded it.
     pub fn merge(&mut self, addition: Self, lost_blobs: &HashSet<String>) -> bool {
+        if self.generation != addition.generation || self.deleting_blob.is_some() {
+            return false;
+        }
         let mut changed = false;
         if self.name.is_empty() && !addition.name.is_empty() {
             self.name.clone_from(&addition.name);

--- a/pnpr/crates/oci/src/document.rs
+++ b/pnpr/crates/oci/src/document.rs
@@ -210,6 +210,10 @@ impl ImageDocument {
     /// bytes and is left alone. Tags reach the same result whichever order
     /// the two documents arrive in, which is what lets a journaled write be
     /// replayed after the one that superseded it.
+    ///
+    /// A generation mismatch or pending blob deletion refuses the addition
+    /// and returns `false`, just like an unchanged document. Older generations
+    /// cannot be replayed after deletion advances the stored generation.
     pub fn merge(&mut self, addition: Self, lost_blobs: &HashSet<String>) -> bool {
         if self.generation != addition.generation || self.deleting_blob.is_some() {
             return false;

--- a/pnpr/crates/oci/src/tests.rs
+++ b/pnpr/crates/oci/src/tests.rs
@@ -318,3 +318,20 @@ fn an_image_referrer_requires_an_artifact_type_or_config_media_type() {
         }
     }
 }
+
+#[test]
+fn deletion_generations_fence_staged_and_recovered_manifest_writes() {
+    let mut stored = ImageDocument::new("acme/app");
+    let mut staged = stored.clone();
+    staged.insert_manifest(entry("manifest"));
+    staged.set_tag(tag("latest", "manifest", 1));
+    stored.generation = 1;
+    stored.deleting_blob = Some(digest_of("layer"));
+    assert!(!stored.merge(staged.clone(), &HashSet::new()));
+    stored.deleting_blob = None;
+    assert!(!stored.merge(staged.clone(), &HashSet::new()));
+    assert!(stored.manifests().is_empty());
+    staged.generation = 1;
+    assert!(stored.merge(staged, &HashSet::new()));
+    assert!(stored.resolve("latest").is_some());
+}

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -79,6 +79,7 @@ miette                        = { workspace = true }
 node-semver                   = { workspace = true }
 pep440_rs                     = { workspace = true }
 pep508_rs                     = { workspace = true }
+p256                          = { workspace = true }
 object_store                  = { workspace = true }
 reqwest                       = { workspace = true }
 rusqlite                      = { workspace = true }

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -428,8 +428,9 @@ manifest removes its referrer entry; removing a tag keeps it.
 `Link` header when another page is available. `last` is an exclusive lexical
 cursor. `n=0` returns an empty list without a continuation link.
 
-The filesystem catalog uses a separate package index to find repositories nested
-under published repositories and repositories containing only uploaded blobs.
+The filesystem catalog uses a separate package index to find published repositories
+nested beneath either published or blob-only parent paths. The blob-only parents
+themselves remain absent until an operation creates their repository document.
 Startup indexes legacy stores once. This initial scan visits existing files;
 subsequent requests enumerate package names without walking layer files.
 
@@ -478,8 +479,8 @@ known CDN hosts. Configured credentials never travel to a layer CDN. Custom
 origins may use a token endpoint and downloads on their own origin.
 
 Manifest bodies are verified before caching. Blob bodies are verified while
-streaming and are cached only after a successful digest check. Clients still
-verify the streamed bytes. Tags refresh according to the configured upstream cache lifetime;
+streaming and are cached only after a successful digest check. A mismatch aborts
+the response stream. Clients still verify the streamed bytes. Tags refresh according to the configured upstream cache lifetime;
 digest-addressed content is immutable. `cache: false` disables this cache.
 Upstream writes, catalog enumeration, tag listing, and referrer discovery are
 not proxied. Hosted manifest and blob deletion require `unpublish` permission,

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -369,8 +369,16 @@ config and layer blobs. Removing a tag alone does not make its image collectible
 Missing or corrupt retained manifests stop collection before any blobs are
 deleted. The inventory includes unpublished repositories and nested repository
 names. Collection streams the inventory into a temporary SQLite database, so
-local temporary storage must have room for the inventory metadata. Online `DELETE` of individual blobs remains unsupported because a manifest
-publish could race the reference check; use offline collection to delete safely.
+local temporary storage must have room for the inventory metadata.
+
+`DELETE /v2/<name>/blobs/<digest>` removes an unreferenced blob when the caller
+has `unpublish` permission. A blob reachable from any retained manifest or index
+is refused. A stored deletion marker blocks concurrent manifest publication,
+and a generation counter rejects publishes staged before the deletion.
+If deletion is interrupted, stop all writers and run `oci-gc` without `--dry-run`
+to finish it and unblock the repository. Recovery of an explicit deletion ignores
+`--min-age-secs`. All replicas sharing a store must run this version before using
+online deletion.
 
 
 `GET /v2/` answers `401` with a `Basic` challenge to an anonymous caller even
@@ -381,7 +389,17 @@ admits anonymous reads still answers its later requests.
 
 Blobs are uploaded in one request or in chunks, streamed to disk rather than
 held in memory, and verified against the digest the client promised before
-anything is stored. A layer may be up to 10 GiB and a manifest up to 4 MiB.
+anything is stored. By default, a layer may be up to 10 GiB and a manifest up to
+4 MiB. Configure positive byte limits with:
+
+```yaml
+oci:
+  maxBlobBytes: 10737418240
+  maxManifestBytes: 4194304
+```
+
+The blob limit applies to the entire resumable upload, including mounted layers.
+It also bounds uncached upstream downloads.
 The manifest write is the point a release becomes visible: it goes through the
 same publish journal as every other ecosystem, so it either lands whole or
 leaves nothing behind. A blob no manifest references is invisible rather than
@@ -410,9 +428,62 @@ manifest removes its referrer entry; removing a tag keeps it.
 `Link` header when another page is available. `last` is an exclusive lexical
 cursor. `n=0` returns an empty list without a continuation link.
 
-Proxying an upstream image registry and online blob deletion are not yet served.
-Deleting a manifest needs a registry whose `unpublish` rule admits the caller,
-which the per-registry default does not.
+The filesystem catalog uses a separate package index to find repositories nested
+under published repositories and repositories containing only uploaded blobs.
+Startup indexes legacy stores once. This initial scan visits existing files;
+subsequent requests enumerate package names without walking layer files.
+
+Set `oci.bearerAuth: true` to offer a Bearer challenge. Clients exchange their
+pnpr credential at `/v2/token` for a five-minute token scoped to repository
+`pull`, `push`, or `delete` actions. The endpoint grants only permitted actions.
+The parent credential's revocation, read-only flag, and network restrictions
+remain effective. Anonymous tokens can pull public repositories. Use the same
+`secret:` and registry configuration on all replicas so their tokens interoperate.
+Scoped tokens cannot access other pnpr APIs or the whole catalog.
+
+An OCI batch entry publishes a manifest whose layers have already been uploaded:
+
+```json
+{
+  "ecosystem": "oci",
+  "name": "acme/app",
+  "reference": "1.0",
+  "manifest": "<base64-encoded manifest bytes>"
+}
+```
+
+Include this entry alongside npm, Cargo, or Python entries in the `packages`
+array of `PUT /-/pnpr/v0/publish`. `contentType` is optional when the manifest
+contains its media type. An index's child manifests must already be published.
+The batch body keeps the endpoint's existing size limit; upload large layers
+through the streaming `/v2/` API first.
+
+Docker Hub and GHCR can be configured as pull-through upstreams:
+
+```yaml
+registries:
+  dockerhub:
+    type: upstream
+    ecosystem: oci
+    url: https://registry-1.docker.io/
+    public: true
+defaultRegistry: dockerhub
+```
+
+Pull an official Hub image as `pnpr.example.com/library/alpine:latest`. For GHCR,
+use `https://ghcr.io/` and the full repository name. Private origins use the
+existing upstream `auth:` configuration and access rules. pnpr negotiates
+repository-scoped pull tokens and restricts layer redirects to the origin's
+known CDN hosts. Configured credentials never travel to a layer CDN. Custom
+origins may use a token endpoint and downloads on their own origin.
+
+Manifest bodies are verified before caching. Blob bodies are verified while
+streaming and are cached only after a successful digest check. Clients still
+verify the streamed bytes. Tags refresh according to the configured upstream cache lifetime;
+digest-addressed content is immutable. `cache: false` disables this cache.
+Upstream writes, catalog enumeration, tag listing, and referrer discovery are
+not proxied. Hosted manifest and blob deletion require `unpublish` permission,
+which the registry default denies.
 
 ## License
 

--- a/pnpr/crates/pnpr/src/oci_maintenance.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance.rs
@@ -42,7 +42,7 @@ pub async fn collect_oci_blobs(
     } else {
         HashSet::new()
     };
-    collect(&storage, min_age, dry_run, &excluded).await
+    collect(&storage, min_age, dry_run, &excluded, config.oci.max_manifest_bytes).await
 }
 
 async fn collect(
@@ -50,6 +50,7 @@ async fn collect(
     min_age: Duration,
     dry_run: bool,
     excluded: &HashSet<&str>,
+    manifest_limit: usize,
 ) -> Result<(usize, u64)> {
     let temporary = tempfile::NamedTempFile::new()?;
     let inventory = Connection::open(temporary.path())?;
@@ -103,7 +104,7 @@ async fn collect(
         .optional()?
     {
         let name = CanonicalPackageName::parse(&repository, Ecosystem::Oci)?;
-        let reachable = referenced_blobs(storage, &name).await?;
+        let reachable = referenced_blobs(storage, &name, manifest_limit).await?;
         for filename in reachable {
             inventory.execute(
                 "UPDATE blobs SET keep = 1 WHERE repository = ? AND filename = ?",
@@ -137,6 +138,40 @@ async fn collect(
             bytes += size;
         }
     }
+    if !dry_run {
+        let mut previous = String::new();
+        while let Some(repository) = inventory
+            .query_row(
+                "SELECT name FROM repositories WHERE name > ? ORDER BY name LIMIT 1",
+                [&previous],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+        {
+            let name = CanonicalPackageName::parse(&repository, Ecosystem::Oci)?;
+            previous = repository;
+            let Some(body) = storage.read_hosted_document(&name).await? else { continue };
+            let mut document = ImageDocument::parse(&body)?;
+            if let Some(digest) = document.deleting_blob.take() {
+                let size = storage
+                    .open_hosted_blob(&name, &digest.blob_filename())
+                    .await?
+                    .and_then(|(_, size)| size)
+                    .unwrap_or_default();
+                if storage.remove_hosted_blob(&name, &digest.blob_filename()).await? {
+                    removed += 1;
+                    bytes += size;
+                }
+                storage
+                    .update_hosted_document_with_retry(
+                        &name,
+                        pnpr_storage::DOCUMENT_WRITE_RETRIES,
+                        |_| Ok(Some(document.to_bytes())),
+                    )
+                    .await?;
+            }
+        }
+    }
     Ok((removed, bytes))
 }
 
@@ -147,9 +182,19 @@ fn filename_digest(filename: &str) -> Option<Digest> {
 async fn referenced_blobs(
     storage: &Storage,
     name: &CanonicalPackageName,
+    manifest_limit: usize,
 ) -> Result<HashSet<String>> {
     let Some(bytes) = storage.read_hosted_document(name).await? else { return Ok(HashSet::new()) };
     let document = ImageDocument::parse(&bytes)?;
+    referenced_document_blobs(storage, name, &document, manifest_limit).await
+}
+
+pub(crate) async fn referenced_document_blobs(
+    storage: &Storage,
+    name: &CanonicalPackageName,
+    document: &ImageDocument,
+    manifest_limit: usize,
+) -> Result<HashSet<String>> {
     let mut pending: Vec<(Digest, Option<String>)> = document
         .manifests()
         .iter()
@@ -170,7 +215,7 @@ async fn referenced_blobs(
             .open_hosted_blob(name, &filename)
             .await?
             .ok_or_else(|| invalid("retained manifest is missing".into()))?;
-        let bytes = axum::body::to_bytes(body, 4 * 1024 * 1024)
+        let bytes = axum::body::to_bytes(body, manifest_limit)
             .await
             .map_err(|error| invalid(error.to_string()))?;
         if Digest::of(&bytes) != digest {
@@ -187,6 +232,15 @@ async fn referenced_blobs(
                 pending.push((reference.digest.clone(), content_type));
             }
         }
+    }
+    if document
+        .deleting_blob
+        .as_ref()
+        .is_some_and(|digest| reachable.contains(&digest.blob_filename()))
+    {
+        return Err(RegistryError::BadRequest {
+            reason: format!("pending deletion in {} references a retained blob", name.as_str()),
+        });
     }
     Ok(reachable)
 }

--- a/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
@@ -8,6 +8,8 @@ use serde_json::json;
 use std::{collections::HashSet, time::Duration};
 use tempfile::TempDir;
 
+const MANIFEST_LIMIT: usize = 4 * 1024 * 1024;
+
 fn setup() -> (TempDir, Storage) {
     let temp = TempDir::new().unwrap();
     let storage =
@@ -56,20 +58,20 @@ async fn collection_keeps_untagged_manifests_and_layers_and_finds_nested_orphans
     let nested = name("acme/app/tool");
     let nested_orphan = blob(&storage, &nested, b"nested orphan").await;
     assert_eq!(
-        collect(&storage, Duration::from_hours(24), false, &HashSet::new(), 4 * 1024 * 1024)
+        collect(&storage, Duration::from_hours(24), false, &HashSet::new(), MANIFEST_LIMIT)
             .await
             .unwrap(),
         (0, 0),
     );
     assert_eq!(
-        collect(&storage, Duration::ZERO, true, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, true, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (2, 19),
     );
     assert!(
         storage.open_hosted_blob(&nested, &nested_orphan.blob_filename()).await.unwrap().is_some(),
     );
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (2, 19),
     );
     assert!(
@@ -89,7 +91,7 @@ async fn corrupt_or_missing_manifests_prevent_deletion() {
     let orphan = blob(&storage, &name("aaa"), b"orphan").await;
     let path = temp.path().join("store/acme/app").join(manifest.blob_filename());
     tokio::fs::write(&path, b"corrupt").await.unwrap();
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT)
         .await
         .unwrap_err();
     assert!(
@@ -99,7 +101,7 @@ async fn corrupt_or_missing_manifests_prevent_deletion() {
         storage.open_hosted_blob(&name("aaa"), &orphan.blob_filename()).await.unwrap().is_some(),
     );
     tokio::fs::remove_file(path).await.unwrap();
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT)
         .await
         .unwrap_err();
     assert!(
@@ -130,11 +132,11 @@ async fn index_keeps_children_removed_from_the_document_and_their_layers() {
         .await
         .unwrap();
     assert_eq!(
-        referenced_blobs(&storage, &repository, 4 * 1024 * 1024).await.unwrap(),
+        referenced_blobs(&storage, &repository, MANIFEST_LIMIT).await.unwrap(),
         HashSet::from([index.blob_filename(), child.blob_filename(), layer.blob_filename()]),
     );
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (0, 0),
     );
 }
@@ -145,7 +147,7 @@ async fn flat_registry_collection_excludes_other_namespaces() {
     blob(&storage, &name("other/app"), b"private").await;
     blob(&storage, &name("app"), b"orphan").await;
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::from(["other"]), 4 * 1024 * 1024)
+        collect(&storage, Duration::ZERO, false, &HashSet::from(["other"]), MANIFEST_LIMIT)
             .await
             .unwrap(),
         (1, 6),
@@ -174,7 +176,7 @@ async fn collection_uses_the_stored_media_type_for_header_only_manifests() {
         .await
         .unwrap();
     assert_eq!(
-        referenced_blobs(&storage, &repository, 4 * 1024 * 1024).await.unwrap(),
+        referenced_blobs(&storage, &repository, MANIFEST_LIMIT).await.unwrap(),
         HashSet::from([digest.blob_filename(), layer.blob_filename()]),
     );
 }
@@ -195,7 +197,7 @@ async fn a_document_without_any_blob_files_still_blocks_collection_when_corrupt(
         .await
         .unwrap();
     let orphan = blob(&storage, &name("aaa"), b"orphan").await;
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT)
         .await
         .unwrap_err();
     assert!(
@@ -219,15 +221,15 @@ async fn collection_streams_an_object_store_inventory() {
     retained_image(&storage, &repository).await;
     blob(&storage, &name("acme/app/nested"), b"orphan").await;
     assert_eq!(
-        collect(&storage, Duration::ZERO, true, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, true, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (1, 6),
     );
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (1, 6),
     );
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (0, 0),
     );
 }
@@ -242,7 +244,7 @@ async fn collection_does_not_remove_a_matching_blob_from_the_shared_cache() {
     tokio::fs::create_dir_all(cache.parent().unwrap()).await.unwrap();
     tokio::fs::write(&cache, b"cached").await.unwrap();
     assert_eq!(
-        collect(&hosted, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        collect(&hosted, Duration::ZERO, false, &HashSet::new(), MANIFEST_LIMIT).await.unwrap(),
         (1, 6),
     );
     assert_eq!(tokio::fs::read(cache).await.unwrap(), b"cached");
@@ -260,15 +262,21 @@ async fn offline_collection_finishes_interrupted_explicit_deletion() {
         .write_hosted_document_if_current(&repository, &document.to_bytes(), None)
         .await
         .unwrap();
-    collect(&storage, Duration::from_hours(24), true, &HashSet::new(), 4 * 1024 * 1024)
-        .await
-        .unwrap();
+    assert_eq!(
+        collect(&storage, Duration::from_hours(24), true, &HashSet::new(), MANIFEST_LIMIT)
+            .await
+            .unwrap(),
+        (0, 0),
+    );
     assert!(
         storage.open_hosted_blob(&repository, &digest.blob_filename()).await.unwrap().is_some(),
     );
-    collect(&storage, Duration::from_hours(24), false, &HashSet::new(), 4 * 1024 * 1024)
-        .await
-        .unwrap();
+    assert_eq!(
+        collect(&storage, Duration::from_hours(24), false, &HashSet::new(), MANIFEST_LIMIT)
+            .await
+            .unwrap(),
+        (1, 16),
+    );
     assert!(
         storage.open_hosted_blob(&repository, &digest.blob_filename()).await.unwrap().is_none(),
     );

--- a/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
+++ b/pnpr/crates/pnpr/src/oci_maintenance/tests.rs
@@ -56,14 +56,22 @@ async fn collection_keeps_untagged_manifests_and_layers_and_finds_nested_orphans
     let nested = name("acme/app/tool");
     let nested_orphan = blob(&storage, &nested, b"nested orphan").await;
     assert_eq!(
-        collect(&storage, Duration::from_hours(24), false, &HashSet::new()).await.unwrap(),
+        collect(&storage, Duration::from_hours(24), false, &HashSet::new(), 4 * 1024 * 1024)
+            .await
+            .unwrap(),
         (0, 0),
     );
-    assert_eq!(collect(&storage, Duration::ZERO, true, &HashSet::new()).await.unwrap(), (2, 19));
+    assert_eq!(
+        collect(&storage, Duration::ZERO, true, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (2, 19),
+    );
     assert!(
         storage.open_hosted_blob(&nested, &nested_orphan.blob_filename()).await.unwrap().is_some(),
     );
-    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (2, 19));
+    assert_eq!(
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (2, 19),
+    );
     assert!(
         storage.open_hosted_blob(&repository, &manifest.blob_filename()).await.unwrap().is_some(),
     );
@@ -81,7 +89,9 @@ async fn corrupt_or_missing_manifests_prevent_deletion() {
     let orphan = blob(&storage, &name("aaa"), b"orphan").await;
     let path = temp.path().join("store/acme/app").join(manifest.blob_filename());
     tokio::fs::write(&path, b"corrupt").await.unwrap();
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+        .await
+        .unwrap_err();
     assert!(
         matches!(error, RegistryError::BadRequest { reason } if reason.contains("manifest digest mismatch")),
     );
@@ -89,7 +99,9 @@ async fn corrupt_or_missing_manifests_prevent_deletion() {
         storage.open_hosted_blob(&name("aaa"), &orphan.blob_filename()).await.unwrap().is_some(),
     );
     tokio::fs::remove_file(path).await.unwrap();
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+        .await
+        .unwrap_err();
     assert!(
         matches!(error, RegistryError::BadRequest { reason } if reason.contains("retained manifest is missing")),
     );
@@ -118,10 +130,13 @@ async fn index_keeps_children_removed_from_the_document_and_their_layers() {
         .await
         .unwrap();
     assert_eq!(
-        referenced_blobs(&storage, &repository).await.unwrap(),
+        referenced_blobs(&storage, &repository, 4 * 1024 * 1024).await.unwrap(),
         HashSet::from([index.blob_filename(), child.blob_filename(), layer.blob_filename()]),
     );
-    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (0, 0));
+    assert_eq!(
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (0, 0),
+    );
 }
 
 #[tokio::test]
@@ -130,7 +145,9 @@ async fn flat_registry_collection_excludes_other_namespaces() {
     blob(&storage, &name("other/app"), b"private").await;
     blob(&storage, &name("app"), b"orphan").await;
     assert_eq!(
-        collect(&storage, Duration::ZERO, false, &HashSet::from(["other"])).await.unwrap(),
+        collect(&storage, Duration::ZERO, false, &HashSet::from(["other"]), 4 * 1024 * 1024)
+            .await
+            .unwrap(),
         (1, 6),
     );
 }
@@ -157,7 +174,7 @@ async fn collection_uses_the_stored_media_type_for_header_only_manifests() {
         .await
         .unwrap();
     assert_eq!(
-        referenced_blobs(&storage, &repository).await.unwrap(),
+        referenced_blobs(&storage, &repository, 4 * 1024 * 1024).await.unwrap(),
         HashSet::from([digest.blob_filename(), layer.blob_filename()]),
     );
 }
@@ -178,7 +195,9 @@ async fn a_document_without_any_blob_files_still_blocks_collection_when_corrupt(
         .await
         .unwrap();
     let orphan = blob(&storage, &name("aaa"), b"orphan").await;
-    let error = collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap_err();
+    let error = collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024)
+        .await
+        .unwrap_err();
     assert!(
         matches!(error, RegistryError::BadRequest { reason } if reason.contains("retained manifest is missing")),
     );
@@ -199,9 +218,18 @@ async fn collection_streams_an_object_store_inventory() {
     let repository = name("acme/app");
     retained_image(&storage, &repository).await;
     blob(&storage, &name("acme/app/nested"), b"orphan").await;
-    assert_eq!(collect(&storage, Duration::ZERO, true, &HashSet::new()).await.unwrap(), (1, 6));
-    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (1, 6));
-    assert_eq!(collect(&storage, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (0, 0));
+    assert_eq!(
+        collect(&storage, Duration::ZERO, true, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (1, 6),
+    );
+    assert_eq!(
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (1, 6),
+    );
+    assert_eq!(
+        collect(&storage, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (0, 0),
+    );
 }
 
 #[tokio::test]
@@ -213,6 +241,40 @@ async fn collection_does_not_remove_a_matching_blob_from_the_shared_cache() {
     let cache = temp.path().join("cache/acme/app").join(digest.blob_filename());
     tokio::fs::create_dir_all(cache.parent().unwrap()).await.unwrap();
     tokio::fs::write(&cache, b"cached").await.unwrap();
-    assert_eq!(collect(&hosted, Duration::ZERO, false, &HashSet::new()).await.unwrap(), (1, 6));
+    assert_eq!(
+        collect(&hosted, Duration::ZERO, false, &HashSet::new(), 4 * 1024 * 1024).await.unwrap(),
+        (1, 6),
+    );
     assert_eq!(tokio::fs::read(cache).await.unwrap(), b"cached");
+}
+
+#[tokio::test]
+async fn offline_collection_finishes_interrupted_explicit_deletion() {
+    let (_temp, storage) = setup();
+    let repository = name("acme/app");
+    let digest = blob(&storage, &repository, b"pending deletion").await;
+    let mut document = ImageDocument::new(repository.as_str());
+    document.generation = 1;
+    document.deleting_blob = Some(digest.clone());
+    storage
+        .write_hosted_document_if_current(&repository, &document.to_bytes(), None)
+        .await
+        .unwrap();
+    collect(&storage, Duration::from_hours(24), true, &HashSet::new(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    assert!(
+        storage.open_hosted_blob(&repository, &digest.blob_filename()).await.unwrap().is_some(),
+    );
+    collect(&storage, Duration::from_hours(24), false, &HashSet::new(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    assert!(
+        storage.open_hosted_blob(&repository, &digest.blob_filename()).await.unwrap().is_none(),
+    );
+    let document =
+        ImageDocument::parse(&storage.read_hosted_document(&repository).await.unwrap().unwrap())
+            .unwrap();
+    assert_eq!(document.generation, 1);
+    assert!(document.deleting_blob.is_none());
 }

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -210,7 +210,13 @@ fn load_active_osv_index(config: &Config) -> pnpr_error::Result<Option<Arc<pnpr_
 /// call this before binding; an embedder that builds a router directly should
 /// call it itself on startup, before serving requests.
 pub async fn recover_publish_journal(config: &Config) -> pnpr_error::Result<()> {
-    pnpr_storage::journal::recover_publish_journal(config, &RegistryDocuments).await
+    pnpr_storage::journal::recover_publish_journal(config, &RegistryDocuments).await?;
+    let storage =
+        Storage::new(&config.hosted_store, config.storage.clone(), config.cache_storage.clone())?;
+    for hosted in config.hosted.values() {
+        storage.for_hosted(&hosted.org).rebuild_package_index().await?;
+    }
+    Ok(())
 }
 
 /// Reclaim blob uploads abandoned before an unclean shutdown, and any left

--- a/pnpr/crates/pnpr/src/server/authentication.rs
+++ b/pnpr/crates/pnpr/src/server/authentication.rs
@@ -90,6 +90,38 @@ pub(super) async fn authenticate(
     let path = request.uri().path().to_owned();
     let peer = request.extensions().get::<ConnectInfo<PeerAddr>>().map(|info| info.0.0);
 
+    if let Some(raw) = header.as_deref().and_then(token_credentials) {
+        match super::oci::tokens::decode(&state, &raw) {
+            Ok(Some(claims)) => {
+                if !claims.permits(&path, &method) {
+                    return super::oci::tokens::rejected(&state, &path, &method);
+                }
+                let identity = match &claims.parent {
+                    Some(parent) => match state.inner.auth.tokens.find_by_key(parent).await {
+                        Ok(Some(record)) => {
+                            if let Err(err) =
+                                check_token_restrictions(&record, &method, &path, peer)
+                            {
+                                return err.into_response();
+                            }
+                            Identity::user(record.username)
+                        }
+                        Ok(None) => return super::oci::tokens::rejected(&state, &path, &method),
+                        Err(err) => return err.into_response(),
+                    },
+                    None => Identity::Anonymous,
+                };
+                request.extensions_mut().insert(AuthedCaller(identity));
+                return next.run(request).await;
+            }
+            Ok(None) => {}
+            Err(RegistryError::Unauthenticated { .. }) => {
+                return super::oci::tokens::rejected(&state, &path, &method);
+            }
+            Err(err) => return err.into_response(),
+        }
+    }
+
     let identity = match resolve_caller(&state, header.as_deref(), &method, &path, peer).await {
         Ok(identity) => identity,
         Err(err) => return err.into_response(),

--- a/pnpr/crates/pnpr/src/server/batch.rs
+++ b/pnpr/crates/pnpr/src/server/batch.rs
@@ -26,6 +26,7 @@
 use super::{
     AppState, AuthedCaller, Identity,
     cargo::{CratePublication, authorize_crate_publish, verify_crate_archive},
+    oci::{OciPublication, authorize_publication},
     publishing::{
         StagedPublish, cleanup_tmp_slots, commit_publishes, publish_created_response,
         report_unrecorded, stage_publish, validate_publish_doc,
@@ -83,12 +84,22 @@ struct PypiEntry {
     sha256_digest: Option<String>,
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OciEntry {
+    name: String,
+    reference: String,
+    manifest: String,
+    content_type: Option<String>,
+}
+
 /// One entry of the batch, checked as far as it can be before any package
 /// lock is held: the caller may publish it, and it carries what it claims.
 enum ValidatedEntry {
     Npm(Box<super::publishing::ValidatedPublish>, String),
     Cargo(CratePublication),
     Pypi(PypiPublication),
+    Oci(OciPublication),
 }
 
 impl ValidatedEntry {
@@ -97,6 +108,7 @@ impl ValidatedEntry {
             ValidatedEntry::Npm(..) => Ecosystem::Npm,
             ValidatedEntry::Cargo(_) => Ecosystem::Cargo,
             ValidatedEntry::Pypi(_) => Ecosystem::Pypi,
+            ValidatedEntry::Oci(_) => Ecosystem::Oci,
         }
     }
 
@@ -105,6 +117,7 @@ impl ValidatedEntry {
             ValidatedEntry::Npm(doc, _) => &doc.name,
             ValidatedEntry::Cargo(publication) => publication.key(),
             ValidatedEntry::Pypi(publication) => publication.key(),
+            ValidatedEntry::Oci(publication) => publication.key(),
         }
     }
 
@@ -113,6 +126,7 @@ impl ValidatedEntry {
             ValidatedEntry::Npm(doc, org) => stage_publish(state, *doc, now, Some(&org)).await,
             ValidatedEntry::Cargo(publication) => publication.stage(state).await,
             ValidatedEntry::Pypi(publication) => publication.stage(state).await,
+            ValidatedEntry::Oci(publication) => publication.stage(state).await.map_err(Into::into),
         }
     }
 }
@@ -240,12 +254,22 @@ async fn validate_entry(
             upload.content = decode_base64(&entry.content, "content")?;
             Ok(ValidatedEntry::Pypi(verify_upload(target, upload)?))
         }
-        // An image release is pushed as many requests — every blob, then the
-        // manifest that references them — so there is no single entry this
-        // endpoint could carry. The manifest PUT is already its atomic point.
-        Ecosystem::Oci => Err(RegistryError::BadRequest {
-            reason: "images are published through the /v2/ endpoints, not this batch".to_string(),
-        }),
+        Ecosystem::Oci => {
+            let entry: OciEntry =
+                serde_json::from_value(package).map_err(|err| malformed_body(&err))?;
+            let target = authorize_publication(state, identity, None, &entry.name)
+                .map_err(RegistryError::from)?;
+            let bytes = decode_base64(&entry.manifest, "manifest")?;
+            OciPublication::new(
+                target,
+                entry.reference,
+                bytes.into(),
+                entry.content_type.as_deref(),
+                state.inner.config.oci.max_manifest_bytes,
+            )
+            .map(ValidatedEntry::Oci)
+            .map_err(RegistryError::from)
+        }
     }
 }
 

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -284,6 +284,7 @@ pub(super) fn upstream_fetch_guard(
         let Some(base) = &base else { return false };
         is_fetchable_artifact_url(url)
             && (url.origin() == base.origin()
+                || pnpr_upstream::oci_download_allowed(base, url)
                 || context.allows_registry(url.as_str())
                 || (base.as_str() == "https://index.crates.io/"
                     && url.origin().ascii_serialization() == "https://static.crates.io")

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -15,13 +15,18 @@
 //! than half-published, which is what makes the split safe, and why
 //! collecting unreferenced blobs is a job of its own.
 
+mod deletion;
+mod proxy;
+mod publication;
+pub(super) mod tokens;
+
+pub(super) use publication::{OciPublication, authorize_publication};
+
 use super::{
     Action, AppState, AuthedCaller, RegistrySource, TargetRegistry, authorize,
-    documents::{read_hosted_document, store_hosted_artifact},
+    documents::read_hosted_document,
     ecosystem::{addressed_registry, caller_scoped, hosted_sources, mount_bases},
-    hosted_read_namespace, private_no_cache,
-    publishing::{PublishTarget, resolve_publish_target_for},
-    resolve_ecosystem_source,
+    hosted_read_namespace, private_no_cache, resolve_ecosystem_source,
 };
 use axum::{
     Router,
@@ -34,8 +39,7 @@ use axum::{
 use futures_util::StreamExt as _;
 use pnpr_error::RegistryError;
 use pnpr_oci::{
-    API_SEGMENT, Digest, ErrorBody, ErrorCode, ImageDocument, Manifest, ManifestEntry, TagEntry,
-    is_valid_tag, media_type,
+    API_SEGMENT, Digest, ErrorBody, ErrorCode, ImageDocument, Manifest, ManifestEntry, media_type,
 };
 use pnpr_package_name::CanonicalPackageName;
 use pnpr_policy::Identity;
@@ -45,24 +49,12 @@ use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentUpdate, Storage, upload::Blob
 use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
 use tokio::io::AsyncReadExt as _;
 
 const ECOSYSTEM: Ecosystem = Ecosystem::Oci;
-
-/// The largest manifest accepted. The distribution spec puts the ceiling at
-/// 4 MiB; a manifest is a list of digests, so real ones are far smaller.
-const MAX_MANIFEST_BYTES: usize = 4 * 1024 * 1024;
-
-/// The largest single blob accepted. Image layers are the only artifact pnpr
-/// serves that routinely runs to gigabytes.
-///
-/// As a `DefaultBodyLimit` this bounds one request. A resumable upload is many
-/// requests, so [`append_body`] holds the whole upload to the same
-/// ceiling; without that, chunks that are each under the limit add up past it.
-const MAX_BLOB_BYTES: usize = 10 * 1024 * 1024 * 1024;
 
 /// The most distinct blobs one manifest may reference. An image index lists
 /// a handful of manifests and an image its layers, so this is far above any
@@ -93,15 +85,13 @@ pub(super) fn routes(prefixed: bool) -> Router<AppState> {
     let mut router = Router::new();
     for base in bases {
         router = router
+            .route(&format!("{base}/{API_SEGMENT}/token"), get(tokens::issue))
             .route(&format!("{base}/{API_SEGMENT}/"), get(get_version_check))
             .route(&format!("{base}/{API_SEGMENT}"), get(get_version_check))
             .route(&format!("{base}/{API_SEGMENT}/{{*path}}"), any(dispatch));
     }
-    // Layers are the one artifact pnpr serves that outgrows the publish body
-    // limit the rest of the router carries. `route_layer` so the limit
-    // applies to these routes without giving the router a fallback of its
-    // own, which would make it unmergeable.
-    router.route_layer(DefaultBodyLimit::max(MAX_BLOB_BYTES))
+    // Streaming handlers enforce the configured cumulative upload limit.
+    router.route_layer(DefaultBodyLimit::disable())
 }
 
 /// `GET /v2/` — the version check every client makes first, and what
@@ -110,6 +100,8 @@ async fn get_version_check(
     State(state): State<AppState>,
     AuthedCaller(identity): AuthedCaller,
     TargetRegistry(registry): TargetRegistry,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
 ) -> Response {
     if addressed_registry(&state, registry.as_deref()).is_none() {
         return error(ErrorCode::NameUnknown, "no registry is addressed here");
@@ -119,8 +111,19 @@ async fn get_version_check(
     // caller is challenged even where reads are open: without the challenge
     // a push could not authenticate. A caller with no credentials carries on
     // regardless, and public repositories still answer its later requests.
-    if identity == Identity::Anonymous {
-        return error(ErrorCode::Unauthorized, "authentication required");
+    if identity == Identity::Anonymous
+        && !headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(super::authentication::token_credentials)
+            .is_some_and(|token| token.starts_with("pnpr_oci_"))
+    {
+        return tokens::challenge(
+            &state,
+            uri.path().trim_end_matches('/'),
+            None,
+            error(ErrorCode::Unauthorized, "authentication required"),
+        );
     }
     api_version(StatusCode::OK.into_response())
 }
@@ -151,7 +154,16 @@ async fn dispatch(
         query: uri.query().unwrap_or_default().to_string(),
         headers: parts.headers,
     };
-    match endpoint {
+    let scope_name = match &endpoint {
+        Endpoint::Catalog => None,
+        Endpoint::Referrers { name, .. }
+        | Endpoint::Tags { name }
+        | Endpoint::Manifest { name, .. }
+        | Endpoint::Blob { name, .. }
+        | Endpoint::StartUpload { name }
+        | Endpoint::Upload { name, .. } => Some(name.clone()),
+    };
+    let response = match endpoint {
         Endpoint::Referrers { name, digest } => request.referrers(&name, &digest).await,
         Endpoint::Catalog => request.catalog().await,
         Endpoint::Tags { name } => request.tags(&name).await,
@@ -159,7 +171,8 @@ async fn dispatch(
         Endpoint::Blob { name, digest } => request.blob(&name, &digest).await,
         Endpoint::StartUpload { name } => request.start_upload(&name, body).await,
         Endpoint::Upload { name, id } => request.upload(&name, &id, body).await,
-    }
+    };
+    request.challenge(scope_name.as_deref(), response)
 }
 
 /// Which endpoint a captured path tail addresses.
@@ -266,6 +279,16 @@ impl Request {
     ) -> Result<Option<Response>, RegistryError> {
         let Ok(digest) = Digest::parse(mount) else { return Ok(None) };
         let Ok((source_key, source)) = self.hosted_source(from) else { return Ok(None) };
+        if let Some(raw) = self
+            .headers
+            .get(header::AUTHORIZATION)
+            .and_then(|value| value.to_str().ok())
+            .and_then(super::authentication::token_credentials)
+            && let Some(claims) = tokens::decode(&self.state, &raw)?
+            && !claims.allows(source_key.as_str(), "pull")
+        {
+            return Ok(None);
+        }
         let source_org = match hosted_read_namespace(
             &self.state,
             &self.identity,
@@ -287,7 +310,10 @@ impl Request {
             return Ok(None);
         };
         let upload = destination.begin_blob_upload(key).await?;
-        if let Err(refusal) = append_body(destination, &upload, body).await {
+        if let Err(refusal) =
+            append_body(destination, &upload, body, self.state.inner.config.oci.max_blob_bytes)
+                .await
+        {
             destination.abort_blob_upload(upload.id()).await?;
             return Ok(Some(refusal.respond()));
         }
@@ -375,8 +401,13 @@ impl Request {
                     };
                     continue;
                 }
-                let bytes = match read_manifest_bytes(&storage, &key, &entry.digest.blob_filename())
-                    .await
+                let bytes = match read_manifest_bytes(
+                    &storage,
+                    &key,
+                    &entry.digest.blob_filename(),
+                    self.state.inner.config.oci.max_manifest_bytes,
+                )
+                .await
                 {
                     Ok(Some(bytes)) => bytes,
                     Ok(None) => {
@@ -412,7 +443,8 @@ impl Request {
                             Err(err) => return registry_error(err.into()),
                         };
                     if !referrers.is_empty()
-                        && response_bytes + descriptor_bytes > MAX_MANIFEST_BYTES
+                        && response_bytes + descriptor_bytes
+                            > self.state.inner.config.oci.max_manifest_bytes
                     {
                         break;
                     }
@@ -511,6 +543,8 @@ impl Request {
             // A listing may only name what this caller could have fetched.
             repositories.extend(names.into_iter().filter(|name| {
                 last.as_ref().is_none_or(|last| name > last)
+                    && CanonicalPackageName::parse(name, ECOSYSTEM).is_ok()
+                    && matches!(resolve_ecosystem_source(&self.state, &target, ECOSYSTEM, name), RegistrySource::Hosted(ref resolved) if resolved == &source)
                     && authorize(
                         &self.state,
                         &self.identity,
@@ -586,6 +620,9 @@ impl Request {
     }
 
     async fn read_manifest(&self, name: &str, reference: &str) -> Response {
+        if let Some((key, source)) = self.upstream_source(name) {
+            return self.proxy_manifest(&key, &source, reference).await;
+        }
         let (key, source) = match self.hosted_source(name) {
             Ok(found) => found,
             Err(refusal) => return refusal.respond(),
@@ -608,7 +645,14 @@ impl Request {
         let storage = self.state.inner.storage.for_hosted(&org);
         // A manifest is small enough to answer from memory, and the response
         // carries its digest and media type either way.
-        let bytes = match read_manifest_bytes(&storage, &key, &entry.digest.blob_filename()).await {
+        let bytes = match read_manifest_bytes(
+            &storage,
+            &key,
+            &entry.digest.blob_filename(),
+            self.state.inner.config.oci.max_manifest_bytes,
+        )
+        .await
+        {
             Ok(Some(bytes)) => bytes,
             Ok(None) => return error(ErrorCode::ManifestUnknown, "no such manifest"),
             Err(err) => return registry_error(err),
@@ -634,117 +678,31 @@ impl Request {
         };
         let content_type =
             self.headers.get(header::CONTENT_TYPE).and_then(|value| value.to_str().ok());
-        let bytes = match collect_body(body, MAX_MANIFEST_BYTES).await {
+        let bytes = match collect_body(body, self.state.inner.config.oci.max_manifest_bytes).await {
             Ok(bytes) => bytes,
             Err(refusal) => return refusal.respond(),
         };
-        let digest = Digest::of(&bytes);
-        // A manifest pushed under a digest must be the bytes that digest
-        // names, or a later pull by it would serve something else.
-        if Digest::parse(reference).is_ok_and(|addressed| addressed != digest) {
-            return error(
-                ErrorCode::DigestInvalid,
-                "manifest does not match the digest it was pushed under",
-            );
-        }
-        let manifest = match Manifest::parse(&bytes, content_type) {
-            Ok(manifest) => manifest,
-            Err(err) => return error(ErrorCode::ManifestInvalid, err.to_string()),
+        let publication = match OciPublication::new(
+            (key, org),
+            reference.to_string(),
+            bytes,
+            content_type,
+            self.state.inner.config.oci.max_manifest_bytes,
+        ) {
+            Ok(publication) => publication,
+            Err(refusal) => return refusal.respond(),
         };
-        let storage = self.state.inner.storage.for_hosted(&org);
-        // One digest is looked up once however often the manifest names it,
-        // and a manifest that names more than any image could is refused:
-        // otherwise a single 4 MiB body of repeated descriptors becomes tens
-        // of thousands of blob lookups.
-        let mut looked_up = HashSet::new();
-        for descriptor in manifest.references() {
-            if !looked_up.insert(descriptor.digest.clone()) {
-                continue;
-            }
-            if looked_up.len() > MAX_MANIFEST_REFERENCES {
-                return error(
-                    ErrorCode::ManifestInvalid,
-                    format!(
-                        "a manifest may not reference more than {MAX_MANIFEST_REFERENCES} blobs",
-                    ),
-                );
-            }
-            // The size is part of what a client verifies, so a descriptor that
-            // disagrees with the stored bytes publishes an image nothing can
-            // pull. Refuse it here rather than at every puller.
-            match storage.open_hosted_blob(&key, &descriptor.digest.blob_filename()).await {
-                Ok(Some((_, Some(size)))) if size != descriptor.size => {
-                    return error(
-                        ErrorCode::ManifestInvalid,
-                        format!(
-                            "{} is {size} bytes, but the manifest declares {}",
-                            descriptor.digest, descriptor.size,
-                        ),
-                    );
-                }
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    return error(
-                        ErrorCode::ManifestBlobUnknown,
-                        format!("{} is not in this repository", descriptor.digest),
-                    );
-                }
-                Err(err) => return registry_error(err),
-            }
-        }
-
-        let referrer = manifest.referrer_metadata();
-        let subject = referrer.subject.clone();
-        let mut addition = ImageDocument::new(key.as_str());
-        addition.insert_manifest(ManifestEntry {
-            digest: digest.clone(),
-            media_type: manifest.media_type().to_string(),
-            size: bytes.len() as u64,
-            referrer: Some(referrer),
-        });
-        if Digest::parse(reference).is_err() {
-            if !is_valid_tag(reference) {
-                return error(ErrorCode::ManifestInvalid, "not a valid tag or digest");
-            }
-            addition.set_tag(TagEntry {
-                tag: reference.to_string(),
-                digest: digest.clone(),
-                updated: now_millis(),
-            });
-        }
-        // An index's children are manifests, not loose blobs, and the check
-        // above only proves the bytes are present. Refusing here rather than
-        // before the write is what makes it race-free: the closure reads the
-        // stored document under the package lock, so a child pushed
-        // concurrently is seen and one deleted concurrently is not missed.
-        //
-        // Re-pushing a manifest is how a client retries and moving a tag is
-        // ordinary, so nothing else is refused; the merge decides what wins.
-        let children: Vec<Digest> = if media_type::is_index(manifest.media_type()) {
-            manifest.references().map(|descriptor| descriptor.digest.clone()).collect()
-        } else {
-            Vec::new()
+        let digest = publication.digest.clone();
+        let key = publication.key.clone();
+        let subject = publication.subject();
+        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
+        let staged = match publication.stage(&self.state).await {
+            Ok(staged) => staged,
+            Err(refusal) => return refusal.respond(),
         };
-        let refuse = move |stored: &ImageDocument| {
-            for child in &children {
-                if stored.manifest(child).is_none() {
-                    return Err(RegistryError::BadRequest {
-                        reason: format!("{child} is not a manifest in this repository"),
-                    });
-                }
-            }
-            Ok(())
-        };
-        match store_hosted_artifact::<ImageDocument>(
-            &self.state,
-            &org,
-            &key,
-            &digest.blob_filename(),
-            &bytes,
-            refuse,
-            addition,
-        )
-        .await
+        match super::publishing::commit_publishes(&self.state, vec![staged])
+            .await
+            .and_then(super::publishing::report_unrecorded)
         {
             Ok(()) => {
                 let mut response =
@@ -763,6 +721,10 @@ impl Request {
             Ok(found) => found,
             Err(refusal) => return refusal.respond(),
         };
+        let org = match hosted_read_namespace(&self.state, &self.identity, &source, key.as_str()) {
+            Ok(org) => org,
+            Err(err) => return registry_error(err),
+        };
         if let Err(err) = authorize(
             &self.state,
             &self.identity,
@@ -772,10 +734,7 @@ impl Request {
         ) {
             return registry_error(err);
         }
-        let Some(hosted) = self.state.inner.config.hosted.get(&source) else {
-            return unknown_repository(name).respond();
-        };
-        let storage = self.state.inner.storage.for_hosted(&hosted.org);
+        let storage = self.state.inner.storage.for_hosted(&org);
         let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
         let outcome = storage
             .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |existing| {
@@ -795,25 +754,21 @@ impl Request {
         }
     }
 
-    /// `HEAD`/`GET /v2/<name>/blobs/<digest>`.
-    ///
-    /// Deleting a blob is optional in the spec and is not offered: nothing
-    /// tracks which manifests reference a blob yet, so removing one would
-    /// leave the repository advertising an image that can no longer be
-    /// pulled. Reclaiming what no manifest names is the collector's job,
-    /// tracked in
-    /// [pnpm/pnpm#14630](https://github.com/pnpm/pnpm/issues/14630).
     async fn blob(&self, name: &str, digest: &str) -> Response {
         let Ok(digest) = Digest::parse(digest) else {
             return error(ErrorCode::DigestInvalid, "not a supported digest");
         };
         match self.method {
             Method::GET | Method::HEAD => self.read_blob(name, &digest).await,
+            Method::DELETE => self.delete_blob(name, &digest).await,
             _ => method_not_allowed(),
         }
     }
 
     async fn read_blob(&self, name: &str, digest: &Digest) -> Response {
+        if let Some((key, source)) = self.upstream_source(name) {
+            return self.proxy_blob(&key, &source, digest).await;
+        }
         let (key, source) = match self.hosted_source(name) {
             Ok(found) => found,
             Err(refusal) => return refusal.respond(),
@@ -907,7 +862,9 @@ impl Request {
             Ok(upload) => upload,
             Err(err) => return registry_error(err),
         };
-        if let Err(refusal) = append_body(&storage, &upload, body).await {
+        if let Err(refusal) =
+            append_body(&storage, &upload, body, self.state.inner.config.oci.max_blob_bytes).await
+        {
             let _ = storage.abort_blob_upload(upload.id()).await;
             return refusal.respond();
         }
@@ -939,7 +896,14 @@ impl Request {
                 if let Err(response) = self.check_chunk_start(&key, &upload).await {
                     return response;
                 }
-                match append_body(&storage, &upload, body).await {
+                match append_body(
+                    &storage,
+                    &upload,
+                    body,
+                    self.state.inner.config.oci.max_blob_bytes,
+                )
+                .await
+                {
                     Ok(()) => self.upload_progress(&key, &upload).await,
                     Err(refusal) => refusal.respond(),
                 }
@@ -951,7 +915,10 @@ impl Request {
                         "a completed upload must name its digest",
                     );
                 };
-                if let Err(refusal) = append_body(&storage, &upload, body).await {
+                if let Err(refusal) =
+                    append_body(&storage, &upload, body, self.state.inner.config.oci.max_blob_bytes)
+                        .await
+                {
                     return refusal.respond();
                 }
                 self.finish_upload(&storage, upload, &key, digest).await
@@ -987,10 +954,11 @@ impl Request {
         let Some(span) = end.checked_sub(start).and_then(|span| span.checked_add(1)) else {
             return Err(error(ErrorCode::BlobUploadInvalid, "Content-Range is not a real span"));
         };
-        if span > MAX_BLOB_BYTES as u64 {
+        let limit = self.state.inner.config.oci.max_blob_bytes;
+        if span > limit {
             return Err(error(
                 ErrorCode::SizeInvalid,
-                format!("a blob may not exceed {MAX_BLOB_BYTES} bytes"),
+                format!("a blob may not exceed {limit} bytes"),
             ));
         }
         if let Some(declared) = self.content_length()
@@ -1060,8 +1028,6 @@ impl Request {
             .ok_or_else(|| Refusal::new(ErrorCode::NameUnknown, "no registry is addressed here"))?;
         match resolve_ecosystem_source(&self.state, &target, ECOSYSTEM, key.as_str()) {
             RegistrySource::Hosted(source) => Ok((key, source)),
-            // Upstream image registries are not proxied yet, so a name routing
-            // to one is not served rather than served wrongly.
             RegistrySource::Upstream(_) | RegistrySource::Unclaimed | RegistrySource::NotFound => {
                 Err(unknown_repository(name))
             }
@@ -1071,29 +1037,7 @@ impl Request {
     /// The hosted registry a write of `name` lands on, once the caller is
     /// allowed to publish it.
     fn publish_target(&self, name: &str) -> Result<(CanonicalPackageName, String), Refusal> {
-        let key = CanonicalPackageName::parse(name, ECOSYSTEM)
-            .map_err(|_| Refusal::new(ErrorCode::NameInvalid, "not a valid repository name"))?;
-        match resolve_publish_target_for(
-            &self.state,
-            &self.identity,
-            self.registry.as_deref(),
-            ECOSYSTEM,
-            key.as_str(),
-        ) {
-            PublishTarget::Hosted { source, org } => {
-                authorize(
-                    &self.state,
-                    &self.identity,
-                    &RegistrySource::Hosted(source),
-                    key.as_str(),
-                    Action::Publish,
-                )?;
-                Ok((key, org))
-            }
-            PublishTarget::Denied(err) => Err(err.into()),
-            PublishTarget::Reject(reason) => Err(Refusal::new(ErrorCode::Denied, reason)),
-            PublishTarget::NotFound => Err(unknown_repository(name)),
-        }
+        authorize_publication(&self.state, &self.identity, self.registry.as_deref(), name)
     }
 }
 
@@ -1179,7 +1123,7 @@ struct TagList<'listing> {
 /// The status is carried rather than re-derived from the code, because a
 /// `RegistryError` has already chosen one, and deriving it back from the spec
 /// code would answer `405` for every error that has no code of its own.
-struct Refusal {
+pub(super) struct Refusal {
     status: StatusCode,
     code: ErrorCode,
     message: String,
@@ -1190,7 +1134,7 @@ impl Refusal {
         Self { status: status_for(code), code, message: message.into() }
     }
 
-    fn respond(self) -> Response {
+    pub(super) fn respond(self) -> Response {
         respond(self.status, self.code, self.message)
     }
 }
@@ -1216,11 +1160,26 @@ impl From<RegistryError> for Refusal {
     }
 }
 
+impl From<Refusal> for RegistryError {
+    fn from(refusal: Refusal) -> Self {
+        match refusal.status {
+            StatusCode::UNAUTHORIZED => Self::Unauthenticated { resource: refusal.message },
+            StatusCode::FORBIDDEN => Self::Forbidden {
+                user: String::new(),
+                action: "publish",
+                resource: refusal.message,
+            },
+            StatusCode::NOT_FOUND => Self::NotFound,
+            _ => Self::BadRequest { reason: refusal.message },
+        }
+    }
+}
+
 fn registry_error(err: RegistryError) -> Response {
     Refusal::from(err).respond()
 }
 
-fn error(code: ErrorCode, message: impl Into<String>) -> Response {
+pub(super) fn error(code: ErrorCode, message: impl Into<String>) -> Response {
     Refusal::new(code, message).respond()
 }
 
@@ -1358,7 +1317,7 @@ async fn collect_body(body: Body, limit: usize) -> Result<Bytes, Refusal> {
 }
 
 /// Stream a request body onto the end of an upload, holding the whole upload
-/// to [`MAX_BLOB_BYTES`]. The per-request body limit cannot do that on its
+/// to the configured byte limit. The per-request body limit cannot do that on its
 /// own: a resumable upload is many requests, each one under the limit.
 ///
 /// An upload that runs over is dropped rather than kept truncated at the
@@ -1371,8 +1330,20 @@ async fn collect_body(body: Body, limit: usize) -> Result<Bytes, Refusal> {
 /// upload actually stands, so the client resumes from the prefix, and the
 /// digest check at `PUT` is what decides whether the assembled bytes are the
 /// blob that was promised.
-async fn append_body(storage: &Storage, upload: &BlobUpload, body: Body) -> Result<(), Refusal> {
+async fn append_body(
+    storage: &Storage,
+    upload: &BlobUpload,
+    body: Body,
+    limit: u64,
+) -> Result<(), Refusal> {
     let mut written = upload.offset().await?;
+    if written > limit {
+        storage.abort_blob_upload(upload.id()).await?;
+        return Err(Refusal::new(
+            ErrorCode::SizeInvalid,
+            format!("a blob may not exceed {limit} bytes"),
+        ));
+    }
     let mut writer = upload.append().await?;
     let mut stream = body.into_data_stream();
     while let Some(chunk) = stream.next().await {
@@ -1380,11 +1351,11 @@ async fn append_body(storage: &Storage, upload: &BlobUpload, body: Body) -> Resu
             writer.finish().await?;
             return Err(Refusal::new(ErrorCode::BlobUploadInvalid, "upload stream ended early"));
         };
-        let Some(next) = advance_within_ceiling(written, chunk.len()) else {
+        let Some(next) = advance_within_ceiling(written, chunk.len(), limit) else {
             let _ = storage.abort_blob_upload(upload.id()).await;
             return Err(Refusal::new(
                 ErrorCode::SizeInvalid,
-                format!("a blob may not exceed {MAX_BLOB_BYTES} bytes"),
+                format!("a blob may not exceed {limit} bytes"),
             ));
         };
         written = next;
@@ -1395,11 +1366,10 @@ async fn append_body(storage: &Storage, upload: &BlobUpload, body: Body) -> Resu
 }
 
 /// The upload's length once `chunk` is accepted, or `None` when that would
-/// take it past [`MAX_BLOB_BYTES`]. Saturating, so a length near `u64::MAX`
-/// refuses rather than wrapping into an accept.
-fn advance_within_ceiling(written: u64, chunk: usize) -> Option<u64> {
-    let next = written.saturating_add(chunk as u64);
-    (next <= MAX_BLOB_BYTES as u64).then_some(next)
+/// take it past the configured byte limit. Overflow refuses the chunk.
+fn advance_within_ceiling(written: u64, chunk: usize, limit: u64) -> Option<u64> {
+    let next = written.checked_add(chunk as u64)?;
+    (next <= limit).then_some(next)
 }
 
 /// Milliseconds since the Unix epoch: the ordering one tag write carries.
@@ -1436,11 +1406,12 @@ async fn read_manifest_bytes(
     storage: &Storage,
     key: &CanonicalPackageName,
     filename: &str,
+    limit: usize,
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     let Some((body, _)) = storage.open_hosted_blob(key, filename).await? else {
         return Ok(None);
     };
-    let bytes = axum::body::to_bytes(body, MAX_MANIFEST_BYTES)
+    let bytes = axum::body::to_bytes(body, limit)
         .await
         .map_err(|_| RegistryError::BadRequest { reason: "manifest is too large".to_string() })?;
     Ok(Some(bytes.to_vec()))

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -116,7 +116,7 @@ async fn get_version_check(
             .get(header::AUTHORIZATION)
             .and_then(|value| value.to_str().ok())
             .and_then(super::authentication::token_credentials)
-            .is_some_and(|token| token.starts_with("pnpr_oci_"))
+            .is_some_and(|token| token.starts_with(tokens::TOKEN_PREFIX))
     {
         return tokens::challenge(
             &state,
@@ -1127,15 +1127,17 @@ pub(super) struct Refusal {
     status: StatusCode,
     code: ErrorCode,
     message: String,
+    original: Option<Box<RegistryError>>,
 }
 
 impl Refusal {
     fn new(code: ErrorCode, message: impl Into<String>) -> Self {
-        Self { status: status_for(code), code, message: message.into() }
+        Self { status: status_for(code), code, message: message.into(), original: None }
     }
 
     pub(super) fn respond(self) -> Response {
-        respond(self.status, self.code, self.message)
+        let status = self.original.map_or(self.status, |err| err.into_response().status());
+        respond(status, self.code, self.message)
     }
 }
 
@@ -1145,7 +1147,7 @@ impl From<RegistryError> for Refusal {
     fn from(err: RegistryError) -> Self {
         let upload_conflict = matches!(err, RegistryError::BlobUploadConflict { .. });
         let message = err.public_message();
-        let status = err.into_response().status();
+        let status = err.status_code();
         let code = match status {
             StatusCode::CONFLICT if upload_conflict => ErrorCode::BlobUploadInvalid,
             StatusCode::UNAUTHORIZED => ErrorCode::Unauthorized,
@@ -1156,12 +1158,15 @@ impl From<RegistryError> for Refusal {
             // what a client acts on.
             _ => ErrorCode::Unsupported,
         };
-        Self { status, code, message }
+        Self { status, code, message, original: Some(Box::new(err)) }
     }
 }
 
 impl From<Refusal> for RegistryError {
     fn from(refusal: Refusal) -> Self {
+        if let Some(original) = refusal.original {
+            return *original;
+        }
         match refusal.status {
             StatusCode::UNAUTHORIZED => Self::Unauthenticated { resource: refusal.message },
             StatusCode::FORBIDDEN => Self::Forbidden {

--- a/pnpr/crates/pnpr/src/server/oci/deletion.rs
+++ b/pnpr/crates/pnpr/src/server/oci/deletion.rs
@@ -46,6 +46,9 @@ impl Request {
                         package: key.as_str().to_string(),
                     });
                 }
+                if storage.open_hosted_blob(&key, &digest.blob_filename()).await?.is_none() {
+                    return Ok(error(ErrorCode::BlobUnknown, "no such blob"));
+                }
                 if referenced_document_blobs(
                     &storage,
                     &key,
@@ -58,9 +61,6 @@ impl Request {
                     return Err(RegistryError::BadRequest {
                         reason: format!("{digest} is referenced by a retained manifest"),
                     });
-                }
-                if storage.open_hosted_blob(&key, &digest.blob_filename()).await?.is_none() {
-                    return Ok(error(ErrorCode::BlobUnknown, "no such blob"));
                 }
                 document.generation =
                     document.generation.checked_add(1).ok_or_else(|| RegistryError::Internal {

--- a/pnpr/crates/pnpr/src/server/oci/deletion.rs
+++ b/pnpr/crates/pnpr/src/server/oci/deletion.rs
@@ -1,0 +1,105 @@
+use super::{Digest, ErrorCode, ImageDocument, Request, error, no_content, registry_error};
+use crate::{
+    oci_maintenance::referenced_document_blobs,
+    server::{Action, RegistrySource, authorize},
+};
+use axum::{http::StatusCode, response::Response};
+use pnpr_error::RegistryError;
+use pnpr_storage::{DOCUMENT_WRITE_RETRIES, DocumentWrite};
+
+impl Request {
+    pub(super) async fn delete_blob(&self, name: &str, digest: &Digest) -> Response {
+        let (key, source) = match self.hosted_source(name) {
+            Ok(target) => target,
+            Err(refusal) => return refusal.respond(),
+        };
+        let org = match crate::server::hosted_read_namespace(
+            &self.state,
+            &self.identity,
+            &source,
+            key.as_str(),
+        ) {
+            Ok(org) => org,
+            Err(err) => return registry_error(err),
+        };
+        if let Err(err) = authorize(
+            &self.state,
+            &self.identity,
+            &RegistrySource::Hosted(source.clone()),
+            key.as_str(),
+            Action::Unpublish,
+        ) {
+            return registry_error(err);
+        }
+        let storage = self.state.inner.storage.for_hosted(&org);
+        let _guard = self.state.inner.package_locks.lock(key.as_str()).await;
+        let result = async {
+            for _ in 0..DOCUMENT_WRITE_RETRIES {
+                let snapshot = storage.read_hosted_document_for_update(&key).await?;
+                let mut document = snapshot
+                    .as_ref()
+                    .map(|stored| ImageDocument::parse(&stored.bytes))
+                    .transpose()?
+                    .unwrap_or_else(|| ImageDocument::new(key.as_str()));
+                if document.deleting_blob.is_some() {
+                    return Err(RegistryError::DocumentWriteConflict {
+                        package: key.as_str().to_string(),
+                    });
+                }
+                if referenced_document_blobs(
+                    &storage,
+                    &key,
+                    &document,
+                    self.state.inner.config.oci.max_manifest_bytes,
+                )
+                .await?
+                .contains(&digest.blob_filename())
+                {
+                    return Err(RegistryError::BadRequest {
+                        reason: format!("{digest} is referenced by a retained manifest"),
+                    });
+                }
+                if storage.open_hosted_blob(&key, &digest.blob_filename()).await?.is_none() {
+                    return Ok(error(ErrorCode::BlobUnknown, "no such blob"));
+                }
+                document.generation =
+                    document.generation.checked_add(1).ok_or_else(|| RegistryError::Internal {
+                        reason: "OCI document generation exhausted".to_string(),
+                    })?;
+                document.deleting_blob = Some(digest.clone());
+                if storage
+                    .write_hosted_document_if_current(
+                        &key,
+                        &document.to_bytes(),
+                        snapshot.as_ref().map(|stored| &stored.version),
+                    )
+                    .await?
+                    == DocumentWrite::Conflict
+                {
+                    continue;
+                }
+                storage.remove_hosted_blob(&key, &digest.blob_filename()).await?;
+                storage
+                    .update_hosted_document_with_retry(&key, DOCUMENT_WRITE_RETRIES, |bytes| {
+                        let mut document = ImageDocument::parse(bytes.ok_or_else(|| {
+                            RegistryError::Internal {
+                                reason: "OCI deletion document disappeared".to_string(),
+                            }
+                        })?)?;
+                        if document.deleting_blob.as_ref() != Some(digest) {
+                            return Err(RegistryError::DocumentWriteConflict {
+                                package: key.as_str().to_string(),
+                            });
+                        }
+                        document.deleting_blob = None;
+                        Ok(Some(document.to_bytes()))
+                    })
+                    .await?;
+                return Ok(no_content(StatusCode::ACCEPTED));
+            }
+            Err(RegistryError::DocumentWriteConflict { package: key.as_str().to_string() })
+        }
+        .await;
+        result.unwrap_or_else(registry_error)
+    }
+}

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -1,0 +1,210 @@
+use super::{
+    DOCKER_CONTENT_DIGEST, Digest, ErrorCode, Manifest, Request, api_version, error,
+    registry_error, server_error,
+};
+use crate::server::{
+    RegistrySource,
+    ecosystem::{addressed_registry, sha256_hex, sha256_integrity, upstream_for},
+    resolve_ecosystem_source, tarball_response, tarball_stream_error,
+};
+use axum::{
+    body::Body,
+    http::{Method, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use futures_util::StreamExt as _;
+use pnpr_error::RegistryError;
+use pnpr_package_name::CanonicalPackageName;
+use pnpr_registry::Ecosystem;
+use pnpr_storage::streaming;
+use pnpr_upstream::FetchOutcome;
+use std::time::Duration;
+
+impl Request {
+    pub(super) fn upstream_source(
+        &self,
+        name: &str,
+    ) -> Option<(CanonicalPackageName, RegistrySource)> {
+        let key = CanonicalPackageName::parse(name, Ecosystem::Oci).ok()?;
+        let target = addressed_registry(&self.state, self.registry.as_deref())?;
+        let source = resolve_ecosystem_source(&self.state, &target, Ecosystem::Oci, key.as_str());
+        matches!(source, RegistrySource::Upstream(_)).then_some((key, source))
+    }
+
+    pub(super) async fn proxy_manifest(
+        &self,
+        key: &CanonicalPackageName,
+        source: &RegistrySource,
+        reference: &str,
+    ) -> Response {
+        let result = self.load_proxy_manifest(key, source, reference).await;
+        let response = match result {
+            Ok(Some(bytes)) => {
+                let manifest = match Manifest::parse(&bytes, None) {
+                    Ok(manifest) => manifest,
+                    Err(err) => return error(ErrorCode::ManifestInvalid, err.to_string()),
+                };
+                let digest = Digest::of(&bytes);
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .header(header::CONTENT_TYPE, manifest.media_type())
+                    .header(header::CONTENT_LENGTH, bytes.len())
+                    .header(DOCKER_CONTENT_DIGEST, digest.to_string())
+                    .body(if self.method == Method::HEAD {
+                        Body::empty()
+                    } else {
+                        Body::from(bytes)
+                    })
+                    .unwrap_or_else(|_| server_error())
+            }
+            Ok(None) => error(ErrorCode::ManifestUnknown, "upstream manifest does not exist"),
+            Err(err) => registry_error(err),
+        };
+        self.caller_scoped(Some(key.as_str()), api_version(response))
+    }
+
+    async fn load_proxy_manifest(
+        &self,
+        key: &CanonicalPackageName,
+        source: &RegistrySource,
+        reference: &str,
+    ) -> Result<Option<Vec<u8>>, RegistryError> {
+        if Digest::parse(reference).is_err() && !pnpr_oci::is_valid_tag(reference) {
+            return Err(RegistryError::BadRequest {
+                reason: "invalid manifest reference".to_string(),
+            });
+        }
+        let (upstream, namespace) = upstream_for(&self.state, &self.identity, source, key)?;
+        let namespace = format!("{namespace}-oci-manifest-{}", sha256_hex(reference.as_bytes()));
+        let storage = &self.state.inner.storage;
+        let ttl = if Digest::parse(reference).is_ok() {
+            Duration::MAX
+        } else {
+            upstream.maxage().unwrap_or(self.state.inner.config.packument_ttl)
+        };
+        if upstream.caches()
+            && let Some(bytes) = storage.read_upstream_document(&namespace, key, ttl).await?
+        {
+            return Ok(Some(bytes));
+        }
+        let fetched = upstream
+            .fetch_oci(
+                key.as_str(),
+                &format!("manifests/{reference}"),
+                &pnpr_oci::MANIFEST_MEDIA_TYPES.join(", "),
+            )
+            .await?;
+        let response = match fetched {
+            FetchOutcome::NotFound => return Ok(None),
+            FetchOutcome::Ok(response) => response,
+        };
+        let declared = response
+            .headers()
+            .get(DOCKER_CONTENT_DIGEST)
+            .map(|value| value.to_str().unwrap_or_default().to_string());
+        let limit = self.state.inner.config.oci.max_manifest_bytes;
+        let mut bytes = Vec::new();
+        let mut stream = Box::pin(response.bytes_stream());
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if chunk.len() > limit.saturating_sub(bytes.len()) {
+                return Err(RegistryError::BadRequest {
+                    reason: "upstream manifest is too large".to_string(),
+                });
+            }
+            bytes.extend_from_slice(&chunk);
+        }
+        let digest = Digest::of(&bytes);
+        if Digest::parse(reference).is_ok_and(|expected| expected != digest)
+            || declared
+                .is_some_and(|declared| Digest::parse(&declared).ok().as_ref() != Some(&digest))
+        {
+            return Err(RegistryError::BadRequest {
+                reason: "upstream manifest digest mismatch".to_string(),
+            });
+        }
+        Manifest::parse(&bytes, None)
+            .map_err(|err| RegistryError::BadRequest { reason: err.to_string() })?;
+        if upstream.caches() {
+            storage.write_upstream_document(&namespace, key, &bytes).await?;
+        }
+        Ok(Some(bytes))
+    }
+
+    pub(super) async fn proxy_blob(
+        &self,
+        key: &CanonicalPackageName,
+        source: &RegistrySource,
+        digest: &Digest,
+    ) -> Response {
+        let (upstream, namespace) = match upstream_for(&self.state, &self.identity, source, key) {
+            Ok(found) => found,
+            Err(err) => return registry_error(err),
+        };
+        let namespace = format!("{namespace}-oci-blobs");
+        let filename = digest.blob_filename();
+        let storage = &self.state.inner.storage;
+        let result = async {
+            if upstream.caches()
+                && let Some((file, len)) =
+                    storage.open_upstream_blob(&namespace, key, &filename).await?
+            {
+                return Ok(tarball_response(
+                    if self.method == Method::HEAD {
+                        Body::empty()
+                    } else {
+                        streaming::stream_file(file)
+                    },
+                    Some(len),
+                ));
+            }
+            if self.method == Method::HEAD {
+                let fetched = upstream.head_oci_blob(key.as_str(), &digest.to_string()).await?;
+                return Ok(match fetched {
+                    FetchOutcome::NotFound => {
+                        error(ErrorCode::BlobUnknown, "upstream blob does not exist")
+                    }
+                    FetchOutcome::Ok(response) => tarball_response(
+                        Body::empty(),
+                        response
+                            .headers()
+                            .get(header::CONTENT_LENGTH)
+                            .and_then(|value| value.to_str().ok())
+                            .and_then(|value| value.parse().ok()),
+                    ),
+                });
+            }
+            let fetched = upstream
+                .fetch_oci(key.as_str(), &format!("blobs/{digest}"), "application/octet-stream")
+                .await?;
+            let response = match fetched {
+                FetchOutcome::NotFound => {
+                    return Ok(error(ErrorCode::BlobUnknown, "upstream blob does not exist"));
+                }
+                FetchOutcome::Ok(response) => response,
+            };
+            let write = storage.open_upstream_blob_tmp(&namespace, key, &filename).await?;
+            let integrity = sha256_integrity(digest.hex()).expect("validated SHA-256 digest");
+            let limit = self.state.inner.config.oci.max_blob_bytes;
+            if !upstream.caches() {
+                let (file, len, path) =
+                    streaming::download_verified_to_temp(response, write, &integrity, limit)
+                        .await
+                        .map_err(|err| tarball_stream_error(err, key, &filename))?;
+                return Ok(tarball_response(
+                    streaming::stream_file_and_remove(file, path),
+                    Some(len),
+                ));
+            }
+            let body = streaming::stream_verified_to_cache(response, write, &integrity, limit)
+                .map_err(|err| tarball_stream_error(err, key, &filename))?;
+            Ok::<_, RegistryError>(tarball_response(body, None))
+        }
+        .await;
+        let mut response = result.unwrap_or_else(IntoResponse::into_response);
+        if response.status().is_success() {
+            super::insert_header(&mut response, DOCKER_CONTENT_DIGEST, &digest.to_string());
+        }
+        self.caller_scoped(Some(key.as_str()), api_version(response))
+    }
+}

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -39,24 +39,7 @@ impl Request {
     ) -> Response {
         let result = self.load_proxy_manifest(key, source, reference).await;
         let response = match result {
-            Ok(Some(bytes)) => {
-                let manifest = match Manifest::parse(&bytes, None) {
-                    Ok(manifest) => manifest,
-                    Err(err) => return error(ErrorCode::ManifestInvalid, err.to_string()),
-                };
-                let digest = Digest::of(&bytes);
-                Response::builder()
-                    .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, manifest.media_type())
-                    .header(header::CONTENT_LENGTH, bytes.len())
-                    .header(DOCKER_CONTENT_DIGEST, digest.to_string())
-                    .body(if self.method == Method::HEAD {
-                        Body::empty()
-                    } else {
-                        Body::from(bytes)
-                    })
-                    .unwrap_or_else(|_| server_error())
-            }
+            Ok(Some(response)) => response,
             Ok(None) => error(ErrorCode::ManifestUnknown, "upstream manifest does not exist"),
             Err(err) => registry_error(err),
         };
@@ -68,7 +51,7 @@ impl Request {
         key: &CanonicalPackageName,
         source: &RegistrySource,
         reference: &str,
-    ) -> Result<Option<Vec<u8>>, RegistryError> {
+    ) -> Result<Option<Response>, RegistryError> {
         if Digest::parse(reference).is_err() && !pnpr_oci::is_valid_tag(reference) {
             return Err(RegistryError::BadRequest {
                 reason: "invalid manifest reference".to_string(),
@@ -85,7 +68,32 @@ impl Request {
         if upstream.caches()
             && let Some(bytes) = storage.read_upstream_document(&namespace, key, ttl).await?
         {
-            return Ok(Some(bytes));
+            return manifest_response(bytes, self.method == Method::HEAD).map(Some);
+        }
+        if self.method == Method::HEAD {
+            let fetched = upstream
+                .head_oci(
+                    key.as_str(),
+                    &format!("manifests/{reference}"),
+                    &pnpr_oci::MANIFEST_MEDIA_TYPES.join(", "),
+                )
+                .await?;
+            return match fetched {
+                FetchOutcome::NotFound => Ok(None),
+                FetchOutcome::Ok(upstream_response) => {
+                    let mut response = Response::new(Body::empty());
+                    for name in [
+                        header::CONTENT_TYPE,
+                        header::CONTENT_LENGTH,
+                        header::HeaderName::from_static(DOCKER_CONTENT_DIGEST),
+                    ] {
+                        if let Some(value) = upstream_response.headers().get(&name) {
+                            response.headers_mut().insert(name, value.clone());
+                        }
+                    }
+                    Ok(Some(response))
+                }
+            };
         }
         let fetched = upstream
             .fetch_oci(
@@ -128,7 +136,7 @@ impl Request {
         if upstream.caches() {
             storage.write_upstream_document(&namespace, key, &bytes).await?;
         }
-        Ok(Some(bytes))
+        manifest_response(bytes, false).map(Some)
     }
 
     pub(super) async fn proxy_blob(
@@ -159,7 +167,9 @@ impl Request {
                 ));
             }
             if self.method == Method::HEAD {
-                let fetched = upstream.head_oci_blob(key.as_str(), &digest.to_string()).await?;
+                let fetched = upstream
+                    .head_oci(key.as_str(), &format!("blobs/{digest}"), "application/octet-stream")
+                    .await?;
                 return Ok(match fetched {
                     FetchOutcome::NotFound => {
                         error(ErrorCode::BlobUnknown, "upstream blob does not exist")
@@ -207,4 +217,16 @@ impl Request {
         }
         self.caller_scoped(Some(key.as_str()), api_version(response))
     }
+}
+
+fn manifest_response(bytes: Vec<u8>, head: bool) -> Result<Response, RegistryError> {
+    let manifest = Manifest::parse(&bytes, None)
+        .map_err(|err| RegistryError::BadRequest { reason: err.to_string() })?;
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, manifest.media_type())
+        .header(header::CONTENT_LENGTH, bytes.len())
+        .header(DOCKER_CONTENT_DIGEST, Digest::of(&bytes).to_string())
+        .body(if head { Body::empty() } else { Body::from(bytes) })
+        .unwrap_or_else(|_| server_error()))
 }

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -78,34 +78,32 @@ impl Request {
                     &pnpr_oci::MANIFEST_MEDIA_TYPES.join(", "),
                 )
                 .await?;
-            return match fetched {
-                FetchOutcome::NotFound => Ok(None),
-                FetchOutcome::Ok(upstream_response) => {
-                    if let Ok(expected) = Digest::parse(reference) {
-                        let declared = upstream_response
-                            .headers()
-                            .get(DOCKER_CONTENT_DIGEST)
-                            .and_then(|value| value.to_str().ok())
-                            .and_then(|value| Digest::parse(value).ok());
-                        if declared.as_ref() != Some(&expected) {
-                            return Err(RegistryError::BadRequest {
-                                reason: "upstream manifest digest mismatch".to_string(),
-                            });
-                        }
-                    }
-                    let mut response = Response::new(Body::empty());
-                    for name in [
-                        header::CONTENT_TYPE,
-                        header::CONTENT_LENGTH,
-                        header::HeaderName::from_static(DOCKER_CONTENT_DIGEST),
-                    ] {
-                        if let Some(value) = upstream_response.headers().get(&name) {
-                            response.headers_mut().insert(name, value.clone());
-                        }
-                    }
-                    Ok(Some(response))
-                }
+            let upstream_response = match fetched {
+                FetchOutcome::NotFound => return Ok(None),
+                FetchOutcome::Ok(response) => response,
             };
+            if let Some(declared) = upstream_response.headers().get(DOCKER_CONTENT_DIGEST) {
+                if let Ok(expected) = Digest::parse(reference) {
+                    let declared =
+                        declared.to_str().ok().and_then(|value| Digest::parse(value).ok());
+                    if declared.as_ref() != Some(&expected) {
+                        return Err(RegistryError::BadRequest {
+                            reason: "upstream manifest digest mismatch".to_string(),
+                        });
+                    }
+                }
+                let mut response = Response::new(Body::empty());
+                for name in [
+                    header::CONTENT_TYPE,
+                    header::CONTENT_LENGTH,
+                    header::HeaderName::from_static(DOCKER_CONTENT_DIGEST),
+                ] {
+                    if let Some(value) = upstream_response.headers().get(&name) {
+                        response.headers_mut().insert(name, value.clone());
+                    }
+                }
+                return Ok(Some(response));
+            }
         }
         let fetched = upstream
             .fetch_oci(
@@ -148,7 +146,7 @@ impl Request {
         if upstream.caches() {
             storage.write_upstream_document(&namespace, key, &bytes).await?;
         }
-        manifest_response(bytes, false).map(Some)
+        manifest_response(bytes, self.method == Method::HEAD).map(Some)
     }
 
     pub(super) async fn proxy_blob(

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -83,14 +83,16 @@ impl Request {
                 FetchOutcome::Ok(response) => response,
             };
             if let Some(declared) = upstream_response.headers().get(DOCKER_CONTENT_DIGEST) {
-                if let Ok(expected) = Digest::parse(reference) {
-                    let declared =
-                        declared.to_str().ok().and_then(|value| Digest::parse(value).ok());
-                    if declared.as_ref() != Some(&expected) {
-                        return Err(RegistryError::BadRequest {
-                            reason: "upstream manifest digest mismatch".to_string(),
-                        });
-                    }
+                let declared =
+                    declared.to_str().ok().and_then(|value| Digest::parse(value).ok()).ok_or_else(
+                        || RegistryError::BadRequest {
+                            reason: "invalid upstream manifest digest".to_string(),
+                        },
+                    )?;
+                if Digest::parse(reference).is_ok_and(|expected| expected != declared) {
+                    return Err(RegistryError::BadRequest {
+                        reason: "upstream manifest digest mismatch".to_string(),
+                    });
                 }
                 let mut response = Response::new(Body::empty());
                 for name in [

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -81,6 +81,18 @@ impl Request {
             return match fetched {
                 FetchOutcome::NotFound => Ok(None),
                 FetchOutcome::Ok(upstream_response) => {
+                    if let Ok(expected) = Digest::parse(reference) {
+                        let declared = upstream_response
+                            .headers()
+                            .get(DOCKER_CONTENT_DIGEST)
+                            .and_then(|value| value.to_str().ok())
+                            .and_then(|value| Digest::parse(value).ok());
+                        if declared.as_ref() != Some(&expected) {
+                            return Err(RegistryError::BadRequest {
+                                reason: "upstream manifest digest mismatch".to_string(),
+                            });
+                        }
+                    }
                     let mut response = Response::new(Body::empty());
                     for name in [
                         header::CONTENT_TYPE,

--- a/pnpr/crates/pnpr/src/server/oci/publication.rs
+++ b/pnpr/crates/pnpr/src/server/oci/publication.rs
@@ -1,0 +1,182 @@
+use super::{
+    Digest, ErrorCode, ImageDocument, MAX_MANIFEST_REFERENCES, Manifest, ManifestEntry, Refusal,
+    now_millis,
+};
+use crate::server::{
+    Action, AppState, Identity, RegistrySource, authorize,
+    documents::stage_hosted_artifact,
+    publishing::{PublishTarget, StagedPublish, resolve_publish_target_for},
+};
+use axum::body::Bytes;
+use pnpr_error::RegistryError;
+use pnpr_oci::TagEntry;
+use pnpr_package_name::CanonicalPackageName;
+use pnpr_registry::Ecosystem;
+use std::collections::HashSet;
+
+pub(in crate::server) struct OciPublication {
+    pub(super) key: CanonicalPackageName,
+    org: String,
+    bytes: Bytes,
+    manifest: Manifest,
+    pub(super) digest: Digest,
+    reference: String,
+}
+
+pub(in crate::server) fn authorize_publication(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    name: &str,
+) -> Result<(CanonicalPackageName, String), Refusal> {
+    let key = CanonicalPackageName::parse(name, Ecosystem::Oci)
+        .map_err(|_| Refusal::new(ErrorCode::NameInvalid, "not a valid repository name"))?;
+    match resolve_publish_target_for(state, identity, registry, Ecosystem::Oci, key.as_str()) {
+        PublishTarget::Hosted { source, org } => {
+            authorize(
+                state,
+                identity,
+                &RegistrySource::Hosted(source),
+                key.as_str(),
+                Action::Publish,
+            )?;
+            Ok((key, org))
+        }
+        PublishTarget::Denied(err) => Err(err.into()),
+        PublishTarget::Reject(reason) => Err(Refusal::new(ErrorCode::Denied, reason)),
+        PublishTarget::NotFound => Err(super::unknown_repository(name)),
+    }
+}
+
+impl OciPublication {
+    pub(in crate::server) fn new(
+        target: (CanonicalPackageName, String),
+        reference: String,
+        bytes: Bytes,
+        content_type: Option<&str>,
+        limit: usize,
+    ) -> Result<Self, Refusal> {
+        if bytes.len() > limit {
+            return Err(Refusal::new(ErrorCode::SizeInvalid, "manifest is too large"));
+        }
+        let digest = Digest::of(&bytes);
+        match Digest::parse(&reference) {
+            Ok(addressed) if addressed != digest => {
+                return Err(Refusal::new(
+                    ErrorCode::DigestInvalid,
+                    "manifest does not match the digest it was pushed under",
+                ));
+            }
+            Err(_) if !pnpr_oci::is_valid_tag(&reference) => {
+                return Err(Refusal::new(ErrorCode::ManifestInvalid, "not a valid tag or digest"));
+            }
+            _ => {}
+        }
+        let manifest = Manifest::parse(&bytes, content_type)
+            .map_err(|err| Refusal::new(ErrorCode::ManifestInvalid, err.to_string()))?;
+        Ok(Self { key: target.0, org: target.1, bytes, manifest, digest, reference })
+    }
+
+    pub(in crate::server) fn key(&self) -> &CanonicalPackageName {
+        &self.key
+    }
+
+    pub(super) fn subject(&self) -> Option<Digest> {
+        self.manifest.referrer_metadata().subject
+    }
+
+    pub(in crate::server) async fn stage(self, state: &AppState) -> Result<StagedPublish, Refusal> {
+        let storage = state.inner.storage.for_hosted(&self.org);
+        let snapshot = storage
+            .read_hosted_document(&self.key)
+            .await?
+            .map(|bytes| ImageDocument::parse(&bytes))
+            .transpose()
+            .map_err(RegistryError::from)?
+            .unwrap_or_default();
+        if snapshot.deleting_blob.is_some() {
+            return Err(RegistryError::DocumentWriteConflict {
+                package: self.key.as_str().to_string(),
+            }
+            .into());
+        }
+        let mut looked_up = HashSet::new();
+        for descriptor in self.manifest.references() {
+            if !looked_up.insert(descriptor.digest.clone()) {
+                continue;
+            }
+            if looked_up.len() > MAX_MANIFEST_REFERENCES {
+                return Err(Refusal::new(
+                    ErrorCode::ManifestInvalid,
+                    format!(
+                        "a manifest may not reference more than {MAX_MANIFEST_REFERENCES} blobs",
+                    ),
+                ));
+            }
+            match storage.open_hosted_blob(&self.key, &descriptor.digest.blob_filename()).await? {
+                Some((_, Some(size))) if size != descriptor.size => {
+                    return Err(Refusal::new(
+                        ErrorCode::ManifestInvalid,
+                        format!(
+                            "{} is {size} bytes, but the manifest declares {}",
+                            descriptor.digest, descriptor.size,
+                        ),
+                    ));
+                }
+                Some(_) => {}
+                None => {
+                    return Err(Refusal::new(
+                        ErrorCode::ManifestBlobUnknown,
+                        format!("{} is not in this repository", descriptor.digest),
+                    ));
+                }
+            }
+        }
+        let mut addition = ImageDocument::new(self.key.as_str());
+        addition.generation = snapshot.generation;
+        addition.insert_manifest(ManifestEntry {
+            digest: self.digest.clone(),
+            media_type: self.manifest.media_type().to_string(),
+            size: self.bytes.len() as u64,
+            referrer: Some(self.manifest.referrer_metadata()),
+        });
+        if Digest::parse(&self.reference).is_err() {
+            addition.set_tag(TagEntry {
+                tag: self.reference,
+                digest: self.digest.clone(),
+                updated: now_millis(),
+            });
+        }
+        let children: Vec<Digest> = if pnpr_oci::media_type::is_index(self.manifest.media_type()) {
+            self.manifest.references().map(|descriptor| descriptor.digest.clone()).collect()
+        } else {
+            Vec::new()
+        };
+        let refuse = |stored: &ImageDocument| {
+            if stored.generation != snapshot.generation || stored.deleting_blob.is_some() {
+                return Err(RegistryError::DocumentWriteConflict {
+                    package: self.key.as_str().to_string(),
+                });
+            }
+            for child in &children {
+                if stored.manifest(child).is_none() {
+                    return Err(RegistryError::BadRequest {
+                        reason: format!("{child} is not a manifest in this repository"),
+                    });
+                }
+            }
+            Ok(())
+        };
+        stage_hosted_artifact(
+            state,
+            &self.org,
+            &self.key,
+            &self.digest.blob_filename(),
+            &self.bytes,
+            &refuse,
+            addition,
+        )
+        .await
+        .map_err(Into::into)
+    }
+}

--- a/pnpr/crates/pnpr/src/server/oci/tests.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tests.rs
@@ -73,17 +73,17 @@ fn a_digest_is_read_from_the_raw_query() {
 
 #[test]
 fn the_blob_ceiling_bounds_the_whole_upload_not_one_chunk() {
-    use super::{MAX_BLOB_BYTES, advance_within_ceiling};
+    use super::advance_within_ceiling;
 
-    let ceiling = MAX_BLOB_BYTES as u64;
-    assert_eq!(advance_within_ceiling(0, 1), Some(1));
-    assert_eq!(advance_within_ceiling(ceiling - 1, 1), Some(ceiling));
+    let ceiling = 10;
+    assert_eq!(advance_within_ceiling(0, 1, ceiling), Some(1));
+    assert_eq!(advance_within_ceiling(ceiling - 1, 1, ceiling), Some(ceiling));
     // A chunk that is itself small still refuses once the upload is full,
     // which is what the per-request body limit cannot see.
-    assert_eq!(advance_within_ceiling(ceiling, 1), None);
-    assert_eq!(advance_within_ceiling(ceiling - 1, 2), None);
+    assert_eq!(advance_within_ceiling(ceiling, 1, ceiling), None);
+    assert_eq!(advance_within_ceiling(ceiling - 1, 2, ceiling), None);
     // Saturating, so a length near the top refuses rather than wrapping.
-    assert_eq!(advance_within_ceiling(u64::MAX, 1), None);
+    assert_eq!(advance_within_ceiling(u64::MAX, 1, ceiling), None);
 }
 
 #[test]

--- a/pnpr/crates/pnpr/src/server/oci/tests.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tests.rs
@@ -102,3 +102,19 @@ fn a_content_range_is_read_whole_or_not_at_all() {
     assert_eq!(parse_content_range("4"), None);
     assert_eq!(parse_content_range(""), None);
 }
+
+#[test]
+fn refusals_preserve_registry_errors_for_batch_responses() {
+    let err = pnpr_error::RegistryError::Forbidden {
+        user: "alice".to_string(),
+        action: "unpublish",
+        resource: "acme/app".to_string(),
+    };
+    let expected = err.public_message();
+    let restored = pnpr_error::RegistryError::from(super::Refusal::from(err));
+    assert_eq!(restored.public_message(), expected);
+    assert_eq!(restored.status_code(), axum::http::StatusCode::FORBIDDEN);
+    let err = pnpr_error::RegistryError::Internal { reason: "test".to_string() };
+    let restored = pnpr_error::RegistryError::from(super::Refusal::from(err));
+    assert_eq!(restored.status_code(), axum::http::StatusCode::INTERNAL_SERVER_ERROR);
+}

--- a/pnpr/crates/pnpr/src/server/oci/tokens.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tokens.rs
@@ -1,0 +1,285 @@
+use super::{Endpoint, ErrorCode, Request, error, json, parse_endpoint};
+use crate::server::{
+    Action, AppState, AuthedCaller, Identity, TargetRegistry,
+    authentication::token_credentials,
+    authorize,
+    ecosystem::{addressed_registry, sha256_hex},
+    resolve_ecosystem_source,
+};
+use axum::{
+    extract::{OriginalUri, State},
+    http::{HeaderMap, Method, StatusCode, header},
+    response::Response,
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use p256::ecdsa::{
+    Signature, SigningKey,
+    signature::{Signer as _, Verifier as _},
+};
+use pnpr_error::RegistryError;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::{collections::BTreeMap, fmt::Write as _};
+
+const TOKEN_PREFIX: &str = "pnpr_oci_";
+const TTL: u64 = 300;
+
+#[derive(Serialize, Deserialize)]
+pub(in crate::server) struct Claims {
+    pub(in crate::server) parent: Option<String>,
+    audience: String,
+    expires: u64,
+    scopes: BTreeMap<String, Vec<String>>,
+}
+
+fn signing_key(state: &AppState) -> Result<SigningKey, RegistryError> {
+    let mut hash = Sha256::new();
+    hash.update(b"pnpr OCI token signing v1\0");
+    hash.update(&state.inner.config.resolution_cache_secret);
+    SigningKey::from_slice(&hash.finalize())
+        .map_err(|_| RegistryError::Internal { reason: "invalid OCI signing key".to_string() })
+}
+
+pub(in crate::server) fn decode(
+    state: &AppState,
+    token: &str,
+) -> Result<Option<Claims>, RegistryError> {
+    let Some(token) = token.strip_prefix(TOKEN_PREFIX) else { return Ok(None) };
+    let invalid = || RegistryError::Unauthenticated { resource: "OCI token".to_string() };
+    if !state.inner.config.oci.bearer_auth || token.len() > 16 * 1024 {
+        return Err(invalid());
+    }
+    verify_claims(&signing_key(state)?, token, super::now_millis() / 1000).map(Some)
+}
+
+fn verify_claims(key: &SigningKey, token: &str, now: u64) -> Result<Claims, RegistryError> {
+    let invalid = || RegistryError::Unauthenticated { resource: "OCI token".to_string() };
+    let (payload, signature) = token.split_once('.').ok_or_else(invalid)?;
+    let bytes = URL_SAFE_NO_PAD.decode(payload).map_err(|_| invalid())?;
+    let signature = URL_SAFE_NO_PAD.decode(signature).map_err(|_| invalid())?;
+    let signature = Signature::from_slice(&signature).map_err(|_| invalid())?;
+    key.verifying_key().verify(&bytes, &signature).map_err(|_| invalid())?;
+    let claims: Claims = serde_json::from_slice(&bytes).map_err(|_| invalid())?;
+    if claims.expires <= now {
+        return Err(invalid());
+    }
+    Ok(claims)
+}
+
+impl Claims {
+    pub(in crate::server) fn permits(&self, path: &str, method: &Method) -> bool {
+        let decoded = pnpr_search::percent_decode(path);
+        let Some(tail) =
+            decoded.strip_prefix(&self.audience).and_then(|tail| tail.strip_prefix("/v2"))
+        else {
+            return false;
+        };
+        if !(tail.is_empty() || tail.starts_with('/')) {
+            return false;
+        }
+        if tail.trim_matches('/').is_empty() {
+            return matches!(*method, Method::GET | Method::HEAD);
+        }
+        let Some(endpoint) = parse_endpoint(tail) else { return false };
+        let upload = matches!(endpoint, Endpoint::StartUpload { .. } | Endpoint::Upload { .. });
+        let name = match endpoint {
+            Endpoint::Catalog => return false,
+            Endpoint::Referrers { name, .. }
+            | Endpoint::Tags { name }
+            | Endpoint::Manifest { name, .. }
+            | Endpoint::Blob { name, .. }
+            | Endpoint::StartUpload { name }
+            | Endpoint::Upload { name, .. } => name,
+        };
+        let Ok(name) =
+            pnpr_package_name::CanonicalPackageName::parse(&name, pnpr_registry::Ecosystem::Oci)
+        else {
+            return false;
+        };
+        let action = if upload {
+            "push"
+        } else {
+            match *method {
+                Method::GET | Method::HEAD => "pull",
+                Method::DELETE => "delete",
+                _ => "push",
+            }
+        };
+        if !self.allows(name.as_str(), action) {
+            return false;
+        }
+        true
+    }
+
+    pub(super) fn allows(&self, name: &str, action: &str) -> bool {
+        self.scopes.get(name).is_some_and(|actions| actions.iter().any(|held| held == action))
+    }
+}
+
+pub(super) async fn issue(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+    TargetRegistry(registry): TargetRegistry,
+    OriginalUri(uri): OriginalUri,
+    headers: HeaderMap,
+) -> Response {
+    match issue_token(&state, &identity, registry.as_deref(), &uri, &headers).await {
+        Ok(response) => response,
+        Err(err) => super::registry_error(err),
+    }
+}
+
+async fn issue_token(
+    state: &AppState,
+    identity: &Identity,
+    registry: Option<&str>,
+    uri: &axum::http::Uri,
+    headers: &HeaderMap,
+) -> Result<Response, RegistryError> {
+    if !state.inner.config.oci.bearer_auth {
+        return Ok(error(ErrorCode::Unsupported, "OCI Bearer authentication is disabled"));
+    }
+    let target = addressed_registry(state, registry).ok_or(RegistryError::NotFound)?;
+    let raw = headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(token_credentials);
+    if raw.is_some() && *identity == Identity::Anonymous {
+        return Ok(error(ErrorCode::Unauthorized, "invalid credentials"));
+    }
+    let parent = raw.as_ref().map(|raw| sha256_hex(raw.as_bytes()));
+    let record = match &parent {
+        Some(parent) => state.inner.auth.tokens.find_by_key(parent).await?,
+        None => None,
+    };
+    let mut scopes = BTreeMap::new();
+    for (key, value) in url::form_urlencoded::parse(uri.query().unwrap_or_default().as_bytes()) {
+        if key == "service" && value != "pnpr" {
+            return Err(RegistryError::BadRequest {
+                reason: "invalid OCI token service".to_string(),
+            });
+        }
+        if key != "scope" {
+            continue;
+        }
+        for scope in value.split_whitespace() {
+            if scopes.len() >= 32 {
+                return Err(RegistryError::BadRequest {
+                    reason: "too many OCI token scopes".to_string(),
+                });
+            }
+            let parts: Vec<_> = scope.split(':').collect();
+            let ["repository", name, actions] = parts.as_slice() else {
+                return Err(RegistryError::BadRequest {
+                    reason: "invalid OCI token scope".to_string(),
+                });
+            };
+            let name = pnpr_package_name::CanonicalPackageName::parse(
+                name,
+                pnpr_registry::Ecosystem::Oci,
+            )?;
+            let source = resolve_ecosystem_source(
+                state,
+                &target,
+                pnpr_registry::Ecosystem::Oci,
+                name.as_str(),
+            );
+            let allowed: &mut Vec<String> = scopes.entry(name.as_str().to_string()).or_default();
+            for action in actions.split(',') {
+                let operation = match action {
+                    "pull" => Action::Access,
+                    "push" => Action::Publish,
+                    "delete" => Action::Unpublish,
+                    _ => continue,
+                };
+                if action != "pull" && record.as_ref().is_some_and(|record| record.readonly) {
+                    continue;
+                }
+                if authorize(state, identity, &source, name.as_str(), Action::Access).is_ok()
+                    && authorize(state, identity, &source, name.as_str(), operation).is_ok()
+                    && !allowed.iter().any(|held| held == action)
+                {
+                    allowed.push(action.to_string());
+                }
+            }
+        }
+    }
+    let audience = pnpr_search::percent_decode(
+        uri.path().strip_suffix("/v2/token").ok_or(RegistryError::NotFound)?,
+    );
+    let claims = Claims { parent, audience, expires: super::now_millis() / 1000 + TTL, scopes };
+    let payload = serde_json::to_vec(&claims)?;
+    let signature: Signature = signing_key(state)?.sign(&payload);
+    let token = format!(
+        "{TOKEN_PREFIX}{}.{}",
+        URL_SAFE_NO_PAD.encode(payload),
+        URL_SAFE_NO_PAD.encode(signature.to_bytes()),
+    );
+    Ok(crate::server::private_no_cache(json(
+        StatusCode::OK,
+        &serde_json::json!({ "token": token, "expires_in": TTL }),
+    )))
+}
+
+pub(super) fn challenge(
+    state: &AppState,
+    base: &str,
+    scope: Option<(&str, &str)>,
+    mut response: Response,
+) -> Response {
+    if response.status() != StatusCode::UNAUTHORIZED || !state.inner.config.oci.bearer_auth {
+        return response;
+    }
+    let realm = format!("{}{base}/token", state.inner.config.public_url.trim_end_matches('/'));
+    let mut value = format!(r#"Bearer realm="{realm}",service="pnpr""#);
+    if let Some((name, actions)) = scope
+        && let Ok(name) =
+            pnpr_package_name::CanonicalPackageName::parse(name, pnpr_registry::Ecosystem::Oci)
+    {
+        write!(value, r#",scope="repository:{}:{actions}""#, name.as_str())
+            .expect("writing to a string cannot fail");
+    }
+    if let Ok(value) = axum::http::HeaderValue::from_str(&value) {
+        response.headers_mut().insert(header::WWW_AUTHENTICATE, value);
+    }
+    crate::server::private_no_cache(response)
+}
+
+impl Request {
+    pub(super) fn challenge(&self, name: Option<&str>, response: Response) -> Response {
+        let actions = match self.method {
+            Method::GET | Method::HEAD => "pull",
+            Method::DELETE => "pull,push,delete",
+            _ => "pull,push",
+        };
+        challenge(&self.state, &self.base, name.map(|name| (name, actions)), response)
+    }
+}
+
+pub(in crate::server) fn rejected(state: &AppState, path: &str, method: &Method) -> Response {
+    let decoded = pnpr_search::percent_decode(path);
+    let response =
+        error(ErrorCode::Unauthorized, "OCI token is expired, revoked, or outside its scope");
+    let Some((prefix, tail)) = decoded.split_once("/v2") else { return response };
+    let endpoint = parse_endpoint(tail);
+    let name = match &endpoint {
+        Some(
+            Endpoint::Referrers { name, .. }
+            | Endpoint::Tags { name }
+            | Endpoint::Manifest { name, .. }
+            | Endpoint::Blob { name, .. }
+            | Endpoint::StartUpload { name }
+            | Endpoint::Upload { name, .. },
+        ) => Some(name.as_str()),
+        _ => None,
+    };
+    let actions = match *method {
+        Method::GET | Method::HEAD => "pull",
+        Method::DELETE => "pull,push,delete",
+        _ => "pull,push",
+    };
+    challenge(state, &format!("{prefix}/v2"), name.map(|name| (name, actions)), response)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/pnpr/src/server/oci/tokens.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tokens.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::{collections::BTreeMap, fmt::Write as _};
 
-const TOKEN_PREFIX: &str = "pnpr_oci_";
+pub(super) const TOKEN_PREFIX: &str = "pnpr_oci_";
 const TTL: u64 = 300;
 
 #[derive(Serialize, Deserialize)]
@@ -81,6 +81,7 @@ impl Claims {
             return matches!(*method, Method::GET | Method::HEAD);
         }
         let Some(endpoint) = parse_endpoint(tail) else { return false };
+        // Upload cancellation requires push scope, just like the rest of the upload session.
         let upload = matches!(endpoint, Endpoint::StartUpload { .. } | Endpoint::Upload { .. });
         let name = match endpoint {
             Endpoint::Catalog => return false,
@@ -163,21 +164,29 @@ async fn issue_token(
             continue;
         }
         for scope in value.split_whitespace() {
-            if scopes.len() >= 32 {
-                return Err(RegistryError::BadRequest {
-                    reason: "too many OCI token scopes".to_string(),
-                });
-            }
-            let parts: Vec<_> = scope.split(':').collect();
-            let ["repository", name, actions] = parts.as_slice() else {
+            let Some((resource, remainder)) = scope.split_once(':') else {
                 return Err(RegistryError::BadRequest {
                     reason: "invalid OCI token scope".to_string(),
                 });
             };
-            let name = pnpr_package_name::CanonicalPackageName::parse(
-                name,
-                pnpr_registry::Ecosystem::Oci,
-            )?;
+            let Some((name, actions)) = remainder.rsplit_once(':') else {
+                return Err(RegistryError::BadRequest {
+                    reason: "invalid OCI token scope".to_string(),
+                });
+            };
+            if resource != "repository" && resource != "repository(plugin)" {
+                continue;
+            }
+            let Ok(name) =
+                pnpr_package_name::CanonicalPackageName::parse(name, pnpr_registry::Ecosystem::Oci)
+            else {
+                continue;
+            };
+            if scopes.len() >= 32 && !scopes.contains_key(name.as_str()) {
+                return Err(RegistryError::BadRequest {
+                    reason: "too many OCI token scopes".to_string(),
+                });
+            }
             let source = resolve_ecosystem_source(
                 state,
                 &target,

--- a/pnpr/crates/pnpr/src/server/oci/tokens/tests.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tokens/tests.rs
@@ -1,0 +1,44 @@
+use super::{Claims, verify_claims};
+use axum::http::Method;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use p256::ecdsa::{Signature, SigningKey, signature::Signer as _};
+use std::collections::BTreeMap;
+
+#[test]
+fn signed_claims_expire_and_cannot_be_tampered_with() {
+    let key = SigningKey::from_slice(&[1; 32]).unwrap();
+    let claims =
+        Claims { parent: None, audience: String::new(), expires: 100, scopes: BTreeMap::new() };
+    let payload = serde_json::to_vec(&claims).unwrap();
+    let signature: Signature = key.sign(&payload);
+    let token = format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(&payload),
+        URL_SAFE_NO_PAD.encode(signature.to_bytes()),
+    );
+    assert!(verify_claims(&key, &token, 99).is_ok());
+    assert!(verify_claims(&key, &token, 100).is_err());
+    let mut tampered = payload;
+    tampered[0] ^= 1;
+    let token = format!(
+        "{}.{}",
+        URL_SAFE_NO_PAD.encode(tampered),
+        URL_SAFE_NO_PAD.encode(signature.to_bytes()),
+    );
+    assert!(verify_claims(&key, &token, 99).is_err());
+}
+
+#[test]
+fn scope_checks_keep_upload_cancellation_and_registry_boundaries() {
+    let claims = Claims {
+        parent: None,
+        audience: "/oci/~images".into(),
+        expires: 100,
+        scopes: BTreeMap::from([("acme/v2/app".into(), vec!["pull".into(), "push".into()])]),
+    };
+    assert!(claims.permits("/oci/~images/v2/acme/v2/app/manifests/latest", &Method::GET));
+    assert!(claims.permits("/oci/~images/v2/acme/v2/app/blobs/uploads/session", &Method::DELETE,));
+    assert!(!claims.permits("/oci/~images/v2/acme/v2/app/manifests/latest", &Method::DELETE));
+    assert!(!claims.permits("/v2/acme/v2/app/manifests/latest", &Method::GET));
+    assert!(!claims.permits("/oci/~other/v2/acme/v2/app/manifests/latest", &Method::GET));
+}

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -790,9 +790,7 @@ async fn a_download_that_fails_the_index_checksum_is_never_cached() {
         )
         .await
         .unwrap();
-    // Streaming has started by the time the mismatch is known; the client
-    // verifies the bytes itself, and the cache is never populated.
-    let _ = body_bytes(response.into_body()).await;
+    assert!(axum::body::to_bytes(response.into_body(), usize::MAX).await.is_err());
     assert!(find_file(&tmp.path().join(".pnpr-cache"), "serde-1.0.0.crate").is_none());
 }
 

--- a/pnpr/crates/pnpr/tests/common/pausing_store.rs
+++ b/pnpr/crates/pnpr/tests/common/pausing_store.rs
@@ -11,11 +11,16 @@ use tokio::sync::Notify;
 pub struct PausingStore {
     inner: InMemory,
     filename: Mutex<Option<String>>,
+    write_filename: Mutex<Option<String>>,
     pub started: Notify,
     pub resume: Notify,
 }
 
 impl PausingStore {
+    pub fn pause_write(&self, filename: String) {
+        *self.write_filename.lock().unwrap() = Some(filename);
+    }
+
     pub fn pause(&self, filename: String) {
         *self.filename.lock().unwrap() = Some(filename);
     }
@@ -57,6 +62,20 @@ impl ObjectStore for PausingStore {
         payload: PutPayload,
         options: PutOptions,
     ) -> object_store::Result<PutResult> {
+        let pause = {
+            let mut filename = self.write_filename.lock().unwrap();
+            let pause = filename
+                .as_ref()
+                .is_some_and(|filename| location.filename() == Some(filename.as_str()));
+            if pause {
+                *filename = None;
+            }
+            pause
+        };
+        if pause {
+            self.started.notify_one();
+            self.resume.notified().await;
+        }
         self.inner.put_opts(location, payload, options).await
     }
 

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -24,6 +24,7 @@ use axum::{
     http::{Request, StatusCode, header},
 };
 use common::{HostedSource, body_bytes, mixed_router_config, sha256_hex};
+use futures_util::StreamExt as _;
 use pnpr::{
     AccessList, AuthState, Config, Ecosystem, PackagePattern, PackageRule, PackageRules,
     router_with_auth,
@@ -2006,7 +2007,17 @@ async fn proxy_does_not_cache_corrupt_content_or_download_blob_bodies_for_head()
             StatusCode::BAD_REQUEST,
         );
         let response = get(&app, &path).await;
-        assert!(axum::body::to_bytes(response.into_body(), usize::MAX).await.is_err());
+        let mut stream = response.into_body().into_data_stream();
+        let mut bytes = Vec::new();
+        loop {
+            match stream.next().await {
+                Some(Ok(chunk)) => bytes.extend_from_slice(&chunk),
+                Some(Err(_)) => break,
+                None => panic!("corrupt content must terminate with an integrity error"),
+            }
+        }
+        assert_eq!(bytes, b"poison");
+        assert!(stream.next().await.is_none());
     }
     head.assert_async().await;
     corrupt_manifest.assert_async().await;
@@ -2185,14 +2196,16 @@ async fn token_scopes_ignore_unknown_resources_and_count_distinct_repositories()
 }
 
 #[tokio::test]
-async fn manifest_head_requires_the_requested_digest_in_upstream_headers() {
-    let digest = digest_of(b"manifest");
+async fn manifest_head_checks_digests_and_verifies_legacy_responses_without_a_header() {
+    let manifest = image_manifest("config", &[]);
+    let digest = digest_of(&manifest);
     let wrong = digest_of(b"different manifest");
-    for (declared, expected) in [
-        (Some(digest.as_str()), StatusCode::OK),
-        (Some(wrong.as_str()), StatusCode::BAD_REQUEST),
-        (Some("invalid"), StatusCode::BAD_REQUEST),
-        (None, StatusCode::BAD_REQUEST),
+    for (declared, valid_body, expected) in [
+        (Some(digest.as_str()), true, StatusCode::OK),
+        (Some(wrong.as_str()), true, StatusCode::BAD_REQUEST),
+        (Some("invalid"), true, StatusCode::BAD_REQUEST),
+        (None, true, StatusCode::OK),
+        (None, false, StatusCode::BAD_REQUEST),
     ] {
         let mut upstream = mockito::Server::new_async().await;
         let path = format!("/v2/other/app/manifests/{digest}");
@@ -2201,12 +2214,23 @@ async fn manifest_head_requires_the_requested_digest_in_upstream_headers() {
             head = head.with_header("docker-content-digest", declared);
         }
         let head = head.create_async().await;
+        let get = upstream
+            .mock("GET", path.as_str())
+            .with_body(if valid_body { manifest.as_slice() } else { b"corrupt" })
+            .expect(usize::from(declared.is_none()))
+            .create_async()
+            .await;
         let tmp = TempDir::new().unwrap();
         let mut config = oci_config(tmp.path().to_path_buf(), "$all");
         config.upstreams.get_mut("dockerhub").unwrap().url = format!("{}/", upstream.url());
         let app = router_with_auth(config, AuthState::in_memory());
         let response = app.oneshot(Request::head(path).body(Body::empty()).unwrap()).await.unwrap();
         assert_eq!(response.status(), expected, "declared digest: {declared:?}");
+        if expected == StatusCode::OK {
+            assert_eq!(response.headers()["docker-content-digest"], digest);
+            assert!(body_bytes(response.into_body()).await.is_empty());
+        }
         head.assert_async().await;
+        get.assert_async().await;
     }
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -1917,6 +1917,8 @@ async fn proxy_verifies_and_caches_manifest_and_blob_content() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(response.headers()[header::CONTENT_LENGTH], manifest.len().to_string());
+    assert_eq!(response.headers()[header::CONTENT_TYPE], pnpr_oci::media_type::OCI_IMAGE_MANIFEST);
+    assert_eq!(response.headers()["docker-content-digest"], digest_of(&manifest));
     assert!(body_bytes(response.into_body()).await.is_empty());
     manifest_mock.assert_async().await;
     blob_mock.assert_async().await;
@@ -2180,4 +2182,31 @@ async fn token_scopes_ignore_unknown_resources_and_count_distinct_repositories()
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
     let response = get(&app, &format!("/v2/token?{query}&scope=repository:other/extra:pull")).await;
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn manifest_head_requires_the_requested_digest_in_upstream_headers() {
+    let digest = digest_of(b"manifest");
+    let wrong = digest_of(b"different manifest");
+    for (declared, expected) in [
+        (Some(digest.as_str()), StatusCode::OK),
+        (Some(wrong.as_str()), StatusCode::BAD_REQUEST),
+        (Some("invalid"), StatusCode::BAD_REQUEST),
+        (None, StatusCode::BAD_REQUEST),
+    ] {
+        let mut upstream = mockito::Server::new_async().await;
+        let path = format!("/v2/other/app/manifests/{digest}");
+        let mut head = upstream.mock("HEAD", path.as_str()).expect(1);
+        if let Some(declared) = declared {
+            head = head.with_header("docker-content-digest", declared);
+        }
+        let head = head.create_async().await;
+        let tmp = TempDir::new().unwrap();
+        let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+        config.upstreams.get_mut("dockerhub").unwrap().url = format!("{}/", upstream.url());
+        let app = router_with_auth(config, AuthState::in_memory());
+        let response = app.oneshot(Request::head(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), expected, "declared digest: {declared:?}");
+        head.assert_async().await;
+    }
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -2200,15 +2200,17 @@ async fn manifest_head_checks_digests_and_verifies_legacy_responses_without_a_he
     let manifest = image_manifest("config", &[]);
     let digest = digest_of(&manifest);
     let wrong = digest_of(b"different manifest");
-    for (declared, valid_body, expected) in [
-        (Some(digest.as_str()), true, StatusCode::OK),
-        (Some(wrong.as_str()), true, StatusCode::BAD_REQUEST),
-        (Some("invalid"), true, StatusCode::BAD_REQUEST),
-        (None, true, StatusCode::OK),
-        (None, false, StatusCode::BAD_REQUEST),
+    for (reference, declared, valid_body, expected) in [
+        (digest.as_str(), Some(digest.as_str()), true, StatusCode::OK),
+        (digest.as_str(), Some(wrong.as_str()), true, StatusCode::BAD_REQUEST),
+        (digest.as_str(), Some("invalid"), true, StatusCode::BAD_REQUEST),
+        (digest.as_str(), None, true, StatusCode::OK),
+        (digest.as_str(), None, false, StatusCode::BAD_REQUEST),
+        ("latest", Some(digest.as_str()), true, StatusCode::OK),
+        ("latest", Some("invalid"), true, StatusCode::BAD_REQUEST),
     ] {
         let mut upstream = mockito::Server::new_async().await;
-        let path = format!("/v2/other/app/manifests/{digest}");
+        let path = format!("/v2/other/app/manifests/{reference}");
         let mut head = upstream.mock("HEAD", path.as_str()).expect(1);
         if let Some(declared) = declared {
             head = head.with_header("docker-content-digest", declared);

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -7,7 +7,7 @@
 #[path = "common/ecosystem.rs"]
 #[allow(
     dead_code,
-    reason = "the shared fixtures also carry the upstream-proxy helpers the Cargo and Python               surfaces use, which this surface has no half of yet"
+    reason = "the shared fixtures include helpers for the Cargo and Python surfaces"
 )]
 mod common;
 
@@ -731,20 +731,18 @@ async fn an_index_over_pushed_children_publishes() {
 }
 
 #[tokio::test]
-async fn deleting_a_blob_is_not_offered() {
+async fn deleting_a_referenced_blob_is_refused() {
     let tmp = TempDir::new().unwrap();
     let app = app_allowing_deletes(&tmp);
     let auth = basic(&token(&app).await);
     push_image(&app, &auth, "acme/app", "1.0").await;
 
-    // Nothing tracks which manifests reference a blob, so removing one would
-    // leave the repository advertising an image that cannot be pulled.
     let request = Request::delete(format!("/v2/acme/app/blobs/{}", digest_of(b"layer")))
         .header(header::AUTHORIZATION, &auth)
         .body(Body::empty())
         .unwrap();
     let response = app.clone().oneshot(request).await.unwrap();
-    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     assert_eq!(
         get(&app, &format!("/v2/acme/app/blobs/{}", digest_of(b"layer"))).await.status(),
         StatusCode::OK,
@@ -1691,4 +1689,395 @@ async fn referrer_migration_does_not_block_writers_or_restore_deleted_manifests(
             .unwrap();
     assert!(document.manifest(&digest).is_none());
     assert_eq!(document.resolve("fresh").unwrap().digest.to_string(), published);
+}
+
+#[tokio::test]
+async fn catalog_lists_repositories_under_published_and_blob_only_parents() {
+    let tmp = TempDir::new().unwrap();
+    let app = app(&tmp);
+    let auth = basic(&token(&app).await);
+    push_image(&app, &auth, "acme/app", "latest").await;
+    push_image(&app, &auth, "acme/app/tool", "latest").await;
+    push_blob(&app, &auth, "acme/blobs", b"loose").await;
+    push_image(&app, &auth, "acme/blobs/tool", "latest").await;
+    let response = get(&app, "/v2/_catalog").await;
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(payload["repositories"], json!(["acme/app", "acme/app/tool", "acme/blobs/tool"]));
+}
+
+#[tokio::test]
+async fn unreferenced_blobs_can_be_deleted_and_uploaded_again() {
+    let tmp = TempDir::new().unwrap();
+    let app = app_allowing_deletes(&tmp);
+    let auth = basic(&token(&app).await);
+    let digest = push_blob(&app, &auth, "acme/app", b"config").await;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::delete(format!("/v2/acme/app/blobs/{digest}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(
+        get(&app, &format!("/v2/acme/app/blobs/{digest}")).await.status(),
+        StatusCode::NOT_FOUND,
+    );
+    push_image(&app, &auth, "acme/app", "after-delete").await;
+    assert_eq!(get(&app, "/v2/acme/app/manifests/after-delete").await.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn configured_limits_bound_monolithic_resumable_and_manifest_uploads() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.oci.max_blob_bytes = 5;
+    config.oci.max_manifest_bytes = 16;
+    let app = router_with_auth(config, AuthState::in_memory());
+    let auth = basic(&token(&app).await);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/v2/acme/app/blobs/uploads/?digest={}", digest_of(b"123456")))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from("123456"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post("/v2/acme/app/blobs/uploads/")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from("123"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let location = response.headers()[header::LOCATION].to_str().unwrap().to_string();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::patch(&location)
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from("456"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::put("/v2/acme/app/manifests/latest")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from(image_manifest("", &[])))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn batch_publishes_an_oci_manifest_and_rolls_back_on_invalid_siblings() {
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
+    let tmp = TempDir::new().unwrap();
+    let app = app(&tmp);
+    let auth = basic(&token(&app).await);
+    push_blob(&app, &auth, "acme/app", b"config").await;
+    let entry = json!({ "ecosystem": "oci", "name": "acme/app", "reference": "release", "manifest": STANDARD.encode(image_manifest("config", &[])) });
+    let invalid = json!({ "ecosystem": "oci", "name": "acme/missing", "reference": "release", "manifest": STANDARD.encode(image_manifest("missing", &[])) });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::put("/-/pnpr/v0/publish")
+                .header(header::AUTHORIZATION, &auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({ "packages": [entry.clone(), invalid] }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(get(&app, "/v2/acme/app/manifests/release").await.status(), StatusCode::NOT_FOUND);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::put("/-/pnpr/v0/publish")
+                .header(header::AUTHORIZATION, &auth)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(json!({ "packages": [entry] }).to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    assert_eq!(get(&app, "/v2/acme/app/manifests/release").await.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scoped_bearer_credentials_cannot_write_escape_repository_or_survive_revocation() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.oci.bearer_auth = true;
+    let auth_state = AuthState::in_memory();
+    let app = router_with_auth(config, auth_state.clone());
+    let parent = token(&app).await;
+    let auth = basic(&parent);
+    push_image(&app, &auth, "acme/app", "latest").await;
+    push_image(&app, &auth, "acme/other", "latest").await;
+    let challenge = get(&app, "/v2/").await;
+    assert!(challenge.headers()[header::WWW_AUTHENTICATE].to_str().unwrap().starts_with("Bearer "));
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/v2/token?service=pnpr&scope=repository:acme/app:pull")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let scoped = format!("Bearer {}", payload["token"].as_str().unwrap());
+    for (method, path, expected) in [
+        ("GET", "/v2/acme/app/manifests/latest", StatusCode::OK),
+        ("GET", "/v2/acme/other/manifests/latest", StatusCode::UNAUTHORIZED),
+        ("POST", "/v2/acme/app/blobs/uploads/", StatusCode::UNAUTHORIZED),
+        ("GET", "/-/npm/v1/tokens", StatusCode::UNAUTHORIZED),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method(method)
+                    .uri(path)
+                    .header(header::AUTHORIZATION, &scoped)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), expected, "{method} {path}");
+    }
+    auth_state.tokens.revoke_by_key(&sha256_hex(parent.as_bytes())).await.unwrap();
+    let response = app
+        .oneshot(
+            Request::get("/v2/acme/app/manifests/latest")
+                .header(header::AUTHORIZATION, scoped)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn proxy_verifies_and_caches_manifest_and_blob_content() {
+    let mut upstream = mockito::Server::new_async().await;
+    let manifest = image_manifest("config", &[]);
+    let manifest_mock = upstream
+        .mock("GET", "/v2/other/app/manifests/latest")
+        .with_header("content-type", "application/vnd.oci.image.manifest.v1+json")
+        .with_header("docker-content-digest", &digest_of(&manifest))
+        .with_body(manifest.clone())
+        .expect(1)
+        .create_async()
+        .await;
+    let blob_mock = upstream
+        .mock("GET", format!("/v2/other/app/blobs/{}", digest_of(b"config")).as_str())
+        .with_body("config")
+        .expect(1)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.upstreams.get_mut("dockerhub").unwrap().url = format!("{}/", upstream.url());
+    let app = router_with_auth(config, AuthState::in_memory());
+    for _ in 0..2 {
+        let response = get(&app, "/v2/other/app/manifests/latest").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_bytes(response.into_body()).await, manifest);
+        let response = get(&app, &format!("/v2/other/app/blobs/{}", digest_of(b"config"))).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_bytes(response.into_body()).await, b"config");
+    }
+    manifest_mock.assert_async().await;
+    blob_mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn blob_deletion_fences_a_manifest_commit_on_another_replica() {
+    let tmp = TempDir::new().unwrap();
+    let objects = std::sync::Arc::new(pausing_store::PausingStore::default());
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.hosted_store = pnpr::HostedStoreConfig::ObjectStore {
+        store: std::sync::Arc::clone(&objects) as std::sync::Arc<dyn object_store::ObjectStore>,
+        prefix: "fenced/".into(),
+    };
+    let hosted = config.hosted.get_mut("images").unwrap();
+    hosted.rules = std::mem::take(&mut hosted.rules)
+        .with_default_unpublish(AccessList::from_tokens(["$authenticated"]));
+    let auth_state = AuthState::in_memory();
+    let first = router_with_auth(config.clone(), auth_state.clone());
+    config.cache_storage = tmp.path().join("second-cache");
+    let second = router_with_auth(config, auth_state);
+    let auth = basic(&token(&first).await);
+    let digest = push_blob(&first, &auth, "acme/app", b"config").await;
+    objects.pause_write("package.json".to_string());
+    let publish = tokio::spawn(
+        first.oneshot(
+            Request::put("/v2/acme/app/manifests/latest")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::from(image_manifest("config", &[])))
+                .unwrap(),
+        ),
+    );
+    tokio::time::timeout(std::time::Duration::from_secs(10), objects.started.notified())
+        .await
+        .unwrap();
+    let deleted = second
+        .clone()
+        .oneshot(
+            Request::delete(format!("/v2/acme/app/blobs/{digest}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(deleted.status(), StatusCode::ACCEPTED);
+    objects.resume.notify_one();
+    assert_eq!(publish.await.unwrap().unwrap().status(), StatusCode::CONFLICT);
+    assert_eq!(get(&second, "/v2/acme/app/manifests/latest").await.status(), StatusCode::NOT_FOUND);
+    push_image(&second, &auth, "acme/app", "retry").await;
+}
+
+#[tokio::test]
+async fn proxy_does_not_cache_corrupt_content_or_download_blob_bodies_for_head() {
+    let mut upstream = mockito::Server::new_async().await;
+    let manifest = image_manifest("config", &[]);
+    let corrupt_manifest = upstream
+        .mock("GET", "/v2/other/app/manifests/latest")
+        .with_header("docker-content-digest", &digest_of(b"different"))
+        .with_body(manifest)
+        .expect(2)
+        .create_async()
+        .await;
+    let path = format!("/v2/other/app/blobs/{}", digest_of(b"config"));
+    let corrupt_blob =
+        upstream.mock("GET", path.as_str()).with_body("poison").expect(2).create_async().await;
+    let head = upstream
+        .mock("HEAD", path.as_str())
+        .with_header("content-length", "6")
+        .expect(1)
+        .create_async()
+        .await;
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.upstreams.get_mut("dockerhub").unwrap().url = format!("{}/", upstream.url());
+    let app = router_with_auth(config, AuthState::in_memory());
+    let response =
+        app.clone().oneshot(Request::head(&path).body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[header::CONTENT_LENGTH], "6");
+    assert!(body_bytes(response.into_body()).await.is_empty());
+    for _ in 0..2 {
+        assert_eq!(
+            get(&app, "/v2/other/app/manifests/latest").await.status(),
+            StatusCode::BAD_REQUEST,
+        );
+        let response = get(&app, &path).await;
+        assert_eq!(body_bytes(response.into_body()).await, b"poison");
+    }
+    head.assert_async().await;
+    corrupt_manifest.assert_async().await;
+    corrupt_blob.assert_async().await;
+}
+
+#[tokio::test]
+async fn deletion_requires_read_access_even_with_a_permissive_unpublish_rule() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "alice");
+    let hosted = config.hosted.get_mut("images").unwrap();
+    hosted.rules =
+        std::mem::take(&mut hosted.rules).with_default_unpublish(AccessList::from_tokens(["$all"]));
+    let app = router_with_auth(config, AuthState::in_memory());
+    let auth = basic(&token(&app).await);
+    push_image(&app, &auth, "acme/app", "latest").await;
+    let digest = push_blob(&app, &auth, "acme/app", b"orphan").await;
+    for path in
+        ["/v2/acme/app/manifests/latest".to_string(), format!("/v2/acme/app/blobs/{digest}")]
+    {
+        let response =
+            app.clone().oneshot(Request::delete(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+    let response = app
+        .oneshot(
+            Request::get(format!("/v2/acme/app/blobs/{digest}"))
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn scoped_mount_without_source_pull_permission_falls_back_to_upload() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.oci.bearer_auth = true;
+    let app = router_with_auth(config, AuthState::in_memory());
+    let auth = basic(&token(&app).await);
+    let digest = push_blob(&app, &auth, "acme/source", b"source layer").await;
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/v2/token?service=pnpr&scope=repository:acme/dest:push")
+                .header(header::AUTHORIZATION, &auth)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let scoped = format!("Bearer {}", payload["token"].as_str().unwrap());
+    let response = app
+        .clone()
+        .oneshot(
+            Request::post(format!("/v2/acme/dest/blobs/uploads/?mount={digest}&from=acme/source"))
+                .header(header::AUTHORIZATION, &scoped)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let location = response.headers()[header::LOCATION].to_str().unwrap().to_string();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get(&location)
+                .header(header::AUTHORIZATION, &scoped)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    assert_eq!(
+        get(&app, &format!("/v2/acme/dest/blobs/{digest}")).await.status(),
+        StatusCode::NOT_FOUND,
+    );
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -2004,7 +2004,7 @@ async fn proxy_does_not_cache_corrupt_content_or_download_blob_bodies_for_head()
             StatusCode::BAD_REQUEST,
         );
         let response = get(&app, &path).await;
-        assert_eq!(body_bytes(response.into_body()).await, b"poison");
+        assert!(axum::body::to_bytes(response.into_body(), usize::MAX).await.is_err());
     }
     head.assert_async().await;
     corrupt_manifest.assert_async().await;
@@ -2128,4 +2128,56 @@ async fn cold_manifest_head_forwards_headers_without_getting_or_caching_a_body()
         }
         head.assert_async().await;
     }
+}
+
+#[tokio::test]
+async fn token_scopes_ignore_unknown_resources_and_count_distinct_repositories() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+    config.oci.bearer_auth = true;
+    let app = router_with_auth(config, AuthState::in_memory());
+    let mut query = url::form_urlencoded::Serializer::new(String::new());
+    for index in 0..32 {
+        query.append_pair("scope", &format!("repository:other/app{index}:pull"));
+    }
+    query.append_pair("scope", "repository(plugin):other/app0:pull");
+    query.append_pair("scope", "registry:catalog:*");
+    query.append_pair("scope", "repository:host:5000/app:pull");
+    let query = query.finish();
+    let response = get(&app, &format!("/v2/token?{query}")).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/v2/_catalog")
+                .header(
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", payload["token"].as_str().unwrap()),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let response = get(&app, "/v2/token?scope=repository(plugin):acme/app:pull").await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let payload: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::get("/v2/acme/app/manifests/latest")
+                .header(
+                    header::AUTHORIZATION,
+                    format!("Bearer {}", payload["token"].as_str().unwrap()),
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let response = get(&app, &format!("/v2/token?{query}&scope=repository:other/extra:pull")).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/pnpr/crates/pnpr/tests/oci_registry.rs
+++ b/pnpr/crates/pnpr/tests/oci_registry.rs
@@ -1910,6 +1910,14 @@ async fn proxy_verifies_and_caches_manifest_and_blob_content() {
         assert_eq!(response.status(), StatusCode::OK);
         assert_eq!(body_bytes(response.into_body()).await, b"config");
     }
+    let response = app
+        .clone()
+        .oneshot(Request::head("/v2/other/app/manifests/latest").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers()[header::CONTENT_LENGTH], manifest.len().to_string());
+    assert!(body_bytes(response.into_body()).await.is_empty());
     manifest_mock.assert_async().await;
     blob_mock.assert_async().await;
 }
@@ -2080,4 +2088,44 @@ async fn scoped_mount_without_source_pull_permission_falls_back_to_upload() {
         get(&app, &format!("/v2/acme/dest/blobs/{digest}")).await.status(),
         StatusCode::NOT_FOUND,
     );
+}
+
+#[tokio::test]
+async fn cold_manifest_head_forwards_headers_without_getting_or_caching_a_body() {
+    for cache in [true, false] {
+        let mut upstream = mockito::Server::new_async().await;
+        let digest = digest_of(b"manifest");
+        let head = upstream
+            .mock("HEAD", "/v2/other/app/manifests/latest")
+            .with_header("content-length", "123")
+            .with_header("content-type", pnpr_oci::media_type::OCI_IMAGE_MANIFEST)
+            .with_header("docker-content-digest", &digest)
+            .expect(2)
+            .create_async()
+            .await;
+        let tmp = TempDir::new().unwrap();
+        let mut config = oci_config(tmp.path().to_path_buf(), "$all");
+        let source = config.upstreams.get_mut("dockerhub").unwrap();
+        source.url = format!("{}/", upstream.url());
+        source.cache = cache;
+        let app = router_with_auth(config, AuthState::in_memory());
+        for _ in 0..2 {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::head("/v2/other/app/manifests/latest").body(Body::empty()).unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[header::CONTENT_LENGTH], "123");
+            assert_eq!(
+                response.headers()[header::CONTENT_TYPE],
+                pnpr_oci::media_type::OCI_IMAGE_MANIFEST,
+            );
+            assert_eq!(response.headers()["docker-content-digest"], digest);
+            assert!(body_bytes(response.into_body()).await.is_empty());
+        }
+        head.assert_async().await;
+    }
 }

--- a/pnpr/crates/pnpr/tests/pypi_registry.rs
+++ b/pnpr/crates/pnpr/tests/pypi_registry.rs
@@ -417,7 +417,7 @@ async fn an_upstream_without_the_json_api_is_a_gateway_error_and_a_bad_hash_is_n
     assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
 
     let response = app.oneshot(get(&format!("/pypi/files/lying/{filename}"), None)).await.unwrap();
-    let _ = body_bytes(response.into_body()).await;
+    assert!(axum::body::to_bytes(response.into_body(), usize::MAX).await.is_err());
     assert!(find_file(&tmp.path().join(".pnpr-cache"), filename).is_none());
 }
 

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -1647,7 +1647,7 @@ async fn tarball_route_preserves_basename_and_binds_to_declaring_version() {
 }
 
 #[tokio::test]
-async fn tampered_upstream_tarball_is_served_but_never_cached() {
+async fn tampered_upstream_tarball_aborts_the_stream_and_is_never_cached() {
     let mut upstream = mockito::Server::new_async().await;
     let good_bytes = b"good-tarball-bytes";
     let poison_bytes = b"poisoned-cache-bytes";

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -1689,10 +1689,6 @@ async fn tampered_upstream_tarball_is_served_but_never_cached() {
     let storage = tmp.path().to_path_buf();
     let cache_path = public_cache_pkg(&storage, "poisoned").join("poisoned-1.0.0.tgz");
 
-    // Upstream serves bytes that don't match the version's `dist.integrity`.
-    // They are streamed to the client (which re-verifies and rejects them),
-    // but the SRI mismatch on the full body means they are never promoted to
-    // the cache — so they can't poison a later request.
     let app = router(config_for(&upstream.url(), storage.clone()));
     let packument_response =
         app.clone().oneshot(Request::get("/poisoned").body(Body::empty()).unwrap()).await.unwrap();
@@ -1705,7 +1701,7 @@ async fn tampered_upstream_tarball_is_served_but_never_cached() {
     assert_eq!(tarball_response.status(), StatusCode::OK);
     // Draining the body runs the end-of-stream SRI check, which abandons the
     // cache temp on the mismatch.
-    assert_eq!(body_bytes(tarball_response.into_body()).await, poison_bytes);
+    assert!(to_bytes(tarball_response.into_body(), usize::MAX).await.is_err());
     assert!(!cache_path.exists(), "unverified tarball must not be written to the cache");
 
     packument_mock.assert_async().await;

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -22,6 +22,10 @@ use std::{
 /// rename or by upload, and how a namespace maps onto paths or key prefixes.
 #[async_trait]
 pub(crate) trait HostedBackend: Debug + Send + Sync {
+    async fn rebuild_package_index(&self) -> Result<()> {
+        Ok(())
+    }
+
     fn upload_store(&self) -> Option<crate::upload::RemoteUploadStore> {
         None
     }

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -401,6 +401,21 @@ pub enum DocumentUpdate {
 /// is promoted by rename.
 #[async_trait]
 impl HostedBackend for Store {
+    async fn rebuild_package_index(&self) -> Result<()> {
+        let complete = self.root.join(".package-index/.complete");
+        if fs::try_exists(&complete).await? {
+            return Ok(());
+        }
+        let mut files = self.list_blob_files();
+        while let Some(file) = files.next().await {
+            let file = file?;
+            let Some(name) = file.path.strip_suffix("/package.json") else { continue };
+            write_atomic(&self.root.join(".package-index").join(name).join(".present"), b"")
+                .await?;
+        }
+        write_atomic(&complete, b"").await
+    }
+
     async fn read_document(&self, name: &CanonicalPackageName) -> Result<Option<Vec<u8>>> {
         Store::read_document_any_age(self, name).await
     }
@@ -421,6 +436,8 @@ impl HostedBackend for Store {
         bytes: &[u8],
         _version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite> {
+        write_atomic(&self.root.join(".package-index").join(name.as_str()).join(".present"), b"")
+            .await?;
         Store::write_document(self, name, bytes).await?;
         Ok(DocumentWrite::Written)
     }
@@ -618,6 +635,11 @@ impl Storage {
 
     /// The hosted package names, used by the local search scan (which
     /// indexes hosted/static packages only, never the proxy mirror).
+    /// Build the filesystem listing index for legacy stores before serving requests.
+    pub async fn rebuild_package_index(&self) -> Result<()> {
+        self.hosted.rebuild_package_index().await
+    }
+
     pub async fn hosted_package_names(&self) -> Result<Vec<String>> {
         self.hosted.list_package_names().await
     }
@@ -1188,21 +1210,34 @@ impl Store {
         }
     }
 
-    /// Walk the storage tree two levels deep to find package names —
-    /// directories holding a `package.json`. Layout is
-    /// `<root>/<pkg>/package.json` for unscoped and
-    /// `<root>/@scope/<name>/package.json` for scoped, so a two-level
-    /// walk suffices and avoids descending into blob-adjacent junk.
-    /// Hidden entries (the `.pnpr-cache` sibling) are skipped.
-    ///
-    /// Per-entry stat/read failures are tolerated (the entry is just
-    /// skipped) so a single unreadable directory or a stray non-package
-    /// file can't fail the whole search — this backs the best-effort,
-    /// verdaccio-style `/-/v1/search`, which prefers partial results
-    /// over a hard error. A failure to open the store root itself still
-    /// propagates.
-    async fn list_package_names(&self) -> Result<Vec<String>> {
+    async fn indexed_package_names(&self) -> Result<Vec<String>> {
         let mut names = Vec::new();
+        let mut pending = vec![(self.root.join(".package-index"), String::new())];
+        while let Some((dir, name)) = pending.pop() {
+            let mut entries = match fs::read_dir(&dir).await {
+                Ok(entries) => entries,
+                Err(err) if err.kind() == ErrorKind::NotFound => continue,
+                Err(err) => return Err(err.into()),
+            };
+            while let Some(entry) = entries.next_entry().await? {
+                let component = entry.file_name().to_string_lossy().into_owned();
+                if component == ".present" && !name.is_empty() {
+                    if fs::try_exists(self.root.join(&name).join(DOCUMENT_FILE)).await? {
+                        names.push(name.clone());
+                    }
+                } else if !component.starts_with('.') && entry.file_type().await?.is_dir() {
+                    pending.push((
+                        entry.path(),
+                        if name.is_empty() { component } else { format!("{name}/{component}") },
+                    ));
+                }
+            }
+        }
+        Ok(names)
+    }
+
+    async fn list_package_names(&self) -> Result<Vec<String>> {
+        let mut names = self.indexed_package_names().await?;
         let mut pending = vec![(self.root.clone(), String::new(), 1usize)];
         while let Some((dir, prefix, depth)) = pending.pop() {
             let mut entries = match fs::read_dir(&dir).await {
@@ -1217,21 +1252,8 @@ impl Store {
                     continue;
                 }
                 if !entry.file_type().await.is_ok_and(|kind| kind.is_dir()) {
-                    // A namespace holds only directories, so a file means
-                    // this is a package that has not written its document
-                    // yet — an ordinary state between an image's blobs and
-                    // its manifest. Reading the rest would enumerate every
-                    // blob it holds, on a path an anonymous listing reaches.
-                    // The root is the exception: it is one directory, and
-                    // abandoning it would truncate the whole listing.
-                    //
-                    // A package nested under this one is missed as a result,
-                    // and which entry comes first is up to the filesystem.
-                    // That is the same gap a package nested under a
-                    // *manifested* one already has, and closing it by reading
-                    // to the end is what makes a listing cost the blob
-                    // population rather than the package count. It wants an
-                    // index, not a wider walk — pnpm/pnpm#14630.
+                    // Legacy package trees keep blobs beside the document.
+                    // Nested packages are discovered through the separate index.
                     if depth > 1 {
                         break;
                     }
@@ -1244,17 +1266,14 @@ impl Store {
                     format!("{prefix}/{name_str}")
                 };
                 if fs::try_exists(entry_path.join(DOCUMENT_FILE)).await.unwrap_or(false) {
-                    // Stopping here is what keeps a listing proportional to
-                    // the number of packages: descending would enumerate
-                    // every blob a package holds, on a path an anonymous
-                    // search reaches. A package nested under another is
-                    // therefore not listed — pnpm/pnpm#14630.
                     names.push(name);
                 } else if depth < MAX_NAME_COMPONENTS {
                     pending.push((entry_path, name, depth + 1));
                 }
             }
         }
+        names.sort();
+        names.dedup();
         Ok(names)
     }
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -436,9 +436,16 @@ impl HostedBackend for Store {
         bytes: &[u8],
         _version: Option<&HostedDocumentVersion>,
     ) -> Result<DocumentWrite> {
-        write_atomic(&self.root.join(".package-index").join(name.as_str()).join(".present"), b"")
-            .await?;
-        Store::write_document(self, name, bytes).await?;
+        let marker = self.root.join(".package-index").join(name.as_str()).join(".present");
+        let indexed = fs::try_exists(&marker).await?;
+        write_atomic(&marker, b"").await?;
+        if let Err(err) = Store::write_document(self, name, bytes).await {
+            if !indexed {
+                fs::remove_file(&marker).await?;
+                self.prune_package_index(name).await?;
+            }
+            return Err(err);
+        }
         Ok(DocumentWrite::Written)
     }
 
@@ -495,7 +502,14 @@ impl HostedBackend for Store {
     }
 
     async fn remove_package(&self, name: &CanonicalPackageName) -> Result<bool> {
-        Store::remove_package(self, name).await
+        let removed = Store::remove_package(self, name).await?;
+        match fs::remove_dir_all(self.root.join(".package-index").join(name.as_str())).await {
+            Ok(()) => {}
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        self.prune_package_index(name).await?;
+        Ok(removed)
     }
 
     fn list_blob_files(&self) -> BoxStream<'_, Result<HostedBlobFile>> {
@@ -1210,6 +1224,21 @@ impl Store {
         }
     }
 
+    async fn prune_package_index(&self, name: &CanonicalPackageName) -> Result<()> {
+        let root = self.root.join(".package-index");
+        let mut directory = root.join(name.as_str());
+        while directory != root {
+            match fs::remove_dir(&directory).await {
+                Ok(()) => {}
+                Err(err) if err.kind() == ErrorKind::NotFound => {}
+                Err(err) if err.kind() == ErrorKind::DirectoryNotEmpty => break,
+                Err(err) => return Err(err.into()),
+            }
+            directory.pop();
+        }
+        Ok(())
+    }
+
     async fn indexed_package_names(&self) -> Result<Vec<String>> {
         let mut names = Vec::new();
         let mut pending = vec![(self.root.join(".package-index"), String::new())];
@@ -1238,6 +1267,10 @@ impl Store {
 
     async fn list_package_names(&self) -> Result<Vec<String>> {
         let mut names = self.indexed_package_names().await?;
+        if fs::try_exists(self.root.join(".package-index/.complete")).await? {
+            names.sort();
+            return Ok(names);
+        }
         let mut pending = vec![(self.root.clone(), String::new(), 1usize)];
         while let Some((dir, prefix, depth)) = pending.pop() {
             let mut entries = match fs::read_dir(&dir).await {

--- a/pnpr/crates/storage/src/streaming.rs
+++ b/pnpr/crates/storage/src/streaming.rs
@@ -55,14 +55,10 @@ pub enum BlobStreamError {
 /// wait for the whole download to land and verify first — and the cache entry
 /// is promoted only once the declared SRI matches the full body.
 ///
-/// SRI can only be checked after the last byte, by which point the body has
-/// already been streamed, so a mismatch can't be turned into an error
-/// response. The guarantees that remain are the ones that matter: a
-/// mismatched (or truncated, or oversize) body is never promoted to the cache,
-/// so it can't poison a future client, and every install client re-verifies
-/// what it received against its own expected integrity and rejects bad bytes.
-/// On any such failure — or a dropped client connection — the temp file is
-/// abandoned (and [`BlobWrite`]'s `Drop` removes it as a backstop).
+/// Integrity failures terminate the body with a stream error and abandon the
+/// temporary cache file. Headers and earlier chunks may already have reached
+/// the client, so clients must still verify the received bytes. Dropping the
+/// connection also abandons the temporary file through [`BlobWrite`]'s `Drop`.
 pub fn stream_verified_to_cache(
     response: ThrottledResponse,
     write: BlobWrite,
@@ -133,6 +129,7 @@ pub fn stream_verified_to_cache(
                     Err(err) => {
                         tracing::warn!(url = %state.url, ?err, "proxied blob failed integrity; not caching it");
                         abandon(state.write.take()).await;
+                        return Some((Err(io::Error::other(err)), None));
                     }
                 }
                 None

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -234,3 +234,21 @@ async fn package_index_migrates_nested_legacy_documents_and_ignores_removed_ones
     fs::remove_file(root.join("acme/app/package.json")).await.unwrap();
     assert_eq!(storage.hosted_package_names().await.unwrap(), ["acme/app/tool"]);
 }
+
+#[tokio::test]
+async fn package_index_removes_deleted_and_failed_package_entries() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let name = pkg("@scope/app");
+    storage
+        .update_hosted_document_with_retry(&name, 1, |_| Ok(Some(b"{}".to_vec())))
+        .await
+        .unwrap();
+    let index = tmp.path().join("storage/.package-index/@scope");
+    assert!(index.exists());
+    storage.remove_package(&name).await.unwrap();
+    assert!(!index.exists());
+    fs::create_dir_all(tmp.path().join("storage/@scope/app/package.json")).await.unwrap();
+    assert!(storage.hosted.write_document_if_current(&name, b"{}", None).await.is_err());
+    assert!(!index.exists());
+}

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -220,3 +220,17 @@ async fn failed_blob_finalize_removes_tmp_file() {
     assert!(write.finalize().await.is_err());
     assert!(!tmp_path.exists(), "failed finalization must remove its temporary file");
 }
+
+#[tokio::test]
+async fn package_index_migrates_nested_legacy_documents_and_ignores_removed_ones() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let root = tmp.path().join("storage");
+    fs::create_dir_all(root.join("acme/app/tool")).await.unwrap();
+    fs::write(root.join("acme/app/package.json"), b"{}").await.unwrap();
+    fs::write(root.join("acme/app/tool/package.json"), b"{}").await.unwrap();
+    storage.rebuild_package_index().await.unwrap();
+    assert_eq!(storage.hosted_package_names().await.unwrap(), ["acme/app", "acme/app/tool"]);
+    fs::remove_file(root.join("acme/app/package.json")).await.unwrap();
+    assert_eq!(storage.hosted_package_names().await.unwrap(), ["acme/app/tool"]);
+}

--- a/pnpr/crates/storage/src/upload/tests.rs
+++ b/pnpr/crates/storage/src/upload/tests.rs
@@ -101,19 +101,15 @@ async fn an_in_progress_upload_is_not_a_repository() {
 }
 
 #[tokio::test]
-async fn a_package_nested_under_another_is_not_listed() {
+async fn a_package_nested_under_another_is_listed() {
     let tmp = TempDir::new().unwrap();
     let storage = storage_in(&tmp);
 
-    // `acme/app` is both a package and the namespace of `acme/app/tool`. The
-    // walk stops at the first document so that a listing stays proportional
-    // to the number of packages rather than the number of blobs, which leaves
-    // the nested one unlisted. Tracked in pnpm/pnpm#14630.
     for name in ["acme/app", "acme/app/tool"] {
         storage.write_hosted_document_if_current(&image(name), b"{}", None).await.unwrap();
     }
 
-    assert_eq!(storage.hosted_package_names().await.unwrap(), ["acme/app"]);
+    assert_eq!(storage.hosted_package_names().await.unwrap(), ["acme/app", "acme/app/tool"]);
 }
 
 #[tokio::test]

--- a/pnpr/crates/upstream/src/lib.rs
+++ b/pnpr/crates/upstream/src/lib.rs
@@ -1,3 +1,7 @@
+mod oci;
+
+pub use oci::oci_download_allowed;
+
 use chrono::{DateTime, Timelike, Utc};
 use pnpm_lockfile::{
     MAX_TARBALL_REVISION, TarballRevision, integrity_addressed_registry_tarball_url,
@@ -64,6 +68,7 @@ pub struct Upstream {
     /// every clone of this `Upstream` (the registry holds one per upstream
     /// and clones it per request) updates the same counters.
     breaker: Arc<CircuitBreaker>,
+    oci_tokens: Arc<Mutex<std::collections::HashMap<String, oci::CachedToken>>>,
 }
 
 impl fmt::Debug for Upstream {
@@ -78,7 +83,7 @@ impl fmt::Debug for Upstream {
             .field("maxage", &self.maxage)
             .field("cache", &self.cache)
             .field("breaker", &self.breaker)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 
@@ -242,6 +247,7 @@ impl Upstream {
             maxage: config.maxage,
             cache: config.cache,
             breaker: Arc::new(CircuitBreaker::new(config.max_fails, config.fail_timeout)),
+            oci_tokens: Arc::default(),
         }
     }
 

--- a/pnpr/crates/upstream/src/oci.rs
+++ b/pnpr/crates/upstream/src/oci.rs
@@ -24,19 +24,14 @@ impl Upstream {
         self.fetch_oci_request(repository, endpoint, accept, reqwest::Method::GET).await
     }
 
-    /// Read blob headers without transferring a layer body.
-    pub async fn head_oci_blob(
+    /// Read OCI object headers without transferring the body.
+    pub async fn head_oci(
         &self,
         repository: &str,
-        digest: &str,
+        endpoint: &str,
+        accept: &str,
     ) -> Result<FetchOutcome<ThrottledResponse>> {
-        self.fetch_oci_request(
-            repository,
-            &format!("blobs/{digest}"),
-            "application/octet-stream",
-            reqwest::Method::HEAD,
-        )
-        .await
+        self.fetch_oci_request(repository, endpoint, accept, reqwest::Method::HEAD).await
     }
 
     async fn fetch_oci_request(

--- a/pnpr/crates/upstream/src/oci.rs
+++ b/pnpr/crates/upstream/src/oci.rs
@@ -1,0 +1,272 @@
+use super::{FetchOutcome, Upstream};
+use pnpm_network::{
+    ThrottledResponse, UNPRIORITIZED, is_url_secure_for_credentials, read_limited_body,
+};
+use pnpr_error::{RegistryError, Result};
+use reqwest::{StatusCode, Url, header};
+use serde::Deserialize;
+use std::time::{Duration, Instant};
+
+pub(super) struct CachedToken {
+    token: String,
+    expires: Instant,
+}
+
+impl Upstream {
+    /// Fetch an OCI object, negotiating repository-scoped pull credentials.
+    /// Credentials never travel to a layer CDN or a redirected token endpoint.
+    pub async fn fetch_oci(
+        &self,
+        repository: &str,
+        endpoint: &str,
+        accept: &str,
+    ) -> Result<FetchOutcome<ThrottledResponse>> {
+        self.fetch_oci_request(repository, endpoint, accept, reqwest::Method::GET).await
+    }
+
+    /// Read blob headers without transferring a layer body.
+    pub async fn head_oci_blob(
+        &self,
+        repository: &str,
+        digest: &str,
+    ) -> Result<FetchOutcome<ThrottledResponse>> {
+        self.fetch_oci_request(
+            repository,
+            &format!("blobs/{digest}"),
+            "application/octet-stream",
+            reqwest::Method::HEAD,
+        )
+        .await
+    }
+
+    async fn fetch_oci_request(
+        &self,
+        repository: &str,
+        endpoint: &str,
+        accept: &str,
+        method: reqwest::Method,
+    ) -> Result<FetchOutcome<ThrottledResponse>> {
+        self.ensure_available()?;
+        let base = Url::parse(&self.base).map_err(|_| self.oci_error("invalid registry URL"))?;
+        let mut url = base
+            .join(&format!("v2/{repository}/{endpoint}"))
+            .map_err(|_| self.oci_error("invalid OCI object URL"))?;
+        let started = Instant::now();
+        let mut bearer = self
+            .oci_tokens
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(repository)
+            .filter(|token| token.expires > Instant::now())
+            .map(|token| token.token.clone());
+        let mut negotiated = false;
+        for _ in 0..8 {
+            self.ensure_allowed_url(url.as_str())?;
+            let guard = self
+                .client
+                .acquire_for_url_without_redirects_with_priority(url.as_str(), UNPRIORITIZED)
+                .await;
+            let mut request = guard
+                .request(method.clone(), url.clone())
+                .timeout(self.timeout.saturating_sub(started.elapsed()))
+                .header(header::ACCEPT, accept);
+            if url.origin() == base.origin() && is_url_secure_for_credentials(url.as_str()) {
+                request = request.headers(self.request_headers(url.as_str()));
+                if let Some(token) = &bearer {
+                    request = request.bearer_auth(token);
+                }
+            }
+            let response = self.run(request, url.as_str()).await?;
+            if response.status() == StatusCode::UNAUTHORIZED
+                && !negotiated
+                && url.origin() == base.origin()
+            {
+                let challenge = response
+                    .headers()
+                    .get(header::WWW_AUTHENTICATE)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(parse_challenge)
+                    .ok_or_else(|| self.oci_error("unsupported OCI authentication challenge"))?;
+                drop(response);
+                drop(guard);
+                bearer = Some(self.oci_token(&base, repository, challenge).await?);
+                negotiated = true;
+                continue;
+            }
+            if response.status().is_redirection() {
+                let target = response
+                    .headers()
+                    .get(header::LOCATION)
+                    .and_then(|value| value.to_str().ok())
+                    .and_then(|value| url.join(value).ok())
+                    .ok_or_else(|| self.oci_error("invalid OCI redirect"))?;
+                if !oci_download_allowed(&base, &target) {
+                    return Err(self.oci_error("OCI redirect is outside the download allowlist"));
+                }
+                url = target;
+                continue;
+            }
+            if response.status() == StatusCode::NOT_FOUND {
+                self.breaker.record_success();
+                return Ok(FetchOutcome::NotFound);
+            }
+            let response = self.checked(response, url.as_str()).await?;
+            self.breaker.record_success();
+            return Ok(FetchOutcome::Ok(
+                guard.retain_for_body(response, self.timeout.saturating_sub(started.elapsed())),
+            ));
+        }
+        Err(self.oci_error("too many OCI redirects"))
+    }
+
+    async fn oci_token(
+        &self,
+        base: &Url,
+        repository: &str,
+        challenge: Challenge,
+    ) -> Result<String> {
+        let mut realm =
+            Url::parse(&challenge.realm).map_err(|_| self.oci_error("invalid OCI token realm"))?;
+        if !token_realm_allowed(base, &realm) {
+            return Err(self.oci_error("OCI token realm is not trusted"));
+        }
+        realm.set_query(None);
+        realm
+            .query_pairs_mut()
+            .append_pair("service", &challenge.service)
+            .append_pair("scope", &format!("repository:{repository}:pull"));
+        let guard = self
+            .client
+            .acquire_for_url_without_redirects_with_priority(realm.as_str(), UNPRIORITIZED)
+            .await;
+        let mut headers = self.request_headers(realm.as_str());
+        if realm.origin() != base.origin()
+            && is_url_secure_for_credentials(realm.as_str())
+            && let Some(authorization) = self.headers.get(header::AUTHORIZATION)
+        {
+            headers.insert(header::AUTHORIZATION, authorization.clone());
+        }
+        let response = guard
+            .get(realm.clone())
+            .timeout(self.timeout)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|source| RegistryError::Upstream { url: self.base.clone(), source })?;
+        if !response.status().is_success() {
+            return Err(self.oci_error("OCI token service refused authentication"));
+        }
+        let body = read_limited_body(response, 64 * 1024)
+            .await
+            .map_err(|source| RegistryError::Upstream { url: self.base.clone(), source })?;
+        if body.truncated {
+            return Err(self.oci_error("OCI token response is too large"));
+        }
+        let token: TokenResponse = serde_json::from_slice(&body.bytes)
+            .map_err(|_| self.oci_error("invalid OCI token response"))?;
+        let expires_in = token.expires_in.unwrap_or(60).min(3600);
+        let token = token
+            .token
+            .or(token.access_token)
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| self.oci_error("OCI token response contains no token"))?;
+        let mut cache = self.oci_tokens.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        cache.retain(|_, token| token.expires > Instant::now());
+        if cache.len() >= 256 {
+            cache.clear();
+        }
+        if expires_in > 5 {
+            cache.insert(
+                repository.to_string(),
+                CachedToken {
+                    token: token.clone(),
+                    expires: Instant::now() + Duration::from_secs(expires_in - 5),
+                },
+            );
+        }
+        Ok(token)
+    }
+
+    fn oci_error(&self, reason: &str) -> RegistryError {
+        RegistryError::UpstreamResponse { url: self.base.clone(), reason: reason.to_string() }
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    token: Option<String>,
+    access_token: Option<String>,
+    expires_in: Option<u64>,
+}
+
+struct Challenge {
+    realm: String,
+    service: String,
+}
+
+fn parse_challenge(value: &str) -> Option<Challenge> {
+    let (scheme, mut remaining) = value.split_once(' ')?;
+    if !scheme.eq_ignore_ascii_case("Bearer") {
+        return None;
+    }
+    let mut realm = None;
+    let mut service = None;
+    while !remaining.trim().is_empty() {
+        let (key, tail) = remaining.trim_start().split_once('=')?;
+        let tail = tail.trim_start().strip_prefix('"')?;
+        let end = tail.find('"')?;
+        let value = &tail[..end];
+        if value.contains('\\') {
+            return None;
+        }
+        match key.trim() {
+            "realm" if realm.is_none() => realm = Some(value.to_string()),
+            "service" if service.is_none() => service = Some(value.to_string()),
+            "realm" | "service" => return None,
+            _ => {}
+        }
+        remaining = tail[end + 1..].trim_start();
+        if !remaining.is_empty() {
+            remaining = remaining.strip_prefix(',')?;
+        }
+    }
+    Some(Challenge { realm: realm?, service: service.unwrap_or_default() })
+}
+
+fn token_realm_allowed(base: &Url, realm: &Url) -> bool {
+    realm.username().is_empty()
+        && realm.password().is_none()
+        && realm.fragment().is_none()
+        && (realm.origin() == base.origin()
+            || (base.origin().ascii_serialization() == "https://registry-1.docker.io"
+                && realm.origin().ascii_serialization() == "https://auth.docker.io"
+                && realm.path() == "/token"))
+}
+
+/// The configured origin and the public layer hosts used by Docker Hub and GHCR.
+#[must_use]
+pub fn oci_download_allowed(base: &Url, target: &Url) -> bool {
+    if !matches!(target.scheme(), "http" | "https")
+        || !target.username().is_empty()
+        || target.password().is_some()
+    {
+        return false;
+    }
+    if target.origin() == base.origin() {
+        return true;
+    }
+    let origin = target.origin().ascii_serialization();
+    match base.origin().ascii_serialization().as_str() {
+        "https://registry-1.docker.io" => matches!(
+            origin.as_str(),
+            "https://production.cloudflare.docker.com"
+                | "https://production.cloudfront.docker.com"
+                | "https://docker-images-prod.6aa30f8b08e16409b46e0173d6de2f56.r2.cloudflarestorage.com",
+        ),
+        "https://ghcr.io" => origin == "https://pkg-containers.githubusercontent.com",
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpr/crates/upstream/src/oci/tests.rs
+++ b/pnpr/crates/upstream/src/oci/tests.rs
@@ -1,0 +1,96 @@
+use super::{oci_download_allowed, parse_challenge, token_realm_allowed};
+use reqwest::Url;
+
+#[test]
+fn parses_pull_challenges_and_rejects_ambiguous_realms() {
+    let challenge = parse_challenge(r#"Bearer realm="https://auth.docker.io/token",service="registry.docker.io",scope="repository:library/alpine:pull,push""#).unwrap();
+    assert_eq!(challenge.realm, "https://auth.docker.io/token");
+    assert_eq!(challenge.service, "registry.docker.io");
+    assert!(parse_challenge(r#"Bearer realm="https://a",realm="https://b""#).is_none());
+}
+
+#[test]
+fn only_trusts_origin_specific_token_and_download_hosts() {
+    let hub = Url::parse("https://registry-1.docker.io/").unwrap();
+    let ghcr = Url::parse("https://ghcr.io/").unwrap();
+    let auth = Url::parse("https://auth.docker.io/token").unwrap();
+    assert!(token_realm_allowed(&hub, &auth));
+    assert!(!token_realm_allowed(&ghcr, &auth));
+    assert!(!token_realm_allowed(&hub, &Url::parse("http://auth.docker.io/token").unwrap()));
+    let cdn = Url::parse("https://production.cloudflare.docker.com/layer").unwrap();
+    assert!(oci_download_allowed(&hub, &cdn));
+    assert!(!oci_download_allowed(&ghcr, &cdn));
+    assert!(!oci_download_allowed(&hub, &Url::parse("http://127.0.0.1/layer").unwrap()));
+}
+
+#[tokio::test]
+async fn negotiates_pull_scope_and_reuses_token_without_forwarding_client_scope() {
+    use crate::{FetchOutcome, Upstream};
+    use pnpr_config::UpstreamConfig;
+    use reqwest::header::HeaderMap;
+    let mut server = mockito::Server::new_async().await;
+    let challenge = server.mock("GET", "/v2/acme/app/manifests/latest")
+        .match_header("authorization", mockito::Matcher::Missing).with_status(401)
+        .with_header("www-authenticate", &format!(r#"Bearer realm="{}/token",service="registry",scope="repository:other/app:pull,push""#, server.url()))
+        .expect(1).create_async().await;
+    let tokens = server
+        .mock("GET", "/token")
+        .match_query(mockito::Matcher::AllOf(vec![
+            mockito::Matcher::UrlEncoded("service".into(), "registry".into()),
+            mockito::Matcher::UrlEncoded("scope".into(), "repository:acme/app:pull".into()),
+        ]))
+        .with_body(r#"{"token":"scoped","expires_in":300}"#)
+        .expect(1)
+        .create_async()
+        .await;
+    let authorized = server
+        .mock("GET", "/v2/acme/app/manifests/latest")
+        .match_header("authorization", "Bearer scoped")
+        .with_body("manifest")
+        .expect(2)
+        .create_async()
+        .await;
+    let upstream = Upstream::new(
+        "registry",
+        &UpstreamConfig::with_defaults(format!("{}/", server.url()), HeaderMap::new()),
+    );
+    for _ in 0..2 {
+        let FetchOutcome::Ok(response) =
+            upstream.fetch_oci("acme/app", "manifests/latest", "application/json").await.unwrap()
+        else {
+            panic!("expected manifest")
+        };
+        assert_eq!(response.bytes().await.unwrap(), "manifest");
+    }
+    challenge.assert_async().await;
+    tokens.assert_async().await;
+    authorized.assert_async().await;
+}
+
+#[tokio::test]
+async fn rejects_an_untrusted_token_realm_without_contacting_it() {
+    use crate::Upstream;
+    use pnpr_config::UpstreamConfig;
+    use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
+    let mut server = mockito::Server::new_async().await;
+    let mut attacker = mockito::Server::new_async().await;
+    let stolen = attacker.mock("GET", "/token").expect(0).create_async().await;
+    let challenge = server
+        .mock("GET", "/v2/acme/app/manifests/latest")
+        .with_status(401)
+        .with_header(
+            "www-authenticate",
+            &format!(r#"Bearer realm="{}/token",service="registry""#, attacker.url()),
+        )
+        .create_async()
+        .await;
+    let mut headers = HeaderMap::new();
+    headers.insert(AUTHORIZATION, HeaderValue::from_static("Basic secret"));
+    let upstream = Upstream::new(
+        "registry",
+        &UpstreamConfig::with_defaults(format!("{}/", server.url()), headers),
+    );
+    assert!(upstream.fetch_oci("acme/app", "manifests/latest", "application/json").await.is_err());
+    challenge.assert_async().await;
+    stolen.assert_async().await;
+}


### PR DESCRIPTION
## Summary

Completes the remaining OCI registry work tracked in pnpm/pnpm#14630, including the catalog and blob-deletion follow-ups in its comments.

- Cache Docker Hub and GHCR manifest/blob pulls, negotiate upstream pull tokens, restrict token realms and layer redirects, and verify cached content by digest.
- Offer optional five-minute Bearer credentials scoped to repositories and actions. Parent credential revocation, read-only restrictions, and network restrictions remain effective.
- Accept OCI manifest entries in cross-ecosystem publish batches after their layers have been uploaded.
- Configure cumulative blob and manifest size limits while preserving the existing defaults.
- Index nested filesystem repositories without scanning layer files during catalog requests.
- Delete unreferenced blobs safely across replicas, using the collector's reference walk and stored generations to reject conflicting staged publishes.

Validation: `just ready` passed all 10,633 Rust tests, workspace checks, Clippy, and formatting. Rustdoc and Dylint also passed. Review follow-ups add body errors on failed stream integrity checks, preserve batch error context, and improve token-scope compatibility.

This change affects pnpr only. Live `skopeo copy` checks successfully pulled Alpine from Docker Hub and ORAS from GHCR through pnpr with Bearer authentication enabled.

## Squash Commit Body

```text
Complete the OCI registry's remaining hosted and upstream workflows.

Reuse the verified streaming cache and publish journal. OCI batch entries
carry a base64 manifest and reference layers uploaded through /v2/ first.
Upstream tokens are cached by repository with bounded expiry and capacity;
credentials are restricted to the configured origin and trusted token service.

Bind short-lived OCI credentials to the original token's hash and the
addressed registry path. Check the original token's restrictions and current
registry policy on subsequent requests. Scoped tokens cannot access other
pnpr APIs, and mounts require pull scope for the source repository.

Maintain a separate filesystem package index, migrating legacy stores once
at startup. Catalog requests can find nested repositories without walking
through the parent's layer population. Prune index entries after removal
or failed creation. Uncached manifest probes use upstream HEAD, falling back to a verified GET
when legacy registries omit the digest header. Integrity failures abort shared
blob streams, and OCI batch validation preserves the original registry errors.

Explicit blob deletion reserves a marker in the repository document before
removing bytes. Increment its generation so a staged or recovered publish
cannot restore a manifest referencing the deleted content. An interrupted
deletion blocks new publishes until offline oci-gc finishes it. All replicas
must be upgraded before using online deletion. Filesystem stores retain
their existing exclusive-owner requirement.

Add regression coverage for scope and expiry checks, credential revocation,
cache poisoning, upstream authentication boundaries, cumulative upload
limits, nested catalogs, batch rollback, interrupted deletion, and a
manifest commit racing blob deletion on another replica.

Closes pnpm/pnpm#14630.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves the remaining work.
- [x] Added changesets for the new pnpr features. The catalog fix affects the unreleased OCI feature.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCI image publishing through batch APIs and the OCI distribution API.
  * Added Docker Hub and GHCR pull-through caching with digest verification.
  * Added scoped, short-lived OCI bearer-token authentication.
  * Added authorized deletion of unreferenced OCI blobs with safeguards for retained manifests.
  * Added configurable blob and manifest size limits.
  * Added OCI catalog support, manifest HEAD requests, and upstream proxying.
  * Added package-index rebuilding and improved nested package discovery.

* **Bug Fixes**
  * Invalid proxied content now aborts streaming and is not cached.
  * Package indexes remain consistent after recovery and failed writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->