### PR TITLE
fix(workspace-state): retry the state-file rename and stop a lost write failing the command

### DIFF
--- a/.changeset/workspace-state-write-race.md
+++ b/.changeset/workspace-state-write-race.md
@@ -1,0 +1,9 @@
+---
+"@pnpm/workspace.state": minor
+"@pnpm/installing.commands": patch
+"@pnpm/deps.status": patch
+"pnpm": patch
+"pacquet": patch
+---
+
+A failed write of the workspace state file is now reported as a warning instead of failing the command. `pnpm run` previously exited with code 1 without starting the script. On Windows, the write retries a transient rename failure for up to one minute, and warns if the file is still locked [#14550](https://github.com/pnpm/pnpm/issues/14550).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,6 +6253,7 @@ dependencies = [
  "derive_more",
  "indexmap 2.14.0",
  "pnpm-diagnostics",
+ "pnpm-fs",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10289,15 +10289,18 @@ importers:
       '@pnpm/config.reader':
         specifier: workspace:*
         version: link:../../config/reader
+      '@pnpm/fs.graceful-fs':
+        specifier: workspace:*
+        version: link:../../fs/graceful-fs
       '@pnpm/types':
         specifier: workspace:*
         version: link:../../core/types
+      path-temp:
+        specifier: 'catalog:'
+        version: 3.0.0
       ramda:
         specifier: 'catalog:'
         version: '@pnpm/ramda@0.28.1'
-      write-file-atomic:
-        specifier: 'catalog:'
-        version: 7.0.1
     devDependencies:
       '@jest/globals':
         specifier: 'catalog:'
@@ -10314,9 +10317,6 @@ importers:
       '@types/ramda':
         specifier: 'catalog:'
         version: 0.32.0
-      '@types/write-file-atomic':
-        specifier: 'catalog:'
-        version: 4.0.3
 
   pnpm11/workspace/task-scheduler:
     dependencies:

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -12,7 +12,9 @@ pub use workspace_state::{
     UpToDateFastPathCheck, UpToDateWorkspace, build_workspace_packages_map,
     check_deps_status_before_run_at, install_already_up_to_date,
 };
-pub(crate) use workspace_state::{build_workspace_state, lockfile_root_dir};
+pub(crate) use workspace_state::{
+    build_workspace_state, lockfile_root_dir, update_workspace_state_or_warn,
+};
 
 mod entry_points;
 
@@ -58,7 +60,7 @@ use pnpm_reporter::{
 use pnpm_resolving_npm_resolver::InMemoryPackageMetaCache;
 use pnpm_resolving_resolver_base::ResolutionVerifier;
 use pnpm_tarball::MemCache;
-use pnpm_workspace_state::{ProjectEntry, WorkspaceState, update_workspace_state};
+use pnpm_workspace_state::{ProjectEntry, WorkspaceState};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     io::IsTerminal,

--- a/pnpm/crates/package-manager/src/install/apply_materialization.rs
+++ b/pnpm/crates/package-manager/src/install/apply_materialization.rs
@@ -18,7 +18,7 @@ use super::{
     BTreeMap, Catalogs, Config, HashSet, HoistedDependencies, Host, IncludedDependencies,
     InstallError, Lockfile, Materialized, Modules, NodeLinker, PackageManifest, Path, PathBuf,
     ProjectMutation, RebuildOptions, Reporter, WorkspaceInstallSelection, build_workspace_state,
-    update_workspace_state,
+    update_workspace_state_or_warn,
 };
 use crate::optimistic_repeat_install::filesystem_now_ms;
 use pnpm_store_dir::VerifiedFileIntegrity;
@@ -234,7 +234,7 @@ fn finish_apply<Reporter: self::Reporter>(
         inputs.current_lockfile.take(),
     ));
 
-    write_applied_workspace_state(&inputs)?;
+    write_applied_workspace_state::<Reporter>(&inputs);
 
     let completion = report_install_completion::<Reporter>(ReportInstallCompletionInputs {
         config: inputs.config,
@@ -253,9 +253,9 @@ fn finish_apply<Reporter: self::Reporter>(
 }
 
 // Publish workspace freshness only after modules.yaml and the current lockfile are committed.
-fn write_applied_workspace_state(
+fn write_applied_workspace_state<Reporter: self::Reporter>(
     inputs: &ApplyMaterializationInputs<'_, '_>,
-) -> Result<(), InstallError> {
+) {
     let phase_start = std::time::Instant::now();
     // Write `node_modules/.pnpm-workspace-state-v1.json`.
     // pnpm's `verifyDepsBeforeRun` gate bails to "outdated" the
@@ -263,7 +263,7 @@ fn write_applied_workspace_state(
     // Writing it after both the `.modules.yaml` and the current
     // lockfile succeed keeps the file pointing at a fully committed
     // install.
-    update_workspace_state(
+    update_workspace_state_or_warn::<Reporter>(
         &inputs.workspace_root,
         &build_workspace_state::<Host>(
             &inputs.workspace_root,
@@ -276,9 +276,7 @@ fn write_applied_workspace_state(
             inputs.filtered_install,
             filesystem_now_ms(&inputs.workspace_root),
         ),
-    )
-    .map_err(InstallError::WriteWorkspaceState)?;
+        "the install",
+    );
     tracing::info!(target: "pacquet::install::phase", phase = "apply.workspace_state", elapsed_ms = phase_start.elapsed().as_millis() as u64, "phase complete");
-
-    Ok(())
 }

--- a/pnpm/crates/package-manager/src/install/errors.rs
+++ b/pnpm/crates/package-manager/src/install/errors.rs
@@ -8,7 +8,6 @@ use pnpm_executor::LifecycleScriptError;
 use pnpm_lockfile::{LoadLockfileError, SaveLockfileError, StalenessReason};
 use pnpm_lockfile_verification::VerifyError;
 use pnpm_modules_yaml::{ReadModulesError, WriteModulesError};
-use pnpm_workspace_state::UpdateWorkspaceStateError;
 use std::path::PathBuf;
 
 pub(super) fn map_frozen_lockfile_error(error: InstallFrozenLockfileError) -> InstallError {
@@ -317,15 +316,6 @@ pub enum InstallError {
     /// `LOCKFILE_RESOLUTION_VERIFICATION`) is what the user sees.
     #[diagnostic(transparent)]
     LockfileVerification(#[error(source)] VerifyError),
-
-    /// Surfaces a failure to persist `.pnpm-workspace-state-v1.json`.
-    /// Missing or unreadable state forces `pnpm run`'s
-    /// `verifyDepsBeforeRun` check to fall back to "outdated", which
-    /// is exactly the regression CI hits when pacquet runs the
-    /// install — fail the install rather than letting a silent write
-    /// error compound into spurious reinstalls.
-    #[diagnostic(transparent)]
-    WriteWorkspaceState(#[error(source)] UpdateWorkspaceStateError),
 
     /// Surfaces a failure to record the `allowBuilds` placeholders for the
     /// builds this install ignored. Fatal rather than silent: the install

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state/up_to_date.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state/up_to_date.rs
@@ -4,7 +4,7 @@ use super::super::{
     ResolutionVerifier, Stage, StageLog, SummaryLog, SystemTime, build_workspace_state,
     frozen_tree_intact, gvs_build_marker_present, has_newly_allowed_ignored_builds,
     has_revoked_allowed_builds, map_frozen_lockfile_error, modules_consistent_with,
-    unapproved_recorded_ignored_builds, update_workspace_state, verify_lockfile_eagerly,
+    unapproved_recorded_ignored_builds, update_workspace_state_or_warn, verify_lockfile_eagerly,
 };
 use crate::optimistic_repeat_install::filesystem_now_ms;
 
@@ -177,7 +177,7 @@ pub(super) async fn report_up_to_date<Reporter: self::Reporter + 'static>(
             context.save_lockfile,
         ),
     )?;
-    refresh_up_to_date_workspace(&context)?;
+    refresh_up_to_date_workspace::<Reporter>(&context);
     Reporter::emit(&LogEvent::Summary(SummaryLog {
         level: LogLevel::Debug,
         prefix: context.prefix.to_string(),
@@ -196,10 +196,10 @@ pub(super) fn enforce_recorded_build_policy(
     }
     Ok(())
 }
-pub(super) fn refresh_up_to_date_workspace(
+pub(super) fn refresh_up_to_date_workspace<Reporter: self::Reporter>(
     context: &UpToDateInstall<'_, '_>,
-) -> Result<(), InstallError> {
-    update_workspace_state(
+) {
+    update_workspace_state_or_warn::<Reporter>(
         context.workspace_root,
         &build_workspace_state::<Host>(
             context.workspace_root,
@@ -212,8 +212,8 @@ pub(super) fn refresh_up_to_date_workspace(
             context.filtered_install,
             filesystem_now_ms(context.workspace_root),
         ),
-    )
-    .map_err(InstallError::WriteWorkspaceState)
+        "the up-to-date check",
+    );
 }
 pub(super) async fn verify_up_to_date_lockfile<Reporter: self::Reporter + 'static>(
     wanted_lockfile: &Lockfile,

--- a/pnpm/crates/package-manager/src/install/tests/reporting.rs
+++ b/pnpm/crates/package-manager/src/install/tests/reporting.rs
@@ -613,6 +613,6 @@ fn a_lost_workspace_state_write_warns_through_the_reporter() {
     assert_eq!(*level, LogLevel::Warn);
     assert!(
         message.starts_with("Failed to write the workspace state after the install: "),
-        "the caller's `after` phrase and the source error both belong in the message, got: {message}"
+        "the caller's `after` phrase and the source error both belong in the message, got: {message}",
     );
 }

--- a/pnpm/crates/package-manager/src/install/tests/reporting.rs
+++ b/pnpm/crates/package-manager/src/install/tests/reporting.rs
@@ -12,9 +12,9 @@ use pnpm_reporter::{
     PackageManifestMessage, ProgressLog, ProgressMessage, Reporter, ScopeLog, SilentReporter,
     Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
-use pnpm_workspace_state::{WorkspaceState, WorkspaceStateSettings};
 use pnpm_store_dir::{STORE_VERSION, VerifiedFileIntegrity};
 use pnpm_testing_utils::registry::TestRegistry;
+use pnpm_workspace_state::{WorkspaceState, WorkspaceStateSettings};
 use std::{sync::Mutex, time::Duration};
 use tempfile::tempdir;
 use text_block_macros::text_block;

--- a/pnpm/crates/package-manager/src/install/tests/reporting.rs
+++ b/pnpm/crates/package-manager/src/install/tests/reporting.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{Install, InstallError, ProjectMutation},
+    super::{Install, InstallError, ProjectMutation, update_workspace_state_or_warn},
     InstallDirs, PARTIAL_INSTALL_LOCKFILE, recorded_verified_file_integrity_report,
     seed_placeholder_virtual_store_slot,
 };
@@ -8,10 +8,11 @@ use pnpm_config::Config;
 use pnpm_lockfile::{Lockfile, MaybeLazyLockfile};
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::{
-    BrokenModulesLog, ContextLog, IgnoredScriptsLog, LogEvent, PackageManifestLog,
+    BrokenModulesLog, ContextLog, IgnoredScriptsLog, LogEvent, LogLevel, PackageManifestLog,
     PackageManifestMessage, ProgressLog, ProgressMessage, Reporter, ScopeLog, SilentReporter,
     Stage, StageLog, StatsLog, StatsMessage, SummaryLog,
 };
+use pnpm_workspace_state::{WorkspaceState, WorkspaceStateSettings};
 use pnpm_store_dir::{STORE_VERSION, VerifiedFileIntegrity};
 use pnpm_testing_utils::registry::TestRegistry;
 use std::{sync::Mutex, time::Duration};
@@ -565,4 +566,53 @@ fn verified_file_integrity_is_scoped_to_one_install() {
     dbg!(this_install);
     assert_eq!(this_install.files, 1);
     assert_eq!(this_install.duration, Duration::from_millis(100));
+}
+
+/// A lost state-file write must not fail the command, and it must not
+/// be silent either: `tracing::warn!` is inert unless `TRACE` is set,
+/// so the warning goes through the reporter, matching the v11 twin's
+/// visible `logger.warn`.
+#[test]
+fn a_lost_workspace_state_write_warns_through_the_reporter() {
+    static MESSAGES: Mutex<Vec<(LogLevel, String)>> = Mutex::new(Vec::new());
+    // One shared static, so one caller at a time: `cargo nextest` gives
+    // each test its own process, a plain `cargo test` does not.
+    static RECORDER: Mutex<()> = Mutex::new(());
+
+    struct RecordingReporter;
+    impl Reporter for RecordingReporter {
+        fn emit(event: &LogEvent) {
+            if let LogEvent::Global(log) = event {
+                MESSAGES.lock().unwrap().push((log.level, log.message.clone()));
+            }
+        }
+    }
+
+    let dir = tempdir().unwrap();
+    // A regular file where the workspace root belongs: `update_workspace_state`
+    // cannot create the directory it writes into, so the write is lost.
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"not a dir").unwrap();
+    let state = WorkspaceState {
+        last_validated_timestamp: 0,
+        projects: Default::default(),
+        pnpmfiles: vec![],
+        filtered_install: false,
+        config_dependencies: None,
+        settings: WorkspaceStateSettings::default(),
+    };
+
+    let _guard = RECORDER.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    MESSAGES.lock().unwrap().clear();
+    // Returns `()`: a lost cache write is not the command's failure.
+    update_workspace_state_or_warn::<RecordingReporter>(&blocker, &state, "the install");
+    let recorded = MESSAGES.lock().unwrap().clone();
+
+    assert_eq!(recorded.len(), 1, "exactly one warning, got: {recorded:?}");
+    let (level, message) = &recorded[0];
+    assert_eq!(*level, LogLevel::Warn);
+    assert!(
+        message.starts_with("Failed to write the workspace state after the install: "),
+        "the caller's `after` phrase and the source error both belong in the message, got: {message}"
+    );
 }

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -18,6 +18,36 @@ use super::{
     unapproved_recorded_ignored_builds,
 };
 use crate::optimistic_repeat_install::{refreshed_validation_baseline_ms, validation_baseline_ms};
+use pnpm_reporter::{GlobalLog, LogEvent, LogLevel, Reporter};
+use pnpm_workspace_state::update_workspace_state;
+
+/// Persist `.pnpm-workspace-state-v1.json`, warning instead of failing
+/// the command when the write is lost.
+///
+/// The state file is a cache: every field in it is re-derived by the
+/// next content check, so a lost write costs that command a repeat of
+/// the check and nothing else. Failing here instead would abort an
+/// install whose `node_modules` is already materialized and whose
+/// lockfile is already committed, turning a recoverable cache miss
+/// into a red install (pnpm/pnpm#14550).
+///
+/// The warning goes through the reporter rather than `tracing`, which
+/// is inert unless `TRACE` is set: `AGENTS.md` requires a bug fixed in
+/// both stacks to keep its observable behavior aligned, and the v11
+/// twin (`updateWorkspaceStateOrWarn`) emits a user-visible
+/// `logger.warn`.
+pub(crate) fn update_workspace_state_or_warn<Reporter: self::Reporter>(
+    workspace_root: &Path,
+    state: &WorkspaceState,
+    after: &str,
+) {
+    if let Err(error) = update_workspace_state(workspace_root, state) {
+        Reporter::emit(&LogEvent::Global(GlobalLog {
+            level: LogLevel::Warn,
+            message: format!("Failed to write the workspace state after {after}: {error}"),
+        }));
+    }
+}
 
 /// Inputs for [`install_already_up_to_date`].
 pub struct UpToDateFastPathCheck<'a> {

--- a/pnpm/crates/workspace-state/Cargo.toml
+++ b/pnpm/crates/workspace-state/Cargo.toml
@@ -12,6 +12,7 @@ repository.workspace = true
 
 [dependencies]
 pnpm-diagnostics = { workspace = true }
+pnpm-fs = { workspace = true }
 
 derive_more = { workspace = true }
 indexmap = { workspace = true }

--- a/pnpm/crates/workspace-state/src/lib.rs
+++ b/pnpm/crates/workspace-state/src/lib.rs
@@ -225,7 +225,10 @@ pub enum UpdateWorkspaceStateError {
 /// Writes to a temporary file in the same directory, then atomically
 /// renames it into place, so a concurrent reader — pnpm or pacquet —
 /// never observes a half-written file
-/// ([#12020](https://github.com/pnpm/pnpm/issues/12020)).
+/// ([#12020](https://github.com/pnpm/pnpm/issues/12020)). The rename
+/// itself retries the transient Windows file locks a concurrent holder
+/// of the destination produces
+/// ([#14550](https://github.com/pnpm/pnpm/issues/14550)).
 ///
 /// The serialized bytes are `JSON.stringify(state, undefined, 2) + '\n'`:
 /// `serde_json`'s pretty printer uses the same 2-space indent and `": "`
@@ -250,10 +253,27 @@ pub fn update_workspace_state(
     temp.write_all(serialized.as_bytes()).map_err(|source| {
         UpdateWorkspaceStateError::WriteFile { path: file_path.clone(), source }
     })?;
-    temp.persist(&file_path).map_err(|error| UpdateWorkspaceStateError::WriteFile {
-        path: file_path,
+    // `NamedTempFile::persist` renames exactly once. On Windows that rename
+    // fails with `ERROR_ACCESS_DENIED` while any other process holds the
+    // destination open — an antivirus scan, the search indexer, or a
+    // concurrent pnpm — so the atomic write needs the same bounded retry the
+    // rest of pacquet applies to renames. Disarming the temp file has to
+    // happen before the rename, because the guard resolves its own path and
+    // the rename has consumed it by the time the guard would drop.
+    let (_file, temp_path) = temp.keep().map_err(|error| UpdateWorkspaceStateError::WriteFile {
+        path: file_path.clone(),
         source: error.error,
     })?;
+    if let Err(source) = pnpm_fs::rename_with_retry(&temp_path, &file_path) {
+        // The temp file no longer deletes itself, so a failed rename would
+        // otherwise leave a stray sibling next to the state file. Ignore a
+        // cleanup failure on purpose: the rename error is the one that
+        // explains the lost write, and replacing it with an unlink error
+        // would hide that cause to report a stray file the next write
+        // overwrites anyway.
+        let _ = fs::remove_file(&temp_path);
+        return Err(UpdateWorkspaceStateError::WriteFile { path: file_path, source });
+    }
     Ok(())
 }
 

--- a/pnpm/crates/workspace-state/src/tests.rs
+++ b/pnpm/crates/workspace-state/src/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    LoadWorkspaceStateError, NodeLinker, ProjectEntry, UpdateWorkspaceStateError, WorkspaceState,
-    WorkspaceStateSettings, get_file_path, load_workspace_state, now_millis,
-    update_workspace_state,
+    LoadWorkspaceStateError, NodeLinker, ProjectEntry, UpdateWorkspaceStateError,
+    WORKSPACE_STATE_FILENAME, WorkspaceState, WorkspaceStateSettings, get_file_path,
+    load_workspace_state, now_millis, update_workspace_state,
 };
 use indexmap::IndexMap;
 use pretty_assertions::assert_eq;
@@ -184,4 +184,116 @@ fn load_surfaces_parse_json_error_on_malformed_state() {
         matches!(err, LoadWorkspaceStateError::ParseJson { .. }),
         "expected ParseJson error, got {err:?}",
     );
+}
+
+/// The write-path tests below assert where the bytes land, not what is
+/// in them, so the payload stays empty.
+fn empty_state() -> WorkspaceState {
+    WorkspaceState {
+        last_validated_timestamp: 0,
+        projects: BTreeMap::new(),
+        pnpmfiles: vec![],
+        filtered_install: false,
+        config_dependencies: None,
+        settings: WorkspaceStateSettings::default(),
+    }
+}
+
+fn node_modules_entries(workspace_dir: &std::path::Path) -> Vec<String> {
+    let mut names: Vec<String> = std::fs::read_dir(workspace_dir.join("node_modules"))
+        .expect("read node_modules")
+        .map(|entry| entry.expect("read entry").file_name().to_string_lossy().into_owned())
+        .collect();
+    names.sort();
+    names
+}
+
+/// The temp file the write goes through is disarmed before the
+/// rename, so nothing deletes it on drop any more. A successful
+/// rename has to be what removes it from the directory.
+#[test]
+fn write_leaves_no_temp_file_beside_the_state_file() {
+    let tmp = tempdir().expect("create temp dir");
+    let workspace_dir = tmp.path();
+
+    update_workspace_state(workspace_dir, &empty_state()).expect("write state");
+    update_workspace_state(workspace_dir, &empty_state()).expect("overwrite state");
+
+    assert_eq!(node_modules_entries(workspace_dir), vec![WORKSPACE_STATE_FILENAME.to_string()]);
+}
+
+/// A rename that cannot succeed still has to clean up after the
+/// disarmed temp file. Renaming onto a directory fails outright on
+/// Unix (`IsADirectory` / `NotADirectory`), which the retry
+/// classifier leaves alone; on Windows the same setup reports
+/// `ERROR_ACCESS_DENIED`, which *is* retried, so this stays Unix-only
+/// rather than burning the retry budget.
+#[cfg(unix)]
+#[test]
+fn failed_rename_reports_write_error_and_leaves_no_temp_file() {
+    let tmp = tempdir().expect("create temp dir");
+    let workspace_dir = tmp.path();
+    let target = get_file_path(workspace_dir);
+    std::fs::create_dir_all(&target).expect("seed a directory where the state file goes");
+
+    let err = update_workspace_state(workspace_dir, &empty_state())
+        .expect_err("renaming onto a directory should fail");
+    assert!(
+        matches!(err, UpdateWorkspaceStateError::WriteFile { .. }),
+        "expected WriteFile error, got {err:?}",
+    );
+    assert_eq!(node_modules_entries(workspace_dir), vec![WORKSPACE_STATE_FILENAME.to_string()]);
+}
+
+/// The write survives another process holding the destination open
+/// without `FILE_SHARE_DELETE` — an antivirus scan or the search
+/// indexer — for as long as that handle lives
+/// ([#14550](https://github.com/pnpm/pnpm/issues/14550)). A single
+/// `MoveFileEx` fails such a rename with `ERROR_ACCESS_DENIED`, so
+/// without the retry this write reports
+/// `ERR_PNPM_WORKSPACE_STATE_WRITE_IO` instead of waiting the lock
+/// out. Windows-only: on Unix the rename is not blocked by an open
+/// handle at all, so there is nothing to retry.
+#[cfg(windows)]
+#[test]
+fn transient_lock_on_the_state_file_does_not_fail_the_write() {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    /// `FILE_SHARE_READ | FILE_SHARE_WRITE`, deliberately without
+    /// `FILE_SHARE_DELETE`: that is the share mode that blocks a
+    /// rename over the open file.
+    const SHARE_READ_WRITE: u32 = 0x0000_0001 | 0x0000_0002;
+    const HOLD: std::time::Duration = std::time::Duration::from_millis(300);
+
+    let tmp = tempdir().expect("create temp dir");
+    let workspace_dir = tmp.path();
+    update_workspace_state(workspace_dir, &empty_state()).expect("seed state file");
+
+    let handle = std::fs::OpenOptions::new()
+        .read(true)
+        .share_mode(SHARE_READ_WRITE)
+        .open(get_file_path(workspace_dir))
+        .expect("hold the state file open");
+    // Start the clock before the releaser, so the measured wait always
+    // covers the whole hold: taking it afterwards lets a descheduled main
+    // thread miss part of the countdown and fail a retry that worked.
+    let started = std::time::Instant::now();
+    let releaser = std::thread::spawn(move || {
+        std::thread::sleep(HOLD);
+        drop(handle);
+    });
+
+    update_workspace_state(workspace_dir, &empty_state())
+        .expect("the write should wait the transient lock out");
+    let waited = started.elapsed();
+
+    releaser.join().expect("release the handle");
+    // Succeeding is not on its own evidence that the retry did it: a rename
+    // the handle never blocked would have returned immediately and passed
+    // just the same. Only having waited for the handle shows otherwise.
+    assert!(
+        waited >= HOLD / 2,
+        "the rename returned after {waited:?}, so the open handle never blocked it",
+    );
+    assert_eq!(node_modules_entries(workspace_dir), vec![WORKSPACE_STATE_FILENAME.to_string()]);
 }

--- a/pnpm11/deps/status/src/checkDepsStatus.ts
+++ b/pnpm11/deps/status/src/checkDepsStatus.ts
@@ -41,7 +41,7 @@ import {
   type ProjectManifest,
 } from '@pnpm/types'
 import { findWorkspaceProjectsNoCheck } from '@pnpm/workspace.projects-reader'
-import { loadWorkspaceState, updateWorkspaceState, WORKSPACE_STATE_SETTING_KEYS, type WorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
+import { loadWorkspaceState, updateWorkspaceStateOrWarn, WORKSPACE_STATE_SETTING_KEYS, type WorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
 import { readWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-reader'
 import { equals, filter, isEmpty, once } from 'ramda'
 
@@ -487,7 +487,7 @@ async function _checkDepsStatus (opts: CheckDepsStatusOptions, workspaceState: W
     }
 
     // update lastValidatedTimestamp to prevent pointless repeat
-    await updateWorkspaceState({
+    await updateWorkspaceStateOrWarn({
       allProjects,
       workspaceDir,
       pnpmfiles: workspaceState.pnpmfiles,

--- a/pnpm11/installing/commands/src/installDeps.ts
+++ b/pnpm11/installing/commands/src/installDeps.ts
@@ -39,7 +39,7 @@ import { filterProjectsBySelectorObjects } from '@pnpm/workspace.projects-filter
 import { createProjectsGraph } from '@pnpm/workspace.projects-graph'
 import { findWorkspaceProjects } from '@pnpm/workspace.projects-reader'
 import { sequenceGraph } from '@pnpm/workspace.projects-sorter'
-import { updateWorkspaceState, type WorkspaceStateSettings } from '@pnpm/workspace.state'
+import { updateWorkspaceStateOrWarn, type WorkspaceStateSettings } from '@pnpm/workspace.state'
 import { updateWorkspaceManifest } from '@pnpm/workspace.workspace-manifest-writer'
 
 import { getSaveType } from './getSaveType.js'
@@ -449,7 +449,7 @@ export async function installDeps (
       ])
     }
     if (!opts.lockfileOnly) {
-      await updateWorkspaceState({
+      await updateWorkspaceStateOrWarn({
         allProjects,
         settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
@@ -534,7 +534,7 @@ export async function installDeps (
     )
   } else {
     if (!opts.lockfileOnly) {
-      await updateWorkspaceState({
+      await updateWorkspaceStateOrWarn({
         allProjects,
         settings: withUpdatedCatalogs(opts, updatedCatalogs),
         workspaceDir: opts.workspaceDir ?? opts.lockfileDir ?? opts.dir,
@@ -562,7 +562,7 @@ async function recursiveInstallThenUpdateWorkspaceState (
 ): Promise<DryRunInstallResult | undefined> {
   const recursiveResult = await recursive(allProjects, params, opts, cmdFullName)
   if (!opts.lockfileOnly) {
-    await updateWorkspaceState({
+    await updateWorkspaceStateOrWarn({
       allProjects,
       settings: withUpdatedCatalogs(opts, updatedCatalogs, recursiveResult.updatedCatalogs),
       workspaceDir: opts.workspaceDir,

--- a/pnpm11/workspace/state/package.json
+++ b/pnpm11/workspace/state/package.json
@@ -34,9 +34,10 @@
   "dependencies": {
     "@pnpm/catalogs.types": "workspace:*",
     "@pnpm/config.reader": "workspace:*",
+    "@pnpm/fs.graceful-fs": "workspace:*",
     "@pnpm/types": "workspace:*",
-    "ramda": "catalog:",
-    "write-file-atomic": "catalog:"
+    "path-temp": "catalog:",
+    "ramda": "catalog:"
   },
   "peerDependencies": {
     "@pnpm/logger": "catalog:"
@@ -46,8 +47,7 @@
     "@pnpm/logger": "workspace:*",
     "@pnpm/prepare": "workspace:*",
     "@pnpm/workspace.state": "workspace:*",
-    "@types/ramda": "catalog:",
-    "@types/write-file-atomic": "catalog:"
+    "@types/ramda": "catalog:"
   },
   "engines": {
     "node": ">=22.13"

--- a/pnpm11/workspace/state/src/index.ts
+++ b/pnpm11/workspace/state/src/index.ts
@@ -1,3 +1,3 @@
 export { loadWorkspaceState } from './loadWorkspaceState.js'
 export { type ProjectsList, WORKSPACE_STATE_SETTING_KEYS, type WorkspaceState, type WorkspaceStateSettings } from './types.js'
-export { updateWorkspaceState, type UpdateWorkspaceStateOptions } from './updateWorkspaceState.js'
+export { updateWorkspaceState, type UpdateWorkspaceStateOptions, updateWorkspaceStateOrWarn } from './updateWorkspaceState.js'

--- a/pnpm11/workspace/state/src/updateWorkspaceState.ts
+++ b/pnpm11/workspace/state/src/updateWorkspaceState.ts
@@ -1,9 +1,11 @@
 import fs from 'node:fs'
 import path from 'node:path'
+import util from 'node:util'
 
+import { renameFileWithRetry } from '@pnpm/fs.graceful-fs'
 import { logger } from '@pnpm/logger'
 import type { ConfigDependencies } from '@pnpm/types'
-import writeFileAtomic from 'write-file-atomic'
+import { pathTemp } from 'path-temp'
 
 import { createWorkspaceState } from './createWorkspaceState.js'
 import { getFilePath } from './filePath.js'
@@ -23,6 +25,37 @@ export async function updateWorkspaceState (opts: UpdateWorkspaceStateOptions): 
   const workspaceState = createWorkspaceState(opts)
   const workspaceStateJSON = JSON.stringify(workspaceState, undefined, 2) + '\n'
   const cacheFile = getFilePath(opts.workspaceDir)
-  await fs.promises.mkdir(path.dirname(cacheFile), { recursive: true })
-  await writeFileAtomic(cacheFile, workspaceStateJSON)
+  const cacheDir = path.dirname(cacheFile)
+  await fs.promises.mkdir(cacheDir, { recursive: true })
+  // Written through a temp sibling so a concurrent reader sees either the
+  // whole old file or the whole new one, and renamed with the retry that
+  // waits out whoever else holds the destination open on Windows.
+  const tmp = pathTemp(cacheDir)
+  try {
+    await fs.promises.writeFile(tmp, workspaceStateJSON)
+    renameFileWithRetry(tmp, cacheFile)
+  } catch (err) {
+    await fs.promises.unlink(tmp).catch(() => {})
+    throw err
+  }
+}
+
+/**
+ * Records the workspace state, reporting a failed write as a warning.
+ *
+ * The state file is a cache: losing a write only costs the next command a
+ * repeat of the content check, so a write failure must not fail a command
+ * whose real work has already succeeded
+ * (https://github.com/pnpm/pnpm/issues/14550).
+ */
+export async function updateWorkspaceStateOrWarn (opts: UpdateWorkspaceStateOptions): Promise<void> {
+  try {
+    await updateWorkspaceState(opts)
+  } catch (err: unknown) {
+    const reason = util.types.isNativeError(err) ? err.message : String(err)
+    logger.warn({
+      message: `Failed to update the workspace state: ${reason}`,
+      prefix: opts.workspaceDir,
+    })
+  }
 }

--- a/pnpm11/workspace/state/test/updateWorkspaceState.test.ts
+++ b/pnpm11/workspace/state/test/updateWorkspaceState.test.ts
@@ -1,0 +1,75 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { afterEach, beforeEach, expect, jest, test } from '@jest/globals'
+import { logger } from '@pnpm/logger'
+import { prepareEmpty } from '@pnpm/prepare'
+
+import { getFilePath } from '../src/filePath.js'
+import { updateWorkspaceState, type UpdateWorkspaceStateOptions, updateWorkspaceStateOrWarn } from '../src/index.js'
+
+const originalLoggerWarn = logger.warn
+beforeEach(() => {
+  logger.warn = jest.fn(originalLoggerWarn)
+})
+afterEach(() => {
+  logger.warn = originalLoggerWarn
+})
+
+function options (workspaceDir: string): UpdateWorkspaceStateOptions {
+  return {
+    allProjects: [],
+    settings: {
+      excludeLinksFromLockfile: false,
+      linkWorkspacePackages: false,
+      preferWorkspacePackages: false,
+    },
+    workspaceDir,
+    pnpmfiles: [],
+    filteredInstall: false,
+  }
+}
+
+function cacheDirEntries (workspaceDir: string): string[] {
+  return fs.readdirSync(path.dirname(getFilePath(workspaceDir))).sort()
+}
+
+test('updateWorkspaceState() leaves no temp file beside the state file', async () => {
+  prepareEmpty()
+  const workspaceDir = process.cwd()
+
+  await updateWorkspaceState(options(workspaceDir))
+  await updateWorkspaceState(options(workspaceDir))
+
+  expect(fs.existsSync(getFilePath(workspaceDir))).toBe(true)
+  expect(cacheDirEntries(workspaceDir)).toStrictEqual([path.basename(getFilePath(workspaceDir))])
+})
+
+// A rename onto a directory fails outright on Unix, which the retry
+// classifier leaves alone. On Windows the same setup reports EPERM, which
+// *is* retried, so this stays Unix-only rather than burning the retry budget.
+const testOnUnix = process.platform === 'win32' ? test.skip : test
+
+testOnUnix('updateWorkspaceState() rejects and leaves no temp file when the write cannot land', async () => {
+  prepareEmpty()
+  const workspaceDir = process.cwd()
+  const cacheFile = getFilePath(workspaceDir)
+  fs.mkdirSync(cacheFile, { recursive: true })
+
+  await expect(updateWorkspaceState(options(workspaceDir))).rejects.toThrow()
+  expect(cacheDirEntries(workspaceDir)).toStrictEqual([path.basename(cacheFile)])
+})
+
+testOnUnix('updateWorkspaceStateOrWarn() warns instead of failing the command', async () => {
+  prepareEmpty()
+  const workspaceDir = process.cwd()
+  fs.mkdirSync(getFilePath(workspaceDir), { recursive: true })
+
+  await expect(updateWorkspaceStateOrWarn(options(workspaceDir))).resolves.toBeUndefined()
+  expect(jest.mocked(logger.warn).mock.calls).toHaveLength(1)
+  expect(jest.mocked(logger.warn).mock.calls[0][0]).toMatchObject({
+    prefix: workspaceDir,
+  })
+  expect((jest.mocked(logger.warn).mock.calls[0][0] as { message: string }).message)
+    .toContain('Failed to update the workspace state')
+})

--- a/pnpm11/workspace/state/tsconfig.json
+++ b/pnpm11/workspace/state/tsconfig.json
@@ -23,6 +23,9 @@
     },
     {
       "path": "../../core/types"
+    },
+    {
+      "path": "../../fs/graceful-fs"
     }
   ]
 }


### PR DESCRIPTION
## Summary

`update_workspace_state` writes `node_modules/.pnpm-workspace-state-v1.json` through a temp file and one rename. On Windows that rename fails with `ERROR_ACCESS_DENIED` while any other process holds the destination open, and two of its four callers turned that into a fatal install error. Because `verifyDepsBeforeRun` defaults to `install`, a lost write to a **cache** file killed a `pnpm run` whose install had already materialized `node_modules` and whose script never started.

Two changes, both taken from patterns the repo already uses:

| | before | after |
| --- | --- | --- |
| the rename | `NamedTempFile::persist` / `write-file-atomic`, one attempt | `rename_with_retry` / `renameFileWithRetry`, the existing bounded Windows backoff |
| a failed write | fatal at 2 of 4 pacquet callers, at 4 of 4 pnpm v11 callers | a warning at all of them, in both stacks |

The retry helpers were already there for exactly this failure: `rename_with_retry` is used for junction creation (pnpm/pnpm#13009), and `renameFileWithRetry` by `importIndexedDir` and `hard-link-dir`. Neither is new code, and both are no-ops on Unix, so nothing changes off Windows except which callers abort.

Closes pnpm/pnpm#14550

## Both stacks are affected, so both are fixed

The triage on the issue reads this as pacquet-only. That is not what the code says, and the reporter measured v11 failing under the same harness (7 in 240 runs):

- **`write-file-atomic@7.0.1` does not retry its rename.** `lib/index.js:144` is a bare `await promisify(fs.rename)(tmpfile, truename)`. The `EPERM` handling at line 72 is `isChownErrOk`, which only guards `chown`/`chmod`.
- **All four v11 call sites awaited the write unguarded** — three in `installDeps.ts`, one in `checkDepsStatus.ts` — so v11 is worse here than v12, which already warned at two of its four.

v11 now routes the write through `renameFileWithRetry` and its callers through a new `updateWorkspaceStateOrWarn`. One helper rather than four copies of the same `try`/`catch`; pacquet keeps the guard at its call sites, where two already were.

Dropping `write-file-atomic` from `@pnpm/workspace.state` also drops its `fsync` and its same-path write serialization. Both are deliberate: pacquet's writer does neither, and the issue notes that last-writer-wins on this file is by design. Every temp name is unique per call, so concurrent writers cannot collide on it.

## What is verified, and what is not

Run locally on macOS:

| gate | result |
| --- | --- |
| `cargo test -p pnpm-workspace-state -p pnpm-package-manager` | 694 passed |
| `cargo clippy --all-targets -- -D warnings` on both crates | clean |
| `@pnpm/workspace.state` | 12 passed |
| `@pnpm/deps.status` | 61 passed |
| `@pnpm/installing.commands` | 249 passed, 6 skipped |
| `pnpm` e2e `test/verifyDepsBeforeRun` | 16 passed |

Both cleanup tests are real witnesses, checked by breaking the implementation:

- pacquet: dropping `fs::remove_file(&temp_path)` leaves a stray temp file and fails `failed_rename_reports_write_error_and_leaves_no_temp_file`.
- v11: unlinking the wrong path fails `updateWorkspaceState() rejects and leaves no temp file when the write cannot land`.

**The retry is witnessed only on Windows, and only by CI.** `rename_with_retry` and `renameFileWithRetry` both run the operation exactly once off Windows, so no Unix test can tell this change from the code it replaces. `transient_lock_on_the_state_file_does_not_fail_the_write` is the witness: it holds the state file open without `FILE_SHARE_DELETE`, releases the handle from another thread after 300 ms, and asserts both that the write succeeds **and that it waited for the handle**. The second half matters — succeeding alone proves nothing, because a rename the handle never blocked would return immediately and pass just the same, and the thread join hides the difference in wall-clock time either way. A rename that does not wait now fails the test.

I have no Windows machine. That test first executed on this PR's `Rust CI / Test / windows` job, where it passed as `8968/8970` in a 8970-test run; the timing assertion above was added afterwards, so the run that proves the retry actually engaged is the one on this push. The `#[cfg(windows)]` block is type-checked locally against `x86_64-pc-windows-msvc`, but that is compilation, not behavior.

I also did not reproduce the reporter's 13-in-240 concurrency failure. What is verified off Windows is the handling: losing the write no longer aborts a command that has already done its work.

## Squash Commit Body

```text
update_workspace_state persisted its temp file with a single rename, so
on Windows the write failed with ERROR_ACCESS_DENIED whenever another
process held .pnpm-workspace-state-v1.json open: an antivirus scan, the
search indexer, or a concurrent pnpm. Both stacks now rename through the
bounded Windows backoff they already use elsewhere, rename_with_retry in
pacquet and renameFileWithRetry in pnpm v11. Both run the operation once
on Unix, so nothing changes there.

Two of pacquet's four callers turned a failed write into a fatal install
error, and all four of v11's did. Because verifyDepsBeforeRun defaults to
install, that aborted a pnpm run whose install had already materialized
node_modules and whose script never started. Every caller now warns and
continues, as two of pacquet's already did; a missing state file only
costs the next command a repeat of the content check.

write-file-atomic renames once too (lib/index.js:144), which is why v11
needed the same fix rather than only the non-fatal half. Its fsync and
same-path serialization go with it, matching pacquet's writer and the
last-writer-wins the issue describes as intended.

That left InstallError::WriteWorkspaceState with no callers.

Closes pnpm/pnpm#14550
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace-state writes now retry transient file-lock errors on Windows and clean up temporary files after success or failure.
  * Installations and dependency status checks now continue with a warning when workspace-state persistence fails, instead of failing.
  * Up-to-date checks no longer fail due to workspace-state write errors.
* **Documentation**
  * Added release notes covering workspace-state warnings, prior install behavior, and Windows retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->