### PR TITLE
fix(patching): put patch-added build work through build approval

### DIFF
--- a/.changeset/patched-install-scripts-need-approval.md
+++ b/.changeset/patched-install-scripts-need-approval.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/building.during-install": patch
+"@pnpm/building.pkg-requires-build": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+A patch that gives a dependency a `preinstall`, `install`, or `postinstall` script, or a `binding.gyp`, now runs that build. pnpm asks for build approval first, so the package is listed under "Ignored build scripts" until it is allowed to build. pnpm 12 ran nothing, and pnpm 11 ran it without asking [#14648](https://github.com/pnpm/pnpm/issues/14648).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1806,6 +1806,9 @@ importers:
       '@pnpm/bins.linker':
         specifier: workspace:*
         version: link:../../bins/linker
+      '@pnpm/building.pkg-requires-build':
+        specifier: workspace:*
+        version: link:../pkg-requires-build
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
@@ -1876,6 +1879,9 @@ importers:
 
   pnpm11/building/pkg-requires-build:
     dependencies:
+      '@pnpm/pkg-manifest.reader':
+        specifier: workspace:*
+        version: link:../../pkg-manifest/reader
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types

--- a/pnpm/crates/cli/tests/suite/patch.rs
+++ b/pnpm/crates/cli/tests/suite/patch.rs
@@ -18,6 +18,23 @@ const IS_POSITIVE_PATCH: &str = include_str!(
     "../../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0.patch"
 );
 
+/// Adds a `postinstall` script the published package does not declare,
+/// plus the script it runs.
+const IS_POSITIVE_POSTINSTALL_PATCH: &str = include_str!(
+    "../../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-postinstall.patch"
+);
+
+/// Creates a `binding.gyp`, which the lifecycle runner turns into an
+/// implicit `node-gyp rebuild`.
+const IS_POSITIVE_BINDING_GYP_PATCH: &str = include_str!(
+    "../../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-binding-gyp.patch"
+);
+
+/// Creates a plain file named `.hooks`, which is not a hook directory.
+const IS_POSITIVE_HOOKS_FILE_PATCH: &str = include_str!(
+    "../../../../../pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-hooks-file.patch"
+);
+
 /// Adds a marker file, so a package's patched state can be read off the
 /// filesystem without depending on the package's own sources.
 const MARKER_PATCH: &str = concat!(
@@ -218,12 +235,9 @@ fn snapshot_keys(lockfile: &pnpm_lockfile::Lockfile) -> Vec<String> {
     keys
 }
 
-/// Assert the store kept the patched `index.js` as a side-effects overlay
-/// rather than overwriting the pristine one it shares with every other
-/// project. The overlay's cache key ends in `;patch=<hash>` — pacquet
-/// composes it in `pnpm_graph_hasher::calc_dep_state`, and the row it
-/// hangs off is keyed by the peer- and patch-free `is-positive@1.0.0`.
-fn assert_patched_side_effects_cached(store_dir: &Path, patch_hash: &str) {
+/// The store index row `is-positive@1.0.0` hangs off, keyed by the peer-
+/// and patch-free package id.
+fn is_positive_store_row(store_dir: &Path) -> pnpm_store_dir::PackageFilesIndex {
     let store = StoreDir::new(store_dir);
     let index = StoreIndex::open_readonly_in(&store).expect("open the store index");
     let row_key = index
@@ -232,7 +246,16 @@ fn assert_patched_side_effects_cached(store_dir: &Path, patch_hash: &str) {
         .into_iter()
         .find(|key| key.ends_with("\tis-positive@1.0.0"))
         .expect("a store index row for is-positive@1.0.0");
-    let row = index.get(&row_key).expect("read the store index row").expect("the row is present");
+    index.get(&row_key).expect("read the store index row").expect("the row is present")
+}
+
+/// Assert the store kept the patched `index.js` as a side-effects overlay
+/// rather than overwriting the pristine one it shares with every other
+/// project. The overlay's cache key ends in `;patch=<hash>` — pacquet
+/// composes it in `pnpm_graph_hasher::calc_dep_state`, and the row it
+/// hangs off is keyed by the peer- and patch-free `is-positive@1.0.0`.
+fn assert_patched_side_effects_cached(store_dir: &Path, patch_hash: &str) {
+    let row = is_positive_store_row(store_dir);
 
     let side_effects =
         row.side_effects.as_ref().expect("a patched package populates `sideEffects`");
@@ -439,6 +462,150 @@ fn install_level_patch_applies_when_the_package_is_not_in_allow_builds() {
         "is-positive@1.0.0.patch",
         "allowBuilds: {}\n",
     );
+}
+
+/// Regression test for <https://github.com/pnpm/pnpm/issues/14648>.
+#[test]
+fn install_level_patch_that_adds_install_scripts_asks_for_approval() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("patches").join("is-positive@1.0.0.patch"),
+        IS_POSITIVE_POSTINSTALL_PATCH,
+    )
+    .expect("write the postinstall patch");
+    let marker = workspace.join("node_modules/is-positive/postinstall-ran.txt");
+
+    let output = pacquet(&workspace, ["install"]).output().expect("run install");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    eprintln!("unapproved install:\n{combined}");
+    assert!(!output.status.success(), "an unapproved build must fail under strictDepBuilds");
+    // The package name is not matched here: the diagnostic wraps it
+    // across lines. The `allowBuilds` entry asserted below names it.
+    assert!(
+        combined.contains("ERR_PNPM_IGNORED_BUILDS") && combined.contains("Ignored build scripts"),
+        "expected the patched package to be reported as an ignored build; got:\n{combined}",
+    );
+    assert!(!marker.exists(), "the postinstall must not run before it is approved");
+
+    // The failed install left an `allowBuilds` entry for the user to
+    // decide on; answering it is what `pnpm approve-builds` writes.
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    assert!(
+        yaml.contains("is-positive: set this to true or false"),
+        "expected an undecided allowBuilds entry; got:\n{yaml}",
+    );
+    fs::write(&yaml_path, yaml.replace("set this to true or false", "true"))
+        .expect("write pnpm-workspace.yaml");
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+    assert!(marker.exists(), "the approved postinstall must run");
+
+    drop((root, mock_instance));
+}
+
+/// A patched package with no build to run caches its overlay under a
+/// dep-graph-free key, which `--ignore-scripts` is the cheapest way to
+/// produce. Deciding `requiresBuild` any later than that key is composed
+/// reads the key back and skips the build the approval just allowed.
+#[test]
+fn install_level_patch_that_adds_install_scripts_outlives_a_pre_fix_cache_entry() {
+    let (root, workspace, npmrc_info) = setup_configured_patch_with_yaml(
+        "is-positive@1.0.0",
+        "is-positive@1.0.0.patch",
+        "allowBuilds:\n  is-positive: true\n",
+    );
+    let AddMockedRegistry { mock_instance, store_dir, .. } = npmrc_info;
+    fs::write(
+        workspace.join("patches").join("is-positive@1.0.0.patch"),
+        IS_POSITIVE_POSTINSTALL_PATCH,
+    )
+    .expect("write the postinstall patch");
+    let marker = workspace.join("node_modules/is-positive/postinstall-ran.txt");
+
+    pacquet(&workspace, ["install", "--ignore-scripts", "--reporter=silent"]).assert().success();
+    assert!(!marker.exists(), "--ignore-scripts must not run the postinstall");
+    let cache_keys: Vec<String> = is_positive_store_row(&store_dir)
+        .side_effects
+        .expect("a patched package populates `sideEffects`")
+        .into_keys()
+        .collect();
+    assert!(
+        cache_keys.iter().any(|key| !key.contains(";deps=")),
+        "the store must hold the dep-graph-free key a pre-fix pnpm 12 wrote; got {cache_keys:?}",
+    );
+
+    remove_dir_if_exists(&workspace.join("node_modules"));
+    pacquet(&workspace, ["install", "--reporter=silent"]).assert().success();
+    assert!(marker.exists(), "the pre-fix cache entry must not suppress the build");
+
+    drop((root, mock_instance));
+}
+
+/// A patch can introduce build work without touching `scripts`: the
+/// lifecycle runner reads a `binding.gyp` as `node-gyp rebuild`.
+#[test]
+fn install_level_patch_that_adds_a_binding_gyp_asks_for_approval() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("patches").join("is-positive@1.0.0.patch"),
+        IS_POSITIVE_BINDING_GYP_PATCH,
+    )
+    .expect("write the binding.gyp patch");
+
+    let output = pacquet(&workspace, ["install"]).output().expect("run install");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    eprintln!("unapproved install:\n{combined}");
+    assert!(!output.status.success(), "an unapproved native build must fail the install");
+    assert!(
+        combined.contains("ERR_PNPM_IGNORED_BUILDS"),
+        "expected the patched package to be reported as an ignored build; got:\n{combined}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Only entries below a `.hooks` directory are hooks, so a plain file by
+/// that name must not hold the install for an approval it does not need.
+#[test]
+fn install_level_patch_that_adds_a_hooks_file_does_not_ask_for_approval() {
+    let (root, workspace, npmrc_info) =
+        setup_configured_patch("is-positive@1.0.0", "is-positive@1.0.0.patch");
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(
+        workspace.join("patches").join("is-positive@1.0.0.patch"),
+        IS_POSITIVE_HOOKS_FILE_PATCH,
+    )
+    .expect("write the .hooks file patch");
+
+    let output = pacquet(&workspace, ["install"]).output().expect("run install");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    eprintln!("install:\n{combined}");
+    assert!(output.status.success(), "a plain `.hooks` file must not fail the install");
+    assert!(
+        !combined.contains("ERR_PNPM_IGNORED_BUILDS"),
+        "the package must not be reported as an ignored build; got:\n{combined}",
+    );
+    let hooks = workspace.join("node_modules/is-positive/.hooks");
+    assert!(hooks.is_file(), "the patch writes a plain file");
+
+    drop((root, mock_instance));
 }
 
 /// Regression test for <https://github.com/pnpm/pnpm/issues/14273>.

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -27,8 +27,10 @@ use pnpm_executor::{
     LifecycleScriptError, RunPostinstallHooks, ScriptsPrependNodePath, run_postinstall_hooks,
 };
 use pnpm_lockfile::{PackageKey, ProjectSnapshot, SnapshotEntry};
-use pnpm_package_manifest::pkg_requires_build;
-use pnpm_patching::{PatchApplyError, apply_patch_to_dir};
+use pnpm_package_manifest::{
+    file_path_requires_build, manifest_requires_build, parse_manifest, pkg_requires_build,
+};
+use pnpm_patching::{ExtendedPatchInfo, PatchApplyError, apply_patch_to_dir, preview_patch};
 use pnpm_reporter::{
     LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
     SkippedOptionalReason,
@@ -398,10 +400,11 @@ impl BuildModules<'_> {
 
         let Some(snapshots) = snapshots else { return Ok(BuildModulesOutput::default()) };
 
-        // Compute `requiresBuild` per snapshot. Warm store-index rows
-        // already carry a precomputed answer, so only misses need to
-        // inspect the materialized package directory.
-        let requires_build_map: HashMap<PackageKey, bool> = snapshots
+        // Compute `requiresBuild` per snapshot from what the package
+        // published. Warm store-index rows already carry a precomputed
+        // answer, so only misses need to inspect the materialized package
+        // directory.
+        let published_requires_build: HashMap<PackageKey, bool> = snapshots
             .keys()
             // Skip snapshots that never landed on disk. `pkg_requires_build`
             // would just return `false` for a missing dir, but the
@@ -420,6 +423,26 @@ impl BuildModules<'_> {
                     (Some(pkg_root), None) => pkg_requires_build(pkg_root),
                 };
                 (key.clone(), requires)
+            })
+            .collect();
+
+        let patch_added_build = patch_added_build_by_package(
+            patches,
+            &published_requires_build,
+            layout,
+            pkg_roots_by_key,
+        );
+
+        let requires_build_map: HashMap<PackageKey, bool> = published_requires_build
+            .into_iter()
+            .map(|(key, requires)| {
+                // `pkg_root_for_key` is asked second: a snapshot the walker
+                // dropped has nothing to build, and this way the lookup only
+                // runs for the few snapshots whose patch adds build work.
+                let requires = requires
+                    || (patch_added_build.get(&key.without_peer()).copied().unwrap_or(false)
+                        && pkg_root_for_key(layout, pkg_roots_by_key, &key).is_some());
+                (key, requires)
             })
             .collect();
 
@@ -578,6 +601,58 @@ impl BuildModules<'_> {
             mutated_slots: slot_mutations.into_inner(),
         })
     }
+}
+
+/// Whether each configured patch adds build work its package's published
+/// manifest does not declare, keyed by the peer-stripped package key.
+///
+/// Everything keyed off `requiresBuild` — the allow-build gate, the build
+/// graph, the side-effects cache key — is decided before the build phase
+/// applies the patch, so build work a patch introduces would otherwise
+/// stay invisible until after the decisions that need it. Previewing the
+/// patch keeps all three describing the package that ends up on disk.
+///
+/// Answered once per patch rather than once per snapshot, and only for a
+/// package `published_requires_build` does not already answer `true` for:
+/// peer variants share both the extracted manifest and the patch, and each
+/// preview reads and parses two files.
+///
+/// A patch that fails to preview is left to the build phase, which
+/// applies it for real and surfaces the failure.
+fn patch_added_build_by_package(
+    patches: Option<&HashMap<PackageKey, ExtendedPatchInfo>>,
+    published_requires_build: &HashMap<PackageKey, bool>,
+    layout: &crate::VirtualStoreLayout,
+    pkg_roots_by_key: Option<&HashMap<PackageKey, Vec<PathBuf>>>,
+) -> HashMap<PackageKey, bool> {
+    let Some(patches) = patches else { return HashMap::new() };
+    let mut answers = HashMap::with_capacity(patches.len());
+    for (key, published) in published_requires_build {
+        // A package already bound for the build gate needs no preview: the
+        // patch cannot subtract the build its manifest declares.
+        if *published {
+            continue;
+        }
+        // Peer-stripped, because patches are configured at the (name,
+        // version) granularity rather than per peer-resolution variant.
+        let metadata_key = key.without_peer();
+        if answers.contains_key(&metadata_key) {
+            continue;
+        }
+        let Some(patch) = patches.get(&metadata_key) else { continue };
+        let Some(patch_file_path) = patch.patch_file_path.as_deref() else { continue };
+        let Some(pkg_root) = pkg_root_for_key(layout, pkg_roots_by_key, key) else { continue };
+        let Ok(preview) = preview_patch(&pkg_root, patch_file_path) else { continue };
+        // The same two triggers `pkg_requires_build` reads off an
+        // extracted package: the manifest's install scripts, and the
+        // presence of `binding.gyp` / `.hooks/`. A patch can add either.
+        let adds_build = preview.written_paths.iter().any(|path| file_path_requires_build(path))
+            || preview.manifest.is_some_and(|manifest| {
+                parse_manifest(&manifest).is_ok_and(|manifest| manifest_requires_build(&manifest))
+            });
+        answers.insert(metadata_key, adds_build);
+    }
+    answers
 }
 
 /// The snapshots `--ignore-scripts` kept from building, sorted for a

--- a/pnpm/crates/package-manifest/src/lib.rs
+++ b/pnpm/crates/package-manifest/src/lib.rs
@@ -1002,13 +1002,32 @@ pub fn pkg_requires_build(pkg_root: &Path) -> bool {
 
 /// Decide whether a parsed manifest declares lifecycle scripts that
 /// make its package a build candidate.
+///
+/// A script has to carry a value to count. An empty `postinstall` runs
+/// nothing, and pnpm v11's `pkgRequiresBuild` reads the same manifest as
+/// build-free, so treating the key's presence as build work would ask the
+/// user to approve a build that does not exist.
 #[must_use]
 pub fn manifest_requires_build(manifest: &Value) -> bool {
     manifest.get("scripts").and_then(Value::as_object).is_some_and(|scripts| {
-        scripts.contains_key("preinstall")
-            || scripts.contains_key("install")
-            || scripts.contains_key("postinstall")
+        ["preinstall", "install", "postinstall"]
+            .iter()
+            .any(|name| scripts.get(*name).is_some_and(script_is_set))
     })
+}
+
+/// Whether a `scripts` entry holds something to run.
+///
+/// Mirrors `Boolean(manifest.scripts.postinstall)` in pnpm v11's
+/// `pkgRequiresBuild`: `null`, `false`, `0`, and `""` are the falsy values
+/// a manifest can carry there.
+fn script_is_set(script: &Value) -> bool {
+    match script {
+        Value::String(script) => !script.is_empty(),
+        Value::Null | Value::Bool(false) => false,
+        Value::Number(number) => number.as_f64() != Some(0.0),
+        _ => true,
+    }
 }
 
 /// Decide whether a store-index file key implies build hooks.

--- a/pnpm/crates/package-manifest/src/tests.rs
+++ b/pnpm/crates/package-manifest/src/tests.rs
@@ -8,8 +8,8 @@ use tempfile::{NamedTempFile, tempdir};
 use super::{
     BundleDependencies, InitAuthor, InitOptions, PackageManifest, PackageManifestError,
     apply_runtime_on_fail_override, convert_dependencies_to_engines_runtime,
-    convert_engines_runtime_to_dependencies, extract_license, node_version_from_engines_runtime,
-    parse_manifest_bytes, safe_read_package_json_from_dir,
+    convert_engines_runtime_to_dependencies, extract_license, manifest_requires_build,
+    node_version_from_engines_runtime, parse_manifest_bytes, safe_read_package_json_from_dir,
 };
 use crate::DependencyGroup;
 use serde_json::json;
@@ -1231,4 +1231,17 @@ fn a_bom_after_the_start_of_the_manifest_is_still_a_parse_error() {
 fn parse_manifest_bytes_accepts_undecoded_bom_prefixed_bytes() {
     let manifest = parse_manifest_bytes(b"\xEF\xBB\xBF{\"name\":\"fixture\"}").unwrap();
     assert_eq!(manifest.get("name").unwrap(), &json!("fixture"));
+}
+
+/// pnpm v11's `pkgRequiresBuild` reads the script's value, not the key, so
+/// a manifest that carries an empty one is build-free in both stacks.
+#[test]
+fn a_script_without_a_value_is_not_build_work() {
+    assert!(manifest_requires_build(&json!({ "scripts": { "postinstall": "node x.js" } })));
+    assert!(!manifest_requires_build(&json!({ "scripts": { "postinstall": "" } })));
+    assert!(!manifest_requires_build(
+        &json!({ "scripts": { "install": serde_json::Value::Null } })
+    ));
+    assert!(!manifest_requires_build(&json!({ "scripts": { "preinstall": false } })));
+    assert!(!manifest_requires_build(&json!({ "scripts": { "test": "node x.js" } })));
 }

--- a/pnpm/crates/patching/src/apply.rs
+++ b/pnpm/crates/patching/src/apply.rs
@@ -2,6 +2,7 @@ mod tolerant;
 
 use derive_more::{Display, Error};
 use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
+use indexmap::IndexSet;
 use miette::Diagnostic;
 use std::{
     fs::{self, OpenOptions, Permissions},
@@ -89,27 +90,7 @@ pub fn apply_patch_to_dir(
     patched_dir: &Path,
     patch_file_path: &Path,
 ) -> Result<(), PatchApplyError> {
-    // Read the patch file. ENOENT becomes `ERR_PNPM_PATCH_NOT_FOUND`.
-    // Every other IO error surfaces with the same diagnostic code but a
-    // different variant so the underlying `io::Error` chain is preserved.
-    let bytes = match fs::read(patch_file_path) {
-        Ok(b) => b,
-        Err(e) if e.kind() == io::ErrorKind::NotFound => {
-            return Err(PatchApplyError::PatchNotFound { path: patch_file_path.to_path_buf() });
-        }
-        Err(source) => {
-            return Err(PatchApplyError::ReadPatchFile {
-                path: patch_file_path.to_path_buf(),
-                source,
-            });
-        }
-    };
-    // Lossy UTF-8 to match Node `fs.readFile(path, 'utf8')` (the
-    // same decoding [`create_hex_hash_from_file`] uses), so a patch
-    // file with stray bytes still parses.
-    //
-    // [`create_hex_hash_from_file`]: crate::create_hex_hash_from_file
-    let text = String::from_utf8_lossy(&bytes);
+    let text = read_patch_file(patch_file_path)?;
 
     let patches = PatchSet::parse(&text, ParseOptions::gitdiff());
     for file_patch_result in patches {
@@ -120,6 +101,180 @@ pub fn apply_patch_to_dir(
         apply_one_file(patched_dir, patch_file_path, &file_patch)?;
     }
     Ok(())
+}
+
+const MANIFEST_FILE_NAME: &str = "package.json";
+
+/// What a patch file would leave behind in a package directory, read
+/// without writing anything.
+///
+/// pnpm decides what a package's build needs well before the build phase
+/// applies the patch, and a patch can introduce build triggers of its
+/// own. [`preview_patch`] lets those decisions see the patched package.
+#[derive(Debug, Default)]
+pub struct PatchPreview {
+    /// The `package.json` the patch would leave, or `None` when it does
+    /// not touch the manifest.
+    pub manifest: Option<String>,
+    /// The paths the patch creates or rewrites, relative to the package
+    /// directory, `/`-separated and free of `.` segments. Deletions are
+    /// left out: a file a patch removes is not one the package has.
+    pub written_paths: Vec<String>,
+}
+
+/// Read what `patch_file_path` would leave in `patched_dir`.
+///
+/// A manifest that already carries the patch reports its content as it
+/// stands, for the same reason [`apply_patch_to_dir`] treats a re-apply
+/// as a no-op.
+pub fn preview_patch(
+    patched_dir: &Path,
+    patch_file_path: &Path,
+) -> Result<PatchPreview, PatchApplyError> {
+    let text = read_patch_file(patch_file_path)?;
+    let failed = |message: String| PatchApplyError::PatchFailed {
+        patch_file_path: patch_file_path.to_path_buf(),
+        patched_dir: patched_dir.to_path_buf(),
+        message,
+    };
+    let mut preview = PatchPreview::default();
+    // Written paths are tracked as a set so a delete record costs one lookup
+    // rather than a scan of everything written so far, and insertion order is
+    // kept because a patch that rewrites a file twice should not report it
+    // twice.
+    let mut written_paths: IndexSet<String> = IndexSet::new();
+    // A patch may delete the manifest and write a new one, so "no manifest
+    // record yet" and "the manifest is gone" are different states.
+    let mut manifest_removed = false;
+    for file_patch_result in PatchSet::parse(&text, ParseOptions::gitdiff()) {
+        let file_patch = file_patch_result.map_err(|source| PatchApplyError::InvalidPatch {
+            patch_file_path: patch_file_path.to_path_buf(),
+            message: source.to_string(),
+        })?;
+        let operation = file_patch.operation().strip_prefix(1);
+        let raw_path = match &operation {
+            FileOperation::Modify { modified, .. } | FileOperation::Create(modified) => {
+                modified.as_ref()
+            }
+            // A patch that writes a file and then removes it leaves the
+            // package without it, so an earlier record's path is dropped
+            // rather than merely skipped.
+            FileOperation::Delete(path) => {
+                let Some(removed) = normalized_patch_path(path.as_ref()) else { continue };
+                if names_manifest(patched_dir, &removed) {
+                    preview.manifest = None;
+                    manifest_removed = true;
+                }
+                written_paths.shift_remove(&removed);
+                continue;
+            }
+            _ => continue,
+        };
+        let Some(written) = normalized_patch_path(raw_path) else { continue };
+        let is_manifest = names_manifest(patched_dir, &written);
+        written_paths.insert(written);
+        if !is_manifest {
+            continue;
+        }
+        let creates = matches!(operation, FileOperation::Create(_));
+        // A package ships a manifest, so a `Create` naming one only makes
+        // sense once an earlier record removed it; `apply_patch_to_dir`
+        // reports every other spelling. A `Modify` of a removed manifest is
+        // left to it for the same reason.
+        if creates != manifest_removed {
+            continue;
+        }
+        let target = patched_dir.join(MANIFEST_FILE_NAME);
+        // A patch may carry more than one record for the same file, and
+        // `apply_patch_to_dir` feeds each the previous one's output. Chain
+        // them here too, or the preview would answer for the last record
+        // alone.
+        let original = if let Some(patched_so_far) = preview.manifest.take() {
+            patched_so_far
+        } else if manifest_removed {
+            String::new()
+        } else {
+            let bytes = fs::read(&target)
+                .map_err(|source| failed(format!("read {}: {source}", target.display())))?;
+            String::from_utf8_lossy(&bytes).into_owned()
+        };
+        manifest_removed = false;
+        let text_patch = file_patch
+            .patch()
+            .as_text()
+            .ok_or_else(|| failed("binary patch is not supported".to_string()))?;
+        preview.manifest = Some(match tolerant::apply(&original, text_patch) {
+            Ok(updated) => updated,
+            Err(_) if tolerant::apply(&original, &text_patch.reverse()).is_ok() => original,
+            Err(message) => {
+                return Err(failed(format!("apply to {}: {message}", target.display())));
+            }
+        });
+    }
+    preview.written_paths = written_paths.into_iter().collect();
+    Ok(preview)
+}
+
+/// Whether `written` names the package's manifest.
+///
+/// A patch header may spell it in another case, and on a case-insensitive
+/// volume the applier still reaches the real `package.json`. The filesystem
+/// is asked rather than the platform guessed: where names are
+/// case-sensitive, `Package.json` is a different file and must not be
+/// mistaken for the manifest. The check costs nothing for the spelling
+/// every patch actually uses.
+fn names_manifest(patched_dir: &Path, written: &str) -> bool {
+    if written == MANIFEST_FILE_NAME {
+        return true;
+    }
+    if !written.eq_ignore_ascii_case(MANIFEST_FILE_NAME) {
+        return false;
+    }
+    let (Ok(spelled), Ok(manifest)) = (
+        fs::canonicalize(patched_dir.join(written)),
+        fs::canonicalize(patched_dir.join(MANIFEST_FILE_NAME)),
+    ) else {
+        return false;
+    };
+    spelled == manifest
+}
+
+/// The path a patch header names, spelled the way [`apply_patch_to_dir`]
+/// resolves it: `.` segments dropped, separators normalized to `/`.
+///
+/// `None` for a path that call would refuse — one that is absolute or
+/// climbs out of the package — so the preview never reports as written a
+/// path the apply will reject.
+fn normalized_patch_path(rel: &str) -> Option<String> {
+    let mut segments = Vec::new();
+    for component in Path::new(rel).components() {
+        match component {
+            Component::CurDir => {}
+            Component::Normal(segment) => segments.push(segment.to_string_lossy().into_owned()),
+            _ => return None,
+        }
+    }
+    (!segments.is_empty()).then(|| segments.join("/"))
+}
+
+/// Read a patch file, mapping a missing file to
+/// `ERR_PNPM_PATCH_NOT_FOUND`.
+///
+/// Decoded lossily to match Node `fs.readFile(path, 'utf8')` (the same
+/// decoding [`create_hex_hash_from_file`] uses), so a patch file with
+/// stray bytes still parses.
+///
+/// [`create_hex_hash_from_file`]: crate::create_hex_hash_from_file
+fn read_patch_file(patch_file_path: &Path) -> Result<String, PatchApplyError> {
+    match fs::read(patch_file_path) {
+        Ok(bytes) => Ok(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            Err(PatchApplyError::PatchNotFound { path: patch_file_path.to_path_buf() })
+        }
+        Err(source) => {
+            Err(PatchApplyError::ReadPatchFile { path: patch_file_path.to_path_buf(), source })
+        }
+    }
 }
 
 fn apply_one_file(

--- a/pnpm/crates/patching/src/apply/tests.rs
+++ b/pnpm/crates/patching/src/apply/tests.rs
@@ -1,4 +1,4 @@
-use crate::apply::{PatchApplyError, apply_patch_to_dir};
+use crate::apply::{PatchApplyError, apply_patch_to_dir, preview_patch};
 use pretty_assertions::assert_eq;
 use std::fs;
 use tempfile::tempdir;
@@ -290,6 +290,346 @@ fn applies_a_zero_context_insertion_without_a_newline_to_an_empty_file() {
         r"\ No newline at end of file"
     };
     assert_eq!(applied_hunk("", hunk), "added");
+}
+
+/// A manifest with no install scripts, and a patch that adds one.
+const MANIFEST: &str = text_block_fnl! {
+    "{"
+    r#"  "name": "is-positive","#
+    r#"  "scripts": {"#
+    r#"    "test": "node test.js""#
+    "  }"
+    "}"
+};
+
+const MANIFEST_PATCH: &str = text_block_fnl! {
+    "diff --git a/package.json b/package.json"
+    "--- a/package.json"
+    "+++ b/package.json"
+    "@@ -2,5 +2,6 @@"
+    r#"   "name": "is-positive","#
+    r#"   "scripts": {"#
+    r#"-    "test": "node test.js""#
+    r#"+    "test": "node test.js","#
+    r#"+    "postinstall": "node postinstall.js""#
+    "   }"
+    " }"
+};
+
+const BINDING_GYP_PATCH: &str = text_block_fnl! {
+    "diff --git a/binding.gyp b/binding.gyp"
+    "new file mode 100644"
+    "--- /dev/null"
+    "+++ b/binding.gyp"
+    "@@ -0,0 +1 @@"
+    "+{}"
+};
+
+/// [`MANIFEST_PATCH`] with a `.` segment in its headers, which
+/// `apply_patch_to_dir` resolves away.
+const MANIFEST_PATCH_WITH_DOT_SEGMENT: &str = text_block_fnl! {
+    "diff --git a/./package.json b/./package.json"
+    "--- a/./package.json"
+    "+++ b/./package.json"
+    "@@ -2,5 +2,6 @@"
+    r#"   "name": "is-positive","#
+    r#"   "scripts": {"#
+    r#"-    "test": "node test.js""#
+    r#"+    "test": "node test.js","#
+    r#"+    "postinstall": "node postinstall.js""#
+    "   }"
+    " }"
+};
+
+/// Removes the manifest [`MANIFEST`] holds, so a later record can write a
+/// fresh one.
+const MANIFEST_DELETE_PATCH: &str = text_block_fnl! {
+    "diff --git a/package.json b/package.json"
+    "deleted file mode 100644"
+    "--- a/package.json"
+    "+++ /dev/null"
+    "@@ -1,6 +0,0 @@"
+    "-{"
+    r#"-  "name": "is-positive","#
+    r#"-  "scripts": {"#
+    r#"-    "test": "node test.js""#
+    "-  }"
+    "-}"
+};
+
+/// Writes a manifest that declares an install script.
+const MANIFEST_CREATE_PATCH: &str = text_block_fnl! {
+    "diff --git a/package.json b/package.json"
+    "new file mode 100644"
+    "--- /dev/null"
+    "+++ b/package.json"
+    "@@ -0,0 +1,6 @@"
+    "+{"
+    r#"+  "name": "is-positive","#
+    r#"+  "scripts": {"#
+    r#"+    "postinstall": "node postinstall.js""#
+    "+  }"
+    "+}"
+};
+
+/// [`MANIFEST_PATCH`] with a differently cased header, which reaches the
+/// same file wherever names are not case-sensitive.
+const MANIFEST_PATCH_MIXED_CASE: &str = text_block_fnl! {
+    "diff --git a/Package.json b/Package.json"
+    "--- a/Package.json"
+    "+++ b/Package.json"
+    "@@ -2,5 +2,6 @@"
+    r#"   "name": "is-positive","#
+    r#"   "scripts": {"#
+    r#"-    "test": "node test.js""#
+    r#"+    "test": "node test.js","#
+    r#"+    "postinstall": "node postinstall.js""#
+    "   }"
+    " }"
+};
+
+/// A second `package.json` record, applying on top of [`MANIFEST_PATCH`]'s
+/// output.
+const MANIFEST_SECOND_PATCH: &str = text_block_fnl! {
+    "diff --git a/package.json b/package.json"
+    "--- a/package.json"
+    "+++ b/package.json"
+    "@@ -3,5 +3,6 @@"
+    r#"   "scripts": {"#
+    r#"     "test": "node test.js","#
+    r#"-    "postinstall": "node postinstall.js""#
+    r#"+    "postinstall": "node postinstall.js","#
+    r#"+    "preinstall": "node preinstall.js""#
+    "   }"
+    " }"
+};
+
+/// Removes the `binding.gyp` [`BINDING_GYP_PATCH`] creates.
+const BINDING_GYP_DELETE_PATCH: &str = text_block_fnl! {
+    "diff --git a/binding.gyp b/binding.gyp"
+    "deleted file mode 100644"
+    "--- a/binding.gyp"
+    "+++ /dev/null"
+    "@@ -1 +0,0 @@"
+    "-{}"
+};
+
+/// The preview must read what the real apply writes, or the build gate
+/// and the build disagree about the same package.
+#[test]
+fn previews_the_manifest_a_patch_would_write() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    let applied = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.as_deref(), Some(applied.as_str()));
+    assert_eq!(preview.written_paths, ["package.json"]);
+}
+
+/// A patch may carry several records for one file, and the real apply
+/// feeds each the previous one's output.
+#[test]
+fn previews_repeated_manifest_records_in_order() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), &format!("{MANIFEST_PATCH}{MANIFEST_SECOND_PATCH}"));
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    let applied = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.as_deref(), Some(applied.as_str()));
+    assert!(applied.contains("preinstall"), "applied: {applied}");
+}
+
+/// The preview has to name a file the way the apply resolves it, or a
+/// patch spelled with a `.` segment would edit the manifest unseen.
+#[test]
+fn previews_a_manifest_named_through_a_dot_segment() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH_WITH_DOT_SEGMENT);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    let applied = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.as_deref(), Some(applied.as_str()));
+    assert_eq!(preview.written_paths, ["package.json"]);
+}
+
+/// A patch may replace the manifest outright rather than editing it, and
+/// the script the replacement declares is build work like any other.
+#[test]
+fn previews_a_manifest_the_patch_deletes_and_writes_again() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch =
+        write_patch(patch_dir.path(), &format!("{MANIFEST_DELETE_PATCH}{MANIFEST_CREATE_PATCH}"));
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    let applied = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.as_deref(), Some(applied.as_str()));
+    assert!(applied.contains("postinstall"), "applied: {applied}");
+    assert_eq!(preview.written_paths, ["package.json"]);
+}
+
+/// A file rewritten twice is one file, and a delete costs a lookup rather
+/// than a scan of everything written before it.
+#[test]
+fn previews_each_written_path_once() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), &format!("{MANIFEST_PATCH}{MANIFEST_SECOND_PATCH}"));
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    assert_eq!(preview.written_paths, ["package.json"]);
+}
+
+/// Where two spellings name one file, the applier writes the real manifest,
+/// so the preview has to read it as the manifest too.
+#[cfg(unix)]
+#[test]
+fn previews_a_manifest_reached_through_another_spelling_of_its_name() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let other_spelling = patched.path().join("Package.json");
+    // A case-insensitive volume already resolves both spellings to the one
+    // manifest, which is the condition under test. Where names are
+    // case-sensitive, a symlink is what makes two names one file.
+    if !other_spelling.exists() {
+        std::os::unix::fs::symlink("package.json", &other_spelling).unwrap();
+    }
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH_MIXED_CASE);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    let manifest = preview.manifest.expect("the patch reaches the manifest");
+    assert!(manifest.contains("postinstall"), "manifest: {manifest:?}");
+}
+
+/// Where the two spellings are two files, the applier edits the other one,
+/// and calling it the manifest would gate a build the package never gains.
+#[test]
+fn previews_no_manifest_for_a_differently_cased_file_of_its_own() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    fs::write(patched.path().join("Package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH_MIXED_CASE);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    // On a case-insensitive volume the two writes above are one file, and
+    // the patch does reach the manifest.
+    let separate_files = fs::read_to_string(patched.path().join("Package.json")).unwrap()
+        == fs::read_to_string(patched.path().join("package.json")).unwrap()
+        && fs::canonicalize(patched.path().join("Package.json")).unwrap()
+            != fs::canonicalize(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.is_none(), separate_files);
+}
+
+/// The global virtual store keeps a slot across installs, so the preview
+/// can meet a directory an earlier install already patched.
+#[test]
+fn previews_an_already_patched_manifest() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH);
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    let applied = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(preview.manifest.as_deref(), Some(applied.as_str()));
+}
+
+/// A manifest a publisher wrote with a byte order mark still has to reach
+/// the caller intact, since the caller parses what it gets back.
+#[test]
+fn previews_a_manifest_that_starts_with_a_byte_order_mark() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), format!("\u{feff}{MANIFEST}")).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    let manifest = preview.manifest.expect("the patch modifies the manifest");
+    assert!(manifest.starts_with('\u{feff}'), "manifest: {manifest:?}");
+    assert!(manifest.contains("postinstall"), "manifest: {manifest:?}");
+}
+
+#[test]
+fn previews_nothing_when_the_patch_leaves_the_manifest_alone() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("index.js"), IS_POSITIVE_INDEX_JS).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), IS_POSITIVE_PATCH);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    assert_eq!(preview.manifest, None);
+    assert_eq!(preview.written_paths, ["index.js"]);
+}
+
+/// A file a patch adds can be a build trigger of its own, so the caller
+/// needs the created paths as well as the manifest.
+#[test]
+fn previews_the_paths_a_patch_creates() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), BINDING_GYP_PATCH);
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    assert_eq!(preview.manifest, None);
+    assert_eq!(preview.written_paths, ["binding.gyp"]);
+}
+
+/// A build trigger a patch writes and then removes is not one the
+/// package ends up with, so it must not hold the install for approval.
+#[test]
+fn previews_no_path_for_a_file_the_patch_creates_and_then_deletes() {
+    let patched = tempdir().unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch =
+        write_patch(patch_dir.path(), &format!("{BINDING_GYP_PATCH}{BINDING_GYP_DELETE_PATCH}"));
+
+    let preview = preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    apply_patch_to_dir(patched.path(), &patch).expect("apply must succeed");
+    assert!(preview.written_paths.is_empty(), "written_paths: {:?}", preview.written_paths);
+    assert!(!patched.path().join("binding.gyp").exists(), "no binding.gyp remains");
+}
+
+/// The build phase owns the real apply. Applying twice to one slot is not
+/// something a read-only question should risk.
+#[test]
+fn previewing_leaves_the_directory_untouched() {
+    let patched = tempdir().unwrap();
+    fs::write(patched.path().join("package.json"), MANIFEST).unwrap();
+    let patch_dir = tempdir().unwrap();
+    let patch = write_patch(patch_dir.path(), MANIFEST_PATCH);
+
+    preview_patch(patched.path(), &patch).expect("preview must succeed");
+
+    let on_disk = fs::read_to_string(patched.path().join("package.json")).unwrap();
+    assert_eq!(on_disk, MANIFEST);
 }
 
 #[test]

--- a/pnpm/crates/patching/src/lib.rs
+++ b/pnpm/crates/patching/src/lib.rs
@@ -36,7 +36,7 @@ mod resolve;
 mod types;
 mod verify;
 
-pub use apply::{PatchApplyError, apply_patch_to_dir};
+pub use apply::{PatchApplyError, PatchPreview, apply_patch_to_dir, preview_patch};
 pub use commit::*;
 pub use get_patch_info::{PatchKeyConflictError, get_patch_info};
 pub use group::{PatchInput, PatchNonSemverRangeError, group_patched_dependencies};

--- a/pnpm11/building/during-install/package.json
+++ b/pnpm11/building/during-install/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@pnpm/bins.linker": "workspace:*",
+    "@pnpm/building.pkg-requires-build": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
     "@pnpm/core-loggers": "workspace:*",
     "@pnpm/deps.graph-hasher": "workspace:*",

--- a/pnpm11/building/during-install/src/index.ts
+++ b/pnpm11/building/during-install/src/index.ts
@@ -4,6 +4,7 @@ import path from 'node:path'
 import util from 'node:util'
 
 import { linkBins, linkBinsOfPackages } from '@pnpm/bins.linker'
+import { dirRequiresBuild } from '@pnpm/building.pkg-requires-build'
 import { getWorkspaceConcurrency } from '@pnpm/config.reader'
 import { skippedOptionalDependencyLogger } from '@pnpm/core-loggers'
 import { calcDepState, type DepsStateCache, findRuntimeNodeVersion } from '@pnpm/deps.graph-hasher'
@@ -144,27 +145,13 @@ export async function buildModules<T extends string> (
     runNode: async (depPath): Promise<TaskCompletion> => {
       if (!shouldBuild(depPath)) return 'passed'
       try {
-        let ignoreScripts = Boolean(buildDepOpts.ignoreScripts)
-        if (!ignoreScripts) {
-          const node = depGraph[depPath]
-          if (node.requiresBuild) {
-            const allowed = allowBuild(node.depPath)
-            switch (allowed) {
-              case false:
-              // Explicitly disallowed - don't report as ignored
-                ignoreScripts = true
-                break
-              case undefined:
-              // Not in allowlist - report as ignored
-                ignoredBuilds.add(node.depPath)
-                ignoreScripts = true
-                break
-            }
-            // allowed === true means build is permitted
-          }
-        }
+        const node = depGraph[depPath]
+        const ignoreScripts = Boolean(buildDepOpts.ignoreScripts) ||
+          (Boolean(node.requiresBuild) && !buildIsAllowed(node.depPath, allowBuild, ignoredBuilds))
         await buildDependency(depPath, depGraph, {
           ...buildDepOpts,
+          allowBuild,
+          ignoredBuilds,
           ignoreScripts,
         })
         return 'passed'
@@ -192,6 +179,21 @@ export async function buildModules<T extends string> (
   }
 }
 
+/**
+ * Whether `depPath`'s lifecycle scripts may run under the allow-build policy.
+ *
+ * A package the policy has no verdict on is recorded in `ignoredBuilds`, which
+ * is what `pnpm approve-builds` later offers the user. An explicit `false` is
+ * a decision already made, so it is not reported.
+ */
+function buildIsAllowed (depPath: DepPath, allowBuild: AllowBuild, ignoredBuilds: Set<DepPath>): boolean {
+  const allowed = allowBuild(depPath)
+  if (allowed === undefined) {
+    ignoredBuilds.add(depPath)
+  }
+  return allowed === true
+}
+
 /** Refuse a build under a read-only global virtual store. See the call site. */
 function throwFrozenStoreNeedsBuild (blocked: Set<string>): never {
   const list = Array.from(blocked).sort()
@@ -208,6 +210,8 @@ async function buildDependency<T extends string> (
   depPath: T,
   depGraph: DependenciesGraph<T>,
   opts: {
+    allowBuild: AllowBuild
+    ignoredBuilds: Set<DepPath>
     extraBinPaths?: string[]
     extraNodePaths?: string[]
     extraEnv?: Record<string, string>
@@ -259,7 +263,22 @@ async function buildDependency<T extends string> (
       }
       isPatched = applyPatchToDir({ patchedDir: depNode.dir, patchFilePath: depNode.patch.patchFilePath })
     }
-    const hasSideEffects = !opts.ignoreScripts && await runPostinstallHooks({
+    // A patch can add install scripts - or a binding.gyp, which the lifecycle
+    // runner turns into `node-gyp rebuild` - to a package that published
+    // neither, and the caller's gate could not have seen that: the files it
+    // read requiresBuild off were still unpatched. Build work a patch
+    // introduces needs approval like any other, so put it through the same gate.
+    // The recompute runs even when scripts are already suppressed, because
+    // `buildPending` below needs to know a build is owed either way.
+    let requiresBuild = depNode.requiresBuild === true
+    let ignoreScripts = Boolean(opts.ignoreScripts)
+    if (isPatched && !requiresBuild) {
+      requiresBuild = await dirRequiresBuild(depNode.dir)
+      if (requiresBuild && !ignoreScripts) {
+        ignoreScripts = !buildIsAllowed(depNode.depPath, opts.allowBuild, opts.ignoredBuilds)
+      }
+    }
+    const hasSideEffects = !ignoreScripts && await runPostinstallHooks({
       depPath,
       extraBinPaths: opts.extraBinPaths,
       extraEnv: opts.extraEnv,
@@ -287,7 +306,12 @@ async function buildDependency<T extends string> (
       opts.pnprServer != null &&
       opts.remoteSideEffectsCache?.packages?.includes(depNode.name) === true &&
       depNode.resolution != null
-    if ((isPatched || hasSideEffects) && (opts.sideEffectsCacheWrite || shouldPublishSharedSideEffects) && !opts.frozenStore) {
+    // A package whose build was withheld - the allow-build policy said so, or
+    // ignoreScripts did - must not be cached as if it were built. The entry
+    // the patch alone produced would replay on the install that finally runs
+    // the build, and the scripts would never get their chance.
+    const buildPending = requiresBuild && ignoreScripts
+    if ((isPatched || hasSideEffects) && !buildPending && (opts.sideEffectsCacheWrite || shouldPublishSharedSideEffects) && !opts.frozenStore) {
       try {
         const sideEffectsCacheKey = calcDepState(depGraph, opts.depsStateCache, depPath, {
           patchFileHash: depNode.patch?.hash,

--- a/pnpm11/building/during-install/tsconfig.json
+++ b/pnpm11/building/during-install/tsconfig.json
@@ -62,6 +62,9 @@
     },
     {
       "path": "../../workspace/task-scheduler"
+    },
+    {
+      "path": "../pkg-requires-build"
     }
   ]
 }

--- a/pnpm11/building/pkg-requires-build/package.json
+++ b/pnpm11/building/pkg-requires-build/package.json
@@ -31,6 +31,7 @@
     "compile": "tsgo --build && pn lint --fix"
   },
   "dependencies": {
+    "@pnpm/pkg-manifest.reader": "workspace:*",
     "@pnpm/types": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm11/building/pkg-requires-build/src/index.ts
+++ b/pnpm11/building/pkg-requires-build/src/index.ts
@@ -1,3 +1,7 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { safeReadPackageJsonFromDir } from '@pnpm/pkg-manifest.reader'
 import type { DependencyManifest } from '@pnpm/types'
 
 type FilesIndexArg = Map<string, unknown> | Record<string, unknown>
@@ -24,4 +28,46 @@ function filesIncludeInstallScripts (filesIndex: FilesIndexArg): boolean {
     }
   }
   return false
+}
+
+/**
+ * [`pkgRequiresBuild`] for a package that is already on disk.
+ *
+ * Reads the same two triggers off the directory: the manifest's install
+ * scripts, and the presence of `binding.gyp` or `.hooks/`. Callers that hold
+ * the package's files index should use [`pkgRequiresBuild`] instead - this is
+ * for the ones that only have the extracted directory, such as a package whose
+ * patch has just been applied.
+ *
+ * A directory that cannot be inspected - a missing or malformed manifest, an
+ * unreadable entry - reports no build, matching the Rust `pkgRequiresBuild`.
+ * There is no build to schedule for a package whose contents cannot be read,
+ * and the lifecycle runner reports the manifest again when scripts do run.
+ */
+export async function dirRequiresBuild (dir: string): Promise<boolean> {
+  const filesIndex = new Map<string, undefined>()
+  if (fs.existsSync(path.join(dir, 'binding.gyp'))) {
+    filesIndex.set('binding.gyp', undefined)
+  }
+  // Only a `.hooks` directory holds hooks, and only its entries are what
+  // `filesIncludeInstallScripts` matches. A plain file by that name is not a
+  // build trigger.
+  if (dirEntryIsDirectory(path.join(dir, '.hooks'))) {
+    filesIndex.set('.hooks/', undefined)
+  }
+  let manifest: Partial<DependencyManifest> | undefined
+  try {
+    manifest = await safeReadPackageJsonFromDir(dir) ?? undefined
+  } catch {
+    return false
+  }
+  return pkgRequiresBuild(manifest, filesIndex)
+}
+
+function dirEntryIsDirectory (entryPath: string): boolean {
+  try {
+    return fs.statSync(entryPath, { throwIfNoEntry: false })?.isDirectory() === true
+  } catch {
+    return false
+  }
 }

--- a/pnpm11/building/pkg-requires-build/tsconfig.json
+++ b/pnpm11/building/pkg-requires-build/tsconfig.json
@@ -11,6 +11,9 @@
   "references": [
     {
       "path": "../../core/types"
+    },
+    {
+      "path": "../../pkg-manifest/reader"
     }
   ]
 }

--- a/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-binding-gyp.patch
+++ b/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-binding-gyp.patch
@@ -1,0 +1,7 @@
+diff --git a/binding.gyp b/binding.gyp
+new file mode 100644
+index 0000000..d7ea4ac
+--- /dev/null
++++ b/binding.gyp
+@@ -0,0 +1 @@
++{ "targets": [] }

--- a/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-hooks-file.patch
+++ b/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-hooks-file.patch
@@ -1,0 +1,7 @@
+diff --git a/.hooks b/.hooks
+new file mode 100644
+index 0000000..8c41a6a
+--- /dev/null
++++ b/.hooks
+@@ -0,0 +1 @@
++not a hooks directory

--- a/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-postinstall.patch
+++ b/pnpm11/installing/deps-installer/test/fixtures/patch-pkg/is-positive@1.0.0-postinstall.patch
@@ -1,0 +1,21 @@
+diff --git a/package.json b/package.json
+index 5c708ce..3b93e9b 100644
+--- a/package.json
++++ b/package.json
+@@ -13,7 +13,8 @@
+     "node": ">=0.10.0"
+   },
+   "scripts": {
+-    "test": "node test.js"
++    "test": "node test.js",
++    "postinstall": "node postinstall.js"
+   },
+   "files": [
+     "index.js"
+diff --git a/postinstall.js b/postinstall.js
+new file mode 100644
+index 0000000..d12e51d
+--- /dev/null
++++ b/postinstall.js
+@@ -0,0 +1 @@
++require('fs').writeFileSync('postinstall-ran.txt', 'ran')

--- a/pnpm11/installing/deps-installer/test/install/patch.ts
+++ b/pnpm11/installing/deps-installer/test/install/patch.ts
@@ -591,6 +591,144 @@ test('patch package when the package is not in allowBuilds list', async () => {
   expect(fs.readFileSync('node_modules/is-positive/index.js', 'utf8')).not.toContain('// patched')
 })
 
+test('a patch that adds install scripts asks for build approval', async () => {
+  const reporter = jest.fn()
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0-postinstall.patch')
+  const patchFileHash = await createHexHashFromFile(patchPath)
+  const marker = 'node_modules/is-positive/postinstall-ran.txt'
+
+  const patchedDependencies = {
+    'is-positive@1.0.0': patchPath,
+  }
+  const opts = testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies,
+    allowBuilds: {},
+    reporter,
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, opts)
+
+  expect(reporter).toHaveBeenCalledWith(expect.objectContaining({
+    packageNames: [`is-positive@1.0.0(patch_hash=${patchFileHash})`],
+    level: 'debug',
+    name: 'pnpm:ignored-scripts',
+  }))
+  expect(fs.existsSync(marker)).toBe(false)
+
+  rimrafSync('node_modules')
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, {
+    ...opts,
+    allowBuilds: { 'is-positive': true },
+  })
+
+  expect(fs.existsSync(marker)).toBe(true)
+})
+
+test('a patch-added install script survives an install that ignored scripts', async () => {
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0-postinstall.patch')
+  const marker = 'node_modules/is-positive/postinstall-ran.txt'
+
+  const installOpts = (ignoreScripts: boolean) => testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies: {
+      'is-positive@1.0.0': patchPath,
+    },
+    allowBuilds: { 'is-positive': true },
+    ignoreScripts,
+  }, {}, {}, { packageImportMethod: 'hardlink' })
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, installOpts(true))
+
+  expect(fs.existsSync(marker)).toBe(false)
+
+  // A second store controller, so the install below reads the side-effects
+  // cache off disk instead of the first one's in-memory view of it.
+  rimrafSync('node_modules')
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, installOpts(false))
+
+  expect(fs.existsSync(marker)).toBe(true)
+})
+
+test('a patch that adds a binding.gyp asks for build approval', async () => {
+  const reporter = jest.fn()
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0-binding-gyp.patch')
+  const patchFileHash = await createHexHashFromFile(patchPath)
+
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies: {
+      'is-positive@1.0.0': patchPath,
+    },
+    allowBuilds: {},
+    reporter,
+  }, {}, {}, { packageImportMethod: 'hardlink' }))
+
+  // An unapproved binding.gyp must not reach the implicit `node-gyp rebuild`.
+  expect(reporter).toHaveBeenCalledWith(expect.objectContaining({
+    packageNames: [`is-positive@1.0.0(patch_hash=${patchFileHash})`],
+    level: 'debug',
+    name: 'pnpm:ignored-scripts',
+  }))
+})
+
+test('a patch that adds a .hooks file does not ask for build approval', async () => {
+  const reporter = jest.fn()
+  prepareEmpty()
+  const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0-hooks-file.patch')
+
+  await install({
+    dependencies: {
+      'is-positive': '1.0.0',
+    },
+  }, testDefaults({
+    fastUnpack: false,
+    sideEffectsCacheRead: true,
+    sideEffectsCacheWrite: true,
+    patchedDependencies: {
+      'is-positive@1.0.0': patchPath,
+    },
+    allowBuilds: {},
+    reporter,
+  }, {}, {}, { packageImportMethod: 'hardlink' }))
+
+  // Only entries below a `.hooks` directory are hooks; a plain file by that
+  // name must not hold the install for approval.
+  expect(reporter).toHaveBeenCalledWith(expect.objectContaining({
+    packageNames: [],
+    level: 'debug',
+    name: 'pnpm:ignored-scripts',
+  }))
+  expect(fs.readFileSync('node_modules/is-positive/.hooks', 'utf8')).toContain('not a hooks directory')
+})
+
 test('patch package when the patched package has no dependencies and appears multiple times', async () => {
   const project = prepareEmpty()
   const patchPath = path.join(f.find('patch-pkg'), 'is-positive@1.0.0.patch')


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14648.

A dependency's `requiresBuild` is read off its published files, which do not carry the patch yet. A patch that adds `preinstall`, `install`, or `postinstall` therefore left the package looking build-free:

- **pnpm 12** never ran the script and never offered the package in `pnpm approve-builds`. This is the reported bug.
- **pnpm 11** ran the script, but skipped the approval gate entirely, so a patch-added script slipped past `onlyBuiltDependencies` / `allowBuilds`. Verified against a control (`esbuild` is gated in the same project).

The same holds for a patch that adds a `binding.gyp`, which the lifecycle runner turns into an implicit `node-gyp rebuild`.

Both stacks now put patch-added build work through the same gate as any other dependency build: the package is reported under "Ignored build scripts" until it is allowed to build, and it builds once it is.

Reproduced with the reporter's repro (a patch adding `postinstall` to `is-number`) against pnpm 12.3.4, pnpm 11.26.0, and both fixed builds.

### Why pnpm 12 previews the patched manifest instead of recomputing after the patch is applied

The obvious fix — recompute `requiresBuild` right after `apply_patch_to_dir` — does not reach existing users. `sideEffectsCache` defaults to on, and a broken pnpm 12 already wrote a "patched, unbuilt" cache entry for these packages. The key it is stored under is derived from the pre-patch answer, so the recomputed install computes the same key, hits that entry, and skips the build permanently. I confirmed this: with a store seeded by 12.3.4, the recompute-after-patch version stayed silent.

So pnpm 12 previews the patched `package.json` in memory (`pnpm_patching::patched_manifest`, a read-only reuse of the existing `tolerant::apply`) while it builds `requires_build_map`, before anything is decided. The allow-build gate, the build graph, `pendingBuilds`, and the side-effects cache key then all describe the package that ends up on disk, and the stale entry is no longer matched.

### pnpm 11

pnpm 11's applier is filesystem-based, so it recomputes from the patched directory (the new `dirRequiresBuild`), and additionally stops writing a side-effects entry for a package whose build is still owed. Without that second half, the entry the patch alone produced would replay on the install that follows an approval and the scripts would never get their chance — I hit exactly that while testing.

### Bot review

Every finding was checked against the code before I acted on it. Nine were real and are fixed; one was declined.

Bugs in the first version of this PR:

- **`--ignore-scripts` poisoned the pnpm 11 cache** (Greptile, Qodo, CodeRabbit). Skipping the recompute when scripts were already suppressed left `buildPending` false, so the patched-unbuilt snapshot was cached and a later approved install replayed it. Reproduced end to end before fixing. The recompute now runs whenever the package is patched; only the policy check and the hooks are skipped.
- **A patch-added `binding.gyp` skipped approval in pnpm 11** (Qodo). `checkBindingGyp` injects `node-gyp rebuild` inside the lifecycle runner, so an unapproved native build ran. Both stacks now read the same two triggers: the new `dirRequiresBuild` mirrors the Rust `pkg_requires_build`, and the pnpm 12 preview reports the paths a patch creates.
- **The pnpm 12 preview bypassed BOM-tolerant parsing** (Qodo). It now returns the manifest verbatim and the caller parses it with `parse_manifest`.
- **Repeated records for one file were not composed** (CodeRabbit). The preview now chains them the way `apply_patch_to_dir` does.
- **A path a later record deletes stayed recorded** (Greptile). `written_paths` documented this and the code did not do it.
- **`./package.json` in a patch header applied but was invisible to the preview** (Qodo, CodeRabbit). `resolve_target` permits `.` segments; the preview compared raw strings. Now normalized through `normalized_patch_path`, which also refuses what the apply would refuse.
- **A plain file named `.hooks` counted as a hook directory in pnpm 11** (CodeRabbit). Now a directory check, matching both `filesIncludeInstallScripts` and the Rust side.

Also addressed: missing coverage for the stale-cache path (Greptile) — `--ignore-scripts` reproduces the exact dep-graph-free key the broken release wrote, so the test fails under a recompute-after-apply implementation; plus comment and changeset style.

Declined: asserting `strictDepBuilds` in the pnpm 11 test (CodeRabbit). That option is enforced in `@pnpm/installing.commands`, not `install()`, so it would be inert at that layer. The test asserts the `pnpm:ignored-scripts` payload `handleIgnoredBuilds` consumes plus non-execution; the pnpm 12 CLI test covers the `ERR_PNPM_IGNORED_BUILDS` exit.

Later rounds:

- **An empty script value gated on pnpm 12 but not on pnpm 11** (Qodo). `manifest_requires_build` tested the key's presence; `pkgRequiresBuild` tests the value's truthiness. It now reads the value, so `"postinstall": ""` is build-free in both stacks. Pre-existing, but this PR claims parity for exactly this decision.
- **The preview ran once per snapshot** (Qodo). Peer variants of one patched package each re-read and re-parsed the patch file and the manifest on the install path. Answered once per patch now.

- **A manifest a patch deletes and writes again was not previewed** (Qodo). My own `Create` guard rested on "a package always ships a manifest", which stopped holding once delete handling landed.
- **`dirRequiresBuild` could reject on a malformed patched manifest** (Qodo). The Rust `pkg_requires_build` collapses that to `false`; since the recompute now runs under `ignoreScripts` too, the TypeScript side would have failed installs that never read a manifest before. It now matches.
- **Written paths were scanned per delete record** (Qodo). Tracked in an `IndexSet` now, which also stops a twice-rewritten file being reported twice.

Declined: a symlink-traversal gap where `alias/package.json` reaches the root manifest through `alias -> .` (Qodo). A package directory in the virtual store cannot contain a symlink — extraction skips every non-regular entry, and `FileOperation::Create` writes a regular file whatever mode the patch names.

Every fix above has a regression test that I confirmed fails with that fix reverted.

### Known divergence

The two stacks agree on what a user sees. They still derive the side-effects cache key differently for a patched package that runs scripts, so such a package rebuilds on every pnpm 11 install — which is what pnpm 11 does today, so this is not a regression.

## Squash Commit Body

```text
A dependency's `requiresBuild` is read off its published files, which do
not carry the patch yet. A patch that adds `preinstall`, `install`, or
`postinstall` — or a `binding.gyp`, which the lifecycle runner turns into
an implicit `node-gyp rebuild` — therefore left the package looking
build-free: pnpm 12 never ran it and never offered it in
`pnpm approve-builds`, while pnpm 11 ran it without asking for approval
at all.

pnpm 12 previews the patch in memory (`pnpm_patching::preview_patch`)
while it builds `requires_build_map`, so the allow-build gate, the build
graph, `pendingBuilds`, and the side-effects cache key all describe the
package that ends up on disk. Deciding it there rather than after
`apply_patch_to_dir` is what makes the fix reach existing users: the key
derived from the pre-patch answer matches the entry a broken version
already wrote, and that cache hit would suppress the build forever on any
machine that had installed once. The preview chains repeated records for
one file the way the real apply does, and reports the manifest verbatim so
the caller's BOM-tolerant parser sees what it would on disk.

pnpm 11 recomputes from the patched directory, where its filesystem-based
applier can reach it, through the new `dirRequiresBuild`. The recompute
runs even under `ignoreScripts`, because pnpm 11 must also stop writing a
side-effects entry for a package whose build is still owed: the entry the
patch alone produced would replay on the install that follows an approval,
and the scripts would never get their chance.

The two stacks agree on what a user sees. They still derive the
side-effects cache key differently for a patched package that runs
scripts, so such a package rebuilds on every pnpm 11 install, as it does
today.

Closes pnpm/pnpm#14648
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FfJR5cXZJJaUqH9u6ATGFw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Patched packages that add install scripts or native build configuration now require approval before running.
  - Unapproved builds appear under **Ignored build scripts** and can be enabled through build approval settings.
  - Approved builds run correctly on subsequent installations.

- **Bug Fixes**
  - Prevented packages with withheld builds from being incorrectly reused from side-effects cache entries.
  - Improved detection of build requirements introduced by package patches.
  - Empty or unset lifecycle scripts are no longer treated as build requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

