### PR TITLE
chore(ci): run checks through pnpm pipelines

### DIFF
--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -443,9 +443,9 @@ function normalizePath (file) {
 }
 
 function parseArgs (args) {
-  let chunk
-  let chunks
-  let script
+  let chunk = Number(process.env.TEST_CHUNK)
+  let chunks = Number(process.env.TEST_CHUNK_TOTAL)
+  let script = process.env.TEST_SCRIPT
   let summary = 'pnpm-exec-summary.json'
   let dryRun = false
 

--- a/.github/scripts/run-ts-tests-chunk.mjs
+++ b/.github/scripts/run-ts-tests-chunk.mjs
@@ -479,5 +479,6 @@ function parseArgs (args) {
 function usage (message) {
   console.error(message)
   console.error('Usage: run-ts-tests-chunk.mjs --script <ci:test-all|ci:test-branch> --chunk <n> --chunks <n> [--summary <file>] [--dry-run]')
+  console.error('--script, --chunk and --chunks default to $TEST_SCRIPT, $TEST_CHUNK and $TEST_CHUNK_TOTAL.')
   process.exit(1)
 }

--- a/.github/workflows/build-pnpr.yml
+++ b/.github/workflows/build-pnpr.yml
@@ -51,11 +51,16 @@ jobs:
       with:
         save-cache: ${{ github.ref_name == 'main' }}
         shared-key: registry-prepare
+    - name: Install pnpm
+      if: steps.pnpr-bins.outputs.cache-hit != 'true'
+      uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        install: false
     - name: Build the pnpr server and registry fixture preparer
       if: steps.pnpr-bins.outputs.cache-hit != 'true'
       shell: bash
       run: |
-        cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare
+        pnpm pipeline build-pnpr --include-workspace-root --full --no-cache
         mkdir -p .pnpr-bin
         ext=""
         [ -f target/release/pnpr.exe ] && ext=".exe"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,14 +82,14 @@ jobs:
         persist-credentials: false
     - name: Install pnpm
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+      with:
+        install: false
     - name: Test release publication scripts
       run: |
         .github/scripts/npm-package-publication-state.test.sh
         .github/scripts/npm-staged-publication.test.sh
-    - name: Compile TypeScript
-      run: pn compile-only
-    - name: Lint
-      run: pn lint
+    - name: Compile and lint TypeScript
+      run: pn pipeline ts-check --include-workspace-root --full --no-cache
     - name: Package compiled artifacts
       shell: bash
       run: |

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,9 +153,6 @@ jobs:
         with:
           tool: just
 
-      - name: Install dependencies
-        run: just install
-
       - name: Install cargo-nextest
         uses: taiki-e/install-action@fa23953489c080190314742a9b907f8e97c6767c # v2.87.10
         with:
@@ -177,7 +174,7 @@ jobs:
           node .github/scripts/measure-command.mjs \
             --name tests.all \
             --output .bench/pacquet-tests-all.json \
-            -- just test-pacquet
+            -- pnpm pipeline rust-test --include-workspace-root --full --no-cache
 
       - name: Test N-API boundary
         if: runner.os == 'Linux'
@@ -198,7 +195,7 @@ jobs:
           node .github/scripts/measure-command.mjs \
             --name tests.all \
             --output .bench/pnpr-tests-all.json \
-            -- just test-pnpr
+            -- pnpm pipeline pnpr-test --include-workspace-root --full --no-cache
 
       - name: Stage Bencher test durations
         env:
@@ -263,8 +260,13 @@ jobs:
         with:
           clippy: true
 
+      - name: Install pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
+
       - name: Clippy
-        run: cargo clippy --locked --workspace --all-targets -- -D warnings
+        run: pnpm pipeline rust-clippy --include-workspace-root --full --no-cache
 
   doc:
     name: Rust CI / Doc
@@ -281,10 +283,15 @@ jobs:
         with:
           docs: true
 
+      - name: Install pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
+
       - name: Doc
         env:
           RUSTDOCFLAGS: '-D warnings'
-        run: cargo doc --no-deps --workspace --document-private-items
+        run: pnpm pipeline rust-doc --include-workspace-root --full --no-cache
 
   npm-wrapper:
     name: Rust CI / npm Wrapper / ${{ matrix.os_label }}
@@ -379,6 +386,12 @@ jobs:
               - 'Cargo.lock'
               - 'deny.toml'
 
+      - name: Install pnpm
+        if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
+
       - name: Install cargo-deny
         if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
         uses: taiki-e/install-action@fa23953489c080190314742a9b907f8e97c6767c # v2.87.10
@@ -386,7 +399,7 @@ jobs:
           tool: cargo-deny
 
       - if: github.event_name == 'merge_group' || steps.filter.outputs.src == 'true'
-        run: cargo deny check
+        run: pnpm pipeline rust-deny --include-workspace-root --full --no-cache
 
   format:
     name: Rust CI / Format
@@ -404,14 +417,18 @@ jobs:
           fmt: true
           restore-cache: false
 
-      - run: cargo fmt --all -- --check
-
       - name: Install Taplo CLI
         uses: $/.github/actions/binstall
         with:
           packages: taplo-cli@0.8.1
 
-      - run: taplo format --check
+      - name: Install pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
+
+      - name: Check Rust and TOML formatting
+        run: pnpm pipeline rust-format --include-workspace-root --full --no-cache
 
   dylint:
     name: Rust CI / Dylint
@@ -492,6 +509,11 @@ jobs:
           # a library built by a newer one.
           packages: cargo-dylint@6.0.4 dylint-link@6.0.4
 
+      - name: Install pnpm
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
+        with:
+          install: false
+
       - name: Run dylint
         # `-D warnings` must come in via `RUSTFLAGS`, not as a trailing
         # `-- -D warnings` after `cargo dylint`'s `--`: `cargo dylint`
@@ -500,7 +522,7 @@ jobs:
         # how KSXGitHub/parallel-disk-usage invokes the same lint.
         env:
           RUSTFLAGS: '-D warnings'
-        run: cargo dylint --all -- --all-targets --workspace
+        run: pnpm pipeline rust-dylint --include-workspace-root --full --no-cache
 
   # Single aggregate gate — the only Rust CI context branch protection
   # needs to require. Listing the individual jobs as required checks does

--- a/.github/workflows/pacquet-ci.yml
+++ b/.github/workflows/pacquet-ci.yml
@@ -153,6 +153,20 @@ jobs:
         with:
           tool: just
 
+      # `pnpm pipeline` installs before it runs anything, but the install has to
+      # happen here: the test steps are wrapped in a timing wrapper whose result
+      # feeds Bencher, and a dependency install inside one would report registry
+      # latency as test duration. This step unsets the same variables the test
+      # steps do so both installs resolve the same store, leaving the pipeline's
+      # frozen install a no-op.
+      - name: Install dependencies
+        shell: bash
+        run: |
+          unset PNPM_HOME
+          unset XDG_DATA_HOME
+
+          just install
+
       - name: Install cargo-nextest
         uses: taiki-e/install-action@fa23953489c080190314742a9b907f8e97c6767c # v2.87.10
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
     - name: Install pnpm and Node
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
+        install: false
         runtime: node@${{ inputs.node }}
     - name: Verify Node version
       shell: bash
@@ -179,15 +180,10 @@ jobs:
         TEST_CHUNK_TOTAL: ${{ inputs.test_chunk_total }}
       run: |
         benchmark="$BENCHMARK"
-        command=(pn run "$TEST_SCRIPT")
+        command=(pn pipeline "$TEST_SCRIPT" --include-workspace-root --full --no-cache)
         if [ "$TEST_CHUNK_TOTAL" != "1" ]; then
           benchmark="${BENCHMARK}.chunk${TEST_CHUNK}"
-          command=(
-            node .github/scripts/run-ts-tests-chunk.mjs
-            --script "$TEST_SCRIPT"
-            --chunk "$TEST_CHUNK"
-            --chunks "$TEST_CHUNK_TOTAL"
-          )
+          command=(pn pipeline ts-test-chunk --include-workspace-root --full --no-cache)
         fi
         node .github/scripts/measure-command.mjs \
           --name "$benchmark" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,10 +63,14 @@ jobs:
       uses: garnet-org/action@3d47f4a9004f7356c980a0e8d420ef5984750e3c # v2.2.0
       with:
         api_token: ${{ secrets.GARNET_API_TOKEN }}
+    # `pnpm pipeline` installs before it runs anything, but the install has to
+    # happen here: the test step is wrapped in a timing wrapper whose result
+    # feeds Bencher, and a dependency install inside it would report registry
+    # latency as test duration. Installing first leaves the pipeline's frozen
+    # install a no-op.
     - name: Install pnpm and Node
       uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
       with:
-        install: false
         runtime: node@${{ inputs.node }}
     - name: Verify Node version
       shell: bash

--- a/package.json
+++ b/package.json
@@ -33,7 +33,19 @@
     "check:node-release-keys": "node pnpm11/crypto/shasums-file/scripts/update-node-release-keys.mjs",
     "update:node-release-keys": "node pnpm11/crypto/shasums-file/scripts/update-node-release-keys.mjs --update",
     "release": "pn --filter=@pnpm/exe run build-artifacts && pn --filter=@pnpm/exe publish --tag=next-11 --access=public --provenance && pn publish --filter=!pnpm --filter=!@pnpm/exe --access=public --provenance && pn publish --filter=pnpm --tag=next-11 --access=public --provenance",
-    "dev-setup": "pn -C=./pnpm11/pnpm/dev link -g"
+    "dev-setup": "pn -C=./pnpm11/pnpm/dev link -g",
+    "ci:compile": "pn compile-only",
+    "ci:lint": "pn lint",
+    "ci:test-chunk": "node .github/scripts/run-ts-tests-chunk.mjs",
+    "ci:rust-test": "just test-pacquet",
+    "ci:pnpr-test": "just test-pnpr",
+    "ci:rust-clippy": "cargo clippy --locked --workspace --all-targets -- -D warnings",
+    "ci:rust-doc": "cargo doc --no-deps --workspace --document-private-items",
+    "ci:rust-deny": "cargo deny check",
+    "ci:rust-fmt": "cargo fmt --all -- --check",
+    "ci:toml-fmt": "taplo format --check",
+    "ci:rust-dylint": "cargo dylint --all -- --all-targets --workspace",
+    "ci:build-pnpr": "cargo build --locked --release -p pnpr --bin pnpr -p pnpr-fixtures --bin pnpr-prepare"
   },
   "devDependencies": {
     "@commitlint/cli": "catalog:",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,54 @@ packages:
   - '!**/test/**'
   - '!pnpm11/resolving/local-resolver/example-package/**'
 
+# CI invokes root tasks with --include-workspace-root --full. Test scope and
+# file sharding are handled by the test runners, which also produce Bencher data.
+pipelines:
+  ts-check: [ci:compile, ci:lint]
+  ci:test-all: [ci:test-all]
+  ci:test-branch: [ci:test-branch]
+  ts-test-chunk: [ci:test-chunk]
+  rust-test: [ci:rust-test]
+  pnpr-test: [ci:pnpr-test]
+  rust-clippy: [ci:rust-clippy]
+  rust-doc: [ci:rust-doc]
+  rust-deny: [ci:rust-deny]
+  rust-format: [ci:rust-fmt, ci:toml-fmt]
+  rust-dylint: [ci:rust-dylint]
+  build-pnpr: [ci:build-pnpr]
+
+# These tasks consume generated artifacts, external tools, or test services.
+# Workflows pass --no-cache so a warm cache never skips these checks.
+tasks:
+  ci:compile:
+    dependsOn: []
+  ci:lint:
+    dependsOn: [ci:compile]
+  ci:test-all:
+    dependsOn: []
+  ci:test-branch:
+    dependsOn: []
+  ci:test-chunk:
+    dependsOn: []
+  ci:rust-test:
+    dependsOn: []
+  ci:pnpr-test:
+    dependsOn: []
+  ci:rust-clippy:
+    dependsOn: []
+  ci:rust-doc:
+    dependsOn: []
+  ci:rust-deny:
+    dependsOn: []
+  ci:rust-fmt:
+    dependsOn: []
+  ci:toml-fmt:
+    dependsOn: []
+  ci:rust-dylint:
+    dependsOn: []
+  ci:build-pnpr:
+    dependsOn: []
+
 # Native workspace release management (consumed by `pnpm change` / `pnpm version -r`).
 # The Rust CLI wrapper is the workspace package `pacquet` (published to npm as
 # `pnpm`); generate-packages.mjs rewrites the name at pack time.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,10 +57,15 @@ packages:
   - '!**/test/**'
   - '!pnpm11/resolving/local-resolver/example-package/**'
 
-# CI invokes root tasks with --include-workspace-root --full. Test scope and
-# file sharding are handled by the test runners, which also produce Bencher data.
+# Every `ci:*` script lives in the root manifest only, so the workflows run
+# these pipelines with `--include-workspace-root --full`; the test runners do
+# their own package selection and file sharding. The workflows also pass
+# `--no-cache`: no task declares `outputs`, so none is cacheable today, and the
+# flag keeps a check from being skipped if one ever does.
 pipelines:
   ts-check: [ci:compile, ci:lint]
+  # Named after the scripts they run: the test workflow passes one value as both
+  # the pipeline name and the `TEST_SCRIPT` the chunk runner re-runs.
   ci:test-all: [ci:test-all]
   ci:test-branch: [ci:test-branch]
   ts-test-chunk: [ci:test-chunk]
@@ -73,37 +78,9 @@ pipelines:
   rust-dylint: [ci:rust-dylint]
   build-pnpr: [ci:build-pnpr]
 
-# These tasks consume generated artifacts, external tools, or test services.
-# Workflows pass --no-cache so a warm cache never skips these checks.
 tasks:
-  ci:compile:
-    dependsOn: []
   ci:lint:
     dependsOn: [ci:compile]
-  ci:test-all:
-    dependsOn: []
-  ci:test-branch:
-    dependsOn: []
-  ci:test-chunk:
-    dependsOn: []
-  ci:rust-test:
-    dependsOn: []
-  ci:pnpr-test:
-    dependsOn: []
-  ci:rust-clippy:
-    dependsOn: []
-  ci:rust-doc:
-    dependsOn: []
-  ci:rust-deny:
-    dependsOn: []
-  ci:rust-fmt:
-    dependsOn: []
-  ci:toml-fmt:
-    dependsOn: []
-  ci:rust-dylint:
-    dependsOn: []
-  ci:build-pnpr:
-    dependsOn: []
 
 # Native workspace release management (consumed by `pnpm change` / `pnpm version -r`).
 # The Rust CLI wrapper is the workspace package `pacquet` (published to npm as

--- a/pnpm/crates/testing-utils/src/command_env.rs
+++ b/pnpm/crates/testing-utils/src/command_env.rs
@@ -15,7 +15,10 @@ pub trait CommandTestExt {
     /// the npm spellings. One such variable in CI or in a contributor's
     /// shell therefore reconfigures the pnpm under test: `pnpm/setup`
     /// exports `PNPM_CONFIG_GLOBAL_SHIMS` to pin the runtime it installed,
-    /// which flipped the shim style the global-shims suites assert on.
+    /// which flipped the shim style the global-shims suites assert on. The
+    /// same goes for `npm_lifecycle_event`, which any parent `pnpm run`
+    /// sets: `pnpm run` reads it as "a script is calling me" and stops
+    /// filtering hidden scripts out of a selector's matches.
     ///
     /// Call this at construction time so a later `env` still wins for
     /// tests that exercise one of these settings deliberately.
@@ -46,15 +49,18 @@ fn ambient_pnpm_config_vars() -> impl Iterator<Item = OsString> {
         .filter(|name| name.to_str().is_some_and(is_pnpm_config_var))
 }
 
-/// Whether `name` configures pnpm: either spelling of the `pnpm_config_`
-/// / `npm_config_` prefixes, or the context-aware shim kill switch.
-/// `PNPM_HOME` is deliberately not one of them — the suites spawn the
-/// ambient pnpm for their compatibility checks.
+/// Whether `name` steers the pnpm under test: either spelling of the
+/// `pnpm_config_` / `npm_config_` prefixes, the context-aware shim kill
+/// switch, or the lifecycle event a parent `pnpm run` sets. `PNPM_HOME`
+/// is deliberately not one of them — the suites spawn the ambient pnpm
+/// for their compatibility checks.
 fn is_pnpm_config_var(name: &str) -> bool {
     const PREFIXES: [&str; 2] = ["pnpm_config_", "npm_config_"];
     const SHIM_BYPASS: &str = "PNPM_SHIM_BYPASS";
+    const LIFECYCLE_EVENT: &str = "npm_lifecycle_event";
 
     name.eq_ignore_ascii_case(SHIM_BYPASS)
+        || name.eq_ignore_ascii_case(LIFECYCLE_EVENT)
         || PREFIXES.iter().any(|prefix| {
             // `get`, not a slice: the environment is outside this process's
             // control, and a name whose prefix-length byte falls inside a

--- a/pnpm/crates/testing-utils/src/command_env/tests.rs
+++ b/pnpm/crates/testing-utils/src/command_env/tests.rs
@@ -16,6 +16,8 @@ fn pnpm_and_npm_settings_match_in_either_spelling() {
         "npm_config_registry",
         "PNPM_SHIM_BYPASS",
         "pnpm_shim_bypass",
+        "npm_lifecycle_event",
+        "NPM_LIFECYCLE_EVENT",
     ] {
         assert!(is_pnpm_config_var(name), "{name} should be stripped");
     }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Run the TypeScript CI, reusable test workflow, Rust CI, and shared pnpr build through 12 named pnpm 12.4 pipelines. Pipelines perform frozen installs and declare the compile-before-lint dependency. Existing runners retain affected-package selection, Windows test sharding, and Bencher report generation.

The two jobs whose commands are wrapped in `measure-command.mjs` still install in an earlier step, so the wall-clock figure they upload to Bencher stays a test duration rather than a test duration plus registry latency. The pipeline's own frozen install is a no-op there. In the Rust test job that earlier step unsets the same variables the test steps do, so both installs resolve the same store.

Validation:
- Verified all 12 pipeline graphs with pnpm 12.4 dry runs.
- Ran `ts-check`, `rust-format` and `rust-deny` end to end against pnpm 12.4.1: compile is ordered before lint, the two format tasks run concurrently, all exit 0.
- Ran `ts-test-chunk` through the pipeline to confirm `TEST_SCRIPT`, `TEST_CHUNK` and `TEST_CHUNK_TOTAL` reach the chunk runner, and that unset or non-numeric values are rejected.
- Confirmed a root-only task needs both `--include-workspace-root` and `--full`: `--full` alone selects nothing, and `--include-workspace-root` alone falls back to affected selection.
- Confirmed the task graph is identical with only the compile-before-lint edge declared, so the other `dependsOn: []` entries were dropped.
- Parsed workflow YAML and checked Bash and JavaScript syntax and whitespace.
- Passed the pre-push compile, bundle, and repository lint checks.

Full CI suites were not run locally.

## Squash Commit Body

```text
Declare CI pipelines and root task scripts, and invoke them from the
TypeScript, Rust, reusable test, and pnpr build workflows. Let pipelines
perform frozen installs and order TypeScript compilation before linting.

Keep existing test runners responsible for affected-package selection,
file-level sharding, and summary generation. Read shard settings from the
workflow environment, with explicit command-line arguments taking precedence.

Run root tasks with --include-workspace-root --full: the scripts live in the
root manifest only, and the test runners already select their own scope. Pass
--no-cache so a task that later declares outputs cannot skip a check.

Keep the dependency install in its own step in the two jobs whose commands are
timed for Bencher, so the reported duration stays a test duration. Preserve
existing job gates and artifact handoffs.
```

## Checklist

- [x] Validated pipeline graphs, ran four pipelines end to end, and checked test shard selection.
- [x] Documented pipeline invocation and caching choices in workspace configuration.
- [x] No changeset needed: changes affect private root tooling and CI only.

---
Written by an agent (Codex, GPT-6), reviewed and revised by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791459911&installation_model_id=426870&pr_number=14690&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14690&signature=075c6ffc42741a657270f100de2a84567df5d62a8c7d4516b50670d5c49785e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved automated test execution with configurable chunked runs and consistent validation across TypeScript and Rust projects.
  * Unified compilation, linting, testing, formatting, documentation, and dependency checks under standardized pipeline commands.

* **Chores**
  * Streamlined continuous integration workflows for builds, testing, formatting, linting, documentation, and dependency checks.
  * Added reusable project-level commands and standardized package manager setup to improve build reliability.
  * Improved environment handling for more predictable automated command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
