### PR TITLE
feat: add android-arm64 and android-x64 builds

### DIFF
--- a/.changeset/add-android-builds.md
+++ b/.changeset/add-android-builds.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+pnpm now runs on Android, on arm64 and x64 [#14431](https://github.com/pnpm/pnpm/issues/14431).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -611,6 +611,14 @@ jobs:
             target: x86_64-unknown-freebsd
             code-target: freebsd-x64
 
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: aarch64-linux-android
+            code-target: android-arm64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-linux-android
+            code-target: android-x64
+
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin
             code-target: darwin-x64
@@ -742,6 +750,14 @@ jobs:
           - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-freebsd
             code-target: freebsd-x64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: aarch64-linux-android
+            code-target: android-arm64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: x86_64-linux-android
+            code-target: android-x64
 
           - os: blacksmith-12vcpu-macos-latest
             target: x86_64-apple-darwin

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,16 @@
+# Image overrides for `cross`. Every other release target builds in the image
+# `cross` picks by default, so only the exceptions belong here.
+#
+# The default Android images carry NDK r21, whose toolchain predates Rust's
+# move from libgcc to libunwind, so linking any binary fails with
+# `cannot find -lunwind`. The images below carry NDK r25b and link.
+#
+# Pinned by digest rather than tag: these build the published, attested release
+# binaries, and `:main` is a moving target. Re-pin deliberately, the way the
+# workflows pin their actions.
+
+[target.aarch64-linux-android]
+image = "ghcr.io/cross-rs/aarch64-linux-android@sha256:85d58ad7dd4cc97903bff4c5e861a2c980d79248bc9c842791b99f1eef2d0f3b"
+
+[target.x86_64-linux-android]
+image = "ghcr.io/cross-rs/x86_64-linux-android@sha256:e60e4a759b4f07ac5d6f7632afc728d2a6a3ad668013ec17d9627b537acf2cdc"

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -108,7 +108,7 @@ The addon ships as prebuilt per-platform packages, the same model as the
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
 `linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-ppc64`, `linux-s390x`,
-`linux-x64-musl`, `linux-arm64-musl`, `freebsd-x64`.
+`linux-x64-musl`, `linux-arm64-musl`, `freebsd-x64`, `android-arm64`, `android-x64`.
 
 ## Local development
 

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -47,6 +47,8 @@ const TARGETS = [
   { platform: 'linux', arch: 'x64', libc: 'musl', codeTarget: 'linux-x64-musl', packageTarget: 'linux-x64-musl' },
   { platform: 'linux', arch: 'arm64', libc: 'musl', codeTarget: 'linux-arm64-musl', packageTarget: 'linux-arm64-musl' },
   { platform: 'freebsd', arch: 'x64', codeTarget: 'freebsd-x64', packageTarget: 'freebsd-x64' },
+  { platform: 'android', arch: 'arm64', codeTarget: 'android-arm64', packageTarget: 'android-arm64' },
+  { platform: 'android', arch: 'x64', codeTarget: 'android-x64', packageTarget: 'android-x64' },
 ]
 
 function nativePackageName(target) {

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -44,6 +44,14 @@ const PLATFORMS = {
   freebsd: {
     x64: '@pnpm/exe.freebsd-x64/pnpm',
   },
+  // Android is bionic, which is neither of the two libcs the linux entries
+  // above are keyed on, so it takes a bare specifier of its own.
+  android: {
+    arm64: '@pnpm/exe.android-arm64/pnpm',
+    x64: '@pnpm/exe.android-x64/pnpm',
+  },
+  // Android is bionic, which is neither of the two libcs the linux entries
+  // above are keyed on, so it takes a bare specifier of its own.
 }
 
 /**

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -193,6 +193,8 @@ const TARGETS = [
   { platform: "linux", arch: "x64", libc: "musl", codeTarget: "linux-x64-musl", packageTarget: "linux-x64-musl" },
   { platform: "linux", arch: "arm64", libc: "musl", codeTarget: "linux-arm64-musl", packageTarget: "linux-arm64-musl" },
   { platform: "freebsd", arch: "x64", codeTarget: "freebsd-x64", packageTarget: "freebsd-x64" },
+  { platform: "android", arch: "arm64", codeTarget: "android-arm64", packageTarget: "android-arm64" },
+  { platform: "android", arch: "x64", codeTarget: "android-x64", packageTarget: "android-x64" },
 ];
 
 for (const target of TARGETS) {

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -128,6 +128,20 @@ test('big-endian POWER resolves nothing, since only the little-endian build ship
   assert.deepEqual(candidates(), ['@pnpm/exe.linux-ppc64/pnpm'])
 })
 
+test('android resolves its own package rather than a linux one', async (t) => {
+  for (const [arch, specifier] of [
+    ['arm64', '@pnpm/exe.android-arm64/pnpm'],
+    ['x64', '@pnpm/exe.android-x64/pnpm'],
+  ]) {
+    fakeHost(t, 'android', arch)
+    const { getBinCandidates: candidates } = await import(`../native-binary.mjs?android-${arch}`)
+
+    // Android is bionic, so the libc ordering the linux entries go through
+    // never applies to it.
+    assert.deepEqual(candidates(), [specifier])
+  }
+})
+
 test('freebsd x64 resolves the native package', async (t) => {
   fakeHost(t, 'freebsd', 'x64')
   const { getBinCandidates: candidates } = await import('../native-binary.mjs?freebsd')


### PR DESCRIPTION
## Summary

Adds `android-arm64` and `android-x64` to the Rust CLI's release targets, so pnpm 12 has a native binary in Termux. Closes pnpm/pnpm#14431.

pnpm 11 reached Android because it was a JavaScript CLI and bionic was irrelevant to it. pnpm 12 ships per-platform native binaries, which turned that into a hard install failure:

```
npm error command sh -c node install.js
npm error pnpm does not ship a prebuilt binary for android-arm64.
```

The same four places name a target, and this adds the two to each: both `release.yml` matrices, both package generators, and `native-binary.mjs`. No Rust or CLI logic changes.

### A dedicated artifact rather than an alias

The issue proposed aliasing android onto the existing `@pnpm/exe.linux-*-musl` packages. This ships real android artifacts instead, for two reasons.

The first is the one raised on the issue: aliasing means dropping `libc: ["musl"]` from the shared packages, which weakens that metadata for Alpine consumers.

The second only became clear while building this. The musl binary genuinely cannot work on Android, so the alias would install something broken. `configure_dns` in `pnpm/crates/network` routes every lookup through the system `getaddrinfo` on all platforms. In a static musl binary that reads `/etc/resolv.conf`, which Android does not have and which cannot be created without root — which is exactly the failure reported on the issue against 12.3.0:

```
pnpm add is-odd@3.0.1
  12.2.1: Done in 889ms
  12.3.0: dns error: failed to lookup address information: Try again
```

A bionic binary resolves through Android's own resolver, so a native artifact fixes the very thing the alias could not. The generated manifests carry `os: ["android"]` and no `libc` field, since bionic is neither value that field can name.

### Cross.toml

New file, and the reason is worth stating. The images `cross` picks for these two targets by default carry NDK r21, whose toolchain predates Rust's move from libgcc to libunwind, so linking any binary fails:

```
/android-ndk/bin/../lib/gcc/aarch64-linux-android/4.9.x/.../ld: cannot find -lunwind
clang90: error: linker command failed with exit code 1
```

`Cross.toml` points the two targets at images carrying NDK r25b. They are pinned **by digest rather than by tag**: these build the published, attested release binaries, and `:main` is a moving target. Re-pin deliberately, the way the workflows pin their actions.

### What already works with no change

Checked rather than assumed, since `android` is a new `process.platform` value in these paths:

- `host_libc()` returns `"unknown"` on Android, not `musl`, because `pnpm_detect_libc::detect()` is gated on `target_os = "linux"`. So `native_target_name` yields `android-arm64` with no libc suffix, and `pnpm self-update` resolves `@pnpm/exe.android-arm64`.
- The NAPI loader's `platformTriples()` returns `android-arm64` from its non-Linux branch.
- `artifact_platform` returns `None` for any OS outside linux/darwin/win32, so shared artifacts opt out cleanly rather than erroring.

### Verification

The release workflow does not run on pull requests, so CI here will not build these targets. Verified locally with `cross` and podman, which is the same path `release.yml` takes:

```
android-arm64  CLI 6m33s   NAPI 4m33s
android-x64    CLI 6m37s   NAPI 4m56s

pnpm: ELF 64-bit LSB pie executable, ARM aarch64, interpreter /system/bin/linker64,
      for Android 28, built by NDK r25b (8937393)
```

with a matching shared object for each addon. Both package generators were then run end to end in an isolated tree with the real binaries staged: `@pnpm/exe.android-arm64` and `-x64` come out as `{"os":["android"],"cpu":["arm64"|"x64"]}` with no `libc` key, and the wrapper lists all fourteen platform packages.

**I could not run these binaries.** There is no Android device or emulator here. Everything above shows they build, link and package correctly; it does not show they run, and in particular it does not prove the DNS reasoning above end to end. The reporter on the issue has the device and offered to test.

### Support tier

Android has no CI behind it. Nothing in the release pipeline or the test suite runs on a device or an emulator, so this is best-effort by construction, which is what the issue asks for. The reporter also proposed a canary job reproducing the conditions Android hits rather than Android itself. That is not included here: with a bionic artifact the specific `/etc/resolv.conf` condition no longer applies, so the canary would need rethinking against the new binary rather than the musl one.

## Squash Commit Body

```text
Build the Rust CLI and the NAPI addon for aarch64-linux-android and
x86_64-linux-android and publish them as `@pnpm/exe.android-*` and
`@pnpm/napi.android-*`, so installing pnpm in Termux resolves a native binary
instead of failing the preinstall with no prebuilt binary for the platform.
Closes pnpm/pnpm#14431.

pnpm 11 reached Android because it was a JavaScript CLI and bionic was
irrelevant to it. pnpm 12 ships per-platform native binaries, which turned that
into a hard install failure.

This ships a dedicated artifact rather than aliasing the existing musl one onto
android. Aliasing would mean dropping `libc: ["musl"]` from the shared packages
and weakening that metadata for Alpine consumers, and it does not work anyway:
the musl binary's `getaddrinfo` reads `/etc/resolv.conf`, which Android does
not have and which cannot be created without root, so every registry lookup
fails there. A bionic binary resolves through Android's own resolver. The
generated manifests carry `os: ["android"]` with no `libc` field, since bionic
is neither of the two the field can name.

Cross.toml pins newer images for the two targets. The ones cross picks by
default carry NDK r21, whose toolchain predates Rust's move from libgcc to
libunwind, so linking fails with `cannot find -lunwind`. They are pinned by
digest rather than tag because they build published, attested binaries.

Android has no CI behind it: nothing in the release pipeline or the test suite
runs on a device or an emulator, so this is best-effort.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14660"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791383641&installation_model_id=426870&pr_number=14660&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14660&signature=a690402d442253b1cf25a9f391ed6385b05f73a04d117da65814552649edc572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running pnpm on Android devices using ARM64 and x64 architectures.
  - Android-specific native packages are now generated and selected automatically for the device architecture.
  - Release builds now include Android ARM64 and x64 artifacts.

- **Documentation**
  - Updated supported platform information to include Android ARM64 and x64.

- **Tests**
  - Added coverage verifying Android devices resolve the correct native packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->