### PR TITLE
perf(cargo): speed up dependency installation

### DIFF
--- a/.changeset/quick-cargo-workspace-discovery.md
+++ b/.changeset/quick-cargo-workspace-discovery.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Sped up `pnpm install` in Cargo workspaces with many member crates.
+Sped up `pnpm install` in Cargo workspaces with many member crates. Repeated installs reuse verified Cargo checksum metadata.

--- a/.changeset/quick-cargo-workspace-discovery.md
+++ b/.changeset/quick-cargo-workspace-discovery.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Sped up `pnpm install` in Cargo workspaces with many member crates.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6135,6 +6135,7 @@ dependencies = [
  "serde-saphyr",
  "tempfile",
  "wax",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -13,7 +13,8 @@ use pnpm_network::{AuthHeaders, RetryOpts, ThrottledClient};
 use pnpm_pnpr_client::{CargoResolveOptions, PnprClient};
 use pnpm_reporter::Reporter;
 use pnpm_store_dir::{
-    SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexWriter,
+    CafsFileInfo, SharedReadonlyStoreIndex, SharedVerifiedFilesCache, StoreDir, StoreIndex,
+    StoreIndexWriter,
 };
 use pnpm_tarball::{ArchiveStoreProjection, IngestTarballToStore};
 use serde::{Deserialize, Serialize};
@@ -28,6 +29,7 @@ use std::{
 };
 
 pub(crate) mod add;
+mod checksum_cache;
 mod git;
 mod registry_auth;
 
@@ -305,7 +307,7 @@ async fn download_crates<Reporter: self::Reporter + 'static>(
             materialize::<Reporter>(MaterializeOptions {
                 package,
                 store_dir,
-                store_index: store_index.clone(),
+                store_index: store_index.as_ref().map(Arc::clone),
                 store_index_writer: Arc::clone(&store_index_writer),
                 http_client: Arc::clone(&http_client),
                 auth_headers: Arc::clone(&auth_headers),
@@ -785,11 +787,11 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     let mut cas_paths = IngestTarballToStore {
         http_client: &http_client,
         store_dir,
-        store_index,
-        store_index_writer: Some(store_index_writer),
+        store_index: store_index.as_ref().map(Arc::clone),
+        store_index_writer: Some(Arc::clone(&store_index_writer)),
         verify_store_integrity,
         strict_store_pkg_content_check,
-        verified_files_cache,
+        verified_files_cache: Arc::clone(&verified_files_cache),
         package_integrity: Some(&integrity),
         package_unpacked_size: None,
         package_file_count: None,
@@ -812,7 +814,13 @@ async fn materialize<Reporter: self::Reporter + 'static>(
     let checksum = package.checksum;
     let slot_for_import = slot.clone();
     tokio::task::spawn_blocking(move || {
-        add_cargo_checksum(store_dir, &mut cas_paths, Some(&checksum))?;
+        checksum_cache::ChecksumCache {
+            store_dir,
+            index: store_index.as_ref(),
+            writer: &store_index_writer,
+            verified_files: &verified_files_cache,
+        }
+        .add(&mut cas_paths, &checksum)?;
         import_indexed_dir::<Reporter>(
             &logged_methods,
             package_import_method,
@@ -837,7 +845,7 @@ fn add_cargo_checksum(
     store_dir: &StoreDir,
     cas_paths: &mut HashMap<String, PathBuf>,
     package_checksum: Option<&str>,
-) -> Result<()> {
+) -> Result<CafsFileInfo> {
     cas_paths.remove(".cargo-checksum.json");
     let files = cas_paths
         .iter()
@@ -851,12 +859,17 @@ fn add_cargo_checksum(
     let checksum = serde_json::to_vec(&CargoChecksum { files, package: package_checksum })
         .into_diagnostic()
         .wrap_err("serialize .cargo-checksum.json")?;
-    let (cas_path, _) = store_dir
+    let (cas_path, hash) = store_dir
         .write_cas_file(&checksum, false)
         .into_diagnostic()
         .wrap_err("store .cargo-checksum.json")?;
     cas_paths.insert(".cargo-checksum.json".to_string(), cas_path);
-    Ok(())
+    Ok(CafsFileInfo {
+        digest: format!("{hash:x}"),
+        mode: 0o644,
+        size: checksum.len() as u64,
+        checked_at: None,
+    })
 }
 
 fn link_workspace(root_dir: &Path, directory: &[&str], slots: &[(String, PathBuf)]) -> Result<()> {

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -95,6 +95,12 @@ struct CargoChecksum<'a> {
 #[derive(Deserialize)]
 struct CargoWorkspaceMetadata {
     workspace_root: PathBuf,
+    packages: Vec<CargoWorkspacePackage>,
+}
+
+#[derive(Deserialize)]
+struct CargoWorkspacePackage {
+    manifest_path: PathBuf,
 }
 
 struct ManagedDirectory {
@@ -325,19 +331,36 @@ async fn download_crates<Reporter: self::Reporter + 'static>(
 }
 
 pub(crate) async fn workspace_root(manifest_path: &Path) -> Result<PathBuf> {
+    workspace_metadata(manifest_path).await.map(|metadata| metadata.workspace_root)
+}
+
+async fn workspace_metadata(manifest_path: &Path) -> Result<CargoWorkspaceMetadata> {
     let metadata = read_cargo_metadata_for_manifest(manifest_path).await?;
     serde_json::from_str::<CargoWorkspaceMetadata>(&metadata)
         .into_diagnostic()
         .wrap_err("read Cargo workspace root from metadata")
-        .map(|metadata| metadata.workspace_root)
 }
 
 async fn discover_workspace_roots(manifests: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    let roots = stream::iter(manifests.iter().cloned())
-        .map(|manifest| async move { workspace_root(&manifest).await })
-        .buffer_unordered(8)
-        .try_collect::<BTreeSet<_>>()
-        .await?;
+    let mut pending = manifests.iter().cloned().collect::<BTreeSet<_>>();
+    let mut roots = BTreeSet::new();
+    while !pending.is_empty() {
+        let concurrency = if roots.is_empty() { 1 } else { WORKSPACE_INSTALL_CONCURRENCY };
+        let batch =
+            std::iter::from_fn(|| pending.pop_first()).take(concurrency).collect::<Vec<_>>();
+        let metadata = stream::iter(batch)
+            .map(|manifest| async move { workspace_metadata(&manifest).await })
+            .buffer_unordered(concurrency)
+            .try_collect::<Vec<_>>()
+            .await?;
+        for workspace in metadata {
+            pending.remove(&workspace.workspace_root.join("Cargo.toml"));
+            for package in workspace.packages {
+                pending.remove(&package.manifest_path);
+            }
+            roots.insert(workspace.workspace_root);
+        }
+    }
     Ok(roots.into_iter().collect())
 }
 

--- a/pnpm/crates/cli/src/cargo_deps.rs
+++ b/pnpm/crates/cli/src/cargo_deps.rs
@@ -344,7 +344,10 @@ async fn workspace_metadata(manifest_path: &Path) -> Result<CargoWorkspaceMetada
 }
 
 async fn discover_workspace_roots(manifests: &[PathBuf]) -> Result<Vec<PathBuf>> {
-    let mut pending = manifests.iter().cloned().collect::<BTreeSet<_>>();
+    let mut pending = manifests
+        .iter()
+        .map(|manifest| canonical_cargo_path(manifest))
+        .collect::<Result<BTreeSet<_>>>()?;
     let mut roots = BTreeSet::new();
     while !pending.is_empty() {
         let concurrency = if roots.is_empty() { 1 } else { WORKSPACE_INSTALL_CONCURRENCY };
@@ -356,14 +359,21 @@ async fn discover_workspace_roots(manifests: &[PathBuf]) -> Result<Vec<PathBuf>>
             .try_collect::<Vec<_>>()
             .await?;
         for workspace in metadata {
-            pending.remove(&workspace.workspace_root.join("Cargo.toml"));
+            let root = canonical_cargo_path(&workspace.workspace_root)?;
+            pending.remove(&root.join("Cargo.toml"));
             for package in workspace.packages {
-                pending.remove(&package.manifest_path);
+                pending.remove(&canonical_cargo_path(&package.manifest_path)?);
             }
-            roots.insert(workspace.workspace_root);
+            roots.insert(root);
         }
     }
     Ok(roots.into_iter().collect())
+}
+
+fn canonical_cargo_path(path: &Path) -> Result<PathBuf> {
+    dunce::canonicalize(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("resolve Cargo workspace path {}", path.display()))
 }
 
 async fn read_or_resolve_lockfile(

--- a/pnpm/crates/cli/src/cargo_deps/checksum_cache.rs
+++ b/pnpm/crates/cli/src/cargo_deps/checksum_cache.rs
@@ -1,0 +1,76 @@
+use super::add_cargo_checksum;
+use miette::Result;
+use pnpm_store_dir::{
+    PackageFilesIndex, SharedReadonlyStoreIndex, StoreDir, StoreIndexWriter, VerifiedFilesCache,
+    check_pkg_files_integrity,
+};
+use std::{collections::HashMap, path::PathBuf};
+
+const CHECKSUM_FILE: &str = ".cargo-checksum.json";
+
+pub(super) struct ChecksumCache<'a> {
+    pub store_dir: &'a StoreDir,
+    pub index: Option<&'a SharedReadonlyStoreIndex>,
+    pub writer: &'a StoreIndexWriter,
+    pub verified_files: &'a VerifiedFilesCache,
+}
+
+impl ChecksumCache<'_> {
+    /// The source CAS files must have passed the install's integrity policy
+    /// before their paths are used to identify a checksum projection.
+    pub(super) fn add(
+        &self,
+        cas_paths: &mut HashMap<String, PathBuf>,
+        package_checksum: &str,
+    ) -> Result<()> {
+        cas_paths.remove(CHECKSUM_FILE);
+        let key = checksum_cache_key(cas_paths, package_checksum);
+        if let Some(path) = self.read(&key) {
+            cas_paths.insert(CHECKSUM_FILE.to_string(), path);
+            return Ok(());
+        }
+        let info = add_cargo_checksum(self.store_dir, cas_paths, Some(package_checksum))?;
+        self.writer.queue(
+            key,
+            PackageFilesIndex {
+                algo: "sha512".to_string(),
+                files: HashMap::from([(CHECKSUM_FILE.to_string(), info)]),
+                ..PackageFilesIndex::default()
+            },
+        );
+        Ok(())
+    }
+
+    fn read(&self, key: &str) -> Option<PathBuf> {
+        let entry = {
+            let index = self.index?;
+            let guard = index.lock().ok()?;
+            match guard.get(key) {
+                Ok(entry) => entry?,
+                Err(error) => {
+                    tracing::debug!(?error, key, "Cargo checksum cache lookup failed");
+                    return None;
+                }
+            }
+        };
+        let mut verified = check_pkg_files_integrity(self.store_dir, entry, self.verified_files);
+        verified.passed.then(|| verified.files_map.remove(CHECKSUM_FILE)).flatten()
+    }
+}
+
+fn checksum_cache_key(cas_paths: &HashMap<String, PathBuf>, package_checksum: &str) -> String {
+    let mut input = package_checksum.as_bytes().to_vec();
+    input.push(0);
+    let mut files = cas_paths.iter().collect::<Vec<_>>();
+    files.sort_unstable_by_key(|(name, _)| *name);
+    for (name, path) in files {
+        for bytes in [name.as_bytes(), path.as_os_str().as_encoded_bytes()] {
+            input.extend_from_slice(&(bytes.len() as u64).to_le_bytes());
+            input.extend_from_slice(bytes);
+        }
+    }
+    format!("cargo-checksum-v1:{}", pnpm_crypto_hash::create_hex_hash_bytes(&input))
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cargo_deps/checksum_cache/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/checksum_cache/tests.rs
@@ -1,0 +1,125 @@
+use super::{CHECKSUM_FILE, ChecksumCache, checksum_cache_key};
+use pnpm_store_dir::{SharedVerifiedFilesCache, StoreDir, StoreIndex, StoreIndexWriter};
+use std::{collections::HashMap, fs, path::PathBuf};
+
+async fn add_cached_checksum(
+    store: &StoreDir,
+    files: &mut HashMap<String, PathBuf>,
+    checksum: &str,
+) {
+    let (writer, task) = StoreIndexWriter::spawn(store);
+    let index = StoreIndex::shared_readonly_in(store);
+    ChecksumCache {
+        store_dir: store,
+        index: index.as_ref(),
+        writer: &writer,
+        verified_files: &SharedVerifiedFilesCache::default(),
+    }
+    .add(files, checksum)
+    .unwrap();
+    drop(writer);
+    StoreIndexWriter::drain(task, "").await;
+}
+
+#[tokio::test]
+async fn repairs_a_corrupted_cached_checksum() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = StoreDir::from(temp.path().join("store"));
+    let (source, _) = store.write_cas_file(b"pub fn demo() {}", false).unwrap();
+    let mut files = HashMap::from([("src/lib.rs".to_string(), source)]);
+    let checksum = "a".repeat(64);
+    add_cached_checksum(&store, &mut files, &checksum).await;
+    let path = files[CHECKSUM_FILE].clone();
+    let expected = fs::read(&path).unwrap();
+    fs::write(&path, b"corrupted checksum").unwrap();
+
+    add_cached_checksum(&store, &mut files, &checksum).await;
+
+    assert_eq!(files[CHECKSUM_FILE], path);
+    assert_eq!(fs::read(&path).unwrap(), expected);
+}
+
+#[tokio::test]
+async fn invalidates_checksums_when_verified_files_change() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = StoreDir::from(temp.path().join("store"));
+    let (source, _) = store.write_cas_file(b"first", false).unwrap();
+    let mut files = HashMap::from([("src/lib.rs".to_string(), source)]);
+    let checksum = "a".repeat(64);
+    add_cached_checksum(&store, &mut files, &checksum).await;
+    let first = files[CHECKSUM_FILE].clone();
+    let (source, _) = store.write_cas_file(b"second", false).unwrap();
+    files.insert("src/lib.rs".to_string(), source);
+
+    add_cached_checksum(&store, &mut files, &checksum).await;
+
+    assert_ne!(files[CHECKSUM_FILE], first);
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&files[CHECKSUM_FILE]).unwrap()).unwrap();
+    assert_eq!(manifest["files"]["src/lib.rs"], pnpm_crypto_hash::create_hex_hash("second"));
+}
+
+#[tokio::test]
+async fn invalidates_checksums_when_the_archive_changes() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = StoreDir::from(temp.path().join("store"));
+    let (source, _) = store.write_cas_file(b"unchanged", false).unwrap();
+    let mut files = HashMap::from([("src/lib.rs".to_string(), source)]);
+    add_cached_checksum(&store, &mut files, &"a".repeat(64)).await;
+    let first = files[CHECKSUM_FILE].clone();
+
+    add_cached_checksum(&store, &mut files, &"b".repeat(64)).await;
+
+    assert_ne!(files[CHECKSUM_FILE], first);
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&files[CHECKSUM_FILE]).unwrap()).unwrap();
+    assert_eq!(manifest["package"], "b".repeat(64));
+}
+
+#[tokio::test]
+async fn reuses_a_persisted_checksum() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = StoreDir::from(temp.path().join("store"));
+    let (source, _) = store.write_cas_file(b"pub fn demo() {}", false).unwrap();
+    let mut files = HashMap::from([("src/lib.rs".to_string(), source)]);
+    let checksum = "a".repeat(64);
+    let key = checksum_cache_key(&files, &checksum);
+    add_cached_checksum(&store, &mut files, &checksum).await;
+
+    let (writer, task) = StoreIndexWriter::spawn(&store);
+    let index = StoreIndex::shared_readonly_in(&store);
+    let cached = ChecksumCache {
+        store_dir: &store,
+        index: index.as_ref(),
+        writer: &writer,
+        verified_files: &SharedVerifiedFilesCache::default(),
+    }
+    .read(&key);
+
+    assert_eq!(cached, Some(files[CHECKSUM_FILE].clone()));
+    drop(writer);
+    StoreIndexWriter::drain(task, "").await;
+}
+
+#[tokio::test]
+async fn invalidates_checksums_when_files_are_renamed() {
+    let temp = tempfile::tempdir().unwrap();
+    let store = StoreDir::from(temp.path().join("store"));
+    let (source, _) = store.write_cas_file(b"unchanged", false).unwrap();
+    let mut files = HashMap::from([("src/lib.rs".to_string(), source)]);
+    let checksum = "a".repeat(64);
+    add_cached_checksum(&store, &mut files, &checksum).await;
+    let first = files[CHECKSUM_FILE].clone();
+    let source = files.remove("src/lib.rs").unwrap();
+    files.insert("src/main.rs".to_string(), source);
+
+    add_cached_checksum(&store, &mut files, &checksum).await;
+
+    assert_ne!(files[CHECKSUM_FILE], first);
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&files[CHECKSUM_FILE]).unwrap()).unwrap();
+    assert_eq!(
+        manifest["files"],
+        serde_json::json!({"src/main.rs": pnpm_crypto_hash::create_hex_hash("unchanged")}),
+    );
+}

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -1,7 +1,8 @@
 use super::{
     ArchiveStoreProjection, Config, LockedCrate, MaterializeOptions, add_cargo_checksum,
-    download_auth_headers, fetch_sparse_index_file, managed_config, materialize, parse_lockfile,
-    resolve_via_pnpr, sparse_index_path, update_managed_config, workspace_root,
+    discover_workspace_roots, download_auth_headers, fetch_sparse_index_file, managed_config,
+    materialize, parse_lockfile, resolve_via_pnpr, sparse_index_path, update_managed_config,
+    workspace_root,
 };
 use cargo_util_schemas::index::RegistryConfig;
 use pnpm_cargo_resolver::CRATES_IO_SPARSE_INDEX;
@@ -476,6 +477,44 @@ async fn asks_cargo_for_the_workspace_root_of_a_member() {
     fs::write(member.join("src/lib.rs"), "").unwrap();
 
     assert_eq!(workspace_root(&member.join("Cargo.toml")).await.unwrap(), cargo_root);
+    assert_eq!(
+        discover_workspace_roots(&[member.join("Cargo.toml"), cargo_root.join("Cargo.toml")])
+            .await
+            .unwrap(),
+        [cargo_root],
+    );
+}
+
+#[tokio::test]
+async fn discovers_independent_workspaces_nested_under_workspace_members() {
+    let repository = tempfile::tempdir().unwrap();
+    let root = repository.path();
+    fs::write(root.join("Cargo.toml"), "[workspace]\nmembers = [\"member\"]\nresolver = \"2\"\n")
+        .unwrap();
+    for (path, name, workspace) in [
+        (root.join("member"), "member", ""),
+        (root.join("member/nested"), "nested", "[workspace]\n"),
+    ] {
+        fs::create_dir_all(path.join("src")).unwrap();
+        fs::write(path.join("src/lib.rs"), "").unwrap();
+        fs::write(
+            path.join("Cargo.toml"),
+            format!(
+                "[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n{workspace}",
+            ),
+        )
+        .unwrap();
+    }
+
+    assert_eq!(
+        discover_workspace_roots(&[
+            root.join("member/Cargo.toml"),
+            root.join("member/nested/Cargo.toml"),
+        ])
+        .await
+        .unwrap(),
+        [root.to_path_buf(), root.join("member/nested")],
+    );
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/src/cargo_deps/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/tests.rs
@@ -481,7 +481,7 @@ async fn asks_cargo_for_the_workspace_root_of_a_member() {
         discover_workspace_roots(&[member.join("Cargo.toml"), cargo_root.join("Cargo.toml")])
             .await
             .unwrap(),
-        [cargo_root],
+        [dunce::canonicalize(cargo_root).unwrap()],
     );
 }
 
@@ -513,7 +513,10 @@ async fn discovers_independent_workspaces_nested_under_workspace_members() {
         ])
         .await
         .unwrap(),
-        [root.to_path_buf(), root.join("member/nested")],
+        [
+            dunce::canonicalize(root).unwrap(),
+            dunce::canonicalize(root.join("member/nested")).unwrap()
+        ],
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/cargo_install.rs
+++ b/pnpm/crates/cli/tests/suite/cargo_install.rs
@@ -243,3 +243,67 @@ fn a_workspace_with_a_cargo_patch_is_not_resolved_from_the_registry() {
     // One word: a diagnostic wraps at a width the path length decides.
     assert!(stderr.contains("[patch]"), "{stderr}");
 }
+
+#[cfg(unix)]
+#[test]
+fn reuses_workspace_metadata_with_aliased_paths_and_nested_workspaces() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let repository = TempDir::new().unwrap();
+    let root = repository.path().join("workspace");
+    fs::create_dir(&root).unwrap();
+    fs::write(root.join("pnpm-workspace.yaml"), "packages: []\ncargo:\n  enabled: true\n").unwrap();
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"a\", \"b\", \"c\"]\nresolver = \"2\"\n",
+    )
+    .unwrap();
+    for (name, workspace) in [("a", ""), ("b", ""), ("c", ""), ("a/nested", "[workspace]\n")] {
+        let project = root.join(name);
+        fs::create_dir_all(project.join("src")).unwrap();
+        fs::write(project.join("src/lib.rs"), "").unwrap();
+        let package = name.replace('/', "-");
+        fs::write(project.join("Cargo.toml"), format!("[package]\nname = \"{package}\"\nversion = \"0.1.0\"\nedition = \"2024\"\n{workspace}")).unwrap();
+    }
+    for project in [&root, &root.join("a/nested")] {
+        Command::new("cargo")
+            .args(["generate-lockfile", "--offline"])
+            .current_dir(project)
+            .assert()
+            .success();
+    }
+    let original_path = std::env::var_os("PATH").unwrap();
+    let cargo = std::env::split_paths(&original_path)
+        .map(|directory| directory.join("cargo"))
+        .find(|path| path.is_file())
+        .expect("cargo on PATH");
+    let bin = repository.path().join("bin");
+    fs::create_dir(&bin).unwrap();
+    let wrapper = bin.join("cargo");
+    fs::write(
+        &wrapper,
+        "#!/bin/sh\nprintf '%s\\n' \"$1\" >> \"$CARGO_CALL_LOG\"\nexec \"$REAL_CARGO\" \"$@\"\n",
+    )
+    .unwrap();
+    fs::set_permissions(&wrapper, fs::Permissions::from_mode(0o755)).unwrap();
+    let path =
+        std::env::join_paths(std::iter::once(bin).chain(std::env::split_paths(&original_path)))
+            .unwrap();
+    let log = repository.path().join("cargo-calls");
+    for alias in [root.clone(), root.join("../workspace"), std::path::PathBuf::from(".")] {
+        fs::write(&log, "").unwrap();
+        Command::cargo_bin("pnpm")
+            .unwrap()
+            .current_dir(&root)
+            .args(["install", "--frozen-lockfile"])
+            .env("PATH", &path)
+            .env("REAL_CARGO", &cargo)
+            .env("CARGO_CALL_LOG", &log)
+            .env("NPM_CONFIG_WORKSPACE_DIR", &alias)
+            .env("PNPM_CONFIG_CACHE_DIR", repository.path().join("cache"))
+            .env("PNPM_CONFIG_STORE_DIR", repository.path().join("store"))
+            .assert()
+            .success();
+        assert_eq!(fs::read_to_string(&log).unwrap(), "metadata\nmetadata\n", "{alias:?}");
+    }
+}

--- a/pnpm/crates/workspace/Cargo.toml
+++ b/pnpm/crates/workspace/Cargo.toml
@@ -29,6 +29,15 @@ wax            = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+  "Wdk_Foundation",
+  "Wdk_Storage_FileSystem",
+  "Win32_Storage_FileSystem",
+  "Win32_System_IO",
+  "Win32_Security",
+] }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile          = { workspace = true }

--- a/pnpm/crates/workspace/src/inventory.rs
+++ b/pnpm/crates/workspace/src/inventory.rs
@@ -1,3 +1,4 @@
+mod open_directory;
 use derive_more::{Display, Error};
 use miette::Diagnostic;
 use std::{

--- a/pnpm/crates/workspace/src/inventory/open_directory.rs
+++ b/pnpm/crates/workspace/src/inventory/open_directory.rs
@@ -1,0 +1,225 @@
+use std::{
+    fs::File,
+    io,
+    path::{Component, Path},
+};
+
+/// Open a descendant without following symlinks in any component. Only normal
+/// relative components are accepted; no parent navigation or identity lookup is used.
+pub(super) fn open_directory(root: &File, path: &Path, opens: &mut usize) -> io::Result<File> {
+    if path.as_os_str().is_empty()
+        || path.components().any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "expected a relative descendant path",
+        ));
+    }
+    platform::open_directory(root, path, opens)
+}
+
+// Older kernels and other Unix platforms lack whole-path no-symlink resolution.
+// Open each component from a pinned handle there, at the cost of depth-dependent opens.
+#[cfg(not(windows))]
+fn open_components(root: &File, path: &Path, opens: &mut usize) -> io::Result<File> {
+    let mut components = path.components();
+    *opens += 1;
+    let mut directory = cap_primitives::fs::open_dir_nofollow(
+        root,
+        Path::new(components.next().expect("nonempty descendant path").as_os_str()),
+    )?;
+    for component in components {
+        *opens += 1;
+        directory =
+            cap_primitives::fs::open_dir_nofollow(&directory, Path::new(component.as_os_str()))?;
+    }
+    Ok(directory)
+}
+
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+mod platform {
+    use std::{
+        ffi::CString,
+        fs::File,
+        io,
+        os::{
+            fd::{AsRawFd, FromRawFd},
+            unix::ffi::OsStrExt,
+        },
+        path::Path,
+    };
+
+    pub(super) fn open_directory(root: &File, path: &Path, opens: &mut usize) -> io::Result<File> {
+        #[cfg(target_os = "macos")]
+        if !supports_nofollow_any() {
+            return super::open_components(root, path, opens);
+        }
+        let name = CString::new(path.as_os_str().as_bytes())?;
+        *opens += 1;
+        let fd = open_nofollow(root, &name);
+        if fd >= 0 {
+            // SAFETY: a successful open returns a new, uniquely owned descriptor.
+            return Ok(unsafe { File::from_raw_fd(fd) });
+        }
+        let error = io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(libc::ENOSYS | libc::EINVAL)) {
+            return super::open_components(root, path, opens);
+        }
+        Err(error)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn open_nofollow(root: &File, name: &CString) -> libc::c_int {
+        // SAFETY: open_how contains only integers; zero initializes reserved fields.
+        let mut how: libc::open_how = unsafe { std::mem::zeroed() };
+        how.flags = (libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) as u64;
+        how.resolve = libc::RESOLVE_BENEATH | libc::RESOLVE_NO_SYMLINKS;
+        // SAFETY: root stays open, name is NUL-terminated, and how is initialized
+        // for the supplied size. The kernel enforces confinement and no symlinks
+        // across the entire lookup; cap-primitives only denies the final symlink.
+        unsafe {
+            libc::syscall(
+                libc::SYS_openat2,
+                root.as_raw_fd(),
+                name.as_ptr(),
+                &raw const how,
+                std::mem::size_of::<libc::open_how>(),
+            ) as libc::c_int
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    fn supports_nofollow_any() -> bool {
+        static SUPPORTED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *SUPPORTED.get_or_init(|| {
+            // macOS 11 (Darwin 20) introduced O_NOFOLLOW_ANY. Older kernels can
+            // ignore unknown open flags, so an EINVAL fallback alone is unsafe.
+            // SAFETY: utsname contains only character arrays.
+            let mut info: libc::utsname = unsafe { std::mem::zeroed() };
+            // SAFETY: info is a valid writable buffer of the required size.
+            if unsafe { libc::uname(&raw mut info) } != 0 {
+                return false;
+            }
+            // SAFETY: uname succeeded and initialized the release C string.
+            unsafe { std::ffi::CStr::from_ptr(info.release.as_ptr()) }
+                .to_str()
+                .ok()
+                .and_then(|release| release.split('.').next())
+                .and_then(|major| major.parse::<u32>().ok())
+                .is_some_and(|major| major >= 20)
+        })
+    }
+
+    #[cfg(target_os = "macos")]
+    fn open_nofollow(root: &File, name: &CString) -> libc::c_int {
+        // SAFETY: root stays open and name is NUL-terminated. The caller rejects
+        // absolute/parent components, and O_NOFOLLOW_ANY rejects every symlink.
+        unsafe {
+            libc::openat(
+                root.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW_ANY,
+            )
+        }
+    }
+}
+
+#[cfg(windows)]
+mod platform {
+    use std::{
+        fs::File,
+        io,
+        os::windows::{
+            ffi::OsStrExt,
+            io::{AsRawHandle, FromRawHandle},
+        },
+        path::Path,
+        ptr,
+    };
+    use windows_sys::{
+        Wdk::{
+            Foundation::OBJECT_ATTRIBUTES,
+            Storage::FileSystem::{
+                FILE_DIRECTORY_FILE, FILE_OPEN, FILE_SYNCHRONOUS_IO_NONALERT, NtCreateFile,
+            },
+        },
+        Win32::{
+            Foundation::{
+                OBJ_DONT_REPARSE, RtlNtStatusToDosError, STATUS_REPARSE_POINT_ENCOUNTERED,
+                UNICODE_STRING,
+            },
+            Storage::FileSystem::{
+                FILE_LIST_DIRECTORY, FILE_READ_ATTRIBUTES, FILE_SHARE_DELETE, FILE_SHARE_READ,
+                FILE_SHARE_WRITE, SYNCHRONIZE,
+            },
+            System::IO::IO_STATUS_BLOCK,
+        },
+    };
+
+    pub(super) fn open_directory(root: &File, path: &Path, opens: &mut usize) -> io::Result<File> {
+        let path: std::path::PathBuf = path.components().collect();
+        let mut name: Vec<u16> = path.as_os_str().encode_wide().collect();
+        let length = u16::try_from(name.len() * size_of::<u16>()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "directory path is too long")
+        })?;
+        if name.contains(&0) {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "directory path contains NUL"));
+        }
+        let name =
+            UNICODE_STRING { Length: length, MaximumLength: length, Buffer: name.as_mut_ptr() };
+        let attributes = OBJECT_ATTRIBUTES {
+            Length: size_of::<OBJECT_ATTRIBUTES>() as u32,
+            RootDirectory: root.as_raw_handle(),
+            ObjectName: &raw const name,
+            Attributes: OBJ_DONT_REPARSE,
+            ..Default::default()
+        };
+        let mut status = IO_STATUS_BLOCK::default();
+        let mut handle = ptr::null_mut();
+        *opens += 1;
+        // SAFETY: all buffers and the root handle outlive this synchronous call.
+        // Only normal relative components reach it. OBJ_DONT_REPARSE rejects all
+        // reparse points, including intermediate junctions; no identity is inferred.
+        let result = unsafe {
+            NtCreateFile(
+                &raw mut handle,
+                FILE_LIST_DIRECTORY | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+                &raw const attributes,
+                &raw mut status,
+                ptr::null(),
+                0,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                FILE_OPEN,
+                FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT,
+                ptr::null(),
+                0,
+            )
+        };
+        if result == STATUS_REPARSE_POINT_ENCOUNTERED {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "directory path contains a reparse point",
+            ));
+        }
+        if result < 0 {
+            // SAFETY: this function translates a status value without dereferencing memory.
+            return Err(io::Error::from_raw_os_error(
+                unsafe { RtlNtStatusToDosError(result) } as i32
+            ));
+        }
+        // SAFETY: NtCreateFile succeeded and transferred a new owned handle to us.
+        Ok(unsafe { File::from_raw_handle(handle) })
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
+mod platform {
+    use std::{fs::File, io, path::Path};
+
+    pub(super) fn open_directory(root: &File, path: &Path, opens: &mut usize) -> io::Result<File> {
+        super::open_components(root, path, opens)
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests;

--- a/pnpm/crates/workspace/src/inventory/open_directory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/open_directory/tests.rs
@@ -1,0 +1,18 @@
+use super::open_components;
+use std::{fs, path::Path};
+
+#[test]
+fn fallback_opens_components_without_following_intermediate_symlinks() {
+    let workspace = tempfile::tempdir().unwrap();
+    fs::create_dir_all(workspace.path().join("real/child")).unwrap();
+    pnpm_fs::symlink_dir(&workspace.path().join("real"), &workspace.path().join("link")).unwrap();
+    let root =
+        cap_primitives::fs::open_ambient_dir(workspace.path(), cap_primitives::ambient_authority())
+            .unwrap();
+    let mut opens = 0;
+    let directory = open_components(&root, Path::new("real/child"), &mut opens).unwrap();
+    assert_eq!(opens, 2);
+    assert!(directory.metadata().unwrap().is_dir());
+    let result = open_components(&root, Path::new("link/child"), &mut 0);
+    assert!(result.is_err(), "{result:?}");
+}

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -215,6 +215,16 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
             find_workspace_inventory(std::path::Path::new(&root), &["Cargo.toml"], &[], &[])
                 .unwrap();
         assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 129);
+        let root = std::path::Path::new(&root);
+        let ignored = super::IgnoredDirectories {
+            root,
+            basenames: std::collections::BTreeSet::default(),
+            paths: std::collections::BTreeSet::default(),
+        };
+        let navigation_opens =
+            super::traversal::walk_workspace(root, &ignored, |_| Ok(()), |_| Ok(()), |_, _| {})
+                .unwrap();
+        assert_eq!(navigation_opens, 2 * 257);
         return;
     }
     let workspace = tempfile::tempdir().unwrap();
@@ -230,15 +240,17 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
     let output = std::process::Command::new("sh")
         .args(["-c", r#"ulimit -n 64; exec "$@""#, "sh"])
         .arg(std::env::current_exe().unwrap())
-        .args([
-            "--exact",
-            "inventory::tests::discovers_deep_trees_with_a_small_handle_limit",
-            "--nocapture",
-        ])
+        .args(["--exact", "--nocapture"])
+        .arg(format!(
+            "{}::discovers_deep_trees_with_a_small_handle_limit",
+            module_path!().split_once("::").unwrap().1,
+        ))
         .env(ROOT_ENV, workspace.path())
         .output()
         .unwrap();
     assert!(output.status.success(), "{output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test result: ok. 1 passed; 0 failed;"), "{output:?}");
 }
 
 #[cfg(unix)]
@@ -267,4 +279,30 @@ fn does_not_follow_an_ancestor_swapped_before_a_queued_child_is_opened() {
     )
     .unwrap();
     assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
+}
+
+#[cfg(unix)]
+#[test]
+fn rejects_a_child_moved_to_a_different_parent_before_ascent() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let child = workspace.path().join("child");
+    fs::create_dir(&child).unwrap();
+    fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
+    let error = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        |path| {
+            if path == child {
+                fs::rename(&child, outside.path().join("moved"))?;
+            }
+            Ok(())
+        },
+        |_| Ok(()),
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("directory ancestry changed"), "{error}");
 }

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -205,3 +205,66 @@ fn reads_children_without_accumulating_unvisited_sibling_handles() {
     assert_eq!(peak.get(), 1);
     assert_eq!(unread.get(), 0);
 }
+
+#[cfg(unix)]
+#[test]
+fn discovers_deep_trees_with_a_small_handle_limit() {
+    const ROOT_ENV: &str = "PNPM_TEST_DEEP_INVENTORY_ROOT";
+    if let Some(root) = std::env::var_os(ROOT_ENV) {
+        let inventory =
+            find_workspace_inventory(std::path::Path::new(&root), &["Cargo.toml"], &[], &[])
+                .unwrap();
+        assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 129);
+        return;
+    }
+    let workspace = tempfile::tempdir().unwrap();
+    let mut directory = workspace.path().to_path_buf();
+    for _ in 0..128 {
+        let sibling = directory.join("s");
+        fs::create_dir(&sibling).unwrap();
+        fs::write(sibling.join("Cargo.toml"), "[workspace]\n").unwrap();
+        directory.push("d");
+        fs::create_dir(&directory).unwrap();
+    }
+    fs::write(directory.join("Cargo.toml"), "[workspace]\n").unwrap();
+    let output = std::process::Command::new("sh")
+        .args(["-c", r#"ulimit -n 64; exec "$@""#, "sh"])
+        .arg(std::env::current_exe().unwrap())
+        .args([
+            "--exact",
+            "inventory::tests::discovers_deep_trees_with_a_small_handle_limit",
+            "--nocapture",
+        ])
+        .env(ROOT_ENV, workspace.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+}
+
+#[cfg(unix)]
+#[test]
+fn does_not_follow_an_ancestor_swapped_before_a_queued_child_is_opened() {
+    let workspace = tempfile::tempdir().unwrap();
+    let outside = tempfile::tempdir().unwrap();
+    let parent = workspace.path().join("parent");
+    let child = parent.join("child");
+    fs::create_dir_all(&child).unwrap();
+    fs::create_dir(outside.path().join("child")).unwrap();
+    fs::write(outside.path().join("child/Cargo.toml"), "[workspace]\n").unwrap();
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        |_| Ok(()),
+        |path| {
+            if path == child {
+                fs::rename(&parent, workspace.path().join("moved"))?;
+                symlink(outside.path(), &parent)?;
+            }
+            Ok(())
+        },
+    )
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
+}

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -171,3 +171,37 @@ fn prunes_managed_paths_before_opening_without_excluding_matching_project_names(
         );
     }
 }
+
+#[test]
+fn reads_children_without_accumulating_unvisited_sibling_handles() {
+    let workspace = tempfile::tempdir().unwrap();
+    for index in 0..128 {
+        let project = workspace.path().join(format!("member-{index}"));
+        fs::create_dir(&project).unwrap();
+        fs::write(project.join("Cargo.toml"), "[workspace]\n").unwrap();
+    }
+    let unread = std::cell::Cell::new(0usize);
+    let peak = std::cell::Cell::new(0usize);
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        |directory| {
+            if directory != workspace.path() {
+                unread.set(unread.get() - 1);
+            }
+            Ok(())
+        },
+        |_| {
+            unread.set(unread.get() + 1);
+            peak.set(peak.get().max(unread.get()));
+            Ok(())
+        },
+    )
+    .unwrap();
+
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 128);
+    assert_eq!(peak.get(), 1);
+    assert_eq!(unread.get(), 0);
+}

--- a/pnpm/crates/workspace/src/inventory/tests.rs
+++ b/pnpm/crates/workspace/src/inventory/tests.rs
@@ -1,9 +1,7 @@
 use super::{find_workspace_inventory, find_workspace_inventory_with};
+use pnpm_fs::symlink_dir as symlink;
 use pretty_assertions::assert_eq;
 use std::fs;
-
-#[cfg(unix)]
-use std::os::unix::fs::symlink;
 
 #[test]
 fn discovers_multiple_manifest_kinds_in_one_inventory() {
@@ -100,20 +98,18 @@ fn reports_the_nested_directory_that_failed() {
     assert!(error.contains("injected read failure"), "{error}");
 }
 
-#[cfg(unix)]
 #[test]
 fn does_not_follow_directory_symlinks() {
     let workspace = tempfile::tempdir().unwrap();
     let outside = tempfile::tempdir().unwrap();
     fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
-    symlink(outside.path(), workspace.path().join("linked")).unwrap();
+    symlink(outside.path(), &workspace.path().join("linked")).unwrap();
 
     let inventory = find_workspace_inventory(workspace.path(), &["Cargo.toml"], &[], &[]).unwrap();
 
     assert!(inventory.manifests("Cargo.toml").unwrap().is_empty());
 }
 
-#[cfg(unix)]
 #[test]
 fn does_not_follow_a_directory_swapped_for_a_symlink_before_descent() {
     let workspace = tempfile::tempdir().unwrap();
@@ -224,7 +220,23 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
         let navigation_opens =
             super::traversal::walk_workspace(root, &ignored, |_| Ok(()), |_| Ok(()), |_, _| {})
                 .unwrap();
-        assert_eq!(navigation_opens, 2 * 257);
+        let root_handle =
+            cap_primitives::fs::open_ambient_dir(root, cap_primitives::ambient_authority())
+                .unwrap();
+        let mut probe_opens = 0;
+        super::open_directory::open_directory(
+            &root_handle,
+            std::path::Path::new("d/d"),
+            &mut probe_opens,
+        )
+        .unwrap();
+        let expected_opens = match probe_opens {
+            1 => 257,
+            2 => 1 + 2 * (1..=128).sum::<usize>(),
+            3 => 257 + 2 * (1..=128).sum::<usize>(),
+            _ => panic!("unexpected directory open count: {probe_opens}"),
+        };
+        assert_eq!(navigation_opens, expected_opens);
         return;
     }
     let workspace = tempfile::tempdir().unwrap();
@@ -253,7 +265,6 @@ fn discovers_deep_trees_with_a_small_handle_limit() {
     assert!(stdout.contains("test result: ok. 1 passed; 0 failed;"), "{output:?}");
 }
 
-#[cfg(unix)]
 #[test]
 fn does_not_follow_an_ancestor_swapped_before_a_queued_child_is_opened() {
     let workspace = tempfile::tempdir().unwrap();
@@ -281,15 +292,17 @@ fn does_not_follow_an_ancestor_swapped_before_a_queued_child_is_opened() {
     assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
 }
 
-#[cfg(unix)]
 #[test]
-fn rejects_a_child_moved_to_a_different_parent_before_ascent() {
+fn continues_after_a_child_is_moved_to_a_different_parent() {
     let workspace = tempfile::tempdir().unwrap();
     let outside = tempfile::tempdir().unwrap();
     let child = workspace.path().join("child");
+    let sibling = workspace.path().join("sibling");
+    fs::create_dir(&sibling).unwrap();
+    fs::write(sibling.join("Cargo.toml"), "[workspace]\n").unwrap();
     fs::create_dir(&child).unwrap();
     fs::write(outside.path().join("Cargo.toml"), "[workspace]\n").unwrap();
-    let error = find_workspace_inventory_with(
+    let inventory = find_workspace_inventory_with(
         workspace.path(),
         &["Cargo.toml"],
         &[],
@@ -302,7 +315,71 @@ fn rejects_a_child_moved_to_a_different_parent_before_ascent() {
         },
         |_| Ok(()),
     )
-    .unwrap_err()
-    .to_string();
-    assert!(error.contains("directory ancestry changed"), "{error}");
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap(), [sibling.join("Cargo.toml")]);
+}
+
+#[test]
+fn continues_after_a_nested_directory_disappears() {
+    let workspace = tempfile::tempdir().unwrap();
+    let child = workspace.path().join("child");
+    fs::create_dir(&child).unwrap();
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        |path| {
+            if path == child {
+                fs::remove_dir(&child)?;
+            }
+            Ok(())
+        },
+        |_| Ok(()),
+    )
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
+}
+
+#[test]
+fn skips_candidates_that_become_unreadable_before_opening() {
+    let workspace = tempfile::tempdir().unwrap();
+    fs::create_dir(workspace.path().join("child")).unwrap();
+    let inventory = find_workspace_inventory_with(
+        workspace.path(),
+        &["Cargo.toml"],
+        &[],
+        &[],
+        |_| Ok(()),
+        |_| Err(std::io::ErrorKind::PermissionDenied.into()),
+    )
+    .unwrap();
+    assert_eq!(inventory.manifests("Cargo.toml").unwrap().len(), 0);
+}
+
+#[test]
+fn rejects_parent_navigation_and_absolute_descendant_paths() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root =
+        cap_primitives::fs::open_ambient_dir(workspace.path(), cap_primitives::ambient_authority())
+            .unwrap();
+    for path in [std::path::Path::new("../outside"), workspace.path(), std::path::Path::new("")] {
+        let error = super::open_directory::open_directory(&root, path, &mut 0).unwrap_err();
+        assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    }
+}
+
+#[test]
+fn rejects_intermediate_links_to_directories_inside_the_workspace() {
+    let workspace = tempfile::tempdir().unwrap();
+    fs::create_dir_all(workspace.path().join("target/child")).unwrap();
+    symlink(&workspace.path().join("target"), &workspace.path().join("linked")).unwrap();
+    let root =
+        cap_primitives::fs::open_ambient_dir(workspace.path(), cap_primitives::ambient_authority())
+            .unwrap();
+    let error =
+        super::open_directory::open_directory(&root, std::path::Path::new("linked/child"), &mut 0)
+            .unwrap_err();
+    eprintln!("intermediate link error: {error}");
+    assert_ne!(error.kind(), std::io::ErrorKind::NotFound);
 }

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -25,59 +25,16 @@ pub(super) fn walk_workspace(
                 source,
             }
         })?;
-    let mut pending =
-        vec![PendingDirectory { path: workspace_root.to_path_buf(), handle: root_handle }];
-
-    while let Some(directory) = pending.pop() {
-        match before_read(&directory.path) {
-            Ok(()) => {}
-            Err(error)
-                if directory.path != workspace_root && is_ignorable_discovery_error(&error) =>
-            {
-                continue;
-            }
-            Err(source) => {
-                return Err(FindWorkspaceInventoryError::ReadDirectory {
-                    path: directory.path,
-                    source,
-                });
-            }
-        }
-        let entries = match fs::read_base_dir(&directory.handle) {
-            Ok(entries) => entries,
-            Err(error)
-                if directory.path != workspace_root && is_ignorable_discovery_error(&error) =>
-            {
-                continue;
-            }
-            Err(source) => {
-                return Err(FindWorkspaceInventoryError::ReadDirectory {
-                    path: directory.path,
-                    source,
-                });
-            }
+    let root = PendingDirectory { path: workspace_root.to_path_buf(), handle: root_handle };
+    let Some(entries) = read_directory(&root, workspace_root, &mut before_read)? else {
+        return Ok(());
+    };
+    let mut pending = vec![(root, entries)];
+    while let Some((directory, entries)) = pending.last_mut() {
+        let Some(entry) = entries.next() else {
+            pending.pop();
+            continue;
         };
-        collect_directory_entries(
-            &directory,
-            entries,
-            ignored,
-            &mut before_open_directory,
-            &mut pending,
-            &mut visit_file,
-        )?;
-    }
-    Ok(())
-}
-
-fn collect_directory_entries(
-    directory: &PendingDirectory,
-    entries: fs::ReadDir,
-    ignored: &IgnoredDirectories<'_>,
-    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
-    pending: &mut Vec<PendingDirectory>,
-    visit_file: &mut impl FnMut(PathBuf, &OsStr),
-) -> Result<(), FindWorkspaceInventoryError> {
-    for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
             Err(error) if is_ignorable_discovery_error(&error) => continue,
@@ -88,9 +45,30 @@ fn collect_directory_entries(
                 });
             }
         };
-        collect_entry(directory, &entry, ignored, before_open_directory, pending, visit_file)?;
+        if let Some(child) =
+            collect_entry(directory, &entry, ignored, &mut before_open_directory, &mut visit_file)?
+            && let Some(entries) = read_directory(&child, workspace_root, &mut before_read)?
+        {
+            pending.push((child, entries));
+        }
     }
     Ok(())
+}
+
+fn read_directory(
+    directory: &PendingDirectory,
+    workspace_root: &Path,
+    before_read: &mut impl FnMut(&Path) -> io::Result<()>,
+) -> Result<Option<fs::ReadDir>, FindWorkspaceInventoryError> {
+    match before_read(&directory.path).and_then(|()| fs::read_base_dir(&directory.handle)) {
+        Ok(entries) => Ok(Some(entries)),
+        Err(error) if directory.path != workspace_root && is_ignorable_discovery_error(&error) => {
+            Ok(None)
+        }
+        Err(source) => {
+            Err(FindWorkspaceInventoryError::ReadDirectory { path: directory.path.clone(), source })
+        }
+    }
 }
 
 fn collect_entry(
@@ -98,28 +76,27 @@ fn collect_entry(
     entry: &fs::DirEntry,
     ignored: &IgnoredDirectories<'_>,
     before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
-    pending: &mut Vec<PendingDirectory>,
     visit_file: &mut impl FnMut(PathBuf, &OsStr),
-) -> Result<(), FindWorkspaceInventoryError> {
+) -> Result<Option<PendingDirectory>, FindWorkspaceInventoryError> {
     let file_name = entry.file_name();
     let path = directory.path.join(&file_name);
     let file_type = match entry.file_type() {
         Ok(file_type) => file_type,
-        Err(error) if is_ignorable_discovery_error(&error) => return Ok(()),
+        Err(error) if is_ignorable_discovery_error(&error) => return Ok(None),
         Err(source) => {
             return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
         }
     };
     if file_type.is_symlink() {
-        return Ok(());
+        return Ok(None);
     }
     if file_type.is_dir() {
-        collect_directory(directory, &file_name, path, ignored, before_open_directory, pending)
+        collect_directory(directory, &file_name, path, ignored, before_open_directory)
     } else {
         if file_type.is_file() {
             visit_file(path, &file_name);
         }
-        Ok(())
+        Ok(None)
     }
 }
 
@@ -129,22 +106,18 @@ fn collect_directory(
     path: PathBuf,
     ignored: &IgnoredDirectories<'_>,
     before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
-    pending: &mut Vec<PendingDirectory>,
-) -> Result<(), FindWorkspaceInventoryError> {
+) -> Result<Option<PendingDirectory>, FindWorkspaceInventoryError> {
     if ignored.contains(file_name, &path) {
-        return Ok(());
+        return Ok(None);
     }
     before_open_directory(&path).map_err(|source| {
         FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
     })?;
     match fs::open_dir_nofollow(&parent.handle, Path::new(file_name)) {
-        Ok(handle) => pending.push(PendingDirectory { path, handle }),
-        Err(error) if is_changed_candidate_error(&error) => {}
-        Err(source) => {
-            return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
-        }
+        Ok(handle) => Ok(Some(PendingDirectory { path, handle })),
+        Err(error) if is_changed_candidate_error(&error) => Ok(None),
+        Err(source) => Err(FindWorkspaceInventoryError::InspectCandidate { path, source }),
     }
-    Ok(())
 }
 
 fn is_changed_candidate_error(error: &io::Error) -> bool {

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -11,13 +11,20 @@ struct OpenDirectory {
     handle: std::fs::File,
 }
 
+struct DirectoryFrame {
+    path: PathBuf,
+    identity: fs::Metadata,
+    children: std::vec::IntoIter<PathBuf>,
+}
+
+/// Return the number of directory navigation opens during the scan.
 pub(super) fn walk_workspace(
     workspace_root: &Path,
     ignored: &IgnoredDirectories<'_>,
     mut before_read: impl FnMut(&Path) -> io::Result<()>,
     mut before_open_directory: impl FnMut(&Path) -> io::Result<()>,
     mut visit_file: impl FnMut(PathBuf, &OsStr),
-) -> Result<(), FindWorkspaceInventoryError> {
+) -> Result<usize, FindWorkspaceInventoryError> {
     let root_handle =
         fs::open_ambient_dir(workspace_root, ambient_authority()).map_err(|source| {
             FindWorkspaceInventoryError::ReadDirectory {
@@ -25,25 +32,75 @@ pub(super) fn walk_workspace(
                 source,
             }
         })?;
-    let mut pending = vec![workspace_root.to_path_buf()];
-    while let Some(path) = pending.pop() {
-        if path != workspace_root {
+    let handle = root_handle.try_clone().map_err(|source| {
+        FindWorkspaceInventoryError::ReadDirectory { path: workspace_root.to_path_buf(), source }
+    })?;
+    let mut navigation_opens = 2;
+    let mut directory = OpenDirectory { path: workspace_root.to_path_buf(), handle };
+    let mut frame =
+        read_frame(&directory, workspace_root, ignored, &mut before_read, &mut visit_file)?;
+    let mut ancestors = Vec::new();
+    loop {
+        if let Some(path) = frame.children.next() {
             before_open_directory(&path).map_err(|source| {
                 FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
             })?;
-        }
-        let relative = path.strip_prefix(workspace_root).expect("inventory paths share the root");
-        let handle = match open_descendant(&root_handle, relative) {
-            Ok(handle) => handle,
-            Err(error) if path != workspace_root && is_changed_candidate_error(&error) => continue,
-            Err(source) => {
-                return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
+            navigation_opens += 1;
+            let handle = match fs::open_dir_nofollow(
+                &directory.handle,
+                Path::new(path.file_name().expect("child basename")),
+            ) {
+                Ok(handle) => handle,
+                Err(error) if is_changed_candidate_error(&error) => continue,
+                Err(source) => {
+                    return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
+                }
+            };
+            ancestors.push(frame);
+            directory = OpenDirectory { path, handle };
+            frame =
+                read_frame(&directory, workspace_root, ignored, &mut before_read, &mut visit_file)?;
+        } else {
+            let Some(parent) = ancestors.pop() else {
+                return Ok(navigation_opens);
+            };
+            navigation_opens += 1;
+            let handle =
+                fs::open_parent_dir(&directory.handle, ambient_authority()).map_err(|source| {
+                    FindWorkspaceInventoryError::InspectCandidate {
+                        path: parent.path.clone(),
+                        source,
+                    }
+                })?;
+            let identity = fs::Metadata::from_file(&handle).map_err(|source| {
+                FindWorkspaceInventoryError::InspectCandidate { path: parent.path.clone(), source }
+            })?;
+            if !same_directory(&parent.identity, &identity) {
+                return Err(FindWorkspaceInventoryError::InspectCandidate {
+                    path: parent.path,
+                    source: io::Error::other(
+                        "directory ancestry changed during workspace discovery",
+                    ),
+                });
             }
-        };
-        let directory = OpenDirectory { path, handle };
-        let Some(entries) = read_directory(&directory, workspace_root, &mut before_read)? else {
-            continue;
-        };
+            directory = OpenDirectory { path: parent.path.clone(), handle };
+            frame = parent;
+        }
+    }
+}
+
+fn read_frame(
+    directory: &OpenDirectory,
+    workspace_root: &Path,
+    ignored: &IgnoredDirectories<'_>,
+    before_read: &mut impl FnMut(&Path) -> io::Result<()>,
+    visit_file: &mut impl FnMut(PathBuf, &OsStr),
+) -> Result<DirectoryFrame, FindWorkspaceInventoryError> {
+    let identity = fs::Metadata::from_file(&directory.handle).map_err(|source| {
+        FindWorkspaceInventoryError::InspectCandidate { path: directory.path.clone(), source }
+    })?;
+    let mut children = Vec::new();
+    if let Some(entries) = read_directory(directory, workspace_root, before_read)? {
         for entry in entries {
             let entry = match entry {
                 Ok(entry) => entry,
@@ -55,21 +112,31 @@ pub(super) fn walk_workspace(
                     });
                 }
             };
-            collect_entry(&directory, &entry, ignored, &mut pending, &mut visit_file)?;
+            collect_entry(directory, &entry, ignored, &mut children, visit_file)?;
         }
     }
-    Ok(())
+    Ok(DirectoryFrame { path: directory.path.clone(), identity, children: children.into_iter() })
 }
 
-// Reopen queued paths from the pinned root one component at a time. This bounds
-// open handles independently of tree width and depth without following symlinks.
-fn open_descendant(root: &std::fs::File, relative: &Path) -> io::Result<std::fs::File> {
-    let mut directory = None;
-    for component in relative.components() {
-        let parent = directory.as_ref().unwrap_or(root);
-        directory = Some(fs::open_dir_nofollow(parent, Path::new(component.as_os_str()))?);
+// Parent handles are released during descent. Validate the reopened parent before
+// inspecting siblings, since a concurrent rename can change a child's ancestry.
+fn same_directory(expected: &fs::Metadata, actual: &fs::Metadata) -> bool {
+    #[cfg(unix)]
+    {
+        use fs::MetadataExt;
+        expected.dev() == actual.dev()
+            && expected.ino() == actual.ino()
+            && expected.created().ok() == actual.created().ok()
     }
-    directory.map_or_else(|| root.try_clone(), Ok)
+    #[cfg(windows)]
+    {
+        use fs::_WindowsByHandle;
+        expected.volume_serial_number().is_some()
+            && expected.volume_serial_number() == actual.volume_serial_number()
+            && expected.file_index().is_some()
+            && expected.file_index() == actual.file_index()
+            && expected.created().ok() == actual.created().ok()
+    }
 }
 
 fn read_directory(

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -6,7 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
-struct PendingDirectory {
+struct OpenDirectory {
     path: PathBuf,
     handle: std::fs::File,
 }
@@ -25,38 +25,55 @@ pub(super) fn walk_workspace(
                 source,
             }
         })?;
-    let root = PendingDirectory { path: workspace_root.to_path_buf(), handle: root_handle };
-    let Some(entries) = read_directory(&root, workspace_root, &mut before_read)? else {
-        return Ok(());
-    };
-    let mut pending = vec![(root, entries)];
-    while let Some((directory, entries)) = pending.last_mut() {
-        let Some(entry) = entries.next() else {
-            pending.pop();
-            continue;
-        };
-        let entry = match entry {
-            Ok(entry) => entry,
-            Err(error) if is_ignorable_discovery_error(&error) => continue,
+    let mut pending = vec![workspace_root.to_path_buf()];
+    while let Some(path) = pending.pop() {
+        if path != workspace_root {
+            before_open_directory(&path).map_err(|source| {
+                FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
+            })?;
+        }
+        let relative = path.strip_prefix(workspace_root).expect("inventory paths share the root");
+        let handle = match open_descendant(&root_handle, relative) {
+            Ok(handle) => handle,
+            Err(error) if path != workspace_root && is_changed_candidate_error(&error) => continue,
             Err(source) => {
-                return Err(FindWorkspaceInventoryError::ReadEntry {
-                    path: directory.path.clone(),
-                    source,
-                });
+                return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
             }
         };
-        if let Some(child) =
-            collect_entry(directory, &entry, ignored, &mut before_open_directory, &mut visit_file)?
-            && let Some(entries) = read_directory(&child, workspace_root, &mut before_read)?
-        {
-            pending.push((child, entries));
+        let directory = OpenDirectory { path, handle };
+        let Some(entries) = read_directory(&directory, workspace_root, &mut before_read)? else {
+            continue;
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) if is_ignorable_discovery_error(&error) => continue,
+                Err(source) => {
+                    return Err(FindWorkspaceInventoryError::ReadEntry {
+                        path: directory.path.clone(),
+                        source,
+                    });
+                }
+            };
+            collect_entry(&directory, &entry, ignored, &mut pending, &mut visit_file)?;
         }
     }
     Ok(())
 }
 
+// Reopen queued paths from the pinned root one component at a time. This bounds
+// open handles independently of tree width and depth without following symlinks.
+fn open_descendant(root: &std::fs::File, relative: &Path) -> io::Result<std::fs::File> {
+    let mut directory = None;
+    for component in relative.components() {
+        let parent = directory.as_ref().unwrap_or(root);
+        directory = Some(fs::open_dir_nofollow(parent, Path::new(component.as_os_str()))?);
+    }
+    directory.map_or_else(|| root.try_clone(), Ok)
+}
+
 fn read_directory(
-    directory: &PendingDirectory,
+    directory: &OpenDirectory,
     workspace_root: &Path,
     before_read: &mut impl FnMut(&Path) -> io::Result<()>,
 ) -> Result<Option<fs::ReadDir>, FindWorkspaceInventoryError> {
@@ -72,52 +89,27 @@ fn read_directory(
 }
 
 fn collect_entry(
-    directory: &PendingDirectory,
+    directory: &OpenDirectory,
     entry: &fs::DirEntry,
     ignored: &IgnoredDirectories<'_>,
-    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
+    pending: &mut Vec<PathBuf>,
     visit_file: &mut impl FnMut(PathBuf, &OsStr),
-) -> Result<Option<PendingDirectory>, FindWorkspaceInventoryError> {
+) -> Result<(), FindWorkspaceInventoryError> {
     let file_name = entry.file_name();
     let path = directory.path.join(&file_name);
     let file_type = match entry.file_type() {
         Ok(file_type) => file_type,
-        Err(error) if is_ignorable_discovery_error(&error) => return Ok(None),
+        Err(error) if is_ignorable_discovery_error(&error) => return Ok(()),
         Err(source) => {
             return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
         }
     };
-    if file_type.is_symlink() {
-        return Ok(None);
+    if file_type.is_dir() && !ignored.contains(&file_name, &path) {
+        pending.push(path);
+    } else if file_type.is_file() {
+        visit_file(path, &file_name);
     }
-    if file_type.is_dir() {
-        collect_directory(directory, &file_name, path, ignored, before_open_directory)
-    } else {
-        if file_type.is_file() {
-            visit_file(path, &file_name);
-        }
-        Ok(None)
-    }
-}
-
-fn collect_directory(
-    parent: &PendingDirectory,
-    file_name: &OsStr,
-    path: PathBuf,
-    ignored: &IgnoredDirectories<'_>,
-    before_open_directory: &mut impl FnMut(&Path) -> io::Result<()>,
-) -> Result<Option<PendingDirectory>, FindWorkspaceInventoryError> {
-    if ignored.contains(file_name, &path) {
-        return Ok(None);
-    }
-    before_open_directory(&path).map_err(|source| {
-        FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
-    })?;
-    match fs::open_dir_nofollow(&parent.handle, Path::new(file_name)) {
-        Ok(handle) => Ok(Some(PendingDirectory { path, handle })),
-        Err(error) if is_changed_candidate_error(&error) => Ok(None),
-        Err(source) => Err(FindWorkspaceInventoryError::InspectCandidate { path, source }),
-    }
+    Ok(())
 }
 
 fn is_changed_candidate_error(error: &io::Error) -> bool {

--- a/pnpm/crates/workspace/src/inventory/traversal.rs
+++ b/pnpm/crates/workspace/src/inventory/traversal.rs
@@ -6,15 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-struct OpenDirectory {
+struct OpenDirectory<'a> {
     path: PathBuf,
-    handle: std::fs::File,
-}
-
-struct DirectoryFrame {
-    path: PathBuf,
-    identity: fs::Metadata,
-    children: std::vec::IntoIter<PathBuf>,
+    handle: &'a std::fs::File,
 }
 
 /// Return the number of directory navigation opens during the scan.
@@ -32,74 +26,50 @@ pub(super) fn walk_workspace(
                 source,
             }
         })?;
-    let handle = root_handle.try_clone().map_err(|source| {
-        FindWorkspaceInventoryError::ReadDirectory { path: workspace_root.to_path_buf(), source }
-    })?;
-    let mut navigation_opens = 2;
-    let mut directory = OpenDirectory { path: workspace_root.to_path_buf(), handle };
-    let mut frame =
-        read_frame(&directory, workspace_root, ignored, &mut before_read, &mut visit_file)?;
-    let mut ancestors = Vec::new();
-    loop {
-        if let Some(path) = frame.children.next() {
-            before_open_directory(&path).map_err(|source| {
-                FindWorkspaceInventoryError::InspectCandidate { path: path.clone(), source }
-            })?;
-            navigation_opens += 1;
-            let handle = match fs::open_dir_nofollow(
-                &directory.handle,
-                Path::new(path.file_name().expect("child basename")),
-            ) {
-                Ok(handle) => handle,
-                Err(error) if is_changed_candidate_error(&error) => continue,
-                Err(source) => {
-                    return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
-                }
-            };
-            ancestors.push(frame);
-            directory = OpenDirectory { path, handle };
-            frame =
-                read_frame(&directory, workspace_root, ignored, &mut before_read, &mut visit_file)?;
-        } else {
-            let Some(parent) = ancestors.pop() else {
-                return Ok(navigation_opens);
-            };
-            navigation_opens += 1;
-            let handle =
-                fs::open_parent_dir(&directory.handle, ambient_authority()).map_err(|source| {
-                    FindWorkspaceInventoryError::InspectCandidate {
-                        path: parent.path.clone(),
-                        source,
-                    }
-                })?;
-            let identity = fs::Metadata::from_file(&handle).map_err(|source| {
-                FindWorkspaceInventoryError::InspectCandidate { path: parent.path.clone(), source }
-            })?;
-            if !same_directory(&parent.identity, &identity) {
-                return Err(FindWorkspaceInventoryError::InspectCandidate {
-                    path: parent.path,
-                    source: io::Error::other(
-                        "directory ancestry changed during workspace discovery",
-                    ),
-                });
+    let mut navigation_opens = 1;
+    let mut pending = Vec::new();
+    read_children(
+        &OpenDirectory { path: workspace_root.to_path_buf(), handle: &root_handle },
+        workspace_root,
+        ignored,
+        &mut before_read,
+        &mut visit_file,
+        &mut pending,
+    )?;
+    while let Some(path) = pending.pop() {
+        let handle = match before_open_directory(&path).and_then(|()| {
+            super::open_directory::open_directory(
+                &root_handle,
+                path.strip_prefix(workspace_root).expect("descendant of workspace root"),
+                &mut navigation_opens,
+            )
+        }) {
+            Ok(handle) => handle,
+            Err(error) if is_changed_candidate_error(&error) => continue,
+            Err(source) => {
+                return Err(FindWorkspaceInventoryError::InspectCandidate { path, source });
             }
-            directory = OpenDirectory { path: parent.path.clone(), handle };
-            frame = parent;
-        }
+        };
+        read_children(
+            &OpenDirectory { path, handle: &handle },
+            workspace_root,
+            ignored,
+            &mut before_read,
+            &mut visit_file,
+            &mut pending,
+        )?;
     }
+    Ok(navigation_opens)
 }
 
-fn read_frame(
-    directory: &OpenDirectory,
+fn read_children(
+    directory: &OpenDirectory<'_>,
     workspace_root: &Path,
     ignored: &IgnoredDirectories<'_>,
     before_read: &mut impl FnMut(&Path) -> io::Result<()>,
     visit_file: &mut impl FnMut(PathBuf, &OsStr),
-) -> Result<DirectoryFrame, FindWorkspaceInventoryError> {
-    let identity = fs::Metadata::from_file(&directory.handle).map_err(|source| {
-        FindWorkspaceInventoryError::InspectCandidate { path: directory.path.clone(), source }
-    })?;
-    let mut children = Vec::new();
+    pending: &mut Vec<PathBuf>,
+) -> Result<(), FindWorkspaceInventoryError> {
     if let Some(entries) = read_directory(directory, workspace_root, before_read)? {
         for entry in entries {
             let entry = match entry {
@@ -112,39 +82,18 @@ fn read_frame(
                     });
                 }
             };
-            collect_entry(directory, &entry, ignored, &mut children, visit_file)?;
+            collect_entry(directory, &entry, ignored, pending, visit_file)?;
         }
     }
-    Ok(DirectoryFrame { path: directory.path.clone(), identity, children: children.into_iter() })
-}
-
-// Parent handles are released during descent. Validate the reopened parent before
-// inspecting siblings, since a concurrent rename can change a child's ancestry.
-fn same_directory(expected: &fs::Metadata, actual: &fs::Metadata) -> bool {
-    #[cfg(unix)]
-    {
-        use fs::MetadataExt;
-        expected.dev() == actual.dev()
-            && expected.ino() == actual.ino()
-            && expected.created().ok() == actual.created().ok()
-    }
-    #[cfg(windows)]
-    {
-        use fs::_WindowsByHandle;
-        expected.volume_serial_number().is_some()
-            && expected.volume_serial_number() == actual.volume_serial_number()
-            && expected.file_index().is_some()
-            && expected.file_index() == actual.file_index()
-            && expected.created().ok() == actual.created().ok()
-    }
+    Ok(())
 }
 
 fn read_directory(
-    directory: &OpenDirectory,
+    directory: &OpenDirectory<'_>,
     workspace_root: &Path,
     before_read: &mut impl FnMut(&Path) -> io::Result<()>,
 ) -> Result<Option<fs::ReadDir>, FindWorkspaceInventoryError> {
-    match before_read(&directory.path).and_then(|()| fs::read_base_dir(&directory.handle)) {
+    match before_read(&directory.path).and_then(|()| fs::read_base_dir(directory.handle)) {
         Ok(entries) => Ok(Some(entries)),
         Err(error) if directory.path != workspace_root && is_ignorable_discovery_error(&error) => {
             Ok(None)
@@ -156,7 +105,7 @@ fn read_directory(
 }
 
 fn collect_entry(
-    directory: &OpenDirectory,
+    directory: &OpenDirectory<'_>,
     entry: &fs::DirEntry,
     ignored: &IgnoredDirectories<'_>,
     pending: &mut Vec<PathBuf>,
@@ -183,6 +132,7 @@ fn is_changed_candidate_error(error: &io::Error) -> bool {
     is_ignorable_discovery_error(error)
         || error.kind() == io::ErrorKind::NotADirectory
         || is_symlink_loop(error)
+        || is_changed_ancestry_error(error)
 }
 
 #[cfg(unix)]
@@ -192,5 +142,15 @@ fn is_symlink_loop(error: &io::Error) -> bool {
 
 #[cfg(not(unix))]
 fn is_symlink_loop(_error: &io::Error) -> bool {
+    false
+}
+
+#[cfg(target_os = "linux")]
+fn is_changed_ancestry_error(error: &io::Error) -> bool {
+    matches!(error.raw_os_error(), Some(libc::EAGAIN | libc::EXDEV))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn is_changed_ancestry_error(_error: &io::Error) -> bool {
     false
 }


### PR DESCRIPTION
## Summary

Speed up `pnpm install` for Cargo dependencies by reusing workspace discovery metadata, keeping directory handles bounded for both wide and deep trees, and caching generated Cargo checksum files. Crate integrity checks, checksum-cache validation, slot repair, and directory-symlink protections remain active.

Warm-install medians from 35 interleaved runs per tool on Linux:

| Cargo-only workload | Cargo fetch | pnpm install |
| --- | ---: | ---: |
| 65 workspace packages, 42 registry dependencies, tmpfs | 29.8 ms | 29.1 ms |
| Same synthetic fixture, Btrfs | 31.4 ms | 29.3 ms |
| This repository: 104 workspace packages, 765 registry dependencies, 1 Git dependency, tmpfs | 176.0 ms | 90.5 ms |

The repository workload is about 49% faster with pnpm. The synthetic tmpfs fixture improves from 138.3 ms before these optimizations to 29.1 ms, a 79% reduction. The before/after local binaries use identical release settings.

The comparison uses `cargo fetch --locked` and `pnpm install --frozen-lockfile`, Rust 1.97.0 for both tools and all Cargo subprocesses, existing identical Cargo.lock files, and separate Cargo homes and pnpm stores/caches. The repository fixture copies its Rust sources and manifests with npm workspace packages disabled. npm dependency installation, dependency resolution from scratch, and compilation are outside these timings. Every timed command succeeded and left Cargo.lock unchanged. These are local Linux measurements, not a cross-platform performance guarantee.

Regression tests count actual metadata invocations for multiple members and an independent nested workspace under absolute, relative, and `..`-aliased paths. A separate subprocess discovers a 128-level branching tree with a 64-descriptor limit and asserts exactly 257 navigation opens for 257 directories on native whole-path implementations (with separate expectations for older-kernel fallbacks). The parent test requires a one-test success summary from the child. Cross-platform regressions cover intermediate symlink/junction swaps, a child moved to another parent, disappearing directories, and permission errors. Parent ascent and file-identity comparisons are no longer used.

Validation: `just ready` passed all 10,859 tests (10 skipped), and Dylint passed. Cross-compilation and Clippy passed for macOS and Windows, including the workspace tests. `cargo metadata --offline --locked --format-version 1` also succeeded against the repository graph installed entirely by pnpm, including its Git patch.

## Squash Commit Body

```text
Reuse package manifest paths returned by Cargo metadata during workspace
root discovery. A 65-package workspace needs one metadata invocation rather
than 65. Preserve discovery of independent nested workspaces.

Canonicalize discovered manifest paths and Cargo metadata paths before
membership filtering so relative paths and lexical aliases reuse metadata.

Queue directory paths and open each from the pinned workspace root. Native
whole-path opens reject every symlink/reparse point: openat2 with
RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS on Linux, O_NOFOLLOW_ANY on macOS 11+,
and NtCreateFile with OBJ_DONT_REPARSE on Windows. Keep handles bounded and
issue one navigation open per directory without ascending or comparing file
identities. Narrow unsafe wrappers use existing libc/windows-sys dependencies.

Older Unix kernels and other Unix platforms use a component-by-component
no-follow fallback with bounded handles but depth-dependent open counts.
Detect older macOS kernels before using the flag, because they may ignore
unknown open flags. Skip transiently removed/unreadable nested directories.

Normalize expected test paths for macOS temporary-directory aliases and Windows
short paths. Verify the limited-descriptor child test actually runs one test.

Cache generated Cargo checksum files in the existing store index, keyed by
the archive checksum and the verified source-file mapping. Validate the
cached checksum CAS file before reuse. Regenerate missing or corrupted
entries and invalidate the cache when source mappings or archive checksums
change. Keep source integrity checks and materialized-slot repair intact.

On the repository's Cargo-only dependency graph, 35 interleaved warm runs
measure 90.5 ms for pnpm install versus 176.0 ms for cargo fetch. Synthetic
warm installs fall from 138.3 ms to 29.1 ms with the same release settings.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version. These optimizations affect Rust ecosystem installation only.
- [x] Added a changeset for `pacquet`.
- [x] Added or updated tests for workspace membership, independent nested workspaces, bounded handles in wide and deep trees, ancestor-symlink swaps, metadata invocation counts for aliased paths, persisted checksum reuse, corruption repair, and cache invalidation.
- [x] Ran `just ready` and verified Cargo can read the pnpm-installed repository dependencies offline.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Faster `pnpm install` for Cargo workspaces with many member crates.
  - Repeated installations reuse verified Cargo checksum metadata.
  - Reduced repeated Cargo metadata lookups across workspace aliases and nested workspaces.

- **Bug Fixes**
  - Improved discovery for nested and overlapping Cargo workspaces.
  - Prevented duplicate workspace and member manifests during discovery.
  - Improved checksum validation and recovery when cached package data changes or becomes corrupted.
  - Improved workspace traversal reliability for deep trees and changing directory layouts.
  - Prevented directory traversal through symlinked paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


