### PR TITLE
fix: support micromatch wildcards in Rust directory filters

### DIFF
--- a/.changeset/fix-rust-filter-globs.md
+++ b/.changeset/fix-rust-filter-globs.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm --filter` directory selectors now support `?` wildcards and character classes such as `[ab]`.
+`pnpm --filter` directory selectors now support `?` wildcards and character classes such as `[ab]`. A `*` or `?` wildcard no longer selects a directory whose name starts with a dot, matching pnpm 11.

--- a/.changeset/fix-rust-filter-globs.md
+++ b/.changeset/fix-rust-filter-globs.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm --filter` directory selectors now support `?` wildcards and character classes such as `[ab]`.

--- a/pnpm/crates/workspace-projects-filter/src/filter.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter.rs
@@ -371,10 +371,10 @@ fn match_projects_by_path<Pkg>(
     use_glob_dir_filtering: bool,
 ) -> Vec<PathBuf> {
     if use_glob_dir_filtering {
-        let pattern = path_starts_with.to_string_lossy();
+        let dir_glob = glob::DirGlob::new(&path_starts_with.to_string_lossy());
         projects_graph
             .keys()
-            .filter(|id| glob::is_match(&id.to_string_lossy(), &pattern))
+            .filter(|id| dir_glob.is_match(&id.to_string_lossy()))
             .cloned()
             .collect()
     } else {

--- a/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/filter/tests.rs
@@ -303,6 +303,36 @@ fn select_by_parent_dir_using_globstar() {
 }
 
 #[test]
+fn select_by_parent_dir_using_micromatch_wildcards() {
+    let mut graph: ProjectGraph<TestPkg> = IndexMap::new();
+    for (key, value) in [
+        node("/packages/pkg-a", "pkg-a", &[]),
+        node("/packages/pkg-b", "pkg-b", &[]),
+        node("/packages/pkg-c", "pkg-c", &[]),
+    ] {
+        graph.insert(key, value);
+    }
+
+    let character_class = selected_with_glob(
+        &graph,
+        &[ProjectSelector {
+            parent_dir: Some(PathBuf::from("/packages/pkg-[ab]")),
+            ..Default::default()
+        }],
+    );
+    assert_eq!(character_class, ["/packages/pkg-a", "/packages/pkg-b"]);
+
+    let question_mark = selected_with_glob(
+        &graph,
+        &[ProjectSelector {
+            parent_dir: Some(PathBuf::from("/packages/pkg-?")),
+            ..Default::default()
+        }],
+    );
+    assert_eq!(question_mark, ["/packages/pkg-a", "/packages/pkg-b", "/packages/pkg-c"]);
+}
+
+#[test]
 fn select_by_parent_dir_with_no_glob() {
     let graph = projects_graph();
     let result = selected_with_glob(

--- a/pnpm/crates/workspace-projects-filter/src/glob.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob.rs
@@ -1,25 +1,47 @@
-//! Minimal path glob matcher for directory selectors, covering the
+//! Path glob matcher for directory selectors, covering the
 //! `micromatch.isMatch(dir, pattern, { format })` call upstream uses for
 //! `useGlobDirFiltering` selections.
 //!
-//! Only the two wildcards directory filters rely on are supported: `*`
-//! matches any run of characters within a single path segment, and `**`
-//! matches any number of whole segments (including zero). Both the
-//! pattern and the candidate are normalized the same way before
-//! matching: backslashes become `/` and a trailing `/` is stripped.
-//! This mirrors upstream's pattern `replace(/\\/g, '/')` together with
-//! micromatch's separator handling, which treats `\` in the candidate
-//! as a path separator too — so a Windows `ProjectRootDir` rendered with
-//! backslashes by `PathBuf::to_string_lossy()` still matches.
+//! `wax` provides the glob syntax used by micromatch for directory
+//! selectors, including `*`, `**`, `?`, and character classes. Windows
+//! drive-prefixed paths are not valid wax expressions, so their drive is
+//! matched separately and the normalized path tail is passed to `wax`.
+
+use wax::{Glob, Program};
 
 /// Whether `candidate` matches the directory glob `pattern`.
 pub fn is_match(candidate: &str, pattern: &str) -> bool {
     let pattern = normalize(pattern);
     let candidate = normalize(candidate);
 
+    if let Some((pattern_drive, pattern_tail)) = split_windows_drive(&pattern) {
+        let Some((candidate_drive, candidate_tail)) = split_windows_drive(&candidate) else {
+            return false;
+        };
+        if !pattern_drive.eq_ignore_ascii_case(candidate_drive) {
+            return false;
+        }
+        if let Ok(glob) = Glob::new(pattern_tail) {
+            return glob.is_match(candidate_tail);
+        }
+    }
+
+    if let Ok(glob) = Glob::new(&pattern) {
+        return glob.is_match(candidate.as_str());
+    }
+
+    // Wax intentionally rejects Windows drive prefixes. Keep matching those
+    // paths so directory filters remain portable across platforms.
     let pattern_segments: Vec<&str> = pattern.split('/').collect();
     let candidate_segments: Vec<&str> = candidate.split('/').collect();
     match_segments(&pattern_segments, &candidate_segments)
+}
+
+/// Split a normalized Windows drive path into its drive and slash-prefixed
+/// path. Wax intentionally does not accept drive prefixes in glob expressions.
+fn split_windows_drive(path: &str) -> Option<(&str, &str)> {
+    let bytes = path.as_bytes();
+    (bytes.len() >= 3 && bytes[1] == b':' && bytes[2] == b'/').then(|| (&path[..2], &path[2..]))
 }
 
 /// Normalize a glob pattern or candidate path: backslashes to `/`, then
@@ -45,10 +67,9 @@ fn match_segments(pattern: &[&str], candidate: &[&str]) -> bool {
     }
 }
 
-/// Match a single pattern segment against a single candidate segment,
-/// treating `*` as any (possibly empty) run of characters. Uses the
-/// classic iterative wildcard match with backtracking so multiple `*`
-/// in one segment (`a*b*c`) match correctly.
+/// Match a single pattern segment against a single candidate segment for
+/// patterns that wax cannot parse, such as Windows drive-prefixed paths.
+/// This preserves the original `*`/`**` behavior for that compatibility path.
 fn segment_match(pattern: &str, text: &str) -> bool {
     let pattern: Vec<char> = pattern.chars().collect();
     let text: Vec<char> = text.chars().collect();

--- a/pnpm/crates/workspace-projects-filter/src/glob.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob.rs
@@ -11,14 +11,20 @@
 //! which is how picomatch keeps a directory whose name contains `[`, `{`
 //! or another metacharacter selectable by its own path.
 //!
+//! A wildcard does not match a segment's leading `.`, matching micromatch's
+//! default `dot: false`. A character class is exempt, as it is upstream:
+//! `[.]hidden` and `[a-z.]hidden` select `.hidden`, `?hidden` does not.
+//!
 //! Both the pattern and the candidate are normalized the same way before
 //! matching: backslashes become `/` and a trailing `/` is stripped. This
 //! mirrors upstream's pattern `replace(/\\/g, '/')` together with
 //! micromatch's separator handling, which treats `\` in the candidate as a
 //! path separator too — so a Windows `ProjectRootDir` rendered with
-//! backslashes by `PathBuf::to_string_lossy()` still matches.
+//! backslashes by [`PathBuf::to_string_lossy`](std::path::PathBuf) still
+//! matches.
 
 /// A directory glob parsed once and matched against many candidate paths.
+/// The [module documentation](self) describes the syntax it accepts.
 pub struct DirGlob {
     normalized: String,
     segments: Vec<Segment>,
@@ -169,9 +175,9 @@ impl CharClass {
 fn match_segments(pattern: &[Segment], candidate: &[&str]) -> bool {
     match pattern.split_first() {
         None => candidate.is_empty(),
-        Some((Segment::Globstar, rest)) => {
-            (0..=candidate.len()).any(|skip| match_segments(rest, &candidate[skip..]))
-        }
+        Some((Segment::Globstar, rest)) => (0..=candidate.len())
+            .take_while(|&skip| skip == 0 || !candidate[skip - 1].starts_with('.'))
+            .any(|skip| match_segments(rest, &candidate[skip..])),
         Some((Segment::Tokens(tokens), rest)) => match candidate.split_first() {
             Some((head, tail)) if segment_match(tokens, head) => match_segments(rest, tail),
             _ => false,
@@ -183,6 +189,11 @@ fn match_segments(pattern: &[Segment], candidate: &[&str]) -> bool {
 /// the classic iterative wildcard match with backtracking so multiple `*`
 /// in one segment (`a*b*c`) match correctly.
 fn segment_match(pattern: &[Token], text: &str) -> bool {
+    let leading_wildcard =
+        matches!(pattern.first(), Some(Token::Star | Token::Char(CharPattern::Any)));
+    if leading_wildcard && text.starts_with('.') {
+        return false;
+    }
     let text: Vec<char> = text.chars().collect();
     let (mut pat, mut txt) = (0usize, 0usize);
     // The last `*` seen and the text position it was matched against, so

--- a/pnpm/crates/workspace-projects-filter/src/glob.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob.rs
@@ -2,46 +2,44 @@
 //! `micromatch.isMatch(dir, pattern, { format })` call upstream uses for
 //! `useGlobDirFiltering` selections.
 //!
-//! `wax` provides the glob syntax used by micromatch for directory
-//! selectors, including `*`, `**`, `?`, and character classes. Windows
-//! drive-prefixed paths are not valid wax expressions, so their drive is
-//! matched separately and the normalized path tail is passed to `wax`.
+//! Four wildcards are supported: `*` matches any run of characters within
+//! a single path segment, `**` matches any number of whole segments
+//! (including zero), `?` matches exactly one character, and `[abc]` /
+//! `[a-c]` matches one character from a set. A leading `^` negates a set;
+//! a leading `!` does not, because micromatch's picomatch backend reads it
+//! as an ordinary member. A candidate equal to the pattern always matches,
+//! which is how picomatch keeps a directory whose name contains `[`, `{`
+//! or another metacharacter selectable by its own path.
+//!
+//! Both the pattern and the candidate are normalized the same way before
+//! matching: backslashes become `/` and a trailing `/` is stripped. This
+//! mirrors upstream's pattern `replace(/\\/g, '/')` together with
+//! micromatch's separator handling, which treats `\` in the candidate as a
+//! path separator too — so a Windows `ProjectRootDir` rendered with
+//! backslashes by `PathBuf::to_string_lossy()` still matches.
 
-use wax::{Glob, Program};
-
-/// Whether `candidate` matches the directory glob `pattern`.
-pub fn is_match(candidate: &str, pattern: &str) -> bool {
-    let pattern = normalize(pattern);
-    let candidate = normalize(candidate);
-
-    if let Some((pattern_drive, pattern_tail)) = split_windows_drive(&pattern) {
-        let Some((candidate_drive, candidate_tail)) = split_windows_drive(&candidate) else {
-            return false;
-        };
-        if !pattern_drive.eq_ignore_ascii_case(candidate_drive) {
-            return false;
-        }
-        if let Ok(glob) = Glob::new(pattern_tail) {
-            return glob.is_match(candidate_tail);
-        }
-    }
-
-    if let Ok(glob) = Glob::new(&pattern) {
-        return glob.is_match(candidate.as_str());
-    }
-
-    // Wax intentionally rejects Windows drive prefixes. Keep matching those
-    // paths so directory filters remain portable across platforms.
-    let pattern_segments: Vec<&str> = pattern.split('/').collect();
-    let candidate_segments: Vec<&str> = candidate.split('/').collect();
-    match_segments(&pattern_segments, &candidate_segments)
+/// A directory glob parsed once and matched against many candidate paths.
+pub struct DirGlob {
+    normalized: String,
+    segments: Vec<Segment>,
 }
 
-/// Split a normalized Windows drive path into its drive and slash-prefixed
-/// path. Wax intentionally does not accept drive prefixes in glob expressions.
-fn split_windows_drive(path: &str) -> Option<(&str, &str)> {
-    let bytes = path.as_bytes();
-    (bytes.len() >= 3 && bytes[1] == b':' && bytes[2] == b'/').then(|| (&path[..2], &path[2..]))
+impl DirGlob {
+    pub fn new(pattern: &str) -> Self {
+        let normalized = normalize(pattern);
+        let segments = normalized.split('/').map(Segment::parse).collect();
+        DirGlob { normalized, segments }
+    }
+
+    /// Whether `candidate` matches this glob.
+    pub fn is_match(&self, candidate: &str) -> bool {
+        let candidate = normalize(candidate);
+        if candidate == self.normalized {
+            return true;
+        }
+        let candidate_segments: Vec<&str> = candidate.split('/').collect();
+        match_segments(&self.segments, &candidate_segments)
+    }
 }
 
 /// Normalize a glob pattern or candidate path: backslashes to `/`, then
@@ -54,24 +52,137 @@ fn normalize(path: &str) -> String {
     }
 }
 
-fn match_segments(pattern: &[&str], candidate: &[&str]) -> bool {
+/// One `/`-delimited part of a pattern.
+enum Segment {
+    /// `**`, which spans whole segments rather than characters.
+    Globstar,
+    Tokens(Vec<Token>),
+}
+
+impl Segment {
+    fn parse(segment: &str) -> Self {
+        if segment == "**" {
+            return Segment::Globstar;
+        }
+        let chars: Vec<char> = segment.chars().collect();
+        let mut tokens = Vec::with_capacity(chars.len());
+        let mut index = 0;
+        while let Some(&character) = chars.get(index) {
+            index += 1;
+            tokens.push(match character {
+                '*' => Token::Star,
+                '?' => Token::Char(CharPattern::Any),
+                '[' => match CharClass::parse(&chars, index) {
+                    Some((class, next)) => {
+                        index = next;
+                        Token::Char(CharPattern::Class(class))
+                    }
+                    None => Token::Char(CharPattern::Literal('[')),
+                },
+                literal => Token::Char(CharPattern::Literal(literal)),
+            });
+        }
+        Segment::Tokens(tokens)
+    }
+}
+
+/// One element of a parsed pattern segment.
+enum Token {
+    /// `*`: any (possibly empty) run of characters.
+    Star,
+    Char(CharPattern),
+}
+
+/// A pattern element that consumes exactly one character.
+enum CharPattern {
+    /// `?`
+    Any,
+    Literal(char),
+    Class(CharClass),
+}
+
+impl CharPattern {
+    fn matches(&self, character: char) -> bool {
+        match self {
+            CharPattern::Any => true,
+            CharPattern::Literal(literal) => *literal == character,
+            CharPattern::Class(class) => class.matches(character),
+        }
+    }
+}
+
+/// A `[...]` bracket expression.
+struct CharClass {
+    negated: bool,
+    members: Vec<ClassMember>,
+}
+
+enum ClassMember {
+    Char(char),
+    Range(char, char),
+}
+
+impl CharClass {
+    /// Parse the bracket expression whose `[` sits just before `start`,
+    /// returning it with the index past its `]`. An unterminated `[` has no
+    /// class, and picomatch then treats the `[` as a literal character.
+    fn parse(chars: &[char], start: usize) -> Option<(Self, usize)> {
+        let mut index = start;
+        let negated = chars.get(index) == Some(&'^');
+        if negated {
+            index += 1;
+        }
+        let mut members = Vec::new();
+        // A `]` in the first position is a member, not the terminator.
+        if chars.get(index) == Some(&']') {
+            members.push(ClassMember::Char(']'));
+            index += 1;
+        }
+        while let Some(&character) = chars.get(index) {
+            if character == ']' {
+                return Some((CharClass { negated, members }, index + 1));
+            }
+            // `a-c` is a range; a `-` that ends the expression is a member.
+            match chars.get(index + 1) {
+                Some('-') if chars.get(index + 2).is_some_and(|&end| end != ']') => {
+                    members.push(ClassMember::Range(character, chars[index + 2]));
+                    index += 3;
+                }
+                _ => {
+                    members.push(ClassMember::Char(character));
+                    index += 1;
+                }
+            }
+        }
+        None
+    }
+
+    fn matches(&self, character: char) -> bool {
+        let contains = self.members.iter().any(|member| match *member {
+            ClassMember::Char(member) => member == character,
+            ClassMember::Range(start, end) => (start..=end).contains(&character),
+        });
+        contains != self.negated
+    }
+}
+
+fn match_segments(pattern: &[Segment], candidate: &[&str]) -> bool {
     match pattern.split_first() {
         None => candidate.is_empty(),
-        Some((&"**", rest)) => {
+        Some((Segment::Globstar, rest)) => {
             (0..=candidate.len()).any(|skip| match_segments(rest, &candidate[skip..]))
         }
-        Some((&segment, rest)) => match candidate.split_first() {
-            Some((&head, tail)) if segment_match(segment, head) => match_segments(rest, tail),
+        Some((Segment::Tokens(tokens), rest)) => match candidate.split_first() {
+            Some((head, tail)) if segment_match(tokens, head) => match_segments(rest, tail),
             _ => false,
         },
     }
 }
 
-/// Match a single pattern segment against a single candidate segment for
-/// patterns that wax cannot parse, such as Windows drive-prefixed paths.
-/// This preserves the original `*`/`**` behavior for that compatibility path.
-fn segment_match(pattern: &str, text: &str) -> bool {
-    let pattern: Vec<char> = pattern.chars().collect();
+/// Match a single pattern segment against a single candidate segment. Uses
+/// the classic iterative wildcard match with backtracking so multiple `*`
+/// in one segment (`a*b*c`) match correctly.
+fn segment_match(pattern: &[Token], text: &str) -> bool {
     let text: Vec<char> = text.chars().collect();
     let (mut pat, mut txt) = (0usize, 0usize);
     // The last `*` seen and the text position it was matched against, so
@@ -79,21 +190,26 @@ fn segment_match(pattern: &str, text: &str) -> bool {
     let mut backtrack: Option<(usize, usize)> = None;
 
     while txt < text.len() {
-        if pattern.get(pat) == Some(&'*') {
-            backtrack = Some((pat, txt));
-            pat += 1;
-        } else if pattern.get(pat) == Some(&text[txt]) {
-            pat += 1;
-            txt += 1;
-        } else if let Some((star_pat, star_txt)) = backtrack {
-            pat = star_pat + 1;
-            txt = star_txt + 1;
-            backtrack = Some((star_pat, txt));
-        } else {
-            return false;
+        match pattern.get(pat) {
+            Some(Token::Star) => {
+                backtrack = Some((pat, txt));
+                pat += 1;
+            }
+            Some(Token::Char(char_pattern)) if char_pattern.matches(text[txt]) => {
+                pat += 1;
+                txt += 1;
+            }
+            _ => match backtrack {
+                Some((star_pat, star_txt)) => {
+                    pat = star_pat + 1;
+                    txt = star_txt + 1;
+                    backtrack = Some((star_pat, txt));
+                }
+                None => return false,
+            },
         }
     }
-    while pattern.get(pat) == Some(&'*') {
+    while matches!(pattern.get(pat), Some(Token::Star)) {
         pat += 1;
     }
     pat == pattern.len()

--- a/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
@@ -109,6 +109,28 @@ fn a_directory_named_like_a_pattern_matches_its_own_path() {
 }
 
 #[test]
+fn wildcards_do_not_match_a_leading_dot() {
+    assert!(!is_match("/packages/.hidden", "/packages/*"));
+    assert!(!is_match("/packages/.hidden", "/packages/?hidden"));
+    assert!(!is_match("/packages/.hidden", "/packages/**"));
+    assert!(!is_match("/packages/.hidden/nested", "/packages/**"));
+    assert!(is_match("/packages/pkg-a", "/packages/*"));
+}
+
+#[test]
+fn a_literal_dot_or_a_character_class_matches_a_hidden_segment() {
+    assert!(is_match("/packages/.hidden", "/packages/.*"));
+    assert!(is_match("/packages/.hidden", "/packages/[.]hidden"));
+    assert!(is_match("/packages/.hidden", "/packages/[a-z.]hidden"));
+}
+
+#[test]
+fn a_dot_inside_a_segment_is_an_ordinary_character() {
+    assert!(is_match("/packages/a.c", "/packages/a?c"));
+    assert!(is_match("/packages/a.c", "/packages/a*c"));
+}
+
+#[test]
 fn backslash_separators_are_normalized_in_both_candidate_and_pattern() {
     assert!(is_match(r"C:\packages\project-0", "C:/packages/*"));
     assert!(is_match("C:/packages/project-0", r"C:\packages\*"));

--- a/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
@@ -1,4 +1,8 @@
-use crate::glob::is_match;
+use crate::glob::DirGlob;
+
+fn is_match(candidate: &str, pattern: &str) -> bool {
+    DirGlob::new(pattern).is_match(candidate)
+}
 
 #[test]
 fn single_star_matches_one_segment() {
@@ -57,6 +61,51 @@ fn character_class_matches_one_character() {
     assert!(is_match("/packages/pkg-a", "/packages/pkg-[ab]"));
     assert!(is_match("/packages/pkg-b", "/packages/pkg-[ab]"));
     assert!(!is_match("/packages/pkg-c", "/packages/pkg-[ab]"));
+}
+
+#[test]
+fn character_class_matches_a_range() {
+    assert!(is_match("/packages/pkg-b", "/packages/pkg-[a-c]"));
+    assert!(!is_match("/packages/pkg-d", "/packages/pkg-[a-c]"));
+}
+
+#[test]
+fn dash_at_either_end_of_a_character_class_is_a_member() {
+    assert!(is_match("/packages/pkg--", "/packages/pkg-[-a]"));
+    assert!(is_match("/packages/pkg--", "/packages/pkg-[a-]"));
+    assert!(!is_match("/packages/pkg-b", "/packages/pkg-[a-]"));
+}
+
+#[test]
+fn caret_negates_a_character_class_but_exclamation_mark_does_not() {
+    assert!(is_match("/packages/pkg-c", "/packages/pkg-[^ab]"));
+    assert!(!is_match("/packages/pkg-a", "/packages/pkg-[^ab]"));
+    assert!(is_match("/packages/pkg-a", "/packages/pkg-[!ab]"));
+    assert!(is_match("/packages/pkg-!", "/packages/pkg-[!ab]"));
+    assert!(!is_match("/packages/pkg-c", "/packages/pkg-[!ab]"));
+}
+
+#[test]
+fn closing_bracket_first_is_a_member() {
+    assert!(is_match("/packages/]", "/packages/[]a]"));
+    assert!(is_match("/packages/a", "/packages/[]a]"));
+    assert!(!is_match("/packages/b", "/packages/[]a]"));
+}
+
+#[test]
+fn unterminated_bracket_is_a_literal() {
+    assert!(is_match("/packages/[ab", "/packages/[ab"));
+    assert!(!is_match("/packages/a", "/packages/[ab"));
+}
+
+#[test]
+fn a_directory_named_like_a_pattern_matches_its_own_path() {
+    assert!(is_match("/packages/pkg[1]", "/packages/pkg[1]"));
+    assert!(is_match("/packages/pkg{1}", "/packages/pkg{1}"));
+    assert!(is_match("/packages/pkg$a", "/packages/pkg$a"));
+    assert!(is_match("/packages/pkg(1)", "/packages/pkg(1)"));
+    assert!(!is_match("/packages/pkg1", "/packages/pkg$a"));
+    assert!(!is_match("/packages/pkg+a", "/packages/pkg$a"));
 }
 
 #[test]

--- a/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
+++ b/pnpm/crates/workspace-projects-filter/src/glob/tests.rs
@@ -46,8 +46,30 @@ fn multiple_stars_in_one_segment_backtrack() {
 }
 
 #[test]
+fn question_mark_matches_one_character() {
+    assert!(is_match("/packages/pkg-a", "/packages/pkg-?"));
+    assert!(!is_match("/packages/pkg-ab", "/packages/pkg-?"));
+    assert!(!is_match("/packages/pkg-", "/packages/pkg-?"));
+}
+
+#[test]
+fn character_class_matches_one_character() {
+    assert!(is_match("/packages/pkg-a", "/packages/pkg-[ab]"));
+    assert!(is_match("/packages/pkg-b", "/packages/pkg-[ab]"));
+    assert!(!is_match("/packages/pkg-c", "/packages/pkg-[ab]"));
+}
+
+#[test]
 fn backslash_separators_are_normalized_in_both_candidate_and_pattern() {
     assert!(is_match(r"C:\packages\project-0", "C:/packages/*"));
     assert!(is_match("C:/packages/project-0", r"C:\packages\*"));
     assert!(is_match(r"C:\packages\project-0\", r"C:\packages\*"));
+}
+
+#[test]
+fn windows_drive_paths_support_micromatch_wildcards() {
+    assert!(is_match(r"C:\packages\pkg-a", r"C:\packages\pkg-?"));
+    assert!(is_match(r"C:\packages\pkg-b", r"C:\packages\pkg-[ab]"));
+    assert!(!is_match(r"C:\packages\pkg-c", r"C:\packages\pkg-[ab]"));
+    assert!(!is_match(r"D:\packages\pkg-a", r"C:\packages\pkg-?"));
 }


### PR DESCRIPTION
## Summary

Rust pnpm v12 directory filters did not support all glob syntax accepted by pnpm v11.

The matcher used by `useGlobDirFiltering` only handled `*` within a path segment and `**` as a complete segment. Patterns such as `{packages/pkg-[ab]}` and `{packages/pkg-?}` therefore failed to select matching workspace projects.

This change extends that matcher with `?` and bracket expressions, following the semantics of micromatch's picomatch backend, which is what pnpm v11 uses for the same selection.

## Squash Commit Body

```text
fix(workspace-projects-filter): support micromatch wildcards in directory filters

The Rust directory matcher only supported `*` and complete-segment `**`,
while pnpm v11 uses micromatch and accepts patterns such as `?` and `[ab]`.

Extend the matcher with `?` and bracket expressions instead of delegating
to a general-purpose glob crate. `wax` accepts a different dialect from the
micromatch call upstream makes, and the matcher normalizes `\` to `/`
before matching, so no metacharacter can be escaped for it. Measured
against micromatch 4.0.8, delegating to `wax` both over- and under-matched
real directory paths: `$` is a `wax` wildcard, so `pkg$a` also selected
`pkga`; a directory literally named `pkg[1]` or `pkg{1}` stopped matching
its own path; and `[!ab]` / `[^ab]` are inverted between the two, because
picomatch negates with `^` and treats `!` as an ordinary set member.

The matcher now follows picomatch: `[abc]`, `[a-c]`, `^` negates, `!` is a
member, a leading `]` is a member, an unterminated `[` is a literal, and a
candidate equal to the pattern matches before any wildcard applies, which
is what keeps a metacharacter-named directory selectable by its path. A
randomized differential run of 4000 cases against micromatch reports no
mismatches.

The pattern is parsed once per selector rather than once per project.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpm v11 already matches these
  patterns through micromatch, so this is a v12-only fix.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14677"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791429056&installation_model_id=426870&pr_number=14677&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14677&signature=2b17ccc12bf56094cbe36c03c983c5c7ecf1ed686f60478d7ce3a23cfe7c8478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm --filter` directory selectors support `?` wildcards and character classes, including ranges and negated classes.
  - Glob matching supports `*`, `**`, `?`, and character classes across supported path formats.

- **Bug Fixes**
  - Wildcards no longer match directories beginning with a dot.
  - Improved matching for Windows drive-prefixed paths and normalized path separators.

- **Documentation**
  - Added release notes describing the enhanced directory selector patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
