### PR TITLE
feat(cargo): install the git-sourced crates a Cargo.lock pins

### DIFF
--- a/.changeset/cargo-lock-install.md
+++ b/.changeset/cargo-lock-install.md
@@ -4,6 +4,8 @@
 
 `pnpm install` and `pnpm add crate:<package>` now manage crates.io dependencies when `cargo.enabled` is set in `pnpm-workspace.yaml`. Mixed-ecosystem workspaces install their dependency graphs in one command. A single `pnpm add` command can include both npm packages and crates. Cargo workspace discovery excludes configured stores and caches.
 
+A workspace can point a crate at a git revision through `[patch.crates-io]` or a git dependency. `pnpm install` reads the revision `Cargo.lock` pins, vendors that crate into the store, and leaves `cargo` able to build it offline.
+
 Cargo lockfiles and source configuration are published after all enabled ecosystems finish successfully. Failed publication restores the previous Cargo metadata. Failed `pnpm add` operations that include crates restore participating manifests and lockfiles.
 
 Cargo index and crate downloads use URL-matched credentials from pnpm configuration. The crates.io index also supports `CARGO_REGISTRY_TOKEN` and the token in `$CARGO_HOME/credentials.toml`, using Cargo's bare `Authorization` header format. Cargo registry requests respect the configured fetch retry budget.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,6 +4593,7 @@ dependencies = [
  "pnpm-env-installer",
  "pnpm-executor",
  "pnpm-fs",
+ "pnpm-git-fetcher",
  "pnpm-global",
  "pnpm-graph-hasher",
  "pnpm-hooks",

--- a/pnpm/crates/cli/Cargo.toml
+++ b/pnpm/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ pnpm-pnpr-client                       = { workspace = true }
 pnpm-env-installer                     = { workspace = true }
 pnpm-executor                          = { workspace = true }
 pnpm-fs                                = { workspace = true }
+pnpm-git-fetcher                       = { workspace = true }
 pnpm-global                            = { workspace = true }
 pnpm-graph-hasher                      = { workspace = true }
 pnpm-hooks                             = { workspace = true }

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -250,6 +250,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
         git_shallow_hosts: &config.git_shallow_hosts,
         package_import_method: config.package_import_method,
         logged_methods,
+        concurrency: config.network_concurrency.clamp(1, 16),
         offline: config.offline,
     })
     .await?;

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -1,4 +1,7 @@
-use crate::ecosystem_install::{EcosystemManifest, EcosystemWorkspaceInventory, InstallContext};
+use crate::{
+    cargo_deps::git::{GIT_SOURCE_DIRECTORY, GIT_SOURCE_NAME, GitPackage, GitSource},
+    ecosystem_install::{EcosystemManifest, EcosystemWorkspaceInventory, InstallContext},
+};
 use cargo_util_schemas::index::RegistryConfig;
 use futures_util::{StreamExt, TryStreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
@@ -25,6 +28,7 @@ use std::{
 };
 
 pub(crate) mod add;
+mod git;
 mod registry_auth;
 
 #[cfg(unix)]
@@ -38,7 +42,9 @@ const CRATES_IO_DOWNLOAD_BASE: &str = "https://static.crates.io/crates";
 const MAX_REGISTRY_CONFIG_BYTES: usize = 64 * 1024;
 const MANAGED_START: &str = "# >>> pnpm-managed cargo sources >>>";
 const MANAGED_END: &str = "# <<< pnpm-managed cargo sources <<<";
-const MANAGED_CONFIG: &str = "# >>> pnpm-managed cargo sources >>>\n[source.crates-io]\nreplace-with = \"pnpm-crates-io\"\n\n[source.pnpm-crates-io]\ndirectory = \".pnpm/crates/crates-io\"\n# <<< pnpm-managed cargo sources <<<";
+/// Directory the registry crates are linked into, relative to the Cargo
+/// workspace root.
+const CRATES_SOURCE_DIRECTORY: [&str; 3] = [".pnpm", "crates", "crates-io"];
 #[cfg(unix)]
 static MANAGED_TEMP_ID: AtomicU64 = AtomicU64::new(0);
 
@@ -55,10 +61,35 @@ struct LockedCrate {
     checksum: String,
 }
 
+/// What a `Cargo.lock` asks the install to provide, grouped by the kind of
+/// source each package comes from. Workspace members carry no source and
+/// are already on disk, so they appear in neither list.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LockedPackages {
+    crates: Vec<LockedCrate>,
+    git: Vec<GitPackage>,
+}
+
+impl LockedPackages {
+    /// The git sources the locked packages come from, deduplicated so the
+    /// managed Cargo configuration declares each one once.
+    fn git_sources(&self) -> Vec<GitSource> {
+        self.git
+            .iter()
+            .map(|package| GitSource::clone(&package.source))
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect()
+    }
+}
+
 #[derive(Serialize)]
 struct CargoChecksum<'a> {
     files: BTreeMap<String, String>,
-    package: &'a str,
+    /// The registry checksum of the `.crate` archive the files came from.
+    /// Null for a package vendored from a git checkout, which has none —
+    /// the same value `cargo vendor` writes for one.
+    package: Option<&'a str>,
 }
 
 #[derive(Deserialize)]
@@ -124,15 +155,27 @@ pub(crate) async fn prepare<Reporter: self::Reporter + 'static>(
 pub(crate) struct Prepared {
     root: PathBuf,
     lock: String,
-    slots: Option<Vec<(String, PathBuf)>>,
+    slots: Option<WorkspaceSlots>,
     index_url: String,
+}
+
+/// The store slots a workspace links, one list per Cargo source the
+/// managed configuration declares.
+#[derive(Debug, Default)]
+struct WorkspaceSlots {
+    crates: Vec<(String, PathBuf)>,
+    git: Vec<(String, PathBuf)>,
+    git_sources: Vec<GitSource>,
 }
 
 impl PreparedInstall for Prepared {
     fn publish(&mut self) -> Result<()> {
         if let Some(slots) = &self.slots {
-            link_workspace(&self.root, slots)?;
-            write_cargo_config(&self.root, &self.index_url)?;
+            link_workspace(&self.root, &CRATES_SOURCE_DIRECTORY, &slots.crates)?;
+            if !slots.git.is_empty() {
+                link_workspace(&self.root, &GIT_SOURCE_DIRECTORY, &slots.git)?;
+            }
+            write_cargo_config(&self.root, &self.index_url, &slots.git_sources)?;
         }
         let path = self.root.join("Cargo.lock");
         let existing = match fs::read_to_string(&path) {
@@ -185,19 +228,60 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     }
     let packages = parse_lockfile(&cargo_lock, &config.cargo.index_url)
         .wrap_err_with(|| format!("parse {}", cargo_lock_path.display()))?;
+    let git_sources = packages.git_sources();
+    let logged_methods = Arc::new(AtomicU8::new(0));
+    let store_dir = &config.store_dir;
+    if !packages.crates.is_empty() || !packages.git.is_empty() {
+        store_dir.init().into_diagnostic().wrap_err_with(|| {
+            format!("initialize cargo package store at {}", store_dir.display())
+        })?;
+    }
+    let crates = download_crates::<Reporter>(DownloadOptions {
+        config,
+        packages: packages.crates,
+        http_client,
+        logged_methods: Arc::clone(&logged_methods),
+        requester: format!("cargo workspace at {}", root_dir.display()),
+    })
+    .await?;
+    let git = git::vendor::<Reporter>(git::VendorOptions {
+        packages: packages.git,
+        store_dir,
+        git_shallow_hosts: &config.git_shallow_hosts,
+        package_import_method: config.package_import_method,
+        logged_methods,
+        offline: config.offline,
+    })
+    .await?;
+
+    Ok(Prepared {
+        root: root_dir.to_path_buf(),
+        lock: cargo_lock,
+        slots: Some(WorkspaceSlots { crates, git, git_sources }),
+        index_url: config.cargo.index_url.clone(),
+    })
+}
+
+struct DownloadOptions {
+    config: &'static Config,
+    packages: Vec<LockedCrate>,
+    http_client: Arc<ThrottledClient>,
+    logged_methods: Arc<AtomicU8>,
+    requester: String,
+}
+
+/// Download every registry crate the lockfile pins into its store slot.
+/// Returns before the registry's configuration is fetched when the lockfile
+/// pins none, so a workspace that takes nothing from the registry never
+/// asks it for anything.
+async fn download_crates<Reporter: self::Reporter + 'static>(
+    options: DownloadOptions,
+) -> Result<Vec<(String, PathBuf)>> {
+    let DownloadOptions { config, packages, http_client, logged_methods, requester } = options;
     if packages.is_empty() {
-        return Ok(Prepared {
-            root: root_dir.to_path_buf(),
-            lock: cargo_lock,
-            slots: Some(Vec::new()),
-            index_url: config.cargo.index_url.clone(),
-        });
+        return Ok(Vec::new());
     }
     let store_dir = &config.store_dir;
-    store_dir
-        .init()
-        .into_diagnostic()
-        .wrap_err_with(|| format!("initialize cargo package store at {}", store_dir.display()))?;
     let store_index = StoreIndex::shared_for(store_dir, config.frozen_store);
     let (store_index_writer, writer_task) =
         StoreIndexWriter::spawn_for(store_dir, config.frozen_store);
@@ -206,9 +290,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
     let registry_config = fetch_registry_config(config, &http_client, &cargo_auth_headers).await?;
     let auth_headers = download_auth_headers(config, &registry_config);
     let verified_files_cache = SharedVerifiedFilesCache::default();
-    let logged_methods = Arc::new(AtomicU8::new(0));
     let retry_opts = config.retry_opts();
-    let requester = format!("cargo workspace at {}", root_dir.display());
     let concurrency = config.network_concurrency.clamp(1, 16);
 
     let slots = stream::iter(packages)
@@ -238,14 +320,7 @@ async fn prepare_workspace<Reporter: self::Reporter + 'static>(
         .collect::<Result<Vec<_>>>();
     drop(store_index_writer);
     StoreIndexWriter::drain(writer_task, "; some Cargo rows may not be persisted").await;
-    let slots = slots?;
-
-    Ok(Prepared {
-        root: root_dir.to_path_buf(),
-        lock: cargo_lock,
-        slots: Some(slots),
-        index_url: config.cargo.index_url.clone(),
-    })
+    slots
 }
 
 pub(crate) async fn workspace_root(manifest_path: &Path) -> Result<PathBuf> {
@@ -289,6 +364,7 @@ async fn read_or_resolve_lockfile(
             "Cargo.lock is absent, but --frozen-lockfile forbids generating it"
         ));
     }
+    reject_redirected_workspace(root_dir)?;
 
     let metadata = read_cargo_metadata(root_dir).await?;
     if let Some(lockfile) = resolve_via_pnpr(config, &metadata).await? {
@@ -299,6 +375,32 @@ async fn read_or_resolve_lockfile(
     let lockfile = pnpm_cargo_resolver::resolve_lockfile(&metadata, &index_files, &source)
         .wrap_err("resolve Cargo dependencies")?;
     Ok(lockfile)
+}
+
+/// Refuse to resolve a workspace whose root manifest redirects a dependency
+/// to another source.
+///
+/// `[patch]` and `[replace]` change which package a requirement resolves to,
+/// and `cargo metadata` does not report either, so a lockfile resolved from
+/// it would name the replaced package. An existing `Cargo.lock` is read
+/// rather than resolved, which is how a workspace with a patch installs.
+fn reject_redirected_workspace(root_dir: &Path) -> Result<()> {
+    let manifest_path = root_dir.join("Cargo.toml");
+    let manifest = fs::read_to_string(&manifest_path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("read {}", manifest_path.display()))?;
+    let document: toml::Table = toml::from_str(&manifest)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("parse {}", manifest_path.display()))?;
+    for table in ["patch", "replace"] {
+        if document.contains_key(table) {
+            let manifest_path = manifest_path.display();
+            return Err(miette::miette!(
+                "{manifest_path} declares [{table}], which pnpm cannot resolve. Commit the Cargo.lock that `cargo generate-lockfile` writes for it.",
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Resolve through the configured pnpr server, which walks the sparse
@@ -686,7 +788,7 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     let checksum = package.checksum;
     let slot_for_import = slot.clone();
     tokio::task::spawn_blocking(move || {
-        add_cargo_checksum(store_dir, &mut cas_paths, &checksum)?;
+        add_cargo_checksum(store_dir, &mut cas_paths, Some(&checksum))?;
         import_indexed_dir::<Reporter>(
             &logged_methods,
             package_import_method,
@@ -710,7 +812,7 @@ async fn materialize<Reporter: self::Reporter + 'static>(
 fn add_cargo_checksum(
     store_dir: &StoreDir,
     cas_paths: &mut HashMap<String, PathBuf>,
-    package_checksum: &str,
+    package_checksum: Option<&str>,
 ) -> Result<()> {
     cas_paths.remove(".cargo-checksum.json");
     let files = cas_paths
@@ -733,8 +835,8 @@ fn add_cargo_checksum(
     Ok(())
 }
 
-fn link_workspace(root_dir: &Path, slots: &[(String, PathBuf)]) -> Result<()> {
-    let source_dir = ensure_workspace_directory(root_dir, &[".pnpm", "crates", "crates-io"])?;
+fn link_workspace(root_dir: &Path, directory: &[&str], slots: &[(String, PathBuf)]) -> Result<()> {
+    let source_dir = ensure_workspace_directory(root_dir, directory)?;
     link_workspace_in(&source_dir, slots)
 }
 
@@ -750,12 +852,16 @@ fn link_workspace_in(source_dir: &ManagedDirectory, slots: &[(String, PathBuf)])
     Ok(())
 }
 
-fn write_cargo_config(root_dir: &Path, index_url: &str) -> Result<()> {
+fn write_cargo_config(root_dir: &Path, index_url: &str, git_sources: &[GitSource]) -> Result<()> {
     let cargo_dir = ensure_workspace_directory(root_dir, &[".cargo"])?;
-    write_cargo_config_in(&cargo_dir, index_url)
+    write_cargo_config_in(&cargo_dir, index_url, git_sources)
 }
 
-fn write_cargo_config_in(cargo_dir: &ManagedDirectory, index_url: &str) -> Result<()> {
+fn write_cargo_config_in(
+    cargo_dir: &ManagedDirectory,
+    index_url: &str,
+    git_sources: &[GitSource],
+) -> Result<()> {
     let config_path = cargo_dir.path.join("config.toml");
     let (existing, mode) = match read_workspace_file(cargo_dir, "config.toml") {
         Ok(existing) => existing,
@@ -766,7 +872,7 @@ fn write_cargo_config_in(cargo_dir: &ManagedDirectory, index_url: &str) -> Resul
                 .wrap_err_with(|| format!("read {}", config_path.display()));
         }
     };
-    let updated = update_managed_config(&existing, index_url)?;
+    let updated = update_managed_config(&existing, index_url, git_sources)?;
     if updated != existing {
         write_workspace_file(cargo_dir, "config.toml", updated.as_bytes(), mode)
             .into_diagnostic()
@@ -1184,8 +1290,12 @@ fn force_workspace_symlink(
     pnpm_fs::force_symlink_dir(target, &directory.path.join(name))
 }
 
-fn update_managed_config(existing: &str, index_url: &str) -> Result<String> {
-    let managed_config = managed_config(index_url);
+fn update_managed_config(
+    existing: &str,
+    index_url: &str,
+    git_sources: &[GitSource],
+) -> Result<String> {
+    let managed_config = managed_config(index_url, git_sources);
     match (existing.find(MANAGED_START), existing.find(MANAGED_END)) {
         (None, None) => {
             let separator = if existing.is_empty() || existing.ends_with("\n\n") {
@@ -1207,46 +1317,82 @@ fn update_managed_config(existing: &str, index_url: &str) -> Result<String> {
     }
 }
 
-fn managed_config(index_url: &str) -> String {
-    if is_crates_io(index_url) {
-        return MANAGED_CONFIG.to_string();
+fn managed_config(index_url: &str, git_sources: &[GitSource]) -> String {
+    let crates = CRATES_SOURCE_DIRECTORY.join("/");
+    let mut body = if is_crates_io(index_url) {
+        format!(
+            "[source.crates-io]\nreplace-with = \"pnpm-crates-io\"\n\n[source.pnpm-crates-io]\ndirectory = \"{crates}\"\n",
+        )
+    } else {
+        let source = toml::Value::from(pnpm_cargo_resolver::sparse_source(index_url));
+        format!(
+            "[source.crates-io]\nreplace-with = \"pnpm-registry\"\n\n[source.pnpm-registry]\nregistry = {source}\nreplace-with = \"pnpm-registry-directory\"\n\n[source.pnpm-registry-directory]\ndirectory = \"{crates}\"\n",
+        )
+    };
+    if !git_sources.is_empty() {
+        let git = GIT_SOURCE_DIRECTORY.join("/");
+        let blocks = git_sources.iter().fold(String::new(), |mut blocks, source| {
+            blocks.push('\n');
+            blocks.push_str(&source.config_block());
+            blocks
+        });
+        body = format!("{body}\n[source.{GIT_SOURCE_NAME}]\ndirectory = \"{git}\"\n{blocks}");
     }
-    let source = toml::Value::from(pnpm_cargo_resolver::sparse_source(index_url));
-    format!(
-        "{MANAGED_START}\n[source.crates-io]\nreplace-with = \"pnpm-registry\"\n\n[source.pnpm-registry]\nregistry = {source}\nreplace-with = \"pnpm-registry-directory\"\n\n[source.pnpm-registry-directory]\ndirectory = \".pnpm/crates/crates-io\"\n{MANAGED_END}",
-    )
+    format!("{MANAGED_START}\n{body}{MANAGED_END}")
 }
 
-fn parse_lockfile(input: &str, index_url: &str) -> Result<Vec<LockedCrate>> {
+fn parse_lockfile(input: &str, index_url: &str) -> Result<LockedPackages> {
     let lockfile =
         cargo_lock::Lockfile::from_str(input).into_diagnostic().wrap_err("parse Cargo.lock")?;
-    let mut packages = Vec::new();
+    let mut packages = LockedPackages::default();
+    // One repository serves every package a checkout of it provides, so the
+    // packages of a source share the description of it.
+    let mut git_sources: BTreeMap<String, Arc<GitSource>> = BTreeMap::new();
     for package in lockfile.packages {
-        if let Some(package) = locked_crate_from_package(package, index_url)? {
-            packages.push(package);
+        let Some(source) = package.source.as_ref() else {
+            continue;
+        };
+        if source.is_git() {
+            let name = package.name.to_string();
+            let version = package.version.to_string();
+            validate_package_identity(&name, &version)?;
+            let source = match git_sources.entry(source.to_string()) {
+                std::collections::btree_map::Entry::Occupied(known) => Arc::clone(known.get()),
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    Arc::clone(slot.insert(Arc::new(GitSource::from_source_id(source)?)))
+                }
+            };
+            packages.git.push(GitPackage { name, version, source });
+            continue;
         }
+        let crate_source = source.clone();
+        packages.crates.push(locked_crate_from_package(package, &crate_source, index_url)?);
     }
 
-    let mut names = BTreeSet::new();
-    for package in &packages {
-        let link_name = package.link_name();
-        if !names.insert(link_name.clone()) {
+    reject_duplicate_links("registry", packages.crates.iter().map(LockedCrate::link_name))?;
+    reject_duplicate_links("git", packages.git.iter().map(GitPackage::link_name))?;
+    Ok(packages)
+}
+
+/// Two packages that link into one Cargo directory source under the same
+/// name are the same package to `cargo`, whichever of them it reads.
+fn reject_duplicate_links(kind: &str, link_names: impl Iterator<Item = String>) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for link_name in link_names {
+        if !seen.insert(link_name.clone()) {
             return Err(miette::miette!(
-                "Cargo.lock contains duplicate crates.io package {}",
-                link_name,
+                "Cargo.lock contains duplicate {kind} package {link_name}",
             ));
         }
     }
-    Ok(packages)
+    Ok(())
 }
 
 fn locked_crate_from_package(
     package: cargo_lock::Package,
+    source: &cargo_lock::SourceId,
     index_url: &str,
-) -> Result<Option<LockedCrate>> {
-    let Some(source) = package.source.as_ref() else {
-        return Ok(None);
-    };
+) -> Result<LockedCrate> {
     // crates.io is spelled two ways in a lockfile — the canonical git
     // identifier and the sparse index — and `cargo` writes either.
     let expected_source = pnpm_cargo_resolver::registry_source(index_url);
@@ -1266,16 +1412,22 @@ fn locked_crate_from_package(
         .checksum
         .ok_or_else(|| miette::miette!("registry package {name} {version} has no checksum"))?
         .to_string();
-    validate_package_field("crate name", &name, |byte| {
-        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
-    })?;
-    validate_package_field("crate version", &version, |byte| {
-        byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+')
-    })?;
+    validate_package_identity(&name, &version)?;
     if checksum.len() != 64 || !checksum.bytes().all(|byte| byte.is_ascii_hexdigit()) {
         return Err(miette::miette!("invalid checksum for crate {name} {version}"));
     }
-    Ok(Some(LockedCrate { name, version, checksum: checksum.to_ascii_lowercase() }))
+    Ok(LockedCrate { name, version, checksum: checksum.to_ascii_lowercase() })
+}
+
+/// Both names reach the filesystem as the `<name>-<version>` directory a
+/// Cargo source is linked under.
+fn validate_package_identity(name: &str, version: &str) -> Result<()> {
+    validate_package_field("crate name", name, |byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+    })?;
+    validate_package_field("crate version", version, |byte| {
+        byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'+')
+    })
 }
 
 fn validate_package_field(label: &str, value: &str, allowed: impl Fn(u8) -> bool) -> Result<()> {

--- a/pnpm/crates/cli/src/cargo_deps/git.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git.rs
@@ -9,6 +9,7 @@
 
 use super::add_cargo_checksum;
 use cargo_lock::package::GitReference;
+use futures_util::{StreamExt, stream};
 use miette::{IntoDiagnostic, Result, WrapErr};
 use pnpm_config::PackageImportMethod;
 use pnpm_deps_restorer::{ImportIndexedDirOpts, import_indexed_dir};
@@ -64,6 +65,7 @@ pub(crate) struct VendorOptions {
     pub(crate) git_shallow_hosts: &'static [String],
     pub(crate) package_import_method: PackageImportMethod,
     pub(crate) logged_methods: Arc<AtomicU8>,
+    pub(crate) concurrency: usize,
     pub(crate) offline: bool,
 }
 
@@ -139,34 +141,43 @@ pub(crate) async fn vendor<Reporter: self::Reporter + 'static>(
         git_shallow_hosts,
         package_import_method,
         logged_methods,
+        concurrency,
         offline,
     } = options;
     let mut sources: BTreeMap<Arc<GitSource>, Vec<GitPackage>> = BTreeMap::new();
     for package in packages {
         sources.entry(Arc::clone(&package.source)).or_default().push(package);
     }
-    let mut vendored = Vec::new();
-    for (source, packages) in sources {
-        let logged_methods = Arc::clone(&logged_methods);
-        // Cloning a repository and copying the files out of it is blocking
-        // work. Each repository is checked out once, for every package it
-        // provides.
-        let linked = tokio::task::spawn_blocking(move || {
-            vendor_source::<Reporter>(&VendorSourceOptions {
-                source: &source,
-                packages: &packages,
-                store_dir,
-                git_shallow_hosts,
-                package_import_method,
-                logged_methods: &logged_methods,
-                offline,
-            })
+    let mut vendored = stream::iter(sources)
+        .map(|(source, packages)| {
+            let logged_methods = Arc::clone(&logged_methods);
+            // Cloning a repository and copying the files out of it is
+            // blocking work. Each repository is checked out once, for
+            // every package it provides.
+            async move {
+                tokio::task::spawn_blocking(move || {
+                    vendor_source::<Reporter>(&VendorSourceOptions {
+                        source: &source,
+                        packages: &packages,
+                        store_dir,
+                        git_shallow_hosts,
+                        package_import_method,
+                        logged_methods: &logged_methods,
+                        offline,
+                    })
+                })
+                .await
+                .into_diagnostic()
+                .wrap_err("join git package vendoring task")?
+            }
         })
+        .buffer_unordered(concurrency)
+        .collect::<Vec<_>>()
         .await
-        .into_diagnostic()
-        .wrap_err("join git package vendoring task")??;
-        vendored.extend(linked);
-    }
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?
+        .concat();
+    vendored.sort();
     Ok(vendored)
 }
 
@@ -232,6 +243,9 @@ fn vendor_source<Reporter: self::Reporter>(
     .wrap_err_with(|| format!("check out {repository} at {}", source.commit))?;
     let checked_out = Checkout::read(checkout.path())?;
     let package_dirs = checked_out.package_dirs();
+    let checkout_root = dunce::canonicalize(checkout.path())
+        .into_diagnostic()
+        .wrap_err_with(|| format!("resolve the checkout of {repository}"))?;
 
     for (package, slot) in missing {
         let found = checked_out.find(&package.name, &package.version)?.ok_or_else(|| {
@@ -242,7 +256,7 @@ fn vendor_source<Reporter: self::Reporter>(
                 package.version,
             )
         })?;
-        let cas_paths = import_package(store_dir, &found, &package_dirs)?;
+        let cas_paths = import_package(store_dir, &checkout_root, &found, &package_dirs)?;
         import_indexed_dir::<Reporter>(
             logged_methods,
             package_import_method,
@@ -275,26 +289,31 @@ struct Manifest {
 }
 
 /// The manifests a git checkout holds, keyed by the directory each one
-/// describes.
+/// describes, and the directories each crate name is declared in.
 struct Checkout {
     manifests: BTreeMap<PathBuf, Manifest>,
+    directories_by_crate: BTreeMap<String, Vec<PathBuf>>,
 }
 
 impl Checkout {
     fn read(root: &Path) -> Result<Self> {
         let mut manifests = BTreeMap::new();
         collect_manifests(root, &mut manifests)?;
-        Ok(Self { manifests })
+        let mut directories_by_crate: BTreeMap<String, Vec<PathBuf>> = BTreeMap::new();
+        for (dir, manifest) in &manifests {
+            if let Some(name) = package_name(&manifest.document) {
+                directories_by_crate.entry(name.to_string()).or_default().push(dir.clone());
+            }
+        }
+        Ok(Self { manifests, directories_by_crate })
     }
 
     /// The directory holding `name` at `version`, if the checkout has one.
     /// A package's name is never inherited, so only the manifests already
     /// naming this crate are resolved against their workspace.
     fn find(&self, name: &str, version: &str) -> Result<Option<CheckoutPackage>> {
-        for (dir, manifest) in &self.manifests {
-            if package_name(&manifest.document) != Some(name) {
-                continue;
-            }
+        for dir in self.directories_by_crate.get(name).map(Vec::as_slice).unwrap_or_default() {
+            let manifest = &self.manifests[dir];
             let workspace = workspace_manifest(dir, &manifest.document, &self.manifests);
             let package = vendored_package(manifest, workspace)
                 .wrap_err_with(|| format!("read {}", dir.join("Cargo.toml").display()))?;
@@ -308,11 +327,7 @@ impl Checkout {
 
     /// Every directory in the checkout that `cargo` reads a package from.
     fn package_dirs(&self) -> BTreeSet<&Path> {
-        self.manifests
-            .iter()
-            .filter(|(_, manifest)| package_name(&manifest.document).is_some())
-            .map(|(dir, _)| dir.as_path())
-            .collect()
+        self.directories_by_crate.values().flatten().map(PathBuf::as_path).collect()
     }
 }
 
@@ -379,7 +394,10 @@ fn workspace_manifest<'a>(
         return Some(document);
     }
     if let Some(path) = document.get("package").and_then(|package| package.get("workspace")) {
-        return Some(&manifests.get(&dir.join(path.as_str()?))?.document);
+        // `Path::join` keeps `..` verbatim, and the checkout was walked
+        // into paths that carry none.
+        let root = pnpm_fs::lexical_normalize(&dir.join(path.as_str()?));
+        return Some(&manifests.get(&root)?.document);
     }
     dir.ancestors().skip(1).find_map(|ancestor| {
         let document = &manifests.get(ancestor)?.document;
@@ -532,6 +550,9 @@ fn inherits_from_workspace(value: &toml::Value) -> bool {
 
 struct ImportContext<'a> {
     store_dir: &'a StoreDir,
+    /// Canonical root of the checkout. A link resolving outside it points
+    /// at something the repository does not contain.
+    root: &'a Path,
     /// Packages nested inside the one being imported. They are vendored
     /// into directories of their own, the way `cargo` keeps a workspace
     /// member out of its root package's file list.
@@ -543,11 +564,13 @@ struct ImportContext<'a> {
 /// vendored manifest in place of the committed one.
 fn import_package(
     store_dir: &StoreDir,
+    root: &Path,
     package: &CheckoutPackage,
     package_dirs: &BTreeSet<&Path>,
 ) -> Result<HashMap<String, PathBuf>> {
     let context = ImportContext {
         store_dir,
+        root,
         nested: package_dirs
             .iter()
             .copied()
@@ -570,51 +593,95 @@ fn import_directory(
     for entry in read_directory(dir)? {
         let name = entry.file_name();
         let name = name.to_string_lossy();
-        // Symlinks are not followed: a target outside the checkout would
-        // put a file the repository does not contain into the store.
-        let file_type = entry_file_type(&entry)?;
         let path = entry.path();
-        if file_type.is_dir() {
-            if EXCLUDED_DIRECTORIES.contains(&name.as_ref())
-                || context.nested.contains(path.as_path())
-            {
-                continue;
+        match entry_kind(context.root, &entry)? {
+            Some(EntryKind::Directory) => {
+                if EXCLUDED_DIRECTORIES.contains(&name.as_ref())
+                    || context.nested.contains(path.as_path())
+                {
+                    continue;
+                }
+                import_directory(context, &path, &format!("{prefix}{name}/"), cas_paths)?;
             }
-            import_directory(context, &path, &format!("{prefix}{name}/"), cas_paths)?;
-        } else if file_type.is_file() {
-            let relative = format!("{prefix}{name}");
-            let contents = if relative == "Cargo.toml" {
-                context.manifest.as_bytes().to_vec()
-            } else {
-                fs::read(&path)
-                    .into_diagnostic()
-                    .wrap_err_with(|| format!("read {}", path.display()))?
-            };
-            let (cas_path, _) = context
-                .store_dir
-                .write_cas_file(&contents, is_executable(&entry)?)
-                .into_diagnostic()
+            Some(EntryKind::File { executable }) => {
+                let relative = format!("{prefix}{name}");
+                let cas_path = if relative == "Cargo.toml" {
+                    context
+                        .store_dir
+                        .write_cas_file(context.manifest.as_bytes(), executable)
+                        .into_diagnostic()
+                        .map(|(cas_path, _)| cas_path)
+                } else {
+                    // Streamed rather than read whole: a repository is free
+                    // to carry a file larger than the install's memory.
+                    let mut file = fs::File::open(&path)
+                        .into_diagnostic()
+                        .wrap_err_with(|| format!("read {}", path.display()))?;
+                    context
+                        .store_dir
+                        .write_cas_file_from_reader(&mut file, executable, None)
+                        .into_diagnostic()
+                        .map(|(cas_path, _, _)| cas_path)
+                }
                 .wrap_err_with(|| format!("store {}", path.display()))?;
-            cas_paths.insert(relative, cas_path);
+                cas_paths.insert(relative, cas_path);
+            }
+            None => {}
         }
     }
     Ok(())
 }
 
+enum EntryKind {
+    Directory,
+    File { executable: bool },
+}
+
+/// What a directory entry contributes to the vendored package.
+///
+/// A symlinked file is vendored as what it points at, which is how
+/// `cargo` reads one out of a checkout. `None` for an entry the package
+/// cannot carry: a link that leaves the checkout or dangles, a symlinked
+/// directory, which could equally lead back into its own parent, and
+/// anything that is neither a file nor a directory.
+fn entry_kind(root: &Path, entry: &fs::DirEntry) -> Result<Option<EntryKind>> {
+    let path = entry.path();
+    if entry_file_type(entry)?.is_symlink() {
+        let Ok(target) = dunce::canonicalize(&path) else {
+            return Ok(None);
+        };
+        if !target.starts_with(root) || !target.is_file() {
+            return Ok(None);
+        }
+    }
+    let metadata = match fs::metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("inspect {}", path.display()));
+        }
+    };
+    Ok(if metadata.is_dir() {
+        Some(EntryKind::Directory)
+    } else if metadata.is_file() {
+        Some(EntryKind::File { executable: is_executable(&metadata) })
+    } else {
+        None
+    })
+}
+
 #[cfg(unix)]
-fn is_executable(entry: &fs::DirEntry) -> Result<bool> {
+fn is_executable(metadata: &fs::Metadata) -> bool {
     use std::os::unix::fs::PermissionsExt as _;
 
-    let metadata = entry
-        .metadata()
-        .into_diagnostic()
-        .wrap_err_with(|| format!("inspect {}", entry.path().display()))?;
-    Ok(pnpm_fs::file_mode::is_executable(metadata.permissions().mode()))
+    pnpm_fs::file_mode::is_executable(metadata.permissions().mode())
 }
 
 #[cfg(not(unix))]
-fn is_executable(_entry: &fs::DirEntry) -> Result<bool> {
-    Ok(false)
+fn is_executable(_metadata: &fs::Metadata) -> bool {
+    false
 }
 
 #[cfg(test)]

--- a/pnpm/crates/cli/src/cargo_deps/git.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git.rs
@@ -1,0 +1,621 @@
+//! Vendor the git-sourced packages a `Cargo.lock` pins, so a workspace that
+//! patches a crate with a git revision installs and builds from the store.
+//!
+//! The layout is the one `cargo vendor` produces for a git package: one
+//! directory per package holding its source and a `.cargo-checksum.json`
+//! whose `package` field is null, reached through a Cargo directory source
+//! that replaces the git source. Cargo then resolves the pinned revision
+//! without a fetch of its own.
+
+use super::add_cargo_checksum;
+use cargo_lock::package::GitReference;
+use miette::{IntoDiagnostic, Result, WrapErr};
+use pnpm_config::PackageImportMethod;
+use pnpm_deps_restorer::{ImportIndexedDirOpts, import_indexed_dir};
+use pnpm_git_fetcher::{CheckoutOptions, checkout_commit};
+use pnpm_network::redact_and_sanitize;
+use pnpm_reporter::Reporter;
+use pnpm_store_dir::StoreDir;
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap},
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{Arc, atomic::AtomicU8},
+};
+
+/// Directory the vendored git packages are linked into, relative to the
+/// Cargo workspace root. Registry crates keep their own directory: a git
+/// package and a registry crate of the same name and version are distinct
+/// packages, and one directory source cannot hold both.
+pub(crate) const GIT_SOURCE_DIRECTORY: [&str; 3] = [".pnpm", "crates", "git"];
+/// Name of the Cargo directory source every replaced git source points at.
+pub(crate) const GIT_SOURCE_NAME: &str = "pnpm-git";
+/// The dependency kinds a manifest can declare, each of them inheritable.
+const DEPENDENCY_KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
+/// Directories `cargo` never reads a package's sources from.
+const EXCLUDED_DIRECTORIES: [&str; 2] = [".git", "target"];
+
+/// A git repository at one revision, as `Cargo.lock` spells it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct GitSource {
+    /// The source identifier without the commit fragment — `git+<url>`
+    /// followed by the `rev`, `tag` or `branch` query the manifest asked
+    /// for. Cargo reads it back as a source-replacement key.
+    id: String,
+    url: String,
+    /// The query pair the identifier carries, absent for a dependency on
+    /// the repository's default branch.
+    reference: Option<(&'static str, String)>,
+    /// The commit the lockfile resolved the reference to.
+    commit: String,
+}
+
+/// One package `Cargo.lock` takes from a [`GitSource`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GitPackage {
+    pub(crate) name: String,
+    pub(crate) version: String,
+    pub(crate) source: Arc<GitSource>,
+}
+
+pub(crate) struct VendorOptions {
+    pub(crate) packages: Vec<GitPackage>,
+    pub(crate) store_dir: &'static StoreDir,
+    pub(crate) git_shallow_hosts: &'static [String],
+    pub(crate) package_import_method: PackageImportMethod,
+    pub(crate) logged_methods: Arc<AtomicU8>,
+    pub(crate) offline: bool,
+}
+
+impl GitSource {
+    /// The source `cargo` recorded for a git-sourced package, or an error
+    /// when the lockfile leaves the revision unpinned.
+    pub(crate) fn from_source_id(source: &cargo_lock::SourceId) -> Result<Self> {
+        let url = source.url().to_string();
+        let reference = match source.git_reference() {
+            Some(GitReference::Branch(branch)) => Some(("branch", branch.clone())),
+            Some(GitReference::Tag(tag)) => Some(("tag", tag.clone())),
+            Some(GitReference::Rev(rev)) => Some(("rev", rev.clone())),
+            Some(GitReference::DefaultBranch) | None => None,
+        };
+        let Some(commit) = source.precise() else {
+            let source = redact_and_sanitize(&source.to_string());
+            return Err(miette::miette!("Cargo source {source} pins no commit"));
+        };
+        if commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+            let repository = redact_and_sanitize(&url);
+            return Err(miette::miette!(
+                "Cargo source {repository} names {commit:?}, which is not a commit hash",
+            ));
+        }
+        Ok(Self {
+            id: source.with_precise(None).to_string(),
+            url,
+            reference,
+            commit: commit.to_ascii_lowercase(),
+        })
+    }
+
+    /// The `[source."…"]` block that sends this git source to the vendored
+    /// directory, keyed the way `cargo vendor` writes it.
+    pub(crate) fn config_block(&self) -> String {
+        let reference = self.reference.as_ref().map_or_else(String::new, |(key, value)| {
+            format!("{key} = {}\n", toml::Value::from(value.as_str()))
+        });
+        format!(
+            "[source.{}]\ngit = {}\n{reference}replace-with = {}\n",
+            toml::Value::from(self.id.as_str()),
+            toml::Value::from(self.url.as_str()),
+            toml::Value::from(GIT_SOURCE_NAME),
+        )
+    }
+}
+
+impl GitPackage {
+    pub(crate) fn link_name(&self) -> String {
+        format!("{}-{}", self.name, self.version)
+    }
+
+    /// The commit identifies the source tree the package was vendored from,
+    /// so it takes the place the registry checksum holds in
+    /// [`super::LockedCrate::store_slot`].
+    fn store_slot(&self, store_root: &Path) -> PathBuf {
+        store_root
+            .join("crates")
+            .join(&self.name)
+            .join(&self.version)
+            .join(format!("git-{}", self.source.commit))
+    }
+}
+
+/// Materialize every git package into the store, returning the
+/// `link name → store slot` pairs the workspace directory source links.
+pub(crate) async fn vendor<Reporter: self::Reporter + 'static>(
+    options: VendorOptions,
+) -> Result<Vec<(String, PathBuf)>> {
+    let VendorOptions {
+        packages,
+        store_dir,
+        git_shallow_hosts,
+        package_import_method,
+        logged_methods,
+        offline,
+    } = options;
+    let mut sources: BTreeMap<Arc<GitSource>, Vec<GitPackage>> = BTreeMap::new();
+    for package in packages {
+        sources.entry(Arc::clone(&package.source)).or_default().push(package);
+    }
+    let mut vendored = Vec::new();
+    for (source, packages) in sources {
+        let logged_methods = Arc::clone(&logged_methods);
+        // Cloning a repository and copying the files out of it is blocking
+        // work. Each repository is checked out once, for every package it
+        // provides.
+        let linked = tokio::task::spawn_blocking(move || {
+            vendor_source::<Reporter>(&VendorSourceOptions {
+                source: &source,
+                packages: &packages,
+                store_dir,
+                git_shallow_hosts,
+                package_import_method,
+                logged_methods: &logged_methods,
+                offline,
+            })
+        })
+        .await
+        .into_diagnostic()
+        .wrap_err("join git package vendoring task")??;
+        vendored.extend(linked);
+    }
+    Ok(vendored)
+}
+
+struct VendorSourceOptions<'a> {
+    source: &'a GitSource,
+    packages: &'a [GitPackage],
+    store_dir: &'a StoreDir,
+    git_shallow_hosts: &'a [String],
+    package_import_method: PackageImportMethod,
+    logged_methods: &'a AtomicU8,
+    offline: bool,
+}
+
+fn vendor_source<Reporter: self::Reporter>(
+    options: &VendorSourceOptions<'_>,
+) -> Result<Vec<(String, PathBuf)>> {
+    let &VendorSourceOptions {
+        source,
+        packages,
+        store_dir,
+        git_shallow_hosts,
+        package_import_method,
+        logged_methods,
+        offline,
+    } = options;
+    let mut linked = Vec::with_capacity(packages.len());
+    let mut missing = Vec::new();
+    for package in packages {
+        let slot = package.store_slot(store_dir.root());
+        // The checksum manifest sorts first among a crate's files, which
+        // makes it the completion marker `import_indexed_dir` writes last.
+        if slot.join(".cargo-checksum.json").exists() {
+            linked.push((package.link_name(), slot));
+        } else {
+            missing.push((package, slot));
+        }
+    }
+    if missing.is_empty() {
+        return Ok(linked);
+    }
+    let repository = redact_and_sanitize(&source.url);
+    if offline {
+        return Err(miette::miette!(
+            "cannot check out {repository} at {} while offline",
+            source.commit,
+        ));
+    }
+
+    let checkout = tempfile::tempdir()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("create a checkout directory for {repository}"))?;
+    checkout_commit(&CheckoutOptions {
+        repo: &source.url,
+        commit: &source.commit,
+        git_shallow_hosts,
+        git_bin: None,
+        dest: checkout.path(),
+    })
+    .map_err(|error| {
+        let error = redact_and_sanitize(&error.to_string());
+        miette::miette!("{error}")
+    })
+    .wrap_err_with(|| format!("check out {repository} at {}", source.commit))?;
+    let checked_out = Checkout::read(checkout.path())?;
+    let package_dirs = checked_out.package_dirs();
+
+    for (package, slot) in missing {
+        let found = checked_out.find(&package.name, &package.version)?.ok_or_else(|| {
+            miette::miette!(
+                "{repository} at {} holds no crate {} {}",
+                source.commit,
+                package.name,
+                package.version,
+            )
+        })?;
+        let cas_paths = import_package(store_dir, &found, &package_dirs)?;
+        import_indexed_dir::<Reporter>(
+            logged_methods,
+            package_import_method,
+            &slot,
+            &cas_paths,
+            ImportIndexedDirOpts {
+                force: true,
+                safe_to_skip: true,
+                ..ImportIndexedDirOpts::default()
+            },
+        )
+        .into_diagnostic()
+        .wrap_err_with(|| format!("materialize cargo package at {}", slot.display()))?;
+        linked.push((package.link_name(), slot));
+    }
+    Ok(linked)
+}
+
+/// A package found in a git checkout, with the manifest the vendored
+/// directory holds in place of the one the repository committed.
+struct CheckoutPackage {
+    dir: PathBuf,
+    manifest: String,
+}
+
+/// A `Cargo.toml` in a git checkout, as text and as a document.
+struct Manifest {
+    text: String,
+    document: toml::Table,
+}
+
+/// The manifests a git checkout holds, keyed by the directory each one
+/// describes.
+struct Checkout {
+    manifests: BTreeMap<PathBuf, Manifest>,
+}
+
+impl Checkout {
+    fn read(root: &Path) -> Result<Self> {
+        let mut manifests = BTreeMap::new();
+        collect_manifests(root, &mut manifests)?;
+        Ok(Self { manifests })
+    }
+
+    /// The directory holding `name` at `version`, if the checkout has one.
+    /// A package's name is never inherited, so only the manifests already
+    /// naming this crate are resolved against their workspace.
+    fn find(&self, name: &str, version: &str) -> Result<Option<CheckoutPackage>> {
+        for (dir, manifest) in &self.manifests {
+            if package_name(&manifest.document) != Some(name) {
+                continue;
+            }
+            let workspace = workspace_manifest(dir, &manifest.document, &self.manifests);
+            let package = vendored_package(manifest, workspace)
+                .wrap_err_with(|| format!("read {}", dir.join("Cargo.toml").display()))?;
+            if package.version != version {
+                continue;
+            }
+            return Ok(Some(CheckoutPackage { dir: dir.clone(), manifest: package.manifest }));
+        }
+        Ok(None)
+    }
+
+    /// Every directory in the checkout that `cargo` reads a package from.
+    fn package_dirs(&self) -> BTreeSet<&Path> {
+        self.manifests
+            .iter()
+            .filter(|(_, manifest)| package_name(&manifest.document).is_some())
+            .map(|(dir, _)| dir.as_path())
+            .collect()
+    }
+}
+
+fn package_name(document: &toml::Table) -> Option<&str> {
+    document.get("package")?.get("name")?.as_str()
+}
+
+/// Read the `Cargo.toml` of every directory under `dir`.
+///
+/// A manifest that does not parse is passed over rather than failing the
+/// checkout, the way `cargo` reads the packages of a git repository: a
+/// repository is free to carry a fixture manifest no package is built
+/// from.
+fn collect_manifests(dir: &Path, manifests: &mut BTreeMap<PathBuf, Manifest>) -> Result<()> {
+    let manifest_path = dir.join("Cargo.toml");
+    match fs::read_to_string(&manifest_path) {
+        Ok(text) => {
+            if let Ok(document) = toml::from_str(&text) {
+                manifests.insert(dir.to_path_buf(), Manifest { text, document });
+            }
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("read {}", manifest_path.display()));
+        }
+    }
+    for entry in read_directory(dir)? {
+        // Symlinked directories are left alone: one can leave the checkout,
+        // and a loop through one would not terminate.
+        if entry_file_type(&entry)?.is_dir()
+            && !EXCLUDED_DIRECTORIES.contains(&entry.file_name().to_string_lossy().as_ref())
+        {
+            collect_manifests(&entry.path(), manifests)?;
+        }
+    }
+    Ok(())
+}
+
+fn read_directory(dir: &Path) -> Result<Vec<fs::DirEntry>> {
+    fs::read_dir(dir)
+        .and_then(Iterator::collect::<io::Result<Vec<_>>>)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("read {}", dir.display()))
+}
+
+fn entry_file_type(entry: &fs::DirEntry) -> Result<fs::FileType> {
+    entry
+        .file_type()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("inspect {}", entry.path().display()))
+}
+
+/// The manifest whose `[workspace]` table `dir`'s package inherits from,
+/// following `cargo`'s rule: the `package.workspace` path when set, and
+/// otherwise the closest ancestor within the checkout that declares one.
+fn workspace_manifest<'a>(
+    dir: &Path,
+    document: &'a toml::Table,
+    manifests: &'a BTreeMap<PathBuf, Manifest>,
+) -> Option<&'a toml::Table> {
+    if document.contains_key("workspace") {
+        return Some(document);
+    }
+    if let Some(path) = document.get("package").and_then(|package| package.get("workspace")) {
+        return Some(&manifests.get(&dir.join(path.as_str()?))?.document);
+    }
+    dir.ancestors().skip(1).find_map(|ancestor| {
+        let document = &manifests.get(ancestor)?.document;
+        document.contains_key("workspace").then_some(document)
+    })
+}
+
+/// A manifest resolved against its workspace, and the version `cargo`
+/// reads from it.
+#[derive(Debug)]
+struct VendoredPackage {
+    version: String,
+    manifest: String,
+}
+
+/// Resolve every `workspace = true` inheritance marker against `workspace`
+/// and drop the `[workspace]` table, so the package's directory carries
+/// everything its manifest refers to.
+///
+/// The manifest text is kept verbatim when it inherits nothing, which
+/// preserves a single-crate repository's own formatting.
+fn vendored_package(
+    manifest: &Manifest,
+    workspace: Option<&toml::Table>,
+) -> Result<VendoredPackage> {
+    let workspace = workspace.and_then(|manifest| manifest.get("workspace")?.as_table());
+    let mut vendored = manifest.document.clone();
+    let mut inherited = false;
+    if let Some(package) = vendored.get_mut("package").and_then(toml::Value::as_table_mut) {
+        let workspace_package =
+            workspace.and_then(|workspace| workspace.get("package")?.as_table());
+        for (field, value) in package.iter_mut() {
+            if !inherits_from_workspace(value) {
+                continue;
+            }
+            *value = workspace_package
+                .and_then(|package| package.get(field))
+                .ok_or_else(|| {
+                    miette::miette!("the workspace declares no `package.{field}` to inherit")
+                })?
+                .clone();
+            inherited = true;
+        }
+    }
+    inherited |= inherit_dependencies(&mut vendored, workspace)?;
+    if let Some(lints) = vendored.get_mut("lints").filter(|lints| inherits_from_workspace(lints)) {
+        *lints = workspace
+            .and_then(|workspace| workspace.get("lints"))
+            .ok_or_else(|| miette::miette!("the workspace declares no `lints` to inherit"))?
+            .clone();
+        inherited = true;
+    }
+    // A `[workspace]` table left in place names members the vendored
+    // directory does not hold, and `cargo` reads it as a workspace root.
+    let had_workspace = vendored.remove("workspace").is_some();
+
+    let version = vendored
+        .get("package")
+        .and_then(|package| package.get("version")?.as_str())
+        .ok_or_else(|| miette::miette!("the package declares no version"))?
+        .to_string();
+    let text = if inherited || had_workspace {
+        toml::to_string(&vendored).into_diagnostic().wrap_err("serialize Cargo.toml")?
+    } else {
+        manifest.text.clone()
+    };
+    Ok(VendoredPackage { version, manifest: text })
+}
+
+/// Resolve the inheritance markers in every dependency table the manifest
+/// declares, including the per-target ones. Reports whether anything was
+/// inherited.
+fn inherit_dependencies(
+    document: &mut toml::Table,
+    workspace: Option<&toml::Table>,
+) -> Result<bool> {
+    let mut inherited = false;
+    for kind in DEPENDENCY_KINDS {
+        if let Some(table) = document.get_mut(kind).and_then(toml::Value::as_table_mut) {
+            inherited |= inherit_dependency_table(table, workspace)?;
+        }
+    }
+    if let Some(targets) = document.get_mut("target").and_then(toml::Value::as_table_mut) {
+        for (_, target) in targets.iter_mut() {
+            for kind in DEPENDENCY_KINDS {
+                if let Some(table) = target.get_mut(kind).and_then(toml::Value::as_table_mut) {
+                    inherited |= inherit_dependency_table(table, workspace)?;
+                }
+            }
+        }
+    }
+    Ok(inherited)
+}
+
+/// Replace each `dep.workspace = true` entry with the workspace's
+/// declaration of that dependency, keeping the `features`, `optional`,
+/// `public` and `default-features` the member added.
+fn inherit_dependency_table(
+    dependencies: &mut toml::Table,
+    workspace: Option<&toml::Table>,
+) -> Result<bool> {
+    let mut inherited = false;
+    for (name, declaration) in dependencies.iter_mut() {
+        if !inherits_from_workspace(declaration) {
+            continue;
+        }
+        let declared =
+            workspace.and_then(|workspace| workspace.get("dependencies")?.get(name)).ok_or_else(
+                || miette::miette!("the workspace declares no dependency {name} to inherit"),
+            )?;
+        let mut merged = match declared {
+            toml::Value::String(version) => {
+                toml::Table::from_iter([("version".to_string(), version.as_str().into())])
+            }
+            toml::Value::Table(table) => table.clone(),
+            _ => {
+                return Err(miette::miette!(
+                    "the workspace declares dependency {name} as neither a version nor a table",
+                ));
+            }
+        };
+        let local = declaration.as_table().expect("an inheriting entry is a table");
+        for key in ["optional", "public", "default-features"] {
+            if let Some(value) = local.get(key) {
+                merged.insert(key.to_string(), value.clone());
+            }
+        }
+        // A member's features add to the workspace's rather than replace them.
+        let features = merged
+            .get("features")
+            .into_iter()
+            .chain(local.get("features"))
+            .filter_map(toml::Value::as_array)
+            .flatten()
+            .cloned()
+            .collect::<Vec<_>>();
+        if !features.is_empty() {
+            merged.insert("features".to_string(), features.into());
+        }
+        *declaration = merged.into();
+        inherited = true;
+    }
+    Ok(inherited)
+}
+
+/// Whether a manifest entry defers to the workspace (`x.workspace = true`).
+fn inherits_from_workspace(value: &toml::Value) -> bool {
+    value.get("workspace").and_then(toml::Value::as_bool).unwrap_or(false)
+}
+
+struct ImportContext<'a> {
+    store_dir: &'a StoreDir,
+    /// Packages nested inside the one being imported. They are vendored
+    /// into directories of their own, the way `cargo` keeps a workspace
+    /// member out of its root package's file list.
+    nested: BTreeSet<&'a Path>,
+    manifest: &'a str,
+}
+
+/// Write a package's files into the content-addressed store, with the
+/// vendored manifest in place of the committed one.
+fn import_package(
+    store_dir: &StoreDir,
+    package: &CheckoutPackage,
+    package_dirs: &BTreeSet<&Path>,
+) -> Result<HashMap<String, PathBuf>> {
+    let context = ImportContext {
+        store_dir,
+        nested: package_dirs
+            .iter()
+            .copied()
+            .filter(|dir| *dir != package.dir && dir.starts_with(&package.dir))
+            .collect(),
+        manifest: &package.manifest,
+    };
+    let mut cas_paths = HashMap::new();
+    import_directory(&context, &package.dir, "", &mut cas_paths)?;
+    add_cargo_checksum(store_dir, &mut cas_paths, None)?;
+    Ok(cas_paths)
+}
+
+fn import_directory(
+    context: &ImportContext<'_>,
+    dir: &Path,
+    prefix: &str,
+    cas_paths: &mut HashMap<String, PathBuf>,
+) -> Result<()> {
+    for entry in read_directory(dir)? {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        // Symlinks are not followed: a target outside the checkout would
+        // put a file the repository does not contain into the store.
+        let file_type = entry_file_type(&entry)?;
+        let path = entry.path();
+        if file_type.is_dir() {
+            if EXCLUDED_DIRECTORIES.contains(&name.as_ref())
+                || context.nested.contains(path.as_path())
+            {
+                continue;
+            }
+            import_directory(context, &path, &format!("{prefix}{name}/"), cas_paths)?;
+        } else if file_type.is_file() {
+            let relative = format!("{prefix}{name}");
+            let contents = if relative == "Cargo.toml" {
+                context.manifest.as_bytes().to_vec()
+            } else {
+                fs::read(&path)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("read {}", path.display()))?
+            };
+            let (cas_path, _) = context
+                .store_dir
+                .write_cas_file(&contents, is_executable(&entry)?)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("store {}", path.display()))?;
+            cas_paths.insert(relative, cas_path);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_executable(entry: &fs::DirEntry) -> Result<bool> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let metadata = entry
+        .metadata()
+        .into_diagnostic()
+        .wrap_err_with(|| format!("inspect {}", entry.path().display()))?;
+    Ok(pnpm_fs::file_mode::is_executable(metadata.permissions().mode()))
+}
+
+#[cfg(not(unix))]
+fn is_executable(_entry: &fs::DirEntry) -> Result<bool> {
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cargo_deps/git.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git.rs
@@ -35,6 +35,10 @@ pub(crate) const GIT_SOURCE_NAME: &str = "pnpm-git";
 const DEPENDENCY_KINDS: [&str; 3] = ["dependencies", "dev-dependencies", "build-dependencies"];
 /// Directories `cargo` never reads a package's sources from.
 const EXCLUDED_DIRECTORIES: [&str; 2] = [".git", "target"];
+/// The transports a git dependency is fetched over. `git` runs whatever a
+/// scheme outside this set names — `ext::` hands the URL to a shell — and
+/// a lockfile is not a place to take a command from.
+const SUPPORTED_SCHEMES: [&str; 5] = ["file", "git", "http", "https", "ssh"];
 
 /// A git repository at one revision, as `Cargo.lock` spells it.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -80,6 +84,13 @@ impl GitSource {
             Some(GitReference::Rev(rev)) => Some(("rev", rev.clone())),
             Some(GitReference::DefaultBranch) | None => None,
         };
+        if !SUPPORTED_SCHEMES.contains(&source.url().scheme()) {
+            let repository = redact_and_sanitize(&url);
+            let scheme = source.url().scheme();
+            return Err(miette::miette!(
+                "Cargo source {repository} asks for the {scheme} transport, which pnpm does not fetch a git dependency over",
+            ));
+        }
         let Some(commit) = source.precise() else {
             let source = redact_and_sanitize(&source.to_string());
             return Err(miette::miette!("Cargo source {source} pins no commit"));
@@ -312,17 +323,30 @@ impl Checkout {
     /// A package's name is never inherited, so only the manifests already
     /// naming this crate are resolved against their workspace.
     fn find(&self, name: &str, version: &str) -> Result<Option<CheckoutPackage>> {
+        // A repository may hold another crate of the same name that it
+        // cannot describe on its own — a fixture, or a member of a
+        // workspace the checkout does not reach. Only the one the
+        // lockfile asks for has to be readable, so a candidate that is
+        // not it takes its error out of the way.
+        let mut unreadable = None;
         for dir in self.directories_by_crate.get(name).map(Vec::as_slice).unwrap_or_default() {
             let manifest = &self.manifests[dir];
             let workspace = workspace_manifest(dir, &manifest.document, &self.manifests);
-            let package = vendored_package(manifest, workspace)
-                .wrap_err_with(|| format!("read {}", dir.join("Cargo.toml").display()))?;
+            let package = match vendored_package(manifest, workspace)
+                .wrap_err_with(|| format!("read {}", dir.join("Cargo.toml").display()))
+            {
+                Ok(package) => package,
+                Err(error) => {
+                    unreadable.get_or_insert(error);
+                    continue;
+                }
+            };
             if package.version != version {
                 continue;
             }
             return Ok(Some(CheckoutPackage { dir: dir.clone(), manifest: package.manifest }));
         }
-        Ok(None)
+        unreadable.map_or(Ok(None), Err)
     }
 
     /// Every directory in the checkout that `cargo` reads a package from.

--- a/pnpm/crates/cli/src/cargo_deps/git.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git.rs
@@ -591,12 +591,18 @@ fn import_directory(
     cas_paths: &mut HashMap<String, PathBuf>,
 ) -> Result<()> {
     for entry in read_directory(dir)? {
-        let name = entry.file_name();
-        let name = name.to_string_lossy();
+        // A lossy name would key one file's contents under another's, and
+        // the checksum manifest that keeps the vendored package honest
+        // cannot spell a name that is not UTF-8 either.
+        let name = entry.file_name().into_string().map_err(|name| {
+            let path = dir.join(name);
+            let path = path.display();
+            miette::miette!("cannot vendor {path}: its name is not valid UTF-8")
+        })?;
         let path = entry.path();
         match entry_kind(context.root, &entry)? {
             Some(EntryKind::Directory) => {
-                if EXCLUDED_DIRECTORIES.contains(&name.as_ref())
+                if EXCLUDED_DIRECTORIES.contains(&name.as_str())
                     || context.nested.contains(path.as_path())
                 {
                     continue;

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -197,6 +197,16 @@ fn vendor_from(
     store_dir: &StoreDir,
     packages: &[(&str, &str)],
 ) -> Vec<(String, std::path::PathBuf)> {
+    vendor_from_offline(repository, commit, store_dir, packages, false)
+}
+
+fn vendor_from_offline(
+    repository: &Path,
+    commit: &str,
+    store_dir: &StoreDir,
+    packages: &[(&str, &str)],
+    offline: bool,
+) -> Vec<(String, std::path::PathBuf)> {
     let source = Arc::new(
         GitSource::from_source_id(&source_id(&format!(
             "git+file://{}#{commit}",
@@ -219,7 +229,7 @@ fn vendor_from(
         git_shallow_hosts: &[],
         package_import_method: pnpm_config::PackageImportMethod::default(),
         logged_methods: &AtomicU8::new(0),
-        offline: false,
+        offline,
     })
     .unwrap()
 }
@@ -303,9 +313,12 @@ fn a_vendored_package_is_taken_from_the_store_without_a_second_checkout() {
     let store_dir = StoreDir::from(temp_dir.path().join("store"));
     store_dir.init().unwrap();
     let linked = vendor_from(&repository, &commit, &store_dir, &[("demo", "1.0.0")]);
-    fs::remove_dir_all(&repository).unwrap();
 
-    assert_eq!(vendor_from(&repository, &commit, &store_dir, &[("demo", "1.0.0")]), linked);
+    // Offline, so a second checkout of the repository would be an error.
+    let relinked =
+        vendor_from_offline(&repository, &commit, &store_dir, &[("demo", "1.0.0")], true);
+
+    assert_eq!(relinked, linked);
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,10 +1,12 @@
 use super::{
-    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
+    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
+    vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
+    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -351,6 +353,33 @@ fn a_symlinked_file_is_vendored_as_its_contents_unless_it_leaves_the_checkout() 
     assert_eq!(fs::read_to_string(slot.join("LICENSE")).unwrap(), "the license\n");
     assert_eq!(fs::read_to_string(slot.join("src/lib.rs")).unwrap(), "the license\n");
     assert!(!slot.join("escaped").exists());
+}
+
+#[cfg(unix)]
+#[test]
+fn a_file_whose_name_is_not_utf8_is_refused() {
+    use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let package_dir = temp_dir.path().join("crate");
+    fs::create_dir_all(&package_dir).unwrap();
+    fs::write(package_dir.join(OsStr::from_bytes(b"lib\xff.rs")), "").unwrap();
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let error = import_package(
+        &store_dir,
+        temp_dir.path(),
+        &CheckoutPackage {
+            dir: package_dir,
+            manifest: "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n".to_string(),
+        },
+        &BTreeSet::new(),
+    )
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.contains("not valid UTF-8"), "{error}");
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -3,10 +3,10 @@ use super::{
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
+use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
     fs,
-    path::Path,
-    process::Command,
+    path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
 };
 
@@ -18,30 +18,15 @@ fn source_id(source: &str) -> cargo_lock::SourceId {
     source.parse().expect("parse Cargo source")
 }
 
-fn git(args: &[&str], cwd: &Path) -> String {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
-    assert!(output.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&output.stderr));
-    String::from_utf8(output.stdout).expect("decode git output")
-}
-
-/// Commit `files` into a fresh repository and answer its commit hash.
-fn commit_repository(dir: &Path, files: &[(&str, &str)]) -> String {
-    fs::create_dir_all(dir).unwrap();
-    git(&["init", "-q", "-b", "main"], dir);
-    git(&["config", "user.email", "test@example.invalid"], dir);
-    git(&["config", "user.name", "Test"], dir);
+/// Commit `files` into a fresh repository, answering the URL and commit
+/// a Cargo git source names it by.
+fn commit_repository(root: &Path, files: &[(&str, &str)]) -> (String, String) {
+    let repository = GitRepoFixture::init(root, "repo");
     for (path, contents) in files {
-        let path = dir.join(path);
-        fs::create_dir_all(path.parent().unwrap()).unwrap();
-        fs::write(path, contents).unwrap();
+        repository.write_file(path, contents);
     }
-    git(&["add", "-A"], dir);
-    git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], dir);
-    git(&["rev-parse", "HEAD"], dir).trim().to_string()
+    let commit = repository.commit("init");
+    (repository.file_url(), commit)
 }
 
 #[test]
@@ -192,27 +177,23 @@ fn a_source_without_a_locked_commit_is_refused() {
 }
 
 fn vendor_from(
-    repository: &Path,
+    repository: &str,
     commit: &str,
     store_dir: &StoreDir,
     packages: &[(&str, &str)],
-) -> Vec<(String, std::path::PathBuf)> {
+) -> Vec<(String, PathBuf)> {
     vendor_from_offline(repository, commit, store_dir, packages, false)
 }
 
 fn vendor_from_offline(
-    repository: &Path,
+    repository: &str,
     commit: &str,
     store_dir: &StoreDir,
     packages: &[(&str, &str)],
     offline: bool,
-) -> Vec<(String, std::path::PathBuf)> {
+) -> Vec<(String, PathBuf)> {
     let source = Arc::new(
-        GitSource::from_source_id(&source_id(&format!(
-            "git+file://{}#{commit}",
-            repository.display(),
-        )))
-        .unwrap(),
+        GitSource::from_source_id(&source_id(&format!("git+{repository}#{commit}"))).unwrap(),
     );
     let packages = packages
         .iter()
@@ -237,9 +218,8 @@ fn vendor_from_offline(
 #[test]
 fn a_workspace_member_is_vendored_without_the_repository_around_it() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let repository = temp_dir.path().join("repo");
-    let commit = commit_repository(
-        &repository,
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
         &[
             (
                 "Cargo.toml",
@@ -256,9 +236,11 @@ fn a_workspace_member_is_vendored_without_the_repository_around_it() {
 
     let (link_name, slot) = linked.first().expect("the member is vendored");
     assert_eq!(link_name, "member-0.3.0");
+    // Trimmed: a checkout on Windows ends the line the way git configures
+    // it to, not the way the fixture wrote it.
     assert_eq!(
-        fs::read_to_string(slot.join("src/lib.rs")).unwrap(),
-        "pub fn answer() -> u8 { 42 }\n",
+        fs::read_to_string(slot.join("src/lib.rs")).unwrap().trim_end(),
+        "pub fn answer() -> u8 { 42 }",
     );
     let manifest: toml::Table =
         toml::from_str(&fs::read_to_string(slot.join("Cargo.toml")).unwrap()).unwrap();
@@ -274,9 +256,8 @@ fn a_workspace_member_is_vendored_without_the_repository_around_it() {
 #[test]
 fn a_root_package_leaves_the_members_nested_in_it_to_their_own_slots() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let repository = temp_dir.path().join("repo");
-    let commit = commit_repository(
-        &repository,
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
         &[
             (
                 "Cargo.toml",
@@ -302,9 +283,8 @@ fn a_root_package_leaves_the_members_nested_in_it_to_their_own_slots() {
 #[test]
 fn a_vendored_package_is_taken_from_the_store_without_a_second_checkout() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let repository = temp_dir.path().join("repo");
-    let commit = commit_repository(
-        &repository,
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
         &[
             ("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n"),
             ("src/lib.rs", "pub fn demo() {}\n"),
@@ -322,21 +302,68 @@ fn a_vendored_package_is_taken_from_the_store_without_a_second_checkout() {
 }
 
 #[test]
+fn a_member_that_names_its_workspace_by_path_inherits_from_it() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
+        &[
+            (
+                "Cargo.toml",
+                "[workspace]\nmembers = [\"crates/member\"]\n\n[workspace.package]\nversion = \"0.3.0\"\n",
+            ),
+            (
+                "crates/member/Cargo.toml",
+                "[package]\nname = \"member\"\nworkspace = \"../..\"\nversion.workspace = true\n",
+            ),
+            ("crates/member/src/lib.rs", "pub fn member() {}\n"),
+        ],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let linked = vendor_from(&repository, &commit, &store_dir, &[("member", "0.3.0")]);
+
+    let (_, slot) = linked.first().expect("the member is vendored");
+    let manifest: toml::Table =
+        toml::from_str(&fs::read_to_string(slot.join("Cargo.toml")).unwrap()).unwrap();
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.3.0"));
+}
+
+#[cfg(unix)]
+#[test]
+fn a_symlinked_file_is_vendored_as_its_contents_unless_it_leaves_the_checkout() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let outside = temp_dir.path().join("outside");
+    fs::write(&outside, "not repository content\n").unwrap();
+    let repository = GitRepoFixture::init(temp_dir.path(), "repo");
+    repository.write_file("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n");
+    repository.write_file("LICENSE-MIT", "the license\n");
+    repository.write_symlink("LICENSE", "LICENSE-MIT");
+    repository.write_symlink("src/lib.rs", "../LICENSE-MIT");
+    repository.write_symlink("escaped", "../outside");
+    let commit = repository.commit("init");
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let linked = vendor_from(&repository.file_url(), &commit, &store_dir, &[("demo", "1.0.0")]);
+
+    let (_, slot) = linked.first().expect("the crate is vendored");
+    assert_eq!(fs::read_to_string(slot.join("LICENSE")).unwrap(), "the license\n");
+    assert_eq!(fs::read_to_string(slot.join("src/lib.rs")).unwrap(), "the license\n");
+    assert!(!slot.join("escaped").exists());
+}
+
+#[test]
 fn a_crate_the_checkout_does_not_hold_is_reported() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let repository = temp_dir.path().join("repo");
-    let commit = commit_repository(
-        &repository,
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
         &[("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n")],
     );
     let store_dir = StoreDir::from(temp_dir.path().join("store"));
     store_dir.init().unwrap();
     let source = Arc::new(
-        GitSource::from_source_id(&source_id(&format!(
-            "git+file://{}#{commit}",
-            repository.display(),
-        )))
-        .unwrap(),
+        GitSource::from_source_id(&source_id(&format!("git+{repository}#{commit}"))).unwrap(),
     );
 
     let error = vendor_source::<SilentReporter>(&VendorSourceOptions {

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -170,6 +170,17 @@ fn a_default_branch_source_names_no_reference() {
 }
 
 #[test]
+fn a_source_that_names_a_transport_pnpm_does_not_fetch_over_is_refused() {
+    let error = GitSource::from_source_id(&source_id(
+        "git+ext::sh#1ae976a0023b4dec80b1a5411ccee8343f91320e",
+    ))
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.contains("does not fetch a git dependency over"), "{error}");
+}
+
+#[test]
 fn a_source_without_a_locked_commit_is_refused() {
     let error = GitSource::from_source_id(&source_id("git+https://example.test/repo?branch=next"))
         .unwrap_err()
@@ -355,7 +366,30 @@ fn a_symlinked_file_is_vendored_as_its_contents_unless_it_leaves_the_checkout() 
     assert!(!slot.join("escaped").exists());
 }
 
-#[cfg(unix)]
+#[test]
+fn a_crate_is_found_past_a_manifest_that_shares_its_name_and_reads_no_version() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let (repository, commit) = commit_repository(
+        temp_dir.path(),
+        &[
+            // Sorts before `wanted`, so the scan reaches it first.
+            ("fixture/Cargo.toml", "[package]\nname = \"demo\"\nversion.workspace = true\n"),
+            ("wanted/Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n"),
+            ("wanted/src/lib.rs", "pub fn demo() {}\n"),
+        ],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let linked = vendor_from(&repository, &commit, &store_dir, &[("demo", "1.0.0")]);
+
+    let (_, slot) = linked.first().expect("the crate is vendored");
+    assert!(slot.join("src/lib.rs").is_file());
+}
+
+// APFS answers `EILSEQ` for a name that is not UTF-8, so macOS cannot
+// hold the file this branch is about.
+#[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn a_file_whose_name_is_not_utf8_is_refused() {
     use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,0 +1,376 @@
+use super::{
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
+};
+use pnpm_reporter::SilentReporter;
+use pnpm_store_dir::StoreDir;
+use std::{
+    fs,
+    path::Path,
+    process::Command,
+    sync::{Arc, atomic::AtomicU8},
+};
+
+fn manifest(text: &str) -> Manifest {
+    Manifest { text: text.to_string(), document: toml::from_str(text).expect("parse manifest") }
+}
+
+fn source_id(source: &str) -> cargo_lock::SourceId {
+    source.parse().expect("parse Cargo source")
+}
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
+    assert!(output.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&output.stderr));
+    String::from_utf8(output.stdout).expect("decode git output")
+}
+
+/// Commit `files` into a fresh repository and answer its commit hash.
+fn commit_repository(dir: &Path, files: &[(&str, &str)]) -> String {
+    fs::create_dir_all(dir).unwrap();
+    git(&["init", "-q", "-b", "main"], dir);
+    git(&["config", "user.email", "test@example.invalid"], dir);
+    git(&["config", "user.name", "Test"], dir);
+    for (path, contents) in files {
+        let path = dir.join(path);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+    git(&["add", "-A"], dir);
+    git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], dir);
+    git(&["rev-parse", "HEAD"], dir).trim().to_string()
+}
+
+#[test]
+fn a_manifest_that_inherits_nothing_is_vendored_verbatim() {
+    let text = "# a comment\n[package]\nname = \"demo\"\nversion = \"1.0.0\"\n";
+
+    let vendored = vendored_package(&manifest(text), None).unwrap();
+
+    assert_eq!(vendored.version, "1.0.0");
+    assert_eq!(vendored.manifest, text);
+}
+
+#[test]
+fn workspace_inheritance_is_resolved_into_the_vendored_manifest() {
+    let workspace = manifest(
+        r#"
+[workspace]
+members = ["member"]
+
+[workspace.package]
+version = "0.3.0"
+edition = "2021"
+
+[workspace.dependencies]
+libc = { version = "0.2", default-features = false, features = ["extra"] }
+serde = "1"
+
+[workspace.lints.rust]
+unsafe_code = "forbid"
+"#,
+    );
+    let member = manifest(
+        r#"
+[package]
+name = "member"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+libc = { workspace = true, optional = true, features = ["std"] }
+
+[build-dependencies]
+serde.workspace = true
+
+[lints]
+workspace = true
+"#,
+    );
+
+    let vendored = vendored_package(&member, Some(&workspace.document)).unwrap();
+
+    assert_eq!(vendored.version, "0.3.0");
+    let document: toml::Table = toml::from_str(&vendored.manifest).expect("valid TOML");
+    dbg!(&document);
+    assert_eq!(document["package"]["edition"].as_str(), Some("2021"));
+    assert_eq!(document["dependencies"]["libc"]["version"].as_str(), Some("0.2"));
+    assert_eq!(document["dependencies"]["libc"]["optional"].as_bool(), Some(true));
+    assert_eq!(document["dependencies"]["libc"]["default-features"].as_bool(), Some(false));
+    assert_eq!(
+        document["dependencies"]["libc"]["features"].as_array().map(Vec::as_slice),
+        Some(["extra".into(), "std".into()].as_slice()),
+    );
+    assert_eq!(document["build-dependencies"]["serde"]["version"].as_str(), Some("1"));
+    assert_eq!(document["lints"]["rust"]["unsafe_code"].as_str(), Some("forbid"));
+}
+
+#[test]
+fn the_workspace_table_is_left_out_of_a_vendored_root_package() {
+    let root = manifest(
+        r#"
+[package]
+name = "root"
+version = "1.0.0"
+
+[workspace]
+members = ["member"]
+"#,
+    );
+
+    let vendored = vendored_package(&root, Some(&root.document)).unwrap();
+
+    assert!(!vendored.manifest.contains("[workspace]"), "{}", vendored.manifest);
+}
+
+#[test]
+fn an_uninheritable_field_is_reported() {
+    let member = manifest("[package]\nname = \"member\"\nversion.workspace = true\n");
+
+    let error = vendored_package(&member, Some(&manifest("[workspace]\n").document))
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("no `package.version` to inherit"), "{error}");
+}
+
+#[test]
+fn a_git_source_is_replaced_by_the_vendored_directory() {
+    let source = GitSource::from_source_id(&source_id(
+        "git+https://example.test/repo?rev=1ae976a#1ae976a0023b4dec80b1a5411ccee8343f91320e",
+    ))
+    .unwrap();
+
+    assert_eq!(
+        source.config_block(),
+        concat!(
+            "[source.\"git+https://example.test/repo?rev=1ae976a\"]\n",
+            "git = \"https://example.test/repo\"\n",
+            "rev = \"1ae976a\"\n",
+            "replace-with = \"pnpm-git\"\n",
+        ),
+    );
+}
+
+#[test]
+fn a_branch_source_keeps_the_branch_it_was_locked_from() {
+    let source = GitSource::from_source_id(&source_id(
+        "git+https://example.test/repo?branch=next#1ae976a0023b4dec80b1a5411ccee8343f91320e",
+    ))
+    .unwrap();
+
+    assert!(source.config_block().contains("branch = \"next\"\n"), "{}", source.config_block());
+}
+
+#[test]
+fn a_default_branch_source_names_no_reference() {
+    let source = GitSource::from_source_id(&source_id(
+        "git+https://example.test/repo#1ae976a0023b4dec80b1a5411ccee8343f91320e",
+    ))
+    .unwrap();
+
+    assert_eq!(
+        source.config_block(),
+        concat!(
+            "[source.\"git+https://example.test/repo\"]\n",
+            "git = \"https://example.test/repo\"\n",
+            "replace-with = \"pnpm-git\"\n",
+        ),
+    );
+}
+
+#[test]
+fn a_source_without_a_locked_commit_is_refused() {
+    let error = GitSource::from_source_id(&source_id("git+https://example.test/repo?branch=next"))
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("pins no commit"), "{error}");
+}
+
+fn vendor_from(
+    repository: &Path,
+    commit: &str,
+    store_dir: &StoreDir,
+    packages: &[(&str, &str)],
+) -> Vec<(String, std::path::PathBuf)> {
+    let source = Arc::new(
+        GitSource::from_source_id(&source_id(&format!(
+            "git+file://{}#{commit}",
+            repository.display(),
+        )))
+        .unwrap(),
+    );
+    let packages = packages
+        .iter()
+        .map(|(name, version)| GitPackage {
+            name: (*name).to_string(),
+            version: (*version).to_string(),
+            source: Arc::clone(&source),
+        })
+        .collect::<Vec<_>>();
+    vendor_source::<SilentReporter>(&VendorSourceOptions {
+        source: &source,
+        packages: &packages,
+        store_dir,
+        git_shallow_hosts: &[],
+        package_import_method: pnpm_config::PackageImportMethod::default(),
+        logged_methods: &AtomicU8::new(0),
+        offline: false,
+    })
+    .unwrap()
+}
+
+#[test]
+fn a_workspace_member_is_vendored_without_the_repository_around_it() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repository = temp_dir.path().join("repo");
+    let commit = commit_repository(
+        &repository,
+        &[
+            (
+                "Cargo.toml",
+                "[workspace]\nmembers = [\"member\"]\n\n[workspace.package]\nversion = \"0.3.0\"\n",
+            ),
+            ("member/Cargo.toml", "[package]\nname = \"member\"\nversion.workspace = true\n"),
+            ("member/src/lib.rs", "pub fn answer() -> u8 { 42 }\n"),
+        ],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let linked = vendor_from(&repository, &commit, &store_dir, &[("member", "0.3.0")]);
+
+    let (link_name, slot) = linked.first().expect("the member is vendored");
+    assert_eq!(link_name, "member-0.3.0");
+    assert_eq!(
+        fs::read_to_string(slot.join("src/lib.rs")).unwrap(),
+        "pub fn answer() -> u8 { 42 }\n",
+    );
+    let manifest: toml::Table =
+        toml::from_str(&fs::read_to_string(slot.join("Cargo.toml")).unwrap()).unwrap();
+    assert_eq!(manifest["package"]["version"].as_str(), Some("0.3.0"));
+    let checksum: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(slot.join(".cargo-checksum.json")).unwrap())
+            .unwrap();
+    assert_eq!(checksum["package"], serde_json::Value::Null);
+    assert!(checksum["files"]["src/lib.rs"].is_string(), "{checksum}");
+    assert!(!slot.join(".git").exists());
+}
+
+#[test]
+fn a_root_package_leaves_the_members_nested_in_it_to_their_own_slots() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repository = temp_dir.path().join("repo");
+    let commit = commit_repository(
+        &repository,
+        &[
+            (
+                "Cargo.toml",
+                "[package]\nname = \"root\"\nversion = \"1.0.0\"\n\n[workspace]\nmembers = [\"member\"]\n",
+            ),
+            ("src/lib.rs", "pub fn root() {}\n"),
+            ("member/Cargo.toml", "[package]\nname = \"member\"\nversion = \"0.3.0\"\n"),
+            ("member/src/lib.rs", "pub fn member() {}\n"),
+        ],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+
+    let linked =
+        vendor_from(&repository, &commit, &store_dir, &[("root", "1.0.0"), ("member", "0.3.0")]);
+
+    let root = &linked.iter().find(|(name, _)| name == "root-1.0.0").expect("the root").1;
+    assert!(root.join("src/lib.rs").is_file());
+    assert!(!root.join("member").exists());
+    assert!(!fs::read_to_string(root.join("Cargo.toml")).unwrap().contains("[workspace]"));
+}
+
+#[test]
+fn a_vendored_package_is_taken_from_the_store_without_a_second_checkout() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repository = temp_dir.path().join("repo");
+    let commit = commit_repository(
+        &repository,
+        &[
+            ("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n"),
+            ("src/lib.rs", "pub fn demo() {}\n"),
+        ],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+    let linked = vendor_from(&repository, &commit, &store_dir, &[("demo", "1.0.0")]);
+    fs::remove_dir_all(&repository).unwrap();
+
+    assert_eq!(vendor_from(&repository, &commit, &store_dir, &[("demo", "1.0.0")]), linked);
+}
+
+#[test]
+fn a_crate_the_checkout_does_not_hold_is_reported() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let repository = temp_dir.path().join("repo");
+    let commit = commit_repository(
+        &repository,
+        &[("Cargo.toml", "[package]\nname = \"demo\"\nversion = \"1.0.0\"\n")],
+    );
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    store_dir.init().unwrap();
+    let source = Arc::new(
+        GitSource::from_source_id(&source_id(&format!(
+            "git+file://{}#{commit}",
+            repository.display(),
+        )))
+        .unwrap(),
+    );
+
+    let error = vendor_source::<SilentReporter>(&VendorSourceOptions {
+        source: &source,
+        packages: &[GitPackage {
+            name: "demo".to_string(),
+            version: "2.0.0".to_string(),
+            source: Arc::clone(&source),
+        }],
+        store_dir: &store_dir,
+        git_shallow_hosts: &[],
+        package_import_method: pnpm_config::PackageImportMethod::default(),
+        logged_methods: &AtomicU8::new(0),
+        offline: false,
+    })
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.contains("holds no crate demo 2.0.0"), "{error}");
+}
+
+#[test]
+fn an_offline_install_does_not_check_out_a_missing_package() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let store_dir = StoreDir::from(temp_dir.path().join("store"));
+    let source = Arc::new(
+        GitSource::from_source_id(&source_id(
+            "git+https://example.test/repo#1ae976a0023b4dec80b1a5411ccee8343f91320e",
+        ))
+        .unwrap(),
+    );
+
+    let error = vendor_source::<SilentReporter>(&VendorSourceOptions {
+        source: &source,
+        packages: &[GitPackage {
+            name: "demo".to_string(),
+            version: "1.0.0".to_string(),
+            source: Arc::clone(&source),
+        }],
+        store_dir: &store_dir,
+        git_shallow_hosts: &[],
+        package_import_method: pnpm_config::PackageImportMethod::default(),
+        logged_methods: &AtomicU8::new(0),
+        offline: true,
+    })
+    .unwrap_err()
+    .to_string();
+
+    assert!(error.contains("while offline"), "{error}");
+}

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,8 +1,7 @@
 use super::{
-    ArchiveStoreProjection, Config, LockedCrate, MANAGED_CONFIG, MaterializeOptions,
-    add_cargo_checksum, download_auth_headers, fetch_sparse_index_file, managed_config,
-    materialize, parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config,
-    workspace_root,
+    ArchiveStoreProjection, Config, LockedCrate, MaterializeOptions, add_cargo_checksum,
+    download_auth_headers, fetch_sparse_index_file, managed_config, materialize, parse_lockfile,
+    resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
 };
 use cargo_util_schemas::index::RegistryConfig;
 use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
@@ -22,8 +21,8 @@ use std::{
 
 #[cfg(unix)]
 use super::{
-    ensure_workspace_directory, link_workspace, link_workspace_in, write_cargo_config,
-    write_cargo_config_in,
+    CRATES_SOURCE_DIRECTORY, ensure_workspace_directory, link_workspace, link_workspace_in,
+    write_cargo_config, write_cargo_config_in,
 };
 
 #[cfg(unix)]
@@ -49,7 +48,7 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 "#;
 
     assert_eq!(
-        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap(),
+        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap().crates,
         vec![LockedCrate {
             name: "serde".to_string(),
             version: "1.0.228".to_string(),
@@ -100,7 +99,7 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 "#;
 
     assert_eq!(
-        parse_lockfile(lockfile, "https://registry.example.test/index/").unwrap(),
+        parse_lockfile(lockfile, "https://registry.example.test/index/").unwrap().crates,
         vec![LockedCrate {
             name: "serde".to_string(),
             version: "1.0.228".to_string(),
@@ -120,7 +119,7 @@ source = "sparse+https://index.crates.io/"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 "#;
 
-    assert_eq!(parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap().len(), 1);
+    assert_eq!(parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap().crates.len(), 1);
 }
 
 #[test]
@@ -141,7 +140,7 @@ source = "registry+https://registry.example/index"
 "#;
 
     assert_eq!(
-        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap(),
+        parse_lockfile(lockfile, CRATES_IO_SPARSE_INDEX).unwrap().crates,
         vec![LockedCrate {
             name: "serde".to_string(),
             version: "1.0.228".to_string(),
@@ -172,22 +171,25 @@ fn crate_store_slots_are_grouped_by_name_version_and_content() {
 #[test]
 fn appends_the_managed_config_without_changing_user_settings() {
     let existing = "[alias]\ncodecov = \"llvm-cov\"\n";
-    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX).unwrap();
+    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX, &[]).unwrap();
 
-    assert_eq!(updated, format!("{existing}\n{MANAGED_CONFIG}\n"));
+    assert_eq!(updated, format!("{existing}\n{}\n", managed_config(CRATES_IO_SPARSE_INDEX, &[])));
 }
 
 #[test]
 fn replaces_only_the_existing_managed_config() {
     let existing = "before\n# >>> pnpm-managed cargo sources >>>\nstale\n# <<< pnpm-managed cargo sources <<<\nafter\n";
-    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX).unwrap();
+    let updated = update_managed_config(existing, CRATES_IO_SPARSE_INDEX, &[]).unwrap();
 
-    assert_eq!(updated, format!("before\n{MANAGED_CONFIG}\nafter\n"));
+    assert_eq!(
+        updated,
+        format!("before\n{}\nafter\n", managed_config(CRATES_IO_SPARSE_INDEX, &[])),
+    );
 }
 
 #[test]
 fn configures_the_selected_sparse_registry_as_the_vendored_source() {
-    let config = managed_config("https://registry.example.test/index/");
+    let config = managed_config("https://registry.example.test/index/", &[]);
 
     assert!(config.contains("[source.crates-io]\nreplace-with = \"pnpm-registry\""));
     assert!(config.contains("[source.pnpm-registry]"));
@@ -197,7 +199,7 @@ fn configures_the_selected_sparse_registry_as_the_vendored_source() {
 
 #[test]
 fn escapes_a_registry_url_that_is_not_a_bare_toml_string() {
-    let config = managed_config("https://registry.example.test/o'brien/index");
+    let config = managed_config("https://registry.example.test/o'brien/index", &[]);
 
     let parsed: toml::Table = toml::from_str(&config).expect("managed config is valid TOML");
     assert_eq!(
@@ -208,10 +210,13 @@ fn escapes_a_registry_url_that_is_not_a_bare_toml_string() {
 
 #[test]
 fn rejects_an_incomplete_managed_config() {
-    let error =
-        update_managed_config("# >>> pnpm-managed cargo sources >>>\n", CRATES_IO_SPARSE_INDEX)
-            .unwrap_err()
-            .to_string();
+    let error = update_managed_config(
+        "# >>> pnpm-managed cargo sources >>>\n",
+        CRATES_IO_SPARSE_INDEX,
+        &[],
+    )
+    .unwrap_err()
+    .to_string();
 
     assert!(error.contains("incomplete"), "{error}");
 }
@@ -230,7 +235,7 @@ fn creates_the_cargo_checksum_manifest_from_cas_files() {
     add_cargo_checksum(
         &store_dir,
         &mut cas_paths,
-        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        Some("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
     )
     .unwrap();
 
@@ -481,7 +486,8 @@ fn rejects_a_symlinked_cargo_source_parent() {
     fs::write(outside.path().join("keep"), "unchanged").unwrap();
     symlink(outside.path(), workspace.path().join(".pnpm")).unwrap();
 
-    let error = link_workspace(workspace.path(), &[]).unwrap_err().to_string();
+    let error =
+        link_workspace(workspace.path(), &CRATES_SOURCE_DIRECTORY, &[]).unwrap_err().to_string();
 
     assert!(error.contains("must be a real directory"), "{error}");
     assert_eq!(fs::read_to_string(outside.path().join("keep")).unwrap(), "unchanged");
@@ -497,7 +503,7 @@ fn rejects_a_symlinked_cargo_config_parent() {
     symlink(outside.path(), workspace.path().join(".cargo")).unwrap();
 
     let error =
-        write_cargo_config(workspace.path(), CRATES_IO_SPARSE_INDEX).unwrap_err().to_string();
+        write_cargo_config(workspace.path(), CRATES_IO_SPARSE_INDEX, &[]).unwrap_err().to_string();
 
     assert!(error.contains("must be a real directory"), "{error}");
     assert_eq!(fs::read_to_string(external_config).unwrap(), "unchanged\n");
@@ -514,10 +520,14 @@ fn config_write_stays_in_the_directory_pinned_before_a_parent_swap() {
     fs::write(outside.path().join("config.toml"), "unchanged\n").unwrap();
     symlink(outside.path(), workspace.path().join(".cargo")).unwrap();
 
-    write_cargo_config_in(&cargo_dir, CRATES_IO_SPARSE_INDEX).unwrap();
+    write_cargo_config_in(&cargo_dir, CRATES_IO_SPARSE_INDEX, &[]).unwrap();
 
     assert_eq!(fs::read_to_string(outside.path().join("config.toml")).unwrap(), "unchanged\n");
-    assert!(fs::read_to_string(pinned_path.join("config.toml")).unwrap().contains(MANAGED_CONFIG));
+    assert!(
+        fs::read_to_string(pinned_path.join("config.toml"))
+            .unwrap()
+            .contains(&managed_config(CRATES_IO_SPARSE_INDEX, &[])),
+    );
 }
 
 #[cfg(unix)]
@@ -527,7 +537,7 @@ fn crate_link_stays_in_the_directory_pinned_before_a_parent_swap() {
     let outside = tempfile::tempdir().unwrap();
     let slot = tempfile::tempdir().unwrap();
     let source_dir =
-        ensure_workspace_directory(workspace.path(), &[".pnpm", "crates", "crates-io"]).unwrap();
+        ensure_workspace_directory(workspace.path(), &CRATES_SOURCE_DIRECTORY).unwrap();
     let source_path = workspace.path().join(".pnpm/crates/crates-io");
     let pinned_path = workspace.path().join(".pnpm/crates/crates-io-pinned");
     fs::rename(&source_path, &pinned_path).unwrap();
@@ -554,8 +564,12 @@ fn crate_link_does_not_overwrite_a_nonempty_stale_backup() {
     fs::create_dir(&stale_backup).unwrap();
     fs::write(stale_backup.join("keep"), "unchanged").unwrap();
 
-    link_workspace(workspace.path(), &[("example-1.0.0".to_string(), slot.path().to_path_buf())])
-        .unwrap();
+    link_workspace(
+        workspace.path(),
+        &CRATES_SOURCE_DIRECTORY,
+        &[("example-1.0.0".to_string(), slot.path().to_path_buf())],
+    )
+    .unwrap();
 
     assert_eq!(fs::read_to_string(stale_backup.join("keep")).unwrap(), "unchanged");
     assert_eq!(

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -239,5 +239,7 @@ fn a_workspace_with_a_cargo_patch_is_not_resolved_from_the_registry() {
         .expect("run pnpm install");
 
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("declares [patch]"), "{stderr}");
+    assert!(!output.status.success(), "{stderr}");
+    // One word: a diagnostic wraps at a width the path length decides.
+    assert!(stderr.contains("[patch]"), "{stderr}");
 }

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -213,8 +213,7 @@ fn install_vendors_a_git_patched_crate_beside_the_registry_crates() {
         "{config}",
     );
     assert!(config.contains(r#"replace-with = "pnpm-git""#), "{config}");
-    // The vendored revision builds without reaching the repository again.
-    fs::remove_dir_all(repository.path()).unwrap();
+    // Offline, so the revision has to come from what the install vendored.
     Command::new("cargo")
         .with_current_dir(root.path())
         .with_args(["check", "--offline"])

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -4,7 +4,7 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use sha2::{Digest, Sha256};
-use std::process::Command;
+use std::{fs, path::Path, process::Command};
 use tempfile::TempDir;
 
 /// A `.crate` archive holding the one source file a dependent needs, laid
@@ -117,4 +117,128 @@ fn offline_install_without_registry_crates_never_reads_the_registry_config() {
     let config = std::fs::read_to_string(root.path().join(".cargo/config.toml"))
         .expect("read managed Cargo configuration");
     assert!(config.contains(r#"registry = "sparse+https://registry.example.test/index/""#));
+}
+
+fn git(args: &[&str], cwd: &Path) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
+    assert!(output.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&output.stderr));
+    String::from_utf8(output.stdout).expect("decode git output")
+}
+
+fn append_manifest_section(manifest: &Path, section: &str) {
+    let mut contents = fs::read_to_string(manifest).expect("read Cargo manifest");
+    contents.push_str(section);
+    fs::write(manifest, contents).expect("write Cargo manifest");
+}
+
+/// A repository whose single commit holds one crate, answering the URL and
+/// revision a Cargo patch names it by.
+fn crate_repository(dir: &Path, name: &str, version: &str) -> (String, String) {
+    fs::create_dir_all(dir.join("src")).unwrap();
+    fs::write(
+        dir.join("Cargo.toml"),
+        format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2024\"\n"),
+    )
+    .unwrap();
+    fs::write(dir.join("src/lib.rs"), "pub fn patched() -> u8 { 7 }\n").unwrap();
+    git(&["init", "-q", "-b", "main"], dir);
+    git(&["config", "user.email", "test@example.invalid"], dir);
+    git(&["config", "user.name", "Test"], dir);
+    git(&["add", "-A"], dir);
+    git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], dir);
+    let url = url::Url::from_file_path(dir).expect("a file URL for the repository");
+    (url.to_string(), git(&["rev-parse", "HEAD"], dir).trim().to_string())
+}
+
+#[test]
+fn install_vendors_a_git_patched_crate_beside_the_registry_crates() {
+    let mut registry = mockito::Server::new();
+    let archive = crate_archive("demo", "1.0.0");
+    let checksum = format!("{:x}", Sha256::digest(&archive));
+    let _config_mock = registry
+        .mock("GET", "/config.json")
+        .with_body(
+            serde_json::json!({
+                "dl": format!("{}/dl/{{crate}}/{{version}}", registry.url()),
+                "api": registry.url(),
+            })
+            .to_string(),
+        )
+        .create();
+    let _download_mock = registry.mock("GET", "/dl/demo/1.0.0").with_body(&archive).create();
+    let root = cargo_workspace(
+        &registry.url(),
+        "demo = \"1\"\npatched = \"1\"\n",
+        "pub use demo::answer;\npub use patched::patched;\n",
+    );
+    // Outside the workspace: a manifest under it would be discovered as a
+    // Cargo workspace of its own.
+    let repository = TempDir::new().expect("create a repository directory");
+    let (repository_url, commit) = crate_repository(repository.path(), "patched", "1.0.0");
+    append_manifest_section(
+        &root.path().join("Cargo.toml"),
+        &format!(
+            "\n[patch.crates-io]\npatched = {{ git = \"{repository_url}\", rev = \"{commit}\" }}\n",
+        ),
+    );
+    let lockfile = format!(
+        concat!(
+            "version = 4\n\n",
+            "[[package]]\nname = \"app\"\nversion = \"0.1.0\"\n",
+            "dependencies = [\n \"demo\",\n \"patched\",\n]\n\n",
+            "[[package]]\nname = \"demo\"\nversion = \"1.0.0\"\n",
+            "source = \"sparse+{registry}/\"\nchecksum = \"{checksum}\"\n\n",
+            "[[package]]\nname = \"patched\"\nversion = \"1.0.0\"\n",
+            "source = \"git+{repository_url}?rev={commit}#{commit}\"\n",
+        ),
+        registry = registry.url(),
+        checksum = checksum,
+        repository_url = repository_url,
+        commit = commit,
+    );
+    std::fs::write(root.path().join("Cargo.lock"), &lockfile).unwrap();
+
+    install_in(&root, &["install", "--frozen-lockfile"]);
+
+    assert_eq!(fs::read_to_string(root.path().join("Cargo.lock")).unwrap(), lockfile);
+    assert!(root.path().join(".pnpm/crates/crates-io/demo-1.0.0/src/lib.rs").is_file());
+    assert!(root.path().join(".pnpm/crates/git/patched-1.0.0/src/lib.rs").is_file());
+    let config = fs::read_to_string(root.path().join(".cargo/config.toml")).unwrap();
+    assert!(
+        config.contains(&format!(r#"[source."git+{repository_url}?rev={commit}"]"#)),
+        "{config}",
+    );
+    assert!(config.contains(r#"replace-with = "pnpm-git""#), "{config}");
+    // The vendored revision builds without reaching the repository again.
+    fs::remove_dir_all(repository.path()).unwrap();
+    Command::new("cargo")
+        .with_current_dir(root.path())
+        .with_args(["check", "--offline"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn a_workspace_with_a_cargo_patch_is_not_resolved_from_the_registry() {
+    let root = cargo_workspace("https://registry.example.test/index/", "demo = \"1\"\n", "");
+    append_manifest_section(
+        &root.path().join("Cargo.toml"),
+        "\n[patch.crates-io]\ndemo = { git = \"https://example.test/demo\" }\n",
+    );
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(root.path())
+        .with_env("PNPM_CONFIG_CACHE_DIR", root.path().join("cache"))
+        .with_env("PNPM_CONFIG_STORE_DIR", root.path().join("store"))
+        .with_args(["install", "--offline"])
+        .output()
+        .expect("run pnpm install");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("declares [patch]"), "{stderr}");
 }

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -3,6 +3,7 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
+use pnpm_testing_utils::git_repo::GitRepoFixture;
 use sha2::{Digest, Sha256};
 use std::{fs, path::Path, process::Command};
 use tempfile::TempDir;
@@ -119,39 +120,32 @@ fn offline_install_without_registry_crates_never_reads_the_registry_config() {
     assert!(config.contains(r#"registry = "sparse+https://registry.example.test/index/""#));
 }
 
-fn git(args: &[&str], cwd: &Path) -> String {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .unwrap_or_else(|error| panic!("run git {args:?}: {error}"));
-    assert!(output.status.success(), "git {args:?}: {}", String::from_utf8_lossy(&output.stderr));
-    String::from_utf8(output.stdout).expect("decode git output")
-}
-
 fn append_manifest_section(manifest: &Path, section: &str) {
     let mut contents = fs::read_to_string(manifest).expect("read Cargo manifest");
     contents.push_str(section);
     fs::write(manifest, contents).expect("write Cargo manifest");
 }
 
-/// A repository whose single commit holds one crate, answering the URL and
-/// revision a Cargo patch names it by.
-fn crate_repository(dir: &Path, name: &str, version: &str) -> (String, String) {
-    fs::create_dir_all(dir.join("src")).unwrap();
-    fs::write(
-        dir.join("Cargo.toml"),
-        format!("[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2024\"\n"),
-    )
-    .unwrap();
-    fs::write(dir.join("src/lib.rs"), "pub fn patched() -> u8 { 7 }\n").unwrap();
-    git(&["init", "-q", "-b", "main"], dir);
-    git(&["config", "user.email", "test@example.invalid"], dir);
-    git(&["config", "user.name", "Test"], dir);
-    git(&["add", "-A"], dir);
-    git(&["-c", "commit.gpgsign=false", "commit", "-q", "-m", "init"], dir);
-    let url = url::Url::from_file_path(dir).expect("a file URL for the repository");
-    (url.to_string(), git(&["rev-parse", "HEAD"], dir).trim().to_string())
+/// A repository holding a Cargo workspace of two crates, `patched` and
+/// the `sibling` it depends on by path. Both take their version from the
+/// workspace, which the vendored copies must carry on their own.
+fn patched_repository(root: &Path) -> GitRepoFixture {
+    let repository = GitRepoFixture::init(root, "patched");
+    repository.write_file(
+        "Cargo.toml",
+        "[workspace]\nmembers = [\"patched\", \"sibling\"]\n\n[workspace.package]\nversion = \"1.0.0\"\nedition = \"2024\"\n",
+    );
+    repository.write_file(
+        "patched/Cargo.toml",
+        "[package]\nname = \"patched\"\nversion.workspace = true\nedition.workspace = true\n\n[dependencies]\nsibling = { path = \"../sibling\", version = \"1.0.0\" }\n",
+    );
+    repository.write_file("patched/src/lib.rs", "pub fn patched() -> u8 { sibling::seven() }\n");
+    repository.write_file(
+        "sibling/Cargo.toml",
+        "[package]\nname = \"sibling\"\nversion.workspace = true\nedition.workspace = true\n",
+    );
+    repository.write_file("sibling/src/lib.rs", "pub fn seven() -> u8 { 7 }\n");
+    repository
 }
 
 #[test]
@@ -177,8 +171,10 @@ fn install_vendors_a_git_patched_crate_beside_the_registry_crates() {
     );
     // Outside the workspace: a manifest under it would be discovered as a
     // Cargo workspace of its own.
-    let repository = TempDir::new().expect("create a repository directory");
-    let (repository_url, commit) = crate_repository(repository.path(), "patched", "1.0.0");
+    let outside = TempDir::new().expect("create a repository directory");
+    let repository = patched_repository(outside.path());
+    let repository_url = repository.file_url();
+    let commit = repository.commit("init");
     append_manifest_section(
         &root.path().join("Cargo.toml"),
         &format!(
@@ -194,6 +190,9 @@ fn install_vendors_a_git_patched_crate_beside_the_registry_crates() {
             "source = \"sparse+{registry}/\"\nchecksum = \"{checksum}\"\n\n",
             "[[package]]\nname = \"patched\"\nversion = \"1.0.0\"\n",
             "source = \"git+{repository_url}?rev={commit}#{commit}\"\n",
+            "dependencies = [\n \"sibling\",\n]\n\n",
+            "[[package]]\nname = \"sibling\"\nversion = \"1.0.0\"\n",
+            "source = \"git+{repository_url}?rev={commit}#{commit}\"\n",
         ),
         registry = registry.url(),
         checksum = checksum,
@@ -207,6 +206,7 @@ fn install_vendors_a_git_patched_crate_beside_the_registry_crates() {
     assert_eq!(fs::read_to_string(root.path().join("Cargo.lock")).unwrap(), lockfile);
     assert!(root.path().join(".pnpm/crates/crates-io/demo-1.0.0/src/lib.rs").is_file());
     assert!(root.path().join(".pnpm/crates/git/patched-1.0.0/src/lib.rs").is_file());
+    assert!(root.path().join(".pnpm/crates/git/sibling-1.0.0/src/lib.rs").is_file());
     let config = fs::read_to_string(root.path().join(".cargo/config.toml")).unwrap();
     assert!(
         config.contains(&format!(r#"[source."git+{repository_url}?rev={commit}"]"#)),

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -64,6 +64,23 @@ impl GitRepoFixture {
         fs::write(&path, contents).unwrap_or_else(|err| panic!("write {}: {err}", path.display()));
     }
 
+    /// Create a symlink at `relative_path` pointing at `target`, which
+    /// is interpreted relative to the link's own directory the way git
+    /// records one. Not committed until [`Self::commit`] runs.
+    ///
+    /// Unix only: Windows needs a privilege ordinary test runs do not
+    /// have, so a test that checks symlink handling gates on the target
+    /// family rather than probing for one.
+    #[cfg(unix)]
+    pub fn write_symlink(&self, relative_path: &str, target: &str) {
+        let path = self.work.join(relative_path);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create fixture parent directory");
+        }
+        std::os::unix::fs::symlink(target, &path)
+            .unwrap_or_else(|err| panic!("link {}: {err}", path.display()));
+    }
+
     /// Stage every change, commit it, mirror to the bare repo, and
     /// return the new commit's SHA.
     #[must_use]


### PR DESCRIPTION
## Summary

A Cargo workspace that points a crate at a git revision, through `[patch.crates-io]` or a git dependency, could not be installed: `locked_crate_from_package` rejected every non-registry source in `Cargo.lock` before anything was fetched. This is what stops `cargo.enabled` from being turned on in this repository, which patches `node-semver` with the pnpm fork (see the exploratory draft pnpm/pnpm#14689).

pnpm now checks out the commit `Cargo.lock` pins and vendors the crate into the store the way `cargo vendor` lays a git package out: the package's own directory, a `.cargo-checksum.json` whose `package` is null, and a Cargo directory source that replaces the git source in the managed `.cargo/config.toml` block. `cargo` then builds the pinned revision with no fetch of its own.

Verified against the issue's own scenario: a workspace depending on `node-semver = "2.2.0"` patched to `https://github.com/pnpm/node-semver-rs` at `1ae976a`. `pnpm install --frozen-lockfile --prefer-offline` installed the 18 registry crates and the patched revision, left `Cargo.lock` byte-identical, and `cargo check --offline` then built the whole graph. A second `pnpm install --frozen-lockfile --offline` relinked from the store without cloning.

Closes pnpm/pnpm#14691

## Squash Commit Body

```text
A Cargo workspace that points a crate at a git revision, through
`[patch.crates-io]` or a git dependency, failed to install: every
non-registry source in `Cargo.lock` was rejected before it was fetched.

pnpm now checks out the commit the lockfile pins and vendors the crate
into the store the way `cargo vendor` lays a git package out — the
package's own directory, a `.cargo-checksum.json` with a null `package`,
and a Cargo directory source that replaces the git source. `cargo` then
builds the pinned revision offline, and `--frozen-lockfile` leaves the
lockfile and its revision untouched. Vendored git packages get their own
`.pnpm/crates/git` directory: a git package and a registry crate can
share a name and version, and one directory source cannot hold both.

A vendored manifest resolves the `workspace = true` fields its repository
supplied and drops the `[workspace]` table, so the directory stands alone
the way `cargo vendor`'s does. The store slot is keyed by the commit, so
a second install links it without cloning again, offline included.

Resolving a workspace that declares `[patch]` or `[replace]` is refused
rather than silently resolved without it: `cargo metadata` does not
report either table, so the lockfile would name the replaced package.

Closes pnpm/pnpm#14691
```

## Design notes for reviewers

- **Why a directory source rather than leaving git deps to `cargo`.** Leaving them alone would make the install succeed, but `cargo` would then fetch the repository itself on the first build, and `cargo build --offline` after a pnpm install would fail. Vendoring keeps the promise the registry path already makes: after `pnpm install`, everything the build needs is in the store.
- **Why the manifest is rewritten.** A vendored directory has no repository around it, so a member manifest that says `version.workspace = true` fails to parse (`failed to find a workspace root`). The inheritance markers are resolved against the owning workspace root, and the `[workspace]` table is dropped, which is what `cargo vendor` emits too. A manifest that inherits nothing is stored verbatim. `path` dependencies are left as they are: `cargo` ignores them for a package that comes from a directory source, which was checked against real `cargo` before this was written.
- **Symlinks.** A symlinked file is vendored as what it points at, which is what `cargo` reads out of a checkout. A link that resolves outside the checkout, dangles, or names a directory is left out — the first is not repository content, and a directory link can lead back into its own parent.
- **Warm installs.** The store slot is `crates/<name>/<version>/git-<commit>`, and `.cargo-checksum.json` sorts first among a package's files, which makes it the completion marker `import_indexed_dir` writes last. A slot that has it is relinked without a checkout, so repeat and `--offline` installs never touch the network.
- **The `[patch]` guard.** `cargo metadata --no-deps` does not report `[patch]` or `[replace]`, so resolving a workspace that declares one would have written a lockfile naming the replaced package. That path now errors instead. Installs that read an existing `Cargo.lock` — the ones this PR is about — are unaffected. Making the resolver itself patch-aware is follow-up work.

## Review follow-ups

`615c72fdec` normalizes an explicit `package.workspace` path, vendors symlinked files, streams file contents into the store instead of reading them whole, checks repositories out concurrently, and indexes the checkout's packages by name. Its tests use the `GitRepoFixture` in `pnpm-testing-utils`, and the end-to-end test now patches a two-member git workspace so sibling path dependencies and workspace inheritance are both proven by a real `cargo check --offline`.

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791462628&installation_model_id=426870&pr_number=14694&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14694&signature=7973b5d8be529ada4d65fe0fa8627004b51843377a29bb1f38e97562e2902e03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `pnpm install` now supports Rust dependencies pinned to Git revisions in `Cargo.lock`.
  - Git-sourced crates are stored alongside registry crates and configured for successful offline Cargo builds.
  - Git repositories are reused when packages are already available locally, reducing unnecessary checkouts.

- **Bug Fixes**
  - Installations now reject unsupported workspace configurations using root-level Cargo patch or replacement declarations.
  - Unsupported Git transport schemes are rejected with a clear error.

- **Documentation**
  - Added documentation covering Git-based Cargo dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
