### PR TITLE
fix(config): route `@jsr` packages through the built-in JSR registry

### DIFF
--- a/.changeset/jsr-scope-routing-in-verification.md
+++ b/.changeset/jsr-scope-routing-in-verification.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Installing a lockfile that holds a JSR dependency no longer fails with `ERR_PNPM_META_FETCH_FAIL`. Every lookup that routes a package by its scope now uses the built-in `@jsr` route to npm.jsr.io. The supply-chain policy check asked the default registry for the `@jsr/*` metadata and got a 404 [#14649](https://github.com/pnpm/pnpm/issues/14649).
+`pnpm install` no longer fails with `ERR_PNPM_META_FETCH_FAIL` on a lockfile that holds a JSR dependency. pnpm now reads `@jsr/*` metadata from npm.jsr.io everywhere, not only when resolving a `jsr:` specifier. The supply-chain policy check asked the default registry for it and got a 404 [#14649](https://github.com/pnpm/pnpm/issues/14649).

--- a/.changeset/jsr-scope-routing-in-verification.md
+++ b/.changeset/jsr-scope-routing-in-verification.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer fails with `ERR_PNPM_META_FETCH_FAIL` on a lockfile that holds a JSR dependency. pnpm now reads `@jsr/*` metadata from npm.jsr.io everywhere, not only when resolving a `jsr:` specifier. The supply-chain policy check asked the default registry for it and got a 404 [#14649](https://github.com/pnpm/pnpm/issues/14649).
+`pnpm install` no longer fails with `ERR_PNPM_META_FETCH_FAIL` on a lockfile that holds a JSR dependency. pnpm reads `@jsr/*` metadata from npm.jsr.io. The supply-chain policy check asked the default registry for it and got a 404 [#14649](https://github.com/pnpm/pnpm/issues/14649).

--- a/.changeset/jsr-scope-routing-in-verification.md
+++ b/.changeset/jsr-scope-routing-in-verification.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Installing a lockfile that holds a JSR dependency no longer fails with `ERR_PNPM_META_FETCH_FAIL`. Every lookup that routes a package by its scope now uses the built-in `@jsr` route to npm.jsr.io. The supply-chain policy check asked the default registry for the `@jsr/*` metadata and got a 404 [#14649](https://github.com/pnpm/pnpm/issues/14649).

--- a/.changeset/pnpr-jsr-builtin-route.md
+++ b/.changeset/pnpr-jsr-builtin-route.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-pnpr now resolves JSR packages without configuration. npm.jsr.io is a built-in public route, like the npm registry.
+pnpr now resolves JSR packages without configuration. npm.jsr.io is a built-in public route, like the npm registry. The built-in routes are reachable over HTTPS only.

--- a/.changeset/pnpr-jsr-builtin-route.md
+++ b/.changeset/pnpr-jsr-builtin-route.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-pnpr now resolves JSR packages without configuration. npm.jsr.io is a built-in public route, alongside the npm registry, so a client whose graph holds a JSR dependency no longer needs the operator to declare that origin.
+pnpr now resolves JSR packages without configuration. npm.jsr.io is a built-in public route, like the npm registry.

--- a/.changeset/pnpr-jsr-builtin-route.md
+++ b/.changeset/pnpr-jsr-builtin-route.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+pnpr now resolves JSR packages without configuration. npm.jsr.io is a built-in public route, alongside the npm registry, so a client whose graph holds a JSR dependency no longer needs the operator to declare that origin.

--- a/pnpm/crates/cli/src/cli_args/changelog.rs
+++ b/pnpm/crates/cli/src/cli_args/changelog.rs
@@ -16,6 +16,7 @@ use miette::IntoDiagnostic;
 use pnpm_config::Config;
 use pnpm_network::{ThrottledClient, encode_package_name, redact_url_credentials};
 use pnpm_registry::Package;
+use pnpm_resolving_npm_resolver::pick_registry_for_package;
 use pnpm_versioning::{
     ChangelogStorage, ReleasePlan, changelog_storage, list_pending_changelogs,
     read_pending_changelog, render_changelog,
@@ -227,15 +228,11 @@ fn previous_version(package: &Package, version: &str) -> Option<String> {
         .map(|(_, key)| key.clone())
 }
 
-/// The registry a package's metadata is read from: the scope's registry when
-/// configured, else the default. Mirrors `pickRegistryForPackage`.
+/// The registry a package's metadata is read from, with the trailing slash
+/// the request paths are joined onto.
 fn registry_for(config: &Config, name: &str) -> String {
-    let registry = name
-        .strip_prefix('@')
-        .and_then(|rest| rest.split('/').next())
-        .and_then(|scope| config.registries_by_scope.get(&format!("@{scope}")))
-        .cloned()
-        .unwrap_or_else(|| config.registry.clone());
+    let registries: HashMap<String, String> = config.resolved_registries().into_iter().collect();
+    let registry = pick_registry_for_package(&registries, name, None);
     if registry.ends_with('/') { registry } else { format!("{registry}/") }
 }
 

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -136,6 +136,7 @@ mod update_jsr;
 mod update_notifier;
 mod update_recursive;
 mod verify_deps_before_run;
+mod verify_jsr;
 mod version;
 mod view;
 mod whoami;

--- a/pnpm/crates/cli/tests/suite/verify_jsr.rs
+++ b/pnpm/crates/cli/tests/suite/verify_jsr.rs
@@ -8,6 +8,9 @@ use assert_cmd::prelude::*;
 use std::fs;
 use tempfile::{TempDir, tempdir};
 
+/// The integrity is a placeholder: the run fails at the metadata lookup this
+/// test is about, so no artifact is ever fetched or hashed. What matters is
+/// the entry's name and its `npm.jsr.io` tarball.
 const JSR_LOCKFILE: &str = r"lockfileVersion: '9.0'
 
 settings:
@@ -25,16 +28,15 @@ importers:
 packages:
 
   '@jsr/std__csv@1.0.6':
-    resolution: {integrity: sha512-9n/SZzjolPQ907gUPksQU3EFURwRl4GA9V6MylA8hpSkpxhcj6J98zDpn9EmDqgE2A4L9MnlUvFhRpeWl+Y/ZQ==, tarball: https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz}
+    resolution: {integrity: sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==, tarball: https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz}
 
 snapshots:
 
   '@jsr/std__csv@1.0.6': {}
 ";
 
-/// A project whose committed lockfile holds a JSR dependency, with an empty
-/// cache and a default registry that is not npmjs, so the host the run reaches
-/// for is the one under test.
+/// The default registry is deliberately neither npmjs nor a reachable host, so
+/// the only registry the run can succeed at naming is the built-in JSR route.
 fn jsr_project() -> TempDir {
     let root = tempdir().expect("create temp directory");
     let workspace = root.path();
@@ -51,10 +53,8 @@ fn jsr_project() -> TempDir {
     root
 }
 
-/// The metadata a `@jsr/*` entry is verified against is asked of npm.jsr.io,
-/// the built-in route for the scope, not of the default registry, which serves
-/// no `@jsr/*` packument. `--offline` names the registry in the mirror path it
-/// looked the metadata up in, so the routing is observable without a request.
+/// `--offline` names the registry in the metadata mirror path it failed to
+/// read, which is what makes the route observable without a request.
 #[test]
 fn a_jsr_lockfile_entry_is_verified_against_the_jsr_registry() {
     let root = jsr_project();

--- a/pnpm/crates/cli/tests/suite/verify_jsr.rs
+++ b/pnpm/crates/cli/tests/suite/verify_jsr.rs
@@ -1,0 +1,78 @@
+//! Registry routing for `@jsr/*` lockfile entries during supply-chain policy
+//! verification, the shape reported in
+//! [pnpm/pnpm#14649](https://github.com/pnpm/pnpm/issues/14649).
+
+use crate::_utils::{flatten_report, pacquet_in};
+
+use assert_cmd::prelude::*;
+use std::fs;
+use tempfile::{TempDir, tempdir};
+
+const JSR_LOCKFILE: &str = r"lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@std/csv':
+        specifier: jsr:^1.0.6
+        version: '@jsr/std__csv@1.0.6'
+
+packages:
+
+  '@jsr/std__csv@1.0.6':
+    resolution: {integrity: sha512-9n/SZzjolPQ907gUPksQU3EFURwRl4GA9V6MylA8hpSkpxhcj6J98zDpn9EmDqgE2A4L9MnlUvFhRpeWl+Y/ZQ==, tarball: https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz}
+
+snapshots:
+
+  '@jsr/std__csv@1.0.6': {}
+";
+
+/// A project whose committed lockfile holds a JSR dependency, with an empty
+/// cache and a default registry that is not npmjs, so the host the run reaches
+/// for is the one under test.
+fn jsr_project() -> TempDir {
+    let root = tempdir().expect("create temp directory");
+    let workspace = root.path();
+    fs::write(workspace.join(".npmrc"), "registry=https://registry.example.test/\n")
+        .expect("write .npmrc");
+    fs::write(workspace.join("pnpm-workspace.yaml"), "storeDir: store\ncacheDir: cache\n")
+        .expect("write pnpm-workspace.yaml");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { "@std/csv": "jsr:^1.0.6" } }).to_string(),
+    )
+    .expect("write project manifest");
+    fs::write(workspace.join("pnpm-lock.yaml"), JSR_LOCKFILE).expect("write lockfile");
+    root
+}
+
+/// The metadata a `@jsr/*` entry is verified against is asked of npm.jsr.io,
+/// the built-in route for the scope, not of the default registry, which serves
+/// no `@jsr/*` packument. `--offline` names the registry in the mirror path it
+/// looked the metadata up in, so the routing is observable without a request.
+#[test]
+fn a_jsr_lockfile_entry_is_verified_against_the_jsr_registry() {
+    let root = jsr_project();
+
+    let assert = pacquet_in(root.path())
+        .args(["install", "--frozen-lockfile", "--offline"])
+        .assert()
+        .failure();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr);
+    eprintln!("STDERR:\n{stderr}\n");
+    let report = flatten_report(&stderr);
+    assert!(
+        report.contains("npm.jsr.io"),
+        "the JSR metadata must be looked up under npm.jsr.io; got:\n{stderr}",
+    );
+    assert!(
+        !report.contains("registry.example.test"),
+        "the default registry must not be asked for an `@jsr/*` packument; got:\n{stderr}",
+    );
+}

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2548,7 +2548,11 @@ pub struct PackageManagerBootstrap {
 
 impl PackageManagerBootstrap {
     /// Registry map in pnpm's `Registries` shape: `default` plus the
-    /// configured scoped routes. Mirrors [`Config::resolved_registries`].
+    /// configured scoped routes.
+    ///
+    /// The built-in `@jsr` route [`Config::resolved_registries`] carries is
+    /// left out: this map resolves the package manager alone, which is never
+    /// a JSR package.
     #[must_use]
     pub fn resolved_registries(&self) -> BTreeMap<String, String> {
         let mut registries = self.registries.clone();
@@ -2807,9 +2811,17 @@ impl Config {
 
     /// Registry map in pnpm's `Registries` shape: `default` plus the
     /// configured scoped routes keyed by `@scope`.
+    ///
+    /// The built-in `@jsr` route is one of them, so every consumer that
+    /// routes a package by its scope — the resolver, the lockfile
+    /// verifier, `pnpm why`, `pnpm view` — reaches JSR packages at
+    /// npm.jsr.io instead of asking the default registry for an
+    /// `@jsr/*` packument it does not serve. A configured `@jsr:registry`
+    /// wins over it.
     #[must_use]
     pub fn resolved_registries(&self) -> BTreeMap<String, String> {
         let mut registries = self.registries_by_scope.clone();
+        registries.entry("@jsr".to_string()).or_insert_with(|| DEFAULT_JSR_REGISTRY.to_string());
         registries.insert("default".to_string(), self.registry.clone());
         registries
     }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3252,10 +3252,8 @@ fn resolved_declarations_declare_every_route() {
     );
 }
 
-/// The map every scope-routed lookup resolves through carries the built-in
-/// `@jsr` route, so an `@jsr/*` package is fetched from npm.jsr.io instead of
-/// being asked of the default registry, which does not serve it. See
-/// <https://github.com/pnpm/pnpm/issues/14649>.
+/// Every scope-routed lookup resolves through this map, so the built-in `@jsr`
+/// route has to be in it. See <https://github.com/pnpm/pnpm/issues/14649>.
 #[test]
 fn resolved_registries_carry_the_builtin_jsr_route() {
     let mut config = Config::new();
@@ -3267,8 +3265,6 @@ fn resolved_registries_carry_the_builtin_jsr_route() {
     assert_eq!(registries.get("@jsr").map(String::as_str), Some("https://npm.jsr.io/"));
 }
 
-/// A configured `@jsr` route wins over the built-in one, so a user who mirrors
-/// JSR resolves through their mirror.
 #[test]
 fn a_configured_jsr_route_beats_the_builtin_one() {
     let mut config = Config::new();

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3252,6 +3252,35 @@ fn resolved_declarations_declare_every_route() {
     );
 }
 
+/// The map every scope-routed lookup resolves through carries the built-in
+/// `@jsr` route, so an `@jsr/*` package is fetched from npm.jsr.io instead of
+/// being asked of the default registry, which does not serve it. See
+/// <https://github.com/pnpm/pnpm/issues/14649>.
+#[test]
+fn resolved_registries_carry_the_builtin_jsr_route() {
+    let mut config = Config::new();
+    config.registry = "https://npm.corp.example/".to_owned();
+
+    let registries = config.resolved_registries();
+
+    assert_eq!(registries.get("default").map(String::as_str), Some("https://npm.corp.example/"));
+    assert_eq!(registries.get("@jsr").map(String::as_str), Some("https://npm.jsr.io/"));
+}
+
+/// A configured `@jsr` route wins over the built-in one, so a user who mirrors
+/// JSR resolves through their mirror.
+#[test]
+fn a_configured_jsr_route_beats_the_builtin_one() {
+    let mut config = Config::new();
+    config.registries_by_scope =
+        BTreeMap::from([("@jsr".to_owned(), "https://jsr.corp.example/".to_owned())]);
+
+    assert_eq!(
+        config.resolved_registries().get("@jsr").map(String::as_str),
+        Some("https://jsr.corp.example/"),
+    );
+}
+
 /// A declaration map survives the round trip through the lookups it is split
 /// into, which is what makes it safe to rebuild one for a pnpr request.
 #[test]

--- a/pnpr/crates/route/src/lib.rs
+++ b/pnpr/crates/route/src/lib.rs
@@ -296,10 +296,12 @@ impl RouteContext {
     #[must_use]
     pub fn from_config(config: &Config) -> Self {
         let hosted_origin = nerf_prefix(&config.public_url);
-        // The official npm registry is a built-in public route, so it is both
-        // allowlisted and classified public without any operator config (and
-        // ahead of any upstream credential for the same origin — public wins).
-        let public_routes = std::iter::once(RouteMatcher::npmjs())
+        // The registries pnpm itself routes to without configuration are
+        // built-in public routes, so they are both allowlisted and classified
+        // public without any operator config (and ahead of any upstream
+        // credential for the same origin — public wins).
+        let public_routes = [RouteMatcher::npmjs(), RouteMatcher::jsr()]
+            .into_iter()
             .chain(config.route_policy.public.iter().filter_map(RouteMatcher::from_public_route))
             .collect();
         // Proxied-route credentials come from `upstreams:` entries that declare
@@ -643,8 +645,12 @@ fn hosted_policy_id(registry: &str, package: &str) -> String {
     format!("{registry}\0{package}")
 }
 
-/// Nerf-darted origin of the official npm registry, the built-in public route.
+/// Nerf-darted origin of the official npm registry, a built-in public route.
 const NPMJS_ORIGIN: &str = "//registry.npmjs.org/";
+
+/// Nerf-darted origin of the JSR registry's npm compatibility layer, the
+/// registry pnpm's built-in `@jsr` scope route points at.
+const JSR_ORIGIN: &str = "//npm.jsr.io/";
 
 impl RouteMatcher {
     /// The built-in public route: the official npm registry, host-level (no
@@ -656,6 +662,14 @@ impl RouteMatcher {
     /// any config, and ahead of any upstream credential for the same origin.
     fn npmjs() -> Self {
         Self { origin: Some(NPMJS_ORIGIN.to_string()), package: None }
+    }
+
+    /// The other built-in public route: JSR, which every pnpm client routes
+    /// the `@jsr` scope to without configuring anything, so a graph holding a
+    /// JSR dependency resolves through a default server. It hosts no private
+    /// content, so the reasoning in [`Self::npmjs`] applies unchanged.
+    fn jsr() -> Self {
+        Self { origin: Some(JSR_ORIGIN.to_string()), package: None }
     }
 
     /// Build a matcher from an operator-declared public route, failing

--- a/pnpr/crates/route/src/lib.rs
+++ b/pnpr/crates/route/src/lib.rs
@@ -710,7 +710,8 @@ impl RouteMatcher {
     /// admits.
     fn allowlists(&self, fetch: &str, scheme: Option<&str>) -> bool {
         self.origin.as_deref().is_some_and(|origin| fetch.starts_with(origin))
-            && (!self.https_only || scheme == Some("https"))
+            && (!self.https_only
+                || scheme.is_some_and(|scheme| scheme.eq_ignore_ascii_case("https")))
     }
 
     fn matches(&self, fetch: &str, package: Option<&str>) -> bool {

--- a/pnpr/crates/route/src/lib.rs
+++ b/pnpr/crates/route/src/lib.rs
@@ -250,6 +250,10 @@ struct RouteMatcher {
     /// any registry.
     origin: Option<String>,
     package: Option<Glob<'static>>,
+    /// Whether the route allowlists `https` fetches only. Set on the built-in
+    /// routes, whose hosts are public and serve TLS — see
+    /// [`RouteContext::allows_registry`].
+    https_only: bool,
 }
 
 #[derive(Clone)]
@@ -492,12 +496,18 @@ impl RouteContext {
     }
 
     /// Whether pnpr is permitted to fetch from `url`'s registry at all. The
-    /// allowlist is the union of every configured route: the built-in npm
-    /// host, operator-declared public routes, configured upstream origins, and
+    /// allowlist is the union of every configured route: the built-in public
+    /// hosts, operator-declared public routes, configured upstream origins, and
     /// pnpr's own origin (which serves its hosted packages and `/~<name>/`
     /// endpoints). A client `registry`/`namedRegistries` matching none of
     /// these is rejected before any server-side fetch — the resolver's SSRF
     /// boundary — so there is no "unknown registry" to resolve anonymously.
+    ///
+    /// Every hop of a redirect is re-checked here too, so a route that admits
+    /// cleartext admits a downgrade to it. The built-in hosts therefore
+    /// allowlist `https` alone; an operator's own routes and upstreams keep
+    /// whatever scheme they are declared with, which on an internal network is
+    /// legitimately plain HTTP.
     #[must_use]
     pub fn allows_registry(&self, url: &str) -> bool {
         let fetch = nerf_dart(url);
@@ -514,11 +524,7 @@ impl RouteContext {
         if self.hosted_origin.as_deref().is_some_and(|hosted| fetch.starts_with(hosted)) {
             return true;
         }
-        if self
-            .public_routes
-            .iter()
-            .any(|route| route.origin.as_deref().is_some_and(|origin| fetch.starts_with(origin)))
-        {
+        if self.public_routes.iter().any(|route| route.allowlists(&fetch, scheme_of(url))) {
             return true;
         }
         self.upstream_origins.iter().any(|origin| fetch.starts_with(origin))
@@ -661,7 +667,7 @@ impl RouteMatcher {
     /// [`RouteContext::from_config`], so it is allowlisted and public without
     /// any config, and ahead of any upstream credential for the same origin.
     fn npmjs() -> Self {
-        Self { origin: Some(NPMJS_ORIGIN.to_string()), package: None }
+        Self { origin: Some(NPMJS_ORIGIN.to_string()), package: None, https_only: true }
     }
 
     /// The other built-in public route: JSR, which every pnpm client routes
@@ -669,7 +675,7 @@ impl RouteMatcher {
     /// JSR dependency resolves through a default server. It hosts no private
     /// content, so the reasoning in [`Self::npmjs`] applies unchanged.
     fn jsr() -> Self {
-        Self { origin: Some(JSR_ORIGIN.to_string()), package: None }
+        Self { origin: Some(JSR_ORIGIN.to_string()), package: None, https_only: true }
     }
 
     /// Build a matcher from an operator-declared public route, failing
@@ -695,7 +701,16 @@ impl RouteMatcher {
                 None
             })?),
         };
-        Some(Self { origin, package })
+        Some(Self { origin, package, https_only: false })
+    }
+
+    /// Whether this route puts `fetch` (nerf-darted, so scheme-less) on the
+    /// allowlist when reached over `scheme`. A package-scoped route with no
+    /// registry allowlists nothing: it narrows an origin another rule already
+    /// admits.
+    fn allowlists(&self, fetch: &str, scheme: Option<&str>) -> bool {
+        self.origin.as_deref().is_some_and(|origin| fetch.starts_with(origin))
+            && (!self.https_only || scheme == Some("https"))
     }
 
     fn matches(&self, fetch: &str, package: Option<&str>) -> bool {

--- a/pnpr/crates/route/src/tests.rs
+++ b/pnpr/crates/route/src/tests.rs
@@ -192,6 +192,27 @@ fn the_builtin_npmjs_route_is_always_allowlisted_and_public() {
     );
 }
 
+/// pnpm resolves the `@jsr` scope through npm.jsr.io with no configuration at
+/// all, so a graph holding a JSR dependency has to resolve through a default
+/// server too. See <https://github.com/pnpm/pnpm/issues/14649>.
+#[test]
+fn the_builtin_jsr_route_is_always_allowlisted_and_public() {
+    let mut config = base_config();
+    config.upstreams.clear();
+    let context = RouteContext::from_config(&config);
+
+    assert!(context.allows_registry("https://npm.jsr.io/@jsr%2fstd__csv"));
+    assert_eq!(
+        context.classify(
+            &user("alice"),
+            "https://npm.jsr.io/@jsr%2fstd__csv",
+            Some("@jsr/std__csv"),
+        ),
+        RouteClass::Public,
+    );
+    assert!(context.allows_registry("https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz"));
+}
+
 #[test]
 fn custom_registry_is_off_allowlist_until_declared_public() {
     let mut config = base_config();

--- a/pnpr/crates/route/src/tests.rs
+++ b/pnpr/crates/route/src/tests.rs
@@ -213,6 +213,33 @@ fn the_builtin_jsr_route_is_always_allowlisted_and_public() {
     assert!(context.allows_registry("https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz"));
 }
 
+/// Every redirect hop is re-checked against this allowlist, so admitting
+/// cleartext on a built-in host would admit a downgrade to it.
+#[test]
+fn the_builtin_routes_admit_https_only() {
+    let mut config = base_config();
+    config.upstreams.clear();
+    let context = RouteContext::from_config(&config);
+
+    assert!(!context.allows_registry("http://registry.npmjs.org/lodash"));
+    assert!(!context.allows_registry("http://npm.jsr.io/@jsr%2fstd__csv"));
+}
+
+/// An operator declares the scheme their own route is reached over, which on
+/// an internal network is legitimately plain HTTP.
+#[test]
+fn an_operator_declared_http_route_is_allowlisted() {
+    let mut config = base_config();
+    config.upstreams.clear();
+    config.route_policy.public.push(PublicRoute {
+        registry: Some("http://npm.internal.example/".to_string()),
+        package: None,
+    });
+    let context = RouteContext::from_config(&config);
+
+    assert!(context.allows_registry("http://npm.internal.example/lodash"));
+}
+
 #[test]
 fn custom_registry_is_off_allowlist_until_declared_public() {
     let mut config = base_config();

--- a/pnpr/crates/route/src/tests.rs
+++ b/pnpr/crates/route/src/tests.rs
@@ -223,6 +223,8 @@ fn the_builtin_routes_admit_https_only() {
 
     assert!(!context.allows_registry("http://registry.npmjs.org/lodash"));
     assert!(!context.allows_registry("http://npm.jsr.io/@jsr%2fstd__csv"));
+    // Schemes are case-insensitive, so only the transport is being refused.
+    assert!(context.allows_registry("HTTPS://npm.jsr.io/@jsr%2fstd__csv"));
 }
 
 /// An operator declares the scheme their own route is reached over, which on


### PR DESCRIPTION
## Summary

Installing a lockfile that holds a JSR dependency failed on pnpm 12 with `ERR_PNPM_META_FETCH_FAIL`: the supply-chain policy verification asked the **default** registry for an `@jsr/*` packument and got a 404. The same lockfile installs on pnpm 11. Closes pnpm/pnpm#14649.

`Config::resolved_registries` is the map every scope-routed lookup picks a registry from — the resolver, the lockfile verifier, `pnpm why`, `pnpm view`, `pnpm audit`. It carried only the user's configured scope routes plus the default registry, so `@jsr` fell through to the default. The built-in route was reachable in two narrower places: the resolver's `jsr:` specifier path (which is why `pnpm add jsr:@std/csv` works) and `resolved_registry_declarations` (which is why `pnpm config list` prints a `@jsr` route the install disagreed with). The TypeScript CLI keeps the route in the scope map itself, so this restores parity.

The route deliberately stays out of two other maps:

- `registry_declarations`, the shape a pnpr server is told about, so npm.jsr.io is not put in front of its allowlist on requests that resolve no JSR package.
- the package-manager bootstrap, which resolves the package manager alone.

`pnpm changelog` had a hand-rolled scope lookup with the same gap; it now calls `pick_registry_for_package` like every other command.

### The pnpr half

Raised in review: pnpr consumes the same map, and its route allowlist — the resolver's SSRF boundary — had exactly one built-in public route, npm. JSR through a default pnpr was already broken on `main` (`resolve_jsr_impl` reaches npm.jsr.io whether or not the client declares the scope, and a lockfile carrying npm.jsr.io tarball URLs is refused up front by `reject_off_allowlist_fetches`), and this PR widens which lookups reach that host. npm.jsr.io is now pnpr's second built-in public route: it is the registry every pnpm client routes `@jsr` to with no configuration, and it hosts no private content, so the reasoning in `RouteMatcher::npmjs` applies unchanged.

Raised in the same review: `allows_registry` matches nerf-darted origins, which carry no scheme, and it is also the redirect guard — so a built-in route admitted `http://` and, with it, a downgrade redirect. Both built-in routes now allowlist `https` alone. Operator-declared `routes.public` entries and upstreams are untouched: an operator declares the scheme of their own routes, and plain HTTP on an internal network is legitimate there.

### Verification

Reproduced the reporter's steps with a debug build: an empty cache dir and `pnpm install --frozen-lockfile` on a pnpm 11 generated lockfile fails before the change with `Failed to fetch metadata from https://registry.npmjs.org/@jsr%2Fstd__csv`, and installs after it. Both new tests were checked against a reverted fix.

Only pnpm v12 is affected; pnpm 11 already routes `@jsr` through `DEFAULT_REGISTRIES_BY_SCOPE`, so there is no TypeScript half.

## Squash Commit Body

```text
`Config::resolved_registries` is the map every scope-routed lookup picks a
registry from: the resolver, the lockfile's supply-chain policy verifier,
`pnpm why`, `pnpm view`, `pnpm audit`. It carried only the user's configured
scope routes plus the default registry, so an `@jsr/*` package fell through to
the default registry, which serves no such packument. Installing a lockfile
holding a JSR dependency then aborted with ERR_PNPM_META_FETCH_FAIL on a 404.

The built-in `@jsr` route was reachable in two narrower places only: the
resolver's `jsr:` specifier path, and `resolved_registry_declarations`, which
is what makes `pnpm config list` print a route the install disagreed with. The
TypeScript CLI puts the route in the scope map itself, which is why the same
lockfile installs there. Add it to the resolved map, where every consumer sees
it, with a configured `@jsr:registry` still winning.

The route stays out of `registry_declarations`, the shape a pnpr server is
told about, so npm.jsr.io is not put in front of its allowlist on requests
that resolve no JSR package. It stays out of the package-manager bootstrap
too: that map resolves the package manager alone.

pnpr consumes the same map, and its route allowlist — the resolver's SSRF
boundary — carried one built-in public route, npm, so a graph holding a JSR
dependency could not resolve through a default server. npm.jsr.io joins it:
pnpm reaches that registry without configuration, and it hosts no private
content. Both built-in routes now allowlist `https` alone, since that
allowlist also gates every redirect hop.

`pnpm changelog` picked its registry with a hand-rolled scope lookup that had
the same gap; it now calls `pick_registry_for_package` like every other
command.

Closes pnpm/pnpm#14649
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ewwKXDj8f1p7BmY3fRt7r


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm install` failures for projects containing JSR dependencies in the lockfile.
  - JSR packages now resolve through the built-in `npm.jsr.io` registry during verification, even when another default registry is configured.
  - Custom `@jsr` registry settings continue to take precedence.

- **Security**
  - Built-in npm and JSR registry routes now require HTTPS, including redirects.

- **Documentation**
  - Clarified built-in registry routing and HTTPS requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->