### PR TITLE
fix(setup): replace alias scripts atomically to avoid ETXTBSY

### DIFF
--- a/.changeset/setup-replaces-busy-alias-scripts.md
+++ b/.changeset/setup-replaces-busy-alias-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm setup` no longer fails with `Text file busy (os error 26)` when writing the `pn` / `pnpx` / `pnx` alias scripts. `$PNPM_HOME/bin` may already hold those names as hardlinks of the pnpm executable — the layout left behind by `npm i -g pnpm` — and truncating one of them in place while that inode is executing raises `ETXTBSY`, which is exactly the case when the process doing the writing is `pnpm setup` itself. The scripts are now written to a sibling temp file and renamed over the target, so the busy inode is left untouched.

--- a/pnpm/crates/cli/src/cli_args/setup.rs
+++ b/pnpm/crates/cli/src/cli_args/setup.rs
@@ -179,20 +179,44 @@ fn create_alias_scripts(target_dir: &Path) -> std::io::Result<()> {
 fn create_shell_script(target_dir: &Path, name: &str, command: &str) -> std::io::Result<()> {
     // Windows can also run shell scripts via mingw / cygwin, so write the
     // POSIX script unconditionally.
-    let shell_script = format!("#!/bin/sh\nexec {command} \"$@\"\n");
-    let script_path = target_dir.join(name);
-    fs::write(&script_path, shell_script)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755))?;
-    }
+    write_script(target_dir, name, &format!("#!/bin/sh\nexec {command} \"$@\"\n"))?;
 
     if cfg!(windows) {
-        fs::write(target_dir.join(format!("{name}.cmd")), format!("@echo off\n{command} %*\n"))?;
-        fs::write(target_dir.join(format!("{name}.ps1")), format!("{command} @args\n"))?;
+        write_script(target_dir, &format!("{name}.cmd"), &format!("@echo off\n{command} %*\n"))?;
+        write_script(target_dir, &format!("{name}.ps1"), &format!("{command} @args\n"))?;
     }
     Ok(())
+}
+
+/// Write `contents` to `target_dir/name`, replacing whatever is already there.
+///
+/// The existing file is never opened for writing. `$PNPM_HOME/bin/{pn,pnpx,pnx}`
+/// are routinely hardlinks of the pnpm executable itself — that is the layout
+/// `npm i -g pnpm` leaves behind — and truncating such a path while the inode
+/// is being executed fails with `ETXTBSY` ("Text file busy") on Linux, which is
+/// exactly the case when it is `pnpm setup` doing the executing. Writing a
+/// sibling temp file and renaming it over the target swaps the directory entry
+/// and leaves the busy inode alone.
+fn write_script(target_dir: &Path, name: &str, contents: &str) -> std::io::Result<()> {
+    // The global bin lock keeps concurrent `setup` runs apart, but the pid
+    // keeps a crashed run's leftovers from being mistaken for this one's.
+    let temp_path = target_dir.join(format!(".{name}.{}.tmp", std::process::id()));
+    let write_and_rename = || {
+        fs::write(&temp_path, contents)?;
+        // Set the mode before the rename so the script is never observable
+        // at its final path without the executable bit.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o755))?;
+        }
+        fs::rename(&temp_path, target_dir.join(name))
+    };
+    let result = write_and_rename();
+    if result.is_err() {
+        let _ = fs::remove_file(&temp_path);
+    }
+    result
 }
 
 /// v10-layout shim names that v11 writes under `pnpm_home_dir/bin` instead.

--- a/pnpm/crates/cli/src/cli_args/setup/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/setup/tests.rs
@@ -89,6 +89,40 @@ fn alias_scripts_are_written_and_executable() {
 }
 
 #[test]
+#[cfg(unix)]
+fn alias_scripts_replace_a_hardlink_of_a_running_executable() {
+    // `npm i -g pnpm` leaves `$PNPM_HOME/bin/{pn,pnpx,pnx}` as hardlinks of
+    // the pnpm executable. Truncating one of those paths in place while the
+    // inode is executing fails with ETXTBSY, and the process doing the
+    // truncating is `pnpm setup` itself, so setup must replace the directory
+    // entry rather than write through to the shared inode.
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let bin_dir = dir.path().join("bin");
+    std::fs::create_dir_all(&bin_dir).expect("create bin dir");
+
+    let pn = bin_dir.join("pn");
+    std::fs::write(&pn, "the pnpm executable\n").expect("write the existing shim");
+    let executable = dir.path().join("pnpm");
+    std::fs::hard_link(&pn, &executable).expect("hard link the existing shim");
+
+    create_alias_scripts(&bin_dir).expect("write alias scripts");
+
+    assert_eq!(std::fs::read_to_string(&pn).expect("read pn"), "#!/bin/sh\nexec pnpm \"$@\"\n");
+    assert_eq!(
+        std::fs::read_to_string(&executable).expect("read the other hardlink"),
+        "the pnpm executable\n",
+        "the old inode must survive untouched; writing through it is what raises ETXTBSY",
+    );
+
+    let leftovers: Vec<_> = std::fs::read_dir(&bin_dir)
+        .expect("read bin dir")
+        .map(|entry| entry.expect("read dir entry").file_name())
+        .filter(|name| name.to_string_lossy().ends_with(".tmp"))
+        .collect();
+    assert_eq!(leftovers, Vec::<std::ffi::OsString>::new(), "no temp file should be left behind");
+}
+
+#[test]
 fn remove_legacy_homedir_shims_unlinks_all_v10_names() {
     // pnpm/pnpm#12496: setup must clean up the v10-layout shims at the top
     // of pnpm_home_dir, otherwise self-update keeps warning about a v10


### PR DESCRIPTION
## Summary

`pnpm setup` can fail outright with `Text file busy (os error 26)`, leaving a broken global `pnpm`:

```
Installing pnpm CLI globally from /home/u/.nvm/versions/node/v24.20.0/lib/node_modules/pnpm
...
dependencies:
+ pnpm file:../../../../../../.nvm/versions/node/v24.20.0/lib/node_modules/pnpm

Error:   × create the pnpm alias scripts
  ╰─▶ Text file busy (os error 26)
```

`create_shell_script` writes `$PNPM_HOME/bin/{pn,pnpx,pnx}` with `fs::write`, which opens the existing path `O_WRONLY|O_TRUNC`. After `npm i -g pnpm`, those three names are already present as **hardlinks of the pnpm executable itself** (same inode, link count > 1). Truncating a path whose inode is currently being executed fails with `ETXTBSY` — and the process doing the executing is `pnpm setup` itself, so the command can never succeed.

This is easy to hit: `npm i -g pnpm`, then run any global install. You get `ERR_PNPM_GLOBAL_BIN_DIR_NOT_IN_PATH`, whose `help:` line tells you to run `pnpm setup`, which then dies as above.

It also leaves the user worse off than before. Setup aborts after `install_cli_globally` but before the shims are consistent, so `.pnpm-shim-v1-pnpm-target` ends up resolving back to the same inode as the shim, and every later invocation dies with `pnpm: the global target of the pnpm shim points back at the shim`. Recovering means deleting `$PNPM_HOME/bin` and `$PNPM_HOME/global` by hand.

## Squash Commit Body

```text
`create_shell_script` wrote `$PNPM_HOME/bin/{pn,pnpx,pnx}` with `fs::write`,
which opens the existing path with `O_WRONLY|O_TRUNC`. Those names are
routinely hardlinks of the pnpm executable itself -- the layout that
`npm i -g pnpm` leaves behind -- and truncating such a path while the inode
is being executed fails with ETXTBSY. The process doing the executing is
`pnpm setup` itself, so the command could not succeed at all.

Write a sibling temp file, set its mode, and rename it over the target
instead. The rename swaps the directory entry and leaves the busy inode
alone. The mode is set before the rename so the script is never observable
at its final path without its executable bit.

This is the same approach taken in #8780, which fixed the equivalent ETXTBSY
in the old TypeScript `copyCli` path; the Rust rewrite of `setup` did not
carry it over. `packages/plugin-commands-setup` is gone from main, so the
Rust CLI is the only affected version.
```

## Verification

Extracting `create_alias_scripts` / `create_shell_script` verbatim from before and after this change, and running each against a real hardlink of a genuinely executing ELF:

| | result |
|---|---|
| before | `create_alias_scripts FAILED: Text file busy (os error 26) (kind ExecutableFileBusy)` |
| after | `create_alias_scripts OK` |

The added test encodes the property that avoids the error — the alias path is replaced while a second hardlink to the old inode keeps its original contents — and it fails on the unpatched code, passes on the patched code. It also asserts no `.tmp` file is left behind.

One caveat for reviewers: I verified formatting with the pinned toolchain's `rustfmt` and compiled/ran the changed functions and the new test with `rustc 1.97.0 --edition 2024`, but I could not run a full `cargo check`/`cargo test` of the workspace locally (insufficient disk for ~800 crates). Please let CI confirm the full build.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version. (The TypeScript `setup` path was fixed in #8780 and no longer exists on main; the Rust CLI is the only affected version.)
- [x] Added a changeset.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed. (No user-facing docs change; behaviour only.)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14663"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791384603&installation_model_id=426870&pr_number=14663&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14663&signature=fd180d06ae9a393f57030c45ffc28edbb3e978dab598d8178617fc5bbac64576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `pnpm setup` failing with a “Text file busy” error when replacing existing `pn`, `pnpx`, or `pnx` alias scripts.
  * Alias scripts are now replaced safely without affecting the running executable or related hardlinks.
  * Temporary files are cleaned up when setup encounters an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->