### PR TITLE
test(patching): parse the diffs that patch-commit writes

### DIFF
--- a/pnpm/crates/patching/src/commit/tests.rs
+++ b/pnpm/crates/patching/src/commit/tests.rs
@@ -4,6 +4,7 @@ use super::{
     prepare_pkg_files_for_diff_with_fs, remove_existing_temp_dir_with_fs, safe_package_file_path,
     temporary_filtered_dir,
 };
+use diffy::patch_set::{FileOperation, ParseOptions, PatchSet};
 use pretty_assertions::assert_eq;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -348,6 +349,47 @@ index 000..123
     eprintln!("normalized:\n{normalized}");
     eprintln!("expected:\n{expected}");
     assert_eq!(normalized, expected);
+}
+
+/// `apply` reads a patch through `PatchSet` with the same options, so a header that
+/// `patch-commit` writes but the parser rejects fails the next install.
+#[test]
+fn patch_commit_diff_dirs_writes_a_parseable_deleted_file_patch() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::write(before.path().join("readme.md"), "package documentation\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    let mut patches = PatchSet::parse(&diff, ParseOptions::gitdiff());
+    let patch = patches.next().expect("deleted file patch").expect("parse generated patch");
+    let FileOperation::Delete(path) = patch.operation().strip_prefix(1) else {
+        panic!("expected a file deletion, diff: {diff}");
+    };
+    assert_eq!(path.as_ref(), "readme.md");
+    assert!(patches.next().is_none(), "expected one file patch, diff: {diff}");
+}
+
+/// See [`patch_commit_diff_dirs_writes_a_parseable_deleted_file_patch`]. The `+++` marker lets
+/// the parser recover the target of an added file even from a malformed `diff --git` header, so
+/// the header is asserted here as well.
+#[test]
+fn patch_commit_diff_dirs_writes_a_parseable_nested_added_file_patch() {
+    let before = tempdir().expect("before dir");
+    let after = tempdir().expect("after dir");
+    fs::create_dir(after.path().join("docs")).unwrap();
+    fs::write(after.path().join("docs").join("readme.md"), "package documentation\n").unwrap();
+
+    let diff = diff_folders(before.path(), after.path()).expect("diff dirs");
+
+    assert_eq!(diff.lines().next(), Some("diff --git a/docs/readme.md b/docs/readme.md"));
+    let mut patches = PatchSet::parse(&diff, ParseOptions::gitdiff());
+    let patch = patches.next().expect("added file patch").expect("parse generated patch");
+    let FileOperation::Create(path) = patch.operation().strip_prefix(1) else {
+        panic!("expected a file creation, diff: {diff}");
+    };
+    assert_eq!(path.as_ref(), "docs/readme.md");
+    assert!(patches.next().is_none(), "expected one file patch, diff: {diff}");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Test-only. The path fix these cover landed in pnpm/pnpm#14621, which closed pnpm/pnpm#14559.

The commit-side tests assert the text of the `diff --git` header that `patch-commit` writes, but nothing checked that the result is what `apply` reads back. These two tests parse the generated diff through `PatchSet` with the options `apply` uses and assert the `FileOperation` that comes out.

The two cases fail differently, which is why they are separate:

- `git diff --irreversible-delete` writes a deleted file without a `---` marker, so a malformed `diff --git` header leaves the parser nothing to recover from and the parse itself fails.
- An added file carries a `+++` marker the parser can recover the target from, so a malformed header can still parse. Its header is asserted directly. I confirmed this by reverting the fix and removing the header assertion: the added-file test still passed.

The added file sits in a new directory, a path shape no other commit-side test covers.

The tests come from pnpm/pnpm#14625 by `@zhsama`, whose branch predates pnpm/pnpm#14621 and no longer carries a production change once rebased. That PR has maintainer edits disabled, so the rebased commit is carried here with authorship preserved.

## Squash Commit Body

```text
The commit-side tests assert the text of the `diff --git` header, but nothing
checked that what `patch-commit` writes is what `apply` reads back. Parse the
generated diff through `PatchSet` with the options `apply` uses and assert the
file operation that comes out.

The two cases fail differently. `git diff --irreversible-delete` writes a
deleted file without a `---` marker, so a malformed header leaves the parser
nothing to recover from and the parse itself fails. An added file carries a
`+++` marker the parser can recover the target from, so its header is asserted
directly. The added file sits in a new directory, a path shape no other
commit-side test covers.

The path fix these cover landed in pnpm/pnpm#14621. Behavior is unchanged, so
there is no changeset.

Supersedes pnpm/pnpm#14625.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Not applicable: no behavior changes, so no changeset.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KAUuXhppXK6XemZrTPSCW8

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791383164&installation_model_id=426870&pr_number=14659&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14659&signature=8b9ab289d71b196a1a592acec7f334f1a73939c974b9f0b4efdaa0228a17f447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage confirming deleted-file patches are parsed as delete operations.
  - Added coverage confirming newly created nested files are parsed correctly.
  - Verified generated patch headers and Git-compatible parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->