### PR TITLE
fix(cli): accept an explicit value on a boolean flag

### DIFF
--- a/.changeset/boolean-flags-take-a-value.md
+++ b/.changeset/boolean-flags-take-a-value.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Boolean flags now accept an explicit value. `pnpm install --prod=false` installs devDependencies, and `--prod=true` skips them [#14553](https://github.com/pnpm/pnpm/issues/14553).

--- a/.changeset/boolean-flags-take-a-value.md
+++ b/.changeset/boolean-flags-take-a-value.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Boolean flags now accept an explicit value. `pnpm install --prod=false` installs devDependencies, and `--prod=true` skips them [#14553](https://github.com/pnpm/pnpm/issues/14553).
+Boolean flags now accept an explicit value written inline. `pnpm install --prod=false` installs devDependencies, and `--prod=true` skips them [#14553](https://github.com/pnpm/pnpm/issues/14553).

--- a/pnpm/crates/cli/src/boolean_negations.rs
+++ b/pnpm/crates/cli/src/boolean_negations.rs
@@ -38,10 +38,10 @@ pub fn with_boolean_negations(mut cmd: Command) -> Command {
             // counterpart. The latter also covers a global flag already
             // seen from an ancestor command on this recursion, so its
             // negation isn't added twice.
-            if long.starts_with("no-") || existing_longs.contains(&format!("no-{long}")) {
+            if long.starts_with("no-") || existing_longs.contains(&negation_of(long)) {
                 return None;
             }
-            Some((arg.get_id().clone(), format!("no-{long}"), arg.is_global_set()))
+            Some((arg.get_id().clone(), negation_of(long), arg.is_global_set()))
         })
         .collect();
 
@@ -69,6 +69,13 @@ pub fn with_boolean_negations(mut cmd: Command) -> Command {
     }
 
     cmd
+}
+
+/// The spelling that negates the boolean flag `long`. The one place the
+/// pairing is named, so [`crate::boolean_values`] resolves a false value
+/// to a flag this pass really adds.
+pub(crate) fn negation_of(long: &str) -> String {
+    format!("no-{long}")
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/boolean_values.rs
+++ b/pnpm/crates/cli/src/boolean_values.rs
@@ -1,0 +1,157 @@
+//! Explicit values for boolean flags.
+//!
+//! nopt gives every option typed as `Boolean` a value form: it splices
+//! `--prod=false` into `--prod` `false` and reads the value back as the
+//! flag's. That is how a build host that appends `--prod=false` to its
+//! install command asks for devDependencies (pnpm/pnpm#14553). pacquet's
+//! clap flags take no value at all, so the token aborts the parse with
+//! "unexpected value".
+//!
+//! Rather than teach clap a value form — which would put a `[<VALUE>]`
+//! placeholder next to every boolean in the help output —
+//! [`resolve_boolean_values`] collapses the token over argv: a true value
+//! leaves the bare flag, a false one becomes the `--no-` negation that
+//! [`crate::boolean_negations`] pairs with every boolean flag. The
+//! grammar clap parses therefore stays exactly as it is written, and the
+//! only command lines this pass rewrites are ones that abort the parse
+//! today.
+//!
+//! A value written as its own token (`--prod false`, which nopt reads the
+//! same way) is deliberately left alone. Claiming it belongs in
+//! [`option_width`], the width rule every pre-clap scan shares, and a
+//! foreign command line names its program with a positional: `pnpm -r
+//! exec --report-summary true` runs `true`, which a flag claiming the
+//! token after it would swallow.
+//!
+//! Only long spellings take a value. A short is clap's own spelling:
+//! nopt reaches one through its shorthand table, which splices `-P` into
+//! `--prod` before the value rule applies, and the two part ways on a
+//! cluster such as `-PD=false`.
+
+use crate::{
+    boolean_negations::negation_of,
+    cli_args::grammar,
+    config_overrides::parse_bool,
+    parse_boundary::{option_width, passthrough_from, union_arity},
+};
+use clap::{Arg, ArgAction, Command};
+use std::{
+    collections::{HashMap, HashSet},
+    ffi::OsString,
+    sync::OnceLock,
+};
+
+/// Rewrite every `--<flag>=<bool>` token in `argv` into the bare flag or
+/// its negation. See the module docs.
+///
+/// Tokens are stepped over with [`option_width`], the width rule the
+/// pre-clap scans share, so a value that happens to spell a boolean flag
+/// is never rewritten and everything a command forwards to a child
+/// process is left untouched.
+pub fn resolve_boolean_values(mut argv: Vec<OsString>) -> Vec<OsString> {
+    let flags = boolean_flags();
+    let arity = union_arity();
+    let owned_by_pnpm = passthrough_from(&argv).unwrap_or(argv.len()).min(argv.len());
+
+    let mut index = 1;
+    while index < owned_by_pnpm {
+        let Some(token) = argv[index].to_str() else {
+            index += 1;
+            continue;
+        };
+        if token == "--" {
+            break;
+        }
+        // A token past the boundary is the child's, so it can be neither
+        // rewritten nor read as an option's value.
+        let next = (index + 1 < owned_by_pnpm).then(|| argv[index + 1].to_str()).flatten();
+        let width = option_width(token, next, arity).unwrap_or(1);
+        if let Some((name, value)) = token.strip_prefix("--").and_then(|rest| rest.split_once('='))
+            && let Some(spelling) = flags.spelling_for(name, value)
+        {
+            argv[index] = spelling;
+        }
+        index += width;
+    }
+
+    argv
+}
+
+/// Every boolean flag spelling in the grammar, paired with the spelling
+/// that means its opposite.
+struct BooleanFlags {
+    opposites: HashMap<String, String>,
+}
+
+impl BooleanFlags {
+    /// The spelling `--<name>=<value>` collapses to, or `None` when
+    /// `name` is no boolean flag, or `value` no boolean — which leaves
+    /// the token for clap to report.
+    fn spelling_for(&self, name: &str, value: &str) -> Option<OsString> {
+        let opposite = self.opposites.get(name)?;
+        let long = if parse_bool(value)? { name } else { opposite.as_str() };
+        Some(OsString::from(format!("--{long}")))
+    }
+
+    /// The grammar's boolean flags, reaching the same depth as the arity
+    /// table the pre-clap scans share, so a flag is never rewritten in a
+    /// token the scan did not recognize as an option.
+    fn collect(command: &Command) -> Self {
+        let mut flags = Self { opposites: HashMap::new() };
+        let mut value_taking = HashSet::new();
+        flags.absorb(command, &mut value_taking);
+        for subcommand in command.get_subcommands() {
+            flags.absorb(subcommand, &mut value_taking);
+        }
+        // A name another command spells as a value-taking option is left
+        // alone: `--foo=false` may well be asking for the value `false`
+        // there.
+        for name in value_taking {
+            flags.opposites.remove(&name);
+        }
+        flags
+    }
+
+    fn absorb(&mut self, command: &Command, value_taking: &mut HashSet<String>) {
+        let longs: HashSet<&str> = command.get_arguments().flat_map(spellings).collect();
+        for arg in command.get_arguments() {
+            if arg.get_action().takes_values() {
+                value_taking.extend(spellings(arg).map(str::to_owned));
+                continue;
+            }
+            if !matches!(arg.get_action(), ArgAction::SetTrue) {
+                continue;
+            }
+            let Some(long) = arg.get_long() else {
+                continue;
+            };
+            let Some(opposite) = (match long.strip_prefix("no-") {
+                // A hand-written negation pairs with the flag it negates,
+                // when the command declares one.
+                Some(positive) => longs.contains(positive).then(|| positive.to_string()),
+                // Every other boolean flag is paired by
+                // [`crate::boolean_negations`].
+                None => Some(negation_of(long)),
+            }) else {
+                continue;
+            };
+            for spelling in spellings(arg) {
+                self.opposites.entry(spelling.to_string()).or_insert_with(|| opposite.clone());
+            }
+            self.opposites.entry(opposite).or_insert_with(|| long.to_string());
+        }
+    }
+}
+
+/// The long spellings `arg` answers to: its own, plus its aliases.
+fn spellings(arg: &Arg) -> impl Iterator<Item = &str> {
+    arg.get_long().into_iter().chain(arg.get_all_aliases().into_iter().flatten())
+}
+
+fn boolean_flags() -> &'static BooleanFlags {
+    static FLAGS: OnceLock<BooleanFlags> = OnceLock::new();
+    FLAGS.get_or_init(|| BooleanFlags::collect(grammar()))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/boolean_values.rs
+++ b/pnpm/crates/cli/src/boolean_values.rs
@@ -1,32 +1,28 @@
 //! Explicit values for boolean flags.
 //!
-//! nopt gives every option typed as `Boolean` a value form: it splices
-//! `--prod=false` into `--prod` `false` and reads the value back as the
-//! flag's. That is how a build host that appends `--prod=false` to its
-//! install command asks for devDependencies (pnpm/pnpm#14553). pacquet's
-//! clap flags take no value at all, so the token aborts the parse with
-//! "unexpected value".
+//! nopt splices `--prod=false` into `--prod` `false` and reads the value
+//! back as the flag's, so pnpm 11 takes an explicit value on every option
+//! typed as `Boolean`. A build host that appends `--prod=false` to its
+//! install command relies on that (pnpm/pnpm#14553), and pacquet's clap
+//! flags take no value at all, so the token aborts the parse.
 //!
-//! Rather than teach clap a value form — which would put a `[<VALUE>]`
-//! placeholder next to every boolean in the help output —
-//! [`resolve_boolean_values`] collapses the token over argv: a true value
-//! leaves the bare flag, a false one becomes the `--no-` negation that
-//! [`crate::boolean_negations`] pairs with every boolean flag. The
-//! grammar clap parses therefore stays exactly as it is written, and the
-//! only command lines this pass rewrites are ones that abort the parse
-//! today.
+//! [`resolve_boolean_values`] collapses the token over argv rather than
+//! teaching clap a value form, which would hang a `[<VALUE>]` placeholder
+//! off every boolean in the help output. A false value resolves to the
+//! `--no-` negation [`crate::boolean_negations`] pairs with every boolean
+//! flag, so the only command lines this pass rewrites are ones that abort
+//! the parse today. A standalone negation such as `--no-runtime` has no
+//! positive spelling to resolve to, which leaves a false value on one for
+//! clap to report.
 //!
-//! A value written as its own token (`--prod false`, which nopt reads the
-//! same way) is deliberately left alone. Claiming it belongs in
+//! Two of nopt's spellings stay with clap as well. A value written as its
+//! own token (`--prod false`) would have to be claimed in
 //! [`option_width`], the width rule every pre-clap scan shares, and a
 //! foreign command line names its program with a positional: `pnpm -r
-//! exec --report-summary true` runs `true`, which a flag claiming the
-//! token after it would swallow.
-//!
-//! Only long spellings take a value. A short is clap's own spelling:
-//! nopt reaches one through its shorthand table, which splices `-P` into
-//! `--prod` before the value rule applies, and the two part ways on a
-//! cluster such as `-PD=false`.
+//! exec --report-summary true` runs `true`. A value on a short
+//! (`-P=false`) reaches nopt through its shorthand table, which splices
+//! `-P` into `--prod` before the value rule applies, where clap parses a
+//! cluster on its own terms.
 
 use crate::{
     boolean_negations::negation_of,
@@ -78,36 +74,35 @@ pub fn resolve_boolean_values(mut argv: Vec<OsString>) -> Vec<OsString> {
 }
 
 /// Every boolean flag spelling in the grammar, paired with the spelling
-/// that means its opposite.
+/// that means its opposite, or `None` for a flag the grammar gives no
+/// opposite.
 struct BooleanFlags {
-    opposites: HashMap<String, String>,
+    opposites: HashMap<String, Option<String>>,
 }
 
 impl BooleanFlags {
-    /// The spelling `--<name>=<value>` collapses to, or `None` when
-    /// `name` is no boolean flag, or `value` no boolean — which leaves
-    /// the token for clap to report.
+    /// The spelling `--<name>=<value>` collapses to. `None` when `name`
+    /// is no boolean flag, `value` no boolean, or the flag has no
+    /// spelling for that value, all of which leave the token for clap to
+    /// report.
     fn spelling_for(&self, name: &str, value: &str) -> Option<OsString> {
         let opposite = self.opposites.get(name)?;
-        let long = if parse_bool(value)? { name } else { opposite.as_str() };
+        let long = if parse_bool(value)? { name } else { opposite.as_deref()? };
         Some(OsString::from(format!("--{long}")))
     }
 
-    /// The grammar's boolean flags, reaching the same depth as the arity
-    /// table the pre-clap scans share, so a flag is never rewritten in a
-    /// token the scan did not recognize as an option.
     fn collect(command: &Command) -> Self {
         let mut flags = Self { opposites: HashMap::new() };
         let mut value_taking = HashSet::new();
         flags.absorb(command, &mut value_taking);
-        for subcommand in command.get_subcommands() {
-            flags.absorb(subcommand, &mut value_taking);
-        }
-        // A name another command spells as a value-taking option is left
+        // A name some command spells as a value-taking option is left
         // alone: `--foo=false` may well be asking for the value `false`
-        // there.
-        for name in value_taking {
-            flags.opposites.remove(&name);
+        // there, and a flag whose opposite is one has no false spelling.
+        flags.opposites.retain(|name, _| !value_taking.contains(name));
+        for opposite in flags.opposites.values_mut() {
+            if opposite.as_ref().is_some_and(|name| value_taking.contains(name)) {
+                *opposite = None;
+            }
         }
         flags
     }
@@ -125,20 +120,23 @@ impl BooleanFlags {
             let Some(long) = arg.get_long() else {
                 continue;
             };
-            let Some(opposite) = (match long.strip_prefix("no-") {
-                // A hand-written negation pairs with the flag it negates,
-                // when the command declares one.
+            let opposite = match long.strip_prefix("no-") {
+                // A negation pairs with the flag it negates, when the
+                // command declares one.
                 Some(positive) => longs.contains(positive).then(|| positive.to_string()),
                 // Every other boolean flag is paired by
                 // [`crate::boolean_negations`].
                 None => Some(negation_of(long)),
-            }) else {
-                continue;
             };
             for spelling in spellings(arg) {
                 self.opposites.entry(spelling.to_string()).or_insert_with(|| opposite.clone());
             }
-            self.opposites.entry(opposite).or_insert_with(|| long.to_string());
+            if let Some(opposite) = opposite {
+                self.opposites.entry(opposite).or_insert_with(|| Some(long.to_string()));
+            }
+        }
+        for subcommand in command.get_subcommands() {
+            self.absorb(subcommand, value_taking);
         }
     }
 }

--- a/pnpm/crates/cli/src/boolean_values.rs
+++ b/pnpm/crates/cli/src/boolean_values.rs
@@ -10,10 +10,10 @@
 //! teaching clap a value form, which would hang a `[<VALUE>]` placeholder
 //! off every boolean in the help output. A false value resolves to the
 //! `--no-` negation [`crate::boolean_negations`] pairs with every boolean
-//! flag, so the only command lines this pass rewrites are ones that abort
-//! the parse today. A standalone negation such as `--no-runtime` has no
-//! positive spelling to resolve to, which leaves a false value on one for
-//! clap to report.
+//! flag. Only a token clap rejects is ever rewritten, so the pass cannot
+//! change what a command line that already parses means. A standalone
+//! negation such as `--no-runtime` has no positive spelling to resolve
+//! to, which leaves a false value on one for clap to report.
 //!
 //! Two of nopt's spellings stay with clap as well. A value written as its
 //! own token (`--prod false`) would have to be claimed in

--- a/pnpm/crates/cli/src/boolean_values/tests.rs
+++ b/pnpm/crates/cli/src/boolean_values/tests.rs
@@ -72,6 +72,18 @@ fn a_negation_spelling_takes_a_value_too() {
     );
 }
 
+/// `--no-runtime` is pnpm 12's only spelling of that flag: it has no
+/// `--runtime` for a false value to resolve to.
+#[test]
+fn a_standalone_negation_takes_a_true_value_only() {
+    assert_eq!(
+        resolve(&["pnpm", "install", "--no-runtime=true"]),
+        ["pnpm", "install", "--no-runtime"],
+    );
+    let unresolvable = ["pnpm", "install", "--no-runtime=false"];
+    assert_eq!(resolve(&unresolvable), unresolvable);
+}
+
 #[test]
 fn a_global_flag_takes_a_value_before_its_command() {
     assert_eq!(
@@ -142,6 +154,8 @@ fn every_opposite_names_a_real_flag() {
     };
     for (name, opposite) in &boolean_flags().opposites {
         assert!(known(name), "--{name} is no flag");
-        assert!(known(opposite), "--{opposite}, the opposite of --{name}, is no flag");
+        if let Some(opposite) = opposite {
+            assert!(known(opposite), "--{opposite}, the opposite of --{name}, is no flag");
+        }
     }
 }

--- a/pnpm/crates/cli/src/boolean_values/tests.rs
+++ b/pnpm/crates/cli/src/boolean_values/tests.rs
@@ -1,0 +1,147 @@
+use super::{boolean_flags, resolve_boolean_values, spellings};
+use crate::{boolean_negations::with_boolean_negations, cli_args::CliArgs};
+use clap::CommandFactory;
+use pretty_assertions::assert_eq;
+use std::ffi::OsString;
+
+fn argv(parts: &[&str]) -> Vec<OsString> {
+    parts.iter().map(OsString::from).collect()
+}
+
+fn resolve(parts: &[&str]) -> Vec<String> {
+    resolve_boolean_values(argv(parts))
+        .into_iter()
+        .map(|token| token.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Resolve a boolean flag on the `install` subcommand the way `main`
+/// does: the pass, then the negation-augmented command.
+fn install_flag(parts: &[&str], flag_id: &str) -> Result<bool, clap::Error> {
+    let argv = resolve_boolean_values(argv(parts));
+    let matches = with_boolean_negations(CliArgs::command()).try_get_matches_from(argv)?;
+    let (name, install) = matches.subcommand().expect("a subcommand");
+    assert_eq!(name, "install");
+    Ok(install.get_flag(flag_id))
+}
+
+#[test]
+fn a_false_value_turns_the_flag_off() {
+    for spelling in ["--prod=false", "--prod=0"] {
+        let prod = install_flag(&["pnpm", "install", spelling], "prod")
+            .unwrap_or_else(|err| panic!("{spelling} should parse: {err}"));
+        assert!(!prod, "{spelling} should leave --prod off");
+    }
+}
+
+#[test]
+fn a_true_value_turns_the_flag_on() {
+    for spelling in ["--prod=true", "--prod=1"] {
+        let prod = install_flag(&["pnpm", "install", spelling], "prod")
+            .unwrap_or_else(|err| panic!("{spelling} should parse: {err}"));
+        assert!(prod, "{spelling} should turn --prod on");
+    }
+}
+
+/// A foreign command line names its program with a positional, so a
+/// boolean token after a flag stays a positional. See the module docs.
+#[test]
+fn a_value_written_as_its_own_token_is_left_alone() {
+    let original = ["pnpm", "install", "--prod", "false"];
+    assert_eq!(resolve(&original), original);
+    let exec = ["pnpm", "-r", "exec", "--report-summary", "true"];
+    assert_eq!(resolve(&exec), exec);
+}
+
+#[test]
+fn an_alias_resolves_to_the_flag_it_names() {
+    let prod = install_flag(&["pnpm", "install", "--production=false"], "prod")
+        .expect("--production=false should parse");
+    assert!(!prod);
+}
+
+#[test]
+fn a_negation_spelling_takes_a_value_too() {
+    assert_eq!(
+        resolve(&["pnpm", "install", "--no-optional=false"]),
+        ["pnpm", "install", "--optional"],
+    );
+    assert_eq!(
+        resolve(&["pnpm", "install", "--no-frozen-lockfile=true"]),
+        ["pnpm", "install", "--no-frozen-lockfile"],
+    );
+}
+
+#[test]
+fn a_global_flag_takes_a_value_before_its_command() {
+    assert_eq!(
+        resolve(&["pnpm", "--recursive=false", "install"]),
+        ["pnpm", "--no-recursive", "install"],
+    );
+}
+
+#[test]
+fn a_value_the_flag_does_not_take_is_left_for_clap() {
+    let original = ["pnpm", "install", "--prod=maybe"];
+    assert_eq!(resolve(&original), original);
+    let err = install_flag(&original, "prod").expect_err("--prod=maybe should not parse");
+    assert_eq!(err.kind(), clap::error::ErrorKind::TooManyValues);
+}
+
+#[test]
+fn an_option_value_that_spells_a_boolean_flag_is_left_alone() {
+    let original = ["pnpm", "install", "--filter", "--prod=false"];
+    assert_eq!(resolve(&original), original);
+}
+
+#[test]
+fn a_forwarded_boolean_value_reaches_the_script() {
+    for original in [
+        &["pnpm", "run", "build", "--prod=false"][..],
+        &["pnpm", "exec", "cmd", "--prod=false"],
+        &["pnpm", "install", "--", "--prod=false"],
+    ] {
+        assert_eq!(resolve(original), original);
+    }
+}
+
+#[test]
+fn a_setting_no_command_declares_is_left_to_the_settings_pass() {
+    // `ConfigOverrides::extract` has already taken `--shamefully-hoist`
+    // by the time this pass runs; a setting a command *does* declare
+    // (`--offline`) is that command's boolean flag here.
+    let original = ["pnpm", "install", "--shamefully-hoist=false"];
+    assert_eq!(resolve(&original), original);
+    assert_eq!(
+        resolve(&["pnpm", "install", "--offline=false"]),
+        ["pnpm", "install", "--no-offline"],
+    );
+}
+
+#[test]
+fn a_value_taking_option_keeps_its_value() {
+    for name in ["filter", "dir", "reporter", "store-dir"] {
+        let flag = format!("--{name}=false");
+        assert_eq!(
+            resolve(&["pnpm", "install", &flag]),
+            ["pnpm", "install", flag.as_str()],
+            "--{name} takes a value of its own",
+        );
+    }
+}
+
+/// Every spelling the pass can emit has to be one the parse accepts, or a
+/// resolved value would abort the parse it was meant to fix.
+#[test]
+fn every_opposite_names_a_real_flag() {
+    let command = with_boolean_negations(CliArgs::command());
+    let known = |long: &str| {
+        let declares =
+            |cmd: &clap::Command| cmd.get_arguments().flat_map(spellings).any(|name| name == long);
+        declares(&command) || command.get_subcommands().any(declares)
+    };
+    for (name, opposite) in &boolean_flags().opposites {
+        assert!(known(name), "--{name} is no flag");
+        assert!(known(opposite), "--{opposite}, the opposite of --{name}, is no flag");
+    }
+}

--- a/pnpm/crates/cli/src/config_overrides.rs
+++ b/pnpm/crates/cli/src/config_overrides.rs
@@ -1082,7 +1082,7 @@ fn setting_value<Value: serde::Serialize>(value: Value) -> serde_json::Value {
     serde_json::to_value(value).unwrap_or(serde_json::Value::Null)
 }
 
-fn parse_bool(value: &str) -> Option<bool> {
+pub(crate) fn parse_bool(value: &str) -> Option<bool> {
     match value.to_ascii_lowercase().as_str() {
         "true" | "1" => Some(true),
         "false" | "0" => Some(false),

--- a/pnpm/crates/cli/src/lib.rs
+++ b/pnpm/crates/cli/src/lib.rs
@@ -1,4 +1,5 @@
 mod boolean_negations;
+mod boolean_values;
 mod cargo_deps;
 mod cargo_manifest;
 mod checkbox_prompt;
@@ -117,6 +118,10 @@ fn run_cli() -> miette::Result<()> {
     // `--reporter=silent`) over argv before parsing; mirror that so they
     // work with every command. See `shorthands`.
     let argv = shorthands::expand_universal_shorthands(&command, argv);
+    // nopt lets every boolean option carry an explicit value; collapse
+    // `--prod=false` into the flag or its negation before clap, which
+    // knows only the bare flag. See `boolean_values`.
+    let argv = boolean_values::resolve_boolean_values(argv);
     // npm's spellings of two of pnpm's options (`--prefix`, `--store`) are
     // hidden clap aliases; pnpm additionally lets the canonical spelling win
     // when a command line uses both. See `renamed_options`.

--- a/pnpm/crates/cli/src/parse_boundary.rs
+++ b/pnpm/crates/cli/src/parse_boundary.rs
@@ -170,7 +170,7 @@ pub(crate) fn subcommand_option_names(argv: &[OsString]) -> HashSet<&'static str
 /// yet. Both halves of the union — a global lives on the top-level
 /// command, a command's own options on its subcommand — and both are
 /// derived from the static [`grammar`], so the table is built once.
-fn union_arity() -> &'static ArgTable {
+pub(crate) fn union_arity() -> &'static ArgTable {
     static ARITY: std::sync::OnceLock<ArgTable> = std::sync::OnceLock::new();
     ARITY.get_or_init(|| {
         let command = grammar();
@@ -224,7 +224,7 @@ fn next_token(argv: &[OsString], index: usize) -> Option<&str> {
 /// (`pnpm dlx --package cowsay --silent cowsay` would forward pnpm's own
 /// `--silent`). The union across subcommands is what the pre-clap passes
 /// have to work with, since the command is not yet known.
-fn option_width(arg: &str, next: Option<&str>, arity: &ArgTable) -> Option<usize> {
+pub(crate) fn option_width(arg: &str, next: Option<&str>, arity: &ArgTable) -> Option<usize> {
     let rest = arg.strip_prefix('-').filter(|rest| !rest.is_empty())?;
     if let Some(long) = rest.strip_prefix('-') {
         // `--config.<key>=<value>` is always self-contained.

--- a/pnpm/crates/cli/tests/suite/install.rs
+++ b/pnpm/crates/cli/tests/suite/install.rs
@@ -275,6 +275,44 @@ fn filtered_fix_lockfile_preserves_unselected_snapshot_metadata() {
     drop((root, mock_instance));
 }
 
+/// A build host that appends `--prod=false` to its install command is
+/// asking for devDependencies, the way nopt reads an explicit boolean
+/// value (pnpm/pnpm#14553).
+#[test]
+fn prod_takes_an_explicit_boolean_value() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { "@pnpm.e2e/foo": "100.0.0" },
+            "devDependencies": { "@pnpm.e2e/bar": "100.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_args(["install", "--prod=false"]).assert().success();
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/bar/package.json").exists(),
+        "--prod=false must install devDependencies",
+    );
+
+    pacquet_in(&workspace).with_args(["install", "--prod=true"]).assert().success();
+    assert!(
+        !workspace.join("node_modules/@pnpm.e2e/bar").exists(),
+        "--prod=true must drop the dev dependency",
+    );
+    assert!(
+        workspace.join("node_modules/@pnpm.e2e/foo/package.json").exists(),
+        "the prod dependency must stay installed",
+    );
+
+    drop((root, mock_instance));
+}
+
 #[test]
 fn no_optional_excludes_transitive_optional_dependencies() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =


### PR DESCRIPTION
## Summary

`pnpm install --prod=false` aborts the parse in pnpm 12 with `error: unexpected value 'false' for '--prod' found; no more were expected`. Build hosts append that flag to their install command (Render does), so a deployment that installs devDependencies fails outright.

nopt, which pnpm 11 parses with, splices `--prod=false` into `--prod` `false` and reads the value back as the flag's, so every option typed as `Boolean` takes an explicit value there. pacquet's clap flags take no value at all.

A new pre-clap pass (`boolean_values`) collapses the token over argv before clap parses it: a true value leaves the bare flag, a false one becomes the `--no-` negation that `boolean_negations` already pairs with every boolean flag. It covers every boolean flag in the grammar, not just `--prod`, including alias spellings (`--production=false` reaches `--no-prod`) and negation spellings (`--no-optional=false` reaches `--optional`). A name another command spells as a value-taking option is left alone, as is everything past the point where pnpm stops parsing and starts forwarding.

Three deliberate limits, all noted in the module docs:

- A value written as its own token (`--prod false`, which nopt reads the same way) is left alone. Claiming it belongs in `option_width`, the width rule every pre-clap scan shares, and a foreign command line names its program with a positional: `pnpm -r exec --report-summary true` runs `true`, which a flag claiming the token after it would swallow. That command line is covered by an existing test, and supporting the space form broke it. Say the word if you want the space form anyway and I will scope the claim to commands that do not take a foreign command line.
- A standalone negation such as `--no-runtime` takes a true value (`--no-runtime=true`) but not a false one. pnpm 12 has no `--runtime` for it to resolve to, and neither inventing a hidden positive flag nor dropping the token is safe: `--runtime` carries a value in the TypeScript CLI, and dropping would silently let a config file win where the user meant to override it. clap reports the value, as it does on `main`.
- Only long spellings take a value. nopt reaches a short through its shorthand table, which splices `-P` into `--prod` before the value rule applies; pacquet's shorts are clap's, and the two part ways on a cluster such as `-PD=false`.

pnpm 11 is unaffected: nopt handles both forms already, so this is a v12-only fix.

Closes pnpm/pnpm#14553

## Squash Commit Body

```text
nopt splices `--prod=false` into `--prod` `false` and reads the value back
as the flag's, so pnpm 11 takes an explicit boolean on every option typed
as `Boolean`. pacquet's clap flags take no value at all, so a build host
that appends `--prod=false` to its install command, as Render does, hits
"unexpected value 'false' for '--prod'" instead of an install that keeps
devDependencies.

A new pre-clap pass collapses the token over argv: a true value leaves the
bare flag, a false one becomes the `--no-` negation that
`boolean_negations` already pairs with every boolean flag. Teaching clap a
value form instead would hang a `[<VALUE>]` placeholder off every boolean
in the help output; rewriting argv leaves the grammar, and the help, as
they are written. Every command line the pass rewrites is one that aborts
the parse today. Aliases resolve to the flag they name, so
`--production=false` reaches `--no-prod`, and a name another command
spells as a value-taking option is left alone.

A value written as its own token (`--prod false`, which nopt reads the
same way) is deliberately left alone. Claiming it belongs in
`option_width`, the width rule every pre-clap scan shares, and a foreign
command line names its program with a positional: `pnpm -r exec
--report-summary true` runs `true`, which a flag claiming the token after
it would swallow.

Closes pnpm/pnpm#14553
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Boolean command-line flags now accept explicit values, such as `--prod=false` and `--prod=true`.
  * Explicit values correctly control whether development dependencies are included during installation.

* **Bug Fixes**
  * Improved handling of boolean flag aliases, negations, forwarded arguments, and global options.
  * Boolean values are interpreted only for supported pnpm options, while invalid values continue to produce clear command-line errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->