### PR TITLE
feat(pnpr): browse hosted packages and fix concurrent registration

### DIFF
--- a/.changeset/pacquet-windows-atomic-writes.md
+++ b/.changeset/pacquet-windows-atomic-writes.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed intermittent access-denied errors when concurrent tasks save cache state on Windows.

--- a/.changeset/pnpr-browse-hosted-packages.md
+++ b/.changeset/pnpr-browse-hosted-packages.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Added paginated browsing of hosted npm packages and Cargo crates through the search APIs with `browse=true`. Results respect registry routing and package access rules.

--- a/.changeset/pnpr-libsql-concurrent-registration.md
+++ b/.changeset/pnpr-libsql-concurrent-registration.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": patch
+---
+
+Fixed transaction errors and panics during concurrent libsql user registrations when a user limit is configured.

--- a/.changeset/pnpr-libsql-concurrent-registration.md
+++ b/.changeset/pnpr-libsql-concurrent-registration.md
@@ -2,4 +2,4 @@
 "@pnpm/pnpr": patch
 ---
 
-Fixed transaction errors and panics during concurrent libsql user registrations when a user limit is configured.
+Fixed failed registrations when multiple users sign up concurrently with a libsql backend and a configured user limit.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6334,6 +6334,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "tokio",
+ "tower 0.5.3",
  "tracing",
  "url",
 ]

--- a/pnpm/crates/fs/src/write_atomic.rs
+++ b/pnpm/crates/fs/src/write_atomic.rs
@@ -66,7 +66,17 @@ fn write_tmp_over(path: &Path, bytes: &[u8], inherit: InheritMode) -> io::Result
     }
     #[cfg(not(unix))]
     let _ = inherit;
-    tmp.persist(path).map_err(|err| err.error)?;
+    let mut pending = Some(tmp.into_temp_path());
+    crate::retry::retry_transient_file_locks(|| {
+        let temporary = pending.take().expect("temporary path retained after a failed persist");
+        match temporary.persist(path) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                pending = Some(error.path);
+                Err(error.error)
+            }
+        }
+    })?;
     Ok(())
 }
 

--- a/pnpm/crates/fs/src/write_atomic/tests.rs
+++ b/pnpm/crates/fs/src/write_atomic/tests.rs
@@ -72,3 +72,44 @@ fn write_atomic_private_does_not_inherit_a_readable_mode() {
     let mode = std::fs::metadata(&path).expect("stat").permissions().mode() & 0o777;
     assert_eq!(mode, 0o600, "got {mode:o}");
 }
+
+#[test]
+fn concurrent_replacements_leave_complete_content() {
+    let directory = TempDir::new().unwrap();
+    let path = directory.path().join("state.json");
+    let barrier = std::sync::Barrier::new(4);
+    std::thread::scope(|scope| {
+        for byte in b'a'..=b'd' {
+            let path = &path;
+            let barrier = &barrier;
+            scope.spawn(move || {
+                barrier.wait();
+                for _ in 0..20 {
+                    write_atomic(path, &[byte; 4096]).unwrap();
+                }
+            });
+        }
+    });
+    let contents = std::fs::read(path).unwrap();
+    assert_eq!(contents.len(), 4096);
+    assert!(contents.iter().all(|byte| *byte == contents[0]));
+}
+
+#[cfg(windows)]
+#[test]
+fn waits_for_a_locked_destination_before_replacing_it() {
+    use std::os::windows::fs::OpenOptionsExt as _;
+
+    let directory = TempDir::new().unwrap();
+    let path = directory.path().join("state.json");
+    std::fs::write(&path, "old").unwrap();
+    let locked = std::fs::OpenOptions::new().read(true).share_mode(1).open(&path).unwrap();
+    std::thread::scope(|scope| {
+        scope.spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            drop(locked);
+        });
+        write_atomic(&path, b"new").unwrap();
+    });
+    assert_eq!(std::fs::read(&path).unwrap(), b"new");
+}

--- a/pnpr/crates/auth/Cargo.toml
+++ b/pnpr/crates/auth/Cargo.toml
@@ -41,6 +41,7 @@ url           = { workspace = true }
 axum     = { workspace = true, features = ["form", "json"] }
 tempfile = { workspace = true }
 tokio    = { workspace = true }
+tower    = { workspace = true, features = ["util"] }
 
 [lints]
 workspace = true

--- a/pnpr/crates/auth/src/libsql_backend.rs
+++ b/pnpr/crates/auth/src/libsql_backend.rs
@@ -24,7 +24,9 @@ use super::{
     verify_returning_user, with_auth_timeout,
 };
 use async_trait::async_trait;
-use libsql::{Builder, Connection, Database, Error as LibsqlError, Row, params};
+use libsql::{
+    Builder, Connection, Database, Error as LibsqlError, Row, TransactionBehavior, params,
+};
 use pnpr_config::{LibsqlSettings, MaxUsers};
 use pnpr_error::{RegistryError, Result};
 use std::{
@@ -159,6 +161,18 @@ impl UserBackend for LibsqlAuth {
         username: &str,
         password: &str,
     ) -> Result<(UpsertOutcome, String)> {
+        let hash = tokio::sync::OnceCell::new();
+        retry_database_conflicts(|| self.add_or_login_attempt(username, password, &hash)).await
+    }
+}
+
+impl LibsqlAuth {
+    async fn add_or_login_attempt(
+        &self,
+        username: &str,
+        password: &str,
+        hash: &tokio::sync::OnceCell<String>,
+    ) -> Result<(UpsertOutcome, String)> {
         validate_username(username)?;
 
         if let Some(stored) = self.stored_hash(username).await? {
@@ -176,13 +190,14 @@ impl UserBackend for LibsqlAuth {
             _ => {}
         }
 
-        let hash = hash_bcrypt(password.to_string(), DEFAULT_BCRYPT_COST).await?;
+        let hash =
+            hash.get_or_try_init(|| hash_bcrypt(password.to_string(), DEFAULT_BCRYPT_COST)).await?;
         if matches!(self.max_users, MaxUsers::Unlimited) {
             let inserted = self
                 .conn
                 .execute(
                     "INSERT INTO users (username, bcrypt_hash) VALUES (?1, ?2)",
-                    params![username, hash],
+                    params![username, hash.as_str()],
                 )
                 .await;
             return match inserted {
@@ -200,7 +215,7 @@ impl UserBackend for LibsqlAuth {
         let _registration_guard = self.registration_lock.lock().await;
         let mut can_retry_after_reconcile = true;
         loop {
-            let tx = self.conn.transaction().await?;
+            let tx = self.conn.transaction_with_behavior(TransactionBehavior::Immediate).await?;
             if let MaxUsers::Limited(max) = self.max_users {
                 let sql_max = i64::try_from(max).map_err(|_| RegistryError::InvalidConfig {
                     reason: "backend.libsql auth max_users must fit a signed BIGINT".to_string(),
@@ -229,7 +244,7 @@ impl UserBackend for LibsqlAuth {
             let inserted = tx
                 .execute(
                     "INSERT INTO users (username, bcrypt_hash) VALUES (?1, ?2)",
-                    params![username, hash],
+                    params![username, hash.as_str()],
                 )
                 .await;
             match inserted {
@@ -357,7 +372,7 @@ async fn ensure_user_counter(conn: &Connection) -> Result<()> {
 }
 
 async fn reconcile_user_counter_overcount(conn: &Connection) -> Result<bool> {
-    let tx = conn.transaction().await?;
+    let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate).await?;
     let mut counter_rows =
         tx.query("SELECT value FROM auth_counters WHERE name = ?1", params!["users"]).await?;
     let Some(counter_row) = counter_rows.next().await? else {
@@ -384,6 +399,48 @@ async fn reconcile_user_counter_overcount(conn: &Connection) -> Result<bool> {
     .await?;
     tx.commit().await?;
     Ok(true)
+}
+
+async fn retry_database_conflicts<Value, Operation, Pending>(
+    mut operation: Operation,
+) -> Result<Value>
+where
+    Operation: FnMut() -> Pending,
+    Pending: std::future::Future<Output = Result<Value>>,
+{
+    let mut retries = 0;
+    loop {
+        match operation().await {
+            Ok(value) => return Ok(value),
+            Err(RegistryError::Libsql(error)) if retries < 8 && is_transaction_conflict(&error) => {
+                tokio::time::sleep(Duration::from_millis(10 << retries.min(5))).await;
+                retries += 1;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+}
+
+fn is_transaction_conflict(error: &LibsqlError) -> bool {
+    match error {
+        LibsqlError::SqliteFailure(code, _) | LibsqlError::RemoteSqliteFailure(_, code, _) => {
+            matches!(code & 0xff, 5 | 6)
+        }
+        LibsqlError::Hrana(error) => {
+            // libsql does not expose Hrana's structured error type publicly.
+            let message = error.to_string();
+            let Some((_, code)) = message.rsplit_once(r#"code: ""#) else {
+                return false;
+            };
+            let Some((code, _)) = code.split_once('"') else {
+                return false;
+            };
+            matches!(code, "SQLITE_BUSY" | "SQLITE_LOCKED")
+                || code.starts_with("SQLITE_BUSY_")
+                || code.starts_with("SQLITE_LOCKED_")
+        }
+        _ => false,
+    }
 }
 
 fn is_unique_violation(err: &LibsqlError) -> bool {

--- a/pnpr/crates/auth/src/libsql_backend.rs
+++ b/pnpr/crates/auth/src/libsql_backend.rs
@@ -57,6 +57,7 @@ pub struct LibsqlAuth {
     secret: [u8; 32],
     counter: AtomicU64,
     max_users: MaxUsers,
+    registration_lock: tokio::sync::Mutex<()>,
     /// Deadline for each request-path auth read.
     timeout: Duration,
 }
@@ -115,6 +116,7 @@ impl LibsqlAuth {
             secret: fresh_secret(),
             counter: AtomicU64::new(0),
             max_users,
+            registration_lock: tokio::sync::Mutex::new(()),
             timeout: DEFAULT_AUTH_TIMEOUT,
         })
     }
@@ -195,6 +197,7 @@ impl UserBackend for LibsqlAuth {
             };
         }
 
+        let _registration_guard = self.registration_lock.lock().await;
         let mut can_retry_after_reconcile = true;
         loop {
             let tx = self.conn.transaction().await?;

--- a/pnpr/crates/auth/src/libsql_backend/tests.rs
+++ b/pnpr/crates/auth/src/libsql_backend/tests.rs
@@ -1,6 +1,7 @@
 use super::{
     Builder, Duration, LibsqlAuth, MaxUsers, RegistryError, Result, TokenBackend, UpsertOutcome,
-    UserBackend, ensure_user_counter, params, sha256_hex, with_auth_timeout,
+    UserBackend, ensure_user_counter, is_transaction_conflict, params, retry_database_conflicts,
+    sha256_hex, with_auth_timeout,
 };
 
 /// In-memory libsql database, exercising the same driver and SQL the
@@ -112,9 +113,6 @@ async fn max_users_caps_registration() {
     backend.add_or_login("alice", "x").await.unwrap();
 }
 
-/// The cap is strict, not best-effort: a concurrent burst of distinct
-/// new users against a cap of 1 admits exactly one. The count-and-insert
-/// runs in a single statement, so the guard can't be raced.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn registration_cap_is_strict_under_concurrency() {
     let backend = std::sync::Arc::new(local_backend(MaxUsers::Limited(1)).await);
@@ -138,6 +136,45 @@ async fn registration_cap_is_strict_under_concurrency() {
     let mut rows = backend.conn.query("SELECT COUNT(*) FROM users", ()).await.unwrap();
     let total: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
     assert_eq!(total, 1, "the cap must be strictly enforced, never exceeded");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn registration_cap_is_strict_across_backend_instances() {
+    let directory = tempfile::tempdir().unwrap();
+    let path = directory.path().join("auth.db");
+    let mut backends = Vec::new();
+    for _ in 0..6 {
+        let db = Builder::new_local(&path).build().await.unwrap();
+        backends.push(LibsqlAuth::from_database(db, MaxUsers::Limited(1)).await.unwrap());
+    }
+    let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(backends.len()));
+    let mut handles = Vec::new();
+    for (index, backend) in backends.into_iter().enumerate() {
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(tokio::spawn(async move {
+            barrier.wait().await;
+            backend.add_or_login(&format!("user{index}"), "x").await
+        }));
+    }
+    let mut created = 0;
+    for handle in handles {
+        match handle.await.unwrap() {
+            Ok((UpsertOutcome::Created, _)) => created += 1,
+            Err(RegistryError::TooManyUsers { max: 1 }) => {}
+            other => panic!("unexpected concurrent registration result: {other:?}"),
+        }
+    }
+    assert_eq!(created, 1);
+    let db = Builder::new_local(&path).build().await.unwrap();
+    let backend = LibsqlAuth::from_database(db, MaxUsers::Limited(1)).await.unwrap();
+    assert_eq!(backend.user_count().await.unwrap(), 1);
+    let mut rows = backend
+        .conn
+        .query("SELECT value FROM auth_counters WHERE name = 'users'", ())
+        .await
+        .unwrap();
+    let count: i64 = rows.next().await.unwrap().unwrap().get(0).unwrap();
+    assert_eq!(count, 1);
 }
 
 #[tokio::test]
@@ -229,4 +266,104 @@ async fn reads_propagate_a_backend_error_instead_of_swallowing_it() {
     assert!(backend.lookup("anything").await.is_err());
     assert!(backend.find_by_key("anything").await.is_err());
     assert!(backend.list_for_user("alice").await.is_err());
+}
+
+#[tokio::test]
+async fn registration_waits_for_another_database_writer() {
+    let directory = tempfile::tempdir().unwrap();
+    let db = Builder::new_local(directory.path().join("auth.db")).build().await.unwrap();
+    let backend = LibsqlAuth::from_database(db, MaxUsers::Limited(1)).await.unwrap();
+    let other_db = Builder::new_local(directory.path().join("auth.db")).build().await.unwrap();
+    let other = other_db.connect().unwrap();
+    let writer =
+        other.transaction_with_behavior(libsql::TransactionBehavior::Immediate).await.unwrap();
+    let pending = begin_registration_transaction(&backend.conn);
+    tokio::pin!(pending);
+    assert!(tokio::time::timeout(Duration::from_millis(20), &mut pending).await.is_err());
+    writer.rollback().await.unwrap();
+    pending.await.unwrap().rollback().await.unwrap();
+}
+
+#[tokio::test]
+async fn registration_transaction_retries_only_remote_lock_conflicts() {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    for (code, expected_attempts) in [("SQLITE_BUSY", 9), ("SQLITE_AUTH", 1)] {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let app = axum::Router::new()
+            .route("/v3/pipeline", axum::routing::post(reject_remote_transaction))
+            .with_state((code, Arc::clone(&attempts)));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let db = Builder::new_remote(format!("http://{address}"), String::new())
+            .connector(tower::service_fn(move |_| tokio::net::TcpStream::connect(address)))
+            .build()
+            .await
+            .unwrap();
+        let conn = db.connect().unwrap();
+        let error =
+            begin_registration_transaction(&conn).await.err().expect("server rejects transaction");
+        server.abort();
+        assert_eq!(attempts.load(Ordering::SeqCst), expected_attempts, "{error:?}");
+        assert!(matches!(error, RegistryError::Libsql(_)));
+    }
+}
+
+#[test]
+fn transaction_conflicts_include_extended_sqlite_codes() {
+    for code in [5, 6, 261, 517, 262] {
+        assert!(is_transaction_conflict(&libsql::Error::SqliteFailure(code, String::new())));
+        assert!(is_transaction_conflict(&libsql::Error::RemoteSqliteFailure(
+            0,
+            code,
+            String::new()
+        )));
+    }
+    for code in [1, 19, 2067] {
+        assert!(!is_transaction_conflict(&libsql::Error::SqliteFailure(code, String::new())));
+    }
+    assert!(!is_transaction_conflict(&libsql::Error::ConnectionFailed("SQLITE_BUSY".to_string())));
+}
+
+async fn reject_remote_transaction(
+    axum::extract::State((code, attempts)): axum::extract::State<(
+        &'static str,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    )>,
+    body: String,
+) -> axum::Json<serde_json::Value> {
+    attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+    let body: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let results: Vec<_> = body["requests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|request| {
+            if request["type"] == "get_autocommit" {
+                serde_json::json!({
+                    "type": "ok",
+                    "response": {"type": "get_autocommit", "is_autocommit": true},
+                })
+            } else {
+                serde_json::json!({
+                    "type": "error",
+                    "error": {"code": code, "message": "test transaction failure"},
+                })
+            }
+        })
+        .collect();
+    axum::Json(serde_json::json!({"baton": null, "base_url": null, "results": results}))
+}
+
+async fn begin_registration_transaction(conn: &libsql::Connection) -> Result<libsql::Transaction> {
+    retry_database_conflicts(|| async {
+        conn.transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .map_err(RegistryError::from)
+    })
+    .await
 }

--- a/pnpr/crates/auth/src/libsql_backend/tests.rs
+++ b/pnpr/crates/auth/src/libsql_backend/tests.rs
@@ -127,8 +127,10 @@ async fn registration_cap_is_strict_under_concurrency() {
     }
     let mut created = 0;
     for handle in handles {
-        if matches!(handle.await.unwrap(), Ok((UpsertOutcome::Created, _))) {
-            created += 1;
+        match handle.await.unwrap() {
+            Ok((UpsertOutcome::Created, _)) => created += 1,
+            Err(RegistryError::TooManyUsers { max: 1 }) => {}
+            other => panic!("unexpected concurrent registration result: {other:?}"),
         }
     }
     assert_eq!(created, 1, "exactly one registration may win the cap of 1");

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -145,6 +145,18 @@ uses only the upstream credentials from its configuration, never a browser
 caller's authorization header. Discovery refuses redirects and sends configured
 upstream headers only over HTTPS or loopback HTTP. Search totals count only
 visible, deduplicated results and are exact across every participating source.
+Hosted npm packages and Cargo crates can be browsed without a search term:
+
+```text
+GET /-/v1/search?browse=true&size=20&from=0
+GET /cargo/api/v1/crates?browse=true&per_page=20&page=1
+```
+
+Use the ecosystem prefix and named registry mount appropriate for your server.
+Browse results follow registry routing and access rules, exclude upstreams and
+staged publications, and use the same response format and pagination limits as
+search. An empty search without `browse=true` still returns no results.
+
 To bound work from a single browser request, pnpr rejects upstream searches
 that would scan more than 2,000 upstream results or eight upstream pages.
 Offsets that would require a larger upstream scan are also rejected. Refine the

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -2345,6 +2345,7 @@ async fn serve_search(
     else {
         return result(Vec::new(), 0);
     };
+    let browse = pnpr_search::browse_requested(query_string);
     let mut page = SearchPage::new(params.from, params.size);
     let mut upstream_budget = UpstreamSearchBudget::default();
     for source in discovery_sources(state, &registry, Ecosystem::Npm) {
@@ -2374,7 +2375,8 @@ async fn serve_search(
                 let Some(config) = state.inner.config.upstreams.get(&source) else {
                     continue;
                 };
-                if !config.search
+                if browse
+                    || !config.search
                     || config.access.as_ref().is_some_and(|access| !access.allows(identity))
                     || !config.rules.all_access_admit(identity)
                 {

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -436,6 +436,15 @@ async fn search_lists_hosted_crates_by_newest_version_and_description() {
     assert_eq!(body["crates"].as_array().unwrap().len(), 1);
     assert_eq!(body["crates"][0]["name"], "inflector");
 
+    for (page, name) in [(1, "demo"), (2, "inflector")] {
+        let body = search(app.clone(), &format!("browse=true&per_page=1&page={page}")).await;
+        assert_eq!(body["meta"]["total"], 2);
+        assert_eq!(body["crates"].as_array().unwrap().len(), 1);
+        assert_eq!(body["crates"][0]["name"], name);
+    }
+    let body = search(app.clone(), "browse=true&per_page=1&page=3").await;
+    assert_eq!(body, json!({ "crates": [], "meta": { "total": 2 } }));
+
     // A query that names nothing is not a request to dump the registry.
     let body = search(app.clone(), "q=nothing-matches-this").await;
     assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
@@ -526,44 +535,43 @@ async fn search_reports_the_newest_unyanked_release() {
 
 #[tokio::test]
 async fn search_hides_a_private_registry_from_an_anonymous_caller() {
-    let tmp = TempDir::new().unwrap();
-    let auth = AuthState::in_memory();
-    let token = auth.tokens.issue("alice").await.unwrap();
-    let app = router_with_auth(
-        cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$authenticated"),
-        auth,
-    );
-    let response = app
-        .clone()
-        .oneshot(publish_request(
-            Some(&token),
-            publish_body(&metadata("demo", "0.1.0"), &crate_archive("demo", "0.1.0")),
-        ))
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
+    for url in ["/cargo/api/v1/crates?q=demo", "/cargo/api/v1/crates?browse=true"] {
+        let tmp = TempDir::new().unwrap();
+        let auth = AuthState::in_memory();
+        let token = auth.tokens.issue("alice").await.unwrap();
+        let app = router_with_auth(
+            cargo_config(tmp.path().to_path_buf(), "http://upstream.invalid/", "$authenticated"),
+            auth,
+        );
+        let response = app
+            .clone()
+            .oneshot(publish_request(
+                Some(&token),
+                publish_body(&metadata("demo", "0.1.0"), &crate_archive("demo", "0.1.0")),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
 
-    let response = app
-        .clone()
-        .oneshot(Request::get("/cargo/api/v1/crates?q=demo").body(Body::empty()).unwrap())
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
-    assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
+        let response =
+            app.clone().oneshot(Request::get(url).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        assert_eq!(body, json!({ "crates": [], "meta": { "total": 0 } }));
 
-    let response = app
-        .oneshot(
-            Request::get("/cargo/api/v1/crates?q=demo")
-                .header(header::AUTHORIZATION, &token)
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
-    assert_eq!(body["crates"][0]["name"], "demo");
+        let response = app
+            .oneshot(
+                Request::get(url)
+                    .header(header::AUTHORIZATION, &token)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        assert_eq!(body["crates"][0]["name"], "demo");
+    }
 }
 
 #[tokio::test]

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4282,8 +4282,6 @@ async fn search_does_not_enumerate_a_private_flat_root_registry() {
             request.body(Body::empty()).unwrap()
         };
 
-        // Neither the anonymous caller nor an authenticated non-member can
-        // enumerate the private registry's packages.
         for authorization in [None, Some(format!("Bearer {outsider}"))] {
             let response = app.clone().oneshot(search_with(authorization)).await.unwrap();
             assert_eq!(response.status(), StatusCode::OK);
@@ -4292,7 +4290,6 @@ async fn search_does_not_enumerate_a_private_flat_root_registry() {
             assert_eq!(body["objects"], json!([]));
         }
 
-        // A member still finds it.
         let response = app.oneshot(search_with(Some(format!("Bearer {member}")))).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let body = body_json(response.into_body()).await;

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4255,47 +4255,49 @@ async fn private_hosted_registry_denies_writes_from_non_members() {
 /// by name/version/description through `/-/v1/search`.
 #[tokio::test]
 async fn search_does_not_enumerate_a_private_flat_root_registry() {
-    let tmp = TempDir::new().unwrap();
-    // The flat root (`org: ""`) stores directly under `storage`.
-    seed_hosted(tmp.path(), "@corp/secret-tool");
+    for url in ["/-/v1/search?text=secret", "/-/v1/search?browse=true"] {
+        let tmp = TempDir::new().unwrap();
+        // The flat root (`org: ""`) stores directly under `storage`.
+        seed_hosted(tmp.path(), "@corp/secret-tool");
 
-    let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-    // Replace the default public flat-root registry (`local`) with a private one;
-    // any surviving `$all` flat-root entry would defeat the gate under test.
-    config.hosted.clear();
-    config.hosted.insert("corp".to_string(), hosted_with_access("", "alice"));
-    config.registries = Registries::new(
-        vec![("corp".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
-        Some("corp".to_string()),
-    );
-    let auth = AuthState::in_memory();
-    let member = auth.tokens.issue("alice").await.unwrap();
-    let outsider = auth.tokens.issue("mallory").await.unwrap();
-    let app = router_with_auth(config, auth);
+        let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
+        // Replace the default public flat-root registry (`local`) with a private one;
+        // any surviving `$all` flat-root entry would defeat the gate under test.
+        config.hosted.clear();
+        config.hosted.insert("corp".to_string(), hosted_with_access("", "alice"));
+        config.registries = Registries::new(
+            vec![("corp".to_string(), Registry::Hosted { patterns: vec![] })].into_iter().collect(),
+            Some("corp".to_string()),
+        );
+        let auth = AuthState::in_memory();
+        let member = auth.tokens.issue("alice").await.unwrap();
+        let outsider = auth.tokens.issue("mallory").await.unwrap();
+        let app = router_with_auth(config, auth);
 
-    let search_with = |authorization: Option<String>| {
-        let mut request = Request::get("/-/v1/search?text=secret");
-        if let Some(value) = authorization {
-            request = request.header(header::AUTHORIZATION, value);
+        let search_with = |authorization: Option<String>| {
+            let mut request = Request::get(url);
+            if let Some(value) = authorization {
+                request = request.header(header::AUTHORIZATION, value);
+            }
+            request.body(Body::empty()).unwrap()
+        };
+
+        // Neither the anonymous caller nor an authenticated non-member can
+        // enumerate the private registry's packages.
+        for authorization in [None, Some(format!("Bearer {outsider}"))] {
+            let response = app.clone().oneshot(search_with(authorization)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = body_json(response.into_body()).await;
+            assert_eq!(body["total"], json!(0), "private package leaked through search");
+            assert_eq!(body["objects"], json!([]));
         }
-        request.body(Body::empty()).unwrap()
-    };
 
-    // Neither the anonymous caller nor an authenticated non-member can
-    // enumerate the private registry's packages.
-    for authorization in [None, Some(format!("Bearer {outsider}"))] {
-        let response = app.clone().oneshot(search_with(authorization)).await.unwrap();
+        // A member still finds it.
+        let response = app.oneshot(search_with(Some(format!("Bearer {member}")))).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let body = body_json(response.into_body()).await;
-        assert_eq!(body["total"], json!(0), "private package leaked through search");
-        assert_eq!(body["objects"], json!([]));
+        assert_eq!(body["objects"][0]["package"]["name"], json!("@corp/secret-tool"));
     }
-
-    // A member still finds it.
-    let response = app.oneshot(search_with(Some(format!("Bearer {member}")))).await.unwrap();
-    assert_eq!(response.status(), StatusCode::OK);
-    let body = body_json(response.into_body()).await;
-    assert_eq!(body["objects"][0]["package"]["name"], json!("@corp/secret-tool"));
 }
 
 #[tokio::test]
@@ -5308,4 +5310,78 @@ fn pipeline_viewer_renders_publisher_data_as_text() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+}
+
+#[tokio::test]
+async fn browse_paginates_hosted_packages_without_contacting_upstreams() {
+    let tmp = TempDir::new().unwrap();
+    seed_hosted(tmp.path(), "alpha");
+    seed_hosted(tmp.path(), "beta");
+    seed_hosted(tmp.path(), "gamma");
+    seed_hosted(tmp.path(), "routed-to-upstream");
+    seed_hosted(tmp.path(), "hidden");
+    let mut upstream = mockito::Server::new_async().await;
+    let search = upstream
+        .mock("GET", "/-/v1/search")
+        .match_query(mockito::Matcher::Any)
+        .expect(0)
+        .create_async()
+        .await;
+    let mut config = config_for(&upstream.url(), tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().search = true;
+    let mut hosted = hosted_with_access("", "$all");
+    hosted.rules = PackageRules::new(
+        vec![access_rule("hidden", "alice")],
+        Some(AccessList::from_tokens(["$all"])),
+    );
+    config.hosted.insert("local".to_string(), hosted);
+    config.registries = Registries::new(
+        [
+            (
+                "local".to_string(),
+                Registry::Hosted {
+                    patterns: ["alpha", "beta", "gamma", "hidden"]
+                        .into_iter()
+                        .map(|name| PackagePattern::parse(name, Ecosystem::Npm).unwrap())
+                        .collect(),
+                },
+            ),
+            ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
+            (
+                "main".to_string(),
+                Registry::Router { sources: vec!["local".to_string(), "npmjs".to_string()] },
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        Some("main".to_string()),
+    );
+    let app = router(config);
+    for base in ["", "/~main"] {
+        for (from, name) in [(0, "alpha"), (1, "beta"), (2, "gamma")] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::get(format!("{base}/-/v1/search?browse=true&size=1&from={from}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[header::CACHE_CONTROL], "private, no-store");
+            let body = body_json(response.into_body()).await;
+            assert_eq!(body["total"], 3);
+            assert_eq!(body["objects"].as_array().unwrap().len(), 1);
+            assert_eq!(body["objects"][0]["package"]["name"], name);
+        }
+    }
+    let response = app
+        .oneshot(Request::get("/-/v1/search?browse=true&from=3").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body = body_json(response.into_body()).await;
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["objects"], json!([]));
+    search.assert_async().await;
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -4257,12 +4257,10 @@ async fn private_hosted_registry_denies_writes_from_non_members() {
 async fn search_does_not_enumerate_a_private_flat_root_registry() {
     for url in ["/-/v1/search?text=secret", "/-/v1/search?browse=true"] {
         let tmp = TempDir::new().unwrap();
-        // The flat root (`org: ""`) stores directly under `storage`.
         seed_hosted(tmp.path(), "@corp/secret-tool");
 
         let mut config = config_for("http://127.0.0.1:1", tmp.path().to_path_buf());
-        // Replace the default public flat-root registry (`local`) with a private one;
-        // any surviving `$all` flat-root entry would defeat the gate under test.
+        // A surviving public flat-root registry would defeat this access check.
         config.hosted.clear();
         config.hosted.insert("corp".to_string(), hosted_with_access("", "alice"));
         config.registries = Registries::new(

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -67,7 +67,6 @@ pub fn parse_query(query_string: &str) -> Option<String> {
     fallback.or_else(|| browse_requested(query_string).then(String::new))
 }
 
-/// Whether the caller requests hosted packages without contacting upstreams.
 #[must_use]
 pub fn browse_requested(query_string: &str) -> bool {
     query_string.split('&').any(|pair| pair == "browse=true")

--- a/pnpr/crates/search/src/lib.rs
+++ b/pnpr/crates/search/src/lib.rs
@@ -42,24 +42,11 @@ pub fn parse_params(query_string: &str, default_size: usize) -> Option<SearchPar
     })
 }
 
-/// Parse the `text` query parameter out of a `/-/v1/search?...`
-/// query string. npm clients always send `text=...`; we accept
-/// `q=...` as a fallback because some older callers use that.
-/// Returns `None` for "no text provided", in which case the
-/// caller should return an empty result rather than dumping the
-/// entire storage.
-///
-/// Three things this avoids:
-/// * The first malformed pair (no `=`) doesn't abort the whole
-///   parse — `size=20&text=foo` shouldn't return None just because
-///   a third pair somewhere is missing an `=`.
-/// * An empty decoded value (`text=`) is treated as "no text",
-///   not as "match everything" — a downstream substring filter
-///   uses `contains(needle)` which is always true for an empty
-///   needle and would dump the entire storage to anonymous
-///   callers.
-/// * `q=` is a *fallback*: when both `text` and `q` are present
-///   `text` wins regardless of order.
+/// Decode `text`, falling back to `q` regardless of parameter order.
+/// Empty values and malformed pairs are ignored. With no nonempty value,
+/// returns `None` unless `browse=true` explicitly requests an empty filter.
+/// Browse callers must restrict discovery to hosted packages and enforce
+/// registry routing and access rules.
 #[must_use]
 pub fn parse_query(query_string: &str) -> Option<String> {
     let mut fallback: Option<String> = None;
@@ -77,7 +64,13 @@ pub fn parse_query(query_string: &str) -> Option<String> {
             _ => {}
         }
     }
-    fallback
+    fallback.or_else(|| browse_requested(query_string).then(String::new))
+}
+
+/// Whether the caller requests hosted packages without contacting upstreams.
+#[must_use]
+pub fn browse_requested(query_string: &str) -> bool {
+    query_string.split('&').any(|pair| pair == "browse=true")
 }
 
 /// The first parsable value of a numeric URL parameter, or `None` when the

--- a/pnpr/crates/search/src/tests.rs
+++ b/pnpr/crates/search/src/tests.rs
@@ -75,3 +75,14 @@ fn parses_maintainer_search_params() {
         Some(SearchParams { text: SearchText::Maintainer("alice".to_string()), from: 0, size: 1 }),
     );
 }
+
+#[test]
+fn browsing_requires_an_explicit_flag() {
+    assert_eq!(parse_query("browse=true&size=1"), Some(String::new()));
+    assert_eq!(parse_query("text=&browse=true"), Some(String::new()));
+    assert_eq!(parse_query("browse=true&text=demo"), Some("demo".to_string()));
+    for query in ["browse=false", "browse=", "text=browse%3Dtrue&browse=false"] {
+        assert!(!super::browse_requested(query));
+    }
+    assert!(parse_query("browse=false").is_none());
+}


### PR DESCRIPTION
## Summary

Add opt-in browsing of hosted npm packages and Cargo crates with `browse=true` on the existing search endpoints. The web UI can show a paginated package list before the user enters a search term. Browsing applies existing routing and access rules and never contacts upstream registries. Ordinary empty searches still return no results.

Fix concurrent libsql registrations within one server and across independent server instances. Keep the atomic database counter authoritative, acquire the write lock before capped registration, and retry temporary SQLite lock conflicts up to eight times. Reuse the password hash across attempts. Non-lock errors propagate immediately.

Fix the Windows CI failure in concurrent task-cache publication. Atomic writes now close the temporary file before replacement and use the existing bounded Windows file-lock retry policy.

Companion UI change: https://bit.cloud/pnpm/pnpr/~change-requests/browse-packages-and-fix-navigation

Validation:
- `just ready`: formatting, workspace checks, 10,827 passing Rust tests, and workspace Clippy.
- `cargo deny check` passed.
- The independent-backend registration regression reproduced the database-lock failure before the fix and passed 20 consecutive runs afterward. HTTP tests cover retry exhaustion and non-lock error propagation.
- Atomic-write tests cover concurrent replacement, permissions, and symlinks. The Windows lock regression cross-compiles; Windows execution is covered by CI.
- Browser integration passed against the populated pnpr server for hosted browsing, overview navigation, and Cargo tarball downloads.

## Squash Commit Body

```text
Add browse=true to the npm and Cargo search APIs. Reuse hosted discovery,
routing, authorization, result projection, and pagination. Skip upstream
search in browse mode. Preserve ordinary empty-search behavior.

Cover pagination and totals, named registry mounts, registry and package
access restrictions, routed-away packages, and zero upstream requests.
Document the endpoints and add a pnpr minor release note.

Serialize capped libsql registration transactions on the shared connection.
Use immediate transactions and bounded retries for SQLite lock conflicts
across independent backends. Retain the atomic counter as the user-limit
authority. Cache the bcrypt hash within each registration request.
Test independent databases opening the same file, lock release, extended
SQLite error codes, and retry behavior through the real libsql HTTP client.

Close temporary-file handles before atomic replacement and retry transient
Windows file locks. This fixes concurrent task-cache publication failures.
Add registration and Windows cache-write patch release notes.
```

## Checklist

- [x] New features are limited to pnpr. The CLI concurrency fix affects the Rust implementation; TypeScript atomic writes already serialize same-file writes.
- [x] Added changesets for published packages.
- [x] Added or updated tests.
- [x] Updated endpoint documentation.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added paginated browsing of hosted npm packages and Cargo crates without a search term.
  * Browse results follow registry routing and package access rules, using standard and router-addressed endpoints.
  * Browse requests use the same response format and pagination limits as regular searches.

* **Bug Fixes**
  * Fixed transaction errors during concurrent user registrations when a user limit is configured.
  * Fixed intermittent Windows access-denied errors when saving cache state concurrently.

* **Documentation**
  * Documented `browse=true` behavior and clarified that empty searches without it return no results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->