### PR TITLE
feat: add freebsd-x64, linux-ppc64 and linux-s390x builds

### DIFF
--- a/.changeset/add-freebsd-ppc64-s390x-builds.md
+++ b/.changeset/add-freebsd-ppc64-s390x-builds.md
@@ -2,4 +2,4 @@
 "pacquet": minor
 ---
 
-pnpm now runs on FreeBSD systems with x64 CPUs [#14597](https://github.com/pnpm/pnpm/issues/14597). It also runs on Linux systems with ppc64le and s390x CPUs, which Node.js ships official binaries for.
+pnpm now runs on FreeBSD systems with x64 CPUs [#14597](https://github.com/pnpm/pnpm/issues/14597). It also runs on Linux systems with ppc64le and s390x CPUs.

--- a/.changeset/add-freebsd-ppc64-s390x-builds.md
+++ b/.changeset/add-freebsd-ppc64-s390x-builds.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+pnpm now runs on FreeBSD systems with x64 CPUs [#14597](https://github.com/pnpm/pnpm/issues/14597). It also runs on Linux systems with ppc64le and s390x CPUs, which Node.js ships official binaries for.

--- a/.changeset/add-freebsd-x64-build.md
+++ b/.changeset/add-freebsd-x64-build.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+pnpm now runs on FreeBSD systems with x64 CPUs [#14597](https://github.com/pnpm/pnpm/issues/14597).

--- a/.changeset/add-freebsd-x64-build.md
+++ b/.changeset/add-freebsd-x64-build.md
@@ -1,5 +1,0 @@
----
-"pacquet": minor
----
-
-pnpm now runs on FreeBSD systems with x64 CPUs [#14597](https://github.com/pnpm/pnpm/issues/14597).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -600,6 +600,14 @@ jobs:
             code-target: linux-riscv64
 
           - os: blacksmith-8vcpu-ubuntu-2404
+            target: powerpc64le-unknown-linux-gnu
+            code-target: linux-ppc64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: s390x-unknown-linux-gnu
+            code-target: linux-s390x
+
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-freebsd
             code-target: freebsd-x64
 
@@ -722,6 +730,14 @@ jobs:
           - os: blacksmith-8vcpu-ubuntu-2404
             target: riscv64gc-unknown-linux-gnu
             code-target: linux-riscv64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: powerpc64le-unknown-linux-gnu
+            code-target: linux-ppc64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: s390x-unknown-linux-gnu
+            code-target: linux-s390x
 
           - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-freebsd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,6 +599,10 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             code-target: linux-riscv64
 
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-unknown-freebsd
+            code-target: freebsd-x64
+
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
@@ -718,6 +722,10 @@ jobs:
           - os: blacksmith-8vcpu-ubuntu-2404
             target: riscv64gc-unknown-linux-gnu
             code-target: linux-riscv64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-unknown-freebsd
+            code-target: freebsd-x64
 
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -107,8 +107,8 @@ The addon ships as prebuilt per-platform packages, the same model as the
   wrapper's `optionalDependencies`.
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
-`linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-x64-musl`,
-`linux-arm64-musl`, `freebsd-x64`.
+`linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-ppc64`, `linux-s390x`,
+`linux-x64-musl`, `linux-arm64-musl`, `freebsd-x64`.
 
 ## Local development
 

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -108,7 +108,7 @@ The addon ships as prebuilt per-platform packages, the same model as the
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
 `linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-x64-musl`,
-`linux-arm64-musl`.
+`linux-arm64-musl`, `freebsd-x64`.
 
 ## Local development
 

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -102,9 +102,9 @@ The addon ships as prebuilt per-platform packages, the same model as the
   `@pnpm/napi.<platform>` optional dependency, then a local build.
 - CI cross-compiles the addon per target (`napi build --release --target
   <rust-triple>`), uploads each as `pnpm-napi.<codeTarget>.node` at the repo
-  root, then runs `scripts/generate-packages.mjs` to produce the eight
-  `@pnpm/napi.<platform>` packages and wire them as this wrapper's
-  `optionalDependencies`.
+  root, then runs `scripts/generate-packages.mjs` to produce the
+  `@pnpm/napi.<platform>` packages listed below and wire them as this
+  wrapper's `optionalDependencies`.
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
 `linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-x64-musl`,

--- a/pnpm/npm/napi/index.js
+++ b/pnpm/npm/napi/index.js
@@ -13,6 +13,7 @@
 
 const path = require('node:path')
 const fs = require('node:fs')
+const os = require('node:os')
 
 // `'glibc' | 'musl' | null` — `null` when the host isn't Linux or the libc
 // can't be probed (`process.report` may be unavailable/disabled). glibc builds
@@ -37,6 +38,14 @@ function platformTriples() {
     return order.map((suffix) => `linux-${arch}${suffix}`)
   }
   return [`${platform}-${arch}`]
+}
+
+// Node reports both POWER endiannesses as `ppc64` and npm's `cpu` field cannot
+// tell them apart, so a big-endian host can install the little-endian addon.
+// Only the little-endian build is released, so no platform package can serve
+// such a host and one built locally is all that is left.
+function hasReleasedPlatformPackage() {
+  return process.arch !== 'ppc64' || os.endianness() === 'LE'
 }
 
 function tryLoad(candidate, loadErrors) {
@@ -73,11 +82,12 @@ function isMissingCandidate(err, candidate) {
 }
 
 function loadFailure(triple, loadErrors) {
-  const error = new Error(
-    `Failed to load the pnpm Rust engine for ${triple}. ` +
-      'Install the matching @pnpm/napi platform package, or point ' +
+  const remedy = hasReleasedPlatformPackage()
+    ? 'Install the matching @pnpm/napi platform package, or point ' +
       'PNPM_NAPI_BINARY at a locally built .node file.'
-  )
+    : 'No addon is published for this host, so point PNPM_NAPI_BINARY at a ' +
+      'locally built .node file.'
+  const error = new Error(`Failed to load the pnpm Rust engine for ${triple}. ${remedy}`)
   if (loadErrors.length > 0) {
     error.cause = loadErrors[0]
   }
@@ -104,9 +114,10 @@ function loadBinding() {
   // Platform packages / local artifacts. On Linux both libc variants are tried,
   // so a wrong-ABI first candidate (an `ERR_DLOPEN_FAILED`) falls through to the
   // other rather than aborting.
+  const platformPackages = hasReleasedPlatformPackage()
   const candidates = [
     ...triples.flatMap((triple) => [
-      `@pnpm/napi.${triple}`,
+      ...(platformPackages ? [`@pnpm/napi.${triple}`] : []),
       path.join(__dirname, `pnpm-napi.${triple}.node`),
     ]),
     path.join(__dirname, 'pnpm-napi.node'),

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -42,6 +42,8 @@ const TARGETS = [
   { platform: 'linux', arch: 'x64', libc: 'glibc', codeTarget: 'linux-x64', packageTarget: 'linux-x64' },
   { platform: 'linux', arch: 'arm64', libc: 'glibc', codeTarget: 'linux-arm64', packageTarget: 'linux-arm64' },
   { platform: 'linux', arch: 'riscv64', libc: 'glibc', codeTarget: 'linux-riscv64', packageTarget: 'linux-riscv64' },
+  { platform: 'linux', arch: 'ppc64', libc: 'glibc', codeTarget: 'linux-ppc64', packageTarget: 'linux-ppc64' },
+  { platform: 'linux', arch: 's390x', libc: 'glibc', codeTarget: 'linux-s390x', packageTarget: 'linux-s390x' },
   { platform: 'linux', arch: 'x64', libc: 'musl', codeTarget: 'linux-x64-musl', packageTarget: 'linux-x64-musl' },
   { platform: 'linux', arch: 'arm64', libc: 'musl', codeTarget: 'linux-arm64-musl', packageTarget: 'linux-arm64-musl' },
   { platform: 'freebsd', arch: 'x64', codeTarget: 'freebsd-x64', packageTarget: 'freebsd-x64' },

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -44,6 +44,7 @@ const TARGETS = [
   { platform: 'linux', arch: 'riscv64', libc: 'glibc', codeTarget: 'linux-riscv64', packageTarget: 'linux-riscv64' },
   { platform: 'linux', arch: 'x64', libc: 'musl', codeTarget: 'linux-x64-musl', packageTarget: 'linux-x64-musl' },
   { platform: 'linux', arch: 'arm64', libc: 'musl', codeTarget: 'linux-arm64-musl', packageTarget: 'linux-arm64-musl' },
+  { platform: 'freebsd', arch: 'x64', codeTarget: 'freebsd-x64', packageTarget: 'freebsd-x64' },
 ]
 
 function nativePackageName(target) {

--- a/pnpm/npm/napi/test/loader.test.mjs
+++ b/pnpm/npm/napi/test/loader.test.mjs
@@ -9,47 +9,62 @@ import { fileURLToPath } from 'node:url'
 
 const loaderPath = path.resolve(fileURLToPath(import.meta.url), '../../index.js')
 
-test('a big-endian POWER host is not pointed at the released addon', (t) => {
-  const message = loadOn(t, { arch: 'ppc64', endianness: 'BE' })
+test('a big-endian POWER host is not offered the released addon', (t) => {
+  const result = loadOn(t, { arch: 'ppc64', endianness: 'BE' })
 
-  assert.match(message, /No addon is published for this host/)
-  // Only a little-endian POWER addon is released, so naming a platform package
-  // here would tell the user to install one that can never load.
-  assert.doesNotMatch(message, /@pnpm\/napi\./)
+  // Both POWER platform packages resolve in there, so loading one would have
+  // succeeded. Failing is what proves neither was offered as a candidate.
+  assert.match(result, /^FAILED /)
+  assert.match(result, /No addon is published for this host/)
+  assert.doesNotMatch(result, /@pnpm\/napi\./)
 })
 
-test('a little-endian POWER host is still pointed at its platform package', (t) => {
-  const message = loadOn(t, { arch: 'ppc64', endianness: 'LE' })
+test('a little-endian POWER host is offered its platform package', (t) => {
+  const result = loadOn(t, { arch: 'ppc64', endianness: 'LE' })
 
-  assert.match(message, /Install the matching @pnpm\/napi platform package/)
+  assert.equal(result, 'LOADED linux-ppc64')
 })
 
 /**
- * Load the addon loader in a child process presenting itself as a Linux host of
- * the given architecture and byte order, from a directory holding nothing but
- * the loader so that neither a platform package nor a locally built artifact
- * resolves.
+ * Load the addon loader in a child process presenting itself as a glibc Linux
+ * host of the given architecture and byte order, from a directory carrying a
+ * stand-in for each POWER platform package. Offering one is therefore
+ * observable: the load succeeds and names the package it came from.
  *
  * @param {import('node:test').TestContext} t The test, for cleanup.
  * @param {{ arch: string, endianness: 'LE' | 'BE' }} host The host to present.
- * @returns {string} The message of the load failure it reports.
+ * @returns {string} `LOADED <triple>`, or `FAILED <message>`.
  */
 function loadOn (t, host) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-napi-loader-'))
   t.after(() => { fs.rmSync(dir, { recursive: true, force: true }) })
   const loaderCopy = path.join(dir, 'index.js')
   fs.copyFileSync(loaderPath, loaderCopy)
+  for (const triple of ['linux-ppc64', 'linux-ppc64-musl']) {
+    const packageDir = path.join(dir, 'node_modules', '@pnpm', `napi.${triple}`)
+    fs.mkdirSync(packageDir, { recursive: true })
+    fs.writeFileSync(
+      path.join(packageDir, 'package.json'),
+      JSON.stringify({ name: `@pnpm/napi.${triple}`, version: '0.0.0', main: 'index.js' })
+    )
+    fs.writeFileSync(path.join(packageDir, 'index.js'), `module.exports = { loadedFrom: ${JSON.stringify(triple)} }\n`)
+  }
 
+  // The libc is faked too, so the candidate order does not depend on the
+  // platform this test itself runs on.
   const script = `
     const os = require('node:os')
     Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
     Object.defineProperty(process, 'arch', { value: ${JSON.stringify(host.arch)}, configurable: true })
+    Object.defineProperty(process, 'report', {
+      value: { getReport: () => ({ header: { glibcVersionRuntime: '2.39' } }) },
+      configurable: true,
+    })
     Object.defineProperty(os, 'endianness', { value: () => ${JSON.stringify(host.endianness)}, configurable: true })
     try {
-      require(${JSON.stringify(loaderCopy)})
-      process.stdout.write('the loader unexpectedly succeeded')
+      process.stdout.write('LOADED ' + require(${JSON.stringify(loaderCopy)}).loadedFrom)
     } catch (err) {
-      process.stdout.write(err.message)
+      process.stdout.write('FAILED ' + err.message)
     }
   `
   const env = { ...process.env }

--- a/pnpm/npm/napi/test/loader.test.mjs
+++ b/pnpm/npm/napi/test/loader.test.mjs
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const loaderPath = path.resolve(fileURLToPath(import.meta.url), '../../index.js')
+
+test('a big-endian POWER host is not pointed at the released addon', (t) => {
+  const message = loadOn(t, { arch: 'ppc64', endianness: 'BE' })
+
+  assert.match(message, /No addon is published for this host/)
+  // Only a little-endian POWER addon is released, so naming a platform package
+  // here would tell the user to install one that can never load.
+  assert.doesNotMatch(message, /@pnpm\/napi\./)
+})
+
+test('a little-endian POWER host is still pointed at its platform package', (t) => {
+  const message = loadOn(t, { arch: 'ppc64', endianness: 'LE' })
+
+  assert.match(message, /Install the matching @pnpm\/napi platform package/)
+})
+
+/**
+ * Load the addon loader in a child process presenting itself as a Linux host of
+ * the given architecture and byte order, from a directory holding nothing but
+ * the loader so that neither a platform package nor a locally built artifact
+ * resolves.
+ *
+ * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {{ arch: string, endianness: 'LE' | 'BE' }} host The host to present.
+ * @returns {string} The message of the load failure it reports.
+ */
+function loadOn (t, host) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'pnpm-napi-loader-'))
+  t.after(() => { fs.rmSync(dir, { recursive: true, force: true }) })
+  const loaderCopy = path.join(dir, 'index.js')
+  fs.copyFileSync(loaderPath, loaderCopy)
+
+  const script = `
+    const os = require('node:os')
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+    Object.defineProperty(process, 'arch', { value: ${JSON.stringify(host.arch)}, configurable: true })
+    Object.defineProperty(os, 'endianness', { value: () => ${JSON.stringify(host.endianness)}, configurable: true })
+    try {
+      require(${JSON.stringify(loaderCopy)})
+      process.stdout.write('the loader unexpectedly succeeded')
+    } catch (err) {
+      process.stdout.write(err.message)
+    }
+  `
+  const env = { ...process.env }
+  delete env.PNPM_NAPI_BINARY
+  return execFileSync(process.execPath, ['-e', script], { encoding: 'utf8', env })
+}

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -2,6 +2,7 @@
 // (`install.js`), which links it over the placeholder bins, and by the Corepack
 // entry (`bin/pnpm.mjs`), which spawns it.
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { fileURLToPath } from 'node:url'
@@ -33,8 +34,6 @@ const PLATFORMS = {
     riscv64: {
       glibc: '@pnpm/exe.linux-riscv64/pnpm',
     },
-    // Node reports both POWER endiannesses as `ppc64`, and the released build
-    // is the little-endian one.
     ppc64: {
       glibc: '@pnpm/exe.linux-ppc64/pnpm',
     },
@@ -59,6 +58,12 @@ export function getBinCandidates () {
   const platformEntry = PLATFORMS?.[platform]?.[arch]
 
   if (platformEntry == null) {
+    return []
+  }
+  // Node reports both POWER endiannesses as `ppc64` and npm's `cpu` field
+  // cannot tell them apart, so a big-endian host installs the little-endian
+  // package it cannot run. Only the little-endian build is released.
+  if (arch === 'ppc64' && os.endianness() !== 'LE') {
     return []
   }
   if (typeof platformEntry === 'string') {

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -34,6 +34,9 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-riscv64/pnpm',
     },
   },
+  freebsd: {
+    x64: '@pnpm/exe.freebsd-x64/pnpm',
+  },
 }
 
 /**

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -29,9 +29,17 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-arm64/pnpm',
       musl: '@pnpm/exe.linux-arm64-musl/pnpm',
     },
-    // Only a glibc build is released for riscv64.
+    // Only a glibc build is released for these three.
     riscv64: {
       glibc: '@pnpm/exe.linux-riscv64/pnpm',
+    },
+    // Node reports both POWER endiannesses as `ppc64`, and the released build
+    // is the little-endian one.
+    ppc64: {
+      glibc: '@pnpm/exe.linux-ppc64/pnpm',
+    },
+    s390x: {
+      glibc: '@pnpm/exe.linux-s390x/pnpm',
     },
   },
   freebsd: {

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -190,6 +190,7 @@ const TARGETS = [
   { platform: "linux", arch: "riscv64", libc: "glibc", codeTarget: "linux-riscv64", packageTarget: "linux-riscv64" },
   { platform: "linux", arch: "x64", libc: "musl", codeTarget: "linux-x64-musl", packageTarget: "linux-x64-musl" },
   { platform: "linux", arch: "arm64", libc: "musl", codeTarget: "linux-arm64-musl", packageTarget: "linux-arm64-musl" },
+  { platform: "freebsd", arch: "x64", codeTarget: "freebsd-x64", packageTarget: "freebsd-x64" },
 ];
 
 for (const target of TARGETS) {

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -188,6 +188,8 @@ const TARGETS = [
   { platform: "linux", arch: "x64", libc: "glibc", codeTarget: "linux-x64", packageTarget: "linux-x64" },
   { platform: "linux", arch: "arm64", libc: "glibc", codeTarget: "linux-arm64", packageTarget: "linux-arm64" },
   { platform: "linux", arch: "riscv64", libc: "glibc", codeTarget: "linux-riscv64", packageTarget: "linux-riscv64" },
+  { platform: "linux", arch: "ppc64", libc: "glibc", codeTarget: "linux-ppc64", packageTarget: "linux-ppc64" },
+  { platform: "linux", arch: "s390x", libc: "glibc", codeTarget: "linux-s390x", packageTarget: "linux-s390x" },
   { platform: "linux", arch: "x64", libc: "musl", codeTarget: "linux-x64-musl", packageTarget: "linux-x64-musl" },
   { platform: "linux", arch: "arm64", libc: "musl", codeTarget: "linux-arm64-musl", packageTarget: "linux-arm64-musl" },
   { platform: "freebsd", arch: "x64", codeTarget: "freebsd-x64", packageTarget: "freebsd-x64" },

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -74,7 +74,7 @@ test('pnpm links a symlink that runs the placeholder when executables are symlin
 })
 
 test('linux riscv64 resolves the glibc package, and nothing under musl', async (t) => {
-  const { setLibc } = fakeHost(t, 'riscv64')
+  const { setLibc } = fakeHost(t, 'linux', 'riscv64')
 
   // `native-binary.mjs` reads process.platform and process.arch at module
   // scope, so it has to be imported again once they are faked. The libc is
@@ -90,8 +90,17 @@ test('linux riscv64 resolves the glibc package, and nothing under musl', async (
   assert.deepEqual(candidates(), [])
 })
 
+test('freebsd x64 resolves the native package', async (t) => {
+  fakeHost(t, 'freebsd', 'x64')
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?freebsd')
+
+  // FreeBSD has no glibc/musl split, so its entry is a bare specifier and the
+  // libc ordering never applies to it.
+  assert.deepEqual(candidates(), ['@pnpm/exe.freebsd-x64/pnpm'])
+})
+
 test('an architecture released for both libcs still offers the other as a fallback', async (t) => {
-  const { setLibc } = fakeHost(t, 'x64')
+  const { setLibc } = fakeHost(t, 'linux', 'x64')
   const { getBinCandidates: candidates } = await import('../native-binary.mjs?x64')
 
   setLibc('glibc')
@@ -232,16 +241,17 @@ function runNpm (args, cwd) {
 }
 
 /**
- * Present the running process as a Linux host of `arch`, restoring the real
+ * Present the running process as a `platform`/`arch` host, restoring the real
  * descriptors when the test ends.
  *
  * @param {import('node:test').TestContext} t The test, for cleanup.
+ * @param {string} platform The `process.platform` to present.
  * @param {string} arch The `process.arch` to present.
  * @returns {{ setLibc: (libc: 'glibc' | 'musl') => void }} `setLibc` fakes the
- *   `process.report` that `detectLinuxLibc` reads, so a case does not depend on
- *   the host's own libc.
+ *   `process.report` that `detectLinuxLibc` reads, so a Linux case does not
+ *   depend on the host's own libc.
  */
-function fakeHost (t, arch) {
+function fakeHost (t, platform, arch) {
   const saved = ['platform', 'arch', 'report']
     .map(key => [key, Object.getOwnPropertyDescriptor(process, key)])
   t.after(() => {
@@ -249,7 +259,7 @@ function fakeHost (t, arch) {
       if (descriptor) Object.defineProperty(process, key, descriptor)
     }
   })
-  Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
   Object.defineProperty(process, 'arch', { value: arch, configurable: true })
   return {
     setLibc (libc) {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -97,12 +97,27 @@ test('linux ppc64 and s390x resolve their glibc packages', async (t) => {
     ['ppc64', '@pnpm/exe.linux-ppc64/pnpm'],
     ['s390x', '@pnpm/exe.linux-s390x/pnpm'],
   ]) {
-    const { setLibc } = fakeHost(t, 'linux', arch)
+    const { setLibc, setEndianness } = fakeHost(t, 'linux', arch)
     const { getBinCandidates: candidates } = await import(`../native-binary.mjs?${arch}`)
 
     setLibc('glibc')
+    setEndianness('LE')
     assert.deepEqual(candidates(), [specifier])
   }
+})
+
+test('big-endian POWER resolves nothing, since only the little-endian build ships', async (t) => {
+  const { setLibc, setEndianness } = fakeHost(t, 'linux', 'ppc64')
+  const { getBinCandidates: candidates } = await import('../native-binary.mjs?ppc64-be')
+
+  setLibc('glibc')
+  // Node labels both byte orders `ppc64` and npm's `cpu` field cannot separate
+  // them, so npm will happily install the little-endian package here.
+  setEndianness('BE')
+  assert.deepEqual(candidates(), [])
+
+  setEndianness('LE')
+  assert.deepEqual(candidates(), ['@pnpm/exe.linux-ppc64/pnpm'])
 })
 
 test('freebsd x64 resolves the native package', async (t) => {
@@ -262,17 +277,20 @@ function runNpm (args, cwd) {
  * @param {import('node:test').TestContext} t The test, for cleanup.
  * @param {string} platform The `process.platform` to present.
  * @param {string} arch The `process.arch` to present.
- * @returns {{ setLibc: (libc: 'glibc' | 'musl') => void }} `setLibc` fakes the
- *   `process.report` that `detectLinuxLibc` reads, so a Linux case does not
- *   depend on the host's own libc.
+ * @returns {{ setLibc: (libc: 'glibc' | 'musl') => void, setEndianness: (order: 'LE' | 'BE') => void }}
+ *   `setLibc` fakes the `process.report` that `detectLinuxLibc` reads and
+ *   `setEndianness` fakes `os.endianness()`, so a case does not depend on the
+ *   host's own libc or byte order.
  */
 function fakeHost (t, platform, arch) {
   const saved = ['platform', 'arch', 'report']
     .map(key => [key, Object.getOwnPropertyDescriptor(process, key)])
+  const savedEndianness = Object.getOwnPropertyDescriptor(os, 'endianness')
   t.after(() => {
     for (const [key, descriptor] of saved) {
       if (descriptor) Object.defineProperty(process, key, descriptor)
     }
+    if (savedEndianness) Object.defineProperty(os, 'endianness', savedEndianness)
   })
   Object.defineProperty(process, 'platform', { value: platform, configurable: true })
   Object.defineProperty(process, 'arch', { value: arch, configurable: true })
@@ -283,6 +301,9 @@ function fakeHost (t, platform, arch) {
         value: { getReport: () => ({ header }) },
         configurable: true,
       })
+    },
+    setEndianness (order) {
+      Object.defineProperty(os, 'endianness', { value: () => order, configurable: true })
     },
   }
 }

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -90,6 +90,21 @@ test('linux riscv64 resolves the glibc package, and nothing under musl', async (
   assert.deepEqual(candidates(), [])
 })
 
+test('linux ppc64 and s390x resolve their glibc packages', async (t) => {
+  // The musl half of the contract is pinned by the riscv64 case above; these
+  // two share that code path and only need their table entries checked.
+  for (const [arch, specifier] of [
+    ['ppc64', '@pnpm/exe.linux-ppc64/pnpm'],
+    ['s390x', '@pnpm/exe.linux-s390x/pnpm'],
+  ]) {
+    const { setLibc } = fakeHost(t, 'linux', arch)
+    const { getBinCandidates: candidates } = await import(`../native-binary.mjs?${arch}`)
+
+    setLibc('glibc')
+    assert.deepEqual(candidates(), [specifier])
+  }
+})
+
 test('freebsd x64 resolves the native package', async (t) => {
   fakeHost(t, 'freebsd', 'x64')
   const { getBinCandidates: candidates } = await import('../native-binary.mjs?freebsd')

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -9,6 +9,14 @@ import { fileURLToPath } from 'node:url'
 
 import { getBinCandidates, splitBinSpecifier } from '../native-binary.mjs'
 
+// Captured once, before any test fakes them. Restoring from these rather than
+// from whatever was current at the call means repeated fakes cannot restore
+// each other's state: `node:test` runs `after` hooks in registration order, so
+// a later fake's hook is the last to run.
+const REAL_HOST = ['platform', 'arch', 'report']
+  .map(key => [key, Object.getOwnPropertyDescriptor(process, key)])
+const REAL_ENDIANNESS = Object.getOwnPropertyDescriptor(os, 'endianness')
+
 const wrapperDir = path.resolve(fileURLToPath(import.meta.url), '../..')
 const wrapperManifest = JSON.parse(fs.readFileSync(path.join(wrapperDir, 'package.json'), 'utf8'))
 const HAS_A_SHELL = process.platform === 'win32' && 'Windows has no sh'
@@ -283,14 +291,11 @@ function runNpm (args, cwd) {
  *   host's own libc or byte order.
  */
 function fakeHost (t, platform, arch) {
-  const saved = ['platform', 'arch', 'report']
-    .map(key => [key, Object.getOwnPropertyDescriptor(process, key)])
-  const savedEndianness = Object.getOwnPropertyDescriptor(os, 'endianness')
   t.after(() => {
-    for (const [key, descriptor] of saved) {
+    for (const [key, descriptor] of REAL_HOST) {
       if (descriptor) Object.defineProperty(process, key, descriptor)
     }
-    if (savedEndianness) Object.defineProperty(os, 'endianness', savedEndianness)
+    if (REAL_ENDIANNESS) Object.defineProperty(os, 'endianness', REAL_ENDIANNESS)
   })
   Object.defineProperty(process, 'platform', { value: platform, configurable: true })
   Object.defineProperty(process, 'arch', { value: arch, configurable: true })


### PR DESCRIPTION
## Summary

Adds three targets to the Rust CLI's release matrix: `freebsd-x64`, `linux-ppc64` and `linux-s390x`. Closes pnpm/pnpm#14597.

pnpm 11's `pnpm` npm package was a JavaScript CLI that ran wherever Node.js ran, so all three platforms worked without anyone having to build for them. pnpm 12 ships per-platform native binaries, which turned that into a hard install failure on each:

```
npm error command sh -c node install.js
npm error pnpm does not ship a prebuilt binary for freebsd-x64.
```

Four places name a target, and this adds the same three to each:

- `release.yml` builds them with `cross` on the existing `ubuntu-2404` runner, in both the `build-rust` and `build-rust-napi` matrices. No new runner and no exotic hardware.
- `pnpm/npm/pnpm/scripts/generate-packages.mjs` emits the `@pnpm/exe.*` packages and lists them in the wrapper's `optionalDependencies`.
- `pnpm/npm/napi/scripts/generate-packages.mjs` emits the matching `@pnpm/napi.*` packages.
- `native-binary.mjs` resolves them at install time.

No Rust or CLI logic changes.

### Why these three

pnpm is a tool that runs on Node.js, so the platform list worth measuring against is Node's own, not another runtime's:

| Target | Node | Bun | Deno | pnpm 12 before | after |
|---|---|---|---|---|---|
| linux x64/arm64 glibc | yes | yes | yes | yes | yes |
| linux x64 musl | yes | yes | no | yes | yes |
| linux arm64 musl | no | yes | no | yes | yes |
| linux riscv64 | no | no | no | yes | yes |
| **linux ppc64le** | **yes** | no | no | **no** | **yes** |
| **linux s390x** | **yes** | no | no | **no** | **yes** |
| freebsd x64 | no | yes | no | no | yes |
| openbsd | no | no | no | no | no |
| aix ppc64 | yes | no | no | no | no |

`ppc64le` and `s390x` were the only two architectures where Node.js ships an official binary and pnpm did not. Both were reported on pnpm/pnpm#14651 alongside OpenBSD.

**pnpm/pnpm#14651 is not closed by this PR.** It is filed for OpenBSD, which is a tier 3 Rust target: rustup distributes no `rust-std` for `x86_64-unknown-openbsd` and `cross` publishes no image, so it needs `-Z build-std` and a container of its own. That is separate work, and no other JavaScript runtime ships OpenBSD either.

### Naming

The little-endian POWER package is `@pnpm/exe.linux-ppc64`, not `-ppc64le`. Node reports both POWER endiannesses as `process.arch === 'ppc64'` (this repo's own `host_arch()` maps `powerpc64le => "ppc64"`), and npm's `cpu` field cannot express endianness, so the package name has to be what the host actually computes. Only the little-endian build is released, which matches Node, whose tarball is named `linux-ppc64le` while its `process.arch` is `ppc64`.

FreeBSD has no glibc/musl split, so its `PLATFORMS` entry is a bare specifier the way darwin's and win32's are and never reaches the libc ordering; its generated manifest carries no `libc` field. `ppc64` and `s390x` are glibc-only, so they take the same shape as `riscv64`.

Only `x86_64` FreeBSD is added: `aarch64-unknown-freebsd` is tier 3 with no distributed `rust-std`.

### What already works with no change

Three paths derive the target name generically rather than from a list, so they pick the new packages up on their own. I checked each:

- `pnpm self-update` on the Rust side: `native_target_name` and `exe_platform_pkg_dir_name_next` yield `freebsd-x64` / `linux-ppc64` / `linux-s390x` and the `exe.*` forms.
- pnpm 11's engine verification, which produced the second error in pnpm/pnpm#14597. `nativeTargetName` in `installPnpm.ts` yields the same names, so `hostPlatformPackage` now finds a candidate instead of throwing `PNPM_ENGINE_NO_NATIVE_BINARY`.
- The NAPI loader's `platformTriples()`.

Shared artifacts opt out cleanly: `artifact_platform` returns `None` for any architecture outside x64/arm64 and any OS outside linux/darwin/win32, so these hosts do not participate rather than erroring.

### Verification

The release workflow does not run on pull requests, so CI here will not build these targets. Verified locally with `cross` and podman instead, which is the same path `release.yml` takes. All six builds, CLI and NAPI addon for each target:

```
freebsd-x64    CLI 6m24s   NAPI 4m21s
linux-ppc64    CLI 7m08s   NAPI 4m25s
linux-s390x    CLI 7m39s   NAPI 5m20s
```

```
freebsd-x64   pnpm: ELF 64-bit LSB pie executable, x86-64, (FreeBSD), interpreter /libexec/ld-elf.so.1
linux-ppc64   pnpm: ELF 64-bit LSB pie executable, 64-bit PowerPC, OpenPOWER ELF V2 ABI, interpreter /lib64/ld64.so.2
linux-s390x   pnpm: ELF 64-bit MSB pie executable, IBM S/390, interpreter /lib/ld64.so.1
```

with a matching shared object for each addon. The endianness is worth noting: `ppc64le` comes out LSB and `s390x` MSB, as they should.

`aws-lc-rs` needs no special handling on any of them. `aws-lc-sys` uses its per-target bindings only in all-bindings mode; the default path emits a `universal` cfg and sets `PREGENERATED`, so no bindgen or libclang is involved.

Both package generators were then run end to end in an isolated tree with the real binaries staged:

```
@pnpm/exe.linux-ppc64   {"os":["linux"],"cpu":["ppc64"],"libc":["glibc"]}   <- LSB PowerPC binary
@pnpm/exe.linux-s390x   {"os":["linux"],"cpu":["s390x"],"libc":["glibc"]}   <- MSB S/390 binary
@pnpm/exe.freebsd-x64   {"os":["freebsd"],"cpu":["x64"]}                    <- no libc field
```

each at mode 755, with the wrapper's `optionalDependencies` listing all twelve. The NAPI generator produces the matching `@pnpm/napi.*` set.

**I could not run any of these binaries.** There is no ppc64le, s390x or FreeBSD host here, and none of them execute in a Linux x86_64 container. Everything above shows they build, link and package correctly; it does not show they run. A `workflow_dispatch` run on this branch would confirm the release legs before tag time, but actually running pnpm on these platforms needs a reporter with the hardware.

### Still needed elsewhere

- `get-pnpm`, which lives in `pnpm/get.pnpm.io` and backs both the Corepack entry point and get.pnpm.io's install scripts, rejects any architecture outside x64/arm64 and any platform outside darwin/linux/win32. `npm install -g pnpm` and `pnpm self-update` work on all three new targets after this change; Corepack and the install script will not until that repo ships a matching change. This already applied to `linux-riscv64` from pnpm/pnpm#14529.
- `pnpm pack-app` embeds a Node.js binary through Node SEA and keeps its own target list, which is unchanged here.

## Squash Commit Body

```text
Build the Rust CLI and the NAPI addon for x86_64-unknown-freebsd,
powerpc64le-unknown-linux-gnu and s390x-unknown-linux-gnu, and publish them as
`@pnpm/exe.*` and `@pnpm/napi.*` platform packages, so installing pnpm on those
hosts resolves a native binary instead of failing the preinstall with no
prebuilt binary for the platform. Closes pnpm/pnpm#14597.

pnpm 11's npm package was a JavaScript CLI that ran wherever Node.js ran, so
all three worked without anyone building for them. pnpm 12 ships per-platform
native binaries, which turned that into a hard install failure. ppc64le and
s390x were the only two architectures Node.js ships an official binary for that
pnpm did not; both were reported on pnpm/pnpm#14651, which stays open for
OpenBSD, a tier 3 Rust target with no rustup std and no cross image.

The release matrix builds all three with cross on the existing x86_64 Linux
runner, the same way it already builds the aarch64 and riscv64 targets, so no
new hardware is involved.

The little-endian POWER package is `@pnpm/exe.linux-ppc64`, not `-ppc64le`.
Node reports both endiannesses as `ppc64` and npm's `cpu` field cannot express
which, so the name has to be what `process.arch` yields. Only the little-endian
build is released, matching Node.

FreeBSD's platform entry is a bare specifier rather than a glibc/musl pair. It
has no libc split, so it takes the same shape as darwin and win32 and never
reaches the libc ordering, and its manifest carries no `libc` field.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native binary support for FreeBSD x64, Linux ppc64le, and Linux s390x.
  * Added platform-specific packages so pnpm can select the appropriate binary automatically.

* **Bug Fixes**
  * Big-endian POWER systems now avoid incompatible packages and provide guidance for using a locally built binary.

* **Documentation**
  * Updated supported-platform documentation with the new targets.

* **Tests**
  * Added coverage for platform selection and POWER architecture handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->