### PR TITLE
fix(config): hand `updateConfig` the resolved config, not one file's settings

### DIFF
--- a/.changeset/update-config-sees-resolved-config.md
+++ b/.changeset/update-config-sees-resolved-config.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The `updateConfig` pnpmfile hook now receives the configuration pnpm resolved, so a hook can read settings that came from `.npmrc`, the command line, or a default. Scoped registries declared in `.npmrc` are visible under `registriesByScope`, and a hook may rewrite that map to change where packages are fetched from [#14676](https://github.com/pnpm/pnpm/issues/14676). A setting nothing set is absent from the configuration a hook receives, as it is on pnpm 11, rather than present with the value `null`.
+The `updateConfig` pnpmfile hook now receives the resolved configuration, including settings that came from `.npmrc`, the command line, or a default. Scoped registries are reported under `registriesByScope`, and a hook may rewrite that map to change where packages are fetched from. Registry credentials are reported under `configByUri`, as pnpm 11 reports them. A setting nothing set is omitted rather than reported as `null` [#14676](https://github.com/pnpm/pnpm/issues/14676).

--- a/.changeset/update-config-sees-resolved-config.md
+++ b/.changeset/update-config-sees-resolved-config.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+The `updateConfig` pnpmfile hook now receives the configuration pnpm resolved, so a hook can read settings that came from `.npmrc`, the command line, or a default. Scoped registries declared in `.npmrc` are visible under `registriesByScope`, and a hook may rewrite that map to change where packages are fetched from [#14676](https://github.com/pnpm/pnpm/issues/14676).

--- a/.changeset/update-config-sees-resolved-config.md
+++ b/.changeset/update-config-sees-resolved-config.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-The `updateConfig` pnpmfile hook now receives the configuration pnpm resolved, so a hook can read settings that came from `.npmrc`, the command line, or a default. Scoped registries declared in `.npmrc` are visible under `registriesByScope`, and a hook may rewrite that map to change where packages are fetched from [#14676](https://github.com/pnpm/pnpm/issues/14676).
+The `updateConfig` pnpmfile hook now receives the configuration pnpm resolved, so a hook can read settings that came from `.npmrc`, the command line, or a default. Scoped registries declared in `.npmrc` are visible under `registriesByScope`, and a hook may rewrite that map to change where packages are fetched from [#14676](https://github.com/pnpm/pnpm/issues/14676). A setting nothing set is absent from the configuration a hook receives, as it is on pnpm 11, rather than present with the value `null`.

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -741,15 +741,15 @@ fn record_explicit_setting_changes(
 }
 
 /// A setting the hook set to null is unset, as it is on pnpm 11, and
-/// resolves to its default. `apply_to` has no value to apply for it, so the
-/// resolved field is restored here.
+/// resolves to the default pnpm would have chosen. `apply_to` has no value
+/// to apply for it, so each is restored through
+/// [`WorkspaceSettings::reset_setting_to_default`].
 fn restore_defaults_of_nulled_settings(config: &mut Config, delta: &Value, base_dir: &Path) {
-    let nulled = |key: &str| delta.get(key).is_some_and(Value::is_null);
-    if nulled("virtualStoreDir") {
-        config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
-    }
-    if nulled("preferFrozenLockfile") {
-        config.prefer_frozen_lockfile = true;
+    let Some(delta) = delta.as_object() else { return };
+    let mut defaults = None;
+    for key in delta.iter().filter(|(_, value)| value.is_null()).map(|(key, _)| key) {
+        let defaults = defaults.get_or_insert_with(Config::default);
+        WorkspaceSettings::reset_setting_to_default::<Host>(config, defaults, key, base_dir);
     }
 }
 
@@ -757,12 +757,12 @@ fn restore_defaults_of_nulled_settings(config: &mut Config, delta: &Value, base_
 /// workspace, the way [`Config::current`] resolves it, so `apply_to` leaves
 /// it to this.
 fn apply_state_dir_change(config: &mut Config, delta: &Value) {
-    let Some(value) = delta.get("stateDir") else { return };
-    let default_state_dir = default_state_dir::<Host>().unwrap_or_default();
-    config.state_dir = match value.as_str().filter(|dir| !dir.is_empty()) {
-        Some(dir) => resolve_configured_state_dir(&default_state_dir, dir),
-        None => default_state_dir,
+    let Some(dir) = delta.get("stateDir").and_then(Value::as_str).filter(|dir| !dir.is_empty())
+    else {
+        return;
     };
+    let default_state_dir = default_state_dir::<Host>().unwrap_or_default();
+    config.state_dir = resolve_configured_state_dir(&default_state_dir, dir);
 }
 
 /// The resolved state an `updateConfig` hook reads that is not a settings

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -541,7 +541,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     let catalogs = serde_json::to_value(&yaml_catalogs).into_diagnostic()?;
-    seed_hook_input(&mut input, config, root_dir, catalogs)?;
+    seed_hook_input(&mut input, config, root_dir, &pnpmfiles, catalogs)?;
 
     let prefix = root_dir.to_string_lossy().into_owned();
     let mut current = input.clone();
@@ -595,6 +595,7 @@ fn seed_hook_input(
     input: &mut Value,
     config: &Config,
     root_dir: &Path,
+    pnpmfiles: &[PathBuf],
     catalogs: Value,
 ) -> Result<()> {
     let Some(object) = input.as_object_mut() else {
@@ -611,6 +612,13 @@ fn seed_hook_input(
     object
         .insert("extraEnv".to_string(), serde_json::to_value(&config.extra_env).into_diagnostic()?);
     object.append(&mut resolved_config_views(config, root_dir).into_diagnostic()?);
+    // The pnpmfiles being run, which is what the setting resolves to and
+    // what pnpm reports, rather than only a pinned `pnpmfile` value.
+    object.insert("pnpmfile".to_string(), serde_json::to_value(pnpmfiles).into_diagnostic()?);
+    // A setting nothing set is absent, as it is on pnpm 11, so that
+    // `'key' in config` answers there and a hook doesn't read a null as a
+    // configured value.
+    object.retain(|_, value| !value.is_null());
     Ok(())
 }
 
@@ -651,28 +659,7 @@ fn apply_hook_delta(
         .transpose()
         .into_diagnostic()
         .wrap_err("the updateConfig hook produced an invalid extraEnv value")?;
-    // Registry routing is read under the `registriesByScope` /
-    // `registriesByPrefix` names, so a hook changes it under those names
-    // too. `WorkspaceSettings` reaches the same lookups through its
-    // file-shaped `registries` key, which `from_value(delta)` below still
-    // honors; these are applied first so an entry the hook wrote through
-    // `registries` wins.
-    for key in ["registriesByScope", "registriesByPrefix"] {
-        let Some(value) = delta.get(key).cloned() else { continue };
-        let routes: BTreeMap<String, String> = serde_json::from_value(value)
-            .into_diagnostic()
-            .wrap_err_with(|| format!("the updateConfig hook produced an invalid {key} value"))?;
-        if key == "registriesByScope" {
-            config.registries_by_scope = routes;
-        } else {
-            config.registries_by_prefix = routes;
-        }
-    }
-    // The default registry is one scope of the routing map and also the
-    // standalone `registry` setting, so keep the two answering the same URL.
-    if let Some(default) = config.registries_by_scope.get("default").cloned() {
-        config.registry = default;
-    }
+    apply_registry_routing_changes(config, &delta)?;
 
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
@@ -710,6 +697,37 @@ fn apply_hook_delta(
         );
     }
     Ok(())
+}
+
+/// Apply the routing a hook rewrote under the `registriesByScope` /
+/// `registriesByPrefix` names it reads it under. `WorkspaceSettings`
+/// reaches the same lookups through its file-shaped `registries` key, which
+/// `apply_to` still honors, so this runs first and an entry the hook wrote
+/// through `registries` wins.
+fn apply_registry_routing_changes(config: &mut Config, delta: &Value) -> Result<()> {
+    if let Some(routes) = hook_registry_routes(delta, "registriesByScope")? {
+        config.registries_by_scope = routes;
+    }
+    if let Some(routes) = hook_registry_routes(delta, "registriesByPrefix")? {
+        config.registries_by_prefix = routes;
+    }
+    // The default registry is one scope of the routing map and also the
+    // standalone `registry` setting, so keep the two answering the same URL.
+    if let Some(default) = config.registries_by_scope.get("default").cloned() {
+        config.registry = default;
+    }
+    Ok(())
+}
+
+/// The routing map the hook output holds under `key`, if it changed one.
+fn hook_registry_routes(delta: &Value, key: &str) -> Result<Option<BTreeMap<String, String>>> {
+    delta
+        .get(key)
+        .cloned()
+        .map(serde_json::from_value)
+        .transpose()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("the updateConfig hook produced an invalid {key} value"))
 }
 
 /// Apply the hook's changes to settings that live in
@@ -750,10 +768,12 @@ fn resolved_config_views(
         views.insert(key.to_string(), value);
     };
 
-    // The scope map reports the built-in `@jsr` route it resolves through;
-    // the prefix map reports only the prefixes the project declares, which
-    // is what a pnpr server may be asked about.
-    let registries_by_scope = config.resolved_registry_lookups().registries_by_scope;
+    // The scope map reports the built-in `@jsr` route it resolves through and
+    // the default registry every unscoped package is fetched from, whether or
+    // not a source named it; the prefix map reports only the prefixes the
+    // project declares, which is what a pnpr server may be asked about.
+    let mut registries_by_scope = config.resolved_registry_lookups().registries_by_scope;
+    registries_by_scope.entry("default".to_string()).or_insert_with(|| config.registry.clone());
     set("registriesByScope", serde_json::to_value(&registries_by_scope)?);
     set("registriesByPrefix", serde_json::to_value(&config.registries_by_prefix)?);
 

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -527,9 +527,6 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         Some((path, _)) => path.parent().map_or_else(|| root_dir.to_path_buf(), Path::to_path_buf),
         None => root_dir.to_path_buf(),
     };
-    // Every setting at its effective value, so a hook reads the same
-    // configuration the install runs with rather than one file's
-    // contribution to it (pnpm/pnpm#14676).
     let mut input = serde_json::to_value(WorkspaceSettings::from_resolved(config))
         .into_diagnostic()
         .wrap_err("serialize the resolved settings for updateConfig hooks")?;
@@ -706,15 +703,16 @@ fn apply_hook_delta(
 /// through `registries` wins.
 fn apply_registry_routing_changes(config: &mut Config, delta: &Value) -> Result<()> {
     if let Some(routes) = hook_registry_routes(delta, "registriesByScope")? {
+        // The default registry is one scope of the routing map and also the
+        // standalone `registry` setting, so keep the two answering the same
+        // URL.
+        if let Some(default) = routes.get("default") {
+            config.registry.clone_from(default);
+        }
         config.registries_by_scope = routes;
     }
     if let Some(routes) = hook_registry_routes(delta, "registriesByPrefix")? {
         config.registries_by_prefix = routes;
-    }
-    // The default registry is one scope of the routing map and also the
-    // standalone `registry` setting, so keep the two answering the same URL.
-    if let Some(default) = config.registries_by_scope.get("default").cloned() {
-        config.registry = default;
     }
     Ok(())
 }
@@ -751,14 +749,12 @@ fn apply_explicit_setting_changes(config: &mut Config, changes: [(&str, Option<V
 /// key, under the names pnpm 11 exposes it as.
 ///
 /// These are derived from the settings rather than written by a user, so
-/// [`WorkspaceSettings`] has no field for them and the write-back below
-/// ignores them — except registry routing, which
-/// [`run_update_config_hooks`] applies.
+/// [`WorkspaceSettings`] has no field for them and the write-back ignores
+/// them, except registry routing, which [`apply_registry_routing_changes`]
+/// applies.
 ///
-/// `configByUri` carries only the default-scope `_authToken` of each
-/// registry, which is all [`Config::auth_tokens_by_uri`] keeps in raw form;
-/// the per-scope credentials and certificate settings pnpm 11 also indexes
-/// there are absent.
+/// `configByUri` carries each registry's credentials by scope; the
+/// per-registry certificate settings pnpm 11 also indexes there are absent.
 fn resolved_config_views(
     config: &Config,
     root_dir: &Path,
@@ -770,12 +766,14 @@ fn resolved_config_views(
 
     // The scope map reports the built-in `@jsr` route it resolves through and
     // the default registry every unscoped package is fetched from, whether or
-    // not a source named it; the prefix map reports only the prefixes the
-    // project declares, which is what a pnpr server may be asked about.
+    // not a source named it. The prefix map reports only the prefixes the
+    // project declares, and nothing when it declares none, as pnpm 11 does.
     let mut registries_by_scope = config.resolved_registry_lookups().registries_by_scope;
     registries_by_scope.entry("default".to_string()).or_insert_with(|| config.registry.clone());
     set("registriesByScope", serde_json::to_value(&registries_by_scope)?);
-    set("registriesByPrefix", serde_json::to_value(&config.registries_by_prefix)?);
+    if !config.registries_by_prefix.is_empty() {
+        set("registriesByPrefix", serde_json::to_value(&config.registries_by_prefix)?);
+    }
 
     // The raw auth keys, plus the registry rows resolved across every
     // source, so `authConfig.registry` and `authConfig['@scope:registry']`
@@ -790,20 +788,7 @@ fn resolved_config_views(
         auth_config.insert(key, Value::String(url.clone()));
     }
     set("authConfig", Value::Object(auth_config));
-    set(
-        "configByUri",
-        Value::Object(
-            config
-                .auth_tokens_by_uri
-                .iter()
-                .map(|(uri, token)| {
-                    let creds = serde_json::json!({ "authToken": token });
-                    let scope = pnpm_config::registries::DEFAULT_REGISTRY_SCOPE;
-                    (uri.clone(), serde_json::json!({ scope: creds }))
-                })
-                .collect(),
-        ),
-    );
+    set("configByUri", serde_json::to_value(&config.registry_creds_by_uri)?);
 
     set("dir", Value::String(root_dir.to_string_lossy().into_owned()));
     set("workspaceDir", serde_json::to_value(&config.workspace_dir)?);

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -10,7 +10,10 @@
 use crate::config_overrides::apply_store_dir_override;
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_catalogs_config::get_catalogs_from_workspace_manifest;
-use pnpm_config::{Config, Host, PNPM_VERSION, WorkspaceSettings};
+use pnpm_config::{
+    Config, Host, PNPM_VERSION, WorkspaceSettings, default_state_dir,
+    known_settings::is_known_setting_key, resolve_configured_state_dir,
+};
 use pnpm_env_installer::{
     ConfigDepsInstallOptions, pnpm_engine_packages, resolve_and_install_config_deps,
     resolve_package_manager_integrities,
@@ -637,10 +640,6 @@ fn apply_hook_delta(
         return Ok(());
     }
     let changed_store_dir = delta.get("storeDir").and_then(Value::as_str).map(str::to_owned);
-    let changed_prefer_frozen_lockfile = delta.get("preferFrozenLockfile").cloned();
-    let changed_virtual_store_dir = delta.get("virtualStoreDir").cloned();
-    let changed_global_virtual_store_dir = delta.get("globalVirtualStoreDir").cloned();
-    let virtual_store_dir_cleared = changed_virtual_store_dir.as_ref().is_some_and(Value::is_null);
     // `extraBinPaths` / `extraEnv` aren't `WorkspaceSettings` fields, so
     // `from_value(delta)` below ignores them. Pull the hook's values out
     // first and assign them directly.
@@ -658,9 +657,10 @@ fn apply_hook_delta(
         .wrap_err("the updateConfig hook produced an invalid extraEnv value")?;
     apply_registry_routing_changes(config, &delta)?;
 
-    let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
+    let delta_settings: WorkspaceSettings = serde_json::from_value(delta.clone())
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
+    record_explicit_setting_changes(config, &delta, &delta_settings);
     delta_settings.apply_to(config, base_dir);
     if script_shell_deleted {
         config.script_shell = None;
@@ -671,17 +671,11 @@ fn apply_hook_delta(
     if let Some(extra_env) = changed_extra_env {
         config.extra_env = extra_env;
     }
-    if virtual_store_dir_cleared {
-        config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
+    restore_defaults_of_nulled_settings(config, &delta, base_dir);
+    apply_state_dir_change(config, &delta);
+    if delta.get("shamefullyHoist").is_some() {
+        config.apply_shamefully_hoist_derivation();
     }
-    apply_explicit_setting_changes(
-        config,
-        [
-            ("preferFrozenLockfile", changed_prefer_frozen_lockfile),
-            ("virtualStoreDir", changed_virtual_store_dir),
-            ("globalVirtualStoreDir", changed_global_virtual_store_dir),
-        ],
-    );
     if let Some(store_dir) = changed_store_dir {
         apply_store_dir_override::<Host>(config, Path::new(&store_dir), base_dir)?;
     } else {
@@ -702,12 +696,12 @@ fn apply_hook_delta(
 /// `apply_to` still honors, so this runs first and an entry the hook wrote
 /// through `registries` wins.
 fn apply_registry_routing_changes(config: &mut Config, delta: &Value) -> Result<()> {
-    if let Some(routes) = hook_registry_routes(delta, "registriesByScope")? {
-        // The default registry is one scope of the routing map and also the
-        // standalone `registry` setting, so keep the two answering the same
-        // URL.
-        if let Some(default) = routes.get("default") {
-            config.registry.clone_from(default);
+    if let Some(mut routes) = hook_registry_routes(delta, "registriesByScope")? {
+        // The hook reads the default registry as the `default` entry of the
+        // map, but the config carries it as the standalone `registry`
+        // setting beside a map of `@scope` routes only.
+        if let Some(default) = routes.remove("default") {
+            config.registry = default;
         }
         config.registries_by_scope = routes;
     }
@@ -728,21 +722,47 @@ fn hook_registry_routes(delta: &Value, key: &str) -> Result<Option<BTreeMap<Stri
         .wrap_err_with(|| format!("the updateConfig hook produced an invalid {key} value"))
 }
 
-/// Apply the hook's changes to settings that live in
-/// [`Config::explicit_settings`] rather than as fields of [`Config`]. A
-/// null is the hook deleting the setting.
-fn apply_explicit_setting_changes(config: &mut Config, changes: [(&str, Option<Value>); 3]) {
-    for (key, value) in changes {
-        match value {
-            Some(Value::Null) => {
-                config.explicit_settings.remove(key);
-            }
-            Some(value) => {
-                config.explicit_settings.insert(key.to_string(), value);
-            }
-            None => {}
+/// Record what the hook set in [`Config::explicit_settings`], as loading a
+/// settings file does, and drop the settings it set to null, so the
+/// derivations that read whether a setting was set at all see the hook's
+/// answer.
+fn record_explicit_setting_changes(
+    config: &mut Config,
+    delta: &Value,
+    delta_settings: &WorkspaceSettings,
+) {
+    config.record_explicit_settings(delta_settings);
+    let Some(delta) = delta.as_object() else { return };
+    for key in delta.iter().filter(|(_, value)| value.is_null()).map(|(key, _)| key) {
+        if is_known_setting_key(key) {
+            config.explicit_settings.remove(key);
         }
     }
+}
+
+/// A setting the hook set to null is unset, as it is on pnpm 11, and
+/// resolves to its default. `apply_to` has no value to apply for it, so the
+/// resolved field is restored here.
+fn restore_defaults_of_nulled_settings(config: &mut Config, delta: &Value, base_dir: &Path) {
+    let nulled = |key: &str| delta.get(key).is_some_and(Value::is_null);
+    if nulled("virtualStoreDir") {
+        config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
+    }
+    if nulled("preferFrozenLockfile") {
+        config.prefer_frozen_lockfile = true;
+    }
+}
+
+/// `stateDir` resolves against the host's state root rather than the
+/// workspace, the way [`Config::current`] resolves it, so `apply_to` leaves
+/// it to this.
+fn apply_state_dir_change(config: &mut Config, delta: &Value) {
+    let Some(value) = delta.get("stateDir") else { return };
+    let default_state_dir = default_state_dir::<Host>().unwrap_or_default();
+    config.state_dir = match value.as_str().filter(|dir| !dir.is_empty()) {
+        Some(dir) => resolve_configured_state_dir(&default_state_dir, dir),
+        None => default_state_dir,
+    };
 }
 
 /// The resolved state an `updateConfig` hook reads that is not a settings
@@ -765,11 +785,12 @@ fn resolved_config_views(
     };
 
     // The scope map reports the built-in `@jsr` route it resolves through and
-    // the default registry every unscoped package is fetched from, whether or
-    // not a source named it. The prefix map reports only the prefixes the
-    // project declares, and nothing when it declares none, as pnpm 11 does.
+    // the default registry every unscoped package is fetched from, which the
+    // config carries as the `registry` setting. The prefix map reports only
+    // the prefixes the project declares, and nothing when it declares none,
+    // as pnpm 11 does.
     let mut registries_by_scope = config.resolved_registry_lookups().registries_by_scope;
-    registries_by_scope.entry("default".to_string()).or_insert_with(|| config.registry.clone());
+    registries_by_scope.insert("default".to_string(), config.registry.clone());
     set("registriesByScope", serde_json::to_value(&registries_by_scope)?);
     if !config.registries_by_prefix.is_empty() {
         set("registriesByPrefix", serde_json::to_value(&config.registries_by_prefix)?);

--- a/pnpm/crates/cli/src/config_deps.rs
+++ b/pnpm/crates/cli/src/config_deps.rs
@@ -499,6 +499,11 @@ pub async fn prepare_config<Reporter: self::Reporter>(
 /// `updateConfig`, so packing can retain the original hook set when the hook
 /// changes a hook-selection setting such as `ignorePnpmfile`.
 ///
+/// A hook is handed the resolved configuration, by way of
+/// [`WorkspaceSettings::from_resolved`] plus the non-settings views in
+/// [`resolved_config_views`], so it reads what the install runs with rather
+/// than one file's contribution to it.
+///
 /// Config round-trips through [`WorkspaceSettings`], so any settings key a
 /// hook changes is applied back the same way `pnpm-workspace.yaml` is. Only
 /// the keys a hook actually changed are applied, so values resolved from
@@ -518,15 +523,16 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         return Ok(hooks);
     }
 
-    let (base_dir, settings) = match WorkspaceSettings::find_and_load(root_dir).into_diagnostic()? {
-        Some((path, settings)) => {
-            (path.parent().map_or_else(|| root_dir.to_path_buf(), Path::to_path_buf), settings)
-        }
-        None => (root_dir.to_path_buf(), WorkspaceSettings::default()),
+    let base_dir = match WorkspaceSettings::find_and_load(root_dir).into_diagnostic()? {
+        Some((path, _)) => path.parent().map_or_else(|| root_dir.to_path_buf(), Path::to_path_buf),
+        None => root_dir.to_path_buf(),
     };
-    let mut input = serde_json::to_value(&settings)
+    // Every setting at its effective value, so a hook reads the same
+    // configuration the install runs with rather than one file's
+    // contribution to it (pnpm/pnpm#14676).
+    let mut input = serde_json::to_value(WorkspaceSettings::from_resolved(config))
         .into_diagnostic()
-        .wrap_err("serialize workspace settings for updateConfig hooks")?;
+        .wrap_err("serialize the resolved settings for updateConfig hooks")?;
     // Seed the hook input with the catalogs read from the workspace
     // manifest (`catalog:` + `catalogs:`), which `WorkspaceSettings`
     // doesn't carry, so a hook can read and extend them.
@@ -535,7 +541,7 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
         .into_diagnostic()
         .wrap_err("reading catalogs for updateConfig hooks")?;
     let catalogs = serde_json::to_value(&yaml_catalogs).into_diagnostic()?;
-    seed_hook_input(&mut input, config, catalogs)?;
+    seed_hook_input(&mut input, config, root_dir, catalogs)?;
 
     let prefix = root_dir.to_string_lossy().into_owned();
     let mut current = input.clone();
@@ -585,21 +591,15 @@ pub async fn run_update_config_hooks<Reporter: self::Reporter>(
 /// Seed the hook input with the values pnpm resolves outside
 /// [`WorkspaceSettings`], so a hook can read and extend them. They are
 /// read back out of the delta rather than through `apply_to`.
-fn seed_hook_input(input: &mut Value, config: &Config, catalogs: Value) -> Result<()> {
+fn seed_hook_input(
+    input: &mut Value,
+    config: &Config,
+    root_dir: &Path,
+    catalogs: Value,
+) -> Result<()> {
     let Some(object) = input.as_object_mut() else {
         return Ok(());
     };
-    // The serialized settings carry `scriptShell` as written in the
-    // manifest; hooks see the workspace-root-resolved value pnpm gives
-    // them, or no key at all when nothing set one.
-    if let Some(script_shell) = &config.script_shell {
-        object.insert("scriptShell".to_string(), Value::String(script_shell.clone()));
-    } else {
-        object.remove("scriptShell");
-    }
-    if let Some(store_dir) = config.explicit_settings.get("storeDir") {
-        object.insert("storeDir".to_string(), store_dir.clone());
-    }
     object.insert("catalogs".to_string(), catalogs);
     // PnpmBuild's `updateConfig` appends its bin dir to `extraBinPaths`
     // and sets `npm_config_nodedir` in `extraEnv`, so both have to arrive
@@ -610,6 +610,7 @@ fn seed_hook_input(input: &mut Value, config: &Config, catalogs: Value) -> Resul
     );
     object
         .insert("extraEnv".to_string(), serde_json::to_value(&config.extra_env).into_diagnostic()?);
+    object.append(&mut resolved_config_views(config, root_dir).into_diagnostic()?);
     Ok(())
 }
 
@@ -650,6 +651,29 @@ fn apply_hook_delta(
         .transpose()
         .into_diagnostic()
         .wrap_err("the updateConfig hook produced an invalid extraEnv value")?;
+    // Registry routing is read under the `registriesByScope` /
+    // `registriesByPrefix` names, so a hook changes it under those names
+    // too. `WorkspaceSettings` reaches the same lookups through its
+    // file-shaped `registries` key, which `from_value(delta)` below still
+    // honors; these are applied first so an entry the hook wrote through
+    // `registries` wins.
+    for key in ["registriesByScope", "registriesByPrefix"] {
+        let Some(value) = delta.get(key).cloned() else { continue };
+        let routes: BTreeMap<String, String> = serde_json::from_value(value)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("the updateConfig hook produced an invalid {key} value"))?;
+        if key == "registriesByScope" {
+            config.registries_by_scope = routes;
+        } else {
+            config.registries_by_prefix = routes;
+        }
+    }
+    // The default registry is one scope of the routing map and also the
+    // standalone `registry` setting, so keep the two answering the same URL.
+    if let Some(default) = config.registries_by_scope.get("default").cloned() {
+        config.registry = default;
+    }
+
     let delta_settings: WorkspaceSettings = serde_json::from_value(delta)
         .into_diagnostic()
         .wrap_err("deserialize the updateConfig hook result")?;
@@ -703,6 +727,81 @@ fn apply_explicit_setting_changes(config: &mut Config, changes: [(&str, Option<V
             None => {}
         }
     }
+}
+
+/// The resolved state an `updateConfig` hook reads that is not a settings
+/// key, under the names pnpm 11 exposes it as.
+///
+/// These are derived from the settings rather than written by a user, so
+/// [`WorkspaceSettings`] has no field for them and the write-back below
+/// ignores them — except registry routing, which
+/// [`run_update_config_hooks`] applies.
+///
+/// `configByUri` carries only the default-scope `_authToken` of each
+/// registry, which is all [`Config::auth_tokens_by_uri`] keeps in raw form;
+/// the per-scope credentials and certificate settings pnpm 11 also indexes
+/// there are absent.
+fn resolved_config_views(
+    config: &Config,
+    root_dir: &Path,
+) -> serde_json::Result<serde_json::Map<String, Value>> {
+    let mut views = serde_json::Map::new();
+    let mut set = |key: &str, value: Value| {
+        views.insert(key.to_string(), value);
+    };
+
+    // The scope map reports the built-in `@jsr` route it resolves through;
+    // the prefix map reports only the prefixes the project declares, which
+    // is what a pnpr server may be asked about.
+    let registries_by_scope = config.resolved_registry_lookups().registries_by_scope;
+    set("registriesByScope", serde_json::to_value(&registries_by_scope)?);
+    set("registriesByPrefix", serde_json::to_value(&config.registries_by_prefix)?);
+
+    // The raw auth keys, plus the registry rows resolved across every
+    // source, so `authConfig.registry` and `authConfig['@scope:registry']`
+    // answer the URL the install fetches from rather than whichever
+    // `.npmrc` line happened to name one. `pnpm config list` merges them
+    // the same way.
+    let mut auth_config: serde_json::Map<String, Value> =
+        config.raw_auth_config.iter().map(|(k, v)| (k.clone(), Value::String(v.clone()))).collect();
+    for (scope, url) in &registries_by_scope {
+        let key =
+            if scope == "default" { "registry".to_string() } else { format!("{scope}:registry") };
+        auth_config.insert(key, Value::String(url.clone()));
+    }
+    set("authConfig", Value::Object(auth_config));
+    set(
+        "configByUri",
+        Value::Object(
+            config
+                .auth_tokens_by_uri
+                .iter()
+                .map(|(uri, token)| {
+                    let creds = serde_json::json!({ "authToken": token });
+                    let scope = pnpm_config::registries::DEFAULT_REGISTRY_SCOPE;
+                    (uri.clone(), serde_json::json!({ scope: creds }))
+                })
+                .collect(),
+        ),
+    );
+
+    set("dir", Value::String(root_dir.to_string_lossy().into_owned()));
+    set("workspaceDir", serde_json::to_value(&config.workspace_dir)?);
+    set("configDir", serde_json::to_value(&config.config_dir)?);
+    set("globalPkgDir", serde_json::to_value(&config.global_pkg_dir)?);
+    set("failIfNoMatch", Value::Bool(config.fail_if_no_match));
+    set("useGitBranchLockfile", Value::Bool(config.use_git_branch_lockfile));
+    set("workspacePackagePatterns", serde_json::to_value(&config.workspace_package_patterns)?);
+    set("sideEffectsCacheRead", Value::Bool(config.side_effects_cache_read()));
+    set("sideEffectsCacheWrite", Value::Bool(config.side_effects_cache_write()));
+    // The settings key of the same name reports only a pinned value; a hook
+    // reading it wants the directory the lockfile is actually written to.
+    set(
+        "lockfileDir",
+        Value::String(config.lockfile_dir_for(root_dir).to_string_lossy().into_owned()),
+    );
+
+    Ok(views)
 }
 
 /// The keys whose value the hooks changed between the serialized input

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -1,6 +1,6 @@
 use std::{fs, path::Path};
 
-use pnpm_config::{Config, Host, PNPM_VERSION, TrustPolicy};
+use pnpm_config::{Config, Host, NodeLinker, PNPM_VERSION, TrustPolicy};
 use pnpm_reporter::SilentReporter;
 
 use super::{resolve_engine_version, run_update_config_hooks};
@@ -56,6 +56,40 @@ async fn update_config_null_restores_the_prefer_frozen_lockfile_default() {
 
     assert!(config.prefer_frozen_lockfile);
     assert!(!config.explicit_settings.contains_key("preferFrozenLockfile"));
+}
+
+/// A setting the hook deletes returns to its default, whichever group of
+/// `from_resolved` it belongs to: reported at its resolved value
+/// (`nodeLinker`), reported only when set (`lockfile`), or anchored on
+/// apply (`storeDir`).
+#[tokio::test]
+async fn update_config_null_restores_the_default_of_any_setting() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(
+        root.path().join("pnpm-workspace.yaml"),
+        "nodeLinker: hoisted\nlockfile: false\nstoreDir: pinned-store\n",
+    )
+    .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.nodeLinker = null; config.lockfile = null; config.storeDir = null; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert_eq!(config.node_linker, NodeLinker::Hoisted);
+    assert!(!config.lockfile);
+    assert!(format!("{:?}", config.store_dir).contains("pinned-store"));
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.node_linker, NodeLinker::Isolated);
+    assert!(config.lockfile);
+    assert!(!format!("{:?}", config.store_dir).contains("pinned-store"));
+    for key in ["nodeLinker", "lockfile", "storeDir"] {
+        assert!(!config.explicit_settings.contains_key(key), "{key} is still explicit");
+    }
 }
 
 /// The public hoist pattern is derived from the explicit `shamefullyHoist`,

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -35,6 +35,103 @@ async fn update_config_records_prefer_frozen_lockfile_as_explicit() {
     }
 }
 
+/// Deleting the setting leaves it unset, so CI regains the frozen-lockfile
+/// default a source had turned off.
+#[tokio::test]
+async fn update_config_null_restores_the_prefer_frozen_lockfile_default() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "preferFrozenLockfile: false\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.preferFrozenLockfile = null; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert!(!config.prefer_frozen_lockfile);
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert!(config.prefer_frozen_lockfile);
+    assert!(!config.explicit_settings.contains_key("preferFrozenLockfile"));
+}
+
+/// The public hoist pattern is derived from the explicit `shamefullyHoist`,
+/// so the hook's answer has to reach both.
+#[tokio::test]
+async fn update_config_shamefully_hoist_false_stops_public_hoisting() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "shamefullyHoist: true\n")
+        .expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.shamefullyHoist = false; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+    assert_eq!(config.public_hoist_pattern, Some(vec!["*".to_string()]));
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert!(!config.shamefully_hoist);
+    assert_eq!(config.public_hoist_pattern, None);
+    assert_eq!(
+        config.explicit_settings.get("shamefullyHoist").and_then(serde_json::Value::as_bool),
+        Some(false),
+    );
+}
+
+#[tokio::test]
+async fn update_config_can_change_the_state_dir() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    let state_dir = root.path().join("hook-state");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        format!(
+            "module.exports = {{ hooks: {{ updateConfig (config) {{ config.stateDir = {}; return config }} }} }}",
+            serde_json::json!(state_dir),
+        ),
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.state_dir, state_dir);
+}
+
+/// The hook reads the default registry as `registriesByScope.default`; the
+/// config carries it as `registry` beside a map of `@scope` routes only.
+#[tokio::test]
+async fn update_config_default_route_lands_on_the_registry_setting() {
+    let root = tempfile::tempdir().expect("workspace tempdir");
+    fs::write(root.path().join("pnpm-workspace.yaml"), "\n").expect("write workspace settings");
+    fs::write(
+        root.path().join(".pnpmfile.cjs"),
+        "module.exports = { hooks: { updateConfig (config) { config.registriesByScope = { ...config.registriesByScope, default: 'https://hook.example/', '@acme': 'https://acme.example/' }; return config } } }",
+    )
+    .expect("write pnpmfile");
+    let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
+
+    run_update_config_hooks::<SilentReporter>(&mut config, root.path())
+        .await
+        .expect("run updateConfig hook");
+
+    assert_eq!(config.registry, "https://hook.example/");
+    assert!(!config.registries_by_scope.contains_key("default"));
+    assert_eq!(
+        config.registries_by_scope.get("@acme").map(String::as_str),
+        Some("https://acme.example/"),
+    );
+}
+
 #[tokio::test]
 async fn update_config_null_clears_virtual_store_dir() {
     let root = tempfile::tempdir().expect("workspace tempdir");

--- a/pnpm/crates/cli/src/config_deps/tests.rs
+++ b/pnpm/crates/cli/src/config_deps/tests.rs
@@ -67,27 +67,36 @@ async fn update_config_null_restores_the_default_of_any_setting() {
     let root = tempfile::tempdir().expect("workspace tempdir");
     fs::write(
         root.path().join("pnpm-workspace.yaml"),
-        "nodeLinker: hoisted\nlockfile: false\nstoreDir: pinned-store\n",
+        "nodeLinker: hoisted\nlockfile: true\npackageLock: false\nstoreDir: pinned-store\nhoist: false\n",
     )
     .expect("write workspace settings");
     fs::write(
         root.path().join(".pnpmfile.cjs"),
-        "module.exports = { hooks: { updateConfig (config) { config.nodeLinker = null; config.lockfile = null; config.storeDir = null; return config } } }",
+        "module.exports = { hooks: { updateConfig (config) { for (const key of ['nodeLinker', 'lockfile', 'storeDir', 'hoist']) config[key] = null; return config } } }",
     )
     .expect("write pnpmfile");
     let mut config = Config::default().current::<Host>(root.path()).expect("load configuration");
     assert_eq!(config.node_linker, NodeLinker::Hoisted);
-    assert!(!config.lockfile);
+    assert_eq!(config.prefer_symlinked_executables, Some(true));
+    assert!(config.lockfile);
     assert!(format!("{:?}", config.store_dir).contains("pinned-store"));
+    assert_eq!(config.hoist_pattern, None);
 
     run_update_config_hooks::<SilentReporter>(&mut config, root.path())
         .await
         .expect("run updateConfig hook");
 
+    // The derivations follow: the isolated linker's executables, the
+    // `lockfile` that `packageLock` still turns off, the hoist pattern.
     assert_eq!(config.node_linker, NodeLinker::Isolated);
-    assert!(config.lockfile);
-    assert!(!format!("{:?}", config.store_dir).contains("pinned-store"));
-    for key in ["nodeLinker", "lockfile", "storeDir"] {
+    assert_eq!(config.prefer_symlinked_executables, None);
+    assert!(!config.lockfile);
+    let mut unpinned = Config::default();
+    unpinned.reset_store_dir_to_default::<Host>(root.path());
+    assert_eq!(config.store_dir, unpinned.store_dir);
+    assert!(config.hoist);
+    assert!(config.hoist_pattern.is_some());
+    for key in ["nodeLinker", "lockfile", "storeDir", "hoist"] {
         assert!(!config.explicit_settings.contains_key(key), "{key} is still explicit");
     }
 }

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -373,9 +373,8 @@ fn update_config_sees_npmrc_scoped_registries() {
     drop(root);
 }
 
-/// The default registry a CLI flag chooses reaches the hook, and so does a
-/// setting nothing set — a hook branching on a setting needs its effective
-/// value, not `null`.
+/// A hook branching on a setting needs its effective value, whether a CLI
+/// flag or a default supplied it.
 #[test]
 fn update_config_sees_cli_flags_and_resolved_defaults() {
     let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
@@ -444,7 +443,7 @@ fn update_config_sees_registry_credentials() {
     fs::write(workspace.join("package.json"), "{}").expect("write package.json");
     fs::write(
         workspace.join(".npmrc"),
-        "@acme:registry=https://acme.example.com/npm/\n//acme.example.com/npm/:_authToken=hook-visible-token\n",
+        "@acme:registry=https://acme.example.com/npm/\n//acme.example.com/npm/:_authToken=hook-visible-token\n//acme.example.com/npm/:@acme:_authToken=scoped-token\n",
     )
     .expect("write .npmrc");
     fs::write(workspace.join(".pnpmfile.cjs"), DUMP_CONFIG_PNPMFILE).expect("write pnpmfile");
@@ -460,6 +459,10 @@ fn update_config_sees_registry_credentials() {
     assert_eq!(
         seen["configByUri"]["//acme.example.com/npm/"]["@"]["authToken"],
         serde_json::json!("hook-visible-token"),
+    );
+    assert_eq!(
+        seen["configByUri"]["//acme.example.com/npm/"]["@acme"]["authToken"],
+        serde_json::json!("scoped-token"),
     );
     // The registry rows resolved across every source, so a hook reading
     // `authConfig` finds the URL the install fetches from.
@@ -485,8 +488,9 @@ fn update_config_can_rewrite_registry_routing() {
 
     let mocked = mock_instance.url();
     let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
-    fs::write(&npmrc_path, npmrc.replace(&format!("registry={mocked}"), DEAD_REGISTRY))
-        .expect("point .npmrc at a dead registry");
+    let dead = npmrc.replace(&format!("registry={mocked}"), DEAD_REGISTRY);
+    assert_ne!(dead, npmrc, "the mocked registry line was not replaced");
+    fs::write(&npmrc_path, dead).expect("point .npmrc at a dead registry");
     fs::write(
         workspace.join("package.json"),
         serde_json::json!({ "dependencies": { CATALOG_DEP: "100.0.0" } }).to_string(),

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -33,6 +33,9 @@ const WRITE_MARKER_SCRIPT: &str =
 
 const CATALOG_DEP: &str = "@pnpm.e2e/dep-of-pkg-with-1-dep";
 
+/// A registry URL nothing serves, so reaching it is a test failure.
+const DEAD_REGISTRY: &str = "registry=http://127.0.0.1:1/";
+
 fn write_catalog_hook_project(workspace: &Path) {
     fs::write(
         workspace.join("package.json"),
@@ -331,4 +334,125 @@ fn update_config_applies_before_the_verify_deps_check() {
     assert!(stdout.contains("ran"), "the script should have run\nSTDOUT:\n{stdout}");
 
     drop(root);
+}
+
+/// Records the whole config the `updateConfig` hook is handed, so a test can
+/// assert on what a hook can read.
+const DUMP_CONFIG_PNPMFILE: &str = "const fs = require('fs');\nconst path = require('path');\nmodule.exports = { hooks: { updateConfig (config) {\n  fs.writeFileSync(path.join(__dirname, 'seen.json'), JSON.stringify(config));\n  return config;\n} } }";
+
+fn config_seen_by_hook(workspace: &Path) -> serde_json::Value {
+    let seen = fs::read_to_string(workspace.join("seen.json")).expect("read the config seen");
+    serde_json::from_str(&seen).expect("the config seen parses as JSON")
+}
+
+/// A hook reads the configuration the install runs with, so a scope routed
+/// by `.npmrc` is visible to it (pnpm/pnpm#14676). `.npmrc` is the only
+/// source of scoped registry routing for many projects, and it never reaches
+/// `pnpm-workspace.yaml`.
+#[test]
+fn update_config_sees_npmrc_scoped_registries() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    fs::write(workspace.join(".npmrc"), "@acme:registry=https://acme.example.com/npm/\n")
+        .expect("write .npmrc");
+    fs::write(workspace.join(".pnpmfile.cjs"), DUMP_CONFIG_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+
+    let seen = config_seen_by_hook(&workspace);
+    dbg!(&seen["registriesByScope"]);
+    assert_eq!(
+        seen["registriesByScope"]["@acme"],
+        serde_json::json!("https://acme.example.com/npm/"),
+    );
+
+    drop(root);
+}
+
+/// The default registry a CLI flag chooses reaches the hook, and so does a
+/// setting nothing set — a hook branching on a setting needs its effective
+/// value, not `null`.
+#[test]
+fn update_config_sees_cli_flags_and_resolved_defaults() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    fs::write(workspace.join(".pnpmfile.cjs"), DUMP_CONFIG_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace)
+        .with_args(["install", "--registry=https://cli.example.com/"])
+        .assert()
+        .success();
+
+    let seen = config_seen_by_hook(&workspace);
+    dbg!(&seen["registry"], &seen["nodeLinker"], &seen["autoInstallPeers"]);
+    assert_eq!(seen["registry"], serde_json::json!("https://cli.example.com/"));
+    assert_eq!(seen["registriesByScope"]["default"], serde_json::json!("https://cli.example.com/"));
+    // Unset everywhere, so only the resolved default can answer.
+    assert_eq!(seen["nodeLinker"], serde_json::json!("isolated"));
+    assert_eq!(seen["autoInstallPeers"], serde_json::json!(true));
+
+    drop(root);
+}
+
+/// The registry credentials a hook reads, the way pnpm 11 exposes them: a
+/// pnpmfile runs as unrestricted Node in both versions, so this is nothing
+/// it could not already read from `.npmrc` itself.
+#[test]
+fn update_config_sees_registry_credentials() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    fs::write(
+        workspace.join(".npmrc"),
+        "@acme:registry=https://acme.example.com/npm/\n//acme.example.com/npm/:_authToken=hook-visible-token\n",
+    )
+    .expect("write .npmrc");
+    fs::write(workspace.join(".pnpmfile.cjs"), DUMP_CONFIG_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+
+    let seen = config_seen_by_hook(&workspace);
+    dbg!(&seen["authConfig"], &seen["configByUri"]);
+    assert_eq!(
+        seen["authConfig"]["//acme.example.com/npm/:_authToken"],
+        serde_json::json!("hook-visible-token"),
+    );
+    assert_eq!(
+        seen["configByUri"]["//acme.example.com/npm/"]["@"]["authToken"],
+        serde_json::json!("hook-visible-token"),
+    );
+
+    drop(root);
+}
+
+/// A hook rewrites registry routing under the name it reads it as, so
+/// `registriesByScope` is writable and the install resolves through the
+/// route the hook chose. The `.npmrc` here points the default registry at a
+/// port nothing listens on, so only the hook's rewrite can make the install
+/// succeed.
+#[test]
+fn update_config_can_rewrite_registry_routing() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, npmrc_path, .. } = npmrc_info;
+
+    let mocked = mock_instance.url();
+    let npmrc = fs::read_to_string(&npmrc_path).expect("read .npmrc");
+    fs::write(&npmrc_path, npmrc.replace(&format!("registry={mocked}"), DEAD_REGISTRY))
+        .expect("point .npmrc at a dead registry");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "dependencies": { CATALOG_DEP: "100.0.0" } }).to_string(),
+    )
+    .expect("write package.json");
+    fs::write(
+        workspace.join(".pnpmfile.cjs"),
+        format!(
+            "module.exports = {{ hooks: {{ updateConfig (config) {{\n  config.registriesByScope = {{ ...config.registriesByScope, default: '{mocked}' }};\n  return config;\n}} }} }}",
+        ),
+    )
+    .expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+
+    drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/hooks.rs
+++ b/pnpm/crates/cli/tests/suite/hooks.rs
@@ -365,6 +365,10 @@ fn update_config_sees_npmrc_scoped_registries() {
         seen["registriesByScope"]["@acme"],
         serde_json::json!("https://acme.example.com/npm/"),
     );
+    // Every unscoped package resolves through the default registry, so it is
+    // reported whether or not a source named it.
+    assert!(seen["registry"].as_str().is_some_and(|url| !url.is_empty()));
+    assert_eq!(seen["registriesByScope"]["default"], seen["registry"]);
 
     drop(root);
 }
@@ -390,6 +394,43 @@ fn update_config_sees_cli_flags_and_resolved_defaults() {
     // Unset everywhere, so only the resolved default can answer.
     assert_eq!(seen["nodeLinker"], serde_json::json!("isolated"));
     assert_eq!(seen["autoInstallPeers"], serde_json::json!(true));
+
+    drop(root);
+}
+
+/// A setting nothing set is absent rather than `null`, as it is on pnpm 11,
+/// so a hook testing for a key gets the same answer in both versions.
+/// `registries` is a shape only `pnpm-workspace.yaml` has, and its resolved
+/// form is reported as `registriesByScope`.
+#[test]
+fn update_config_omits_the_settings_nothing_set() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    fs::write(workspace.join("package.json"), "{}").expect("write package.json");
+    fs::write(workspace.join(".pnpmfile.cjs"), DUMP_CONFIG_PNPMFILE).expect("write pnpmfile");
+
+    pacquet_in(&workspace).with_arg("install").assert().success();
+
+    let seen = config_seen_by_hook(&workspace);
+    let settings = seen.as_object().expect("the configuration seen is an object");
+    let reported_as_null: Vec<&String> =
+        settings.iter().filter(|(_, value)| value.is_null()).map(|(key, _)| key).collect();
+    dbg!(&reported_as_null);
+    assert!(reported_as_null.is_empty());
+    assert!(!settings.contains_key("registries"));
+
+    // The pnpmfiles being run, and the cache directory pnpm chose for the
+    // host, neither of which anything here set.
+    dbg!(&seen["pnpmfile"], &seen["cacheDir"]);
+    let pnpmfiles: Vec<&str> = seen["pnpmfile"]
+        .as_array()
+        .expect("the pnpmfiles seen are an array")
+        .iter()
+        .map(|path| path.as_str().expect("a pnpmfile path is a string"))
+        .collect();
+    assert_eq!(pnpmfiles.len(), 1);
+    assert!(pnpmfiles[0].ends_with(".pnpmfile.cjs"));
+    assert!(Path::new(pnpmfiles[0]).is_absolute());
+    assert!(seen["cacheDir"].as_str().is_some_and(|dir| Path::new(dir).is_absolute()));
 
     drop(root);
 }
@@ -420,6 +461,13 @@ fn update_config_sees_registry_credentials() {
         seen["configByUri"]["//acme.example.com/npm/"]["@"]["authToken"],
         serde_json::json!("hook-visible-token"),
     );
+    // The registry rows resolved across every source, so a hook reading
+    // `authConfig` finds the URL the install fetches from.
+    assert_eq!(
+        seen["authConfig"]["@acme:registry"],
+        serde_json::json!("https://acme.example.com/npm/"),
+    );
+    assert_eq!(seen["authConfig"]["registry"], seen["registry"]);
 
     drop(root);
 }

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -2655,6 +2655,15 @@ impl Config {
     /// are declared too, unless the user pointed them elsewhere.
     #[must_use]
     pub fn resolved_registry_declarations(&self) -> BTreeMap<String, RegistryDeclaration> {
+        registries::to_resolved_declarations(&self.resolved_registry_lookups())
+    }
+
+    /// The scope and prefix routes the CLI resolves a package's registry
+    /// through, including the built-in ones pnpm answers without being
+    /// told: the `@jsr` scope and the [`BUILTIN_REGISTRIES_BY_PREFIX`]
+    /// prefixes, unless the user pointed them elsewhere.
+    #[must_use]
+    pub fn resolved_registry_lookups(&self) -> RegistryLookups {
         let mut lookups = self.registry_lookups(Some(self.registry.clone()));
         lookups
             .registries_by_scope
@@ -2666,7 +2675,7 @@ impl Config {
                 .entry((*prefix).to_string())
                 .or_insert_with(|| (*registry).to_string());
         }
-        registries::to_resolved_declarations(&lookups)
+        lookups
     }
 
     fn registry_lookups(&self, default_registry: Option<String>) -> RegistryLookups {

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::{
         resolve_child_concurrency, resolve_configured_state_dir, standalone_install_command,
     },
     global_bin_check::{CheckGlobalBinDirError, check_global_bin_dir},
-    npmrc_auth::{is_json_auth_scope, validate_json_auth_registry},
+    npmrc_auth::{BasicAuth, RegistryCreds, is_json_auth_scope, validate_json_auth_registry},
 };
 pub use workspace_yaml::{
     AllowBuild, AuditSettings, CargoSettings, GLOBAL_CONFIG_YAML_FILENAME, LoadWorkspaceYamlError,
@@ -2541,6 +2541,14 @@ pub struct Config {
     /// `pnpm logout` can read it back to revoke it on the registry.
     /// The subset of raw auth config the auth commands consult.
     pub auth_tokens_by_uri: std::collections::HashMap<String, String>,
+
+    /// Every registry credential, keyed `[uri][scope]` the way pnpm's
+    /// `configByUri` is: the nerf-darted registry URI, then the package
+    /// scope it is for, with [`pnpm_network::DEFAULT_REGISTRY_SCOPE`] for
+    /// the registry-wide credential. This is what an `updateConfig` hook
+    /// reads; the fetchers read [`Self::auth_headers`].
+    pub registry_creds_by_uri:
+        std::collections::HashMap<String, BTreeMap<String, npmrc_auth::RegistryCreds>>,
 
     pub package_manager_bootstrap: PackageManagerBootstrap,
 

--- a/pnpm/crates/config/src/lib.rs
+++ b/pnpm/crates/config/src/lib.rs
@@ -3213,6 +3213,13 @@ impl Config {
         }
     }
 
+    /// Record the settings `settings` sets in [`Self::explicit_settings`],
+    /// as loading a settings file does, so the derivations that read whether
+    /// a setting was set at all see them.
+    pub fn record_explicit_settings(&mut self, settings: &WorkspaceSettings) {
+        collect_explicit_settings(&mut self.explicit_settings, settings);
+    }
+
     /// Apply the legacy `shamefullyHoist` setting to the public hoist pattern.
     ///
     /// This runs after all config sources have been merged because an explicit

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -647,46 +647,19 @@ impl NpmrcAuth {
             self.default_creds.is_empty(),
             "rescope_unscoped must pin unscoped credentials before headers are built",
         );
-        let mut auth_header_by_uri: HashMap<String, String> = HashMap::new();
-        let mut auth_header_by_scope_by_uri: HashMap<String, HashMap<String, String>> =
-            HashMap::new();
-        let mut token_helper_by_uri: HashMap<String, Vec<String>> = HashMap::new();
-        let mut token_helper_by_scope_by_uri: HashMap<String, HashMap<String, Vec<String>>> =
-            HashMap::new();
-        // Raw `_authToken` per nerf-darted registry URI, default scope
-        // only, preserved alongside the baked header for `pnpm logout`.
-        // See [`Config::auth_tokens_by_uri`].
-        let mut auth_tokens_by_uri: HashMap<String, String> = HashMap::new();
+        let mut tables = AuthTables::default();
         for (uri, raw_by_scope) in self.creds_by_scope_by_uri {
             for (scope, raw) in raw_by_scope {
-                if let Some(token) = default_scope_token(&scope, &raw) {
-                    auth_tokens_by_uri.insert(uri.clone(), token);
-                }
-                if let Some(command) = parse_token_helper_field(raw.token_helper.as_deref())? {
-                    insert_by_scope(
-                        &mut token_helper_by_uri,
-                        &mut token_helper_by_scope_by_uri,
-                        &uri,
-                        scope,
-                        command,
-                    );
-                } else if let Some(header) = creds_to_header(&raw)? {
-                    insert_by_scope(
-                        &mut auth_header_by_uri,
-                        &mut auth_header_by_scope_by_uri,
-                        &uri,
-                        scope,
-                        header,
-                    );
-                }
+                tables.record(&uri, scope, &raw)?;
             }
         }
-        config.auth_tokens_by_uri = auth_tokens_by_uri;
+        config.auth_tokens_by_uri = tables.auth_tokens;
+        config.registry_creds_by_uri = tables.registry_creds;
         config.auth_headers = Arc::new(AuthHeaders::from_parts_with_token_helpers(
-            auth_header_by_uri,
-            auth_header_by_scope_by_uri,
-            token_helper_by_uri,
-            token_helper_by_scope_by_uri,
+            tables.auth_headers,
+            tables.scoped_auth_headers,
+            tables.token_helpers,
+            tables.scoped_token_helpers,
         ));
         Ok(())
     }
@@ -866,6 +839,109 @@ impl NpmrcAuth {
             .entry(scope.unwrap_or_else(|| DEFAULT_REGISTRY_SCOPE.to_owned()))
             .or_default()
     }
+}
+
+/// The per-registry lookups [`NpmrcAuth::build_auth_headers`] fills, one
+/// credential at a time.
+#[derive(Default)]
+struct AuthTables {
+    auth_headers: HashMap<String, String>,
+    scoped_auth_headers: HashMap<String, HashMap<String, String>>,
+    token_helpers: HashMap<String, Vec<String>>,
+    scoped_token_helpers: HashMap<String, HashMap<String, Vec<String>>>,
+    /// See [`Config::auth_tokens_by_uri`].
+    auth_tokens: HashMap<String, String>,
+    /// See [`Config::registry_creds_by_uri`].
+    registry_creds: HashMap<String, BTreeMap<String, RegistryCreds>>,
+}
+
+impl AuthTables {
+    /// Record the credential `raw` names for `scope` at `uri`.
+    fn record(
+        &mut self,
+        uri: &str,
+        scope: String,
+        raw: &RawCreds,
+    ) -> Result<(), LoadWorkspaceYamlError> {
+        if let Some(token) = default_scope_token(&scope, raw) {
+            self.auth_tokens.insert(uri.to_owned(), token);
+        }
+        let creds = RegistryCreds::from_raw(raw)?;
+        if let Some(command) = creds.token_helper.clone() {
+            insert_by_scope(
+                &mut self.token_helpers,
+                &mut self.scoped_token_helpers,
+                uri,
+                scope.clone(),
+                command,
+            );
+        } else if let Some(header) = creds_to_header(raw)? {
+            insert_by_scope(
+                &mut self.auth_headers,
+                &mut self.scoped_auth_headers,
+                uri,
+                scope.clone(),
+                header,
+            );
+        }
+        if creds != RegistryCreds::default() {
+            self.registry_creds.entry(uri.to_owned()).or_default().insert(scope, creds);
+        }
+        Ok(())
+    }
+}
+
+/// A registry's credentials for one scope, in the shape pnpm reports them
+/// under `configByUri`.
+///
+/// The token is reported as written, the basic-auth pair decoded, and the
+/// `tokenHelper` split into its command. A pair that does not decode is
+/// left out rather than failing the load; building the `Authorization`
+/// header is where a malformed pair is an error.
+#[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegistryCreds {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auth_token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub basic_auth: Option<BasicAuth>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_helper: Option<Vec<String>>,
+}
+
+/// A decoded `username` / `password` pair of a [`RegistryCreds`].
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: String,
+}
+
+impl RegistryCreds {
+    /// Fails only where the `tokenHelper` value is not a command pnpm runs;
+    /// see [`parse_token_helper_field`].
+    fn from_raw(raw: &RawCreds) -> Result<Self, LoadWorkspaceYamlError> {
+        Ok(Self {
+            auth_token: raw.auth_token.clone(),
+            basic_auth: decode_basic_auth(raw),
+            token_helper: parse_token_helper_field(raw.token_helper.as_deref())?,
+        })
+    }
+}
+
+/// The `username:password` pair `raw` carries, from a base64 `_auth` or
+/// from `username` plus a base64 `_password`, the way
+/// [`creds_to_header`] reads them. `None` when `raw` names no pair or the
+/// pair does not decode.
+fn decode_basic_auth(raw: &RawCreds) -> Option<BasicAuth> {
+    if let Some(pair) = raw.auth_pair_base64.as_deref().filter(|pair| !pair.is_empty()) {
+        let decoded = base64_decode(pair)?;
+        let (username, password) = decoded.split_once(':')?;
+        return Some(BasicAuth { username: username.to_owned(), password: password.to_owned() });
+    }
+    let username = raw.username.clone()?;
+    let password_b64 = raw.password.as_ref()?;
+    let password = base64_decode(password_b64).unwrap_or_else(|| password_b64.clone());
+    Some(BasicAuth { username, password })
 }
 
 /// The registry a file's unscoped settings pin to: the one it declares, or

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -897,9 +897,9 @@ impl AuthTables {
 /// The token is reported as written, the basic-auth pair decoded, and the
 /// `tokenHelper` split into its command. An empty token or an empty half of
 /// a pair, the shape an unresolved `${VAR}` leaves, names no credential, as
-/// on pnpm 11. A `_auth` that does not decode is left out rather than
-/// failing the load; building the `Authorization` header is where it is an
-/// error.
+/// on pnpm 11. A `_auth` that does not decode is left out of this view;
+/// whether it fails the load is decided where the `Authorization` header
+/// is built.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistryCreds {

--- a/pnpm/crates/config/src/npmrc_auth.rs
+++ b/pnpm/crates/config/src/npmrc_auth.rs
@@ -895,9 +895,11 @@ impl AuthTables {
 /// under `configByUri`.
 ///
 /// The token is reported as written, the basic-auth pair decoded, and the
-/// `tokenHelper` split into its command. A pair that does not decode is
-/// left out rather than failing the load; building the `Authorization`
-/// header is where a malformed pair is an error.
+/// `tokenHelper` split into its command. An empty token or an empty half of
+/// a pair, the shape an unresolved `${VAR}` leaves, names no credential, as
+/// on pnpm 11. A `_auth` that does not decode is left out rather than
+/// failing the load; building the `Authorization` header is where it is an
+/// error.
 #[derive(Debug, Default, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RegistryCreds {
@@ -921,7 +923,7 @@ impl RegistryCreds {
     /// see [`parse_token_helper_field`].
     fn from_raw(raw: &RawCreds) -> Result<Self, LoadWorkspaceYamlError> {
         Ok(Self {
-            auth_token: raw.auth_token.clone(),
+            auth_token: raw.auth_token.clone().filter(|token| !token.is_empty()),
             basic_auth: decode_basic_auth(raw),
             token_helper: parse_token_helper_field(raw.token_helper.as_deref())?,
         })
@@ -929,17 +931,18 @@ impl RegistryCreds {
 }
 
 /// The `username:password` pair `raw` carries, from a base64 `_auth` or
-/// from `username` plus a base64 `_password`, the way
-/// [`creds_to_header`] reads them. `None` when `raw` names no pair or the
-/// pair does not decode.
+/// from `username` plus a base64 `_password`, read the way
+/// [`creds_to_header`] reads them: a `_password` that is not base64 is the
+/// password as written, since that is what the header carries. `None` when
+/// `raw` names no complete pair or `_auth` does not decode.
 fn decode_basic_auth(raw: &RawCreds) -> Option<BasicAuth> {
     if let Some(pair) = raw.auth_pair_base64.as_deref().filter(|pair| !pair.is_empty()) {
         let decoded = base64_decode(pair)?;
         let (username, password) = decoded.split_once(':')?;
         return Some(BasicAuth { username: username.to_owned(), password: password.to_owned() });
     }
-    let username = raw.username.clone()?;
-    let password_b64 = raw.password.as_ref()?;
+    let username = raw.username.clone().filter(|username| !username.is_empty())?;
+    let password_b64 = raw.password.as_ref().filter(|password| !password.is_empty())?;
     let password = base64_decode(password_b64).unwrap_or_else(|| password_b64.clone());
     Some(BasicAuth { username, password })
 }

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -674,6 +674,19 @@ fn build_auth_headers_keeps_every_credential_by_scope() {
     );
 }
 
+/// An unresolved `${VAR}` leaves an empty token, which pnpm 11 reports as
+/// no credential at all.
+#[test]
+fn an_empty_credential_is_not_reported_to_hooks() {
+    let ini =
+        "//reg.example/:_authToken=\n//pair.example/:username=alice\n//pair.example/:_password=\n";
+    let mut config = Config::new();
+    NpmrcAuth::from_ini::<NoEnv>(ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect("empty credentials do not fail the load");
+    assert!(config.registry_creds_by_uri.is_empty(), "got: {:?}", config.registry_creds_by_uri);
+}
+
 #[test]
 fn unknown_per_registry_suffix_is_silently_dropped() {
     let ini = "//reg.example/:registry=https://other.example/\n";

--- a/pnpm/crates/config/src/npmrc_auth/tests.rs
+++ b/pnpm/crates/config/src/npmrc_auth/tests.rs
@@ -5,7 +5,10 @@ use pretty_assertions::assert_eq;
 
 use crate::{Config, workspace_yaml::LoadWorkspaceYamlError};
 
-use super::{DeclaredRegistries, EnvVar, NpmrcAuth, RawCreds, base64_decode, base64_encode};
+use super::{
+    BasicAuth, DeclaredRegistries, EnvVar, NpmrcAuth, RawCreds, RegistryCreds, base64_decode,
+    base64_encode,
+};
 
 /// Generate a per-test unit struct implementing [`EnvVar`] from a
 /// `&[(&str, &str)]` literal — saves each cascade test from spelling
@@ -634,6 +637,40 @@ fn per_registry_username_password_apply_through_build_auth_headers() {
     assert_eq!(
         config.auth_headers.for_url("https://reg.example/foo").as_deref(),
         Some(format!("Basic {}", base64_encode("alice:hunter2")).as_str()),
+    );
+}
+
+/// The credentials an `updateConfig` hook reads, keyed the way pnpm's
+/// `configByUri` is: every scope of a registry, with the basic-auth pair
+/// decoded and the token helper split into its command.
+#[test]
+fn build_auth_headers_keeps_every_credential_by_scope() {
+    let ini = format!(
+        "//reg.example/:_authToken=registry-wide\n//reg.example/:@acme:_auth={}\n//other.example/:tokenHelper=get-token --json\n",
+        base64_encode("alice:hunter2"),
+    );
+    let mut config = Config::new();
+    NpmrcAuth::from_ini::<NoEnv>(&ini, Path::new(""))
+        .build_auth_headers(&mut config)
+        .expect("every credential parses");
+    let reg = &config.registry_creds_by_uri["//reg.example/"];
+    assert_eq!(
+        reg[DEFAULT_REGISTRY_SCOPE],
+        RegistryCreds { auth_token: Some("registry-wide".to_string()), ..RegistryCreds::default() },
+    );
+    assert_eq!(
+        reg["@acme"],
+        RegistryCreds {
+            basic_auth: Some(BasicAuth {
+                username: "alice".to_string(),
+                password: "hunter2".to_string(),
+            }),
+            ..RegistryCreds::default()
+        },
+    );
+    assert_eq!(
+        config.registry_creds_by_uri["//other.example/"][DEFAULT_REGISTRY_SCOPE].token_helper,
+        Some(vec!["get-token".to_string(), "--json".to_string()]),
     );
 }
 

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2809,6 +2809,8 @@ impl WorkspaceSettings {
             "virtualStoreOnly" => {
                 config.virtual_store_only = defaults.virtual_store_only;
                 config.restore_hoist_patterns_after_virtual_store_only();
+                reset_hoist_pattern(config, defaults);
+                reset_public_hoist_pattern(config, defaults);
             }
             "packages" => {
                 config.workspace_package_patterns.clone_from(&defaults.workspace_package_patterns);
@@ -2899,20 +2901,24 @@ fn derive_lockfile(config: &mut Config) {
 }
 
 /// The hoist pattern `hoist` allows: the one still set, or the default,
-/// and none at all while hoisting is off.
+/// and none at all while hoisting is off. A `virtualStoreOnly` install
+/// still in force keeps both patterns empty.
 fn reset_hoist_pattern(config: &mut Config, defaults: &Config) {
     config.hoist_pattern = config
         .hoist
-        .then(|| explicit_or_default(config, "hoistPattern", defaults.hoist_pattern.as_ref()))
+        .then(|| explicit_or_default(config, "hoistPattern", defaults.hoist_pattern.as_deref()))
         .flatten();
+    config.apply_virtual_store_only_derivation();
 }
 
 /// The public hoist pattern still set, or the default, with an explicit
-/// `shamefullyHoist` overriding it as it does when the config is built.
+/// `shamefullyHoist` overriding it as it does when the config is built,
+/// and a `virtualStoreOnly` install still in force keeping it empty.
 fn reset_public_hoist_pattern(config: &mut Config, defaults: &Config) {
     config.public_hoist_pattern =
-        explicit_or_default(config, "publicHoistPattern", defaults.public_hoist_pattern.as_ref());
+        explicit_or_default(config, "publicHoistPattern", defaults.public_hoist_pattern.as_deref());
     config.apply_shamefully_hoist_derivation();
+    config.apply_virtual_store_only_derivation();
 }
 
 /// Restore one proxy key and re-resolve the cascade the keys feed.
@@ -2933,13 +2939,13 @@ fn reset_proxy_setting(config: &mut Config, defaults: &Config, key: &str) {
 fn explicit_or_default(
     config: &Config,
     key: &str,
-    default: Option<&Vec<String>>,
+    default: Option<&[String]>,
 ) -> Option<Vec<String>> {
     config
         .explicit_settings
         .get(key)
         .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_else(|| default.cloned())
+        .unwrap_or_else(|| default.map(<[String]>::to_vec))
 }
 
 /// Warn that a file sets both the `audit` section and the deprecated

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -1470,6 +1470,71 @@ impl DroppedKeys {
     }
 }
 
+/// The settings [`WorkspaceSettings`] and [`Config`] name identically and
+/// hold at the same type, so a value moves between them by plain assignment.
+///
+/// Expands to a call of `$mac!` with the field list.
+/// [`WorkspaceSettings::apply_to`] and [`WorkspaceSettings::from_resolved`]
+/// are inverses over it, and naming a setting here is what keeps them so:
+/// teaching one direction about a setting teaches the other.
+macro_rules! identically_named_settings {
+    ($mac:ident) => {
+        $mac! {
+            bail, ci, update_notifier, color, embed_readme, ignore_workspace_root_check,
+            optional, package_lock, pending, recursive_install, reverse,
+            stream, aggregate_output, use_stderr, ignore_workspace, shell_emulator,
+            skip_manifest_obfuscation, sort, use_beta_cli,
+            hoist, shamefully_hoist,
+            node_linker, node_experimental_package_map, node_package_map_type,
+            symlink, package_import_method, modules_cache_max_age,
+            virtual_store_dir_max_length,
+            peers_suffix_max_length,
+            lockfile, prefer_frozen_lockfile,
+            deploy_all_files, force_legacy_deploy, shared_workspace_lockfile,
+            merge_git_branch_lockfiles, merge_git_branch_lockfiles_branch_pattern,
+            offline, prefer_offline,
+            lockfile_include_tarball_url,
+            auto_install_peers, auto_install_peers_from_highest_match,
+            exclude_links_from_lockfile,
+            optimistic_repeat_install,
+            init_package_manager,
+            init_type,
+            hoist_workspace_packages,
+            extend_node_path,
+            hoisting_limits, external_dependencies,
+            dedupe_peer_dependents, dedupe_peers,
+            dedupe_direct_deps, dedupe_injected_deps,
+            strict_peer_dependencies, ignore_compatibility_db,
+            resolve_peers_from_workspace_root, verify_store_integrity,
+            strict_store_pkg_content_check, frozen_store,
+            include_workspace_root,
+            ignore_workspace_cycles, disallow_workspace_cycles,
+            verify_deps_before_run,
+            block_exotic_subdeps,
+            link_workspace_packages,
+            save_workspace_protocol,
+            inject_workspace_packages,
+            prefer_workspace_packages,
+            side_effects_cache_readonly,
+            fetch_retries, fetch_retry_factor,
+            fetch_retry_mintimeout, fetch_retry_maxtimeout,
+            network_concurrency, fetch_timeout,
+            fetch_warn_timeout_ms, fetch_min_speed_ki_bps, user_agent,
+            enable_global_virtual_store,
+            virtual_store_only, enable_modules_dir,
+            git_shallow_hosts,
+            test_pattern, changed_files_ignore_pattern, legacy_dir_filtering,
+            sync_injected_deps_after_scripts,
+            resolution_mode, catalog_mode, catalog_prune,
+            minimum_release_age_exclude_prune, save_peer, save_exact,
+            registry_supports_time_field,
+            allowed_deprecated_versions, update_config, peer_dependency_rules,
+            enable_pre_post_scripts, dlx_cache_max_age,
+            allow_unused_patches, tasks, pipelines,
+        }
+    };
+}
+
 impl WorkspaceSettings {
     /// Read the global config.yaml at `<config_dir>/config.yaml`, if
     /// present.
@@ -2089,59 +2154,7 @@ impl WorkspaceSettings {
             )*};
         }
 
-        apply! {
-            bail, ci, update_notifier, color, embed_readme, ignore_workspace_root_check,
-            optional, package_lock, pending, recursive_install, reverse,
-            stream, aggregate_output, use_stderr, ignore_workspace, shell_emulator,
-            skip_manifest_obfuscation, sort, use_beta_cli,
-            hoist, shamefully_hoist,
-            node_linker, node_experimental_package_map, node_package_map_type,
-            symlink, package_import_method, modules_cache_max_age,
-            virtual_store_dir_max_length,
-            peers_suffix_max_length,
-            lockfile, prefer_frozen_lockfile,
-            deploy_all_files, force_legacy_deploy, shared_workspace_lockfile,
-            merge_git_branch_lockfiles, merge_git_branch_lockfiles_branch_pattern,
-            offline, prefer_offline,
-            lockfile_include_tarball_url,
-            auto_install_peers, auto_install_peers_from_highest_match,
-            exclude_links_from_lockfile,
-            optimistic_repeat_install,
-            init_package_manager,
-            init_type,
-            hoist_workspace_packages,
-            extend_node_path,
-            hoisting_limits, external_dependencies,
-            dedupe_peer_dependents, dedupe_peers,
-            dedupe_direct_deps, dedupe_injected_deps,
-            strict_peer_dependencies, ignore_compatibility_db,
-            resolve_peers_from_workspace_root, verify_store_integrity,
-            strict_store_pkg_content_check, frozen_store,
-            include_workspace_root,
-            ignore_workspace_cycles, disallow_workspace_cycles,
-            verify_deps_before_run,
-            block_exotic_subdeps,
-            link_workspace_packages,
-            save_workspace_protocol,
-            inject_workspace_packages,
-            prefer_workspace_packages,
-            side_effects_cache_readonly,
-            fetch_retries, fetch_retry_factor,
-            fetch_retry_mintimeout, fetch_retry_maxtimeout,
-            network_concurrency, fetch_timeout,
-            fetch_warn_timeout_ms, fetch_min_speed_ki_bps, user_agent,
-            enable_global_virtual_store,
-            virtual_store_only, enable_modules_dir,
-            git_shallow_hosts,
-            test_pattern, changed_files_ignore_pattern, legacy_dir_filtering,
-            sync_injected_deps_after_scripts,
-            resolution_mode, catalog_mode, catalog_prune,
-            minimum_release_age_exclude_prune, save_peer, save_exact,
-            registry_supports_time_field,
-            allowed_deprecated_versions, update_config, peer_dependency_rules,
-            enable_pre_post_scripts, dlx_cache_max_age,
-            allow_unused_patches, tasks, pipelines,
-        }
+        identically_named_settings!(apply);
 
         overlay_some(&mut config.pipeline_base, self.pipeline_base.take());
 
@@ -2442,6 +2455,235 @@ impl WorkspaceSettings {
             config.audit_config.ignore_ghsas = ignore;
         }
         overlay_some(&mut config.audit_ignore_prune, audit.ignore_prune);
+    }
+
+    /// Every setting at the value `config` resolved it to, for a consumer
+    /// that must read the effective configuration rather than one file's
+    /// contribution to it.
+    ///
+    /// The inverse of [`Self::apply_to`]: applying the result to a default
+    /// [`Config`] reproduces `config`'s settings. Defaults are therefore
+    /// present as values, not as `None` — `None` here means "pnpm has no
+    /// such setting to report", which is true of exactly two groups:
+    ///
+    /// - Keys that name a shape only a file has, whose resolved form
+    ///   [`Config`] keeps under a different name. `registries` becomes the
+    ///   `registriesByScope` / `registriesByPrefix` lookups, `catalog`
+    ///   becomes the `default` entry of [`Self::catalogs`], and the build
+    ///   allow-lists become one `allowBuilds` record.
+    /// - Deprecated spellings, which report under the canonical one:
+    ///   `maxsockets`, `noproxy`, `updateConfig`, `auditLevel`,
+    ///   `auditConfig`, `cleanupUnusedCatalogs`, `namedRegistries`, and
+    ///   `virtualStoreType`.
+    ///
+    /// `_auth` stays `None` because a project file may not carry it, and
+    /// [`Self::key_issues`] is diagnostics about one file rather than a
+    /// setting.
+    ///
+    /// Two groups report as the user set them rather than as they resolved,
+    /// and so read as `None` when nothing set them: the path settings
+    /// [`Self::apply_to`] anchors against a base directory, and the settings
+    /// pnpm reads for whether they were set at all. See the comments at their
+    /// assignments for why each must.
+    #[must_use]
+    pub fn from_resolved(config: &Config) -> Self {
+        macro_rules! read {
+            ($($field:ident),* $(,)?) => {
+                Self { $($field: Some(config.$field.clone()),)* ..Self::default() }
+            };
+        }
+        let identity = identically_named_settings!(read);
+
+        fn path(path: &Path) -> String {
+            path.to_string_lossy().into_owned()
+        }
+        fn opt_path(value: Option<&Path>) -> Option<String> {
+            value.map(path)
+        }
+        /// The value a source set for `key`, as written, or `None` when
+        /// nothing set it.
+        fn as_set<Setting: serde::de::DeserializeOwned>(
+            config: &Config,
+            key: &str,
+        ) -> Option<Setting> {
+            config
+                .explicit_settings
+                .get(key)
+                .cloned()
+                .and_then(|value| serde_json::from_value(value).ok())
+        }
+
+        Self {
+            hoist_pattern: Some(config.hoist_pattern.clone()),
+            public_hoist_pattern: Some(config.public_hoist_pattern.clone()),
+            state_dir: Some(path(&config.state_dir)),
+            lockfile_dir: opt_path(config.lockfile_dir.as_deref()),
+            npmrc_auth_file: opt_path(config.npmrc_auth_file.as_deref()),
+            global_pnpmfile: opt_path(config.global_pnpmfile.as_deref()),
+            pnpmfile: config
+                .pnpmfile
+                .as_ref()
+                .map(|paths| PnpmfileSetting::Multiple(paths.iter().map(|p| path(p)).collect())),
+
+            // The path settings `apply_to` anchors against the file's
+            // directory report as the user wrote them, relative form
+            // included, matching pnpm. Anchoring happens when a value is
+            // applied, so reporting the anchored path would re-anchor a
+            // relative setting against wherever the hook's answer is
+            // applied from.
+            store_dir: as_set(config, "storeDir"),
+            cache_dir: as_set(config, "cacheDir"),
+            modules_dir: as_set(config, "modulesDir"),
+            virtual_store_dir: as_set(config, "virtualStoreDir"),
+            global_virtual_store_dir: as_set(config, "globalVirtualStoreDir"),
+            global_dir: as_set(config, "globalDir"),
+            global_bin_dir: as_set(config, "globalBinDir"),
+
+            // A setting pnpm reads for *whether* it was set, not only for
+            // its value, reports as the user set it. Reporting the resolved
+            // value instead would leave a hook assigning that same value
+            // with no change for the caller to notice, and the setting
+            // would go on counting as unset.
+            prefer_frozen_lockfile: as_set(config, "preferFrozenLockfile"),
+            lockfile: as_set(config, "lockfile"),
+            shamefully_hoist: as_set(config, "shamefullyHoist"),
+            merge_git_branch_lockfiles: as_set(config, "mergeGitBranchLockfiles"),
+            optimistic_repeat_install: as_set(config, "optimisticRepeatInstall"),
+            minimum_release_age: as_set(config, "minimumReleaseAge"),
+            prefer_symlinked_executables: as_set(config, "preferSymlinkedExecutables"),
+
+            global_shims: Some(crate::GlobalShimsSetting::Entries(
+                config
+                    .global_shims
+                    .entries()
+                    .map(|(name, policy)| {
+                        // `Off` has no named spelling; it is written as the
+                        // `false` shorthand.
+                        let value = match policy {
+                            crate::ShimPolicy::Off => crate::ShimPolicyValue::Toggle(false),
+                            crate::ShimPolicy::Auto => {
+                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Auto)
+                            }
+                            crate::ShimPolicy::Prompt => {
+                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Prompt)
+                            }
+                            crate::ShimPolicy::Always => {
+                                crate::ShimPolicyValue::Named(crate::NamedShimPolicy::Always)
+                            }
+                        };
+                        (name.to_string(), value)
+                    })
+                    .collect(),
+            )),
+
+            frozen_lockfile: config.frozen_lockfile,
+            git_branch_lockfile: Some(config.use_git_branch_lockfile),
+            registry: Some(config.registry.clone()),
+            scope: config.scope.clone(),
+            pnpr_server: config.pnpr_server.clone(),
+            cargo: Some(config.cargo.clone()),
+            python: Some(config.python.clone()),
+            remote_side_effects_cache: config.remote_side_effects_cache.clone(),
+            reporter_hide_prefix: config.reporter_hide_prefix,
+            max_sockets: config.max_sockets,
+            patched_dependencies: config.patched_dependencies.clone(),
+            patches_dir: config.patches_dir.clone(),
+            config_dependencies: config.config_dependencies.clone(),
+            packages: config.workspace_package_patterns.clone(),
+            dangerously_allow_all_builds: Some(config.dangerously_allow_all_builds),
+            strict_dep_builds: Some(config.strict_dep_builds),
+            ignore_scripts: Some(config.ignore_scripts),
+            ignore_pnpmfile: Some(config.ignore_pnpmfile),
+            git_checks: Some(config.git_checks),
+            engine_strict: Some(config.engine_strict),
+            node_version: config.node_version.clone(),
+            runtime_on_fail: config.runtime_on_fail,
+            node_download_mirrors: Some(config.node_download_mirrors.clone()),
+            scripts_prepend_node_path: Some(config.scripts_prepend_node_path),
+            script_shell: Some(config.script_shell.clone()),
+            node_options: Some(config.node_options.clone()),
+            unsafe_perm: Some(config.unsafe_perm),
+            supported_architectures: config.supported_architectures.clone(),
+            ignored_optional_dependencies: config.ignored_optional_dependencies.clone(),
+            overrides: config.overrides.clone(),
+            package_extensions: config.package_extensions.clone(),
+            // The flattened lookup, which is the by-name form of the setting
+            // whichever of the two forms the file wrote it in.
+            package_configs: config.package_configs.clone().map(PackageConfigsSetting::ByName),
+            minimum_release_age_exclude: config.minimum_release_age_exclude.clone(),
+            minimum_release_age_ignore_missing_time: Some(
+                config.minimum_release_age_ignore_missing_time,
+            ),
+            minimum_release_age_strict: config.minimum_release_age_strict,
+            trust_lockfile: Some(config.trust_lockfile),
+            trust_policy: Some(config.trust_policy),
+            trust_policy_exclude: config.trust_policy_exclude.clone(),
+            trust_policy_exclude_prune: Some(config.trust_policy_exclude_prune),
+            trust_policy_ignore_after: config.trust_policy_ignore_after,
+            init_author_name: config.init_author_name.clone(),
+            init_author_email: config.init_author_email.clone(),
+            init_author_url: config.init_author_url.clone(),
+            init_license: config.init_license.clone(),
+            init_version: config.init_version.clone(),
+            pm_on_fail: config.pm_on_fail,
+            versioning: Some(config.versioning.clone()),
+            save_catalog_name: config.save_catalog_name.clone(),
+            save_prefix: config.save_prefix.clone(),
+            pipeline_base: config.pipeline_base.clone(),
+
+            // `child_concurrency` / `workspace_concurrency` are resolved to
+            // a positive count on `Config`, which the settings hold as the
+            // signed type the file's negative "all but N cores" forms need.
+            child_concurrency: Some(i32::try_from(config.child_concurrency).unwrap_or(i32::MAX)),
+            workspace_concurrency: Some(
+                i32::try_from(config.workspace_concurrency).unwrap_or(i32::MAX),
+            ),
+
+            side_effects_cache: Some(SideEffectsCacheSetting::Settings(Box::new(
+                SideEffectsCacheSettings {
+                    read: config.side_effects_cache_read_setting,
+                    write: config.side_effects_cache_write_setting,
+                    remote: config.remote_side_effects_cache.clone(),
+                },
+            ))),
+
+            catalogs: config.catalogs.as_ref().map(|catalogs| {
+                catalogs
+                    .iter()
+                    .map(|(name, entries)| {
+                        (
+                            name.clone(),
+                            entries.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
+                        )
+                    })
+                    .collect()
+            }),
+            allow_builds: Some(
+                config
+                    .allow_builds
+                    .iter()
+                    .map(|(name, allowed)| (name.clone(), AllowBuild::Decided(*allowed)))
+                    .collect(),
+            ),
+
+            https_proxy: config.proxy.https_proxy.clone(),
+            http_proxy: config.proxy.http_proxy.clone(),
+            no_proxy: config.proxy.no_proxy.as_ref().map(|no_proxy| match no_proxy {
+                pnpm_network::NoProxySetting::Bypass => serde_json::Value::Bool(true),
+                pnpm_network::NoProxySetting::List(hosts) => {
+                    serde_json::Value::String(hosts.join(","))
+                }
+            }),
+
+            // `audit` and `update` are the canonical spellings, so the
+            // deprecated `auditLevel`, `auditConfig`, and `updateConfig`
+            // stay unset rather than restating them.
+            audit: config.resolved_audit_settings(),
+            update: config.resolved_update_settings(),
+            update_config: None,
+
+            ..identity
+        }
     }
 
     /// Overlay this file's proxy keys onto the merged view and re-resolve.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2749,16 +2749,23 @@ impl WorkspaceSettings {
             save_prefix, pipeline_base, child_concurrency, workspace_concurrency, catalogs,
             allow_builds,
         });
-        if let Some((_, reset)) = resets.iter().find(|(name, _)| name == key) {
-            reset(config, defaults);
+        if Self::reset_derived_setting_to_default::<Sys>(config, defaults, key, base_dir) {
             return true;
         }
-        Self::reset_renamed_setting_to_default::<Sys>(config, defaults, key, base_dir)
+        let Some((_, reset)) = resets.iter().find(|(name, _)| name == key) else {
+            return false;
+        };
+        reset(config, defaults);
+        true
     }
 
-    /// [`Self::reset_setting_to_default`] for the settings [`Config`] holds
-    /// under another name or shape, and the deprecated spellings.
-    fn reset_renamed_setting_to_default<Sys>(
+    /// [`Self::reset_setting_to_default`] for the settings another setting
+    /// is derived from, the ones [`Config`] holds under another name or
+    /// shape, and the deprecated spellings. A derivation reads the settings
+    /// still set, so an explicit `hoistPattern` survives `hoist` being
+    /// unset, and `lockfile` follows `packageLock` as it does when nothing
+    /// set it.
+    fn reset_derived_setting_to_default<Sys>(
         config: &mut Config,
         defaults: &Config,
         key: &str,
@@ -2769,25 +2776,46 @@ impl WorkspaceSettings {
     {
         match key {
             "storeDir" => config.reset_store_dir_to_default::<Sys>(base_dir),
-            "modulesDir" => config.modules_dir = base_dir.join("node_modules"),
-            "virtualStoreDir" => {
-                config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
+            "lockfileDir" => {
+                config.lockfile_dir = None;
+                reanchor_lockfile_paths(config, base_dir);
             }
+            "modulesDir" | "virtualStoreDir" => reanchor_lockfile_paths(config, base_dir),
             // Derived from the virtual store directory once that is settled.
             "globalVirtualStoreDir" => {}
+            "packageLock" => {
+                config.package_lock = defaults.package_lock;
+                derive_lockfile(config);
+            }
+            "lockfile" => derive_lockfile(config),
+            "hoist" => {
+                config.hoist = defaults.hoist;
+                reset_hoist_pattern(config, defaults);
+            }
+            "hoistPattern" => reset_hoist_pattern(config, defaults),
             "shamefullyHoist" => {
                 config.shamefully_hoist = defaults.shamefully_hoist;
-                config.public_hoist_pattern.clone_from(&defaults.public_hoist_pattern);
+                reset_public_hoist_pattern(config, defaults);
+            }
+            "publicHoistPattern" => reset_public_hoist_pattern(config, defaults),
+            "nodeLinker" => {
+                config.node_linker = defaults.node_linker;
+                config.apply_prefer_symlinked_executables_derivation();
             }
             "preferSymlinkedExecutables" => {
                 config.prefer_symlinked_executables = None;
                 config.apply_prefer_symlinked_executables_derivation();
+            }
+            "virtualStoreOnly" => {
+                config.virtual_store_only = defaults.virtual_store_only;
+                config.restore_hoist_patterns_after_virtual_store_only();
             }
             "packages" => {
                 config.workspace_package_patterns.clone_from(&defaults.workspace_package_patterns);
             }
             "gitBranchLockfile" => {
                 config.use_git_branch_lockfile = defaults.use_git_branch_lockfile;
+                config.git_branch_lockfile_name = None;
             }
             "sideEffectsCache" => {
                 config.side_effects_cache_read_setting = defaults.side_effects_cache_read_setting;
@@ -2795,15 +2823,7 @@ impl WorkspaceSettings {
                 config.remote_side_effects_cache.clone_from(&defaults.remote_side_effects_cache);
             }
             "httpsProxy" | "httpProxy" | "proxy" | "noProxy" | "noproxy" => {
-                let (keys, default_keys) = (&mut config.proxy_keys, &defaults.proxy_keys);
-                match key {
-                    "httpsProxy" => keys.https_proxy = default_keys.https_proxy.clone(),
-                    "httpProxy" => keys.http_proxy = default_keys.http_proxy.clone(),
-                    "proxy" => keys.legacy_proxy = default_keys.legacy_proxy.clone(),
-                    "noProxy" => keys.no_proxy = default_keys.no_proxy.clone(),
-                    _ => keys.noproxy = default_keys.noproxy.clone(),
-                }
-                config.proxy = config.proxy_keys.resolve();
+                reset_proxy_setting(config, defaults, key);
             }
             "audit" | "auditLevel" | "auditConfig" => {
                 config.audit_level = defaults.audit_level;
@@ -2860,6 +2880,66 @@ impl WorkspaceSettings {
         }
         *proxy_config = keys.resolve();
     }
+}
+
+/// The paths anchored on the lockfile directory, re-anchored the way
+/// pinning it does, so a `modulesDir` still set keeps its shape and a
+/// pinned lockfile directory keeps its paths.
+fn reanchor_lockfile_paths(config: &mut Config, base_dir: &Path) {
+    let dir = config.lockfile_dir.clone().unwrap_or_else(|| base_dir.to_path_buf());
+    config.anchor_lockfile_paths(&dir);
+}
+
+/// `lockfile` follows `packageLock` while nothing sets it, as it does when
+/// the config is built.
+fn derive_lockfile(config: &mut Config) {
+    if !config.explicit_settings.contains_key("lockfile") {
+        config.lockfile = config.package_lock;
+    }
+}
+
+/// The hoist pattern `hoist` allows: the one still set, or the default,
+/// and none at all while hoisting is off.
+fn reset_hoist_pattern(config: &mut Config, defaults: &Config) {
+    config.hoist_pattern = config
+        .hoist
+        .then(|| explicit_or_default(config, "hoistPattern", defaults.hoist_pattern.as_ref()))
+        .flatten();
+}
+
+/// The public hoist pattern still set, or the default, with an explicit
+/// `shamefullyHoist` overriding it as it does when the config is built.
+fn reset_public_hoist_pattern(config: &mut Config, defaults: &Config) {
+    config.public_hoist_pattern =
+        explicit_or_default(config, "publicHoistPattern", defaults.public_hoist_pattern.as_ref());
+    config.apply_shamefully_hoist_derivation();
+}
+
+/// Restore one proxy key and re-resolve the cascade the keys feed.
+fn reset_proxy_setting(config: &mut Config, defaults: &Config, key: &str) {
+    let (keys, default_keys) = (&mut config.proxy_keys, &defaults.proxy_keys);
+    match key {
+        "httpsProxy" => keys.https_proxy = default_keys.https_proxy.clone(),
+        "httpProxy" => keys.http_proxy = default_keys.http_proxy.clone(),
+        "proxy" => keys.legacy_proxy = default_keys.legacy_proxy.clone(),
+        "noProxy" => keys.no_proxy = default_keys.no_proxy.clone(),
+        _ => keys.noproxy = default_keys.noproxy.clone(),
+    }
+    config.proxy = config.proxy_keys.resolve();
+}
+
+/// The pattern a source still sets under `key`, or `default` when none
+/// does.
+fn explicit_or_default(
+    config: &Config,
+    key: &str,
+    default: Option<&Vec<String>>,
+) -> Option<Vec<String>> {
+    config
+        .explicit_settings
+        .get(key)
+        .and_then(|value| serde_json::from_value(value.clone()).ok())
+        .unwrap_or_else(|| default.cloned())
 }
 
 /// Warn that a file sets both the `audit` section and the deprecated

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -6,7 +6,7 @@ use crate::{
     NodeLinker, NodePackageMapType, PackageImportMethod, PmOnFail, ResolutionMode, RuntimeOnFail,
     SaveWorkspaceProtocol, ScriptsPrependNodePath, TrustPolicy, VerifyDepsBeforeRun,
     VirtualStoreType,
-    api::{EnvVar, GetHomeDir},
+    api::{EnvVar, GetCurrentDir, GetHomeDir, LinkProbe},
     config_types::is_config_file_key,
     known_settings::{SCHEMA_DIRECTIVE_KEY, annotate_unknown_setting, is_known_setting_key},
     naming_cases::{is_camel_case, to_camel_case, to_kebab_case},
@@ -2698,6 +2698,136 @@ impl WorkspaceSettings {
 
             ..identity
         }
+    }
+
+    /// Restore the setting `key` names to the value `defaults` holds for
+    /// it, for a source that unset the setting. [`Self::apply_to`] has no
+    /// value to apply for an unset setting, so this is its counterpart for
+    /// deletion. The path settings `apply_to` anchors return to their
+    /// default under `base_dir`, and a setting another is derived from
+    /// carries the derivation with it. Reports whether `key` named a
+    /// setting.
+    pub fn reset_setting_to_default<Sys>(
+        config: &mut Config,
+        defaults: &Config,
+        key: &str,
+        base_dir: &Path,
+    ) -> bool
+    where
+        Sys: EnvVar + GetCurrentDir + GetHomeDir + LinkProbe,
+    {
+        type Reset = fn(&mut Config, &Config);
+        macro_rules! same_named {
+            ($($field:ident),* $(,)?) => {
+                vec![$((
+                    to_camel_case(stringify!($field)),
+                    (|config: &mut Config, defaults: &Config| {
+                        config.$field = defaults.$field.clone();
+                    }) as Reset,
+                ),)*]
+            };
+        }
+        let mut resets: Vec<(String, Reset)> = identically_named_settings!(same_named);
+        // The settings both structs name identically but hold at different
+        // types, plus the ones `from_resolved` reports only when set.
+        resets.extend(same_named! {
+            hoist_pattern, public_hoist_pattern, state_dir, lockfile_dir, npmrc_auth_file,
+            global_pnpmfile, pnpmfile, global_dir, global_bin_dir, cache_dir,
+            prefer_frozen_lockfile, lockfile, merge_git_branch_lockfiles,
+            optimistic_repeat_install, minimum_release_age, global_shims, frozen_lockfile,
+            registry, scope, pnpr_server, cargo, python, remote_side_effects_cache,
+            reporter_hide_prefix, max_sockets, patched_dependencies, patches_dir,
+            config_dependencies, dangerously_allow_all_builds, strict_dep_builds,
+            ignore_scripts, ignore_pnpmfile, git_checks, engine_strict, node_version,
+            runtime_on_fail, node_download_mirrors, scripts_prepend_node_path, script_shell,
+            node_options, unsafe_perm, supported_architectures, ignored_optional_dependencies,
+            overrides, package_extensions, package_configs, minimum_release_age_exclude,
+            minimum_release_age_ignore_missing_time, minimum_release_age_strict,
+            trust_lockfile, trust_policy, trust_policy_exclude, trust_policy_exclude_prune,
+            trust_policy_ignore_after, init_author_name, init_author_email, init_author_url,
+            init_license, init_version, pm_on_fail, versioning, save_catalog_name,
+            save_prefix, pipeline_base, child_concurrency, workspace_concurrency, catalogs,
+            allow_builds,
+        });
+        if let Some((_, reset)) = resets.iter().find(|(name, _)| name == key) {
+            reset(config, defaults);
+            return true;
+        }
+        Self::reset_renamed_setting_to_default::<Sys>(config, defaults, key, base_dir)
+    }
+
+    /// [`Self::reset_setting_to_default`] for the settings [`Config`] holds
+    /// under another name or shape, and the deprecated spellings.
+    fn reset_renamed_setting_to_default<Sys>(
+        config: &mut Config,
+        defaults: &Config,
+        key: &str,
+        base_dir: &Path,
+    ) -> bool
+    where
+        Sys: EnvVar + GetCurrentDir + GetHomeDir + LinkProbe,
+    {
+        match key {
+            "storeDir" => config.reset_store_dir_to_default::<Sys>(base_dir),
+            "modulesDir" => config.modules_dir = base_dir.join("node_modules"),
+            "virtualStoreDir" => {
+                config.virtual_store_dir = base_dir.join("node_modules").join(".pnpm");
+            }
+            // Derived from the virtual store directory once that is settled.
+            "globalVirtualStoreDir" => {}
+            "shamefullyHoist" => {
+                config.shamefully_hoist = defaults.shamefully_hoist;
+                config.public_hoist_pattern.clone_from(&defaults.public_hoist_pattern);
+            }
+            "preferSymlinkedExecutables" => {
+                config.prefer_symlinked_executables = None;
+                config.apply_prefer_symlinked_executables_derivation();
+            }
+            "packages" => {
+                config.workspace_package_patterns.clone_from(&defaults.workspace_package_patterns);
+            }
+            "gitBranchLockfile" => {
+                config.use_git_branch_lockfile = defaults.use_git_branch_lockfile;
+            }
+            "sideEffectsCache" => {
+                config.side_effects_cache_read_setting = defaults.side_effects_cache_read_setting;
+                config.side_effects_cache_write_setting = defaults.side_effects_cache_write_setting;
+                config.remote_side_effects_cache.clone_from(&defaults.remote_side_effects_cache);
+            }
+            "httpsProxy" | "httpProxy" | "proxy" | "noProxy" | "noproxy" => {
+                let (keys, default_keys) = (&mut config.proxy_keys, &defaults.proxy_keys);
+                match key {
+                    "httpsProxy" => keys.https_proxy = default_keys.https_proxy.clone(),
+                    "httpProxy" => keys.http_proxy = default_keys.http_proxy.clone(),
+                    "proxy" => keys.legacy_proxy = default_keys.legacy_proxy.clone(),
+                    "noProxy" => keys.no_proxy = default_keys.no_proxy.clone(),
+                    _ => keys.noproxy = default_keys.noproxy.clone(),
+                }
+                config.proxy = config.proxy_keys.resolve();
+            }
+            "audit" | "auditLevel" | "auditConfig" => {
+                config.audit_level = defaults.audit_level;
+                config.audit_config.clone_from(&defaults.audit_config);
+                config.audit_ignore_prune = defaults.audit_ignore_prune;
+            }
+            "update" | "updateConfig" => config.update_config.clone_from(&defaults.update_config),
+            "cleanupUnusedCatalogs" => config.catalog_prune = defaults.catalog_prune,
+            "virtualStoreType" => {
+                config.enable_global_virtual_store = defaults.enable_global_virtual_store;
+            }
+            "maxsockets" => config.max_sockets = defaults.max_sockets,
+            // Shapes only a file has, whose resolved form lives under the
+            // keys above, or one nothing resolves from: nothing to restore.
+            "registries"
+            | "namedRegistries"
+            | "catalog"
+            | "onlyBuiltDependencies"
+            | "neverBuiltDependencies"
+            | "ignoredBuiltDependencies"
+            | "_auth" => {}
+            _ => return false,
+        }
+        true
     }
 
     /// Overlay this file's proxy keys onto the merged view and re-resolve.

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2484,7 +2484,8 @@ impl WorkspaceSettings {
     /// and so read as `None` when nothing set them: the path settings
     /// [`Self::apply_to`] anchors against a base directory, and the settings
     /// pnpm reads for whether they were set at all. See the comments at their
-    /// assignments for why each must.
+    /// assignments for why each must. `cacheDir` belongs to the first group
+    /// but falls back to the resolved directory, as pnpm reports it.
     #[must_use]
     pub fn from_resolved(config: &Config) -> Self {
         macro_rules! read {
@@ -2532,12 +2533,16 @@ impl WorkspaceSettings {
             // relative setting against wherever the hook's answer is
             // applied from.
             store_dir: as_set(config, "storeDir"),
-            cache_dir: as_set(config, "cacheDir"),
             modules_dir: as_set(config, "modulesDir"),
             virtual_store_dir: as_set(config, "virtualStoreDir"),
             global_virtual_store_dir: as_set(config, "globalVirtualStoreDir"),
             global_dir: as_set(config, "globalDir"),
             global_bin_dir: as_set(config, "globalBinDir"),
+
+            // `cacheDir` is one of those settings when a source set it, and
+            // the directory pnpm chose for the host when none did, which is
+            // where the cache is read and written either way.
+            cache_dir: as_set(config, "cacheDir").or_else(|| Some(path(&config.cache_dir))),
 
             // A setting pnpm reads for *whether* it was set, not only for
             // its value, reports as the user set it. Reporting the resolved
@@ -2639,13 +2644,22 @@ impl WorkspaceSettings {
                 i32::try_from(config.workspace_concurrency).unwrap_or(i32::MAX),
             ),
 
-            side_effects_cache: Some(SideEffectsCacheSetting::Settings(Box::new(
-                SideEffectsCacheSettings {
-                    read: config.side_effects_cache_read_setting,
-                    write: config.side_effects_cache_write_setting,
-                    remote: config.remote_side_effects_cache.clone(),
-                },
-            ))),
+            // Reads and writes as resolved, in the boolean shorthand when they
+            // agree and no remote cache is configured. That is the shape pnpm
+            // reports and the one a hook is likeliest to assign.
+            side_effects_cache: Some({
+                let read = config.side_effects_cache_read();
+                let write = config.side_effects_cache_write();
+                if read == write && config.remote_side_effects_cache.is_none() {
+                    SideEffectsCacheSetting::Enabled(read)
+                } else {
+                    SideEffectsCacheSetting::Settings(Box::new(SideEffectsCacheSettings {
+                        read: Some(read),
+                        write: Some(write),
+                        remote: config.remote_side_effects_cache.clone(),
+                    }))
+                }
+            }),
 
             catalogs: config.catalogs.as_ref().map(|catalogs| {
                 catalogs

--- a/pnpm/crates/config/src/workspace_yaml.rs
+++ b/pnpm/crates/config/src/workspace_yaml.rs
@@ -2808,9 +2808,7 @@ impl WorkspaceSettings {
             }
             "virtualStoreOnly" => {
                 config.virtual_store_only = defaults.virtual_store_only;
-                config.restore_hoist_patterns_after_virtual_store_only();
-                reset_hoist_pattern(config, defaults);
-                reset_public_hoist_pattern(config, defaults);
+                leave_virtual_store_only(config);
             }
             "packages" => {
                 config.workspace_package_patterns.clone_from(&defaults.workspace_package_patterns);
@@ -2934,6 +2932,24 @@ fn reset_proxy_setting(config: &mut Config, defaults: &Config, key: &str) {
     config.proxy = config.proxy_keys.resolve();
 }
 
+/// Leave `virtualStoreOnly` mode with the hoist patterns the mode
+/// snapshotted, a pattern a source explicitly disabled included, unless a
+/// source still sets a pattern, and with the derivations that read the
+/// patterns re-run.
+fn leave_virtual_store_only(config: &mut Config) {
+    config.restore_hoist_patterns_after_virtual_store_only();
+    if let Some(pattern) = explicit_pattern(config, "hoistPattern") {
+        config.hoist_pattern = Some(pattern);
+    }
+    if !config.hoist {
+        config.hoist_pattern = None;
+    }
+    if let Some(pattern) = explicit_pattern(config, "publicHoistPattern") {
+        config.public_hoist_pattern = Some(pattern);
+    }
+    config.apply_shamefully_hoist_derivation();
+}
+
 /// The pattern a source still sets under `key`, or `default` when none
 /// does.
 fn explicit_or_default(
@@ -2941,11 +2957,12 @@ fn explicit_or_default(
     key: &str,
     default: Option<&[String]>,
 ) -> Option<Vec<String>> {
-    config
-        .explicit_settings
-        .get(key)
-        .and_then(|value| serde_json::from_value(value.clone()).ok())
-        .unwrap_or_else(|| default.map(<[String]>::to_vec))
+    explicit_pattern(config, key).or_else(|| default.map(<[String]>::to_vec))
+}
+
+/// The pattern a source still sets under `key`.
+fn explicit_pattern(config: &Config, key: &str) -> Option<Vec<String>> {
+    config.explicit_settings.get(key).and_then(|value| serde_json::from_value(value.clone()).ok())
 }
 
 /// Warn that a file sets both the `audit` section and the deprecated

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3915,6 +3915,32 @@ fn reset_setting_to_default_keeps_virtual_store_only_hoisting_empty() {
     assert_eq!(config.public_hoist_pattern, defaults.public_hoist_pattern);
 }
 
+/// A pattern a source disabled with `null` is absent from the explicit
+/// settings, so leaving `virtualStoreOnly` keeps the disabled pattern the
+/// mode snapshotted rather than falling back to the default.
+#[test]
+fn reset_setting_to_default_keeps_disabled_patterns_when_leaving_virtual_store_only() {
+    let defaults = Config::default();
+    let mut config = Config {
+        virtual_store_only: true,
+        hoist_pattern: None,
+        public_hoist_pattern: None,
+        ..Config::default()
+    };
+    config.apply_virtual_store_only_derivation();
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
+
+    WorkspaceSettings::reset_setting_to_default::<crate::Host>(
+        &mut config,
+        &defaults,
+        "virtualStoreOnly",
+        Path::new("/tmp/project"),
+    );
+    assert!(!config.virtual_store_only);
+    assert_eq!(config.hoist_pattern, None);
+    assert_eq!(config.public_hoist_pattern, None);
+}
+
 /// The settings that report as the user set them are outside this property
 /// by design, since an unset one reports nothing to apply; see
 /// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3816,9 +3816,6 @@ fn from_resolved_reports_every_setting() {
     );
 }
 
-/// `from_resolved` is the inverse of `apply_to`: what a resolved config
-/// reports, applied to a fresh config, resolves to the same values.
-///
 /// The settings that report as the user set them are outside this property
 /// by design, since an unset one reports nothing to apply; see
 /// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3882,6 +3882,39 @@ fn reset_setting_to_default_rederives_from_the_settings_still_set() {
     assert_eq!(config.hoist_pattern, defaults.hoist_pattern);
 }
 
+/// A `virtualStoreOnly` install keeps both hoist patterns empty whatever
+/// hoist setting is unset beside it, and leaving that mode recomputes the
+/// patterns from the settings still set rather than from the snapshot the
+/// mode took.
+#[test]
+fn reset_setting_to_default_keeps_virtual_store_only_hoisting_empty() {
+    let defaults = Config::default();
+    let base_dir = Path::new("/tmp/project");
+    let mut config = Config { virtual_store_only: true, hoist: false, ..Config::default() };
+    config.apply_virtual_store_only_derivation();
+
+    WorkspaceSettings::reset_setting_to_default::<crate::Host>(
+        &mut config,
+        &defaults,
+        "hoist",
+        base_dir,
+    );
+    assert!(config.hoist);
+    assert_eq!(config.hoist_pattern, Some(Vec::new()));
+    assert_eq!(config.public_hoist_pattern, Some(Vec::new()));
+
+    config.explicit_settings.insert("hoistPattern".to_string(), serde_json::json!(["eslint-*"]));
+    WorkspaceSettings::reset_setting_to_default::<crate::Host>(
+        &mut config,
+        &defaults,
+        "virtualStoreOnly",
+        base_dir,
+    );
+    assert!(!config.virtual_store_only);
+    assert_eq!(config.hoist_pattern, Some(vec!["eslint-*".to_string()]));
+    assert_eq!(config.public_hoist_pattern, defaults.public_hoist_pattern);
+}
+
 /// The settings that report as the user set them are outside this property
 /// by design, since an unset one reports nothing to apply; see
 /// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -1,16 +1,19 @@
 use super::{
-    AllowBuild, LoadWorkspaceYamlError, SideEffectsCacheSetting, WORKSPACE_MANIFEST_FILENAME,
-    WorkspaceSettings,
+    AllowBuild, LoadWorkspaceYamlError, RemoteSideEffectsCacheSettings, SideEffectsCacheSetting,
+    UpdateConfig, WORKSPACE_MANIFEST_FILENAME, WorkspaceSettings,
+    package_configs::ProjectConfig,
     registries::{RegistryDeclaration, RegistryEntry},
 };
 use crate::{
     AuditLevel, CatalogMode, ColorMode, Config, GlobalShims, GlobalShimsSetting, HoistingLimits,
-    LinkWorkspacePackages, NodeLinker, NodePackageMapType, ResolutionMode, ScriptsPrependNodePath,
-    ShimPolicy, TrustPolicy,
+    LinkWorkspacePackages, NodeLinker, NodePackageMapType, PmOnFail, ResolutionMode, RuntimeOnFail,
+    ScriptsPrependNodePath, ShimPolicy, TrustPolicy,
     api::{EnvVar, GetHomeDir},
 };
+use indexmap::IndexMap;
 use pipe_trait::Pipe;
 use pnpm_lockfile::{RegistryOptions, RegistryServerType};
+use pnpm_package_is_installable::SupportedArchitectures;
 use pnpm_store_dir::StoreDir;
 use pnpm_workspace_state::{ConfigDependency, ConfigDependencyDetail};
 use pretty_assertions::assert_eq;
@@ -3669,4 +3672,196 @@ fn a_tilde_without_a_separator_is_left_alone() {
     settings.expand_global_dir_home_prefixes::<FakeHome>();
     assert_eq!(settings.global_dir.as_deref(), Some("~backup/global"));
     assert_eq!(settings.global_bin_dir.as_deref(), Some("bin/~/nested"));
+}
+
+/// The settings [`WorkspaceSettings::from_resolved`] deliberately leaves
+/// unset, each because pnpm reports the same thing under another name. See
+/// that method's documentation for why each one is here.
+const UNREPORTED_SETTINGS: &[&str] = &[
+    // Shapes only a file has; the resolved form reports elsewhere.
+    "registries",
+    "namedRegistries",
+    "catalog",
+    "onlyBuiltDependencies",
+    "neverBuiltDependencies",
+    "ignoredBuiltDependencies",
+    // Deprecated spellings of a canonical key.
+    "maxsockets",
+    "noproxy",
+    // npm's spelling, which resolves into `httpsProxy` / `httpProxy`.
+    "proxy",
+    "updateConfig",
+    "auditLevel",
+    "auditConfig",
+    "cleanupUnusedCatalogs",
+    "virtualStoreType",
+    // Never read from a project file.
+    "_auth",
+];
+
+/// Every setting must report its resolved value, so that a hook reading the
+/// configuration sees what the install runs with. A key absent from the
+/// projection reads as `null`, which is indistinguishable from "explicitly
+/// unset" — so adding a setting to [`WorkspaceSettings`] without teaching
+/// [`WorkspaceSettings::from_resolved`] about it fails here.
+///
+/// Settings that are genuinely `Option` on [`Config`] are exempt: a `None`
+/// there is pnpm's own "unset", not a gap in the projection. The fixture
+/// below therefore sets every such value, so anything still `null` is
+/// unmapped.
+#[test]
+fn from_resolved_reports_every_setting() {
+    let config = Config {
+        scope: Some("@acme".to_string()),
+        pnpr_server: Some("https://pnpr.example".to_string()),
+        frozen_lockfile: Some(true),
+        reporter_hide_prefix: Some(true),
+        prefer_symlinked_executables: Some(true),
+        max_sockets: Some(4),
+        node_version: Some("24.0.0".to_string()),
+        script_shell: Some("/bin/bash".to_string()),
+        node_options: Some("--max-old-space-size=8192".to_string()),
+        patches_dir: Some("patches".to_string()),
+        save_prefix: Some("~".to_string()),
+        save_catalog_name: Some("default".to_string()),
+        pipeline_base: Some("origin/main".to_string()),
+        init_author_name: Some("Example".to_string()),
+        init_author_email: Some("example@example.com".to_string()),
+        init_author_url: Some("https://example.com".to_string()),
+        init_license: Some("MIT".to_string()),
+        init_version: Some("1.0.0".to_string()),
+        minimum_release_age_strict: Some(true),
+        minimum_release_age_exclude: Some(vec!["is-positive".to_string()]),
+        trust_policy_exclude: Some(vec!["is-negative".to_string()]),
+        trust_policy_ignore_after: Some(1),
+        lockfile_dir: Some(PathBuf::from("/tmp/project")),
+        npmrc_auth_file: Some(PathBuf::from("/tmp/auth.ini")),
+        global_pnpmfile: Some(PathBuf::from("/tmp/global/pnpmfile.cjs")),
+        pnpmfile: Some(vec![PathBuf::from("/tmp/project/.pnpmfile.cjs")]),
+        workspace_package_patterns: Some(vec!["packages/*".to_string()]),
+        patched_dependencies: Some(IndexMap::from([(
+            "is-positive".to_string(),
+            "patches/is-positive.patch".to_string(),
+        )])),
+        overrides: Some(IndexMap::from([("is-positive".to_string(), "1.0.0".to_string())])),
+        package_configs: Some(IndexMap::from([(
+            "@acme/app".to_string(),
+            ProjectConfig { save_exact: Some(true), ..ProjectConfig::default() },
+        )])),
+        ignored_optional_dependencies: Some(vec!["fsevents".to_string()]),
+        supported_architectures: Some(SupportedArchitectures::default()),
+        config_dependencies: Some(BTreeMap::new()),
+        package_extensions: Some(IndexMap::default()),
+        catalogs: Some(BTreeMap::default()),
+        remote_side_effects_cache: Some(RemoteSideEffectsCacheSettings::default()),
+        runtime_on_fail: Some(RuntimeOnFail::Warn),
+        pm_on_fail: Some(PmOnFail::Warn),
+        side_effects_cache_read_setting: Some(true),
+        side_effects_cache_write_setting: Some(true),
+        audit_level: Some(AuditLevel::Low),
+        proxy: pnpm_network::ProxyConfig {
+            https_proxy: Some("https://proxy.example".to_string()),
+            http_proxy: Some("http://proxy.example".to_string()),
+            no_proxy: Some(pnpm_network::NoProxySetting::List(vec!["example.com".to_string()])),
+        },
+        update_config: UpdateConfig { changeset: Some(true), ..UpdateConfig::default() },
+        // The settings that report as written, rather than as resolved.
+        explicit_settings: [
+            "storeDir",
+            "cacheDir",
+            "modulesDir",
+            "virtualStoreDir",
+            "globalVirtualStoreDir",
+            "globalDir",
+            "globalBinDir",
+        ]
+        .into_iter()
+        .map(|key| (key.to_string(), serde_json::Value::String(format!("../{key}"))))
+        .chain(
+            [
+                "preferFrozenLockfile",
+                "lockfile",
+                "shamefullyHoist",
+                "mergeGitBranchLockfiles",
+                "optimisticRepeatInstall",
+                "preferSymlinkedExecutables",
+            ]
+            .into_iter()
+            .map(|key| (key.to_string(), serde_json::Value::Bool(true))),
+        )
+        .chain(std::iter::once((
+            "minimumReleaseAge".to_string(),
+            serde_json::Value::Number(60.into()),
+        )))
+        .collect(),
+        ..Config::default()
+    };
+
+    let projected = WorkspaceSettings::from_resolved(&config);
+    let Ok(serde_json::Value::Object(map)) = serde_json::to_value(&projected) else {
+        panic!("the projected settings serialize to a JSON object");
+    };
+
+    let unreported: Vec<&str> =
+        map.iter().filter(|(_, value)| value.is_null()).map(|(key, _)| key.as_str()).collect();
+    let mut expected = UNREPORTED_SETTINGS.to_vec();
+    expected.sort_unstable();
+    let mut found = unreported;
+    found.sort_unstable();
+    dbg!(&found);
+    assert_eq!(
+        found, expected,
+        "a setting reporting `null` is one `from_resolved` does not map; add the mapping, or add \
+         the key to UNREPORTED_SETTINGS with the reason it reports elsewhere",
+    );
+}
+
+/// `from_resolved` is the inverse of `apply_to`: what a resolved config
+/// reports, applied to a fresh config, resolves to the same values.
+///
+/// The settings that report as the user set them are outside this property
+/// by design, since an unset one reports nothing to apply; see
+/// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].
+#[test]
+fn from_resolved_round_trips_through_apply_to() {
+    let original = Config {
+        node_linker: NodeLinker::Hoisted,
+        registry: "https://reg.example/".to_string(),
+        save_exact: true,
+        fetch_retries: 9,
+        user_agent: "pnpm/test".to_string(),
+        ..Config::default()
+    };
+
+    let mut applied = Config::default();
+    WorkspaceSettings::from_resolved(&original).apply_to(&mut applied, Path::new("/tmp/project"));
+
+    assert_eq!(applied.node_linker, original.node_linker);
+    assert_eq!(applied.registry, original.registry);
+    assert_eq!(applied.save_exact, original.save_exact);
+    assert_eq!(applied.fetch_retries, original.fetch_retries);
+    assert_eq!(applied.user_agent, original.user_agent);
+}
+
+/// A setting pnpm reads for whether it was set reports as unset until a
+/// source sets it, even though [`Config`] resolved it to a value. A caller
+/// diffing the projection against a hook's answer can then tell "the hook
+/// set this" from "the hook left it alone", which is what decides whether
+/// the setting counts as configured at all.
+#[test]
+fn from_resolved_leaves_explicitness_sensitive_settings_unset() {
+    let unset = Config { prefer_frozen_lockfile: true, lockfile: true, ..Config::default() };
+    let projected = WorkspaceSettings::from_resolved(&unset);
+    assert_eq!(projected.prefer_frozen_lockfile, None);
+    assert_eq!(projected.lockfile, None);
+
+    let configured = Config {
+        prefer_frozen_lockfile: true,
+        explicit_settings: serde_json::Map::from_iter([(
+            "preferFrozenLockfile".to_string(),
+            serde_json::Value::Bool(false),
+        )]),
+        ..Config::default()
+    };
+    assert_eq!(WorkspaceSettings::from_resolved(&configured).prefer_frozen_lockfile, Some(false));
 }

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3846,6 +3846,42 @@ fn reset_setting_to_default_covers_every_setting() {
     assert_eq!(config.lockfile, defaults.lockfile);
 }
 
+/// Unsetting a setting another is derived from re-runs the derivation
+/// against the settings still set, so an explicit `publicHoistPattern`
+/// outlives `shamefullyHoist`, `lockfile` follows `packageLock`, and the
+/// hoist pattern returns with `hoist`.
+#[test]
+fn reset_setting_to_default_rederives_from_the_settings_still_set() {
+    let defaults = Config::default();
+    let base_dir = Path::new("/tmp/project");
+    let mut config = Config {
+        shamefully_hoist: true,
+        public_hoist_pattern: Some(vec!["*".to_string()]),
+        package_lock: false,
+        lockfile: true,
+        hoist: false,
+        hoist_pattern: None,
+        explicit_settings: serde_json::Map::from_iter([(
+            "publicHoistPattern".to_string(),
+            serde_json::json!(["@types/*"]),
+        )]),
+        ..Config::default()
+    };
+    for key in ["shamefullyHoist", "lockfile", "hoist"] {
+        assert!(WorkspaceSettings::reset_setting_to_default::<crate::Host>(
+            &mut config,
+            &defaults,
+            key,
+            base_dir,
+        ));
+    }
+    assert!(!config.shamefully_hoist);
+    assert_eq!(config.public_hoist_pattern, Some(vec!["@types/*".to_string()]));
+    assert!(!config.lockfile);
+    assert!(config.hoist);
+    assert_eq!(config.hoist_pattern, defaults.hoist_pattern);
+}
+
 /// The settings that report as the user set them are outside this property
 /// by design, since an unset one reports nothing to apply; see
 /// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].

--- a/pnpm/crates/config/src/workspace_yaml/tests.rs
+++ b/pnpm/crates/config/src/workspace_yaml/tests.rs
@@ -3816,6 +3816,36 @@ fn from_resolved_reports_every_setting() {
     );
 }
 
+/// Every setting `from_resolved` reports can be unset again, deprecated
+/// spellings included, so a source deleting a setting never leaves the
+/// resolved value behind.
+#[test]
+fn reset_setting_to_default_covers_every_setting() {
+    let defaults = Config::default();
+    let Ok(serde_json::Value::Object(map)) =
+        serde_json::to_value(WorkspaceSettings::from_resolved(&defaults))
+    else {
+        panic!("the projected settings serialize to a JSON object");
+    };
+    let mut config =
+        Config { node_linker: NodeLinker::Hoisted, lockfile: false, ..Config::default() };
+    let unhandled: Vec<&str> = map
+        .keys()
+        .map(String::as_str)
+        .filter(|key| {
+            !WorkspaceSettings::reset_setting_to_default::<crate::Host>(
+                &mut config,
+                &defaults,
+                key,
+                Path::new("/tmp/project"),
+            )
+        })
+        .collect();
+    assert_eq!(unhandled, Vec::<&str>::new(), "settings with no reset");
+    assert_eq!(config.node_linker, defaults.node_linker);
+    assert_eq!(config.lockfile, defaults.lockfile);
+}
+
 /// The settings that report as the user set them are outside this property
 /// by design, since an unset one reports nothing to apply; see
 /// [`from_resolved_leaves_explicitness_sensitive_settings_unset`].

--- a/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
+++ b/pnpm/crates/deps-restorer/src/install_package_from_registry/tests.rs
@@ -230,6 +230,7 @@ fn create_config(
         peer_dependency_rules: Default::default(),
         auth_headers: Default::default(),
         auth_tokens_by_uri: Default::default(),
+        registry_creds_by_uri: Default::default(),
         proxy: Default::default(),
         proxy_keys: Default::default(),
         tls: Default::default(),


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

In pnpm 12, the `updateConfig` pnpmfile hook is handed the parsed contents of `pnpm-workspace.yaml`, so the hook can't read any settings from `.npmrc`, the command line, or a default. Of the 188 keys in the input, 184 arrive `null`. This is an undocumented behavior change: pnpm 11 handed the hook its resolved `Config`.

This PR gives the hook the resolved configuration. `WorkspaceSettings::from_resolved` is the inverse of `apply_to`, and `resolved_config_views` supplies the resolved state that is not a settings key, under the names pnpm 11 uses. A hook may also rewrite `registriesByScope` / `registriesByPrefix`, since it reads routing under those names.

Also, the resolved config now omits keys for config options that aren't defined, instead of showing those config options as set to `null`, matching pnpm 11's behavior.

With this PR, `updateConfig` now reports the same value for every key both versions carry, apart from the two noted below.

Fixes https://github.com/pnpm/pnpm/issues/14676

## Remaining differences from pnpm 11

`userAgent` reports `node/?` and `maxSockets` reports nothing. Both are deliberate: pnpm v12 embeds no Node runtime, and it leaves the per-origin socket count uncapped, which its HTTP/1.1 network topology depends on. `minimumReleaseAge` and `optimisticRepeatInstall` are absent when unset, since pnpm reads those for whether they were set at all. `extraEnv` is empty where pnpm 11 seeds `pnpm_config_verify_deps_before_run`.

14 keys pnpm 11 reports have no pnpm 12 counterpart at all: `bin`, `dev`, `maxSockets`, `minimumReleaseAge`, `optimisticRepeatInstall`, `packageManagerNetworkConfig`, `packageManagerRegistries`, `pnpmHomeDir`, `production`, `tryLoadDefaultPnpmfile`, `useLockfile`, `userConfig`, `userconfig`, and `workspacePrefix`. Most are pnpm 11 internals or legacy aliases of a key pnpm 12 already reports under its current name, `workspacePrefix` for `workspaceDir` among them. `bin`, `pnpmHomeDir`, `useLockfile`, `userconfig`, and `workspacePrefix` might be useful to add as a follow-up, though.

## Related: Hook vs. CLI precedence

This PR matches pnpm 11's behavior regarding precedence: Values returned from `updateConfig` take precedence over CLI arguments such as `--registry`. That behavior is an open question discussed in pnpm/pnpm#14063, which has an open PR to change the precedence order: https://github.com/pnpm/pnpm/pull/14070

## Squash Commit Body

```text
The `updateConfig` pnpmfile hook was passed the parsed contents of
`pnpm-workspace.yaml`, so a hook could not read a setting that came from
`.npmrc`, the command line, or a default. Scoped registries declared in
`.npmrc` were the case that surfaced it: `registriesByScope` was absent
from the input entirely, and `registries` was null, so a hook that routes
packages by scope could not work on pnpm 12. pnpm 11 passes the hook its
resolved `Config`.

`WorkspaceSettings::from_resolved` is the inverse of `apply_to`: it
reports every setting at the value the config resolved it to. Two groups
report as the user set them instead, and read as unset when nothing did:

- The path settings `apply_to` anchors against a base directory.
  Anchoring happens on apply, so reporting the anchored path would
  re-anchor a relative setting against wherever the hook's answer lands.
  pnpm reports these as written too.
- The settings pnpm reads for *whether* they were set, `preferFrozenLockfile`
  among them. Reporting the resolved value would leave a hook assigning
  that same value with no change for the delta to notice, and the setting
  would go on counting as unset -- which would have made a CI install
  keep the frozen-lockfile default the hook meant to override.

The identically-named settings `apply_to` and `from_resolved` share now
live in one macro, so teaching either direction about a setting teaches
the other. `from_resolved_reports_every_setting` fails if a new setting
reaches `WorkspaceSettings` without a mapping.

`resolved_config_views` adds the resolved state that is not a settings
key, under the names pnpm 11 uses: the registry routing maps, `authConfig`
and `configByUri`, and the resolved directories. `configByUri` carries
every credential scope of a registry, from a new
`Config::registry_creds_by_uri`, and `registriesByPrefix` is omitted when
the project declares no prefix, as pnpm 11 omits it. A pnpmfile runs as
unrestricted Node in both versions, so the credentials among these are
nothing a hook could not already read from `.npmrc` itself.

Every setting a hook changes is recorded in `explicit_settings`, as loading
a settings file records it, and a setting set to null is dropped from
there, so the derivations that read whether a setting was set at all see
the hook's answer. A setting set to null returns to its default through
`WorkspaceSettings::reset_setting_to_default`, the deletion counterpart of
`apply_to`, which re-runs the derivations that read the setting against
the settings still set. `stateDir` is applied against the host's state
root.

A hook may also rewrite `registriesByScope` and `registriesByPrefix`,
since it reads routing under those names. This matches pnpm 11, including
its precedence: an explicit hook assignment outranks `--registry`. See
pnpm/pnpm#14063 for the open question of whether that precedence is right
in either version.

A setting nothing set is absent from the configuration a hook receives
rather than present with the value `null`, so `'key' in config` answers the
same in both versions and a hook cannot mistake a null for a configured
value. This also retires the `registries: null` the issue was reported
against: `registries` is a shape only `pnpm-workspace.yaml` has.

These keys report what pnpm 11 reports: `registriesByScope.default` and
`authConfig.registry`, the default registry every unscoped package is
fetched from, which the config holds beside the scope map rather than in
it; `pnpmfile`, the pnpmfiles being run; `cacheDir`, falling back to the
directory pnpm chose for the host; and `sideEffectsCache`, in the boolean
shorthand when reads and writes agree.

Closes pnpm/pnpm#14676
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpm 11 already passes the hook
  its resolved config, so this is a v12-only fix.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14680"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791434246&installation_model_id=426870&pr_number=14680&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14680&signature=070d4d27423da263080e281b14f832bca8db1b7ae5ff7bc5f340676ea92c7c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The `updateConfig` hook now receives the fully resolved configuration, including configuration files, command-line options, and defaults.
  - Hooks can view scoped registry routes and registry credentials.
  - Hooks can update package registry routing through `registriesByScope`.

- **Bug Fixes**
  - Unconfigured settings are omitted instead of represented as `null`, matching pnpm 11 behavior.
  - Registry changes made by hooks are applied when resolving packages.
  - Hook changes to configuration paths and related settings are preserved correctly.
  - Settings explicitly reset to `null` now correctly return to their defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



