### PR TITLE
fix(network): filter empty segments in no-proxy matcher

### DIFF
--- a/.changeset/no-proxy-leading-dot.md
+++ b/.changeset/no-proxy-leading-dot.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, so they bypass the proxy for the domain and its subdomains [#14686](https://github.com/pnpm/pnpm/issues/14686).
+`NO_PROXY` entries that start with a dot, such as `.npmjs.org`, now bypass the proxy for the domain and its subdomains [#14686](https://github.com/pnpm/pnpm/issues/14686).

--- a/.changeset/no-proxy-leading-dot.md
+++ b/.changeset/no-proxy-leading-dot.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, never bypassing the proxy [#14686](https://github.com/pnpm/pnpm/issues/14686). Entries without the leading dot already worked correctly.

--- a/.changeset/no-proxy-leading-dot.md
+++ b/.changeset/no-proxy-leading-dot.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, never bypassing the proxy [#14686](https://github.com/pnpm/pnpm/issues/14686). Entries without the leading dot already worked correctly.
+Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, never bypassing the proxy. Entries without the leading dot already worked correctly [#14686](https://github.com/pnpm/pnpm/issues/14686).

--- a/.changeset/no-proxy-leading-dot.md
+++ b/.changeset/no-proxy-leading-dot.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, never bypassing the proxy. Entries without the leading dot already worked correctly [#14686](https://github.com/pnpm/pnpm/issues/14686).
+Fixed `NO_PROXY` entries that start with a dot, such as `.npmjs.org`, so they bypass the proxy for the domain and its subdomains [#14686](https://github.com/pnpm/pnpm/issues/14686).

--- a/pnpm/crates/network/src/proxy.rs
+++ b/pnpm/crates/network/src/proxy.rs
@@ -133,7 +133,10 @@ pub(crate) fn strip_userinfo(mut url: Url) -> (Url, Option<(String, String)>) {
 /// matches when the entry's reversed segments are a prefix of the
 /// host's reversed segments. `npmjs.org` thus matches
 /// `registry.npmjs.org` and `foo.bar.npmjs.org` but not
-/// `evilnpmjs.org`. Empty entries (from stray commas) never match.
+/// `evilnpmjs.org`. A leading dot (`.npmjs.org`) is the conventional
+/// spelling of the same rule, so entries and hosts are normalized with
+/// [`reverse_dot_segments`] and match alike. Empty entries (from stray
+/// commas) never match.
 #[derive(Debug)]
 pub(crate) struct NoProxyMatcher {
     bypass: bool,
@@ -149,14 +152,7 @@ impl NoProxyMatcher {
                 bypass: false,
                 entries: list
                     .iter()
-                    .map(|entry| {
-                        entry
-                            .split('.')
-                            .filter(|segment| !segment.is_empty())
-                            .rev()
-                            .map(str::to_string)
-                            .collect()
-                    })
+                    .map(|entry| reverse_dot_segments(entry).map(str::to_string).collect())
                     .collect(),
             },
         }
@@ -166,8 +162,7 @@ impl NoProxyMatcher {
         if self.bypass {
             return true;
         }
-        let host_rev: Vec<&str> =
-            host.split('.').filter(|segment| !segment.is_empty()).rev().collect();
+        let host_rev: Vec<&str> = reverse_dot_segments(host).collect();
         self.entries.iter().any(|entry_rev| {
             !entry_rev.is_empty()
                 && entry_rev.len() <= host_rev.len()
@@ -181,4 +176,16 @@ impl NoProxyMatcher {
             None => false,
         }
     }
+}
+
+/// Split a `no-proxy` entry or a candidate host into dot-segments,
+/// most-significant label first.
+///
+/// Empty segments are dropped so a leading dot (`.npmjs.org`), a
+/// trailing root dot (`npmjs.org.`), and a doubled dot all normalize to
+/// the same segment list. Both sides of the comparison in
+/// [`NoProxyMatcher::matches_host`] go through this, so the entry and
+/// the host are always segmented the same way.
+fn reverse_dot_segments(host: &str) -> impl Iterator<Item = &str> {
+    host.split('.').filter(|segment| !segment.is_empty()).rev()
 }

--- a/pnpm/crates/network/src/proxy.rs
+++ b/pnpm/crates/network/src/proxy.rs
@@ -149,7 +149,14 @@ impl NoProxyMatcher {
                 bypass: false,
                 entries: list
                     .iter()
-                    .map(|entry| entry.split('.').rev().map(str::to_string).collect())
+                    .map(|entry| {
+                        entry
+                            .split('.')
+                            .filter(|s| !s.is_empty())
+                            .rev()
+                            .map(str::to_string)
+                            .collect()
+                    })
                     .collect(),
             },
         }
@@ -159,7 +166,7 @@ impl NoProxyMatcher {
         if self.bypass {
             return true;
         }
-        let host_rev: Vec<&str> = host.split('.').rev().collect();
+        let host_rev: Vec<&str> = host.split('.').filter(|s| !s.is_empty()).rev().collect();
         self.entries.iter().any(|entry_rev| {
             !entry_rev.is_empty()
                 && entry_rev.len() <= host_rev.len()

--- a/pnpm/crates/network/src/proxy.rs
+++ b/pnpm/crates/network/src/proxy.rs
@@ -152,7 +152,7 @@ impl NoProxyMatcher {
                     .map(|entry| {
                         entry
                             .split('.')
-                            .filter(|s| !s.is_empty())
+                            .filter(|segment| !segment.is_empty())
                             .rev()
                             .map(str::to_string)
                             .collect()
@@ -166,7 +166,8 @@ impl NoProxyMatcher {
         if self.bypass {
             return true;
         }
-        let host_rev: Vec<&str> = host.split('.').filter(|s| !s.is_empty()).rev().collect();
+        let host_rev: Vec<&str> =
+            host.split('.').filter(|segment| !segment.is_empty()).rev().collect();
         self.entries.iter().any(|entry_rev| {
             !entry_rev.is_empty()
                 && entry_rev.len() <= host_rev.len()

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -158,7 +158,6 @@ fn no_proxy_matcher_reverse_dot_match() {
 
 #[test]
 fn no_proxy_matcher_leading_dot_matches_subdomains() {
-    // A leading dot (e.g. `.npmjs.org`) must still match, not just the bare domain.
     let matcher = NoProxyMatcher::from(Some(&list(&[".npmjs.org"])));
     eprintln!("matcher={matcher:?}");
     for (host, expected) in [

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -159,7 +159,6 @@ fn no_proxy_matcher_reverse_dot_match() {
 #[test]
 fn no_proxy_matcher_leading_dot_matches_subdomains() {
     let matcher = NoProxyMatcher::from(Some(&list(&[".npmjs.org"])));
-    eprintln!("matcher={matcher:?}");
     for (host, expected) in [
         ("npmjs.org", true),
         ("registry.npmjs.org", true),

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -148,6 +148,7 @@ fn no_proxy_matcher_reverse_dot_match() {
         ("npmjs.org", true),
         ("registry.npmjs.org", true),
         ("foo.bar.npmjs.org", true),
+        ("registry.npmjs.org.", true),
         ("evilnpmjs.org", false),
         ("org", false),
     ] {

--- a/pnpm/crates/network/src/tests.rs
+++ b/pnpm/crates/network/src/tests.rs
@@ -157,6 +157,22 @@ fn no_proxy_matcher_reverse_dot_match() {
 }
 
 #[test]
+fn no_proxy_matcher_leading_dot_matches_subdomains() {
+    // A leading dot (e.g. `.npmjs.org`) must still match, not just the bare domain.
+    let matcher = NoProxyMatcher::from(Some(&list(&[".npmjs.org"])));
+    eprintln!("matcher={matcher:?}");
+    for (host, expected) in [
+        ("npmjs.org", true),
+        ("registry.npmjs.org", true),
+        ("foo.bar.npmjs.org", true),
+        ("evilnpmjs.org", false),
+    ] {
+        let got = matcher.matches_host(host);
+        assert_eq!(got, expected, "host={host}: expected match={expected}, got={got}");
+    }
+}
+
+#[test]
 fn no_proxy_matcher_empty_entries_never_match() {
     // Trailing/leading commas in `.npmrc` already get filtered in the
     // config layer's `parse_no_proxy`, but a malformed `List(vec![""])`


### PR DESCRIPTION
## What

`NoProxyMatcher::from` reverses each `no-proxy` entry's dot-segments to build a reverse-dot-segment-prefix lookup table, but does so without filtering out empty segments first. This PR adds that filter on both the entry and host side.

## Why

A leading-dot entry such as `.npmjs.org` (the conventional "match this host and every subdomain" form used by curl, npm, and many corporate `NO_PROXY` values) splits to `["", "npmjs", "org"]`. Reversed without filtering, that's `["org", "npmjs", ""]`. `matches_host`'s position-by-position comparison against the host's reversed segments then hits the trailing `""` and fails at every length, so a leading-dot entry can never match any host, at any subdomain depth. Entries without a leading dot are unaffected.

Closes #14686, which has the full repro (a local proxy plus `NO_PROXY=.npmjs.org` vs `NO_PROXY=npmjs.org`) and already points at the same lines.

I ran into this independently while debugging a real corporate-proxy `NO_PROXY` hang: `pnpm install --frozen-lockfile` on pnpm 12.3.4 timed out fetching a tarball from a registry host explicitly covered by a leading-dot `NO_PROXY` entry, while `curl` against the same host succeeded instantly. Confirmed the same list without the leading dot fixed it, then traced it to this code.

## Test plan

- [x] Added `no_proxy_matcher_leading_dot_matches_subdomains`, which fails on current `main` and passes with this fix (verified by temporarily reverting the fix and confirming it fails for the expected reason before restoring it).
- [x] `cargo fmt --check -p pnpm-network`
- [x] `cargo test -p pnpm-network --lib` — 8/8 pass
- [x] `cargo clippy -p pnpm-network --lib -- --deny warnings` — clean
- [x] Added a changeset (`pacquet`, patch)

---

Written by an agent (Claude Code, claude-sonnet-5), reviewed and directed by me.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791475006&installation_model_id=426870&pr_number=14698&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14698&signature=ea4820d983dadbd3b8b1c05fa3fe18216fe41e96aff26b45a45131838b942ddf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `NO_PROXY` handling for entries beginning with a dot.
  * Proxy bypass now applies to the specified domain and its subdomains, while excluding unrelated hosts.
  * Improved matching for hostnames with trailing dots and empty dot segments.

* **Tests**
  * Added coverage for leading-dot entries, nested subdomains, trailing-dot hostnames, and non-matching hosts.

* **Documentation**
  * Documented the patch-level fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->