### PR TITLE
feat(pnpr): scope registry identity by ecosystem and expose directory

### DIFF
--- a/.changeset/pnpr-registry-directory.md
+++ b/.changeset/pnpr-registry-directory.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/pnpr": minor
+---
+
+Added a registry directory endpoint for discovering named registries, ecosystem endpoints, and routing order. The directory only includes registries visible to the current user.

--- a/.changeset/pnpr-registry-directory.md
+++ b/.changeset/pnpr-registry-directory.md
@@ -3,3 +3,5 @@
 ---
 
 Added a registry directory endpoint for discovering named registries, ecosystem endpoints, and routing order. The directory only includes registries visible to the current user.
+
+Registry names can now be reused across ecosystems by grouping configuration under `registries.npm`, `registries.cargo`, `registries.pypi`, or `registries.oci`. Router sources and defaults resolve within each ecosystem.

--- a/pnpr/crates/config/src/lib.rs
+++ b/pnpr/crates/config/src/lib.rs
@@ -944,12 +944,12 @@ struct HostedFile {
     /// The package ecosystem this registry serves, which selects the protocol
     /// spoken at its `/~<name>/` endpoint. Omitted ⇒ `npm`.
     #[serde(default)]
-    ecosystem: Ecosystem,
+    ecosystem: Option<Ecosystem>,
     /// Storage namespace for this registry's packages, so two hosted registries can
-    /// hold the same `name@version` without colliding. Omitted ⇒ the flat
-    /// `storage` root (`""`).
+    /// hold the same `name@version` without colliding. A grouped registry defaults
+    /// to `ecosystem~name`; a flat entry defaults to the storage root (`""`).
     #[serde(default)]
-    org: String,
+    org: Option<String>,
     /// The registry-level default: who may read this registry's packages when
     /// no `packages:` entry refines it. Omitted ⇒ `$all`.
     #[serde(default)]
@@ -980,7 +980,7 @@ struct UpstreamFile {
     /// `cargo`, `url` is a sparse index root (`https://index.crates.io/`); for
     /// `pypi`, a Simple API root (`https://pypi.org/simple/`).
     #[serde(default)]
-    ecosystem: Ecosystem,
+    ecosystem: Option<Ecosystem>,
     url: String,
     /// An anonymous, world-readable origin (e.g. the public npm registry).
     /// Mutually exclusive with `auth`.
@@ -1028,6 +1028,23 @@ struct UpstreamFile {
 struct RouterFile {
     #[serde(default)]
     sources: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(
+    untagged,
+    expecting = "a registry with type hosted, upstream, or router, or an ecosystem group of registries"
+)]
+enum RegistryGroupFile {
+    Registry(RegistryFile),
+    Ecosystem(IndexMap<String, RegistryFile>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum DefaultRegistryFile {
+    Shared(String),
+    Ecosystems(IndexMap<Ecosystem, String>),
 }
 
 /// Disk shape of the YAML file. Fields verdaccio supports but
@@ -1082,11 +1099,11 @@ struct ConfigFile {
     /// exposed at `/~<name>/`. The only routing surface — there is no legacy
     /// `upstreams:`/`packages: proxy:` fallback.
     #[serde(default)]
-    registries: IndexMap<String, RegistryFile>,
+    registries: IndexMap<String, RegistryGroupFile>,
     /// The registry the path-less base URL aliases. Absent ⇒ the bare host has no
     /// registry and clients must address a `/~<name>/`.
     #[serde(default, rename = "defaultRegistry")]
-    default_registry: Option<String>,
+    default_registry: Option<DefaultRegistryFile>,
     /// The removed top-level ACL block, kept only to *reject* it loudly.
     /// Per-package rules live on each registry's `packages:` map now; a
     /// config still carrying the global block previously enforced access
@@ -1804,7 +1821,7 @@ impl Config {
             }
         }
         for name in self.registries.names() {
-            validate_registry_name(name)?;
+            validate_registry_key(name)?;
             // A concrete registry needs its serving config — a hosted graph
             // entry without its `hosted` table row (or an upstream without
             // its serving entry) would answer every request not-found at
@@ -1836,7 +1853,7 @@ impl Config {
             }
         }
         for (index, (name, hosted)) in self.hosted.iter().enumerate() {
-            validate_registry_name(name)?;
+            validate_registry_key(name)?;
             validate_org_namespace(name, &hosted.org)?;
             // The mirror of the upstream collision above: a hosted serving row
             // under a name the graph declares as a different kind would leave
@@ -1945,6 +1962,72 @@ fn registry_err(err: &RegistryConfigError) -> RegistryError {
     RegistryError::InvalidConfig { reason: err.to_string() }
 }
 
+fn set_group_ecosystem(
+    name: &str,
+    declared: &mut Option<Ecosystem>,
+    ecosystem: Ecosystem,
+) -> Result<(), RegistryError> {
+    if declared.is_some_and(|declared| declared != ecosystem) {
+        return Err(RegistryError::InvalidConfig {
+            reason: format!(
+                "registry {name:?} declares an ecosystem different from its {ecosystem} group",
+            ),
+        });
+    }
+    *declared = Some(ecosystem);
+    Ok(())
+}
+
+fn flatten_registry_groups(
+    groups: IndexMap<String, RegistryGroupFile>,
+) -> Result<IndexMap<String, RegistryFile>, RegistryError> {
+    let mut entries = IndexMap::new();
+    for (name, group) in groups {
+        match group {
+            RegistryGroupFile::Registry(registry) => {
+                validate_registry_name(&name)?;
+                entries.insert(name, registry);
+            }
+            RegistryGroupFile::Ecosystem(registries) => {
+                let ecosystem = Ecosystem::all()
+                    .find(|ecosystem| ecosystem.as_str() == name)
+                    .ok_or_else(|| RegistryError::InvalidConfig {
+                        reason: format!("unknown registry ecosystem {name:?}"),
+                    })?;
+                for (name, mut registry) in registries {
+                    validate_registry_name(&name)?;
+                    match &mut registry {
+                        RegistryFile::Hosted(hosted) => {
+                            set_group_ecosystem(&name, &mut hosted.ecosystem, ecosystem)?;
+                            hosted.org.get_or_insert_with(|| format!("{ecosystem}~{name}"));
+                        }
+                        RegistryFile::Upstream(upstream) => {
+                            set_group_ecosystem(&name, &mut upstream.ecosystem, ecosystem)?;
+                        }
+                        RegistryFile::Router(router) => {
+                            for source in &mut router.sources {
+                                validate_registry_name(source)?;
+                                *source = format!("{ecosystem}/{source}");
+                            }
+                        }
+                    }
+                    entries.insert(format!("{ecosystem}/{name}"), registry);
+                }
+            }
+        }
+    }
+    Ok(entries)
+}
+
+fn validate_registry_key(key: &str) -> Result<(), RegistryError> {
+    if let Some((prefix, name)) = key.split_once('/')
+        && Ecosystem::all().any(|ecosystem| ecosystem.as_str() == prefix)
+    {
+        return validate_registry_name(name);
+    }
+    validate_registry_name(key)
+}
+
 /// Build the validated [`Registries`] graph (and the hosted table) from the
 /// resolved upstreams and the `registries:` block. Every upstream is an upstream
 /// registry; `registries:` adds hosted, further upstream, and router registries.
@@ -1958,10 +2041,25 @@ fn registry_err(err: &RegistryConfigError) -> RegistryError {
 /// on (or carry) upstream secrets it never uses.
 fn build_registries(
     upstreams: &mut IndexMap<String, UpstreamConfig>,
-    registry_files: IndexMap<String, RegistryFile>,
-    default_registry: Option<String>,
+    registry_files: IndexMap<String, RegistryGroupFile>,
+    default_registry: Option<DefaultRegistryFile>,
     resolve_upstreams: bool,
 ) -> Result<(IndexMap<String, HostedConfig>, Registries), RegistryError> {
+    let registry_files = flatten_registry_groups(registry_files)?;
+    let (default_registry, defaults) = match default_registry {
+        Some(DefaultRegistryFile::Shared(name)) => (Some(name), IndexMap::new()),
+        Some(DefaultRegistryFile::Ecosystems(defaults)) => {
+            let defaults = defaults
+                .into_iter()
+                .map(|(ecosystem, name)| {
+                    validate_registry_name(&name)?;
+                    Ok((ecosystem, format!("{ecosystem}/{name}")))
+                })
+                .collect::<Result<IndexMap<_, _>, RegistryError>>()?;
+            (None, defaults)
+        }
+        None => (None, IndexMap::new()),
+    };
     let mut hosted: IndexMap<String, HostedConfig> = IndexMap::new();
     let mut graph: IndexMap<String, Registry> = IndexMap::new();
     let mut ecosystems: IndexMap<String, Ecosystem> = IndexMap::new();
@@ -1972,7 +2070,7 @@ fn build_registries(
         graph.insert(name.clone(), Registry::Upstream { patterns: Vec::new() });
     }
     for (name, file) in registry_files {
-        validate_registry_name(&name)?;
+        validate_registry_key(&name)?;
         if graph.contains_key(&name) {
             return Err(RegistryError::InvalidConfig {
                 reason: format!(
@@ -1982,21 +2080,30 @@ fn build_registries(
         }
         match file {
             RegistryFile::Hosted(registry) => {
-                validate_org_namespace(&name, &registry.org)?;
-                if let Some((other, _)) = hosted
-                    .iter()
-                    .find(|(_, existing): &(_, &HostedConfig)| existing.org == registry.org)
+                let org = registry.org.unwrap_or_default();
+                validate_org_namespace(&name, &org)?;
+                if let Some((other, _)) =
+                    hosted.iter().find(|(_, existing): &(_, &HostedConfig)| existing.org == org)
                 {
-                    return Err(org_collision_error(&name, &registry.org, other));
+                    return Err(org_collision_error(&name, &org, other));
                 }
                 let teams = build_teams(&name, &registry.teams)?;
                 let access = registry_access_list(&name, registry.access.as_ref(), &teams)?;
-                let packages =
-                    ecosystem_package_keys(&name, registry.ecosystem, registry.packages)?;
-                let rules = build_rules(&name, registry.ecosystem, &packages, access, &teams)?;
+                let packages = ecosystem_package_keys(
+                    &name,
+                    registry.ecosystem.unwrap_or_default(),
+                    registry.packages,
+                )?;
+                let rules = build_rules(
+                    &name,
+                    registry.ecosystem.unwrap_or_default(),
+                    &packages,
+                    access,
+                    &teams,
+                )?;
                 let patterns = rules.patterns();
-                hosted.insert(name.clone(), HostedConfig { org: registry.org, rules, teams });
-                ecosystems.insert(name.clone(), registry.ecosystem);
+                hosted.insert(name.clone(), HostedConfig { org, rules, teams });
+                ecosystems.insert(name.clone(), registry.ecosystem.unwrap_or_default());
                 graph.insert(name, Registry::Hosted { patterns });
             }
             RegistryFile::Upstream(upstream) => {
@@ -2008,10 +2115,19 @@ fn build_registries(
                 // write can land on — fails startup on every tier too.
                 let teams = build_teams(&name, &upstream.teams)?;
                 let access = registry_access_list(&name, upstream.access.as_ref(), &teams)?;
-                let packages =
-                    ecosystem_package_keys(&name, upstream.ecosystem, upstream.packages.clone())?;
-                let rules = build_rules(&name, upstream.ecosystem, &packages, access, &teams)?;
-                ecosystems.insert(name.clone(), upstream.ecosystem);
+                let packages = ecosystem_package_keys(
+                    &name,
+                    upstream.ecosystem.unwrap_or_default(),
+                    upstream.packages.clone(),
+                )?;
+                let rules = build_rules(
+                    &name,
+                    upstream.ecosystem.unwrap_or_default(),
+                    &packages,
+                    access,
+                    &teams,
+                )?;
+                ecosystems.insert(name.clone(), upstream.ecosystem.unwrap_or_default());
                 if rules.refines_writes() {
                     return Err(RegistryError::InvalidConfig {
                         reason: format!(
@@ -2040,6 +2156,15 @@ fn build_registries(
         .fold(Registries::new(graph, default_registry), |registries, (name, ecosystem)| {
             registries.with_ecosystem(name, *ecosystem)
         });
+    let defaults = defaults
+        .into_iter()
+        .map(|(ecosystem, target)| {
+            let local = Registries::local_name(&target);
+            let key = registries.addressed(local, ecosystem).unwrap_or(&target).to_string();
+            (ecosystem, key)
+        })
+        .collect();
+    let registries = registries.with_defaults(defaults);
     registries.validate().map_err(|err| registry_err(&err))?;
     Ok((hosted, registries))
 }

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -2837,3 +2837,27 @@ fn ecosystem_groups_reject_ambiguous_or_cross_ecosystem_configuration() {
         assert!(result.is_err(), "must reject ambiguous or cross-ecosystem config: {yaml}");
     }
 }
+
+#[test]
+fn ecosystem_default_requires_a_router_source_for_that_ecosystem() {
+    for (sources, valid) in [("npm", false), ("npm, crates", true)] {
+        let yaml = format!(
+            "registries:\n  npm: {{type: hosted, org: npm}}\n  crates: {{type: hosted, ecosystem: cargo, org: crates}}\n  main: {{type: router, sources: [{sources}]}}\ndefaultRegistry:\n  cargo: main\n",
+        );
+        let result = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None);
+        if valid {
+            let config = result.unwrap();
+            assert_eq!(
+                config.registries.resolve_default(Ecosystem::Cargo, "demo"),
+                pnpr_registry::Resolved::Concrete {
+                    registry: "crates",
+                    kind: pnpr_registry::ConcreteKind::Hosted,
+                },
+            );
+        } else {
+            let error = result.expect_err("a Cargo default must have a Cargo source");
+            assert!(error.to_string().contains("cargo"), "{error}");
+            assert!(error.to_string().contains("main"), "{error}");
+        }
+    }
+}

--- a/pnpr/crates/config/src/tests.rs
+++ b/pnpr/crates/config/src/tests.rs
@@ -14,6 +14,7 @@ use pnpr_policy::Identity;
 use pnpr_registry::Ecosystem;
 use reqwest::header::AUTHORIZATION;
 use std::{
+    fmt::Write as _,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
     path::{Path, PathBuf},
     time::Duration,
@@ -2784,5 +2785,55 @@ fn oci_limits_are_positive_and_preserve_defaults() {
             Config::from_yaml_str(yaml, Path::new("/config"), listen(), None).is_err(),
             "{yaml}",
         );
+    }
+}
+
+#[test]
+fn ecosystem_groups_scope_names_sources_defaults_and_hosted_storage() {
+    let mut yaml = String::from("registries:\n");
+    for ecosystem in Ecosystem::all() {
+        write!(yaml,
+            "  {ecosystem}:\n    internal:\n      type: hosted\n    main:\n      type: router\n      sources: [internal]\n",
+        ).unwrap();
+    }
+    yaml.push_str("defaultRegistry:\n  npm: main\n  cargo: main\n  pypi: main\n  oci: main\n");
+    let mut config = Config::from_yaml_str(&yaml, Path::new("/x"), listen(), None).unwrap();
+    config.ensure_valid_registry_graph().unwrap();
+    for ecosystem in Ecosystem::all() {
+        let key = format!("{ecosystem}/internal");
+        let router = format!("{ecosystem}/main");
+        assert_eq!(config.registries.default_for(ecosystem), Some(router.as_str()));
+        assert_eq!(config.registries.sources("main", ecosystem), [key.as_str()]);
+        assert_eq!(config.hosted[&key].org, format!("{ecosystem}~internal"));
+        for resolution in [
+            config.registries.resolve("internal", ecosystem, "demo"),
+            config.registries.resolve("main", ecosystem, "demo"),
+            config.registries.resolve_default(ecosystem, "demo"),
+        ] {
+            assert_eq!(
+                resolution,
+                pnpr_registry::Resolved::Concrete {
+                    registry: key.as_str(),
+                    kind: pnpr_registry::ConcreteKind::Hosted,
+                },
+            );
+        }
+    }
+    assert_eq!(config.registries.addressed("cargo/internal", Ecosystem::Npm), None);
+}
+
+#[test]
+fn ecosystem_groups_reject_ambiguous_or_cross_ecosystem_configuration() {
+    for yaml in [
+        "registries:\n  npm:\n    internal: {type: hosted, ecosystem: cargo}\n",
+        "registries:\n  internal: {type: hosted}\n  npm:\n    internal: {type: hosted}\n",
+        "registries:\n  npm:\n    main: {type: router, sources: [internal]}\n  cargo:\n    internal: {type: hosted}\n",
+        "registries:\n  npm:\n    main: {type: router, sources: ['cargo/internal']}\n  cargo:\n    internal: {type: hosted}\n",
+        "registries:\n  cargo:\n    internal: {type: hosted}\ndefaultRegistry:\n  npm: internal\n",
+        "registries:\n  cargo:\n    internal: {type: hosted, ecosystem: npm}\n",
+        "registries:\n  npm:\n    internal: {type: hosted}\n    internal: {type: hosted}\n",
+    ] {
+        let result = Config::from_yaml_str(yaml, Path::new("/x"), listen(), None);
+        assert!(result.is_err(), "must reject ambiguous or cross-ecosystem config: {yaml}");
     }
 }

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -4,6 +4,24 @@ A pnpm-compatible npm registry server, written in Rust.
 
 Lives in the [pnpm monorepo](https://github.com/pnpm/pnpm) under `registry/`.
 
+## Registry directory
+
+`GET /-/pnpr/v0/registries` lists the named registries visible to the caller.
+It returns `registries`, the visible `defaultRegistry` (or `null`), and the
+mounted `ecosystems` with their `available` and `prefixed` flags.
+
+Each entry contains its `name`, `kind` (`hosted`, `upstream`, or `router`),
+and supported `ecosystems`. Concrete registries report namespace `patterns`;
+routers report ordered `sources`. These fields are `null` when their details
+cannot be disclosed under the caller's access rules. Upstream addresses,
+credentials, storage paths, and package access rules are never returned.
+Responses are private and must not be cached.
+
+An explicit `/~name` chooses a registry; the path without a name uses the
+configured default. Within an ecosystem, a router selects the first source
+whose namespace claims the package. A missing package or failed upstream is
+final, without fallback to another source. Package access rules still apply.
+
 ## OpenID Connect
 
 [Configure OIDC sign-in and keyless CI publishing](./OIDC.md) with Okta,

--- a/pnpr/crates/pnpr/README.md
+++ b/pnpr/crates/pnpr/README.md
@@ -7,20 +7,60 @@ Lives in the [pnpm monorepo](https://github.com/pnpm/pnpm) under `registry/`.
 ## Registry directory
 
 `GET /-/pnpr/v0/registries` lists the named registries visible to the caller.
-It returns `registries`, the visible `defaultRegistry` (or `null`), and the
+It returns `registries`, the visible `defaultRegistries` keyed by ecosystem, and the
 mounted `ecosystems` with their `available` and `prefixed` flags.
 
 Each entry contains its `name`, `kind` (`hosted`, `upstream`, or `router`),
-and supported `ecosystems`. Concrete registries report namespace `patterns`;
+and `ecosystem`. The identity is `(ecosystem, name)`. Concrete registries report namespace `patterns`;
 routers report ordered `sources`. These fields are `null` when their details
 cannot be disclosed under the caller's access rules. Upstream addresses,
 credentials, storage paths, and package access rules are never returned.
 Responses are private and must not be cached.
 
-An explicit `/~name` chooses a registry; the path without a name uses the
-configured default. Within an ecosystem, a router selects the first source
+An explicit `/<ecosystem>/~name` chooses a registry; the path without a name uses
+that ecosystem's configured default. A single-ecosystem server omits the ecosystem prefix. Within an ecosystem, a router selects the first source
 whose namespace claims the package. A missing package or failed upstream is
 final, without fallback to another source. Package access rules still apply.
+
+## Ecosystem-scoped registries
+
+Group registries by ecosystem to reuse a name across protocols:
+
+```yaml
+registries:
+  npm:
+    internal:
+      type: hosted
+      packages:
+        '@example/*': {}
+    public:
+      type: upstream
+      url: https://registry.npmjs.org/
+      public: true
+    main:
+      type: router
+      sources: [internal, public]
+  cargo:
+    internal:
+      type: hosted
+    main:
+      type: router
+      sources: [internal]
+defaultRegistry:
+  npm: main
+  cargo: main
+```
+
+Here `/npm/~internal` and `/cargo/~internal` are independent registries. Router
+sources resolve within their ecosystem group, and each ecosystem has its own
+default. Source references cannot cross ecosystem groups. Access rules, teams,
+upstream credentials, and caches belong to the individual registry.
+
+A grouped hosted registry defaults to the storage namespace `<ecosystem>~<name>`.
+Set `org` explicitly to use an existing namespace when moving a flat registry
+into a group, including `org: ''` for the flat storage root. Two hosted registries
+cannot share a storage namespace. The existing flat configuration format and
+its shared `defaultRegistry: main` remain supported.
 
 ## OpenID Connect
 

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -9,6 +9,7 @@ mod oidc;
 mod package_mutation;
 mod publishing;
 mod pypi;
+mod registry_directory;
 mod routing;
 mod staged;
 mod striped_locks;

--- a/pnpr/crates/pnpr/src/server.rs
+++ b/pnpr/crates/pnpr/src/server.rs
@@ -472,7 +472,7 @@ impl<RouterState: Send + Sync> FromRequestParts<RouterState> for TargetRegistry 
         let Some((_, registry)) = params.iter().find(|(name, _)| *name == "registry") else {
             return Ok(Self(None));
         };
-        if registry.is_empty() {
+        if !pnpr_package_name::is_safe_path_segment(registry) {
             return Err(RegistryError::NotFound.into_response());
         }
         Ok(Self(Some(registry.to_string())))
@@ -563,7 +563,9 @@ async fn serve_packument(
     registry: Option<&str>,
     raw_name: &str,
 ) -> Response {
-    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let Some(target) = addressed_registry(state, registry, Ecosystem::Npm) else {
+        return not_found();
+    };
     let base = registry_endpoint(state, Ecosystem::Npm, registry);
     let response =
         serve_registry_packument(state, identity, headers, &target, raw_name, &base).await;
@@ -577,7 +579,9 @@ async fn serve_version_manifest(
     raw_name: &str,
     version_or_tag: &str,
 ) -> Response {
-    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let Some(target) = addressed_registry(state, registry, Ecosystem::Npm) else {
+        return not_found();
+    };
     let base = registry_endpoint(state, Ecosystem::Npm, registry);
     let response =
         serve_registry_version_manifest(state, identity, &target, raw_name, version_or_tag, &base)
@@ -945,7 +949,7 @@ async fn load_packument_for_read(
 ) -> Result<Option<Vec<u8>>, RegistryError> {
     let target = match registry {
         Some(registry) => registry.to_string(),
-        None => match default_registry_target(state) {
+        None => match default_registry_target(state, Ecosystem::Npm) {
             Some(target) => target,
             None => return Ok(None),
         },
@@ -1575,8 +1579,8 @@ impl UpstreamSearchBudget {
 /// bare host has no registry and every request is a not-found, so clients must
 /// address a `/~<name>/`. There is no legacy hosted-then-proxy path: a
 /// path-less request resolves through the registry graph or it does not resolve.
-fn default_registry_target(state: &AppState) -> Option<String> {
-    state.inner.config.registries.default_registry().map(str::to_string)
+fn default_registry_target(state: &AppState, ecosystem: Ecosystem) -> Option<String> {
+    state.inner.config.registries.default_for(ecosystem).map(str::to_string)
 }
 
 /// Resolve an npm request; see [`resolve_ecosystem_source`].
@@ -1863,7 +1867,9 @@ async fn serve_tarball(
     raw_name: &str,
     filename: &str,
 ) -> Response {
-    let Some(target) = addressed_registry(state, registry) else { return not_found() };
+    let Some(target) = addressed_registry(state, registry, Ecosystem::Npm) else {
+        return not_found();
+    };
     let response = serve_registry_tarball(state, identity, &target, raw_name, filename).await;
     caller_scoped(state, Ecosystem::Npm, registry, Some(raw_name), response)
 }
@@ -2342,7 +2348,8 @@ async fn serve_search(
     let Some(params) = pnpr_search::parse_params(query_string, 20) else {
         return result(Vec::new(), 0);
     };
-    let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
+    let Some(registry) =
+        registry.map(str::to_string).or_else(|| default_registry_target(state, Ecosystem::Npm))
     else {
         return result(Vec::new(), 0);
     };
@@ -2550,7 +2557,8 @@ async fn serve_org_packages(
     {
         return not_found();
     }
-    let Some(registry) = registry.map(str::to_string).or_else(|| default_registry_target(state))
+    let Some(registry) =
+        registry.map(str::to_string).or_else(|| default_registry_target(state, Ecosystem::Npm))
     else {
         return not_found();
     };
@@ -2665,7 +2673,7 @@ fn team_registry<'a>(
     }
     let target = match registry {
         Some(registry) => registry.to_string(),
-        None => match default_registry_target(state) {
+        None => match default_registry_target(state, Ecosystem::Npm) {
             Some(target) => target,
             None => return Err(RegistryError::NotFound),
         },

--- a/pnpr/crates/pnpr/src/server/cargo.rs
+++ b/pnpr/crates/pnpr/src/server/cargo.rs
@@ -105,7 +105,7 @@ async fn get_search(
     else {
         return respond(Vec::new(), 0);
     };
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let size = pnpr_search::parse_usize_param(&query_string, "per_page")
@@ -181,7 +181,7 @@ async fn get_index_config(
     State(state): State<AppState>,
     TargetRegistry(registry): TargetRegistry,
 ) -> Response {
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let config = IndexConfig::for_registry(
@@ -219,7 +219,7 @@ async fn get_index_file(
     if path != segments.join("/") {
         return not_found();
     }
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let index = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, key.as_str()) {
@@ -279,7 +279,7 @@ async fn get_download(
     if !is_safe_path_segment(version) {
         return not_found();
     }
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let response = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, key.as_str()) {

--- a/pnpr/crates/pnpr/src/server/ecosystem.rs
+++ b/pnpr/crates/pnpr/src/server/ecosystem.rs
@@ -28,8 +28,15 @@ use std::sync::Arc;
 
 /// The registry a request addressed: the `~<name>` it named, else the
 /// configured default target. `None` when the path-less form has no default.
-pub(super) fn addressed_registry(state: &AppState, registry: Option<&str>) -> Option<String> {
-    registry.map(str::to_string).or_else(|| default_registry_target(state))
+pub(super) fn addressed_registry(
+    state: &AppState,
+    registry: Option<&str>,
+    ecosystem: Ecosystem,
+) -> Option<String> {
+    match registry {
+        Some(name) => state.inner.config.registries.addressed(name, ecosystem).map(str::to_string),
+        None => default_registry_target(state, ecosystem),
+    }
 }
 
 /// The two addresses a surface answers on: the default target, and one named
@@ -77,7 +84,7 @@ pub(super) fn caller_scoped(
     if registry.is_some() {
         return private_no_cache(response);
     }
-    match (default_registry_target(state), package) {
+    match (default_registry_target(state, ecosystem), package) {
         (Some(target), Some(package))
             if resolves_to_private_source(state, &target, ecosystem, package) =>
         {

--- a/pnpr/crates/pnpr/src/server/oci.rs
+++ b/pnpr/crates/pnpr/src/server/oci.rs
@@ -103,7 +103,7 @@ async fn get_version_check(
     OriginalUri(uri): OriginalUri,
     headers: HeaderMap,
 ) -> Response {
-    if addressed_registry(&state, registry.as_deref()).is_none() {
+    if addressed_registry(&state, registry.as_deref(), Ecosystem::Oci).is_none() {
         return error(ErrorCode::NameUnknown, "no registry is addressed here");
     }
     // A client fixes its authentication scheme from this one response and
@@ -518,7 +518,9 @@ impl Request {
         if self.method != Method::GET {
             return method_not_allowed();
         }
-        let Some(target) = addressed_registry(&self.state, self.registry.as_deref()) else {
+        let Some(target) =
+            addressed_registry(&self.state, self.registry.as_deref(), Ecosystem::Oci)
+        else {
             return error(ErrorCode::NameUnknown, "no registry is addressed here");
         };
         match self.page_size() {
@@ -1024,7 +1026,7 @@ impl Request {
     fn hosted_source(&self, name: &str) -> Result<(CanonicalPackageName, String), Refusal> {
         let key = CanonicalPackageName::parse(name, ECOSYSTEM)
             .map_err(|_| Refusal::new(ErrorCode::NameInvalid, "not a valid repository name"))?;
-        let target = addressed_registry(&self.state, self.registry.as_deref())
+        let target = addressed_registry(&self.state, self.registry.as_deref(), Ecosystem::Oci)
             .ok_or_else(|| Refusal::new(ErrorCode::NameUnknown, "no registry is addressed here"))?;
         match resolve_ecosystem_source(&self.state, &target, ECOSYSTEM, key.as_str()) {
             RegistrySource::Hosted(source) => Ok((key, source)),

--- a/pnpr/crates/pnpr/src/server/oci/proxy.rs
+++ b/pnpr/crates/pnpr/src/server/oci/proxy.rs
@@ -26,7 +26,7 @@ impl Request {
         name: &str,
     ) -> Option<(CanonicalPackageName, RegistrySource)> {
         let key = CanonicalPackageName::parse(name, Ecosystem::Oci).ok()?;
-        let target = addressed_registry(&self.state, self.registry.as_deref())?;
+        let target = addressed_registry(&self.state, self.registry.as_deref(), Ecosystem::Oci)?;
         let source = resolve_ecosystem_source(&self.state, &target, Ecosystem::Oci, key.as_str());
         matches!(source, RegistrySource::Upstream(_)).then_some((key, source))
     }

--- a/pnpr/crates/pnpr/src/server/oci/tokens.rs
+++ b/pnpr/crates/pnpr/src/server/oci/tokens.rs
@@ -17,6 +17,7 @@ use p256::ecdsa::{
     signature::{Signer as _, Verifier as _},
 };
 use pnpr_error::RegistryError;
+use pnpr_registry::Ecosystem;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::{collections::BTreeMap, fmt::Write as _};
@@ -140,7 +141,8 @@ async fn issue_token(
     if !state.inner.config.oci.bearer_auth {
         return Ok(error(ErrorCode::Unsupported, "OCI Bearer authentication is disabled"));
     }
-    let target = addressed_registry(state, registry).ok_or(RegistryError::NotFound)?;
+    let target =
+        addressed_registry(state, registry, Ecosystem::Oci).ok_or(RegistryError::NotFound)?;
     let raw = headers
         .get(header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())

--- a/pnpr/crates/pnpr/src/server/publishing.rs
+++ b/pnpr/crates/pnpr/src/server/publishing.rs
@@ -67,8 +67,13 @@ pub(super) fn resolve_publish_target_for(
     package: &str,
 ) -> PublishTarget {
     let (target, context) = match registry {
-        Some(registry) => (registry.to_string(), format!("through registry {registry:?}")),
-        None => match default_registry_target(state) {
+        Some(registry) => {
+            let Some(target) = state.inner.config.registries.addressed(registry, ecosystem) else {
+                return PublishTarget::NotFound;
+            };
+            (target.to_string(), format!("through registry {registry:?}"))
+        }
+        None => match default_registry_target(state, ecosystem) {
             Some(target) => (target, "to the path-less base".to_string()),
             None => return PublishTarget::NotFound,
         },

--- a/pnpr/crates/pnpr/src/server/pypi.rs
+++ b/pnpr/crates/pnpr/src/server/pypi.rs
@@ -115,7 +115,7 @@ async fn get_project_list(
     TargetRegistry(registry): TargetRegistry,
     headers: HeaderMap,
 ) -> Response {
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let mut names = BTreeSet::new();
@@ -171,7 +171,7 @@ async fn get_project_page(
             .body(Body::empty())
             .expect("static-shape response always builds");
     }
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let document = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, project) {
@@ -255,7 +255,7 @@ async fn get_file(
     if !is_safe_path_segment(filename) {
         return not_found();
     }
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), ECOSYSTEM) else {
         return not_found();
     };
     let response = match resolve_ecosystem_source(&state, &target, ECOSYSTEM, project) {

--- a/pnpr/crates/pnpr/src/server/registry_directory.rs
+++ b/pnpr/crates/pnpr/src/server/registry_directory.rs
@@ -3,7 +3,7 @@ use axum::{
     extract::State,
     response::{IntoResponse as _, Response},
 };
-use pnpr_registry::{Ecosystem, Registry};
+use pnpr_registry::{Ecosystem, Registries, Registry};
 use serde_json::{Value, json};
 
 use super::{AppState, AuthedCaller, private_no_cache};
@@ -14,77 +14,79 @@ pub(super) async fn serve(
 ) -> Response {
     let config = &state.inner.config;
     let registries = &config.registries;
-    let visible = |name: &str| match registries.get(name) {
+    let visible = |key: &str| match registries.get(key) {
         Some(Registry::Hosted { .. }) => config
             .hosted
-            .get(name)
+            .get(key)
             .is_some_and(|hosted| hosted.rules.default_access().allows(&identity)),
-        Some(Registry::Upstream { .. }) => config.upstreams.get(name).is_some_and(|upstream| {
+        Some(Registry::Upstream { .. }) => config.upstreams.get(key).is_some_and(|upstream| {
             upstream.access.as_ref().is_none_or(|access| access.allows(&identity))
                 && upstream.rules.default_access().allows(&identity)
         }),
         _ => false,
     };
     let mut entries = Vec::new();
-    for name in registries.names() {
-        let Some(registry) = registries.get(name) else { continue };
-        let sources = match registry {
-            Registry::Router { sources } => sources.iter().map(String::as_str).collect(),
-            _ => vec![name],
-        };
-        let ecosystems: Vec<_> = Ecosystem::all()
-            .filter(|ecosystem| {
-                sources.iter().any(|source| {
-                    visible(source) && registries.ecosystem(source) == Some(*ecosystem)
-                })
-            })
-            .map(|ecosystem| ecosystem.to_string())
-            .collect();
-        if ecosystems.is_empty() {
-            continue;
+    let mut defaults = serde_json::Map::new();
+    for ecosystem in Ecosystem::all() {
+        for key in registries.names() {
+            if registries.ecosystem(key).is_some_and(|declared| declared != ecosystem) {
+                continue;
+            }
+            let sources = registries.sources(key, ecosystem);
+            if !sources.iter().any(|source| visible(source)) {
+                continue;
+            }
+            let Some(registry) = registries.get(key) else { continue };
+            let (kind, patterns, route_sources) = match registry {
+                Registry::Hosted { patterns } | Registry::Upstream { patterns } => {
+                    let (kind, rules) = match registry {
+                        Registry::Hosted { .. } => ("hosted", &config.hosted[key].rules),
+                        _ => ("upstream", &config.upstreams[key].rules),
+                    };
+                    let patterns = (!rules.refines_access()).then(|| {
+                        if patterns.is_empty() {
+                            vec!["**".to_string()]
+                        } else {
+                            patterns.iter().map(ToString::to_string).collect()
+                        }
+                    });
+                    (kind, patterns, None)
+                }
+                Registry::Router { .. } => {
+                    let disclosed = sources.iter().all(|source| visible(source)).then(|| {
+                        sources
+                            .iter()
+                            .map(|source| Registries::local_name(source))
+                            .collect::<Vec<_>>()
+                    });
+                    ("router", None, disclosed)
+                }
+            };
+            let name = Registries::local_name(key);
+            entries.push(json!({
+                "name": name, "kind": kind, "ecosystem": ecosystem.to_string(),
+                "patterns": patterns, "sources": route_sources,
+            }));
+            if registries.default_for(ecosystem) == Some(key) {
+                defaults.insert(ecosystem.to_string(), json!(name));
+            }
         }
-        let (kind, patterns, route_sources) = match registry {
-            Registry::Hosted { patterns } | Registry::Upstream { patterns } => {
-                let (kind, rules) = match registry {
-                    Registry::Hosted { .. } => ("hosted", &config.hosted[name].rules),
-                    _ => ("upstream", &config.upstreams[name].rules),
-                };
-                let patterns = (!rules.refines_access()).then(|| {
-                    if patterns.is_empty() {
-                        vec!["**".to_string()]
-                    } else {
-                        patterns.iter().map(ToString::to_string).collect()
-                    }
-                });
-                (kind, patterns, None)
-            }
-            Registry::Router { sources } => {
-                ("router", None, sources.iter().all(|source| visible(source)).then_some(sources))
-            }
-        };
-        entries.push(json!({
-            "name": name, "kind": kind, "ecosystems": ecosystems,
-            "patterns": patterns, "sources": route_sources,
-        }));
     }
-    let default_registry = registries
-        .default_registry()
-        .filter(|name| entries.iter().any(|entry| entry["name"] == *name));
     let ecosystems: serde_json::Map<String, Value> = Ecosystem::all()
         .map(|ecosystem| {
             let name = ecosystem.to_string();
-            let available = entries.iter().any(|entry| {
-                entry["ecosystems"]
-                    .as_array()
-                    .is_some_and(|ecosystems| ecosystems.iter().any(|value| value == &name))
-            });
+            let available = entries.iter().any(|entry| entry["ecosystem"] == name);
             let prefixed = ecosystem != Ecosystem::Oci && !registries.is_only_ecosystem(ecosystem);
-            (name, json!({ "available": available, "prefixed": prefixed }))
+            let mut capability = json!({ "available": available, "prefixed": prefixed });
+            if ecosystem == Ecosystem::Oci {
+                capability["namedPrefixed"] = json!(!registries.is_only_ecosystem(ecosystem));
+            }
+            (name, capability)
         })
         .collect();
     private_no_cache(
         Json(json!({
-            "registries": entries, "defaultRegistry": default_registry, "ecosystems": ecosystems,
+            "registries": entries, "defaultRegistries": defaults, "ecosystems": ecosystems,
         }))
         .into_response(),
     )

--- a/pnpr/crates/pnpr/src/server/registry_directory.rs
+++ b/pnpr/crates/pnpr/src/server/registry_directory.rs
@@ -1,0 +1,91 @@
+use axum::{
+    Json,
+    extract::State,
+    response::{IntoResponse as _, Response},
+};
+use pnpr_registry::{Ecosystem, Registry};
+use serde_json::{Value, json};
+
+use super::{AppState, AuthedCaller, private_no_cache};
+
+pub(super) async fn serve(
+    State(state): State<AppState>,
+    AuthedCaller(identity): AuthedCaller,
+) -> Response {
+    let config = &state.inner.config;
+    let registries = &config.registries;
+    let visible = |name: &str| match registries.get(name) {
+        Some(Registry::Hosted { .. }) => config
+            .hosted
+            .get(name)
+            .is_some_and(|hosted| hosted.rules.default_access().allows(&identity)),
+        Some(Registry::Upstream { .. }) => config.upstreams.get(name).is_some_and(|upstream| {
+            upstream.access.as_ref().is_none_or(|access| access.allows(&identity))
+                && upstream.rules.default_access().allows(&identity)
+        }),
+        _ => false,
+    };
+    let mut entries = Vec::new();
+    for name in registries.names() {
+        let Some(registry) = registries.get(name) else { continue };
+        let sources = match registry {
+            Registry::Router { sources } => sources.iter().map(String::as_str).collect(),
+            _ => vec![name],
+        };
+        let ecosystems: Vec<_> = Ecosystem::all()
+            .filter(|ecosystem| {
+                sources.iter().any(|source| {
+                    visible(source) && registries.ecosystem(source) == Some(*ecosystem)
+                })
+            })
+            .map(|ecosystem| ecosystem.to_string())
+            .collect();
+        if ecosystems.is_empty() {
+            continue;
+        }
+        let (kind, patterns, route_sources) = match registry {
+            Registry::Hosted { patterns } | Registry::Upstream { patterns } => {
+                let (kind, rules) = match registry {
+                    Registry::Hosted { .. } => ("hosted", &config.hosted[name].rules),
+                    _ => ("upstream", &config.upstreams[name].rules),
+                };
+                let patterns = (!rules.refines_access()).then(|| {
+                    if patterns.is_empty() {
+                        vec!["**".to_string()]
+                    } else {
+                        patterns.iter().map(ToString::to_string).collect()
+                    }
+                });
+                (kind, patterns, None)
+            }
+            Registry::Router { sources } => {
+                ("router", None, sources.iter().all(|source| visible(source)).then_some(sources))
+            }
+        };
+        entries.push(json!({
+            "name": name, "kind": kind, "ecosystems": ecosystems,
+            "patterns": patterns, "sources": route_sources,
+        }));
+    }
+    let default_registry = registries
+        .default_registry()
+        .filter(|name| entries.iter().any(|entry| entry["name"] == *name));
+    let ecosystems: serde_json::Map<String, Value> = Ecosystem::all()
+        .map(|ecosystem| {
+            let name = ecosystem.to_string();
+            let available = entries.iter().any(|entry| {
+                entry["ecosystems"]
+                    .as_array()
+                    .is_some_and(|ecosystems| ecosystems.iter().any(|value| value == &name))
+            });
+            let prefixed = ecosystem != Ecosystem::Oci && !registries.is_only_ecosystem(ecosystem);
+            (name, json!({ "available": available, "prefixed": prefixed }))
+        })
+        .collect();
+    private_no_cache(
+        Json(json!({
+            "registries": entries, "defaultRegistry": default_registry, "ecosystems": ecosystems,
+        }))
+        .into_response(),
+    )
+}

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -240,7 +240,8 @@ pub(super) fn router_with_auth_and_osv(
         router = router
             // One publish transaction for packages of any ecosystem. It
             // answers here rather than inside the npm surface.
-            .route("/-/pnpr/v0/publish", put(batch::serve_ecosystem_publish));
+            .route("/-/pnpr/v0/publish", put(batch::serve_ecosystem_publish))
+            .route("/-/pnpr/v0/registries", get(super::registry_directory::serve));
         if state.inner.config.registries.is_only_ecosystem(Ecosystem::Npm) {
             router = router.merge(npm);
         } else {

--- a/pnpr/crates/pnpr/src/server/routing.rs
+++ b/pnpr/crates/pnpr/src/server/routing.rs
@@ -576,7 +576,7 @@ async fn get_revision_tarball(
     TargetRegistry(registry): TargetRegistry,
     Path(path): Path<DigestPath>,
 ) -> Response {
-    let Some(target) = addressed_registry(&state, registry.as_deref()) else {
+    let Some(target) = addressed_registry(&state, registry.as_deref(), Ecosystem::Npm) else {
         return not_found();
     };
     serve_revision_tarball(&state, &identity, &target, &path.digest).await

--- a/pnpr/crates/pnpr/tests/cargo_registry.rs
+++ b/pnpr/crates/pnpr/tests/cargo_registry.rs
@@ -6,6 +6,9 @@
 #[path = "common/ecosystem.rs"]
 mod common;
 
+#[path = "common/registry_groups.rs"]
+mod registry_groups;
+
 use axum::{
     body::Body,
     http::{Request, StatusCode, header},
@@ -988,4 +991,47 @@ async fn a_crashed_publish_keeps_what_was_published_while_it_was_down() {
         .map(|line| serde_json::from_str::<Value>(line).unwrap()["vers"].clone())
         .collect();
     assert_eq!(versions, vec!["0.2.0", "0.1.0"]);
+}
+
+#[tokio::test]
+async fn grouped_cargo_publish_stays_out_of_same_named_npm_registry() {
+    let tmp = TempDir::new().unwrap();
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(registry_groups::grouped_config(tmp.path(), "$all"), auth);
+    let archive = crate_archive("demo", "0.1.0");
+    let request = Request::put("/cargo/~internal/api/v1/crates/new")
+        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+        .body(Body::from(publish_body(&metadata("demo", "0.1.0"), &archive)))
+        .unwrap();
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    for base in ["/cargo/~internal", "/cargo/~main", "/cargo"] {
+        let response = app
+            .clone()
+            .oneshot(Request::get(format!("{base}/index/de/mo/demo")).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{base}");
+        let entry: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        assert_eq!(entry["vers"], "0.1.0");
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(format!("{base}/api/v1/crates/demo/0.1.0/download"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK, "{base}");
+        assert_eq!(body_bytes(response.into_body()).await, archive);
+    }
+    for path in
+        ["/npm/~internal/demo", "/npm/~main/demo", "/npm/demo", "/pypi/~internal/simple/demo/"]
+    {
+        let response =
+            app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+    }
 }

--- a/pnpr/crates/pnpr/tests/common/registry_groups.rs
+++ b/pnpr/crates/pnpr/tests/common/registry_groups.rs
@@ -1,0 +1,21 @@
+use pnpr::{Config, Ecosystem};
+use std::{fmt::Write as _, fs, path::Path};
+
+pub fn grouped_config(root: &Path, npm_access: &str) -> Config {
+    let mut yaml = String::from("storage: ./storage\nregistries:\n");
+    for ecosystem in Ecosystem::all() {
+        let access = if ecosystem == Ecosystem::Npm { npm_access } else { "$all" };
+        write!(yaml,
+            "  {ecosystem}:\n    internal:\n      type: hosted\n      access: '{access}'\n    main:\n      type: router\n      sources: [internal]\n",
+        ).unwrap();
+    }
+    yaml.push_str("defaultRegistry:\n  npm: main\n  cargo: main\n  pypi: main\n  oci: main\n");
+    let path = root.join("config.yaml");
+    fs::write(&path, yaml).unwrap();
+    Config::from_yaml(
+        &path,
+        "127.0.0.1:4873".parse().unwrap(),
+        Some("http://pnpr.test".to_string()),
+    )
+    .unwrap()
+}

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -1,3 +1,6 @@
+#[path = "common/registry_groups.rs"]
+mod registry_groups;
+
 use axum::{
     body::{Body, Bytes, to_bytes},
     http::{HeaderValue, Request, StatusCode, header},
@@ -5417,16 +5420,16 @@ async fn registry_directory_filters_private_registries_and_routing_details() {
         }
         let response = app.clone().oneshot(request.body(Body::empty()).unwrap()).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        assert!(response.headers()[header::CACHE_CONTROL].to_str().unwrap().contains("no-store"));
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "private, no-store");
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let body: Value = serde_json::from_slice(&bytes).unwrap();
-        assert_eq!(body["defaultRegistry"], "main");
+        assert_eq!(body["defaultRegistries"], json!({"npm": "main", "cargo": "main"}));
         assert_eq!(body["ecosystems"]["cargo"], json!({"available": true, "prefixed": true}));
         let entries = body["registries"].as_array().unwrap();
         let main = entries.iter().find(|registry| registry["name"] == "main").unwrap();
         assert_eq!(entries.iter().any(|registry| registry["name"] == "private"), authenticated);
         if authenticated {
-            assert_eq!(main["sources"], json!(["private", "crates", "npmjs"]));
+            assert_eq!(main["sources"], json!(["private", "npmjs"]));
         } else {
             assert!(main["sources"].is_null());
             assert!(!String::from_utf8_lossy(&bytes).contains("secret"));
@@ -5464,11 +5467,104 @@ async fn registry_directory_hides_upstream_access_and_package_rule_metadata() {
         .oneshot(Request::builder().uri("/-/pnpr/v0/registries").body(Body::empty()).unwrap())
         .await
         .unwrap();
-    let body: Value =
-        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
-    assert!(body["defaultRegistry"].is_null());
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(!text.contains("secret-package"), "directory exposes a restricted package name");
+    assert!(!text.contains("alice"), "directory exposes an access rule");
+    assert_eq!(body["defaultRegistries"], json!({}));
     assert_eq!(body["registries"].as_array().unwrap().len(), 1);
     assert_eq!(body["registries"][0]["name"], "public");
     assert!(body["registries"][0]["patterns"].is_null());
     assert_eq!(body["ecosystems"]["npm"]["prefixed"], false);
+}
+
+#[tokio::test]
+async fn same_named_registries_keep_ecosystem_access_and_defaults_separate() {
+    let tmp = TempDir::new().unwrap();
+    let config = registry_groups::grouped_config(tmp.path(), "alice");
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+    for authenticated in [false, true] {
+        let mut request = Request::get("/-/pnpr/v0/registries");
+        if authenticated {
+            request = request.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        let response = app.clone().oneshot(request.body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let directory: Value =
+            serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+        for ecosystem in Ecosystem::all() {
+            let visible = ecosystem != Ecosystem::Npm || authenticated;
+            assert_eq!(
+                directory["defaultRegistries"][ecosystem.as_str()],
+                if visible { json!("main") } else { Value::Null },
+            );
+            let entries: Vec<_> = directory["registries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter(|entry| entry["ecosystem"] == ecosystem.as_str())
+                .collect();
+            assert_eq!(entries.len(), if visible { 2 } else { 0 }, "{ecosystem}");
+            if visible {
+                assert_eq!(entries[0]["name"], "internal");
+                assert_eq!(entries[1]["name"], "main");
+                assert_eq!(entries[1]["sources"], json!(["internal"]));
+            }
+        }
+    }
+    for path in [
+        "/cargo/~internal/index/config.json",
+        "/cargo/~main/index/config.json",
+        "/cargo/index/config.json",
+        "/pypi/~internal/simple/",
+        "/pypi/~main/simple/",
+        "/pypi/simple/",
+        "/oci/~internal/v2/",
+        "/oci/~main/v2/",
+        "/v2/",
+    ] {
+        let response =
+            app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(
+            response.status(),
+            if path.ends_with("/v2/") { StatusCode::UNAUTHORIZED } else { StatusCode::OK },
+            "{path}",
+        );
+    }
+    for path in [
+        "/npm/~internal/demo",
+        "/npm/~cargo%2Finternal/demo",
+        "/cargo/~npm%2Finternal/index/config.json",
+    ] {
+        let response =
+            app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND, "{path}");
+    }
+}
+
+#[tokio::test]
+async fn registry_directory_describes_oci_only_named_endpoints() {
+    let tmp = TempDir::new().unwrap();
+    let path = tmp.path().join("config.yaml");
+    fs::write(&path, "storage: ./storage\nregistries:\n  oci:\n    internal: {type: hosted}\ndefaultRegistry:\n  oci: internal\n").unwrap();
+    let config = Config::from_yaml(&path, "127.0.0.1:4873".parse().unwrap(), None).unwrap();
+    let app = router(config);
+    let response = app
+        .clone()
+        .oneshot(Request::get("/-/pnpr/v0/registries").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let directory: Value = serde_json::from_slice(&body_bytes(response.into_body()).await).unwrap();
+    assert_eq!(
+        directory["ecosystems"]["oci"],
+        json!({"available": true, "prefixed": false, "namedPrefixed": false}),
+    );
+    for path in ["/~internal/v2/", "/v2/"] {
+        let response =
+            app.clone().oneshot(Request::get(path).body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{path}");
+    }
 }

--- a/pnpr/crates/pnpr/tests/server.rs
+++ b/pnpr/crates/pnpr/tests/server.rs
@@ -5380,3 +5380,95 @@ async fn browse_paginates_hosted_packages_without_contacting_upstreams() {
     assert_eq!(body["objects"], json!([]));
     search.assert_async().await;
 }
+
+#[tokio::test]
+async fn registry_directory_filters_private_registries_and_routing_details() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://example.invalid/secret-upstream", tmp.path().to_path_buf());
+    config.hosted.insert("private".to_string(), hosted_with_access("private", "alice"));
+    config.hosted.insert("crates".to_string(), hosted_with_access("crates", "$all"));
+    config.registries = Registries::new(
+        [
+            (
+                "private".to_string(),
+                Registry::Hosted { patterns: vec![PackagePattern::Scope("secret".to_string())] },
+            ),
+            ("crates".to_string(), Registry::Hosted { patterns: vec![] }),
+            ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
+            (
+                "main".to_string(),
+                Registry::Router {
+                    sources: vec!["private".to_string(), "crates".to_string(), "npmjs".to_string()],
+                },
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        Some("main".to_string()),
+    )
+    .with_ecosystem("crates", Ecosystem::Cargo);
+    let auth = AuthState::in_memory();
+    let token = auth.tokens.issue("alice").await.unwrap();
+    let app = router_with_auth(config, auth);
+    for authenticated in [false, true] {
+        let mut request = Request::builder().uri("/-/pnpr/v0/registries");
+        if authenticated {
+            request = request.header(header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        let response = app.clone().oneshot(request.body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response.headers()[header::CACHE_CONTROL].to_str().unwrap().contains("no-store"));
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["defaultRegistry"], "main");
+        assert_eq!(body["ecosystems"]["cargo"], json!({"available": true, "prefixed": true}));
+        let entries = body["registries"].as_array().unwrap();
+        let main = entries.iter().find(|registry| registry["name"] == "main").unwrap();
+        assert_eq!(entries.iter().any(|registry| registry["name"] == "private"), authenticated);
+        if authenticated {
+            assert_eq!(main["sources"], json!(["private", "crates", "npmjs"]));
+        } else {
+            assert!(main["sources"].is_null());
+            assert!(!String::from_utf8_lossy(&bytes).contains("secret"));
+        }
+        assert!(!String::from_utf8_lossy(&bytes).contains("example.invalid"));
+    }
+}
+
+#[tokio::test]
+async fn registry_directory_hides_upstream_access_and_package_rule_metadata() {
+    let tmp = TempDir::new().unwrap();
+    let mut config = config_for("http://example.invalid", tmp.path().to_path_buf());
+    config.upstreams.get_mut("npmjs").unwrap().access = Some(AccessList::from_tokens(["alice"]));
+    let mut hosted = hosted_with_access("public", "$all");
+    hosted.rules = PackageRules::new(
+        vec![access_rule("secret-package", "alice")],
+        Some(AccessList::from_tokens(["$all"])),
+    );
+    config.hosted.insert("public".to_string(), hosted);
+    config.registries = Registries::new(
+        [
+            (
+                "public".to_string(),
+                Registry::Hosted {
+                    patterns: vec![PackagePattern::Exact("secret-package".to_string())],
+                },
+            ),
+            ("npmjs".to_string(), Registry::Upstream { patterns: vec![] }),
+        ]
+        .into_iter()
+        .collect(),
+        Some("npmjs".to_string()),
+    );
+    let response = router(config)
+        .oneshot(Request::builder().uri("/-/pnpr/v0/registries").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    let body: Value =
+        serde_json::from_slice(&to_bytes(response.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert!(body["defaultRegistry"].is_null());
+    assert_eq!(body["registries"].as_array().unwrap().len(), 1);
+    assert_eq!(body["registries"][0]["name"], "public");
+    assert!(body["registries"][0]["patterns"].is_null());
+    assert_eq!(body["ecosystems"]["npm"]["prefixed"], false);
+}

--- a/pnpr/crates/registry/src/lib.rs
+++ b/pnpr/crates/registry/src/lib.rs
@@ -309,16 +309,64 @@ pub struct Registries {
     /// The registry the path-less base URL (`https://<pnpr>/`) aliases. `None`
     /// disables the path-less base entirely — clients must address a registry.
     default_registry: Option<String>,
+    defaults: IndexMap<Ecosystem, String>,
     /// The ecosystem of every concrete registry that is not npm. A concrete
-    /// registry absent here is an npm registry; a router's ecosystem is the one
-    /// its sources share.
+    /// registry absent here is an npm registry. A flat router can span ecosystems;
+    /// a grouped router only includes sources in its own ecosystem.
     ecosystems: IndexMap<String, Ecosystem>,
 }
 
 impl Registries {
     #[must_use]
     pub fn new(registries: IndexMap<String, Registry>, default_registry: Option<String>) -> Self {
-        Self { entries: registries, default_registry, ecosystems: IndexMap::new() }
+        let ecosystems = registries
+            .iter()
+            .filter(|(_, registry)| registry.is_concrete())
+            .filter_map(|(key, _)| {
+                let (prefix, _) = key.split_once('/')?;
+                Ecosystem::all()
+                    .find(|ecosystem| ecosystem.as_str() == prefix)
+                    .map(|ecosystem| (key.clone(), ecosystem))
+            })
+            .collect();
+        Self { entries: registries, default_registry, defaults: IndexMap::new(), ecosystems }
+    }
+
+    /// Set ecosystem-specific defaults. Each target is an internal registry key.
+    #[must_use]
+    pub fn with_defaults(mut self, defaults: IndexMap<Ecosystem, String>) -> Self {
+        self.defaults = defaults;
+        self
+    }
+
+    /// Resolve an ecosystem-local name to its serving-table key. Qualified keys
+    /// are also accepted internally; HTTP callers must pass a single segment.
+    #[must_use]
+    pub fn addressed(&self, name: &str, ecosystem: Ecosystem) -> Option<&str> {
+        let qualified = format!("{ecosystem}/{name}");
+        self.entries
+            .get_key_value(&qualified)
+            .or_else(|| {
+                self.entries.get_key_value(name).filter(|(key, kind)| match key.split_once('/') {
+                    Some((prefix, _)) => prefix == ecosystem.as_str(),
+                    None => !kind.is_concrete() || self.concrete_ecosystem(key) == ecosystem,
+                })
+            })
+            .map(|(key, _)| key.as_str())
+    }
+
+    /// The name used in an ecosystem's `~name` URL, without its internal prefix.
+    #[must_use]
+    pub fn local_name(key: &str) -> &str {
+        key.split_once('/').map_or(key, |(_, name)| name)
+    }
+
+    /// The default serving-table key for one ecosystem.
+    #[must_use]
+    pub fn default_for(&self, ecosystem: Ecosystem) -> Option<&str> {
+        self.defaults.get(&ecosystem).map(String::as_str).or_else(|| {
+            self.default_registry.as_deref().and_then(|name| self.addressed(name, ecosystem))
+        })
     }
 
     /// Declare the ecosystem a concrete registry serves. Every registry is npm
@@ -375,7 +423,7 @@ impl Registries {
     /// serves that ecosystem, a router's matching sources, nothing otherwise.
     #[must_use]
     pub fn sources(&self, registry: &str, ecosystem: Ecosystem) -> Vec<&str> {
-        match self.entries.get_key_value(registry) {
+        match self.addressed(registry, ecosystem).and_then(|key| self.entries.get_key_value(key)) {
             Some((id, Registry::Hosted { .. } | Registry::Upstream { .. })) => {
                 if self.concrete_ecosystem(id) == ecosystem { vec![id] } else { Vec::new() }
             }
@@ -406,7 +454,7 @@ impl Registries {
         self.default_registry.as_deref()
     }
 
-    /// The declared registry names, in declaration order.
+    /// The internal serving-table keys, in declaration order. Grouped keys are `ecosystem/name`.
     pub fn names(&self) -> impl Iterator<Item = &str> {
         self.entries.keys().map(String::as_str)
     }
@@ -425,6 +473,12 @@ impl Registries {
     pub fn ensure_upstream(&mut self, name: &str) {
         if !self.entries.contains_key(name) {
             self.entries.insert(name.to_string(), Registry::Upstream { patterns: Vec::new() });
+            if let Some((prefix, _)) = name.split_once('/')
+                && let Some(ecosystem) =
+                    Ecosystem::all().find(|ecosystem| ecosystem.as_str() == prefix)
+            {
+                self.ecosystems.insert(name.to_string(), ecosystem);
+            }
         }
     }
 
@@ -445,7 +499,9 @@ impl Registries {
         ecosystem: Ecosystem,
         package: &str,
     ) -> Resolved<'a> {
-        let Some((registry_id, kind)) = self.entries.get_key_value(registry) else {
+        let Some((registry_id, kind)) =
+            self.addressed(registry, ecosystem).and_then(|key| self.entries.get_key_value(key))
+        else {
             return Resolved::UnknownRegistry;
         };
         let claim = |id: &'a str, kind: &Registry| -> Option<Resolved<'a>> {
@@ -478,7 +534,7 @@ impl Registries {
     /// is [`Resolved::UnknownRegistry`].
     #[must_use]
     pub fn resolve_default<'a>(&'a self, ecosystem: Ecosystem, package: &str) -> Resolved<'a> {
-        match self.default_registry.as_deref() {
+        match self.default_for(ecosystem) {
             Some(target) => self.resolve(target, ecosystem, package),
             None => Resolved::UnknownRegistry,
         }
@@ -493,6 +549,13 @@ impl Registries {
         {
             return Err(RegistryConfigError::UndefinedDefaultRegistry { target: target.clone() });
         }
+        for (ecosystem, target) in &self.defaults {
+            if self.addressed(target, *ecosystem).is_none() {
+                return Err(RegistryConfigError::UndefinedDefaultRegistry {
+                    target: target.clone(),
+                });
+            }
+        }
         for (name, ecosystem) in &self.ecosystems {
             match self.entries.get(name) {
                 Some(kind) if kind.is_concrete() => {}
@@ -505,6 +568,28 @@ impl Registries {
             }
         }
         for (name, kind) in &self.entries {
+            if let Some((prefix, local)) = name.split_once('/') {
+                let ecosystem = Ecosystem::all().find(|ecosystem| ecosystem.as_str() == prefix);
+                let valid = ecosystem.is_some_and(|ecosystem| {
+                    let duplicate = self.entries.get(local).is_some_and(|other| {
+                        !other.is_concrete() || self.concrete_ecosystem(local) == ecosystem
+                    });
+                    let matches = match kind {
+                        Registry::Hosted { .. } | Registry::Upstream { .. } => {
+                            self.concrete_ecosystem(name) == ecosystem
+                        }
+                        Registry::Router { sources } => sources
+                            .iter()
+                            .all(|source| self.concrete_ecosystem(source) == ecosystem),
+                    };
+                    !duplicate && matches
+                });
+                if !valid {
+                    return Err(RegistryConfigError::InvalidRegistryIdentity {
+                        registry: name.clone(),
+                    });
+                }
+            }
             match kind {
                 Registry::Hosted { patterns } | Registry::Upstream { patterns } => {
                     validate_namespace(name, patterns)?;
@@ -637,6 +722,8 @@ fn validate_namespace(
 /// `InvalidConfig` so a bad registry set fails server startup and config reload.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RegistryConfigError {
+    /// A qualified identity conflicts with another entry or its ecosystem.
+    InvalidRegistryIdentity { registry: String },
     /// An unsupported wildcard in a registry pattern. Carries the ecosystem
     /// so the message can name the shapes that ecosystem admits, rather than
     /// sending an operator to one it always refuses.
@@ -694,6 +781,10 @@ fn invalid_pattern(pattern: &str, ecosystem: Ecosystem) -> RegistryConfigError {
 impl fmt::Display for RegistryConfigError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            RegistryConfigError::InvalidRegistryIdentity { registry } => write!(
+                f,
+                "registry identity {registry:?} duplicates a registry or conflicts with its ecosystem or sources",
+            ),
             RegistryConfigError::InvalidPattern { pattern, ecosystem } => write!(
                 f,
                 "unsupported {ecosystem} registry pattern {pattern:?}: use an exact name, {}, or \

--- a/pnpr/crates/registry/src/lib.rs
+++ b/pnpr/crates/registry/src/lib.rs
@@ -555,6 +555,12 @@ impl Registries {
                     target: target.clone(),
                 });
             }
+            if self.sources(target, *ecosystem).is_empty() {
+                return Err(RegistryConfigError::DefaultRegistryWithoutEcosystem {
+                    target: target.clone(),
+                    ecosystem: *ecosystem,
+                });
+            }
         }
         for (name, ecosystem) in &self.ecosystems {
             match self.entries.get(name) {
@@ -739,6 +745,8 @@ pub enum RegistryConfigError {
     NamespacePatternNotANamespace { pattern: String },
     /// `defaultRegistry` names a registry that does not exist.
     UndefinedDefaultRegistry { target: String },
+    /// An ecosystem-specific default has no concrete source serving its protocol.
+    DefaultRegistryWithoutEcosystem { target: String, ecosystem: Ecosystem },
     /// A router has no sources at all, so it can never serve any package.
     EmptyRouter { router: String },
     /// A router lists itself as a source.
@@ -809,6 +817,10 @@ impl fmt::Display for RegistryConfigError {
             RegistryConfigError::UndefinedDefaultRegistry { target } => {
                 write!(f, "defaultRegistry {target:?} is not a defined registry")
             }
+            RegistryConfigError::DefaultRegistryWithoutEcosystem { target, ecosystem } => write!(
+                f,
+                "defaultRegistry for {ecosystem} targets {target:?}, which has no source serving {ecosystem}",
+            ),
             RegistryConfigError::EmptyRouter { router } => write!(
                 f,
                 "router {router:?} has no sources, so it can never serve any package; add \

--- a/pnpr/crates/registry/src/tests.rs
+++ b/pnpr/crates/registry/src/tests.rs
@@ -585,8 +585,7 @@ fn a_router_serves_every_ecosystem_its_sources_speak() {
         Resolved::Concrete { registry: "python", kind: ConcreteKind::Hosted },
     );
     assert_eq!(set.resolve("main", Ecosystem::Pypi, "requests"), Resolved::Unclaimed);
-    // A concrete registry addressed with another ecosystem's protocol claims nothing.
-    assert_eq!(set.resolve("crates", Ecosystem::Npm, "demo"), Resolved::Unclaimed);
+    assert_eq!(set.resolve("crates", Ecosystem::Npm, "demo"), Resolved::UnknownRegistry);
     assert_eq!(set.sources("main", Ecosystem::Pypi), vec!["python"]);
 }
 

--- a/pnpr/crates/route/src/lib.rs
+++ b/pnpr/crates/route/src/lib.rs
@@ -300,6 +300,10 @@ impl RouteContext {
     #[must_use]
     pub fn from_config(config: &Config) -> Self {
         let hosted_origin = nerf_prefix(&config.public_url);
+        let mut registries = config.registries.clone();
+        for name in config.upstreams.keys() {
+            registries.ensure_upstream(name);
+        }
         // The registries pnpm itself routes to without configuration are
         // built-in public routes, so they are both allowlisted and classified
         // public without any operator config (and ahead of any upstream
@@ -333,7 +337,7 @@ impl RouteContext {
             public_routes,
             aliases,
             upstream_origins,
-            registries: config.registries.clone(),
+            registries,
             hosted_rules,
             upstream_rules,
         }
@@ -415,6 +419,9 @@ impl RouteContext {
                     rest.strip_prefix('~').and_then(|rest| rest.split('/').next())
                 && !registry.is_empty()
             {
+                let Some(registry) = self.registries.addressed(registry, Ecosystem::Npm) else {
+                    return RouteClass::Public;
+                };
                 if let Some(alias) = self
                     .aliases
                     .iter()

--- a/pnpr/crates/route/src/tests.rs
+++ b/pnpr/crates/route/src/tests.rs
@@ -757,3 +757,27 @@ fn descriptor_digest_id_depends_on_secret() {
     };
     assert_ne!(descriptor.digest_id(b"secret-a"), qualified.digest_id(b"secret-a"));
 }
+
+#[test]
+fn self_upstream_endpoint_uses_ecosystem_scoped_credentials() {
+    let mut config = base_config();
+    config.upstreams.insert(
+        "npm/internal".to_string(),
+        upstream_with_access("https://npm.corp.example/", "alice"),
+    );
+    config.upstreams.insert(
+        "cargo/internal".to_string(),
+        upstream_with_access("https://cargo.corp.example/", "bob"),
+    );
+    let context = RouteContext::from_config(&config);
+    let url = format!("{}/npm/~internal/demo", config.public_url);
+    assert_eq!(
+        context.classify(&user("alice"), &url, Some("demo")),
+        RouteClass::Proxied {
+            alias: "npm/internal".to_string(),
+            credential_digest: corp_credential()
+        },
+    );
+    assert_eq!(context.classify(&user("bob"), &url, Some("demo")), RouteClass::Public);
+    assert_eq!(context.classify(&anon(), &url, Some("demo")), RouteClass::Public);
+}


### PR DESCRIPTION
## Summary

Allow npm, Cargo, PyPI, and OCI registries to reuse the same name. Configuration can group entries under `registries.npm`, `registries.cargo`, `registries.pypi`, and `registries.oci`; `/npm/~internal` and `/cargo/~internal` then address independent registries. Router sources and defaults resolve within the ecosystem. Existing flat configurations remain supported. Ecosystem defaults reject routers with no source serving that ecosystem.

Grouped hosted registries get separate storage namespaces by default. An explicit `org` preserves an existing namespace during migration. Serving, publishing, discovery, default routing, and resolver credential classification use the ecosystem-qualified identity.

Add `GET /-/pnpr/v0/registries` for the web UI. It returns caller-visible registry identities, kinds, namespace patterns, router source order, ecosystem defaults, and mount information. Private registries and restricted routing details are withheld; upstream URLs, credentials, storage paths, and package ACLs are excluded. Responses are private and not cacheable.

Companion UI: https://bit.cloud/pnpm/pnpr/~change-requests/named-registries-and-routing

Validation: `just ready` (10,859 Rust tests, workspace checks, formatting, and Clippy), Dylint, 199 UI tests, and browser integration for same-named registries across all four ecosystems, including detail pages, reloads, and mobile layout.

## Squash Commit Body

```text
Scope registry addressing by ecosystem and local name. Accept ecosystem
configuration groups, qualify their serving-table keys and router sources,
and support ecosystem-specific defaults while preserving flat configurations.
Give grouped hosted registries isolated default storage namespaces; retain
explicit org overrides for existing storage.

Use ecosystem-aware addressing for reads, writes, discovery, and defaults.
Keep upstream credential classification tied to the qualified identity and
reject encoded path separators in named HTTP endpoints.

Expose a caller-filtered registry directory with one entry per ecosystem and
name, ecosystem defaults, mount information, namespace patterns, and source
order. Withhold inaccessible registries and restricted routing metadata,
exclude secrets and upstream addresses, and disable response caching.

Test configuration ambiguity, source/default isolation, same-named registry
visibility, grouped Cargo publication and downloads, absence of cross-protocol
package reads, and resolver credential isolation. Document configuration,
migration, and directory semantics and include a pnpr minor changeset.
```

## Checklist

- [x] Added a changeset for the published pnpr package.
- [x] Added or updated tests.
- [x] Updated the documentation.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ecosystem-scoped registries for npm, Cargo, PyPI, and OCI, including separate defaults and same-name support across ecosystems.
  * Added a registry directory endpoint showing available registries, ecosystem endpoints, routing order, and per-ecosystem defaults.
  * Added grouped configuration while preserving compatibility with existing flat configuration.
* **Bug Fixes**
  * Improved registry routing, publishing, and upstream resolution to prevent cross-ecosystem mismatches.
  * Restricted registry directory results to visible sources and strengthened access-data protection.
  * Added validation for unsafe or inconsistent registry names and configurations.
* **Documentation**
  * Expanded registry configuration and endpoint documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
