### PR TITLE
fix(resolving-npm-resolver): route built-in JSR verification

### DIFF
--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier.rs
@@ -28,7 +28,7 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use miette::Diagnostic as _;
 use pipe_trait::Pipe;
-use pnpm_config::{TrustPolicy, version_policy::PackageVersionPolicy};
+use pnpm_config::{DEFAULT_JSR_REGISTRY, TrustPolicy, version_policy::PackageVersionPolicy};
 use pnpm_lockfile::{
     LockfileResolution, PkgName, TarballRevision, is_git_hosted_tarball_url,
     is_integrity_addressed_registry_tarball_url,
@@ -239,6 +239,8 @@ impl std::fmt::Debug for NpmResolutionVerifier {
 pub fn create_npm_resolution_verifier(
     opts: CreateNpmResolutionVerifierOptions,
 ) -> NpmResolutionVerifier {
+    let mut registries = opts.registries;
+    registries.entry("@jsr".to_string()).or_insert_with(|| DEFAULT_JSR_REGISTRY.to_string());
     let age_check_active = opts.minimum_release_age.is_some_and(|minutes| minutes > 0);
 
     let cutoff = if age_check_active {
@@ -286,7 +288,7 @@ pub fn create_npm_resolution_verifier(
         trust_policy_ignore_after: opts.trust_policy_ignore_after,
         sorted_min_age_excludes,
         sorted_trust_excludes,
-        registries: opts.registries,
+        registries,
         named_registry_prefixes,
         registries_by_prefix,
         http_client: opts.http_client,

--- a/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
+++ b/pnpm/crates/resolving-npm-resolver/src/create_npm_resolution_verifier/tests.rs
@@ -200,6 +200,30 @@ fn ctx<'a>(name: &'a PkgName, version: &'a str) -> VerifyCtx<'a> {
     VerifyCtx { name, version, registry_name: None }
 }
 
+#[test]
+fn unconfigured_jsr_scope_uses_the_builtin_jsr_registry() {
+    let verifier = create_npm_resolution_verifier(default_opts("https://registry.npmjs.org/"));
+    let name: PkgName = "@jsr/std__csv".parse().expect("parse");
+
+    assert_eq!(
+        verifier.pick_registry(&name, Some("https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz"),),
+        pnpm_config::DEFAULT_JSR_REGISTRY,
+    );
+}
+
+#[test]
+fn configured_jsr_scope_overrides_the_builtin_jsr_registry() {
+    let mut opts = default_opts("https://registry.npmjs.org/");
+    opts.registries.insert("@jsr".to_string(), "https://jsr.example/".to_string());
+    let verifier = create_npm_resolution_verifier(opts);
+    let name: PkgName = "@jsr/std__csv".parse().expect("parse");
+
+    assert_eq!(
+        verifier.pick_registry(&name, Some("https://npm.jsr.io/~/11/@jsr/std__csv/1.0.6.tgz"),),
+        "https://jsr.example/",
+    );
+}
+
 #[tokio::test]
 async fn verifies_tarball_url_when_no_policy_active() {
     let mut server = mockito::Server::new_async().await;


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14649.

The lockfile verifier now supplies the built-in `@jsr` registry route when no explicit route is configured. An explicit `@jsr` registry still takes precedence.

## Squash Commit Body

```text
Route lockfile verification for the built-in @jsr scope to npm.jsr.io when no explicit registry is configured. Preserve an explicit @jsr registry override.

Fixes pnpm/pnpm#14649.
```

## Validation

- `cargo test -p pnpm-resolving-npm-resolver --lib` (440 passed)
- `cargo fmt --all -- --check`
- Pre-push checks: TypeScript compile, ESLint, Clippy, Rustdoc, spelling, and TOML format

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. This bug affects the Rust v12 verifier; pnpm 11 already routes JSR verification correctly.
- [x] Added or updated tests.

---

Created with Codex (GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791374976&installation_model_id=426870&pr_number=14657&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14657&signature=d7409962a03627482609ed158bf5a9ca7eb3d49a8eb7418999ded64746aae56d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Unconfigured `@jsr` packages now use the built-in JSR registry automatically.
  - Explicitly configured `@jsr` registries continue to take precedence over the default.

- **Tests**
  - Added coverage for default and custom JSR registry selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->