### PR TITLE
feat(pnpr): keep pipeline run records with the hosted packages

### DIFF
--- a/.changeset/pipeline-runs-in-the-hosted-store.md
+++ b/.changeset/pipeline-runs-in-the-hosted-store.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+Pipeline run records are now stored with the hosted packages, so a run submitted through one replica is listed and served by every other. On a local storage root they move from `<storage>/pipeline-runs/v0` to `<storage>/.pipeline-runs/v0`; move an existing directory there to keep its runs [#12199](https://github.com/pnpm/pnpm/issues/12199).

--- a/.changeset/pipeline-runs-in-the-hosted-store.md
+++ b/.changeset/pipeline-runs-in-the-hosted-store.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Pipeline run records are now stored with the hosted packages, so a run submitted through one replica is listed and served by every other. On a local storage root they move from `<storage>/pipeline-runs/v0` to `<storage>/.pipeline-runs/v0`; move an existing directory there to keep its runs [#12199](https://github.com/pnpm/pnpm/issues/12199).
+Pipeline run records are now stored with the hosted packages. A run submitted through one replica is listed and served by every other. On a local storage root the records move from `pipeline-runs/v0` to `.pipeline-runs/v0`. Move an existing directory there to keep its runs [#12199](https://github.com/pnpm/pnpm/issues/12199).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6454,6 +6454,8 @@ dependencies = [
 name = "pnpr-pipeline-runs"
 version = "0.0.1"
 dependencies = [
+ "object_store",
+ "pnpr-config",
  "pnpr-error",
  "pnpr-storage",
  "serde",

--- a/pnpr/crates/pipeline-runs/Cargo.toml
+++ b/pnpr/crates/pipeline-runs/Cargo.toml
@@ -18,7 +18,9 @@ serde_json   = { workspace = true }
 tokio        = { workspace = true }
 
 [dev-dependencies]
-tempfile = { workspace = true }
+object_store = { workspace = true }
+pnpr-config  = { workspace = true }
+tempfile     = { workspace = true }
 
 [lints]
 workspace = true

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -4,19 +4,15 @@
 //! more: it schedules nothing and executes nothing.
 //!
 //! Records are testimony about something that happened once, not
-//! regenerable derived data, so they live under the authoritative
-//! `storage` root rather than the disposable cache root. This
-//! proof-of-concept tier is filesystem-only; an S3-hosted deployment
-//! keeps its run records on the replica's local storage path.
+//! regenerable derived data, so they live in the hosted store — the
+//! authoritative one every replica of a deployment shares — rather than on
+//! the replica that happened to receive the submission.
 
 use pnpr_error::{RegistryError, Result};
-use pnpr_storage::write_atomic_new;
+use pnpr_storage::Storage;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::{
-    collections::BTreeSet,
-    path::{Path, PathBuf},
-};
+use std::collections::BTreeSet;
 
 /// Bounds a submission the same way the artifact endpoints bound theirs:
 /// a malformed or hostile client must not be able to grow a record
@@ -26,7 +22,8 @@ pub const MAX_NAME_LEN: usize = 100;
 pub const MAX_RUN_EVENTS: usize = 10_000;
 pub const MAX_LIST_RUNS: usize = 200;
 
-const RUNS_DIR: &str = "pipeline-runs/v0";
+/// What a run's key ends in, so a later record kind can share the namespace.
+const RECORD_SUFFIX: &str = ".json";
 
 /// One submitted run: the machine-readable account `pnpm pipeline`
 /// produced, verbatim. The server stores the summary and events as
@@ -55,14 +52,13 @@ pub struct PipelineRunEntry {
 }
 
 pub struct PipelineRunStore {
-    root: PathBuf,
+    storage: Storage,
 }
 
 impl PipelineRunStore {
-    pub fn new(storage_root: &Path) -> Result<Self> {
-        let root = storage_root.join(RUNS_DIR);
-        std::fs::create_dir_all(&root)?;
-        Ok(Self { root })
+    #[must_use]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage }
     }
 
     /// Record one run. Append-only: a run id that already exists for the
@@ -79,61 +75,44 @@ impl PipelineRunStore {
                 ),
             });
         }
-        let path = self.run_path(&run.workspace, &run.run_id);
-        std::fs::create_dir_all(path.parent().expect("run path has a workspace parent"))?;
         let document = serde_json::to_vec(&run)?;
-        match write_atomic_new(&path, &document).await {
-            Err(RegistryError::Io(error)) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                Err(RegistryError::BadRequest {
-                    reason: format!(
-                        "run {} is already recorded for workspace {} (runs are append-only)",
-                        run.run_id, run.workspace,
-                    ),
-                })
-            }
-            result => result,
+        let key = format!("{}{RECORD_SUFFIX}", run.run_id);
+        if self.storage.create_pipeline_run(&run.workspace, &key, &document).await? {
+            return Ok(());
         }
+        Err(RegistryError::BadRequest {
+            reason: format!(
+                "run {} is already recorded for workspace {} (runs are append-only)",
+                run.run_id, run.workspace,
+            ),
+        })
     }
 
     /// The most recent runs, newest first — run ids sort by their leading
     /// timestamp. `workspace` narrows the listing to one workspace.
-    pub fn list(&self, workspace: Option<&str>, limit: usize) -> Result<Vec<PipelineRunEntry>> {
+    pub async fn list(
+        &self,
+        workspace: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<PipelineRunEntry>> {
         let limit = limit.clamp(1, MAX_LIST_RUNS);
-        let workspaces: Vec<String> = if let Some(workspace) = workspace {
+        if let Some(workspace) = workspace {
             validate_name(workspace, "workspace")?;
-            vec![workspace.to_string()]
-        } else {
-            let mut workspaces = Vec::new();
-            for entry in read_dir_or_empty(&self.root)? {
-                let entry = entry?;
-                if entry.file_type()?.is_dir()
-                    && let Some(name) = entry.file_name().to_str()
-                {
-                    workspaces.push(name.to_string());
-                }
-            }
-            workspaces
-        };
+        }
         let mut newest = BTreeSet::new();
-        for workspace in workspaces {
-            for entry in read_dir_or_empty(&self.root.join(&workspace))? {
-                let entry = entry?;
-                let file_name = entry.file_name();
-                let Some(run_id) = file_name.to_str().and_then(|name| name.strip_suffix(".json"))
-                else {
-                    continue;
-                };
-                if entry.file_type()?.is_file() {
-                    newest.insert((run_id.to_string(), workspace.clone()));
-                    if newest.len() > limit {
-                        newest.pop_first();
-                    }
-                }
+        for (recorded_workspace, run_id) in self.storage.list_pipeline_runs().await? {
+            if workspace.is_some_and(|wanted| wanted != recorded_workspace) {
+                continue;
+            }
+            let Some(run_id) = run_id.strip_suffix(RECORD_SUFFIX) else { continue };
+            newest.insert((run_id.to_string(), recorded_workspace));
+            if newest.len() > limit {
+                newest.pop_first();
             }
         }
         let mut entries = Vec::with_capacity(newest.len());
         for (run_id, workspace) in newest.into_iter().rev() {
-            if let Some(record) = self.get(&workspace, &run_id)? {
+            if let Some(record) = self.get(&workspace, &run_id).await? {
                 entries.push(PipelineRunEntry { workspace, run_id, summary: record.summary });
             }
         }
@@ -142,35 +121,15 @@ impl PipelineRunStore {
 
     /// One run's full record — summary and event stream — or `None` when
     /// nothing was recorded under that identity.
-    pub fn get(&self, workspace: &str, run_id: &str) -> Result<Option<PublishPipelineRun>> {
+    pub async fn get(&self, workspace: &str, run_id: &str) -> Result<Option<PublishPipelineRun>> {
         validate_name(workspace, "workspace")?;
         validate_name(run_id, "runId")?;
-        read_run(&self.run_path(workspace, run_id))
+        let key = format!("{run_id}{RECORD_SUFFIX}");
+        let Some(bytes) = self.storage.read_pipeline_run(workspace, &key).await? else {
+            return Ok(None);
+        };
+        Ok(Some(serde_json::from_slice(&bytes)?))
     }
-
-    fn run_path(&self, workspace: &str, run_id: &str) -> PathBuf {
-        self.root.join(workspace).join(format!("{run_id}.json"))
-    }
-}
-
-fn read_run(path: &Path) -> Result<Option<PublishPipelineRun>> {
-    let text = match std::fs::read(path) {
-        Ok(text) => text,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(error) => return Err(error.into()),
-    };
-    Ok(Some(serde_json::from_slice(&text)?))
-}
-
-fn read_dir_or_empty(
-    path: &Path,
-) -> Result<impl Iterator<Item = std::io::Result<std::fs::DirEntry>>> {
-    let entries = match std::fs::read_dir(path) {
-        Ok(entries) => Some(entries),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
-        Err(error) => return Err(error.into()),
-    };
-    Ok(entries.into_iter().flatten())
 }
 
 /// The identifiers key filesystem paths, so their alphabet is closed:

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -101,7 +101,13 @@ impl PipelineRunStore {
         for workspace in workspaces {
             validate_name(workspace, "workspace")?;
             for key in self.storage.list_pipeline_runs(workspace).await? {
+                // Only what this store writes is a run: anything else under
+                // the workspace — a nested path, a file with another suffix —
+                // is passed over rather than failing the listing.
                 let Some(run_id) = key.strip_suffix(RECORD_SUFFIX) else { continue };
+                if validate_name(run_id, "runId").is_err() {
+                    continue;
+                }
                 newest.insert((run_id.to_string(), (*workspace).to_string()));
                 if newest.len() > limit {
                     newest.pop_first();
@@ -126,7 +132,11 @@ impl PipelineRunStore {
         let Some(bytes) = self.storage.read_pipeline_run(workspace, &key).await? else {
             return Ok(None);
         };
-        Ok(Some(serde_json::from_slice(&bytes)?))
+        serde_json::from_slice(&bytes).map(Some).map_err(|error| RegistryError::Internal {
+            // Name the record: it is one of many in a store several replicas
+            // write, and an operator has to be able to find the one at fault.
+            reason: format!("pipeline run {workspace}/{run_id} is not readable: {error}"),
+        })
     }
 }
 

--- a/pnpr/crates/pipeline-runs/src/lib.rs
+++ b/pnpr/crates/pipeline-runs/src/lib.rs
@@ -88,26 +88,24 @@ impl PipelineRunStore {
         })
     }
 
-    /// The most recent runs, newest first — run ids sort by their leading
-    /// timestamp. `workspace` narrows the listing to one workspace.
-    pub async fn list(
-        &self,
-        workspace: Option<&str>,
-        limit: usize,
-    ) -> Result<Vec<PipelineRunEntry>> {
+    /// The most recent runs across `workspaces`, newest first — run ids sort
+    /// by their leading timestamp.
+    ///
+    /// Only the runs that make the page are read: the ids are picked from the
+    /// listing first, so a long history costs a listing rather than a read per
+    /// record. Every workspace to search is named, because which ones a caller
+    /// may see is the endpoint's decision, not the store's.
+    pub async fn list(&self, workspaces: &[&str], limit: usize) -> Result<Vec<PipelineRunEntry>> {
         let limit = limit.clamp(1, MAX_LIST_RUNS);
-        if let Some(workspace) = workspace {
-            validate_name(workspace, "workspace")?;
-        }
         let mut newest = BTreeSet::new();
-        for (recorded_workspace, run_id) in self.storage.list_pipeline_runs().await? {
-            if workspace.is_some_and(|wanted| wanted != recorded_workspace) {
-                continue;
-            }
-            let Some(run_id) = run_id.strip_suffix(RECORD_SUFFIX) else { continue };
-            newest.insert((run_id.to_string(), recorded_workspace));
-            if newest.len() > limit {
-                newest.pop_first();
+        for workspace in workspaces {
+            validate_name(workspace, "workspace")?;
+            for key in self.storage.list_pipeline_runs(workspace).await? {
+                let Some(run_id) = key.strip_suffix(RECORD_SUFFIX) else { continue };
+                newest.insert((run_id.to_string(), (*workspace).to_string()));
+                if newest.len() > limit {
+                    newest.pop_first();
+                }
             }
         }
         let mut entries = Vec::with_capacity(newest.len());

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -124,8 +124,8 @@ async fn listing_does_not_parse_records_outside_the_requested_page() {
     assert_eq!(store.list(&["demo"], 1).await.unwrap()[0].run_id, "200-default");
 }
 
-/// A listing reads one workspace's keys, not the whole store's: a workspace
-/// no one asked about cannot slow down or break the answer.
+/// A workspace no one asked about must not be able to slow down or break the
+/// answer.
 #[tokio::test]
 async fn a_listing_is_scoped_to_the_workspaces_it_was_given() {
     let root = TempDir::new().unwrap();
@@ -139,9 +139,41 @@ async fn a_listing_is_scoped_to_the_workspaces_it_was_given() {
     assert_eq!(listed[0].run_id, "100-default");
 }
 
-/// Run records are the account of something that happened once, so they
-/// belong to the deployment rather than to the replica that was asked. A run
-/// recorded through one replica is served by every other.
+/// An operator should hear that a record cannot be read, and be told which.
+#[tokio::test]
+async fn a_corrupt_record_on_the_page_is_named() {
+    let root = TempDir::new().unwrap();
+    let storage = storage_in(&HostedStoreConfig::Fs, &root);
+    let store = PipelineRunStore::new(storage.clone());
+    storage.create_pipeline_run("demo", "100-default.json", b"invalid JSON").await.unwrap();
+
+    let error = store.list(&["demo"], 10).await.expect_err("the listing fails");
+    let rendered = error.to_string();
+    assert!(rendered.contains("demo/100-default"), "unexpected error: {rendered}");
+}
+
+/// A listing must not fail because something the store did not write is under
+/// the workspace.
+#[tokio::test]
+async fn a_key_the_store_did_not_write_is_passed_over() {
+    let root = TempDir::new().unwrap();
+    let storage = storage_in(&HostedStoreConfig::Fs, &root);
+    let store = PipelineRunStore::new(storage.clone());
+    store.publish(&run("demo", "100-default")).await.unwrap();
+    std::fs::create_dir_all(root.path().join("storage/.pipeline-runs/v0/demo/nested")).unwrap();
+    std::fs::write(
+        root.path().join("storage/.pipeline-runs/v0/demo/nested/deeper.json"),
+        b"invalid JSON",
+    )
+    .unwrap();
+    std::fs::write(root.path().join("storage/.pipeline-runs/v0/demo/notes.txt"), b"notes").unwrap();
+
+    let listed = store.list(&["demo"], 10).await.expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].run_id, "100-default");
+}
+
+/// Run records belong to the deployment, not to the replica that was asked.
 #[tokio::test]
 async fn a_run_recorded_on_one_replica_is_served_by_another() {
     let bucket: Arc<dyn object_store::ObjectStore> =

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -14,7 +14,6 @@ fn run(workspace: &str, run_id: &str) -> PublishPipelineRun {
     }
 }
 
-/// A run store over a local storage root, as a single-node deployment has.
 fn local_store(root: &TempDir) -> PipelineRunStore {
     PipelineRunStore::new(storage_in(&HostedStoreConfig::Fs, root))
 }
@@ -44,15 +43,15 @@ async fn list_returns_newest_first_and_honors_the_workspace_filter() {
     store.publish(&run("ws-a", "200-default")).await.expect("publish");
     store.publish(&run("ws-b", "150-default")).await.expect("publish");
 
-    let all = store.list(None, 10).await.expect("list");
+    let all = store.list(&["ws-a", "ws-b"], 10).await.expect("list");
     let ids: Vec<&str> = all.iter().map(|entry| entry.run_id.as_str()).collect();
     assert_eq!(ids, ["200-default", "150-default", "100-default"]);
 
-    let only_a = store.list(Some("ws-a"), 10).await.expect("list");
+    let only_a = store.list(&["ws-a"], 10).await.expect("list");
     assert_eq!(only_a.len(), 2);
     assert!(only_a.iter().all(|entry| entry.workspace == "ws-a"));
 
-    let limited = store.list(None, 1).await.expect("list");
+    let limited = store.list(&["ws-a", "ws-b"], 1).await.expect("list");
     assert_eq!(limited.len(), 1);
     assert_eq!(limited[0].run_id, "200-default");
 }
@@ -122,7 +121,22 @@ async fn listing_does_not_parse_records_outside_the_requested_page() {
     let store = PipelineRunStore::new(storage.clone());
     store.publish(&run("demo", "200-default")).await.unwrap();
     storage.create_pipeline_run("demo", "100-default.json", b"invalid JSON").await.unwrap();
-    assert_eq!(store.list(Some("demo"), 1).await.unwrap()[0].run_id, "200-default");
+    assert_eq!(store.list(&["demo"], 1).await.unwrap()[0].run_id, "200-default");
+}
+
+/// A listing reads one workspace's keys, not the whole store's: a workspace
+/// no one asked about cannot slow down or break the answer.
+#[tokio::test]
+async fn a_listing_is_scoped_to_the_workspaces_it_was_given() {
+    let root = TempDir::new().unwrap();
+    let storage = storage_in(&HostedStoreConfig::Fs, &root);
+    let store = PipelineRunStore::new(storage.clone());
+    store.publish(&run("wanted", "100-default")).await.unwrap();
+    storage.create_pipeline_run("ignored", "999-default.json", b"invalid JSON").await.unwrap();
+
+    let listed = store.list(&["wanted"], 10).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].run_id, "100-default");
 }
 
 /// Run records are the account of something that happened once, so they
@@ -143,7 +157,7 @@ async fn a_run_recorded_on_one_replica_is_served_by_another() {
 
     let stored = serving.get("demo", "100-default").await.expect("get").expect("run exists");
     assert_eq!(stored.summary["runId"], "100-default");
-    let listed = serving.list(None, 10).await.expect("list");
+    let listed = serving.list(&["demo"], 10).await.expect("list");
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].run_id, "100-default");
     assert!(

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -139,6 +139,16 @@ async fn a_listing_is_scoped_to_the_workspaces_it_was_given() {
     assert_eq!(listed[0].run_id, "100-default");
 }
 
+/// The state every deployment starts in: a configured workspace nothing has
+/// reported a run for yet.
+#[tokio::test]
+async fn a_workspace_with_no_runs_lists_empty() {
+    let root = TempDir::new().unwrap();
+    let store = local_store(&root);
+    assert!(store.list(&["never-run"], 10).await.expect("list").is_empty());
+    assert!(store.get("never-run", "100-default").await.expect("get").is_none());
+}
+
 /// An operator should hear that a record cannot be read, and be told which.
 #[tokio::test]
 async fn a_corrupt_record_on_the_page_is_named() {

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -1,5 +1,8 @@
 use super::{PipelineRunStore, PublishPipelineRun};
+use pnpr_config::HostedStoreConfig;
+use pnpr_storage::Storage;
 use serde_json::json;
+use std::sync::Arc;
 use tempfile::TempDir;
 
 fn run(workspace: &str, run_id: &str) -> PublishPipelineRun {
@@ -11,35 +14,45 @@ fn run(workspace: &str, run_id: &str) -> PublishPipelineRun {
     }
 }
 
+/// A run store over a local storage root, as a single-node deployment has.
+fn local_store(root: &TempDir) -> PipelineRunStore {
+    PipelineRunStore::new(storage_in(&HostedStoreConfig::Fs, root))
+}
+
+fn storage_in(hosted: &HostedStoreConfig, root: &TempDir) -> Storage {
+    Storage::new(hosted, root.path().join("storage"), root.path().join("cache"))
+        .expect("open storage")
+}
+
 #[tokio::test]
 async fn publish_then_get_roundtrips_the_record() {
     let root = TempDir::new().expect("create storage root");
-    let store = PipelineRunStore::new(root.path()).expect("open store");
+    let store = local_store(&root);
     store.publish(&run("demo-1234", "100-default")).await.expect("publish");
 
-    let stored = store.get("demo-1234", "100-default").expect("get").expect("run exists");
+    let stored = store.get("demo-1234", "100-default").await.expect("get").expect("run exists");
     assert_eq!(stored.summary["pipeline"], "default");
     assert_eq!(stored.events.len(), 1);
-    assert!(store.get("demo-1234", "999-missing").expect("get").is_none());
+    assert!(store.get("demo-1234", "999-missing").await.expect("get").is_none());
 }
 
 #[tokio::test]
 async fn list_returns_newest_first_and_honors_the_workspace_filter() {
     let root = TempDir::new().expect("create storage root");
-    let store = PipelineRunStore::new(root.path()).expect("open store");
+    let store = local_store(&root);
     store.publish(&run("ws-a", "100-default")).await.expect("publish");
     store.publish(&run("ws-a", "200-default")).await.expect("publish");
     store.publish(&run("ws-b", "150-default")).await.expect("publish");
 
-    let all = store.list(None, 10).expect("list");
+    let all = store.list(None, 10).await.expect("list");
     let ids: Vec<&str> = all.iter().map(|entry| entry.run_id.as_str()).collect();
     assert_eq!(ids, ["200-default", "150-default", "100-default"]);
 
-    let only_a = store.list(Some("ws-a"), 10).expect("list");
+    let only_a = store.list(Some("ws-a"), 10).await.expect("list");
     assert_eq!(only_a.len(), 2);
     assert!(only_a.iter().all(|entry| entry.workspace == "ws-a"));
 
-    let limited = store.list(None, 1).expect("list");
+    let limited = store.list(None, 1).await.expect("list");
     assert_eq!(limited.len(), 1);
     assert_eq!(limited[0].run_id, "200-default");
 }
@@ -47,7 +60,7 @@ async fn list_returns_newest_first_and_honors_the_workspace_filter() {
 #[tokio::test]
 async fn a_run_id_is_append_only() {
     let root = TempDir::new().expect("create storage root");
-    let store = PipelineRunStore::new(root.path()).expect("open store");
+    let store = local_store(&root);
     store.publish(&run("demo", "100-default")).await.expect("publish");
 
     let error = store.publish(&run("demo", "100-default")).await.expect_err("re-publish refused");
@@ -58,7 +71,7 @@ async fn a_run_id_is_append_only() {
 #[tokio::test]
 async fn path_shaped_identifiers_are_refused() {
     let root = TempDir::new().expect("create storage root");
-    let store = PipelineRunStore::new(root.path()).expect("open store");
+    let store = local_store(&root);
     for (workspace, run_id) in [
         ("../escape", "100-default"),
         ("demo/nested", "100-default"),
@@ -72,15 +85,18 @@ async fn path_shaped_identifiers_are_refused() {
             rendered.contains("ASCII"),
             "unexpected error for {workspace}/{run_id}: {rendered}",
         );
-        assert!(store.get(workspace, run_id).is_err(), "get must refuse {workspace}/{run_id}");
+        assert!(
+            store.get(workspace, run_id).await.is_err(),
+            "get must refuse {workspace}/{run_id}",
+        );
     }
 }
 
 #[tokio::test]
 async fn concurrent_publications_cannot_replace_the_winner() {
     let root = TempDir::new().unwrap();
-    let first_store = PipelineRunStore::new(root.path()).unwrap();
-    let second_store = PipelineRunStore::new(root.path()).unwrap();
+    let first_store = local_store(&root);
+    let second_store = local_store(&root);
     let first = run("demo", "100-default");
     let mut second = run("demo", "100-default");
     second.summary = json!({"publisher": "second"});
@@ -89,19 +105,49 @@ async fn concurrent_publications_cannot_replace_the_winner() {
     let (first_result, second_result) = tokio::join!(first_publication, second_publication);
     assert_ne!(first_result.is_ok(), second_result.is_ok(), "exactly one writer must succeed");
     let expected = if first_result.is_ok() { first.summary } else { second.summary };
-    assert_eq!(first_store.get("demo", "100-default").unwrap().unwrap().summary, expected);
+    let winner = first_store.get("demo", "100-default").await.unwrap().unwrap();
+    assert_eq!(winner.summary, expected);
     assert!(
         second_store.publish(&run("demo", "100-default")).await.is_err(),
         "later publication must be refused",
     );
-    assert_eq!(second_store.get("demo", "100-default").unwrap().unwrap().summary, expected);
+    let seen_by_second = second_store.get("demo", "100-default").await.unwrap().unwrap();
+    assert_eq!(seen_by_second.summary, expected);
 }
 
 #[tokio::test]
 async fn listing_does_not_parse_records_outside_the_requested_page() {
     let root = TempDir::new().unwrap();
-    let store = PipelineRunStore::new(root.path()).unwrap();
+    let storage = storage_in(&HostedStoreConfig::Fs, &root);
+    let store = PipelineRunStore::new(storage.clone());
     store.publish(&run("demo", "200-default")).await.unwrap();
-    std::fs::write(store.run_path("demo", "100-default"), "invalid JSON").unwrap();
-    assert_eq!(store.list(Some("demo"), 1).unwrap()[0].run_id, "200-default");
+    storage.create_pipeline_run("demo", "100-default.json", b"invalid JSON").await.unwrap();
+    assert_eq!(store.list(Some("demo"), 1).await.unwrap()[0].run_id, "200-default");
+}
+
+/// Run records are the account of something that happened once, so they
+/// belong to the deployment rather than to the replica that was asked. A run
+/// recorded through one replica is served by every other.
+#[tokio::test]
+async fn a_run_recorded_on_one_replica_is_served_by_another() {
+    let bucket: Arc<dyn object_store::ObjectStore> =
+        Arc::new(object_store::memory::InMemory::new());
+    let hosted =
+        HostedStoreConfig::ObjectStore { store: Arc::clone(&bucket), prefix: String::new() };
+    let recording_root = TempDir::new().unwrap();
+    let serving_root = TempDir::new().unwrap();
+    let recording = PipelineRunStore::new(storage_in(&hosted, &recording_root));
+    let serving = PipelineRunStore::new(storage_in(&hosted, &serving_root));
+
+    recording.publish(&run("demo", "100-default")).await.expect("publish");
+
+    let stored = serving.get("demo", "100-default").await.expect("get").expect("run exists");
+    assert_eq!(stored.summary["runId"], "100-default");
+    let listed = serving.list(None, 10).await.expect("list");
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].run_id, "100-default");
+    assert!(
+        serving.publish(&run("demo", "100-default")).await.is_err(),
+        "a run recorded on one replica is append-only on every replica",
+    );
 }

--- a/pnpr/crates/pipeline-runs/src/tests.rs
+++ b/pnpr/crates/pipeline-runs/src/tests.rs
@@ -124,8 +124,8 @@ async fn listing_does_not_parse_records_outside_the_requested_page() {
     assert_eq!(store.list(&["demo"], 1).await.unwrap()[0].run_id, "200-default");
 }
 
-/// A workspace no one asked about must not be able to slow down or break the
-/// answer.
+/// A listing costs what the workspaces asked about hold, not what the
+/// deployment holds.
 #[tokio::test]
 async fn a_listing_is_scoped_to_the_workspaces_it_was_given() {
     let root = TempDir::new().unwrap();
@@ -152,8 +152,6 @@ async fn a_corrupt_record_on_the_page_is_named() {
     assert!(rendered.contains("demo/100-default"), "unexpected error: {rendered}");
 }
 
-/// A listing must not fail because something the store did not write is under
-/// the workspace.
 #[tokio::test]
 async fn a_key_the_store_did_not_write_is_passed_over() {
     let root = TempDir::new().unwrap();

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3071,21 +3071,22 @@ async fn serve_list_pipeline_runs(
         return private_no_cache(error.into_response());
     }
     let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
-    let mut runs = Vec::new();
-    for (name, policy) in &state.inner.config.pipeline.workspaces {
-        if !policy.access.allows(&identity)
-            || workspace.as_ref().is_some_and(|requested| requested != name)
-        {
-            continue;
-        }
-        match store.list(Some(name), limit).await {
-            Ok(entries) => runs.extend(entries),
-            Err(error) => return private_no_cache(error.into_response()),
-        }
-        runs.sort_by(|left, right| right.run_id.cmp(&left.run_id));
-        runs.truncate(limit);
-    }
-    private_no_cache(axum::Json(serde_json::json!({ "runs": runs })).into_response())
+    let visible: Vec<&str> = state
+        .inner
+        .config
+        .pipeline
+        .workspaces
+        .iter()
+        .filter(|(name, policy)| {
+            policy.access.allows(&identity)
+                && workspace.as_ref().is_none_or(|requested| requested == *name)
+        })
+        .map(|(name, _)| name.as_str())
+        .collect();
+    private_no_cache(match store.list(&visible, limit).await {
+        Ok(runs) => axum::Json(serde_json::json!({ "runs": runs })).into_response(),
+        Err(error) => error.into_response(),
+    })
 }
 
 /// `GET /-/pnpr/v0/pipeline/runs/{workspace}/{run_id}` — one run's full

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -3070,31 +3070,22 @@ async fn serve_list_pipeline_runs(
     {
         return private_no_cache(error.into_response());
     }
-    let result = tokio::task::spawn_blocking(move || {
-        let store =
-            state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
-        let mut runs = Vec::new();
-        for (name, policy) in &state.inner.config.pipeline.workspaces {
-            if !policy.access.allows(&identity)
-                || workspace.as_ref().is_some_and(|requested| requested != name)
-            {
-                continue;
-            }
-            match store.list(Some(name), limit) {
-                Ok(entries) => runs.extend(entries),
-                Err(error) => return Err(error),
-            }
-            runs.sort_by(|left, right| right.run_id.cmp(&left.run_id));
-            runs.truncate(limit);
+    let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
+    let mut runs = Vec::new();
+    for (name, policy) in &state.inner.config.pipeline.workspaces {
+        if !policy.access.allows(&identity)
+            || workspace.as_ref().is_some_and(|requested| requested != name)
+        {
+            continue;
         }
-        Ok::<_, RegistryError>(runs)
-    })
-    .await;
-    private_no_cache(match result {
-        Ok(Ok(runs)) => axum::Json(serde_json::json!({ "runs": runs })).into_response(),
-        Ok(Err(error)) => error.into_response(),
-        Err(error) => RegistryError::Io(std::io::Error::other(error)).into_response(),
-    })
+        match store.list(Some(name), limit).await {
+            Ok(entries) => runs.extend(entries),
+            Err(error) => return private_no_cache(error.into_response()),
+        }
+        runs.sort_by(|left, right| right.run_id.cmp(&left.run_id));
+        runs.truncate(limit);
+    }
+    private_no_cache(axum::Json(serde_json::json!({ "runs": runs })).into_response())
 }
 
 /// `GET /-/pnpr/v0/pipeline/runs/{workspace}/{run_id}` — one run's full
@@ -3108,7 +3099,7 @@ async fn serve_get_pipeline_run(
         return private_no_cache(error.into_response());
     }
     let store = state.inner.pipeline_runs.as_ref().expect("pipeline routes require a run store");
-    private_no_cache(match store.get(&workspace, &run_id) {
+    private_no_cache(match store.get(&workspace, &run_id).await {
         Ok(Some(run)) => axum::Json(run).into_response(),
         Ok(None) => not_found(),
         Err(err) => err.into_response(),

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -65,9 +65,8 @@ pub(super) fn router_with_auth_and_osv(
     let resolver_enabled = config.resolver.enabled;
     let artifacts_enabled = config.artifacts.enabled;
     let pipeline_enabled = config.pipeline.enabled;
-    let pipeline_runs = pipeline_enabled
-        .then(|| pnpr_pipeline_runs::PipelineRunStore::new(&config.storage))
-        .transpose()?;
+    let pipeline_runs =
+        pipeline_enabled.then(|| pnpr_pipeline_runs::PipelineRunStore::new(storage.clone()));
     let artifacts = artifacts_enabled
         .then(|| {
             pnpr_shared_artifacts::SharedArtifactStore::new(

--- a/pnpr/crates/storage/src/backend.rs
+++ b/pnpr/crates/storage/src/backend.rs
@@ -123,30 +123,43 @@ pub(crate) trait HostedBackend: Debug + Send + Sync {
     /// through `std::fs` and needs a real path.
     fn local_scratch_root(&self) -> &Path;
 
-    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>>;
+    // --- Records ---------------------------------------------------------
+    //
+    // The store also holds what the registry itself keeps beside the packages:
+    // staged publishes waiting for approval, pipeline run records. Each such
+    // kind owns a reserved namespace of the hosted store — a dot-prefixed
+    // segment, which no package name can occupy — and addresses its records by
+    // a key within it. `Storage` names the namespaces; a backend only maps a
+    // namespace and key onto a path or an object key.
 
-    /// Write a staged object that does not exist yet. A staged object is
-    /// named by a freshly generated stage id, so an occupied key means
-    /// another record already owns it and must not be overwritten.
-    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()>;
+    async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>>;
 
-    /// Replace a staged object only while it still holds `expected`.
+    /// Write a record where nothing is stored yet, reporting `false` when the
+    /// key is taken. Records that must not be rewritten — an approved-once
+    /// staged publish, an append-only run record — are created this way, so a
+    /// second writer is told rather than overwriting the first.
+    async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool>;
+
+    /// Replace a record only while it still holds `expected`.
     ///
-    /// This is what makes an approval exclusive: the approving replica
-    /// rewrites the record it read, and a replica whose copy is no longer
-    /// what the store holds — because another approval claimed it, or a
-    /// rejection removed it — gets [`DocumentWrite::Conflict`] instead of
-    /// acting on a record that has moved on.
-    async fn replace_staged_if_current(
+    /// This is what makes a staged approval exclusive: the approving replica
+    /// rewrites the record it read, and a replica whose copy is no longer what
+    /// the store holds — because another approval claimed it, or a rejection
+    /// removed it — gets [`DocumentWrite::Conflict`] instead of acting on a
+    /// record that has moved on.
+    async fn replace_record_if_current(
         &self,
-        object: &str,
+        namespace: &str,
+        key: &str,
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite>;
 
-    async fn remove_staged(&self, object: &str) -> Result<bool>;
+    async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool>;
 
-    async fn list_staged_ids(&self) -> Result<Vec<String>>;
+    /// Every key stored in `namespace`, in unspecified order, relative to the
+    /// namespace and `/`-separated whatever the backend stores them on.
+    async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>>;
 }
 
 #[derive(Debug)]

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -1084,14 +1084,12 @@ impl Storage {
         self.hosted.create_record(PIPELINE_RUNS_DIR, &key, bytes).await
     }
 
-    /// Every recorded run as `(workspace, run id)`, in unspecified order.
-    pub async fn list_pipeline_runs(&self) -> Result<Vec<(String, String)>> {
-        let keys = self.hosted.list_record_keys(PIPELINE_RUNS_DIR).await?;
-        Ok(keys
-            .iter()
-            .filter_map(|key| key.split_once('/'))
-            .map(|(workspace, run_id)| (workspace.to_string(), run_id.to_string()))
-            .collect())
+    /// One workspace's recorded run keys, in unspecified order. Scoped to the
+    /// workspace so a listing costs what that workspace holds rather than what
+    /// the deployment holds.
+    pub async fn list_pipeline_runs(&self, workspace: &str) -> Result<Vec<String>> {
+        let namespace = format!("{PIPELINE_RUNS_DIR}/{}", validated_record_name(workspace)?);
+        self.hosted.list_record_keys(&namespace).await
     }
 }
 

--- a/pnpr/crates/storage/src/lib.rs
+++ b/pnpr/crates/storage/src/lib.rs
@@ -595,29 +595,30 @@ impl HostedBackend for Store {
         &self.root
     }
 
-    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
-        Store::read_staged(self, object).await
+    async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+        Store::read_record(self, namespace, key).await
     }
 
-    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        Store::create_staged(self, object, bytes).await
+    async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool> {
+        Store::create_record(self, namespace, key, bytes).await
     }
 
-    async fn replace_staged_if_current(
+    async fn replace_record_if_current(
         &self,
-        object: &str,
+        namespace: &str,
+        key: &str,
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite> {
-        Store::replace_staged_if_current(self, object, expected, bytes).await
+        Store::replace_record_if_current(self, namespace, key, expected, bytes).await
     }
 
-    async fn remove_staged(&self, object: &str) -> Result<bool> {
-        Store::remove_staged(self, object).await
+    async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool> {
+        Store::remove_record(self, namespace, key).await
     }
 
-    async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        Store::list_staged_ids(self).await
+    async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>> {
+        Store::list_record_keys(self, namespace).await
     }
 }
 
@@ -986,11 +987,17 @@ impl Storage {
     // metadata remembers which registry the stage was addressed through.
 
     pub async fn read_staged_meta(&self, stage_id: &str) -> Result<Option<Vec<u8>>> {
-        self.hosted.read_staged(&staged_meta_object(stage_id)?).await
+        self.hosted.read_record(STAGED_DIR, &staged_meta_object(stage_id)?).await
     }
 
     pub async fn create_staged_meta(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
-        self.hosted.create_staged(&staged_meta_object(stage_id)?, bytes).await
+        let key = staged_meta_object(stage_id)?;
+        if self.hosted.create_record(STAGED_DIR, &key, bytes).await? {
+            return Ok(());
+        }
+        // Stage ids are minted from the CSPRNG, so a taken key is not a
+        // publisher's doing.
+        Err(RegistryError::Internal { reason: format!("staged record {stage_id} already exists") })
     }
 
     /// Rewrite a staged record's metadata only while it still holds
@@ -1003,15 +1010,23 @@ impl Storage {
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite> {
-        self.hosted.replace_staged_if_current(&staged_meta_object(stage_id)?, expected, bytes).await
+        self.hosted
+            .replace_record_if_current(STAGED_DIR, &staged_meta_object(stage_id)?, expected, bytes)
+            .await
     }
 
     pub async fn read_staged_body(&self, stage_id: &str) -> Result<Option<Vec<u8>>> {
-        self.hosted.read_staged(&staged_body_object(stage_id)?).await
+        self.hosted.read_record(STAGED_DIR, &staged_body_object(stage_id)?).await
     }
 
     pub async fn create_staged_body(&self, stage_id: &str, bytes: &[u8]) -> Result<()> {
-        self.hosted.create_staged(&staged_body_object(stage_id)?, bytes).await
+        let key = staged_body_object(stage_id)?;
+        if self.hosted.create_record(STAGED_DIR, &key, bytes).await? {
+            return Ok(());
+        }
+        Err(RegistryError::Internal {
+            reason: format!("staged record {stage_id} already has a body"),
+        })
     }
 
     /// Remove a staged record — the metadata first, so a concurrent list
@@ -1021,8 +1036,10 @@ impl Storage {
     /// reader, and an error here would misreport that while leaving nothing
     /// for a retry to find (bodies are only discovered through metadata).
     pub async fn remove_staged(&self, stage_id: &str) -> Result<bool> {
-        let removed = self.hosted.remove_staged(&staged_meta_object(stage_id)?).await?;
-        if let Err(err) = self.hosted.remove_staged(&staged_body_object(stage_id)?).await {
+        let removed = self.hosted.remove_record(STAGED_DIR, &staged_meta_object(stage_id)?).await?;
+        if let Err(err) =
+            self.hosted.remove_record(STAGED_DIR, &staged_body_object(stage_id)?).await
+        {
             tracing::warn!(error = %err, stage_id, "staged body cleanup failed after removing its metadata");
         }
         Ok(removed)
@@ -1031,7 +1048,50 @@ impl Storage {
     /// Every staged record's id, in unspecified order (the listing endpoint
     /// sorts by staging time).
     pub async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        self.hosted.list_staged_ids().await
+        let keys = self.hosted.list_record_keys(STAGED_DIR).await?;
+        Ok(keys
+            .iter()
+            .filter_map(|key| staged_id_of_meta_object(key))
+            .map(str::to_string)
+            .collect())
+    }
+
+    // --- Pipeline runs (`/-/pnpr/v0/pipeline`) ----------------------------
+    //
+    // A run record is the account `pnpm pipeline` gave of one run: testimony
+    // about something that happened once, not derived data a replica can
+    // rebuild, so it lives in the hosted store every replica shares rather
+    // than on the replica that happened to receive it. Records are
+    // append-only, keyed `<workspace>/<run id>`.
+
+    pub async fn read_pipeline_run(
+        &self,
+        workspace: &str,
+        run_id: &str,
+    ) -> Result<Option<Vec<u8>>> {
+        self.hosted.read_record(PIPELINE_RUNS_DIR, &pipeline_run_key(workspace, run_id)?).await
+    }
+
+    /// Record a run, reporting `false` when that workspace already has one
+    /// under this id — a run record is written once and never rewritten.
+    pub async fn create_pipeline_run(
+        &self,
+        workspace: &str,
+        run_id: &str,
+        bytes: &[u8],
+    ) -> Result<bool> {
+        let key = pipeline_run_key(workspace, run_id)?;
+        self.hosted.create_record(PIPELINE_RUNS_DIR, &key, bytes).await
+    }
+
+    /// Every recorded run as `(workspace, run id)`, in unspecified order.
+    pub async fn list_pipeline_runs(&self) -> Result<Vec<(String, String)>> {
+        let keys = self.hosted.list_record_keys(PIPELINE_RUNS_DIR).await?;
+        Ok(keys
+            .iter()
+            .filter_map(|key| key.split_once('/'))
+            .map(|(workspace, run_id)| (workspace.to_string(), run_id.to_string()))
+            .collect())
     }
 }
 
@@ -1047,6 +1107,29 @@ fn validate_revision_digest(digest: &str) -> Result<()> {
 /// The leading dot keeps it out of the package namespace: a package name
 /// can never start with `.`.
 pub(crate) const STAGED_DIR: &str = ".staged";
+
+/// Reserved namespace holding pipeline run records, versioned so a later
+/// record shape can live beside this one.
+pub(crate) const PIPELINE_RUNS_DIR: &str = ".pipeline-runs/v0";
+
+/// A run's key within its namespace. The identifiers are the client's, so
+/// they are checked here as well as by the endpoint that accepts them.
+fn pipeline_run_key(workspace: &str, run_id: &str) -> Result<String> {
+    Ok(format!("{}/{}", validated_record_name(workspace)?, validated_record_name(run_id)?))
+}
+
+/// Reject any identifier that could smuggle a path segment before it reaches
+/// a filesystem path or object key.
+fn validated_record_name(name: &str) -> Result<&str> {
+    let valid = !name.is_empty()
+        && !name.starts_with('.')
+        && name.chars().all(|char| char.is_ascii_alphanumeric() || matches!(char, '.' | '_' | '-'));
+    if valid {
+        Ok(name)
+    } else {
+        Err(RegistryError::BadRequest { reason: format!("invalid record name {name:?}") })
+    }
+}
 const STAGED_META_SUFFIX: &str = ".json";
 const STAGED_BODY_SUFFIX: &str = ".body.json";
 
@@ -1076,11 +1159,11 @@ fn validated_stage_id(stage_id: &str) -> Result<&str> {
 struct Store {
     root: PathBuf,
     revision_ref_write_lock: Arc<tokio::sync::Mutex<()>>,
-    /// Serializes the read-compare-write of a staged record against every
-    /// other write to it, removals included. One process owns this store, so
-    /// an in-process lock is the whole of the compare-and-set the
-    /// object-store backend gets from an `ETag`.
-    staged_write_lock: Arc<tokio::sync::Mutex<()>>,
+    /// Serializes the read-compare-write of a record against every other
+    /// write to it, removals included. One process owns this store, so an
+    /// in-process lock is the whole of the compare-and-set the object-store
+    /// backend gets from an `ETag`.
+    record_write_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 impl Store {
@@ -1088,7 +1171,7 @@ impl Store {
         Self {
             root,
             revision_ref_write_lock: Arc::new(tokio::sync::Mutex::new(())),
-            staged_write_lock: Arc::new(tokio::sync::Mutex::new(())),
+            record_write_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -1099,7 +1182,7 @@ impl Store {
         Store {
             root: self.root.join(prefix),
             revision_ref_write_lock: Arc::clone(&self.revision_ref_write_lock),
-            staged_write_lock: Arc::clone(&self.staged_write_lock),
+            record_write_lock: Arc::clone(&self.record_write_lock),
         }
     }
 
@@ -1413,58 +1496,79 @@ impl Store {
         self.revision_refs_dir(digest).join(HOSTED_REVISION_REF_INDEX_FILE)
     }
 
-    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
-        match fs::read(self.root.join(STAGED_DIR).join(object)).await {
+    /// A record's path. The key's `/` separators become path components, so a
+    /// key never rides into a path as one string on a platform that would read
+    /// it differently.
+    fn record_path(&self, namespace: &str, key: &str) -> PathBuf {
+        let mut path = self.root.join(namespace);
+        path.extend(key.split('/'));
+        path
+    }
+
+    async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+        match fs::read(self.record_path(namespace, key)).await {
             Ok(bytes) => Ok(Some(bytes)),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(None),
             Err(err) => Err(err.into()),
         }
     }
 
-    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        write_atomic_new(&self.root.join(STAGED_DIR).join(object), bytes).await
+    async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool> {
+        match write_atomic_new(&self.record_path(namespace, key), bytes).await {
+            Ok(()) => Ok(true),
+            Err(RegistryError::Io(err)) if err.kind() == ErrorKind::AlreadyExists => Ok(false),
+            Err(err) => Err(err),
+        }
     }
 
-    async fn replace_staged_if_current(
+    async fn replace_record_if_current(
         &self,
-        object: &str,
+        namespace: &str,
+        key: &str,
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite> {
-        let _guard = self.staged_write_lock.lock().await;
-        if self.read_staged(object).await?.as_deref() != Some(expected) {
+        let _guard = self.record_write_lock.lock().await;
+        if self.read_record(namespace, key).await?.as_deref() != Some(expected) {
             return Ok(DocumentWrite::Conflict);
         }
-        write_atomic(&self.root.join(STAGED_DIR).join(object), bytes).await?;
+        write_atomic(&self.record_path(namespace, key), bytes).await?;
         Ok(DocumentWrite::Written)
     }
 
-    /// Under the staged-write lock, so a removal cannot land between a
+    /// Under the record-write lock, so a removal cannot land between a
     /// conditional replace's comparison and its write and see the record it
     /// deleted written back.
-    async fn remove_staged(&self, object: &str) -> Result<bool> {
-        let _guard = self.staged_write_lock.lock().await;
-        match fs::remove_file(self.root.join(STAGED_DIR).join(object)).await {
+    async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool> {
+        let _guard = self.record_write_lock.lock().await;
+        match fs::remove_file(self.record_path(namespace, key)).await {
             Ok(()) => Ok(true),
             Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
             Err(err) => Err(err.into()),
         }
     }
 
-    async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        let mut entries = match fs::read_dir(self.root.join(STAGED_DIR)).await {
-            Ok(entries) => entries,
-            Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
-            Err(err) => return Err(err.into()),
-        };
-        let mut ids = Vec::new();
-        while let Some(entry) = entries.next_entry().await? {
-            let name = entry.file_name().to_string_lossy().into_owned();
-            if let Some(id) = staged_id_of_meta_object(&name) {
-                ids.push(id.to_string());
+    async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>> {
+        let root = self.root.join(namespace);
+        let mut keys = Vec::new();
+        let mut pending = vec![(root, String::new())];
+        while let Some((dir, prefix)) = pending.pop() {
+            let mut entries = match fs::read_dir(&dir).await {
+                Ok(entries) => entries,
+                Err(err) if err.kind() == ErrorKind::NotFound => continue,
+                Err(err) => return Err(err.into()),
+            };
+            while let Some(entry) = entries.next_entry().await? {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                let key = if prefix.is_empty() { name } else { format!("{prefix}/{name}") };
+                if entry.file_type().await?.is_dir() {
+                    pending.push((entry.path(), key));
+                } else {
+                    keys.push(key);
+                }
             }
         }
-        Ok(ids)
+        Ok(keys)
     }
 }
 

--- a/pnpr/crates/storage/src/s3.rs
+++ b/pnpr/crates/storage/src/s3.rs
@@ -16,8 +16,7 @@
 use crate::{
     BlobFinalize, DocumentWrite, HOSTED_REVISION_REF_INDEX_FILE, HOSTED_REVISION_REFS_DIR,
     HostedBackend, HostedDocumentForUpdate, HostedDocumentVersion, HostedRevisionRefIndex,
-    HostedRevisionRefWrite, STAGED_DIR, staged_id_of_meta_object,
-    wait_after_document_write_conflict,
+    HostedRevisionRefWrite, wait_after_document_write_conflict,
 };
 use async_trait::async_trait;
 use axum::body::Body;
@@ -514,40 +513,49 @@ impl S3Store {
         ))
     }
 
-    // Staged-publish records (see `storage::Storage`'s staged section for
-    // the layout contract shared with the fs backend).
+    // Records (see `storage::Storage` for the namespaces and the layout
+    // contract shared with the fs backend).
 
-    pub async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
-        match self.store.get(&self.staged_key(object)).await {
+    pub async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+        match self.store.get(&self.record_key(namespace, key)).await {
             Ok(result) => Ok(Some(result.bytes().await?.to_vec())),
             Err(object_store::Error::NotFound { .. }) => Ok(None),
             Err(err) => Err(err.into()),
         }
     }
 
-    pub async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        self.store
+    pub async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool> {
+        match self
+            .store
             .put_opts(
-                &self.staged_key(object),
+                &self.record_key(namespace, key),
                 PutPayload::from(bytes.to_vec()),
                 PutOptions { mode: PutMode::Create, ..PutOptions::default() },
             )
-            .await?;
-        Ok(())
+            .await
+        {
+            Ok(_) => Ok(true),
+            Err(
+                object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. },
+            ) => Ok(false),
+            Err(err) => Err(err.into()),
+        }
     }
 
-    /// Rewrite a staged object under `If-Match` on the version the caller
-    /// read, so only one replica can claim a record whose copy is current.
-    /// The bytes are compared as well: a rewrite the caller computed from
-    /// something other than what the bucket holds is a conflict even where
-    /// the version still matches.
-    pub async fn replace_staged_if_current(
+    /// Rewrite a record under `If-Match` on the version the caller read, so
+    /// only one replica can claim a record whose copy is current. The bytes
+    /// are compared as well: a rewrite the caller computed from something
+    /// other than what the bucket holds is a conflict even where the version
+    /// still matches.
+    pub async fn replace_record_if_current(
         &self,
-        object: &str,
+        namespace: &str,
+        key: &str,
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite> {
-        let key = self.staged_key(object);
+        let key = self.record_key(namespace, key);
         let result = match self.store.get(&key).await {
             Ok(result) => result,
             // Gone: an approval that finished, or a rejection. A store that
@@ -581,32 +589,34 @@ impl S3Store {
         }
     }
 
-    pub async fn remove_staged(&self, object: &str) -> Result<bool> {
-        match self.store.delete(&self.staged_key(object)).await {
+    pub async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool> {
+        match self.store.delete(&self.record_key(namespace, key)).await {
             Ok(()) => Ok(true),
             Err(object_store::Error::NotFound { .. }) => Ok(false),
             Err(err) => Err(err.into()),
         }
     }
 
-    pub async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        let scope = ObjectPath::from(format!("{}{STAGED_DIR}", self.prefix));
-        let mut listing = self.store.list(Some(&scope));
-        let mut ids = Vec::new();
+    pub async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>> {
+        let scope = format!("{}{namespace}/", self.prefix);
+        let mut listing = self.store.list(Some(&ObjectPath::from(scope.as_str())));
+        let mut keys = Vec::new();
         while let Some(meta) = listing.next().await {
             let meta = meta?;
-            let Some(object) = meta.location.as_ref().rsplit('/').next() else {
+            // `ObjectPath` normalizes what it is built from, so compare
+            // against the same normalization rather than the raw prefix.
+            let Some(key) =
+                meta.location.as_ref().strip_prefix(ObjectPath::from(scope.as_str()).as_ref())
+            else {
                 continue;
             };
-            if let Some(id) = staged_id_of_meta_object(object) {
-                ids.push(id.to_string());
-            }
+            keys.push(key.trim_start_matches('/').to_string());
         }
-        Ok(ids)
+        Ok(keys)
     }
 
-    fn staged_key(&self, object: &str) -> ObjectPath {
-        ObjectPath::from(format!("{}{STAGED_DIR}/{object}", self.prefix))
+    fn record_key(&self, namespace: &str, key: &str) -> ObjectPath {
+        ObjectPath::from(format!("{}{namespace}/{key}", self.prefix))
     }
 }
 
@@ -795,28 +805,29 @@ impl HostedBackend for S3Store {
         &self.cache_root
     }
 
-    async fn read_staged(&self, object: &str) -> Result<Option<Vec<u8>>> {
-        S3Store::read_staged(self, object).await
+    async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>> {
+        S3Store::read_record(self, namespace, key).await
     }
 
-    async fn create_staged(&self, object: &str, bytes: &[u8]) -> Result<()> {
-        S3Store::create_staged(self, object, bytes).await
+    async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool> {
+        S3Store::create_record(self, namespace, key, bytes).await
     }
 
-    async fn replace_staged_if_current(
+    async fn replace_record_if_current(
         &self,
-        object: &str,
+        namespace: &str,
+        key: &str,
         expected: &[u8],
         bytes: &[u8],
     ) -> Result<DocumentWrite> {
-        S3Store::replace_staged_if_current(self, object, expected, bytes).await
+        S3Store::replace_record_if_current(self, namespace, key, expected, bytes).await
     }
 
-    async fn remove_staged(&self, object: &str) -> Result<bool> {
-        S3Store::remove_staged(self, object).await
+    async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool> {
+        S3Store::remove_record(self, namespace, key).await
     }
 
-    async fn list_staged_ids(&self) -> Result<Vec<String>> {
-        S3Store::list_staged_ids(self).await
+    async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>> {
+        S3Store::list_record_keys(self, namespace).await
     }
 }

--- a/pnpr/crates/storage/src/s3/tests.rs
+++ b/pnpr/crates/storage/src/s3/tests.rs
@@ -452,21 +452,31 @@ async fn maintenance_inventory_includes_nested_and_unmanifested_repositories() {
 #[tokio::test]
 async fn a_staged_record_is_replaced_only_while_it_is_unchanged() {
     let (store, _staging) = store_with_prefix("");
-    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
+    store.create_record(".staged", "stage.json", br#"{"id":"stage"}"#).await.unwrap();
 
     let first = store
-        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","a":1}"#)
+        .replace_record_if_current(
+            ".staged",
+            "stage.json",
+            br#"{"id":"stage"}"#,
+            br#"{"id":"stage","a":1}"#,
+        )
         .await
         .unwrap();
     assert_eq!(first, DocumentWrite::Written);
 
     let second = store
-        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","b":2}"#)
+        .replace_record_if_current(
+            ".staged",
+            "stage.json",
+            br#"{"id":"stage"}"#,
+            br#"{"id":"stage","b":2}"#,
+        )
         .await
         .unwrap();
     assert_eq!(second, DocumentWrite::Conflict);
     assert_eq!(
-        store.read_staged("stage.json").await.unwrap().as_deref(),
+        store.read_record(".staged", "stage.json").await.unwrap().as_deref(),
         Some(&br#"{"id":"stage","a":1}"#[..]),
     );
 }
@@ -476,25 +486,46 @@ async fn a_staged_record_is_replaced_only_while_it_is_unchanged() {
 #[tokio::test]
 async fn a_removed_staged_record_is_not_replaced() {
     let (store, _staging) = store_with_prefix("");
-    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
-    assert!(store.remove_staged("stage.json").await.unwrap());
+    store.create_record(".staged", "stage.json", br#"{"id":"stage"}"#).await.unwrap();
+    assert!(store.remove_record(".staged", "stage.json").await.unwrap());
 
     let replaced = store
-        .replace_staged_if_current("stage.json", br#"{"id":"stage"}"#, br#"{"id":"stage","a":1}"#)
+        .replace_record_if_current(
+            ".staged",
+            "stage.json",
+            br#"{"id":"stage"}"#,
+            br#"{"id":"stage","a":1}"#,
+        )
         .await
         .unwrap();
     assert_eq!(replaced, DocumentWrite::Conflict);
-    assert!(store.read_staged("stage.json").await.unwrap().is_none());
+    assert!(store.read_record(".staged", "stage.json").await.unwrap().is_none());
 }
 
-/// Stage ids are minted fresh, so an occupied key belongs to another record.
+/// A record that must not be rewritten is created, not put: the second
+/// writer is told the key is taken and the first record stands.
 #[tokio::test]
-async fn creating_a_staged_record_twice_fails() {
+async fn creating_a_record_twice_leaves_the_first_one() {
     let (store, _staging) = store_with_prefix("");
-    store.create_staged("stage.json", br#"{"id":"stage"}"#).await.unwrap();
-    assert!(store.create_staged("stage.json", br#"{"id":"other"}"#).await.is_err());
+    assert!(store.create_record(".staged", "stage.json", br#"{"id":"stage"}"#).await.unwrap());
+    assert!(!store.create_record(".staged", "stage.json", br#"{"id":"other"}"#).await.unwrap());
     assert_eq!(
-        store.read_staged("stage.json").await.unwrap().as_deref(),
+        store.read_record(".staged", "stage.json").await.unwrap().as_deref(),
         Some(&br#"{"id":"stage"}"#[..]),
     );
+}
+
+/// Keys come back relative to their namespace, nested ones included: a run
+/// record is addressed `<workspace>/<run id>`.
+#[tokio::test]
+async fn record_keys_are_listed_relative_to_their_namespace() {
+    let (store, _staging) = store_with_prefix("bucket-prefix/");
+    store.create_record(".pipeline-runs/v0", "demo/100.json", b"{}").await.unwrap();
+    store.create_record(".pipeline-runs/v0", "other/200.json", b"{}").await.unwrap();
+    store.create_record(".staged", "stage.json", b"{}").await.unwrap();
+
+    let mut keys = store.list_record_keys(".pipeline-runs/v0").await.unwrap();
+    keys.sort();
+    assert_eq!(keys, ["demo/100.json", "other/200.json"]);
+    assert_eq!(store.list_record_keys(".staged").await.unwrap(), ["stage.json"]);
 }

--- a/pnpr/npm/pnpr/README.md
+++ b/pnpr/npm/pnpr/README.md
@@ -340,8 +340,10 @@ What stays local to each replica:
 - blob upload sessions of the image registry when hosted packages are on
   local disk, which is why `docker push` needs sticky sessions there; with
   `s3:` an upload continues on any replica
-- pipeline run records
 - accounts and tokens, unless a `backend:` database is configured
+
+Pipeline run records are shared: a run submitted through one replica is listed
+and served by every other, and a run id stays append-only across all of them.
 
 ## License
 


### PR DESCRIPTION
## Summary

Related to pnpm/pnpm#12199 — the follow-up named in [its status comment](https://github.com/pnpm/pnpm/issues/12199#issuecomment-5574593926) as the one remaining item a user can see.

A pipeline run record is the account `pnpm pipeline` gave of one run. Unlike the proxy cache or the resolver cache, it is not derived data a replica can rebuild: it is testimony about something that happened once. It lived under `<storage>/pipeline-runs/v0` on the replica that received the submission, so behind a load balancer `GET /-/pnpr/v0/pipeline/runs` returned a different history depending on which replica answered, and a scale-to-zero container took its records with it.

Run records now live in the hosted store, beside the packages every replica already shares. Their append-only rule holds across replicas: the create-only write both backends offer decides the winner, so a run id recorded on one replica is refused on every other.

### The record API

Staged publishes already needed exactly this of the hosted backend — read, create-only write, compare-and-set replace, remove, list — over a reserved namespace of the store. Rather than a second copy of that plumbing for run records, the five staged-specific backend methods become a record API addressed by namespace and key:

```rust
async fn read_record(&self, namespace: &str, key: &str) -> Result<Option<Vec<u8>>>;
async fn create_record(&self, namespace: &str, key: &str, bytes: &[u8]) -> Result<bool>;
async fn replace_record_if_current(&self, namespace: &str, key: &str, expected: &[u8], bytes: &[u8]) -> Result<DocumentWrite>;
async fn remove_record(&self, namespace: &str, key: &str) -> Result<bool>;
async fn list_record_keys(&self, namespace: &str) -> Result<Vec<String>>;
```

`Storage` names the namespaces, as it already did for `.staged`, and keeps its staged and pipeline-run methods as the two callers. Staged behavior is unchanged — its own tests, including the approval-claim ones from pnpm/pnpm#14665, pass untouched. `create_record` reports a taken key rather than erroring, because for a run record that is a client error (append-only) while for a staged record it is impossible (the id comes from the CSPRNG) and stays an internal error at the `Storage` layer.

### Behavior change

On a local storage root the records move from `pipeline-runs/v0` to the reserved `.pipeline-runs/v0`. That is called out in the changeset with the one-line fix (move the directory). The dot also takes them out of reach of a package named `pipeline-runs`, which could otherwise share the directory.

The listing endpoint no longer wraps its work in `spawn_blocking`, because reading records is now async whichever backend serves them.

### Tests

- A run recorded through one replica is served, listed and refused-as-duplicate by another — two stores over one in-memory bucket with separate local roots.
- Record keys come back relative to their namespace, nested ones included, under a bucket prefix.
- Creating a record twice leaves the first one and reports the key as taken.
- The existing run-store tests keep their coverage on the local backend: roundtrip, newest-first listing with the workspace filter, append-only, path-shaped identifiers refused, concurrent publications, and a corrupt record outside the requested page.

## Squash Commit Body

```text
A run record is the account `pnpm pipeline` gave of one run: testimony about
something that happened once, not derived data a replica can rebuild. It lived
on the replica that received the submission, so behind a load balancer the
pipeline UI showed a different history depending on which replica answered,
and a scale-to-zero container took its records with it.

Run records now live in the hosted store, beside the packages every replica
shares. They keep their append-only rule across replicas: the create-only
write the object store and the local backend both offer decides the winner, so
a run id recorded on one replica is refused on every other.

The staged-publish namespace already needed read, create-only write,
compare-and-set replace, remove and list on a reserved namespace of the hosted
store. That is now the backend's record API, addressed by namespace and key,
with staged publishes and run records as its two callers rather than a second
copy of the plumbing. `Storage` names the namespaces, as it already did for
`.staged`.

On a local storage root the records move from `pipeline-runs/v0` to the
reserved `.pipeline-runs/v0`, which also takes them out of reach of a package
named `pipeline-runs`.

Related to pnpm/pnpm#12199.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791399745&installation_model_id=426870&pr_number=14668&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14668&signature=aba6ed86d215b68bf3135e9759fbaa384a63464c42f6dcb71de3f82515b63f91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pipeline run records are now shared across hosted replicas.
  - Runs submitted through one replica can be listed and retrieved from another.
  - Pipeline run storage is append-only, with duplicate records rejected.
  - Listings support workspace filtering, newest-first ordering, and result limits.

- **Bug Fixes**
  - Invalid records no longer disrupt valid pipeline run listings.

- **Documentation**
  - Updated replica deployment guidance to describe shared pipeline run records.
  - Local pipeline-run data now uses `.pipeline-runs/v0`; existing data must be relocated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->