### PR TITLE
fix(deploy): run the source workspace's pnpmfile, not the deployed copy

### DIFF
--- a/.changeset/deploy-ignores-the-deployed-pnpmfile.md
+++ b/.changeset/deploy-ignores-the-deployed-pnpmfile.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm deploy` now runs the source workspace's pnpmfile, not the copy of it that the deployed project's files leave in the deploy directory. A project that ships its own `.pnpmfile.mjs` no longer fails the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` [#14671](https://github.com/pnpm/pnpm/issues/14671).

--- a/.changeset/deploy-ignores-the-deployed-pnpmfile.md
+++ b/.changeset/deploy-ignores-the-deployed-pnpmfile.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm deploy` now runs the source workspace's pnpmfile. It used to run the copy of it that the deployed project's own files leave in the deploy directory, which failed the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` for any project that ships a `.pnpmfile.mjs` [#14671](https://github.com/pnpm/pnpm/issues/14671).
+`pnpm deploy` now runs the source workspace's pnpmfile. It used to run the copy of that pnpmfile that the deploy leaves in the target directory. That failed the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` for any project that ships a `.pnpmfile.mjs` [#14671](https://github.com/pnpm/pnpm/issues/14671).

--- a/.changeset/deploy-ignores-the-deployed-pnpmfile.md
+++ b/.changeset/deploy-ignores-the-deployed-pnpmfile.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm deploy` now runs the source workspace's pnpmfile, not the copy of it that the deployed project's files leave in the deploy directory. A project that ships its own `.pnpmfile.mjs` no longer fails the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` [#14671](https://github.com/pnpm/pnpm/issues/14671).
+`pnpm deploy` now runs the source workspace's pnpmfile. It used to run the copy of it that the deployed project's own files leave in the deploy directory, which failed the deploy with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` for any project that ships a `.pnpmfile.mjs` [#14671](https://github.com/pnpm/pnpm/issues/14671).

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -203,7 +203,7 @@ impl DeployArgs {
                 workspace_dir,
                 &selected,
                 &deploy_dir,
-                Arc::clone(&source_hooks),
+                source_hooks.as_ref().map(Arc::clone),
             ))
             .await?
             {
@@ -236,7 +236,7 @@ impl DeployArgs {
         workspace_dir: &Path,
         selected: &SelectedProject,
         deploy_dir: &Path,
-        source_hooks: Arc<dyn pnpm_hooks::PnpmfileHooks>,
+        source_hooks: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
     ) -> miette::Result<SharedDeployOutcome> {
         // The shared lockfile, and the importer ids naming the projects in
         // it, belong to the lockfile dir — which `lockfileDir` can move
@@ -299,7 +299,7 @@ impl DeployArgs {
         deploy_dir: &Path,
         mode: DeployInstallMode,
         frozen_lockfile: bool,
-        source_hooks: Arc<dyn pnpm_hooks::PnpmfileHooks>,
+        source_hooks: Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>,
     ) -> miette::Result<()> {
         let node_linker = self
             .install_args
@@ -311,6 +311,12 @@ impl DeployArgs {
         // bypasses the installability check so optional dependencies of
         // every platform are materialized (see `Config::force`).
         deploy_config.force = self.install_args.force;
+        // `source_hooks` is the whole of the pnpmfile this install runs.
+        // With none to run there is nothing left to discover either: the
+        // install must not fall back to looking next to the deployed
+        // manifest, where `copy_project` may have left the deployed
+        // project's own pnpmfile.
+        deploy_config.ignore_pnpmfile = source_hooks.is_none();
 
         let legacy = matches!(&mode, DeployInstallMode::Legacy);
         // The lockfile a shared deploy generates records no
@@ -318,11 +324,9 @@ impl DeployArgs {
         // claim one either. The legacy path resolves the deployed project
         // from scratch and writes its own lockfile, which records the
         // checksum as any other install does.
-        let pnpmfile_hook: Arc<dyn pnpm_hooks::PnpmfileHooks> = if legacy {
-            source_hooks
-        } else {
-            Arc::new(pnpm_hooks::ChecksumFreeHooks::from(source_hooks))
-        };
+        let pnpmfile_hook = source_hooks.map(|hooks| -> Arc<dyn pnpm_hooks::PnpmfileHooks> {
+            if legacy { hooks } else { Arc::new(pnpm_hooks::ChecksumFreeHooks::from(hooks)) }
+        });
         match mode {
             DeployInstallMode::Legacy => {}
             DeployInstallMode::Shared { workspace_config } => {
@@ -419,7 +423,7 @@ impl DeployArgs {
             deps_requiring_build_sink: None,
             catalogs_override: None,
             disable_optimistic_repeat_install: true,
-            pnpmfile_hook_override: Some(pnpmfile_hook),
+            pnpmfile_hook_override: pnpmfile_hook,
             workspace_projects_override,
         };
         if legacy {
@@ -432,28 +436,20 @@ impl DeployArgs {
 }
 
 /// The pnpmfile the deploy install runs, resolved the way an install of
-/// the selected project resolves its own.
-///
-/// Never discovered from the deploy directory. [`copy_project`] copies the
-/// project's files there, a `.pnpmfile.*` among them, and the pnpmfile
-/// that shapes a deployed dependency graph is the source workspace's,
-/// whose effects are already part of the snapshots the deploy writes.
-/// [`pnpm_hooks::NoopHooks`] stands in when there is nothing to run, so
-/// the install has an answer and does not go looking next to the
-/// deployed manifest for one.
+/// the selected project resolves its own: from the source workspace,
+/// whose hooks shape the dependency graph the deploy writes out.
 fn source_pnpmfile_hooks(
     config: &Config,
     project_dir: &Path,
-) -> miette::Result<Arc<dyn pnpm_hooks::PnpmfileHooks>> {
+) -> miette::Result<Option<Arc<dyn pnpm_hooks::PnpmfileHooks>>> {
     if config.ignore_pnpmfile {
-        return Ok(Arc::new(pnpm_hooks::NoopHooks));
+        return Ok(None);
     }
     pnpm_hooks::finder::load_pnpmfiles(
         config.lockfile_dir_for(project_dir),
         pnpm_package_manager::pnpmfile_selection(config),
     )
     .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))
-    .map(|hooks| hooks.unwrap_or_else(|| Arc::new(pnpm_hooks::NoopHooks)))
 }
 
 fn create_deploy_install_config(

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -173,6 +173,11 @@ impl DeployArgs {
             return Err(DeployError::InvalidDeployTarget.into());
         }
 
+        // Resolved before the target is prepared: a `pnpmfile` setting
+        // naming a file that is not there fails the deploy, and it should
+        // do so without having emptied the target first.
+        let source_hooks = source_pnpmfile_hooks(config, &selected.project.root_dir)?;
+
         let force_legacy = self.legacy || config.force_legacy_deploy;
         let deploy_dir = resolve_target_dir(dir, &self.target_dirs[0]);
         // Deploy's `--force` (declared on the flattened `InstallArgs`)
@@ -198,6 +203,7 @@ impl DeployArgs {
                 workspace_dir,
                 &selected,
                 &deploy_dir,
+                Arc::clone(&source_hooks),
             ))
             .await?
             {
@@ -219,6 +225,7 @@ impl DeployArgs {
             &deploy_dir,
             DeployInstallMode::Legacy,
             false,
+            source_hooks,
         ))
         .await
     }
@@ -229,6 +236,7 @@ impl DeployArgs {
         workspace_dir: &Path,
         selected: &SelectedProject,
         deploy_dir: &Path,
+        source_hooks: Arc<dyn pnpm_hooks::PnpmfileHooks>,
     ) -> miette::Result<SharedDeployOutcome> {
         // The shared lockfile, and the importer ids naming the projects in
         // it, belong to the lockfile dir — which `lockfileDir` can move
@@ -279,6 +287,7 @@ impl DeployArgs {
             deploy_dir,
             DeployInstallMode::Shared { workspace_config: deploy_files.workspace_config },
             true,
+            source_hooks,
         ))
         .await?;
         Ok(SharedDeployOutcome::Deployed)
@@ -290,6 +299,7 @@ impl DeployArgs {
         deploy_dir: &Path,
         mode: DeployInstallMode,
         frozen_lockfile: bool,
+        source_hooks: Arc<dyn pnpm_hooks::PnpmfileHooks>,
     ) -> miette::Result<()> {
         let node_linker = self
             .install_args
@@ -303,6 +313,16 @@ impl DeployArgs {
         deploy_config.force = self.install_args.force;
 
         let legacy = matches!(&mode, DeployInstallMode::Legacy);
+        // The lockfile a shared deploy generates records no
+        // `pnpmfileChecksum`, so the pnpmfile behind these hooks must not
+        // claim one either. The legacy path resolves the deployed project
+        // from scratch and writes its own lockfile, which records the
+        // checksum as any other install does.
+        let pnpmfile_hook: Arc<dyn pnpm_hooks::PnpmfileHooks> = if legacy {
+            source_hooks
+        } else {
+            Arc::new(pnpm_hooks::ChecksumFreeHooks::from(source_hooks))
+        };
         match mode {
             DeployInstallMode::Legacy => {}
             DeployInstallMode::Shared { workspace_config } => {
@@ -399,7 +419,7 @@ impl DeployArgs {
             deps_requiring_build_sink: None,
             catalogs_override: None,
             disable_optimistic_repeat_install: true,
-            pnpmfile_hook_override: None,
+            pnpmfile_hook_override: Some(pnpmfile_hook),
             workspace_projects_override,
         };
         if legacy {
@@ -409,6 +429,31 @@ impl DeployArgs {
         }
         .wrap_err("installing deployed dependencies")
     }
+}
+
+/// The pnpmfile the deploy install runs, resolved the way an install of
+/// the selected project resolves its own.
+///
+/// Never discovered from the deploy directory. `copy_project` copies the
+/// project's files there, a `.pnpmfile.*` among them, and the pnpmfile
+/// that shapes a deployed dependency graph is the source workspace's,
+/// whose effects are already part of the snapshots the deploy writes.
+/// [`pnpm_hooks::NoopHooks`] stands in when there is nothing to run, so
+/// the install has an answer and does not go looking next to the
+/// deployed manifest for one.
+fn source_pnpmfile_hooks(
+    config: &Config,
+    project_dir: &Path,
+) -> miette::Result<Arc<dyn pnpm_hooks::PnpmfileHooks>> {
+    if config.ignore_pnpmfile {
+        return Ok(Arc::new(pnpm_hooks::NoopHooks));
+    }
+    pnpm_hooks::finder::load_pnpmfiles(
+        config.lockfile_dir_for(project_dir),
+        pnpm_package_manager::pnpmfile_selection(config),
+    )
+    .map_err(|error| miette::miette!(code = "ERR_PNPM_PNPMFILE_NOT_FOUND", "{error}"))
+    .map(|hooks| hooks.unwrap_or_else(|| Arc::new(pnpm_hooks::NoopHooks)))
 }
 
 fn create_deploy_install_config(

--- a/pnpm/crates/cli/src/cli_args/deploy.rs
+++ b/pnpm/crates/cli/src/cli_args/deploy.rs
@@ -434,7 +434,7 @@ impl DeployArgs {
 /// The pnpmfile the deploy install runs, resolved the way an install of
 /// the selected project resolves its own.
 ///
-/// Never discovered from the deploy directory. `copy_project` copies the
+/// Never discovered from the deploy directory. [`copy_project`] copies the
 /// project's files there, a `.pnpmfile.*` among them, and the pnpmfile
 /// that shapes a deployed dependency graph is the source workspace's,
 /// whose effects are already part of the snapshots the deploy writes.

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1356,6 +1356,126 @@ fn virtual_store_entries(deploy_dir: &Path) -> Vec<String> {
         .collect()
 }
 
+/// `copy_project` copies the deployed project's packlist, a `.pnpmfile.mjs`
+/// among it, so the deploy directory ends up holding a pnpmfile of its own.
+/// The install that populates it must not run that copy — only the pnpmfile
+/// the source workspace resolves.
+#[test]
+fn shared_lockfile_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    let project_dir = workspace.join("packages/app");
+    write_recording_pnpmfile(&project_dir);
+    pack_pnpmfile_with_project(&project_dir);
+
+    pacquet.with_arg("install").assert().success();
+
+    pacquet_cmd(&workspace).with_args(["--filter", "app", "deploy", "deploy"]).assert().success();
+
+    let deploy_dir = workspace.join("deploy");
+    assert!(
+        deploy_dir.join(".pnpmfile.mjs").exists(),
+        "the deployed packlist should have carried the project's pnpmfile over",
+    );
+    assert!(
+        !deploy_dir.join(PNPMFILE_SENTINEL).exists(),
+        "the deploy install must not load the pnpmfile it just copied",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// The mirror of the check above: the pnpmfile the deploy install *does*
+/// run is the source workspace's, as on pnpm 11.
+#[test]
+fn shared_lockfile_deploy_runs_the_source_workspace_pnpmfile() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    write_recording_pnpmfile(&workspace);
+
+    pacquet.with_arg("install").assert().success();
+    fs::remove_file(workspace.join(PNPMFILE_SENTINEL)).expect("the install ran the pnpmfile");
+
+    pacquet_cmd(&workspace).with_args(["--filter", "app", "deploy", "deploy"]).assert().success();
+
+    assert!(
+        workspace.join(PNPMFILE_SENTINEL).exists(),
+        "the deploy install should run the source workspace's pnpmfile",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Without a shared lockfile the deploy takes the legacy path, and the
+/// pnpmfile an install of the selected project would load is the project's
+/// own — still never the deployed copy.
+#[test]
+fn legacy_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    write_workspace(&workspace, true);
+    append_workspace_yaml_key(&workspace, "sharedWorkspaceLockfile", false);
+    let project_dir = workspace.join("packages/app");
+    write_recording_pnpmfile(&project_dir);
+    pack_pnpmfile_with_project(&project_dir);
+
+    pacquet.with_arg("install").assert().success();
+    fs::remove_file(project_dir.join(PNPMFILE_SENTINEL)).expect("the install ran the pnpmfile");
+
+    pacquet_cmd(&workspace).with_args(["--filter", "app", "deploy", "deploy"]).assert().success();
+
+    assert!(
+        project_dir.join(PNPMFILE_SENTINEL).exists(),
+        "the legacy deploy install should run the selected project's pnpmfile",
+    );
+    assert!(
+        !workspace.join("deploy").join(PNPMFILE_SENTINEL).exists(),
+        "the legacy deploy install must not load the pnpmfile it just copied",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// Written by the pnpmfile [`write_recording_pnpmfile`] installs, next to
+/// that pnpmfile, so a test can tell which copy of it an install loaded.
+const PNPMFILE_SENTINEL: &str = "pnpmfile-ran.txt";
+
+/// Ship the project's `.pnpmfile.mjs` in its packlist, so a default deploy
+/// copies it into the deploy directory.
+fn pack_pnpmfile_with_project(project_dir: &Path) {
+    let manifest_path = project_dir.join("package.json");
+    let mut manifest: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&manifest_path).unwrap()).unwrap();
+    manifest["files"]
+        .as_array_mut()
+        .expect("a project packlist")
+        .push(serde_json::Value::from(".pnpmfile.mjs"));
+    fs::write(&manifest_path, manifest.to_string()).unwrap();
+}
+
+fn write_recording_pnpmfile(dir: &Path) {
+    fs::write(
+        dir.join(".pnpmfile.mjs"),
+        format!(
+            "import {{ writeFileSync }} from 'node:fs'
+
+export const hooks = {{
+  readPackage (pkg) {{
+    writeFileSync(new URL('./{PNPMFILE_SENTINEL}', import.meta.url), 'ran')
+    return pkg
+  }},
+}}
+"
+        ),
+    )
+    .unwrap();
+}
+
 fn write_workspace(workspace: &Path, inject_workspace_packages: bool) {
     let mut workspace_yaml = fs::read_to_string(workspace.join("pnpm-workspace.yaml")).unwrap();
     workspace_yaml.push_str("packages:\n  - 'packages/*'\n");

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1470,7 +1470,7 @@ export const hooks = {{
     return pkg
   }},
 }}
-"
+",
         ),
     )
     .unwrap();

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1430,8 +1430,13 @@ fn legacy_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
         project_dir.join(PNPMFILE_SENTINEL).exists(),
         "the legacy deploy install should run the selected project's pnpmfile",
     );
+    let deploy_dir = workspace.join("deploy");
     assert!(
-        !workspace.join("deploy").join(PNPMFILE_SENTINEL).exists(),
+        deploy_dir.join(".pnpmfile.mjs").exists(),
+        "the deployed packlist should have carried the project's pnpmfile over",
+    );
+    assert!(
+        !deploy_dir.join(PNPMFILE_SENTINEL).exists(),
         "the legacy deploy install must not load the pnpmfile it just copied",
     );
 

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1358,8 +1358,6 @@ fn virtual_store_entries(deploy_dir: &Path) -> Vec<String> {
 
 /// `copy_project` copies the deployed project's packlist, a `.pnpmfile.mjs`
 /// among it, so the deploy directory ends up holding a pnpmfile of its own.
-/// The install that populates it must not run that copy — only the pnpmfile
-/// the source workspace resolves.
 #[test]
 fn shared_lockfile_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -1387,8 +1385,8 @@ fn shared_lockfile_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
     drop((root, mock_instance));
 }
 
-/// The mirror of the check above: the pnpmfile the deploy install *does*
-/// run is the source workspace's, as on pnpm 11.
+/// Parity with pnpm 11, which hands the deploy install the hooks it
+/// loaded for the source workspace.
 #[test]
 fn shared_lockfile_deploy_runs_the_source_workspace_pnpmfile() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
@@ -1410,9 +1408,8 @@ fn shared_lockfile_deploy_runs_the_source_workspace_pnpmfile() {
     drop((root, mock_instance));
 }
 
-/// Without a shared lockfile the deploy takes the legacy path, and the
-/// pnpmfile an install of the selected project would load is the project's
-/// own — still never the deployed copy.
+/// Without a shared lockfile the deploy takes the legacy path, where the
+/// pnpmfile an install of the selected project loads is the project's own.
 #[test]
 fn legacy_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
     let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =

--- a/pnpm/crates/cli/tests/suite/deploy.rs
+++ b/pnpm/crates/cli/tests/suite/deploy.rs
@@ -1441,8 +1441,8 @@ fn legacy_deploy_ignores_the_pnpmfile_copied_into_the_deploy_dir() {
     drop((root, mock_instance));
 }
 
-/// Written by the pnpmfile [`write_recording_pnpmfile`] installs, next to
-/// that pnpmfile, so a test can tell which copy of it an install loaded.
+/// Written next to whichever copy of [`write_recording_pnpmfile`]'s
+/// pnpmfile an install loads, so a test can tell the copies apart.
 const PNPMFILE_SENTINEL: &str = "pnpmfile-ran.txt";
 
 /// Ship the project's `.pnpmfile.mjs` in its packlist, so a default deploy

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -308,6 +308,11 @@ pub trait CustomResolver: Send + Sync {
 /// exports any. Only a lockfile that records no checksum needs the
 /// pnpmfile evaluated, to tell "no pnpmfile" from "a pnpmfile that
 /// exports none".
+///
+/// A `hooks` that answers `None` from
+/// [`PnpmfileHooks::calculate_pnpmfile_checksum`] to stay out of the
+/// comparison, such as [`ChecksumFreeHooks`], therefore only stays out
+/// of it while `recorded` is `None`.
 pub async fn current_pnpmfile_checksum(
     hooks: Option<&Arc<dyn PnpmfileHooks>>,
     recorded: Option<&str>,
@@ -351,6 +356,13 @@ impl PnpmfileHooks for NoopHooks {
 /// generates for the deploy directory: the hooks' effects are already
 /// part of the recorded snapshots, so a checksum could only fail the
 /// frozen-lockfile gate.
+///
+/// That is the whole of the contract: against a lockfile that *does*
+/// record a checksum, [`current_pnpmfile_checksum`] answers from
+/// [`PnpmfileHooks::source_path`] without consulting the hooks, so this
+/// wrapper does not suppress the comparison. `source_path` keeps
+/// answering on purpose — it is what names the pnpmfile in the
+/// `pnpm:hook` log events a hook's `context.log` produces.
 #[derive(derive_more::From)]
 pub struct ChecksumFreeHooks(Arc<dyn PnpmfileHooks>);
 
@@ -421,3 +433,6 @@ impl PnpmfileHooks for ChecksumFreeHooks {
         self.0.run_finder(finder_name, ctx).await
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -309,10 +309,10 @@ pub trait CustomResolver: Send + Sync {
 /// pnpmfile evaluated, to tell "no pnpmfile" from "a pnpmfile that
 /// exports none".
 ///
-/// A `hooks` that answers `None` from
+/// Hooks that answer `None` from
 /// [`PnpmfileHooks::calculate_pnpmfile_checksum`] to stay out of the
-/// comparison, such as [`ChecksumFreeHooks`], therefore only stays out
-/// of it while `recorded` is `None`.
+/// comparison, such as [`ChecksumFreeHooks`], therefore only stay out of
+/// it while `recorded` is `None`.
 pub async fn current_pnpmfile_checksum(
     hooks: Option<&Arc<dyn PnpmfileHooks>>,
     recorded: Option<&str>,

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -357,12 +357,10 @@ impl PnpmfileHooks for NoopHooks {
 /// part of the recorded snapshots, so a checksum could only fail the
 /// frozen-lockfile gate.
 ///
-/// That is the whole of the contract: against a lockfile that *does*
-/// record a checksum, [`current_pnpmfile_checksum`] answers from
-/// [`PnpmfileHooks::source_path`] without consulting the hooks, so this
-/// wrapper does not suppress the comparison. `source_path` keeps
-/// answering on purpose — it is what names the pnpmfile in the
-/// `pnpm:hook` log events a hook's `context.log` produces.
+/// The suppression is bounded to that case:
+/// [`current_pnpmfile_checksum`] answers a lockfile that does record one
+/// from [`PnpmfileHooks::source_path`], which this wrapper keeps
+/// delegating.
 #[derive(derive_more::From)]
 pub struct ChecksumFreeHooks(Arc<dyn PnpmfileHooks>);
 

--- a/pnpm/crates/hooks/src/lib.rs
+++ b/pnpm/crates/hooks/src/lib.rs
@@ -342,3 +342,82 @@ impl PnpmfileHooks for NoopHooks {
         true
     }
 }
+
+/// Hooks that run but contribute no `pnpmfileChecksum`, pnpm's
+/// `calculatePnpmfileChecksum: undefined`.
+///
+/// For an install against a lockfile that was written elsewhere and
+/// deliberately records no checksum, such as the one `pnpm deploy`
+/// generates for the deploy directory: the hooks' effects are already
+/// part of the recorded snapshots, so a checksum could only fail the
+/// frozen-lockfile gate.
+#[derive(derive_more::From)]
+pub struct ChecksumFreeHooks(Arc<dyn PnpmfileHooks>);
+
+#[async_trait]
+impl PnpmfileHooks for ChecksumFreeHooks {
+    async fn read_package(
+        &self,
+        pkg: Value,
+        ctx: HookContext,
+    ) -> Result<ReadPackageResult, HookError> {
+        self.0.read_package(pkg, ctx).await
+    }
+
+    async fn after_all_resolved(
+        &self,
+        lockfile: Value,
+        ctx: HookContext,
+    ) -> Result<Value, HookError> {
+        self.0.after_all_resolved(lockfile, ctx).await
+    }
+
+    async fn update_config(&self, config: Value, ctx: HookContext) -> Result<Value, HookError> {
+        self.0.update_config(config, ctx).await
+    }
+
+    async fn before_packing(
+        &self,
+        manifest: Value,
+        dir: &std::path::Path,
+        ctx: HookContext,
+    ) -> Result<Value, HookError> {
+        self.0.before_packing(manifest, dir, ctx).await
+    }
+
+    async fn pre_resolution(&self, ctx: PreResolutionHookContext, logger: PreResolutionHookLogger) {
+        self.0.pre_resolution(ctx, logger).await;
+    }
+
+    async fn filter_log(&self, log: Value, ctx: HookContext) -> bool {
+        self.0.filter_log(log, ctx).await
+    }
+
+    async fn has_filter_log(&self) -> bool {
+        self.0.has_filter_log().await
+    }
+
+    async fn calculate_pnpmfile_checksum(&self) -> Option<String> {
+        None
+    }
+
+    fn source_path(&self) -> Option<&std::path::Path> {
+        self.0.source_path()
+    }
+
+    async fn get_custom_resolvers(&self) -> Result<Vec<Arc<dyn CustomResolver>>, HookError> {
+        self.0.get_custom_resolvers().await
+    }
+
+    async fn get_custom_fetchers(&self) -> Result<Vec<Arc<dyn CustomFetcher>>, HookError> {
+        self.0.get_custom_fetchers().await
+    }
+
+    async fn get_finder_names(&self) -> Result<Vec<String>, HookError> {
+        self.0.get_finder_names().await
+    }
+
+    async fn run_finder(&self, finder_name: &str, ctx: Value) -> Result<Value, HookError> {
+        self.0.run_finder(finder_name, ctx).await
+    }
+}

--- a/pnpm/crates/hooks/src/tests.rs
+++ b/pnpm/crates/hooks/src/tests.rs
@@ -1,0 +1,94 @@
+use super::{
+    ChecksumFreeHooks, HookContext, HookError, PnpmfileHooks, PreResolutionHookContext,
+    PreResolutionHookLogger, ReadPackageResult, current_pnpmfile_checksum,
+};
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+const CHECKSUM: &str = "sha256-inner";
+
+struct CheckedHooks {
+    source: PathBuf,
+}
+
+#[async_trait]
+impl PnpmfileHooks for CheckedHooks {
+    async fn read_package(
+        &self,
+        mut pkg: Value,
+        _: HookContext,
+    ) -> Result<ReadPackageResult, HookError> {
+        pkg["hooked"] = json!(true);
+        Ok(Arc::new(pkg))
+    }
+
+    async fn after_all_resolved(&self, _: Value, _: HookContext) -> Result<Value, HookError> {
+        Ok(Value::Null)
+    }
+
+    async fn pre_resolution(&self, _: PreResolutionHookContext, _: PreResolutionHookLogger) {}
+
+    async fn filter_log(&self, _: Value, _: HookContext) -> bool {
+        true
+    }
+
+    async fn calculate_pnpmfile_checksum(&self) -> Option<String> {
+        Some(CHECKSUM.to_string())
+    }
+
+    fn source_path(&self) -> Option<&Path> {
+        Some(&self.source)
+    }
+}
+
+fn wrapped_at(source: PathBuf) -> Arc<dyn PnpmfileHooks> {
+    let inner: Arc<dyn PnpmfileHooks> = Arc::new(CheckedHooks { source });
+    Arc::new(ChecksumFreeHooks::from(inner))
+}
+
+fn wrapped() -> Arc<dyn PnpmfileHooks> {
+    wrapped_at(PathBuf::from("/workspace/.pnpmfile.mjs"))
+}
+
+#[tokio::test]
+async fn checksum_free_hooks_still_run_their_hooks() {
+    let hooked = wrapped()
+        .read_package(json!({ "name": "app" }), HookContext { log: Arc::new(|_| {}), dir: None })
+        .await
+        .expect("run the wrapped readPackage hook");
+
+    assert_eq!(hooked["hooked"], json!(true));
+}
+
+#[tokio::test]
+async fn checksum_free_hooks_contribute_no_checksum() {
+    assert_eq!(wrapped().calculate_pnpmfile_checksum().await, None);
+}
+
+/// The wrapper keeps answering `source_path`, which names the pnpmfile in
+/// `pnpm:hook` log events. That leaves the checksum short-circuit in
+/// [`current_pnpmfile_checksum`] able to hash the file, so the
+/// suppression only covers a lockfile that records no checksum — the case
+/// `pnpm deploy` generates. Pinned so a caller that gates a lockfile
+/// carrying one is not surprised by it.
+#[tokio::test]
+async fn a_recorded_checksum_is_still_answered_from_the_pnpmfile() {
+    let dir = tempfile::tempdir().expect("create a temp dir");
+    let pnpmfile = dir.path().join(".pnpmfile.mjs");
+    std::fs::write(&pnpmfile, "export const hooks = {}\n").expect("write a pnpmfile");
+    let hooks = wrapped_at(pnpmfile.clone());
+
+    assert_eq!(current_pnpmfile_checksum(Some(&hooks), None).await, None);
+
+    let against_recorded = current_pnpmfile_checksum(Some(&hooks), Some("sha256-recorded")).await;
+    dbg!(&against_recorded);
+    assert_eq!(
+        against_recorded,
+        pnpm_crypto_hash::create_hash_from_file(&pnpmfile).ok(),
+        "a recorded checksum is compared against the file `source_path` names",
+    );
+}

--- a/pnpm/crates/hooks/src/tests.rs
+++ b/pnpm/crates/hooks/src/tests.rs
@@ -69,12 +69,10 @@ async fn checksum_free_hooks_contribute_no_checksum() {
     assert_eq!(wrapped().calculate_pnpmfile_checksum().await, None);
 }
 
-/// The wrapper keeps answering `source_path`, which names the pnpmfile in
-/// `pnpm:hook` log events. That leaves the checksum short-circuit in
-/// [`current_pnpmfile_checksum`] able to hash the file, so the
-/// suppression only covers a lockfile that records no checksum — the case
-/// `pnpm deploy` generates. Pinned so a caller that gates a lockfile
-/// carrying one is not surprised by it.
+/// Pins the bound on [`ChecksumFreeHooks`]: it suppresses the checksum
+/// only for a lockfile that records none, because the wrapper keeps
+/// answering `source_path` and [`current_pnpmfile_checksum`] hashes that
+/// file whenever there is a recorded value to compare against.
 #[tokio::test]
 async fn a_recorded_checksum_is_still_answered_from_the_pnpmfile() {
     let dir = tempfile::tempdir().expect("create a temp dir");
@@ -85,7 +83,6 @@ async fn a_recorded_checksum_is_still_answered_from_the_pnpmfile() {
     assert_eq!(current_pnpmfile_checksum(Some(&hooks), None).await, None);
 
     let against_recorded = current_pnpmfile_checksum(Some(&hooks), Some("sha256-recorded")).await;
-    dbg!(&against_recorded);
     assert_eq!(
         against_recorded,
         pnpm_crypto_hash::create_hash_from_file(&pnpmfile).ok(),


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14671.

`pnpm deploy` ran the `.pnpmfile.mjs` it had just copied into the deploy directory, and skipped the source workspace's own. Both directions are wrong, and the first one is fatal: the lockfile a shared deploy generates deliberately records no `pnpmfileChecksum`, so discovering a pnpmfile next to it fails the frozen-lockfile gate with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Any workspace whose deployed project ships a pnpmfile cannot use the default deploy path at all.

Measured against pnpm 11.26.0 and pnpm 12.3.4 on the same fixture:

| | deploy dir's copied pnpmfile | source workspace's pnpmfile |
|---|---|---|
| pnpm 11.26.0 | not run | runs |
| pnpm 12.3.4 | **run**, then `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` | **not run** |
| this PR | not run | runs |

pnpm 11 is correct here, so this is a v12-only fix.

## Squash Commit Body

```text
The deploy install resolved its pnpmfile relative to its own root, which
the shared-lockfile path points at the deploy directory. `copy_project`
puts the deployed project's packlist there, a `.pnpmfile.mjs` among it,
so the install loaded that copy and then failed the frozen-lockfile gate
with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH against the `pnpmfileChecksum`
the generated lockfile deliberately omits. The source workspace's own
pnpmfile went unloaded, inverting pnpm 11 on both counts.

Resolve the hooks up front from the selected project's lockfile root, the
directory an install of that project reads its pnpmfile from, and hand
them to the install as `pnpmfile_hook_override`. Where the source
workspace has no pnpmfile, the deploy install runs with `ignorePnpmfile`
on instead: discovery never runs next to the deployed manifest, and an
install with nothing to hook keeps the resolver fast paths that a hook
handle would switch off. The shared path wraps the hooks in
`ChecksumFreeHooks`, matching
pnpm's `calculatePnpmfileChecksum: undefined`: the hooks' effects are
already part of the deployed snapshots.

Resolving before the target is prepared also means a `pnpmfile` setting
naming a file that is not there fails the deploy without having emptied
the target first.

The legacy path keeps recording a checksum in the lockfile it resolves
for itself, and picks up the same fix where `sharedWorkspaceLockfile:
false` had pointed it at the deploy directory too.

Closes pnpm/pnpm#14671
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791413324&installation_model_id=426870&pr_number=14672&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14672&signature=dae581b4df3ba7cc8b3c332772d42642cf19e030a0c2f2bf4e8a592e8b666060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed `pnpm deploy` failures for projects that include a `.pnpmfile.mjs`.
  - Deployments now consistently use the source project’s pnpmfile instead of a copied file in the target directory.
  - Improved pnpmfile handling for shared-lockfile and legacy deployment workflows.
  - Added clearer errors when a required pnpmfile cannot be found.

- **Tests**
  - Added coverage for pnpmfile behavior across deployment modes and checksum scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
