### PR TITLE
chore: install the Rust dependencies with pnpm

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -66,15 +66,15 @@ jobs:
         git checkout "origin/pr-${PR_NUMBER}"
         echo "Checked out PR #$PR_NUMBER at $(git rev-parse --short HEAD)"
 
-    - name: Install pnpm and Node
-      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
-      with:
-        runtime: node@26.8.2
-
     - name: Install Rust Toolchain
       uses: $/.github/actions/rustup
       with:
         shared-key: pnpm-benchmark
+
+    - name: Install pnpm and Node
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        runtime: node@26.8.2
 
     - name: Install hyperfine
       uses: $/.github/actions/binstall

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,10 @@ jobs:
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - name: Initialize Rust before dependency installation
+      uses: $/.github/actions/rustup
+      with:
+        restore-cache: false
     - name: Install pnpm
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -56,6 +56,11 @@ jobs:
         # single-use remote URL in the "Commit and push" step.
         persist-credentials: false
 
+    - name: Initialize Rust before dependency installation
+      uses: $/.github/actions/rustup
+      with:
+        restore-cache: false
+
     - name: Install pnpm and Node
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
@@ -148,6 +153,15 @@ jobs:
           exit 1
         fi
         pnpm run bump -- "${args[@]}"
+
+    # `pnpm install` writes a machine-local Cargo source replacement into the
+    # tracked `.cargo/config.toml`, pointing at the uncommitted `.pnpm/crates`.
+    # The release commit below is a `git add -A`, so without this the block
+    # would land on the release branch and break every Rust job in a checkout
+    # that has not installed. It would also make the change check below always
+    # report a change.
+    - name: Discard the pnpm-managed Cargo source block
+      run: git checkout -- .cargo/config.toml
 
     - name: Check for changes
       id: changes

--- a/.github/workflows/ecosystem-e2e.yml
+++ b/.github/workflows/ecosystem-e2e.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install pnpm
-        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
-
       - name: Setup Rust toolchain
         uses: $/.github/actions/rustup
+
+      - name: Install pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
 
       - name: Build pnpm and the harness
         run: cargo build --release --bin pnpm --bin ecosystem-e2e

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -331,13 +331,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Initialize Rust before dependency installation
+        uses: $/.github/actions/rustup
+        with:
+          restore-cache: false
+
       - name: Install pnpm
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           install: false
 
       # Only the wrapper's own dependencies: get-pnpm, which the published
-      # package carries in its dist/ payload and the tests stand in for.
+      # package carries in its dist/ payload and the tests stand in for. The
+      # filter does not narrow the Cargo half of the install, which is why the
+      # step above provisions Rust.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --filter pacquet
 
@@ -399,6 +406,15 @@ jobs:
             src:
               - 'Cargo.lock'
               - 'deny.toml'
+
+      # `pnpm pipeline` installs before it runs anything, and that install
+      # runs `cargo`. Provision the pinned toolchain first so it does not race
+      # `cargo deny` over a rustup download.
+      - name: Initialize Rust before dependency installation
+        if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
+        uses: $/.github/actions/rustup
+        with:
+          restore-cache: false
 
       - name: Install pnpm
         if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -268,6 +268,10 @@ jobs:
       - uses: garnet-org/action@3d47f4a9004f7356c980a0e8d420ef5984750e3c # v2.2.0
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
+      - name: Initialize Rust before dependency installation
+        uses: $/.github/actions/rustup
+        with:
+          restore-cache: false
       - name: Install pnpm and Node
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
@@ -422,6 +426,10 @@ jobs:
       - uses: garnet-org/action@3d47f4a9004f7356c980a0e8d420ef5984750e3c # v2.2.0
         with:
           api_token: ${{ secrets.GARNET_API_TOKEN }}
+      - name: Initialize Rust before dependency installation
+        uses: $/.github/actions/rustup
+        with:
+          restore-cache: false
       - name: Install pnpm and Node
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
@@ -529,6 +537,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Initialize Rust before dependency installation
+        uses: $/.github/actions/rustup
+        with:
+          restore-cache: false
 
       - name: Install pnpm and Node
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
       uses: garnet-org/action@3d47f4a9004f7356c980a0e8d420ef5984750e3c # v2.2.0
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
+    - name: Initialize Rust before dependency installation
+      uses: $/.github/actions/rustup
+      with:
+        restore-cache: false
     # `pnpm pipeline` installs before it runs anything, but the install has to
     # happen here: the test step is wrapped in a timing wrapper whose result
     # feeds Bencher, and a dependency install inside it would report registry

--- a/.github/workflows/update-lockfile.yml
+++ b/.github/workflows/update-lockfile.yml
@@ -36,6 +36,14 @@ jobs:
         # through a single-use credential helper.
         persist-credentials: false
 
+    # pnpm/update's install also installs the Rust dependencies, which runs
+    # `cargo`. Provision the pinned toolchain up front so that install does not
+    # race a rustup download.
+    - name: Initialize Rust before dependency installation
+      uses: $/.github/actions/rustup
+      with:
+        restore-cache: false
+
     # pnpm/update runs the install itself, so the action's auto-install would
     # be wasted work.
     - name: Install pnpm
@@ -55,7 +63,16 @@ jobs:
         # back from self-update (the repo's minimumReleaseAgeExclude is
         # deliberately ignored there).
         update-pnpm-minimum-release-age: 0
-        post-update: pnpm update-manifests
+        # `pnpm install` writes a machine-local Cargo source replacement into
+        # the tracked `.cargo/config.toml`, pointing at the uncommitted
+        # `.pnpm/crates`. Discard it here: post-update runs after the action's
+        # own install and before the `git status` that decides whether to
+        # commit, so the block neither reaches the commit, where it would break
+        # every Rust job in a checkout that has not installed, nor makes the
+        # action open a pull request on a run that updated nothing.
+        post-update: |
+          pnpm update-manifests
+          git checkout -- .cargo/config.toml
         branch: chore/update-lockfile
         token: ${{ secrets.UPDATE_LOCKFILE_TOKEN }}
         commit-message: 'chore: update dependencies, Node.js, pnpm, and GitHub Actions'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,7 @@ The repository holds two implementations of the same package manager: the TypeSc
 ### JavaScript and TypeScript CLI
 
 1. Install pnpm using one of the [official installation methods](https://pnpm.io/installation). **Do not use Corepack.** The scripts in this repository invoke pnpm through the `pn` and `pnx` aliases, which the official installation methods create. Corepack only provides the `pnpm` and `pnpx` commands, so with a Corepack-managed pnpm the build fails with errors like `pn: Permission denied` ([pnpm/pnpm#12448](https://github.com/pnpm/pnpm/issues/12448)).
+1. Set up the Rust toolchain first, as described under [Rust toolchain and git hooks](#rust-toolchain-and-git-hooks). `pnpm install` also installs the Rust dependencies and runs `cargo`, so it fails when `cargo` is not on `PATH`.
 1. Run `pnpm install` in the root of the repository to install all dependencies.
 1. Run `pnpm add ./pnpm/dev -g` to make pnpm from the repository available in the command line via the `pd` command.
 1. Run `pnpm run compile` to create an initial build of pnpm from the source in the repository.
@@ -61,6 +62,10 @@ Rust is now the primary language in this repository, so most contributions need 
    ```
 
    Install these from source rather than with `cargo binstall`. The prebuilt `cargo-dylint` binaries reference the `dylint_driver` crate at the path where they were built, so building the per-toolchain driver fails locally with an error that points at a nonexistent `.../dylint/driver` directory. A `cargo install` build resolves the driver against your local cargo registry and works.
+
+`pnpm install` at the repository root installs the Rust dependencies alongside the JavaScript ones. It reads `Cargo.lock`, links the registry crates into `.pnpm/crates/crates-io` and the git-sourced ones into `.pnpm/crates/git`, and writes a source replacement block into `.cargo/config.toml` that points Cargo at both. `cargo build` and `cargo test` work as before, and `cargo metadata --locked --offline` confirms that every dependency resolves without network access.
+
+That block is machine-local: it only works in a checkout where `pnpm install` has run. `.cargo/config.toml` is tracked, so `git status` reports it as modified after every install. Leave it out of your commits. Rust-only CI jobs, which never run `pnpm install`, keep using Cargo's own registry cache.
 
 Make sure `~/.cargo/bin` is on your `PATH`, ahead of any system-wide Rust in `/usr/bin`. `rustup`'s installer adds this entry through `~/.cargo/env`; ensure your shell sources it. This matters for the git hooks. The `pnpm install` step above wires up husky, and its `pre-push` hook runs the Rust checks in `pnpm/scripts/pre-push-rust.sh` (format, doc, dylint, typos) alongside the TypeScript compile and lint. That script locates `cargo`, `rustup`, `taplo`, `typos`, and `cargo-dylint` through `PATH`, and it **skips** a check when the tool is not found rather than failing. A push that appears to pass locally with the tools off `PATH` has silently skipped the format, doc, and dylint checks, so those problems surface only in CI.
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -144,6 +144,9 @@ auditConfig:
     # API (yaml.safeLoad), so its transitive js-yaml cannot be upgraded.
     - GHSA-h67p-54hq-rp68
 
+cargo:
+  enabled: true
+
 catalog:
   # @babel/core 8.x (and its plugins) require Node.js ^22.18.0 || >=24.11.0,
   # above pnpm's supported floor of Node.js >=22.13.


### PR DESCRIPTION
## Summary

Turn on `cargo.enabled` so this repository's own `pnpm install` installs the crates `Cargo.lock` pins alongside the JavaScript dependencies. pnpm links the registry crates into `.pnpm/crates/crates-io` and the git-sourced ones into `.pnpm/crates/git`, then writes a source replacement block into `.cargo/config.toml` that points Cargo at both. Cargo builds and tests the workspace as before.

The `node-semver` fork stays patched in. pnpm installs git-sourced crates since pnpm/pnpm#14694, which shipped in the pnpm 12.4.1 this repository pins, so enabling this no longer costs the fork's partial `<=` range and `Ord for Bound` fixes. `Cargo.toml` and `Cargo.lock` are unchanged.

Every `pnpm install` now shells out to `cargo metadata`, and nothing can opt a single run out: `cargo.enabled` is read from `pnpm-workspace.yaml` only, no CLI flag or `PNPM_CONFIG_*` variable overrides it, and `--filter` does not narrow the Cargo half. So every CI job whose install runs gets the pinned toolchain first: the jobs where `pnpm/setup` installs by default, the lockfile update where `pnpm/update` runs its own install, and the deny job, whose `pnpm pipeline rust-deny` installs before it runs anything and would otherwise race `cargo deny` over a rustup download. The step precedes the install rather than following it, because the rustup action ends with `git restore .`, which would otherwise wipe the generated block back out of `.cargo/config.toml`.

Two workflows commit with `git add -A`. That block points at the gitignored `.pnpm/crates`, so a commit carrying it would break every Rust-only job and every checkout that has not installed. Both also decide whether to commit at all by reading `git status --porcelain`, which the block would make non-empty on every run. Each discards it right before that check: the release PR in a step of its own, the lockfile update through the `post-update` command `pnpm/update` runs between its install and its commit.

Verified with pnpm 12.4.1:

- `pnpm install --frozen-lockfile` and `pnpm install --frozen-lockfile --offline` pass.
- `cargo metadata --locked --offline` resolves every dependency, `node-semver` from the git source.
- `cargo check --locked --offline -p pnpm-semver-include-prerelease` compiles the fork.
- `cargo build --offline -p pnpr-fixtures -p pnpr` builds ~700 crates entirely from `.pnpm/crates`.
- Every workflow file parses, and a per-job audit finds no remaining install without a preceding rustup step.

Follow-up worth considering: a `--no-cargo` flag or a `PNPM_CONFIG_CARGO_ENABLED` override, so a run that needs only the JavaScript graph can skip the Cargo half. Two costs would go away with it. Every TypeScript test shard vendors the crates it never builds. And `cargo.enabled` disqualifies the up-to-date fast path in `fast_path_is_eligible`, which is correct as written, since a single-directory probe over the npm graph cannot speak for the Cargo one, but it does mean a no-op `pnpm install` in this repository now takes about 0.55s rather than 0.39s.

## Squash Commit Body

```text
Turn on `cargo.enabled` so `pnpm install` installs the crates `Cargo.lock`
pins alongside the JavaScript dependencies. pnpm links the registry crates
into `.pnpm/crates/crates-io` and the git-sourced ones into
`.pnpm/crates/git`, then writes a source replacement block into
`.cargo/config.toml` that points Cargo at both.

The `node-semver` fork stays patched in. pnpm installs git-sourced crates
since pnpm/pnpm#14694, which shipped in the 12.4.1 the repository pins, so
enabling this no longer costs the fork's `<=` range and `Ord for Bound`
fixes.

Every `pnpm install` now shells out to `cargo metadata`, and there is no
way to opt one out: `cargo.enabled` is read from `pnpm-workspace.yaml`
only, no CLI flag or `PNPM_CONFIG_*` variable overrides it, and `--filter`
does not narrow the Cargo half. So each job whose install runs gets the
pinned toolchain first. The step has to precede the install rather than
follow it: the rustup action ends with `git restore .`, which would
otherwise wipe the block back out of `.cargo/config.toml`.

Keep that block out of the two workflows that commit. It points at the
gitignored `.pnpm/crates`, so a commit carrying it would break every
Rust-only job and every checkout that has not installed. Both workflows
also decide whether to commit at all by reading `git status --porcelain`,
which the block would make non-empty on every run. Each discards it right
before that check: the release PR in a step of its own, the lockfile
update through the `post-update` command pnpm/update runs between its
install and its commit.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Not applicable: this changes repository tooling only, no published
  package.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SDxJNVEeyUBb4pcepEpGcj
