### PR TITLE
fix(pnpr): approve a staged publish once across replicas

### DIFF
--- a/.changeset/approve-a-stage-once-across-replicas.md
+++ b/.changeset/approve-a-stage-once-across-replicas.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-A staged publish is now approved once, whichever replica of a shared hosted store the approval reaches. The approving request claims the record with a conditional write, so a second approval of the same stage answers 409 instead of replaying the held publish [#12199](https://github.com/pnpm/pnpm/issues/12199).
+A staged publish is now approved once, whichever replica of a shared registry the approval reaches. A second approval of the same stage answers 409. Rejecting a stage stops an approval that has not published it yet [#12199](https://github.com/pnpm/pnpm/issues/12199).

--- a/.changeset/approve-a-stage-once-across-replicas.md
+++ b/.changeset/approve-a-stage-once-across-replicas.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+A staged publish is now approved once, whichever replica of a shared hosted store the approval reaches. The approving request claims the record with a conditional write, so a second approval of the same stage answers 409 instead of replaying the held publish [#12199](https://github.com/pnpm/pnpm/issues/12199).

--- a/pnpr/crates/error/src/lib.rs
+++ b/pnpr/crates/error/src/lib.rs
@@ -202,6 +202,17 @@ pub enum RegistryError {
         package: String,
     },
 
+    /// Another request is already approving this staged publish. A staged
+    /// record is approved exactly once: the approving request claims it with
+    /// a conditional write, and a second one is refused rather than
+    /// publishing the held document twice.
+    #[display("Staged publish {stage_id:?} is already being approved")]
+    #[from(skip)]
+    StagedApprovalInFlight {
+        #[error(not(source))]
+        stage_id: String,
+    },
+
     #[display("Hosted revision digest already has the maximum of {limit} references")]
     #[from(skip)]
     RevisionReferenceLimit { limit: usize },
@@ -349,6 +360,7 @@ impl RegistryError {
             RegistryError::PublishNotRecorded { .. } => "publish_not_recorded",
             RegistryError::BlobUploadConflict { .. } => "blob_upload_conflict",
             RegistryError::DocumentWriteConflict { .. } => "document_write_conflict",
+            RegistryError::StagedApprovalInFlight { .. } => "staged_approval_in_flight",
             RegistryError::RevisionReferenceLimit { .. } => "revision_reference_limit",
             RegistryError::RevisionReferenceWriteConflict { .. } => {
                 "revision_reference_write_conflict"
@@ -444,6 +456,7 @@ impl RegistryError {
             | RegistryError::PublishNotRecorded { .. }
             | RegistryError::BlobUploadConflict { .. }
             | RegistryError::DocumentWriteConflict { .. }
+            | RegistryError::StagedApprovalInFlight { .. }
             | RegistryError::RevisionReferenceLimit { .. }
             | RegistryError::RevisionReferenceWriteConflict { .. } => StatusCode::CONFLICT,
             RegistryError::NotFound => StatusCode::NOT_FOUND,

--- a/pnpr/crates/pnpr/Cargo.toml
+++ b/pnpr/crates/pnpr/Cargo.toml
@@ -99,6 +99,7 @@ wax                           = { workspace = true }
 zip                           = { workspace = true }
 
 [dev-dependencies]
+chrono             = { workspace = true }
 mockito            = { workspace = true }
 walkdir            = { workspace = true }
 tar                = { workspace = true }

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -31,7 +31,8 @@ use serde_json::{Value, json};
 
 use super::{
     Action, AppState, AuthedCaller, Identity, RegistrySource, TargetRegistry, authorize,
-    commit_publishes, json_response, not_found, private_no_cache, publishing::report_unrecorded,
+    commit_publishes, json_response, not_found, private_no_cache,
+    publishing::{cleanup_tmp_slots, report_unrecorded},
     resolve_write_target, stage_publish, validate_publish_doc,
 };
 use pnpr_error::RegistryError;
@@ -90,7 +91,10 @@ struct ApprovalClaim {
 /// How long a claim on a staged record is honored. An approval releases its
 /// claim on every outcome, so the lease only matters when the replica holding
 /// one died mid-approval: after it the record can be approved again instead of
-/// being stranded until someone rejects it.
+/// being stranded until someone rejects it. An approval slower than the lease
+/// can therefore be joined by a second one, which is bounded rather than
+/// unsafe: both replay the same held bytes onto the same immutable blob slot
+/// and merge the same version into the document.
 const APPROVAL_CLAIM_LEASE: Duration = Duration::from_mins(10);
 
 impl StagedRecord {
@@ -385,12 +389,8 @@ async fn serve_staged_reject(
     }
 }
 
-/// `POST /-/stage/:id/approve` — publish the held document through the
-/// regular validate → stage → commit flow, then drop the staged record.
-///
-/// The record is claimed with a conditional write first, so a stage is
-/// approved once even when two requests reach two replicas of one hosted
-/// store: the second finds the record is no longer the one it read.
+/// `POST /-/stage/:id/approve` — claim the record, publish the held document
+/// through the regular validate → stage → commit flow, then drop the record.
 async fn serve_staged_approve(
     state: &AppState,
     identity: &Identity,
@@ -405,7 +405,7 @@ async fn serve_staged_approve(
         Ok(claim) => claim,
         Err(err) => return err.into_response(),
     };
-    match approve_claimed(state, identity, stage_id, &claim.record).await {
+    match approve_claimed(state, identity, stage_id, &claim).await {
         Ok(response) => response,
         Err(err) => {
             release_approval_claim(state, stage_id, &claim).await;
@@ -450,17 +450,35 @@ async fn claim_for_approval(
     }
 }
 
-/// Whether a claim started at `since` still holds the record. An unparsable
-/// timestamp is treated as expired: a value pnpr cannot read must not be able
-/// to hold a stage forever.
+/// Whether a claim started at `since` still holds the record.
+///
+/// A claim from the future is live: replicas time their claims by their own
+/// clocks, and one running ahead must not have its claim read as expired by
+/// one running behind. An unparsable timestamp is expired instead — a value
+/// pnpr cannot read must not be able to hold a stage forever.
 fn approval_claim_is_live(since: &str) -> bool {
     let Ok(started) = chrono::DateTime::parse_from_rfc3339(since) else {
         return false;
     };
-    chrono::Utc::now()
-        .signed_duration_since(started)
-        .to_std()
-        .is_ok_and(|held| held < APPROVAL_CLAIM_LEASE)
+    let Ok(held) = chrono::Utc::now().signed_duration_since(started).to_std() else {
+        return true;
+    };
+    held < APPROVAL_CLAIM_LEASE
+}
+
+/// Whether the record this approval claimed is still the one it claimed: a
+/// rejection removes it, and a claim the lease handed to another approval is
+/// no longer this one's.
+async fn still_claimed(
+    state: &AppState,
+    stage_id: &str,
+    claim: &ApprovalClaim,
+) -> Result<(), RegistryError> {
+    match state.inner.storage.read_staged_meta(stage_id).await? {
+        Some(stored) if stored == claim.claimed_bytes => Ok(()),
+        Some(_) => Err(RegistryError::StagedApprovalInFlight { stage_id: stage_id.to_string() }),
+        None => Err(RegistryError::NotFound),
+    }
 }
 
 /// Put back the record this approval claimed, so a failed approval can be
@@ -483,8 +501,9 @@ async fn approve_claimed(
     state: &AppState,
     identity: &Identity,
     stage_id: &str,
-    record: &StagedRecord,
+    claim: &ApprovalClaim,
 ) -> Result<Response, RegistryError> {
+    let record = &claim.record;
     let Some(body) = state.inner.storage.read_staged_body(stage_id).await? else {
         return Err(RegistryError::Io(std::io::Error::other(format!(
             "staged publish {stage_id} has no stored body",
@@ -501,6 +520,12 @@ async fn approve_claimed(
 
     let _packument_guard = state.inner.package_locks.lock(validated.name.as_str()).await;
     let staged = stage_publish(state, validated, &now_iso(), Some(&target.org)).await?;
+    // Nothing is visible yet, which is the last moment a rejection can still
+    // take the stage back. Past the commit it cannot: the publish is served.
+    if let Err(err) = still_claimed(state, stage_id, claim).await {
+        cleanup_tmp_slots(staged.slots).await;
+        return Err(err);
+    }
     let outcome = commit_publishes(state, vec![staged]).await?;
     // Past the commit the stage is spent, whatever the transaction could not
     // record: leaving the record listed would offer an approval that cannot

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -13,6 +13,11 @@
 //! addressed with. Stage ids are random UUIDs, so the id itself is an
 //! unguessable capability; denials answer loudly (401/403) like the publish
 //! endpoint rather than masking.
+//!
+//! Records live in the hosted store, which every replica of a deployment
+//! shares, so an approval claims the record it is about to replay with a
+//! conditional write. A stage is therefore approved once no matter which
+//! replica each request reaches.
 
 use axum::{
     body::Body,
@@ -32,7 +37,11 @@ use super::{
 use pnpr_error::RegistryError;
 use pnpr_package_name::CanonicalPackageName;
 use pnpr_search::percent_decode;
-use pnpr_storage::publish::{extract_attachments, now_iso};
+use pnpr_storage::{
+    DocumentWrite,
+    publish::{extract_attachments, now_iso},
+};
+use std::time::Duration;
 
 /// One staged publish's metadata, stored next to the held publish body and
 /// served by the list/view endpoints (without the `registry` field, which is
@@ -56,7 +65,33 @@ struct StagedRecord {
     /// through the same address it was created with.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     registry: Option<String>,
+    /// When the approval holding this record started, if one holds it.
+    /// Written by the conditional claim that makes an approval exclusive.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    approving_since: Option<String>,
 }
+
+/// A staged record as the store holds it. The bytes are what a conditional
+/// rewrite compares against, so they are the stored ones rather than a
+/// re-serialization of `record`.
+struct StoredStagedRecord {
+    bytes: Vec<u8>,
+    record: StagedRecord,
+}
+
+/// A staged record this request has claimed for approval, with the bytes on
+/// both sides of the claim so it can be released if the approval fails.
+struct ApprovalClaim {
+    record: StagedRecord,
+    unclaimed_bytes: Vec<u8>,
+    claimed_bytes: Vec<u8>,
+}
+
+/// How long a claim on a staged record is honored. An approval releases its
+/// claim on every outcome, so the lease only matters when the replica holding
+/// one died mid-approval: after it the record can be approved again instead of
+/// being stranded until someone rejects it.
+const APPROVAL_CLAIM_LEASE: Duration = Duration::from_mins(10);
 
 impl StagedRecord {
     /// The list/view representation: the record without its routing state.
@@ -248,15 +283,16 @@ async fn serve_staged_publish(
         actor_type,
         shasum: dist.get("shasum").and_then(Value::as_str).map(str::to_string),
         registry: registry.map(str::to_string),
+        approving_since: None,
     };
 
     // Body first, metadata last: a record whose metadata exists always has
     // its body. On a metadata failure the body is cleaned up best-effort.
-    if let Err(err) = state.inner.storage.write_staged_body(&stage_id, body).await {
+    if let Err(err) = state.inner.storage.create_staged_body(&stage_id, body).await {
         return err.into_response();
     }
     let meta_bytes = serde_json::to_vec(&record).expect("a staged record serializes");
-    if let Err(err) = state.inner.storage.write_staged_meta(&stage_id, &meta_bytes).await {
+    if let Err(err) = state.inner.storage.create_staged_meta(&stage_id, &meta_bytes).await {
         let _ = state.inner.storage.remove_staged(&stage_id).await;
         return err.into_response();
     }
@@ -279,9 +315,10 @@ async fn serve_staged_list(
     };
     let mut records: Vec<StagedRecord> = Vec::new();
     for stage_id in ids {
-        let Ok(Some(record)) = read_staged_record(state, &stage_id).await else {
+        let Ok(Some(stored)) = read_staged_record(state, &stage_id).await else {
             continue;
         };
+        let record = stored.record;
         if record.registry.as_deref() != registry {
             continue;
         }
@@ -321,11 +358,11 @@ async fn serve_staged_view(
     registry: Option<&str>,
     stage_id: &str,
 ) -> Response {
-    let record = match load_authorized_record(state, identity, registry, stage_id).await {
-        Ok(record) => record,
+    let stored = match load_authorized_record(state, identity, registry, stage_id).await {
+        Ok(stored) => stored,
         Err(err) => return err.into_response(),
     };
-    json_response(StatusCode::OK, &record.metadata())
+    json_response(StatusCode::OK, &stored.record.metadata())
 }
 
 /// `DELETE /-/stage/:id` — reject a staged publish, deleting its record and
@@ -350,57 +387,121 @@ async fn serve_staged_reject(
 
 /// `POST /-/stage/:id/approve` — publish the held document through the
 /// regular validate → stage → commit flow, then drop the staged record.
+///
+/// The record is claimed with a conditional write first, so a stage is
+/// approved once even when two requests reach two replicas of one hosted
+/// store: the second finds the record is no longer the one it read.
 async fn serve_staged_approve(
     state: &AppState,
     identity: &Identity,
     registry: Option<&str>,
     stage_id: &str,
 ) -> Response {
-    let record = match load_authorized_record(state, identity, registry, stage_id).await {
-        Ok(record) => record,
+    let stored = match load_authorized_record(state, identity, registry, stage_id).await {
+        Ok(stored) => stored,
         Err(err) => return err.into_response(),
     };
-    let body = match state.inner.storage.read_staged_body(stage_id).await {
-        Ok(Some(body)) => body,
-        Ok(None) => {
-            return RegistryError::Io(std::io::Error::other(format!(
-                "staged publish {stage_id} has no stored body",
-            )))
-            .into_response();
+    let claim = match claim_for_approval(state, stage_id, stored).await {
+        Ok(claim) => claim,
+        Err(err) => return err.into_response(),
+    };
+    match approve_claimed(state, identity, stage_id, &claim.record).await {
+        Ok(response) => response,
+        Err(err) => {
+            release_approval_claim(state, stage_id, &claim).await;
+            err.into_response()
         }
-        Err(err) => return err.into_response(),
+    }
+}
+
+/// Take the staged record for this approval, refusing one another approval
+/// holds. The claim is the record rewritten with the time it started, under a
+/// conditional write on the bytes that were read: a record another request
+/// claimed, or a rejection removed, is no longer those bytes.
+async fn claim_for_approval(
+    state: &AppState,
+    stage_id: &str,
+    stored: StoredStagedRecord,
+) -> Result<ApprovalClaim, RegistryError> {
+    if stored.record.approving_since.as_deref().is_some_and(approval_claim_is_live) {
+        return Err(RegistryError::StagedApprovalInFlight { stage_id: stage_id.to_string() });
+    }
+    let mut record = stored.record;
+    record.approving_since = Some(now_iso());
+    let claimed_bytes = serde_json::to_vec(&record).expect("a staged record serializes");
+    let written = state
+        .inner
+        .storage
+        .replace_staged_meta_if_current(stage_id, &stored.bytes, &claimed_bytes)
+        .await?;
+    match written {
+        DocumentWrite::Written => {
+            Ok(ApprovalClaim { record, unclaimed_bytes: stored.bytes, claimed_bytes })
+        }
+        // Something got between the read and the claim. Another approval
+        // leaves its claim behind; one that finished, or a rejection, leaves
+        // no record at all.
+        DocumentWrite::Conflict => match state.inner.storage.read_staged_meta(stage_id).await? {
+            Some(_) => {
+                Err(RegistryError::StagedApprovalInFlight { stage_id: stage_id.to_string() })
+            }
+            None => Err(RegistryError::NotFound),
+        },
+    }
+}
+
+/// Whether a claim started at `since` still holds the record. An unparsable
+/// timestamp is treated as expired: a value pnpr cannot read must not be able
+/// to hold a stage forever.
+fn approval_claim_is_live(since: &str) -> bool {
+    let Ok(started) = chrono::DateTime::parse_from_rfc3339(since) else {
+        return false;
     };
-    let incoming: Value = match serde_json::from_slice(&body) {
-        Ok(value) => value,
-        Err(err) => return RegistryError::Json(err).into_response(),
+    chrono::Utc::now()
+        .signed_duration_since(started)
+        .to_std()
+        .is_ok_and(|held| held < APPROVAL_CLAIM_LEASE)
+}
+
+/// Put back the record this approval claimed, so a failed approval can be
+/// retried without waiting the claim out. Conditional on the claim still
+/// standing: an approval that got as far as removing the record has nothing
+/// to put back, and a record something else changed is not ours to restore.
+async fn release_approval_claim(state: &AppState, stage_id: &str, claim: &ApprovalClaim) {
+    let restored = state
+        .inner
+        .storage
+        .replace_staged_meta_if_current(stage_id, &claim.claimed_bytes, &claim.unclaimed_bytes)
+        .await;
+    if let Err(err) = restored {
+        tracing::warn!(error = %err, stage_id, "failed to release the claim on a staged publish");
+    }
+}
+
+/// Publish the held document of a record this request holds the claim on.
+async fn approve_claimed(
+    state: &AppState,
+    identity: &Identity,
+    stage_id: &str,
+    record: &StagedRecord,
+) -> Result<Response, RegistryError> {
+    let Some(body) = state.inner.storage.read_staged_body(stage_id).await? else {
+        return Err(RegistryError::Io(std::io::Error::other(format!(
+            "staged publish {stage_id} has no stored body",
+        ))));
     };
-    let name = match CanonicalPackageName::parse(
-        &record.package_name,
-        pnpr_package_name::Ecosystem::Npm,
-    ) {
-        Ok(name) => name,
-        Err(err) => return err.into_response(),
-    };
+    let incoming: Value = serde_json::from_slice(&body).map_err(RegistryError::Json)?;
+    let name =
+        CanonicalPackageName::parse(&record.package_name, pnpr_package_name::Ecosystem::Npm)?;
     // Re-validate against the registry state of *now*: rules may have
     // changed since staging, and the version may have been published in
     // the meantime (which surfaces as the usual 409).
     let (validated, target) =
-        match validate_publish_doc(state, identity, record.registry.as_deref(), name, incoming)
-            .await
-        {
-            Ok(validated) => validated,
-            Err(err) => return err.into_response(),
-        };
+        validate_publish_doc(state, identity, record.registry.as_deref(), name, incoming).await?;
 
     let _packument_guard = state.inner.package_locks.lock(validated.name.as_str()).await;
-    let staged = match stage_publish(state, validated, &now_iso(), Some(&target.org)).await {
-        Ok(staged) => staged,
-        Err(err) => return err.into_response(),
-    };
-    let outcome = match commit_publishes(state, vec![staged]).await {
-        Ok(outcome) => outcome,
-        Err(err) => return err.into_response(),
-    };
+    let staged = stage_publish(state, validated, &now_iso(), Some(&target.org)).await?;
+    let outcome = commit_publishes(state, vec![staged]).await?;
     // Past the commit the stage is spent, whatever the transaction could not
     // record: leaving the record listed would offer an approval that cannot
     // happen again.
@@ -409,10 +510,8 @@ async fn serve_staged_approve(
         // cleanup must not report the approval as failed.
         tracing::warn!(error = %err, stage_id, "approved staged publish but its record cleanup failed");
     }
-    if let Err(err) = report_unrecorded(outcome) {
-        return err.into_response();
-    }
-    json_response(StatusCode::CREATED, &json!({ "ok": true }))
+    report_unrecorded(outcome)?;
+    Ok(json_response(StatusCode::CREATED, &json!({ "ok": true })))
 }
 
 /// `GET /-/stage/:id/tarball` — the held tarball's bytes, decoded from the
@@ -472,17 +571,17 @@ async fn load_authorized_record(
     identity: &Identity,
     registry: Option<&str>,
     stage_id: &str,
-) -> Result<StagedRecord, RegistryError> {
-    let record = match read_staged_record(state, stage_id).await {
-        Ok(Some(record)) => record,
+) -> Result<StoredStagedRecord, RegistryError> {
+    let stored = match read_staged_record(state, stage_id).await {
+        Ok(Some(stored)) => stored,
         Ok(None) => return Err(RegistryError::NotFound),
         Err(err) => return Err(err),
     };
-    if record.registry.as_deref() != registry {
+    if stored.record.registry.as_deref() != registry {
         return Err(RegistryError::NotFound);
     }
-    authorize_staged(state, identity, &record).await?;
-    Ok(record)
+    authorize_staged(state, identity, &stored.record).await?;
+    Ok(stored)
 }
 
 /// The `publish` authorization a staged record's package demands, resolved
@@ -507,11 +606,12 @@ async fn authorize_staged(
 async fn read_staged_record(
     state: &AppState,
     stage_id: &str,
-) -> Result<Option<StagedRecord>, RegistryError> {
+) -> Result<Option<StoredStagedRecord>, RegistryError> {
     let Some(bytes) = state.inner.storage.read_staged_meta(stage_id).await? else {
         return Ok(None);
     };
-    serde_json::from_slice(&bytes).map(Some).map_err(RegistryError::Json)
+    let record = serde_json::from_slice(&bytes).map_err(RegistryError::Json)?;
+    Ok(Some(StoredStagedRecord { bytes, record }))
 }
 
 fn actor_of(identity: &Identity) -> (String, String) {

--- a/pnpr/crates/pnpr/src/server/staged.rs
+++ b/pnpr/crates/pnpr/src/server/staged.rs
@@ -15,9 +15,8 @@
 //! endpoint rather than masking.
 //!
 //! Records live in the hosted store, which every replica of a deployment
-//! shares, so an approval claims the record it is about to replay with a
-//! conditional write. A stage is therefore approved once no matter which
-//! replica each request reaches.
+//! shares, so an approval claims the record it is about to replay: a stage is
+//! approved once no matter which replica each request reaches.
 
 use axum::{
     body::Body,
@@ -67,7 +66,6 @@ struct StagedRecord {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     registry: Option<String>,
     /// When the approval holding this record started, if one holds it.
-    /// Written by the conditional claim that makes an approval exclusive.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     approving_since: Option<String>,
 }
@@ -415,9 +413,7 @@ async fn serve_staged_approve(
 }
 
 /// Take the staged record for this approval, refusing one another approval
-/// holds. The claim is the record rewritten with the time it started, under a
-/// conditional write on the bytes that were read: a record another request
-/// claimed, or a rejection removed, is no longer those bytes.
+/// holds.
 async fn claim_for_approval(
     state: &AppState,
     stage_id: &str,

--- a/pnpr/crates/pnpr/src/server/striped_locks.rs
+++ b/pnpr/crates/pnpr/src/server/striped_locks.rs
@@ -1,10 +1,10 @@
 /// A fixed stripe set bounds lock memory while serializing writers for the
 /// same logical resource. Hash collisions only reduce concurrency.
 ///
-/// This guards concurrency **within one instance**. Across replicas
-/// sharing one hosted store, the same race needs a conditional write
-/// (S3 `If-Match` / `ETag`); that is the cross-replica half tracked in
-/// [pnpm/pnpm#12199](https://github.com/pnpm/pnpm/issues/12199).
+/// This guards concurrency **within one instance**. Across replicas sharing
+/// one hosted store the same race is settled by the conditional write every
+/// shared record is written under (S3 `If-Match` / `ETag`), which is what
+/// makes the lock an optimization there rather than the guarantee.
 pub(crate) struct StripedLocks {
     stripes: Box<[tokio::sync::Mutex<()>]>,
 }

--- a/pnpr/crates/pnpr/tests/common/npm.rs
+++ b/pnpr/crates/pnpr/tests/common/npm.rs
@@ -1,0 +1,57 @@
+//! The npm publish fixtures the integration suites send: the document a
+//! client `PUT`s for one version, and the two digests it carries.
+
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use serde_json::{Value, json};
+use std::fmt::Write;
+
+/// The publish document an npm client sends for one version of `name`, with
+/// `tarball` attached. Scoped names take their filename from the last
+/// segment, as npm does.
+pub fn publish_doc(name: &str, version: &str, tarball: &[u8]) -> Value {
+    let basename = name.rsplit('/').next().unwrap_or(name);
+    let filename = format!("{basename}-{version}.tgz");
+    json!({
+        "_id": name,
+        "name": name,
+        "description": "test",
+        "dist-tags": { "latest": version },
+        "versions": {
+            version: {
+                "name": name,
+                "version": version,
+                "dist": {
+                    "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
+                    "shasum": sha1_hex(tarball),
+                    "integrity": sri_sha512(tarball),
+                }
+            }
+        },
+        "_attachments": {
+            filename: {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(tarball),
+                "length": tarball.len()
+            }
+        }
+    })
+}
+
+/// The SRI `sha512-...` string npm clients send in `dist.integrity`.
+pub fn sri_sha512(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+/// The 40-char hex SHA-1 npm clients send in the legacy `dist.shasum` field.
+pub fn sha1_hex(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
+    opts.input(bytes);
+    let integrity = opts.result();
+    let digest_bytes = BASE64.decode(&integrity.hashes[0].digest).unwrap();
+    digest_bytes.iter().fold(String::with_capacity(40), |mut hex, byte| {
+        write!(hex, "{byte:02x}").unwrap();
+        hex
+    })
+}

--- a/pnpr/crates/pnpr/tests/multi_replica.rs
+++ b/pnpr/crates/pnpr/tests/multi_replica.rs
@@ -148,9 +148,15 @@ async fn one_stage_approved_on_two_replicas_publishes_once() {
     let approve_here = first.approve(&stage_id);
     let approve_there = second.approve(&stage_id);
     let (left, right) = tokio::join!(approve_here, approve_there);
-    let approved =
-        [left, right].into_iter().filter(|status| *status == StatusCode::CREATED).count();
-    assert_eq!(approved, 1, "exactly one approval may publish: {left}, {right}");
+    let (approved, refused) =
+        if left == StatusCode::CREATED { (left, right) } else { (right, left) };
+    assert_eq!(approved, StatusCode::CREATED, "one approval must publish: {left}, {right}");
+    assert!(
+        // Whether the loser saw the winner's claim or the record it had
+        // already consumed depends on how far the winner got.
+        refused == StatusCode::CONFLICT || refused == StatusCode::NOT_FOUND,
+        "the other must be refused, not failed: {refused}",
+    );
 
     let packument = first.packument("staged-pkg").await;
     assert_eq!(packument["versions"].as_object().expect("versions").len(), 1);

--- a/pnpr/crates/pnpr/tests/multi_replica.rs
+++ b/pnpr/crates/pnpr/tests/multi_replica.rs
@@ -1,0 +1,241 @@
+//! Several pnpr replicas behind one load balancer: separate processes, each
+//! with its own local scratch and accounts, sharing one hosted object store.
+//!
+//! What holds the deployment together is that every write into that shared
+//! store is conditional, so a request can land on any replica. These tests
+//! drive two routers over one bucket the way a load balancer would spread
+//! requests over two containers.
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use object_store::{ObjectStore, memory::InMemory};
+use pnpr::{Config, HostedStoreConfig, MaxUsers, router};
+use serde_json::{Value, json};
+use std::{
+    fmt::Write,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    sync::Arc,
+};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+/// One replica: its own storage directory (accounts, cache, publish journal)
+/// over the hosted store every replica shares.
+struct Replica {
+    app: axum::Router,
+    token: String,
+    _storage: TempDir,
+}
+
+impl Replica {
+    async fn start(store: &Arc<dyn ObjectStore>) -> Replica {
+        let storage = TempDir::new().unwrap();
+        let listen = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4873));
+        let mut config = Config::static_serve(listen, storage.path().to_path_buf());
+        config.public_url = "http://example.test".to_string();
+        config.auth.htpasswd.max_users = MaxUsers::Unlimited;
+        config.hosted_store =
+            HostedStoreConfig::ObjectStore { store: Arc::clone(store), prefix: String::new() };
+        let app = router(config);
+        // Accounts are per-replica state, so every replica registers the
+        // publisher and issues it a token of its own.
+        let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+        Replica { app, token, _storage: storage }
+    }
+
+    async fn send(&self, method: &str, path: &str, body: Body) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("content-type", "application/json")
+            .header("Authorization", format!("Bearer {}", self.token))
+            .body(body)
+            .unwrap();
+        let response = self.app.clone().oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap_or(Value::Null))
+    }
+
+    async fn publish(&self, name: &str, version: &str, tarball: &[u8]) -> StatusCode {
+        let body = publish_doc(name, version, tarball);
+        self.send("PUT", &format!("/{name}"), Body::from(serde_json::to_vec(&body).unwrap()))
+            .await
+            .0
+    }
+
+    async fn packument(&self, name: &str) -> Value {
+        let (status, document) = self.send("GET", &format!("/{name}"), Body::empty()).await;
+        assert_eq!(status, StatusCode::OK, "{name} must be served by every replica");
+        document
+    }
+
+    async fn stage(&self, name: &str, version: &str, tarball: &[u8]) -> String {
+        let body = publish_doc(name, version, tarball);
+        let (status, payload) = self
+            .send(
+                "POST",
+                &format!("/-/stage/package/{name}"),
+                Body::from(serde_json::to_vec(&body).unwrap()),
+            )
+            .await;
+        assert_eq!(status, StatusCode::CREATED);
+        payload["stageId"].as_str().expect("stageId in response").to_string()
+    }
+
+    async fn approve(&self, stage_id: &str) -> StatusCode {
+        self.send("POST", &format!("/-/stage/{stage_id}/approve"), Body::empty()).await.0
+    }
+}
+
+/// Two replicas publishing different versions of one package at the same time
+/// keep both: the conditional document write makes the loser re-read and merge
+/// rather than write over the version it never saw.
+#[tokio::test]
+async fn concurrent_publishes_of_one_package_keep_both_versions() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let first = Replica::start(&store).await;
+    let second = Replica::start(&store).await;
+
+    let publish_one = first.publish("shared-pkg", "1.0.0", b"one");
+    let publish_two = second.publish("shared-pkg", "2.0.0", b"two");
+    let (left, right) = tokio::join!(publish_one, publish_two);
+    assert_eq!(left, StatusCode::CREATED);
+    assert_eq!(right, StatusCode::CREATED);
+
+    for replica in [&first, &second] {
+        let packument = replica.packument("shared-pkg").await;
+        let versions = packument["versions"].as_object().expect("versions");
+        assert!(versions.contains_key("1.0.0"), "1.0.0 is missing: {versions:?}");
+        assert!(versions.contains_key("2.0.0"), "2.0.0 is missing: {versions:?}");
+    }
+}
+
+/// A staged publish is shared state: it can be created on one replica and
+/// approved on another, and it is spent once it has been.
+#[tokio::test]
+async fn a_stage_created_on_one_replica_is_approved_on_another() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let first = Replica::start(&store).await;
+    let second = Replica::start(&store).await;
+
+    let stage_id = first.stage("staged-pkg", "1.0.0", b"the tarball").await;
+    assert_eq!(second.approve(&stage_id).await, StatusCode::CREATED);
+    assert!(first.packument("staged-pkg").await["versions"]["1.0.0"].is_object());
+    assert_eq!(
+        first.approve(&stage_id).await,
+        StatusCode::NOT_FOUND,
+        "the stage is spent on every replica",
+    );
+}
+
+/// Approving the same stage on two replicas at once publishes it once. The
+/// approval claims the record with a conditional write, so the second replica
+/// finds a record that is no longer the one it read.
+#[tokio::test]
+async fn one_stage_approved_on_two_replicas_publishes_once() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let first = Replica::start(&store).await;
+    let second = Replica::start(&store).await;
+
+    let stage_id = first.stage("staged-pkg", "1.0.0", b"the tarball").await;
+    let approve_here = first.approve(&stage_id);
+    let approve_there = second.approve(&stage_id);
+    let (left, right) = tokio::join!(approve_here, approve_there);
+    let approved =
+        [left, right].into_iter().filter(|status| *status == StatusCode::CREATED).count();
+    assert_eq!(approved, 1, "exactly one approval may publish: {left}, {right}");
+
+    let packument = first.packument("staged-pkg").await;
+    assert_eq!(packument["versions"].as_object().expect("versions").len(), 1);
+    let (status, listing) = second.send("GET", "/-/stage", Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(listing["total"], 0, "the stage is spent");
+}
+
+/// A dist-tag moved through one replica is what every replica serves.
+#[tokio::test]
+async fn a_dist_tag_written_on_one_replica_is_served_by_the_other() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let first = Replica::start(&store).await;
+    let second = Replica::start(&store).await;
+
+    assert_eq!(first.publish("tagged-pkg", "1.0.0", b"one").await, StatusCode::CREATED);
+    assert_eq!(second.publish("tagged-pkg", "2.0.0", b"two").await, StatusCode::CREATED);
+    let (status, _) =
+        first.send("PUT", "/-/package/tagged-pkg/dist-tags/next", Body::from(r#""2.0.0""#)).await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, tags) = second.send("GET", "/-/package/tagged-pkg/dist-tags", Body::empty()).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(tags["next"], "2.0.0");
+}
+
+async fn add_user_and_get_token(app: axum::Router, username: &str, password: &str) -> String {
+    let path = format!("/-/user/org.couchdb.user:{username}");
+    let body = json!({
+        "_id": format!("org.couchdb.user:{username}"),
+        "name": username,
+        "password": password,
+        "email": "foo@bar.net",
+        "type": "user",
+        "roles": [],
+    });
+    let request = Request::put(&path)
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&bytes).unwrap();
+    payload["token"].as_str().expect("token in response").to_string()
+}
+
+fn publish_doc(name: &str, version: &str, tarball: &[u8]) -> Value {
+    let filename = format!("{name}-{version}.tgz");
+    json!({
+        "_id": name,
+        "name": name,
+        "description": "test",
+        "dist-tags": { "latest": version },
+        "versions": {
+            version: {
+                "name": name,
+                "version": version,
+                "dist": {
+                    "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
+                    "shasum": sha1_hex(tarball),
+                    "integrity": sri_sha512(tarball),
+                }
+            }
+        },
+        "_attachments": {
+            filename: {
+                "content_type": "application/octet-stream",
+                "data": BASE64.encode(tarball),
+                "length": tarball.len()
+            }
+        }
+    })
+}
+
+fn sri_sha512(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
+    opts.input(bytes);
+    opts.result().to_string()
+}
+
+fn sha1_hex(bytes: &[u8]) -> String {
+    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
+    opts.input(bytes);
+    let integrity = opts.result();
+    let digest_bytes = BASE64.decode(&integrity.hashes[0].digest).unwrap();
+    digest_bytes.iter().fold(String::with_capacity(40), |mut acc, byte| {
+        write!(acc, "{byte:02x}").unwrap();
+        acc
+    })
+}

--- a/pnpr/crates/pnpr/tests/multi_replica.rs
+++ b/pnpr/crates/pnpr/tests/multi_replica.rs
@@ -6,16 +6,22 @@
 //! drive two routers over one bucket the way a load balancer would spread
 //! requests over two containers.
 
+#[path = "common/npm.rs"]
+mod npm;
+#[path = "common/pausing_store.rs"]
+#[expect(dead_code, reason = "the shared store pauses writes too, which this suite does not need")]
+mod pausing_store;
+
 use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use npm::publish_doc;
 use object_store::{ObjectStore, memory::InMemory};
+use pausing_store::PausingStore;
 use pnpr::{Config, HostedStoreConfig, MaxUsers, router};
 use serde_json::{Value, json};
 use std::{
-    fmt::Write,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     sync::Arc,
 };
@@ -91,9 +97,8 @@ impl Replica {
     }
 }
 
-/// Two replicas publishing different versions of one package at the same time
-/// keep both: the conditional document write makes the loser re-read and merge
-/// rather than write over the version it never saw.
+/// The publish that loses the conditional document write must re-read and
+/// merge; it must not write over the version it never saw.
 #[tokio::test]
 async fn concurrent_publishes_of_one_package_keep_both_versions() {
     let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -114,8 +119,7 @@ async fn concurrent_publishes_of_one_package_keep_both_versions() {
     }
 }
 
-/// A staged publish is shared state: it can be created on one replica and
-/// approved on another, and it is spent once it has been.
+/// A staged record is shared state, not the state of the replica that took it.
 #[tokio::test]
 async fn a_stage_created_on_one_replica_is_approved_on_another() {
     let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -132,9 +136,8 @@ async fn a_stage_created_on_one_replica_is_approved_on_another() {
     );
 }
 
-/// Approving the same stage on two replicas at once publishes it once. The
-/// approval claims the record with a conditional write, so the second replica
-/// finds a record that is no longer the one it read.
+/// Approving one stage on two replicas at once publishes it once: the held
+/// document is replayed by whichever approval claims the record.
 #[tokio::test]
 async fn one_stage_approved_on_two_replicas_publishes_once() {
     let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
@@ -154,6 +157,45 @@ async fn one_stage_approved_on_two_replicas_publishes_once() {
     let (status, listing) = second.send("GET", "/-/stage", Body::empty()).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(listing["total"], 0, "the stage is spent");
+}
+
+/// A rejection reaching one replica takes the stage back from an approval
+/// under way on another, as long as it lands before that approval commits.
+///
+/// The approving replica is paused after it has the held publish in hand,
+/// inside the read of the package it is about to write, which is where a
+/// rejection can still be observed.
+#[tokio::test]
+async fn a_rejection_stops_an_approval_that_has_not_committed() {
+    let objects = Arc::new(PausingStore::default());
+    let store: Arc<dyn ObjectStore> = Arc::clone(&objects) as Arc<dyn ObjectStore>;
+    let approving = Replica::start(&store).await;
+    let rejecting = Replica::start(&store).await;
+
+    let stage_id = approving.stage("staged-pkg", "1.0.0", b"the tarball").await;
+    objects.pause("package.json".to_string());
+    let approval = tokio::spawn({
+        let app = approving.app.clone();
+        let token = approving.token.clone();
+        let path = format!("/-/stage/{stage_id}/approve");
+        async move {
+            let request = Request::post(&path)
+                .header("Authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap();
+            app.oneshot(request).await.unwrap().status()
+        }
+    });
+
+    objects.started.notified().await;
+    let (rejected, _) =
+        rejecting.send("DELETE", &format!("/-/stage/{stage_id}"), Body::empty()).await;
+    assert_eq!(rejected, StatusCode::NO_CONTENT);
+    objects.resume.notify_one();
+
+    assert_ne!(approval.await.unwrap(), StatusCode::CREATED, "the rejection stands");
+    let (status, _) = approving.send("GET", "/staged-pkg", Body::empty()).await;
+    assert_eq!(status, StatusCode::NOT_FOUND, "a rejected publish must not be served");
 }
 
 /// A dist-tag moved through one replica is what every replica serves.
@@ -193,49 +235,4 @@ async fn add_user_and_get_token(app: axum::Router, username: &str, password: &st
     let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     let payload: Value = serde_json::from_slice(&bytes).unwrap();
     payload["token"].as_str().expect("token in response").to_string()
-}
-
-fn publish_doc(name: &str, version: &str, tarball: &[u8]) -> Value {
-    let filename = format!("{name}-{version}.tgz");
-    json!({
-        "_id": name,
-        "name": name,
-        "description": "test",
-        "dist-tags": { "latest": version },
-        "versions": {
-            version: {
-                "name": name,
-                "version": version,
-                "dist": {
-                    "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
-                    "shasum": sha1_hex(tarball),
-                    "integrity": sri_sha512(tarball),
-                }
-            }
-        },
-        "_attachments": {
-            filename: {
-                "content_type": "application/octet-stream",
-                "data": BASE64.encode(tarball),
-                "length": tarball.len()
-            }
-        }
-    })
-}
-
-fn sri_sha512(bytes: &[u8]) -> String {
-    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
-    opts.input(bytes);
-    opts.result().to_string()
-}
-
-fn sha1_hex(bytes: &[u8]) -> String {
-    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
-    opts.input(bytes);
-    let integrity = opts.result();
-    let digest_bytes = BASE64.decode(&integrity.hashes[0].digest).unwrap();
-    digest_bytes.iter().fold(String::with_capacity(40), |mut acc, byte| {
-        write!(acc, "{byte:02x}").unwrap();
-        acc
-    })
 }

--- a/pnpr/crates/pnpr/tests/staged_publish.rs
+++ b/pnpr/crates/pnpr/tests/staged_publish.rs
@@ -470,6 +470,118 @@ async fn an_approval_that_reports_a_conflict_still_consumes_the_stage() {
     assert_eq!(body_json(list.into_body()).await["total"], 0, "the approved stage is spent");
 }
 
+/// Rewrite the stored record of `stage_id` as if another replica had claimed
+/// it for approval `age` ago. The record lives in the hosted store, which is
+/// the one thing replicas of a stateless deployment share.
+fn claim_stage_on_disk(storage: &std::path::Path, stage_id: &str, age: chrono::Duration) {
+    let path = storage.join(".staged").join(format!("{stage_id}.json"));
+    let mut record: Value =
+        serde_json::from_slice(&std::fs::read(&path).expect("staged record on disk")).unwrap();
+    let since = chrono::Utc::now() - age;
+    record["approvingSince"] = json!(since.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+    std::fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
+}
+
+/// A stage is approved once. While another replica's approval holds the
+/// record, this one is refused rather than replaying the held publish a
+/// second time.
+#[tokio::test]
+async fn an_approval_is_refused_while_another_holds_the_record() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+    let doc = publish_doc("staged-pkg", "1.0.0", b"the tarball");
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    claim_stage_on_disk(tmp.path(), &stage_id, chrono::Duration::seconds(3));
+
+    let approve = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CONFLICT);
+    let message = String::from_utf8(body_bytes(approve.into_body()).await).unwrap();
+    assert!(message.contains("already being approved"), "unexpected message: {message}");
+
+    let packument =
+        app.clone().oneshot(request("GET", "/staged-pkg", Body::empty(), None)).await.unwrap();
+    assert_eq!(packument.status(), StatusCode::NOT_FOUND, "the held publish stays held");
+
+    let list = app
+        .oneshot(request("GET", "/-/stage?page=0&perPage=100", Body::empty(), Some(&token)))
+        .await
+        .unwrap();
+    assert_eq!(body_json(list.into_body()).await["total"], 1, "the stage is still approvable");
+}
+
+/// A replica that dies mid-approval leaves its claim behind. The claim is a
+/// lease, so the stage becomes approvable again instead of being stranded
+/// until someone rejects it.
+#[tokio::test]
+async fn a_claim_left_behind_by_a_dead_replica_expires() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+    let doc = publish_doc("staged-pkg", "1.0.0", b"the tarball");
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    claim_stage_on_disk(tmp.path(), &stage_id, chrono::Duration::hours(1));
+
+    let approve = app
+        .clone()
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CREATED);
+
+    let packument = app.oneshot(request("GET", "/staged-pkg", Body::empty(), None)).await.unwrap();
+    assert_eq!(packument.status(), StatusCode::OK);
+}
+
+/// An approval that fails leaves the stage exactly as it found it: the claim
+/// is released, so the next attempt is not turned away as a second approval.
+#[tokio::test]
+async fn a_failed_approval_releases_its_claim() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+    let doc = publish_doc("staged-pkg", "1.0.0", b"the tarball");
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    // Publishing the staged version directly makes every approval of the
+    // stage fail the same way, whatever its claim does.
+    let published =
+        app.clone().oneshot(json_request("PUT", "/staged-pkg", &doc, Some(&token))).await.unwrap();
+    assert_eq!(published.status(), StatusCode::CREATED);
+
+    for attempt in 0..2 {
+        let approve = app
+            .clone()
+            .oneshot(request(
+                "POST",
+                &format!("/-/stage/{stage_id}/approve"),
+                Body::empty(),
+                Some(&token),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(approve.status(), StatusCode::CONFLICT);
+        let message = String::from_utf8(body_bytes(approve.into_body()).await).unwrap();
+        assert!(
+            message.contains("previously published version"),
+            "attempt {attempt} must report the publish conflict, not a claim: {message}",
+        );
+    }
+}
+
 /// Compute the SRI `sha512-...` string the way npm clients send it
 /// in `dist.integrity`.
 fn sri_sha512(bytes: &[u8]) -> String {

--- a/pnpr/crates/pnpr/tests/staged_publish.rs
+++ b/pnpr/crates/pnpr/tests/staged_publish.rs
@@ -1,11 +1,14 @@
 //! Integration tests for the `-/stage` endpoints — the server half of
 //! `pnpm stage`. Static-mode (no upstream) to keep the tests hermetic.
 
+#[path = "common/npm.rs"]
+mod npm;
+
 use axum::{
     body::{Body, to_bytes},
     http::{Request, StatusCode},
 };
-use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
+use npm::{publish_doc, sha1_hex};
 use pnpr::{Config, MaxUsers, router};
 use serde_json::{Value, json};
 use std::{
@@ -58,35 +61,6 @@ async fn add_user_and_get_token(app: axum::Router, username: &str, password: &st
     assert_eq!(response.status(), StatusCode::CREATED);
     let payload = body_json(response.into_body()).await;
     payload["token"].as_str().expect("token in response").to_string()
-}
-
-fn publish_doc(name: &str, version: &str, tarball: &[u8]) -> Value {
-    let basename = name.rsplit('/').next().unwrap_or(name);
-    let filename = format!("{basename}-{version}.tgz");
-    json!({
-        "_id": name,
-        "name": name,
-        "description": "test",
-        "dist-tags": { "latest": version },
-        "versions": {
-            version: {
-                "name": name,
-                "version": version,
-                "dist": {
-                    "tarball": format!("http://localhost:4873/{name}/-/{filename}"),
-                    "shasum": sha1_hex(tarball),
-                    "integrity": sri_sha512(tarball),
-                }
-            }
-        },
-        "_attachments": {
-            filename: {
-                "content_type": "application/octet-stream",
-                "data": BASE64.encode(tarball),
-                "length": tarball.len()
-            }
-        }
-    })
 }
 
 /// Stage `doc` and return the stage id the registry minted.
@@ -580,27 +554,4 @@ async fn a_failed_approval_releases_its_claim() {
             "attempt {attempt} must report the publish conflict, not a claim: {message}",
         );
     }
-}
-
-/// Compute the SRI `sha512-...` string the way npm clients send it
-/// in `dist.integrity`.
-fn sri_sha512(bytes: &[u8]) -> String {
-    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha512);
-    opts.input(bytes);
-    opts.result().to_string()
-}
-
-/// Compute the 40-char hex SHA-1 the way npm clients send it in the
-/// legacy `dist.shasum` field.
-fn sha1_hex(bytes: &[u8]) -> String {
-    let mut opts = ssri::IntegrityOpts::new().algorithm(ssri::Algorithm::Sha1);
-    opts.input(bytes);
-    let integrity = opts.result();
-    let digest_base64 = &integrity.hashes[0].digest;
-    let digest_bytes = BASE64.decode(digest_base64).unwrap();
-    digest_bytes.iter().fold(String::with_capacity(40), |mut acc, byte| {
-        use std::fmt::Write;
-        write!(acc, "{byte:02x}").unwrap();
-        acc
-    })
 }

--- a/pnpr/crates/pnpr/tests/staged_publish.rs
+++ b/pnpr/crates/pnpr/tests/staged_publish.rs
@@ -448,12 +448,68 @@ async fn an_approval_that_reports_a_conflict_still_consumes_the_stage() {
 /// it for approval `age` ago. The record lives in the hosted store, which is
 /// the one thing replicas of a stateless deployment share.
 fn claim_stage_on_disk(storage: &std::path::Path, stage_id: &str, age: chrono::Duration) {
+    let since = chrono::Utc::now() - age;
+    write_claim_on_disk(
+        storage,
+        stage_id,
+        &since.to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    );
+}
+
+/// Stamp `approvingSince` verbatim, for the values a well-behaved replica
+/// does not write.
+fn write_claim_on_disk(storage: &std::path::Path, stage_id: &str, since: &str) {
     let path = storage.join(".staged").join(format!("{stage_id}.json"));
     let mut record: Value =
         serde_json::from_slice(&std::fs::read(&path).expect("staged record on disk")).unwrap();
-    let since = chrono::Utc::now() - age;
-    record["approvingSince"] = json!(since.to_rfc3339_opts(chrono::SecondsFormat::Millis, true));
+    record["approvingSince"] = json!(since);
     std::fs::write(&path, serde_json::to_vec(&record).unwrap()).unwrap();
+}
+
+/// Replicas time their claims by their own clocks. A claim from a replica
+/// running ahead of this one must hold: reading it as expired would hand the
+/// stage to a second approval while the first is still publishing it.
+#[tokio::test]
+async fn a_claim_from_a_replica_whose_clock_runs_ahead_holds() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+    let doc = publish_doc("staged-pkg", "1.0.0", b"the tarball");
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    claim_stage_on_disk(tmp.path(), &stage_id, -chrono::Duration::minutes(2));
+
+    let approve = app
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CONFLICT);
+}
+
+/// A claim pnpr cannot read must not be able to hold a stage forever.
+#[tokio::test]
+async fn a_claim_pnpr_cannot_read_does_not_hold_the_stage() {
+    let tmp = TempDir::new().unwrap();
+    let app = router(static_config(tmp.path().to_path_buf()));
+    let token = add_user_and_get_token(app.clone(), "alice", "secret").await;
+    let doc = publish_doc("staged-pkg", "1.0.0", b"the tarball");
+    let stage_id = stage_package(app.clone(), "staged-pkg", &doc, &token).await;
+    write_claim_on_disk(tmp.path(), &stage_id, "whenever");
+
+    let approve = app
+        .oneshot(request(
+            "POST",
+            &format!("/-/stage/{stage_id}/approve"),
+            Body::empty(),
+            Some(&token),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(approve.status(), StatusCode::CREATED);
 }
 
 /// A stage is approved once. While another replica's approval holds the

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -125,7 +125,24 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
 
     async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>>;
 
-    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()>;
+    /// Write a staged object that does not exist yet. A staged object is
+    /// named by a freshly generated stage id, so an occupied key means
+    /// another record already owns it and must not be overwritten.
+    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()>;
+
+    /// Replace a staged object only while it still holds `expected`.
+    ///
+    /// This is what makes an approval exclusive: the approving replica
+    /// rewrites the record it read, and a replica whose copy is no longer
+    /// what the store holds — because another approval claimed it, or a
+    /// rejection removed it — gets [`DocumentWrite::Conflict`] instead of
+    /// acting on a record that has moved on.
+    async fn replace_staged_if_current(
+        &self,
+        object: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite>;
 
     async fn remove_staged(&self, object: &str) -> Result<bool>;
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -599,8 +599,17 @@ impl HostedBackend for Store {
         Store::read_staged(self, object).await
     }
 
-    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        Store::write_staged(self, object, bytes).await
+    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        Store::create_staged(self, object, bytes).await
+    }
+
+    async fn replace_staged_if_current(
+        &self,
+        object: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite> {
+        Store::replace_staged_if_current(self, object, expected, bytes).await
     }
 
     async fn remove_staged(&self, object: &str) -> Result<bool> {
@@ -980,16 +989,29 @@ impl Storage {
         self.hosted.read_staged(&staged_meta_object(stage_id)?).await
     }
 
-    pub async fn write_staged_meta(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
-        self.hosted.write_staged(&staged_meta_object(stage_id)?, bytes).await
+    pub async fn create_staged_meta(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
+        self.hosted.create_staged(&staged_meta_object(stage_id)?, bytes).await
+    }
+
+    /// Rewrite a staged record's metadata only while it still holds
+    /// `expected`, so an approval acts on the record it read or not at all.
+    /// [`DocumentWrite::Conflict`] means another writer claimed or removed
+    /// the record in the meantime.
+    pub async fn replace_staged_meta_if_current(
+        &self,
+        stage_id: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite> {
+        self.hosted.replace_staged_if_current(&staged_meta_object(stage_id)?, expected, bytes).await
     }
 
     pub async fn read_staged_body(&self, stage_id: &str) -> Result<Option<Vec<u8>>> {
         self.hosted.read_staged(&staged_body_object(stage_id)?).await
     }
 
-    pub async fn write_staged_body(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
-        self.hosted.write_staged(&staged_body_object(stage_id)?, bytes).await
+    pub async fn create_staged_body(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
+        self.hosted.create_staged(&staged_body_object(stage_id)?, bytes).await
     }
 
     /// Remove a staged record — the metadata first, so a concurrent list
@@ -1054,11 +1076,19 @@ fn validated_stage_id(stage_id: &str) -> Result<&str> {
 struct Store {
     root: PathBuf,
     revision_ref_write_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Serializes the read-compare-write of a staged record. One process
+    /// owns this store, so an in-process lock is the whole of the
+    /// compare-and-set the object-store backend gets from an `ETag`.
+    staged_write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Store {
     fn new(root: PathBuf) -> Self {
-        Self { root, revision_ref_write_lock: Arc::new(tokio::sync::Mutex::new(())) }
+        Self {
+            root,
+            revision_ref_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            staged_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+        }
     }
 
     /// A disposable store rooted at a sub-path of this one. Used to give a
@@ -1068,6 +1098,7 @@ impl Store {
         Store {
             root: self.root.join(prefix),
             revision_ref_write_lock: Arc::clone(&self.revision_ref_write_lock),
+            staged_write_lock: Arc::clone(&self.staged_write_lock),
         }
     }
 
@@ -1389,8 +1420,22 @@ impl Store {
         }
     }
 
-    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        write_atomic(&self.root.join(STAGED_DIR).join(object), bytes).await
+    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        write_atomic_new(&self.root.join(STAGED_DIR).join(object), bytes).await
+    }
+
+    async fn replace_staged_if_current(
+        &self,
+        object: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite> {
+        let _guard = self.staged_write_lock.lock().await;
+        if self.read_staged(object).await?.as_deref() != Some(expected) {
+            return Ok(DocumentWrite::Conflict);
+        }
+        write_atomic(&self.root.join(STAGED_DIR).join(object), bytes).await?;
+        Ok(DocumentWrite::Written)
     }
 
     async fn remove_staged(&self, object: &str) -> Result<bool> {

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -1076,9 +1076,10 @@ fn validated_stage_id(stage_id: &str) -> Result<&str> {
 struct Store {
     root: PathBuf,
     revision_ref_write_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Serializes the read-compare-write of a staged record. One process
-    /// owns this store, so an in-process lock is the whole of the
-    /// compare-and-set the object-store backend gets from an `ETag`.
+    /// Serializes the read-compare-write of a staged record against every
+    /// other write to it, removals included. One process owns this store, so
+    /// an in-process lock is the whole of the compare-and-set the
+    /// object-store backend gets from an `ETag`.
     staged_write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
@@ -1438,7 +1439,11 @@ impl Store {
         Ok(DocumentWrite::Written)
     }
 
+    /// Under the staged-write lock, so a removal cannot land between a
+    /// conditional replace's comparison and its write and see the record it
+    /// deleted written back.
     async fn remove_staged(&self, object: &str) -> Result<bool> {
+        let _guard = self.staged_write_lock.lock().await;
         match fs::remove_file(self.root.join(STAGED_DIR).join(object)).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -525,9 +525,60 @@ impl S3Store {
         }
     }
 
-    pub async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        self.store.put(&self.staged_key(object), PutPayload::from(bytes.to_vec())).await?;
+    pub async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        self.store
+            .put_opts(
+                &self.staged_key(object),
+                PutPayload::from(bytes.to_vec()),
+                PutOptions { mode: PutMode::Create, ..PutOptions::default() },
+            )
+            .await?;
         Ok(())
+    }
+
+    /// Rewrite a staged object under `If-Match` on the version the caller
+    /// read, so only one replica can claim a record whose copy is current.
+    /// The bytes are compared as well: a rewrite the caller computed from
+    /// something other than what the bucket holds is a conflict even where
+    /// the version still matches.
+    pub async fn replace_staged_if_current(
+        &self,
+        object: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite> {
+        let key = self.staged_key(object);
+        let result = match self.store.get(&key).await {
+            Ok(result) => result,
+            // Gone: an approval that finished, or a rejection. A store that
+            // failed for any other reason is an error, not a conflict.
+            Err(object_store::Error::NotFound { .. }) => return Ok(DocumentWrite::Conflict),
+            Err(err) => return Err(err.into()),
+        };
+        let version = UpdateVersion {
+            e_tag: result.meta.e_tag.clone(),
+            version: result.meta.version.clone(),
+        };
+        if result.bytes().await?.as_ref() != expected {
+            return Ok(DocumentWrite::Conflict);
+        }
+        match self
+            .store
+            .put_opts(
+                &key,
+                PutPayload::from(bytes.to_vec()),
+                PutOptions { mode: PutMode::Update(version), ..PutOptions::default() },
+            )
+            .await
+        {
+            Ok(_) => Ok(DocumentWrite::Written),
+            Err(
+                object_store::Error::AlreadyExists { .. }
+                | object_store::Error::NotFound { .. }
+                | object_store::Error::Precondition { .. },
+            ) => Ok(DocumentWrite::Conflict),
+            Err(err) => Err(err.into()),
+        }
     }
 
     pub async fn remove_staged(&self, object: &str) -> Result<bool> {
@@ -748,8 +799,17 @@ impl HostedBackend for S3Store {
         S3Store::read_staged(self, object).await
     }
 
-    async fn write_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        S3Store::write_staged(self, object, bytes).await
+    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
+        S3Store::create_staged(self, object, bytes).await
+    }
+
+    async fn replace_staged_if_current(
+        &self,
+        object: &str,
+        expected: &[u8],
+        bytes: &[u8],
+    ) -> Result<DocumentWrite> {
+        S3Store::replace_staged_if_current(self, object, expected, bytes).await
     }
 
     async fn remove_staged(&self, object: &str) -> Result<bool> {

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -1,5 +1,5 @@
 use super::{Body, ObjectStore, S3Store};
-use crate::HostedRevisionRefWrite;
+use crate::{DocumentWrite, HostedRevisionRefWrite};
 use futures_util::TryStreamExt;
 use object_store::{ObjectStoreExt, PutPayload, memory::InMemory, path::Path as ObjectPath};
 use pnpr_config::S3Settings;
@@ -444,4 +444,57 @@ async fn maintenance_inventory_includes_nested_and_unmanifested_repositories() {
         crate::HostedBackend::list_blob_files(&store).try_collect::<Vec<_>>().await.unwrap();
     assert_eq!(files.len(), 3);
     assert!(files.iter().any(|file| file.path == "acme/app/tool/sha256-child"));
+}
+
+/// A staged record is claimed by rewriting it. Two replicas that read the same
+/// record both compute a claim, and only the one whose read is still current
+/// gets to write it.
+#[tokio::test]
+async fn a_staged_record_is_replaced_only_while_it_is_unchanged() {
+    let (store, _staging) = store_with_prefix("");
+    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
+
+    let first = store
+        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","a":1}"#)
+        .await
+        .unwrap();
+    assert_eq!(first, DocumentWrite::Written);
+
+    let second = store
+        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","b":2}"#)
+        .await
+        .unwrap();
+    assert_eq!(second, DocumentWrite::Conflict);
+    assert_eq!(
+        store.read_staged("stage.json").await.unwrap().as_deref(),
+        Some(&br#"{"id":"stage","a":1}"#[..]),
+    );
+}
+
+/// A record another replica removed — a rejection, or an approval that
+/// finished — is not one to write back.
+#[tokio::test]
+async fn a_removed_staged_record_is_not_replaced() {
+    let (store, _staging) = store_with_prefix("");
+    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
+    assert!(store.remove_staged("stage.json").await.unwrap());
+
+    let replaced = store
+        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","a":1}"#)
+        .await
+        .unwrap();
+    assert_eq!(replaced, DocumentWrite::Conflict);
+    assert!(store.read_staged("stage.json").await.unwrap().is_none());
+}
+
+/// Stage ids are minted fresh, so an occupied key belongs to another record.
+#[tokio::test]
+async fn creating_a_staged_record_twice_fails() {
+    let (store, _staging) = store_with_prefix("");
+    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
+    assert!(store.create_staged("stage.json", br#"{"id":"other"}"#).await.is_err());
+    assert_eq!(
+        store.read_staged("stage.json").await.unwrap().as_deref(),
+        Some(&br#"{"id":"stage"}"#[..]),
+    );
 }

--- a/pnpr/crates/storage/src/tests.rs
+++ b/pnpr/crates/storage/src/tests.rs
@@ -252,3 +252,41 @@ async fn package_index_removes_deleted_and_failed_package_entries() {
     assert!(storage.hosted.write_document_if_current(&name, b"{}", None).await.is_err());
     assert!(!index.exists());
 }
+
+/// The local backend has no `ETag`, so its claim on a staged record compares
+/// the bytes: only the writer whose copy is what the store holds wins.
+#[tokio::test]
+async fn a_staged_record_is_replaced_only_while_it_is_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let storage = storage_in(&tmp);
+    let stage_id = "11111111-2222-3333-4444-555555555555";
+    storage.create_staged_meta(stage_id, br#"{"id":"stage"}"#).await.unwrap();
+
+    let first = storage
+        .replace_staged_meta_if_current(stage_id, br#"{"id":"stage"}"#, br#"{"id":"stage","a":1}"#)
+        .await
+        .unwrap();
+    assert_eq!(first, super::DocumentWrite::Written);
+
+    let second = storage
+        .replace_staged_meta_if_current(stage_id, br#"{"id":"stage"}"#, br#"{"id":"stage","b":2}"#)
+        .await
+        .unwrap();
+    assert_eq!(second, super::DocumentWrite::Conflict);
+    assert_eq!(
+        storage.read_staged_meta(stage_id).await.unwrap().as_deref(),
+        Some(&br#"{"id":"stage","a":1}"#[..]),
+    );
+
+    assert!(storage.remove_staged(stage_id).await.unwrap());
+    let removed = storage
+        .replace_staged_meta_if_current(
+            stage_id,
+            br#"{"id":"stage","a":1}"#,
+            br#"{"id":"stage","c":3}"#,
+        )
+        .await
+        .unwrap();
+    assert_eq!(removed, super::DocumentWrite::Conflict);
+    assert!(storage.read_staged_meta(stage_id).await.unwrap().is_none());
+}

--- a/pnpr/npm/pnpr/README.md
+++ b/pnpr/npm/pnpr/README.md
@@ -311,6 +311,38 @@ When the `backend:` block is absent, auth stays on local disk and the
 `auth.htpasswd` / `auth.tokens` settings apply as before. The
 `auth.htpasswd.max_users` registration cap is honored either way.
 
+### Running several replicas
+
+Several `pnpr` processes can serve one registry behind a load balancer once
+they share their state. Give every replica the same `s3:` bucket for hosted
+packages and the same `backend:` database for users and tokens, and give each
+its own `storage` path for what stays local.
+
+Requests need no affinity. Every write into the shared bucket is conditional:
+a publish, a `dist-tag` change, a partial unpublish, and the approval of a
+staged publish each rewrite the package document under the `ETag` they read it
+at, and a replica that loses the race re-reads and merges on top of what the
+other one wrote. A published tarball is written only if its key is still free,
+so two replicas publishing one version can never overwrite each other's bytes:
+the one whose bytes did not land is told so with a `409` instead of
+advertising an integrity the store no longer serves. A staged publish is
+approved once, whichever replica the approval reaches.
+
+This needs an object store that honors the `If-Match` and `If-None-Match`
+preconditions. AWS S3, Cloudflare R2 and MinIO do.
+
+What stays local to each replica:
+
+- the proxy cache of upstream registries, and the resolver cache
+- publish staging scratch and the commit journal that rolls an interrupted
+  publish forward, so keep each replica's `storage` path on a volume that
+  outlives its restarts
+- blob upload sessions of the image registry when hosted packages are on
+  local disk, which is why `docker push` needs sticky sessions there; with
+  `s3:` an upload continues on any replica
+- pipeline run records
+- accounts and tokens, unless a `backend:` database is configured
+
 ## License
 
 Source-available under the [PolyForm Shield License 1.0.0](https://github.com/pnpm/pnpm/blob/main/pnpr/LICENSE.md) — **not** open source. You may run, modify, and self-host pnpr for any purpose except providing a product that competes with it. Commercial / non-compete licenses are available from Zoltan Kochan (<https://kochan.io>).


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#12199 — the cross-replica half of its "cross-cutting caveat".

Most of that half already landed: `#12832` made every hosted packument write compare-and-set on the object's `ETag` (publish, dist-tag, partial unpublish, journal roll-forward) and made a tarball's promotion create-only, and `#14608` made the losing publisher hear about a lost blob. Auditing the shared hosted store for what was still written unconditionally left one path: **staged publishes**.

A staged record lives in the hosted store, which every replica shares, but an approval only *read* it. It never wrote the record back, so nothing arbitrated between two approvals:

- two approvals of one stage reaching two replicas both replayed the held publish (both answered `201`, both uploaded the tarball);
- a rejection landing between another replica's read and its publish did not stop that publish.

The approval now claims the record before replaying it. It rewrites the record with the time the approval started, conditional on the bytes it read: the object-store backend puts that write under `If-Match` on the record's `ETag`, and the local backend, which one process owns, compares the bytes under a staged-write lock. The second approval finds a record that is no longer the one it read and answers `409` (`staged_approval_in_flight`), or `404` once the winner has consumed the stage. The claim is released on every failure path, so a failed approval can be retried at once, and it expires after ten minutes so a replica that died mid-approval does not strand the stage.

The approval also rechecks its claim once its blobs are staged and before it commits — the last moment nothing is visible — and abandons the staged blobs if the record is no longer the one it claimed. That is what makes a rejection meaningful against an approval already under way: rejection stays unconditional (it is the only way to clear a stage whose approving replica died), and it wins whenever it lands before the commit. What no fence removes is the lease overlap itself, which is bounded rather than unsafe: two approvals of one stage replay the same held bytes onto the same immutable blob slot and merge the same version into the document.

Staged records are also created create-only now, so a record can never be written over one another request owns.

The PR also adds `pnpr/crates/pnpr/tests/multi_replica.rs`, which drives two routers over one object store the way a load balancer spreads requests over two containers — the deployment shape the issue is about, which nothing tested before:

- concurrent publishes of one package from both replicas keep both versions;
- a stage created on one replica is approved on another, and is spent everywhere afterwards;
- two replicas approving one stage publish it once (this test fails without the claim, with two `201`s);
- a rejection on one replica stops an approval under way on another — the approving replica is held inside the read of the package it is about to write, through the repo's `PausingStore`, while the rejection goes through (this test publishes the rejected stage without the recheck);
- a dist-tag written on one replica is served by the other.

And a "Running several replicas" section in the pnpr README: what the replicas share, what stays local to each, and that the object store has to honor `If-Match` / `If-None-Match`.

### Still open on pnpm/pnpm#12199 after this

Not write conflicts, but the remaining reasons a deployment is not fully stateless: the proxy cache and accelerator CAS are still local (phase 2), grants and public-packages are still local SQLite (phase 4), pipeline run records are filesystem-only, and each replica's publish journal and staging scratch need a volume that outlives its restarts.

## Squash Commit Body

```text
Staged publish records live in the hosted store, which every replica of an
S3-backed deployment shares, but an approval read the record and replayed the
held publish without ever writing the record back. Two approvals of one stage
reaching two replicas therefore both ran the publish, and a rejection that
landed between another replica's read and its publish did not stop it.

The approval now claims the record first: it rewrites it with the time the
approval started, conditional on the bytes it read. The object-store backend
puts that write under `If-Match` on the record's `ETag`; the local backend,
which one process owns, compares the bytes under a staged-write lock. A second
approval finds a record that is no longer the one it read and answers 409, or
404 once the winner has consumed the stage. The claim is released on every
failure path, and expires after ten minutes so a replica that died mid-approval
does not strand the stage.

Staged records are also written create-only now, so a record can never be
written over one another request owns.

Adds a multi-replica test suite that drives two routers over one object store
the way a load balancer spreads requests over two containers: concurrent
publishes of one package keep both versions, a stage created on one replica is
approved on another, two replicas approving one stage publish it once, and a
dist-tag written on one replica is served by the other.

Related to pnpm/pnpm#12199.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multiple registry replicas can safely share hosted package storage.
  - Staged publish approvals are coordinated across replicas, allowing only one approval to publish.
  - Duplicate approvals return a conflict, while rejected stages stop pending approvals.

- **Bug Fixes**
  - Improved consistency for concurrent publishes, staged records, dist-tags, and removals.
  - Prevented stale or conflicting staged updates from overwriting newer records.

- **Documentation**
  - Added guidance for running multiple replicas, shared storage requirements, and supported object stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->