### PR TITLE
fix(pipeline): hash symlinked inputs as link targets

### DIFF
--- a/.changeset/pipeline-symlinked-inputs.md
+++ b/.changeset/pipeline-symlinked-inputs.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm pipeline` no longer fails on a project that tracks a symlink, such as a `CLAUDE.md` pointing at `AGENTS.md`. Changing a symlinked input's target invalidates that task's cache. `pnpm pipeline --no-cache` no longer hashes task inputs [#14692](https://github.com/pnpm/pnpm/issues/14692).

--- a/pnpm/crates/cli/src/cli_args/pipeline.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline.rs
@@ -312,8 +312,14 @@ pub fn run_pipeline(
     // Keys are computed for every task before anything runs, walking the
     // sequenced order so a task's dependency keys exist when its own is
     // built. This is also what a distributed tier would need: the whole
-    // plan, priced, without executing.
-    let task_keys = compute_task_keys(&task_graph, &sequenced_tasks, &graph, &cache, config)?;
+    // plan, priced, without executing. `--no-cache` skips the pricing
+    // altogether: nothing reads a key, and hashing every tracked file of
+    // every project is the bulk of what the flag exists to avoid.
+    let task_keys = if invocation.no_cache {
+        HashMap::new()
+    } else {
+        compute_task_keys(&task_graph, &sequenced_tasks, &graph, &cache, config)?
+    };
 
     capture::install_forward(emit);
     let concurrency = usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1);
@@ -337,7 +343,7 @@ pub fn run_pipeline(
             config,
             invocation,
             cache: &cache,
-            task_key: task_keys[&key].as_deref(),
+            task_key: task_keys.get(&key).and_then(Option::as_deref),
             init_cwd: &init_cwd,
             base_extra_env: &base_extra_env,
             emit,

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache.rs
@@ -8,11 +8,13 @@
 
 use super::{
     capture::CapturedScript,
-    paths::{check_ancestors, validate_relative_path},
+    paths::{check_ancestors, check_input_directories, validate_relative_path},
 };
 use miette::IntoDiagnostic;
 use pnpm_config::TaskSettings;
-use pnpm_crypto_hash::{create_hex_hash, create_hex_hash_from_file, create_short_hash};
+use pnpm_crypto_hash::{
+    create_hex_hash, create_hex_hash_bytes, create_hex_hash_from_file, create_short_hash,
+};
 use pnpm_workspace_task_scheduler::TaskNode;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -452,23 +454,11 @@ impl TaskCache {
             if rel_path == "node_modules" || rel_path.starts_with("node_modules/") {
                 continue;
             }
-            check_ancestors(project, Path::new(rel_path)).into_diagnostic()?;
-            let absolute = project.join(rel_path);
-            let hash = match create_hex_hash_from_file(&absolute) {
-                Ok(hash) => hash,
-                Err(error)
-                    if error.kind() == io::ErrorKind::NotFound
-                        && fs::symlink_metadata(&absolute)
-                            .is_err_and(|error| error.kind() == io::ErrorKind::NotFound) =>
-                {
-                    continue;
-                }
-                Err(error) => {
-                    return Err(miette::miette!(
-                        "hashing cache input {rel_path:?} in {project_display}: {error}",
-                    ));
-                }
-            };
+            check_input_directories(project, Path::new(rel_path)).into_diagnostic()?;
+            let hash = hash_input(&project.join(rel_path)).map_err(|error| {
+                miette::miette!("hashing cache input {rel_path:?} in {project_display}: {error}")
+            })?;
+            let Some(hash) = hash else { continue };
             files.push(HashedFile { rel_path: rel_path.to_string(), hash });
         }
         files.sort_by(|left, right| left.rel_path.cmp(&right.rel_path));
@@ -478,6 +468,37 @@ impl TaskCache {
             .expect("project-files lock is not poisoned")
             .insert(project.to_path_buf(), Some(Arc::clone(&files)));
         Ok(Some(files))
+    }
+}
+
+/// A tracked input's contribution to the key, or `None` when the file is
+/// gone by the time it is hashed.
+///
+/// A symlink contributes its target path the way git records it, rather
+/// than the content it points at: following the link would hash a file
+/// the project does not own, and a link that dangles has nothing to
+/// hash at all. The `symlink:` tag keeps a link apart from a regular
+/// file that happens to hold the same bytes.
+fn hash_input(path: &Path) -> io::Result<Option<String>> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() {
+        return match fs::read_link(path) {
+            Ok(target) => {
+                let target = create_hex_hash_bytes(target.as_os_str().as_encoded_bytes());
+                Ok(Some(format!("symlink:{target}")))
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
+        };
+    }
+    match create_hex_hash_from_file(path) {
+        Ok(hash) => Ok(Some(hash)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/cache/tests.rs
@@ -1,6 +1,6 @@
 use super::{RecordedFile, TaskCache, collect_output_files};
 #[cfg(unix)]
-use pnpm_crypto_hash::create_hex_hash_from_file;
+use pnpm_crypto_hash::{create_hex_hash_bytes, create_hex_hash_from_file};
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::fs;
 
@@ -235,12 +235,13 @@ fn hashing_inputs_keeps_literal_backslashes_distinct_from_separators() {
 
 #[cfg(unix)]
 #[test]
-fn hashing_inputs_rejects_dangling_symlinks() {
+fn hashing_inputs_covers_a_dangling_symlink_by_its_target() {
     let (root, _repo, cache) = setup_input_cache();
     let project = root.path().join("inputs-src");
     std::os::unix::fs::symlink("missing", project.join("linked-input")).unwrap();
-    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
-    assert!(error.contains("linked-input"), "{error}");
+    let files = cache.hashed_project_files(&project).unwrap().unwrap();
+    let file = files.iter().find(|file| file.rel_path == "linked-input").expect("linked input");
+    assert_eq!(file.hash, format!("symlink:{}", create_hex_hash_bytes(b"missing")));
 }
 
 #[cfg(unix)]
@@ -260,14 +261,29 @@ fn hashing_inputs_rejects_dangling_parent_symlinks() {
 
 #[cfg(unix)]
 #[test]
-fn hashing_inputs_rejects_valid_leaf_symlinks() {
+fn hashing_inputs_covers_a_leaf_symlink_without_following_it() {
     let (root, _repo, cache) = setup_input_cache();
     let project = root.path().join("inputs-src");
     let outside = root.path().join("outside-input");
     fs::write(&outside, "external source").unwrap();
     std::os::unix::fs::symlink(&outside, project.join("linked-input")).unwrap();
-    let error = cache.hashed_project_files(&project).unwrap_err().to_string();
-    assert!(error.contains("symlink") && error.contains("linked-input"), "{error}");
+    let files = cache.hashed_project_files(&project).unwrap().unwrap();
+    let file = files.iter().find(|file| file.rel_path == "linked-input").expect("linked input");
+    assert_eq!(
+        file.hash,
+        format!("symlink:{}", create_hex_hash_bytes(outside.as_os_str().as_encoded_bytes())),
+    );
+    assert_ne!(file.hash, create_hex_hash_from_file(&outside).unwrap());
+}
+
+#[cfg(unix)]
+#[test]
+fn hashing_inputs_rejects_symlinked_project_roots() {
+    let (root, _repo, cache) = setup_input_cache();
+    let link = root.path().join("linked-project");
+    std::os::unix::fs::symlink(root.path().join("inputs-src"), &link).unwrap();
+    let error = cache.hashed_project_files(&link).unwrap_err().to_string();
+    assert!(error.contains("symlink") && error.contains("linked-project"), "{error}");
     assert!(cache.project_files.lock().unwrap().is_empty(), "unsafe inputs must not be cached");
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
+++ b/pnpm/crates/cli/src/cli_args/pipeline/paths.rs
@@ -40,3 +40,10 @@ fn reject_symlink(path: &Path) -> io::Result<()> {
     }
     Ok(())
 }
+
+/// [`check_ancestors`] without the leaf, so hashing an input cannot read
+/// a file outside `root`. Only the leaf may be a symlink: it is hashed
+/// as its link target, never followed.
+pub(super) fn check_input_directories(root: &Path, relative: &Path) -> io::Result<()> {
+    check_ancestors(root, relative.parent().unwrap_or_else(|| Path::new("")))
+}

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -305,3 +305,98 @@ fn projects_rooted_in_submodules_bypass_task_caching() {
         }
     }
 }
+
+#[cfg(unix)]
+fn symlinked_input_project(project: &std::path::Path, task_settings: &str) {
+    use std::os::unix::fs::symlink;
+
+    assert!(Command::new("git").arg("init").arg(project).output().unwrap().status.success());
+    fs::write(project.join("AGENTS.md"), "shared text").unwrap();
+    fs::write(project.join("NOTES.md"), "shared text").unwrap();
+    symlink("AGENTS.md", project.join("CLAUDE.md")).unwrap();
+    symlink("MISSING.md", project.join("DANGLING.md")).unwrap();
+    fs::write(project.join(".gitignore"), "out/\nnode_modules/\nruns\n").unwrap();
+    fs::write(project.join("package.json"), serde_json::json!({
+        "name": "probe", "version": "1.0.0", "scripts": {
+            "build": r#"node -e "const fs=require('fs');fs.mkdirSync('out',{recursive:true});fs.writeFileSync('out/result',fs.readFileSync('CLAUDE.md','utf8'));fs.appendFileSync('runs','x')""#
+        }
+    }).to_string()).unwrap();
+    fs::write(
+        project.join("pnpm-workspace.yaml"),
+        format!(
+            "packages: []\nincludeWorkspaceRoot: true\npipelines:\n  default: [build]\ntasks:\n  build:\n    dependsOn: []\n{task_settings}",
+        ),
+    )
+    .unwrap();
+    Command::new("git").current_dir(project).args(["add", "-A"]).assert().success();
+}
+
+#[cfg(unix)]
+#[test]
+fn no_cache_runs_tasks_without_hashing_their_inputs() {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir().unwrap();
+    symlinked_input_project(project.path(), "");
+    let outside = tempfile::tempdir().unwrap();
+    fs::create_dir(project.path().join("dir")).unwrap();
+    fs::write(project.path().join("dir/input"), "source").unwrap();
+    Command::new("git").current_dir(project.path()).args(["add", "-A"]).assert().success();
+    fs::remove_file(project.path().join("dir/input")).unwrap();
+    fs::remove_dir(project.path().join("dir")).unwrap();
+    symlink(outside.path(), project.path().join("dir")).unwrap();
+    let storage = tempfile::tempdir().unwrap();
+    let command = || {
+        let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
+        command
+            .current_dir(project.path())
+            .env("XDG_CACHE_HOME", storage.path())
+            .env("XDG_CONFIG_HOME", storage.path().join("config"));
+        command
+    };
+    command().arg("install").assert().success();
+    command().args(["pipeline", "--full", "--no-cache"]).assert().success();
+    assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "shared text");
+    assert_eq!(fs::read_to_string(project.path().join("runs")).unwrap(), "x");
+    // The symlinked directory a tracked input sits under is still refused,
+    // which is what makes the run above evidence that nothing was hashed.
+    command().args(["pipeline", "--full"]).assert().failure();
+    assert_eq!(fs::read_to_string(project.path().join("runs")).unwrap(), "x");
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_inputs_are_hashed_as_link_targets() {
+    use std::os::unix::fs::symlink;
+
+    let project = tempfile::tempdir().unwrap();
+    symlinked_input_project(project.path(), "    outputs: ['out/**']\n");
+    let storage = tempfile::tempdir().unwrap();
+    let command = || {
+        let mut command = Command::cargo_bin("pnpm").unwrap().without_ambient_pnpm_config();
+        command
+            .current_dir(project.path())
+            .env("XDG_CACHE_HOME", storage.path())
+            .env("XDG_CONFIG_HOME", storage.path().join("config"));
+        command
+    };
+    command().arg("install").assert().success();
+    let run = |expected_runs: &str, expected_hit: bool| {
+        let result = command().args(["pipeline", "--full"]).assert().success();
+        let output = String::from_utf8_lossy(&result.get_output().stdout).into_owned();
+        assert_eq!(output.contains("restored from cache"), expected_hit, "{output}");
+        assert_eq!(fs::read_to_string(project.path().join("runs")).unwrap(), expected_runs);
+    };
+    run("x", false);
+    run("x", true);
+    // Both targets hold the same text, so only a key built from the link
+    // target itself — not from the content it resolves to — misses here.
+    fs::remove_file(project.path().join("CLAUDE.md")).unwrap();
+    symlink("NOTES.md", project.path().join("CLAUDE.md")).unwrap();
+    run("xx", false);
+    // The file a link points at is a tracked input in its own right, so
+    // editing it still invalidates the task that reads it through the link.
+    fs::write(project.path().join("NOTES.md"), "edited text").unwrap();
+    run("xxx", false);
+    assert_eq!(fs::read_to_string(project.path().join("out/result")).unwrap(), "edited text");
+}


### PR DESCRIPTION
## Summary

`pnpm pipeline` aborted before running a single task in any repository that tracks a symlink. Task cache keys hash every tracked file of a project, and each path went through `check_ancestors`, which rejects a symlink anywhere along it. pnpm's own `CLAUDE.md` is a symlink to `AGENTS.md`, so the TypeScript compile-and-lint pipeline in pnpm/pnpm#14690 died with `Cache path is a symlink: .../CLAUDE.md` right after its frozen install succeeded.

A symlinked input now contributes its link target to the key, the way git records it. `--no-cache` skips key computation entirely, since nothing reads a key on that path.

This reverses the leaf half of pnpm/pnpm#14635: its two unit tests for a rejected leaf symlink now assert the target hash instead. Its parent-directory checks stand, so a working tree that swaps a directory for a symlink still cannot redirect a hash out of the project, and the restore path is untouched.

Closes pnpm/pnpm#14692

## Squash Commit Body

```text
Task cache keys covered a project's tracked files by hashing each one
through `check_ancestors`, which rejects any symlink on the path. A
repository that tracks a symlink (pnpm's own `CLAUDE.md` points at
`AGENTS.md`) therefore aborted `pnpm pipeline` before a single task ran.

A symlink now contributes its link target to the key, the way git
records it, tagged so it cannot collide with a regular file holding the
same bytes. Following the link would hash a file the project does not
own, and a dangling link has no content to hash at all. Directories on
the way to an input are still rejected when they are symlinks, so a
locally modified working tree cannot redirect a hash outside the
project. Restoring cached outputs keeps the original check unchanged.

This reverses the leaf half of pnpm/pnpm#14635, whose two unit tests for
a rejected leaf symlink now assert the target hash instead. Its parent
directory checks stand.

`--no-cache` no longer computes keys at all. Nothing reads them on that
path, and hashing every tracked file of every project is the bulk of the
work the flag exists to skip.

Closes pnpm/pnpm#14692
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (`pnpm pipeline` is v12-only.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5[1m]).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm pipeline` supports projects containing symlinked input files, including dangling symlinks.
  - Cache keys account for symlink target paths, so changing a link target correctly invalidates cached results.

- **Bug Fixes**
  - Running pipelines with `--no-cache` skips cache-key calculation and completes reliably with symlinked inputs.
  - Inputs that disappear during processing no longer cause pipeline failures.
  - Symlinked parent directories are rejected to prevent invalid project input paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->