### PR TITLE
feat: add linux-loong64 build

### DIFF
--- a/.changeset/add-linux-loong64-build.md
+++ b/.changeset/add-linux-loong64-build.md
@@ -1,0 +1,5 @@
+---
+"pacquet": minor
+---
+
+pnpm now runs on Linux systems with LoongArch (loong64) CPUs that use glibc.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,6 +608,10 @@ jobs:
             code-target: linux-s390x
 
           - os: blacksmith-8vcpu-ubuntu-2404
+            target: loongarch64-unknown-linux-gnu
+            code-target: linux-loong64
+
+          - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-freebsd
             code-target: freebsd-x64
 
@@ -746,6 +750,10 @@ jobs:
           - os: blacksmith-8vcpu-ubuntu-2404
             target: s390x-unknown-linux-gnu
             code-target: linux-s390x
+
+          - os: blacksmith-8vcpu-ubuntu-2404
+            target: loongarch64-unknown-linux-gnu
+            code-target: linux-loong64
 
           - os: blacksmith-8vcpu-ubuntu-2404
             target: x86_64-unknown-freebsd

--- a/Cross.toml
+++ b/Cross.toml
@@ -14,3 +14,7 @@ image = "ghcr.io/cross-rs/aarch64-linux-android@sha256:85d58ad7dd4cc97903bff4c5e
 
 [target.x86_64-linux-android]
 image = "ghcr.io/cross-rs/x86_64-linux-android@sha256:e60e4a759b4f07ac5d6f7632afc728d2a6a3ad668013ec17d9627b537acf2cdc"
+
+# FIXME: Remove this with cross > 0.2.5
+[target.loongarch64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/loongarch64-unknown-linux-gnu@sha256:df9c23b328318d31037a1300d51d0a08990abf8b801e9742d5739bd782ad5f50"

--- a/pnpm/npm/napi/README.md
+++ b/pnpm/npm/napi/README.md
@@ -108,7 +108,8 @@ The addon ships as prebuilt per-platform packages, the same model as the
 
 Supported targets: `win32-x64`, `win32-arm64`, `darwin-x64`, `darwin-arm64`,
 `linux-x64`, `linux-arm64`, `linux-riscv64`, `linux-ppc64`, `linux-s390x`,
-`linux-x64-musl`, `linux-arm64-musl`, `freebsd-x64`, `android-arm64`, `android-x64`.
+`linux-loong64`, `linux-x64-musl`, `linux-arm64-musl`, `freebsd-x64`,
+`android-arm64`, `android-x64`.
 
 ## Local development
 

--- a/pnpm/npm/napi/scripts/generate-packages.mjs
+++ b/pnpm/npm/napi/scripts/generate-packages.mjs
@@ -44,6 +44,7 @@ const TARGETS = [
   { platform: 'linux', arch: 'riscv64', libc: 'glibc', codeTarget: 'linux-riscv64', packageTarget: 'linux-riscv64' },
   { platform: 'linux', arch: 'ppc64', libc: 'glibc', codeTarget: 'linux-ppc64', packageTarget: 'linux-ppc64' },
   { platform: 'linux', arch: 's390x', libc: 'glibc', codeTarget: 'linux-s390x', packageTarget: 'linux-s390x' },
+  { platform: 'linux', arch: 'loong64', libc: 'glibc', codeTarget: 'linux-loong64', packageTarget: 'linux-loong64' },
   { platform: 'linux', arch: 'x64', libc: 'musl', codeTarget: 'linux-x64-musl', packageTarget: 'linux-x64-musl' },
   { platform: 'linux', arch: 'arm64', libc: 'musl', codeTarget: 'linux-arm64-musl', packageTarget: 'linux-arm64-musl' },
   { platform: 'freebsd', arch: 'x64', codeTarget: 'freebsd-x64', packageTarget: 'freebsd-x64' },

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -30,7 +30,7 @@ const PLATFORMS = {
       glibc: '@pnpm/exe.linux-arm64/pnpm',
       musl: '@pnpm/exe.linux-arm64-musl/pnpm',
     },
-    // Only a glibc build is released for these three.
+    // Only a glibc build is released for these architectures.
     riscv64: {
       glibc: '@pnpm/exe.linux-riscv64/pnpm',
     },

--- a/pnpm/npm/pnpm/native-binary.mjs
+++ b/pnpm/npm/pnpm/native-binary.mjs
@@ -40,6 +40,9 @@ const PLATFORMS = {
     s390x: {
       glibc: '@pnpm/exe.linux-s390x/pnpm',
     },
+    loong64: {
+      glibc: '@pnpm/exe.linux-loong64/pnpm',
+    },
   },
   freebsd: {
     x64: '@pnpm/exe.freebsd-x64/pnpm',

--- a/pnpm/npm/pnpm/scripts/generate-packages.mjs
+++ b/pnpm/npm/pnpm/scripts/generate-packages.mjs
@@ -190,6 +190,7 @@ const TARGETS = [
   { platform: "linux", arch: "riscv64", libc: "glibc", codeTarget: "linux-riscv64", packageTarget: "linux-riscv64" },
   { platform: "linux", arch: "ppc64", libc: "glibc", codeTarget: "linux-ppc64", packageTarget: "linux-ppc64" },
   { platform: "linux", arch: "s390x", libc: "glibc", codeTarget: "linux-s390x", packageTarget: "linux-s390x" },
+  { platform: "linux", arch: "loong64", libc: "glibc", codeTarget: "linux-loong64", packageTarget: "linux-loong64" },
   { platform: "linux", arch: "x64", libc: "musl", codeTarget: "linux-x64-musl", packageTarget: "linux-x64-musl" },
   { platform: "linux", arch: "arm64", libc: "musl", codeTarget: "linux-arm64-musl", packageTarget: "linux-arm64-musl" },
   { platform: "freebsd", arch: "x64", codeTarget: "freebsd-x64", packageTarget: "freebsd-x64" },

--- a/pnpm/npm/pnpm/test/install.test.mjs
+++ b/pnpm/npm/pnpm/test/install.test.mjs
@@ -98,12 +98,13 @@ test('linux riscv64 resolves the glibc package, and nothing under musl', async (
   assert.deepEqual(candidates(), [])
 })
 
-test('linux ppc64 and s390x resolve their glibc packages', async (t) => {
+test('linux ppc64, s390x and loong64 resolve their glibc packages', async (t) => {
   // The musl half of the contract is pinned by the riscv64 case above; these
-  // two share that code path and only need their table entries checked.
+  // architectures share that code path and only need their table entries checked.
   for (const [arch, specifier] of [
     ['ppc64', '@pnpm/exe.linux-ppc64/pnpm'],
     ['s390x', '@pnpm/exe.linux-s390x/pnpm'],
+    ['loong64', '@pnpm/exe.linux-loong64/pnpm'],
   ]) {
     const { setLibc, setEndianness } = fakeHost(t, 'linux', arch)
     const { getBinCandidates: candidates } = await import(`../native-binary.mjs?${arch}`)


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved the PR and
CI is green. Please wait for both conditions to be met before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Add Linux LoongArch (`loong64` / `loongarch64-unknown-linux-gnu`) support for the Rust pnpm v12 CLI and its NAPI addon on glibc systems.

The LoongArch cross image is pinned by digest because cross 0.2.5 does not provide an image for this target by default.

### Verification

Both builds completed successfully with the following commands:
```sh
.github/scripts/cross-build.sh --locked -p pnpm-cli --bin pnpm --release --target="loongarch64-unknown-linux-gnu"
.github/scripts/cross-build.sh --locked -p pnpm-napi --profile napi-release --target="loongarch64-unknown-linux-gnu"
```

The built CLI binary also passed a smoke test on a LoongArch machine:
```text
$ uname -m
loongarch64
$ file ./pnpm
./pnpm: ELF 64-bit LSB pie executable, LoongArch, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-loongarch-lp64d.so.1, for GNU/Linux 5.19.16, stripped
$ ./pnpm view is-odd version
3.0.1
```

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Add Linux LoongArch (`loong64` / `loongarch64-unknown-linux-gnu`) support for
the Rust pnpm v12 CLI and its NAPI addon on glibc systems.

Pin the cross image by digest because cross 0.2.5 does not provide animage for
this target by default.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it resolves it.
- [x] I added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] I added or updated tests.
- [x] I updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14683"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791447641&installation_model_id=426870&pr_number=14683&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14683&signature=0c71769837c5876e60d4db5613daf6cfc1aaff1062b58dafc590c0025b5c4827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Linux systems with LoongArch (loong64) CPUs using glibc.
  * Added loong64 CLI and native packages for pnpm.
  * Included loong64 in supported platform documentation.
  * Linux package resolution now selects the appropriate loong64 binary.
  * Release builds now produce loong64 command-line and native artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->