### PR TITLE
fix(sbom): truncate SPDX creationInfo.created to whole seconds

### DIFF
--- a/.changeset/sbom-spdx-timestamp-seconds.md
+++ b/.changeset/sbom-spdx-timestamp-seconds.md
@@ -1,8 +1,7 @@
 ---
 "@pnpm/deps.compliance.sbom": patch
-"@pnpm/deps.compliance.commands": patch
 "pacquet": patch
 "pnpm": patch
 ---
 
-`pnpm sbom --sbom-format spdx` now writes `creationInfo.created` truncated to whole seconds (e.g. `2026-09-08T10:38:21Z`) instead of including fractional seconds, which SPDX 2.3 §6.9 forbids. Strict SPDX consumers rejected the previous output [#14684](https://github.com/pnpm/pnpm/issues/14684).
+`pnpm sbom --sbom-format spdx` now writes `creationInfo.created` with whole seconds, such as `2026-09-08T10:38:21Z`. The timestamp carried fractional seconds, which strict SPDX consumers rejected [#14684](https://github.com/pnpm/pnpm/issues/14684).

--- a/.changeset/sbom-spdx-timestamp-seconds.md
+++ b/.changeset/sbom-spdx-timestamp-seconds.md
@@ -1,0 +1,8 @@
+---
+"@pnpm/deps.compliance.sbom": patch
+"@pnpm/deps.compliance.commands": patch
+"pacquet": patch
+"pnpm": patch
+---
+
+`pnpm sbom --sbom-format spdx` now writes `creationInfo.created` truncated to whole seconds (e.g. `2026-09-08T10:38:21Z`) instead of including fractional seconds, which SPDX 2.3 §6.9 forbids. Strict SPDX consumers rejected the previous output [#14684](https://github.com/pnpm/pnpm/issues/14684).

--- a/pnpm/crates/cli/src/cli_args/sbom.rs
+++ b/pnpm/crates/cli/src/cli_args/sbom.rs
@@ -1665,7 +1665,7 @@ fn serialize_spdx(result: &SbomResult, compact: bool) -> String {
     }
     let spdx_relationships = spdx_relationships(result, root_spdx_id, &spdx_id_map);
 
-    let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
+    let timestamp = chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     let doc_namespace = format!(
         "https://spdx.org/spdxdocs/{}-{}-{}",
         sanitize_spdx_id(&result.root_name),

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -523,6 +523,19 @@ fn sbom_spdx_creation_info() {
 }
 
 #[test]
+fn sbom_spdx_creation_info_no_fractional_seconds() {
+    let tmp = copy_fixture("simple-sbom");
+    let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
+    let created = parsed["creationInfo"]["created"].as_str().expect("created string");
+    assert!(
+        !created.contains('.'),
+        "SPDX 2.3 (6.9) requires whole-second timestamps (YYYY-MM-DDThh:mm:ssZ), got {created}",
+    );
+    assert_eq!(created.len(), 20, "expected YYYY-MM-DDThh:mm:ssZ format, got {created}");
+    assert!(created.ends_with('Z'), "timestamp should be UTC, got {created}");
+}
+
+#[test]
 fn sbom_spdx_describes_relationship() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);

--- a/pnpm/crates/cli/tests/suite/sbom.rs
+++ b/pnpm/crates/cli/tests/suite/sbom.rs
@@ -523,16 +523,18 @@ fn sbom_spdx_creation_info() {
 }
 
 #[test]
-fn sbom_spdx_creation_info_no_fractional_seconds() {
+fn sbom_spdx_creation_info_whole_seconds() {
     let tmp = copy_fixture("simple-sbom");
     let parsed = run_sbom_json(tmp.path(), "spdx", &[]);
     let created = parsed["creationInfo"]["created"].as_str().expect("created string");
-    assert!(
-        !created.contains('.'),
-        "SPDX 2.3 (6.9) requires whole-second timestamps (YYYY-MM-DDThh:mm:ssZ), got {created}",
+    let shape: String = created
+        .chars()
+        .map(|character| if character.is_ascii_digit() { 'd' } else { character })
+        .collect();
+    assert_eq!(
+        shape, "dddd-dd-ddTdd:dd:ddZ",
+        "SPDX 2.3 (6.9) requires whole-second UTC timestamps (YYYY-MM-DDThh:mm:ssZ), got {created}",
     );
-    assert_eq!(created.len(), 20, "expected YYYY-MM-DDThh:mm:ssZ format, got {created}");
-    assert!(created.ends_with('Z'), "timestamp should be UTC, got {created}");
 }
 
 #[test]

--- a/pnpm11/deps/compliance/sbom/src/serializeSpdx.ts
+++ b/pnpm11/deps/compliance/sbom/src/serializeSpdx.ts
@@ -140,7 +140,7 @@ export function serializeSpdx (result: SbomResult, opts?: SpdxOptions): string {
     name: rootComponent.name,
     documentNamespace,
     creationInfo: {
-      created: new Date().toISOString(),
+      created: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
       creators: [
         'Tool: pnpm',
       ],

--- a/pnpm11/deps/compliance/sbom/src/serializeSpdx.ts
+++ b/pnpm11/deps/compliance/sbom/src/serializeSpdx.ts
@@ -140,7 +140,7 @@ export function serializeSpdx (result: SbomResult, opts?: SpdxOptions): string {
     name: rootComponent.name,
     documentNamespace,
     creationInfo: {
-      created: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+      created: `${new Date().toISOString().split('.')[0]}Z`,
       creators: [
         'Tool: pnpm',
       ],

--- a/pnpm11/deps/compliance/sbom/test/serializeSpdx.test.ts
+++ b/pnpm11/deps/compliance/sbom/test/serializeSpdx.test.ts
@@ -49,6 +49,13 @@ describe('serializeSpdx', () => {
     expect(parsed.creationInfo.created).toBeDefined()
   })
 
+  it('should format created as whole seconds per SPDX 2.3 (6.9)', () => {
+    const result = makeSbomResult()
+    const parsed = JSON.parse(serializeSpdx(result))
+
+    expect(parsed.creationInfo.created).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/)
+  })
+
   it('should include root package and dependency packages', () => {
     const result = makeSbomResult()
     const parsed = JSON.parse(serializeSpdx(result))


### PR DESCRIPTION
## Summary

`pnpm sbom --sbom-format spdx` wrote `creationInfo.created` with fractional seconds (e.g. `2026-09-08T10:38:21.537Z`), which SPDX 2.3 §6.9 forbids — the field must be `YYYY-MM-DDThh:mm:ssZ`. Strict SPDX consumers such as `spdx-tools` rejected the document.

Both SBOM implementations in this repo build the SPDX `created` timestamp the same way and had the same bug:
- The Rust v12 CLI (`pnpm/crates/cli/src/cli_args/sbom.rs`) used `chrono::SecondsFormat::Millis`.
- The legacy TypeScript v11 CLI (`pnpm11/deps/compliance/sbom/src/serializeSpdx.ts`) used `Date.prototype.toISOString()`, which always includes milliseconds.

Both are now truncated to whole seconds. The CycloneDX `metadata.timestamp` in each implementation, which does allow fractional seconds, is unchanged.

Closes pnpm/pnpm#14684

## Squash Commit Body

```text
`pnpm sbom --sbom-format spdx` wrote `creationInfo.created` with fractional
seconds, which SPDX 2.3 (6.9) forbids — the field must be
YYYY-MM-DDThh:mm:ssZ. Strict SPDX consumers such as spdx-tools rejected the
document.

Truncate the SPDX creationInfo.created timestamp to whole seconds in both
SBOM implementations: the Rust v12 CLI (SecondsFormat::Secs instead of
Millis) and the legacy TypeScript v11 CLI (strip the .toISOString()
fractional-second suffix). The CycloneDX metadata.timestamp in each, which
does allow fractional seconds, is unchanged.

Closes pnpm/pnpm#14684
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UHoV4KcSRcDrUoNmk2ohVD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791457253&installation_model_id=426870&pr_number=14688&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14688&signature=7aa63f94c6ca68088cae41281296859e1e21b57d877fc56d2025d7e0d87398c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SPDX SBOM creation timestamps now use whole-second UTC precision, matching the SPDX 2.3 specification.
  * Improved compatibility with strict SPDX consumers by removing fractional seconds from generated timestamps.

* **Tests**
  * Added coverage to verify the timestamp format is `YYYY-MM-DDTHH:MM:SSZ`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->