### PR TITLE
fix(tarball): install a tarball entry that sits at the archive root

### DIFF
--- a/.changeset/install-tarball-root-level-entry.md
+++ b/.changeset/install-tarball-root-level-entry.md
@@ -3,3 +3,5 @@
 ---
 
 `pnpm install` no longer fails on a package tarball that carries a file at the archive root, such as the `._*` entries macOS `tar` adds. The file is installed at the root of the package, the same place pnpm 11 puts it [#14701](https://github.com/pnpm/pnpm/issues/14701).
+
+A `file:` tarball packed without the usual `package/` directory is now recorded under the name and version in its own `package.json`, not under the alias the dependency was given.

--- a/.changeset/install-tarball-root-level-entry.md
+++ b/.changeset/install-tarball-root-level-entry.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` no longer fails on a package tarball that carries a file at the archive root, such as the `._*` entries macOS `tar` adds. The file is installed at the root of the package, the same place pnpm 11 puts it [#14701](https://github.com/pnpm/pnpm/issues/14701).

--- a/.changeset/install-tarball-root-level-entry.md
+++ b/.changeset/install-tarball-root-level-entry.md
@@ -2,6 +2,6 @@
 "pacquet": patch
 ---
 
-`pnpm install` no longer fails on a package tarball that carries a file at the archive root, such as the `._*` entries macOS `tar` adds. The file is installed at the root of the package, the same place pnpm 11 puts it [#14701](https://github.com/pnpm/pnpm/issues/14701).
+`pnpm install` no longer fails on a package tarball that carries a file at the archive root, such as the `._*` entries macOS `tar` adds. The file is installed at the root of the package [#14701](https://github.com/pnpm/pnpm/issues/14701).
 
-A `file:` tarball packed without the usual `package/` directory is now recorded under the name and version in its own `package.json`, not under the alias the dependency was given.
+A `file:` tarball packed without the usual `package/` directory is now recorded under the name and version from its own `package.json`. It was recorded under the alias the dependency was given, at version 0.0.0.

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,12 +1,10 @@
 use super::{
-    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
-    vendor_source, vendored_package,
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
-    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -392,7 +390,8 @@ fn a_crate_is_found_past_a_manifest_that_shares_its_name_and_reads_no_version() 
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn a_file_whose_name_is_not_utf8_is_refused() {
-    use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+    use super::{CheckoutPackage, import_package};
+    use std::{collections::BTreeSet, ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
     let temp_dir = tempfile::tempdir().unwrap();
     let package_dir = temp_dir.path().join("crate");

--- a/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
+++ b/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
@@ -128,11 +128,11 @@ fn local_tarball_without_a_bundled_manifest_installs_under_its_alias() {
     drop((root, mock_instance));
 }
 
-/// An entry at the archive root has no top-level directory to strip, and
-/// rejecting it used to fail the whole install with
-/// `ERR_PNPM_TARBALL_IO_ERROR` after exhausting the network retries.
-/// pnpm 11 installs the same archive, so pnpm 12 does too, keying the
-/// entry by its own name.
+/// An entry at the archive root has no top-level directory to strip, so
+/// it is keyed by its own name. pnpm 11 installs such an archive, and
+/// rejecting it here instead fails the whole install with
+/// `ERR_PNPM_TARBALL_IO_ERROR`, only after exhausting the network
+/// retries.
 ///
 /// Covers <https://github.com/pnpm/pnpm/issues/14701>.
 #[test]

--- a/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
+++ b/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
@@ -12,7 +12,7 @@ use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{
     bin::{AddMockedRegistry, CommandTempCwd},
-    fixtures::{tarball_with_manifest, tarball_without_manifest},
+    fixtures::{tarball_entries, tarball_with_manifest, tarball_without_manifest},
 };
 use std::{fs, path::Path, process::Command};
 
@@ -128,32 +128,6 @@ fn local_tarball_without_a_bundled_manifest_installs_under_its_alias() {
     drop((root, mock_instance));
 }
 
-/// Returns a gzipped tarball whose payload lives under `package/` while
-/// a zero-length `._package` sits beside it at the archive root. macOS
-/// `bsdtar` emits that `AppleDouble` entry when the source cannot store
-/// xattrs natively, so packing with `tar` rather than `npm pack`
-/// produces this shape.
-fn tarball_with_a_root_level_entry(manifest: &serde_json::Value) -> Vec<u8> {
-    use std::io::Write;
-
-    let mut builder = tar::Builder::new(Vec::new());
-    for (path, contents) in
-        [("._package", b"".as_slice()), ("package/package.json", manifest.to_string().as_bytes())]
-    {
-        let mut header = tar::Header::new_gnu();
-        header.set_path(path).expect("set tar entry path");
-        header.set_size(contents.len() as u64);
-        header.set_mode(0o644);
-        header.set_cksum();
-        builder.append(&header, contents).expect("append entry to tar");
-    }
-    let tar_bytes = builder.into_inner().expect("finish tar");
-
-    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
-    encoder.write_all(&tar_bytes).expect("gzip tar");
-    encoder.finish().expect("finish gzip")
-}
-
 /// An entry at the archive root has no top-level directory to strip, and
 /// rejecting it used to fail the whole install with
 /// `ERR_PNPM_TARBALL_IO_ERROR` after exhausting the network retries.
@@ -167,11 +141,13 @@ fn local_tarball_with_a_root_level_entry_installs() {
         CommandTempCwd::init().add_mocked_registry();
     let AddMockedRegistry { mock_instance, .. } = npmrc_info;
 
+    // macOS `bsdtar` emits the zero-length `AppleDouble` `._package` when
+    // the source cannot store xattrs natively, so packing with `tar`
+    // rather than `npm pack` produces this shape.
+    let manifest = serde_json::json!({ "name": "pkg-root-entry", "version": "1.0.0" }).to_string();
     fs::write(
         workspace.join("pkg-root-entry-1.0.0.tgz"),
-        tarball_with_a_root_level_entry(
-            &serde_json::json!({ "name": "pkg-root-entry", "version": "1.0.0" }),
-        ),
+        tarball_entries(&[("._package", b""), ("package/package.json", manifest.as_bytes())]),
     )
     .expect("write tarball");
     fs::write(
@@ -198,6 +174,67 @@ fn local_tarball_with_a_root_level_entry_installs() {
         installed.join("._package").exists(),
         "the root-level entry must be extracted under its own name, as pnpm 11 does",
     );
+
+    drop((root, mock_instance));
+}
+
+/// An archive with no wrapping directory at all keys its `package.json`
+/// at the package root, so the resolve-time read finds the name and
+/// version there and the dependency is recorded under them rather than
+/// under the alias the consumer happened to give it. pnpm 11 records
+/// `real-name@file:...` at `9.9.9` for this archive, and a lockfile the
+/// two CLIs disagree about fails a `--frozen-lockfile` install.
+#[test]
+fn flat_local_tarball_is_recorded_under_its_bundled_name() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("flat-1.0.0.tgz"),
+        tarball_entries(&[
+            ("package.json", br#"{"name":"real-name","version":"9.9.9"}"#),
+            ("index.js", b"module.exports = 1\n"),
+            ("lib/helper.js", b"module.exports = 2\n"),
+        ]),
+    )
+    .expect("write tarball");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "dependencies": { "myalias": "file:./flat-1.0.0.tgz" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let lockfile =
+        fs::read_to_string(workspace.join("pnpm-lock.yaml")).expect("read pnpm-lock.yaml");
+    assert!(
+        lockfile.contains("real-name@file:flat-1.0.0.tgz:"),
+        "the bundled name must key the tarball, not the alias `myalias`:\n{lockfile}",
+    );
+    assert!(
+        lockfile.contains("version: 9.9.9"),
+        "the version read from the manifest at the archive root must be recorded:\n{lockfile}",
+    );
+
+    let installed =
+        workspace.join("node_modules/.pnpm/real-name@file+flat-1.0.0.tgz/node_modules/real-name");
+    assert!(
+        installed.join("index.js").exists(),
+        "the package must be materialized under its bundled name",
+    );
+    // A nested entry still loses its first component, so `lib/helper.js`
+    // lands at the package root and `lib/` is gone. pnpm 11 flattens the
+    // same way, its `parseString` trimming through the first separator
+    // whatever that separator separates.
+    assert!(installed.join("helper.js").exists(), "a nested entry is flattened, as on pnpm 11");
+    assert!(!installed.join("lib").exists());
 
     drop((root, mock_instance));
 }

--- a/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
+++ b/pnpm/crates/cli/tests/suite/local_tarball_dependency.rs
@@ -128,6 +128,80 @@ fn local_tarball_without_a_bundled_manifest_installs_under_its_alias() {
     drop((root, mock_instance));
 }
 
+/// Returns a gzipped tarball whose payload lives under `package/` while
+/// a zero-length `._package` sits beside it at the archive root. macOS
+/// `bsdtar` emits that `AppleDouble` entry when the source cannot store
+/// xattrs natively, so packing with `tar` rather than `npm pack`
+/// produces this shape.
+fn tarball_with_a_root_level_entry(manifest: &serde_json::Value) -> Vec<u8> {
+    use std::io::Write;
+
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, contents) in
+        [("._package", b"".as_slice()), ("package/package.json", manifest.to_string().as_bytes())]
+    {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(path).expect("set tar entry path");
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, contents).expect("append entry to tar");
+    }
+    let tar_bytes = builder.into_inner().expect("finish tar");
+
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(&tar_bytes).expect("gzip tar");
+    encoder.finish().expect("finish gzip")
+}
+
+/// An entry at the archive root has no top-level directory to strip, and
+/// rejecting it used to fail the whole install with
+/// `ERR_PNPM_TARBALL_IO_ERROR` after exhausting the network retries.
+/// pnpm 11 installs the same archive, so pnpm 12 does too, keying the
+/// entry by its own name.
+///
+/// Covers <https://github.com/pnpm/pnpm/issues/14701>.
+#[test]
+fn local_tarball_with_a_root_level_entry_installs() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    fs::write(
+        workspace.join("pkg-root-entry-1.0.0.tgz"),
+        tarball_with_a_root_level_entry(
+            &serde_json::json!({ "name": "pkg-root-entry", "version": "1.0.0" }),
+        ),
+    )
+    .expect("write tarball");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "name": "root",
+            "version": "1.0.0",
+            "dependencies": { "pkg-root-entry": "file:./pkg-root-entry-1.0.0.tgz" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    pacquet.with_arg("install").assert().success();
+
+    let installed = workspace.join(
+        "node_modules/.pnpm/pkg-root-entry@file+pkg-root-entry-1.0.0.tgz/node_modules/pkg-root-entry",
+    );
+    assert!(
+        installed.join("package.json").exists(),
+        "the manifest under `package/` must still be extracted to the package root",
+    );
+    assert!(
+        installed.join("._package").exists(),
+        "the root-level entry must be extracted under its own name, as pnpm 11 does",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// A local tarball's own dependencies are readable only from the
 /// manifest bundled in the archive, so they exercise the resolve-time
 /// read from a second angle: the dep path alone would not reveal them.

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -700,7 +700,7 @@ fn capture_bundled_manifest(entry_data: &[u8]) -> (bool, Option<serde_json::Valu
 /// path layer and the `index.db` both implementations share. Callers
 /// pass the `to_string_lossy` rendering, which coerces non-UTF-8 bytes
 /// to U+FFFD per component.
-fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
+pub(crate) fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
     let Some(mut parts) = archive_entry_segments(raw) else {
         return Err(TarballError::ReadTarballEntries(std::io::Error::new(
             std::io::ErrorKind::InvalidData,

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -685,6 +685,16 @@ fn capture_bundled_manifest(entry_data: &[u8]) -> (bool, Option<serde_json::Valu
 /// Rejected rather than normalized so a tampered tarball is visible
 /// instead of silently landing outside the store.
 ///
+/// An entry that is only one segment long keeps that segment. Such an
+/// entry sits at the archive root beside `package/`, so there is no
+/// top-level directory on it to drop, and pnpm keys it by its own name
+/// (`parseString` in `parseTarball.ts` advances past the first
+/// separator, which a single segment has none of). Dropping the segment
+/// instead would leave nothing to key the file by, and rejecting the
+/// entry would fail an archive that every other installer accepts. A
+/// lone `.` is the exception: it names the archive root rather than
+/// anything inside it, so there is no file for a key to address.
+///
 /// Joined by hand rather than with `PathBuf`, whose native separator
 /// would desynchronize these keys from pnpm's always-forward-slashed
 /// path layer and the `index.db` both implementations share. Callers
@@ -699,13 +709,15 @@ fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError> {
             ),
         )));
     };
-    parts.remove(0);
-    if parts.is_empty() {
+    if parts.len() > 1 {
+        parts.remove(0);
+    }
+    if let [only] = parts.as_slice()
+        && only == "."
+    {
         return Err(TarballError::ReadTarballEntries(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
-            format!(
-                "tar entry path has no payload after dropping the top-level component: {raw:?}",
-            ),
+            format!("tar entry path names the archive root itself, not a file in it: {raw:?}"),
         )));
     }
     Ok(parts.join("/"))

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -1034,19 +1034,18 @@ pub(crate) fn tar_entry_payload<'a, Reader: std::io::Read>(
 /// component removed by `strip: 1`. Other `.` components are ignored.
 ///
 /// `None` for an absolute path or one climbing past the root.
-pub(crate) fn archive_entry_segments(raw: &str) -> Option<Vec<String>> {
-    let normalized = raw.replace('\\', "/");
-    if normalized.starts_with('/') {
+pub(crate) fn archive_entry_segments(raw: &str) -> Option<Vec<&str>> {
+    if raw.starts_with(['/', '\\']) {
         return None;
     }
     let mut segments = Vec::new();
-    for (index, segment) in normalized.split('/').enumerate() {
+    for (index, segment) in raw.split(['/', '\\']).enumerate() {
         match segment {
             "" => {}
-            "." if index == 0 => segments.push(segment.to_string()),
+            "." if index == 0 => segments.push(segment),
             "." => {}
             ".." => return None,
-            other => segments.push(other.to_string()),
+            other => segments.push(other),
         }
     }
     (!segments.is_empty()).then_some(segments)

--- a/pnpm/crates/tarball/src/extract.rs
+++ b/pnpm/crates/tarball/src/extract.rs
@@ -686,7 +686,8 @@ fn capture_bundled_manifest(entry_data: &[u8]) -> (bool, Option<serde_json::Valu
 /// instead of silently landing outside the store.
 ///
 /// An entry that is only one segment long keeps that segment. Such an
-/// entry sits at the archive root beside `package/`, so there is no
+/// entry sits at the archive root — beside `package/`, or in a flat
+/// archive with no wrapping directory at all — so there is no
 /// top-level directory on it to drop, and pnpm keys it by its own name
 /// (`parseString` in `parseTarball.ts` advances past the first
 /// separator, which a single segment has none of). Dropping the segment
@@ -709,16 +710,14 @@ pub(crate) fn clean_archive_entry_path(raw: &str) -> Result<String, TarballError
             ),
         )));
     };
-    if parts.len() > 1 {
-        parts.remove(0);
-    }
-    if let [only] = parts.as_slice()
-        && only == "."
-    {
+    if parts.as_slice() == ["."] {
         return Err(TarballError::ReadTarballEntries(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("tar entry path names the archive root itself, not a file in it: {raw:?}"),
         )));
+    }
+    if parts.len() > 1 {
+        parts.remove(0);
     }
     Ok(parts.join("/"))
 }

--- a/pnpm/crates/tarball/src/lib.rs
+++ b/pnpm/crates/tarball/src/lib.rs
@@ -3,9 +3,10 @@ pub use error::*;
 pub(crate) use extract::{
     GZIP_MAGIC, STREAM_ENTRY_BUFFER_MAX, STREAM_EXTRACT_COMPRESSED_THRESHOLD,
     STREAM_EXTRACT_DURING_DOWNLOAD_THRESHOLD, allocate_tarball_buffer, apply_append_manifest,
-    apply_placeholder_manifest, body_chunk_channel, decompress_gzip, extract_gzipped_tarball,
-    is_eager_decode_limit_exceeded, non_gzip_body_error, normalize_bundled_manifest,
-    oversized_manifest_error, stream_extract_gzipped_channel, tar_entry_payload,
+    apply_placeholder_manifest, body_chunk_channel, clean_archive_entry_path, decompress_gzip,
+    extract_gzipped_tarball, is_eager_decode_limit_exceeded, non_gzip_body_error,
+    normalize_bundled_manifest, oversized_manifest_error, stream_extract_gzipped_channel,
+    tar_entry_payload,
 };
 pub use local_tarball::*;
 pub use pnpm_network::RetryOpts;

--- a/pnpm/crates/tarball/src/local_tarball.rs
+++ b/pnpm/crates/tarball/src/local_tarball.rs
@@ -4,10 +4,10 @@
 //! local archive without going through the store.
 
 use super::{
-    Component, Cursor, HashMap, MAX_UNTRUSTED_PREALLOC_BYTES, Path, PathBuf, Read, TarballError,
-    allocate_tarball_buffer, decompress_gzip, io, is_eager_decode_limit_exceeded,
-    normalize_bundled_manifest, oversized_manifest_error, post_download_semaphore,
-    tar_entry_payload, verify_tarball_integrity,
+    Cursor, HashMap, MAX_UNTRUSTED_PREALLOC_BYTES, Path, PathBuf, Read, TarballError,
+    allocate_tarball_buffer, clean_archive_entry_path, decompress_gzip, io,
+    is_eager_decode_limit_exceeded, normalize_bundled_manifest, oversized_manifest_error,
+    post_download_semaphore, tar_entry_payload, verify_tarball_integrity,
 };
 use crate::extraction_task::spawn_extraction;
 use pnpm_package_manifest::parse_manifest_bytes;
@@ -307,13 +307,18 @@ fn read_bundled_manifest_streaming(
     finish_bundled_manifest(&payload, tarball_path)
 }
 
-/// Whether an archive entry is the package's own `package.json` — the
-/// one directly inside the top-level directory every published tarball
-/// wraps its payload in, not a `package.json` shipped in a subdirectory.
+/// Whether an archive entry is the package's own `package.json`: the one
+/// that lands at the package root once the entry path is cleaned, not a
+/// `package.json` shipped in a subdirectory.
+///
+/// Answered by [`clean_archive_entry_path`] rather than by a rule of its
+/// own, so this resolve-time read and the extraction that follows it
+/// cannot disagree about which entry is the manifest. They did once, and
+/// a `file:` archive whose manifest sits at the archive root installed
+/// under the consumer's alias at version `0.0.0` while its extracted
+/// `package.json` said otherwise.
 fn is_root_manifest_entry_path(path: &Path) -> bool {
-    let mut components = path.components().skip(1);
-    components.next() == Some(Component::Normal("package.json".as_ref()))
-        && components.next().is_none()
+    clean_archive_entry_path(&path.to_string_lossy()).is_ok_and(|cleaned| cleaned == "package.json")
 }
 
 fn finish_bundled_manifest(

--- a/pnpm/crates/tarball/src/local_tarball.rs
+++ b/pnpm/crates/tarball/src/local_tarball.rs
@@ -312,11 +312,11 @@ fn read_bundled_manifest_streaming(
 /// `package.json` shipped in a subdirectory.
 ///
 /// Answered by [`clean_archive_entry_path`] rather than by a rule of its
-/// own, so this resolve-time read and the extraction that follows it
-/// cannot disagree about which entry is the manifest. They did once, and
-/// a `file:` archive whose manifest sits at the archive root installed
-/// under the consumer's alias at version `0.0.0` while its extracted
-/// `package.json` said otherwise.
+/// own, because this resolve-time read and the extraction that follows it
+/// must name the same entry. A `file:` archive whose manifest they
+/// disagree about is recorded under the alias its consumer gave it at
+/// version `0.0.0`, while the `package.json` extracted beside it names
+/// something else.
 fn is_root_manifest_entry_path(path: &Path) -> bool {
     clean_archive_entry_path(&path.to_string_lossy()).is_ok_and(|cleaned| cleaned == "package.json")
 }

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5925,8 +5925,9 @@ fn tar_with_root_level_entries() -> Vec<u8> {
 
 /// An entry at the archive root has no top-level directory on it to
 /// strip, so it is keyed by its own name — what pnpm does, and what
-/// keeps the shared `index.db` describing one file layout. Rejecting it
-/// failed the whole install for an archive npm and pnpm both accept.
+/// keeps the shared `index.db` describing one file layout. Rejecting
+/// such an entry fails the whole archive, which npm and pnpm both
+/// install.
 #[test]
 fn extract_keys_a_root_level_entry_by_its_own_name() {
     let (tempdir, store_path) = tempdir_with_leaked_path();
@@ -5966,10 +5967,10 @@ fn streaming_extract_keys_a_root_level_entry_by_its_own_name() {
 }
 
 /// A flat archive keys its `package.json` at the package root, so the
-/// resolve-time metadata read has to recognize it as the manifest.
-/// Extraction and resolution disagreeing here is what named a `file:`
-/// dependency after the consumer's alias at version `0.0.0` while the
-/// `package.json` beside it said otherwise.
+/// resolve-time metadata read has to recognize it as the manifest. When
+/// it and extraction disagree, a `file:` dependency is named after the
+/// consumer's alias at version `0.0.0` while the `package.json` beside
+/// it names something else.
 #[tokio::test]
 async fn read_local_tarball_metadata_reads_a_manifest_at_the_archive_root() {
     let local_dir = tempdir().unwrap();

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -6057,6 +6057,30 @@ fn extract_rejects_an_entry_naming_the_archive_root() {
     drop(tempdir);
 }
 
+/// An absolute entry path names a destination of its own, so joining
+/// it onto the package directory would write wherever the archive says.
+/// A leading `\` counts, since it is the separator pnpm folds to `/`
+/// before validating.
+#[test]
+fn extract_rejects_an_absolute_entry_path() {
+    for name in [&b"/etc/passwd"[..], &br"\windows\evil.txt"[..]] {
+        let (tempdir, store_path) = tempdir_with_leaked_path();
+
+        let tar_bytes = tar_with_raw_entry_name(name, b"bytes");
+        let err = extract_tarball_entries(&tar_bytes, store_path, None)
+            .expect_err("an absolute entry path must be rejected");
+
+        match err {
+            TarballError::ReadTarballEntries(io_err) => {
+                assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+            }
+            other => panic!("expected a rejected tar entry, got {other:?}"),
+        }
+
+        drop(tempdir);
+    }
+}
+
 /// A backslash is an ordinary filename character on Unix but a
 /// separator on Windows, and these keys travel between the two through
 /// the shared `index.db`. pnpm folds `\` to `/` before validating

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5901,6 +5901,91 @@ fn extract_strips_only_one_component_from_a_dot_prefixed_entry_path() {
     drop(tempdir);
 }
 
+/// Build a tar whose payload directory sits beside two root-level
+/// entries: macOS `bsdtar` emits the zero-length `AppleDouble` `._package`
+/// when the source cannot store xattrs natively, and `tar czf README
+/// package` puts an ordinary file up there too.
+fn tar_with_root_level_entries() -> Vec<u8> {
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, body) in [
+        ("._package", &b""[..]),
+        ("README", &b"a file that sits at the archive root\n"[..]),
+        ("package/package.json", &br#"{"name":"pkg-root-entry","version":"1.0.0"}"#[..]),
+        ("package/index.js", &b"module.exports = 'hello'\n"[..]),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder.append_data(&mut header, path, body).expect("append entry");
+    }
+    builder.into_inner().expect("finish tar")
+}
+
+/// An entry at the archive root has no top-level directory on it to
+/// strip, so it is keyed by its own name — what pnpm does, and what
+/// keeps the shared `index.db` describing one file layout. Rejecting it
+/// failed the whole install for an archive npm and pnpm both accept.
+#[test]
+fn extract_keys_a_root_level_entry_by_its_own_name() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_root_level_entries();
+    let (cas_paths, pkg_files_idx) =
+        extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
+
+    let mut keys = cas_paths.keys().collect::<Vec<_>>();
+    keys.sort();
+    assert_eq!(keys, vec!["._package", "README", "index.js", "package.json"]);
+    assert_eq!(
+        pkg_files_idx.manifest.as_ref().and_then(|manifest| manifest["name"].as_str()),
+        Some("pkg-root-entry"),
+        "the manifest under `package/` is still the one captured",
+    );
+
+    drop(tempdir);
+}
+
+/// The streaming extractor keys a root-level entry the same way, since
+/// [`should_stream_extract`] routes between the two per download and the
+/// shared `index.db` must not be able to tell them apart.
+#[test]
+fn streaming_extract_keys_a_root_level_entry_by_its_own_name() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_root_level_entries();
+    let (cas_paths, _) = stream_extract_gzipped_tarball(&gzip_bytes(&tar_bytes), store_path, None)
+        .expect("extract the tarball");
+
+    let mut keys = cas_paths.keys().collect::<Vec<_>>();
+    keys.sort();
+    assert_eq!(keys, vec!["._package", "README", "index.js", "package.json"]);
+
+    drop(tempdir);
+}
+
+/// A lone `.` names the archive root rather than a file inside it, so no
+/// key can address it. It stays rejected, unlike the root-level entries
+/// above that have a name to be keyed by.
+#[test]
+fn extract_rejects_an_entry_naming_the_archive_root() {
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+
+    let tar_bytes = tar_with_raw_entry_name(b"./.");
+    let err = extract_tarball_entries(&tar_bytes, store_path, None)
+        .expect_err("an entry naming the archive root must be rejected");
+
+    match err {
+        TarballError::ReadTarballEntries(io_err) => {
+            assert_eq!(io_err.kind(), std::io::ErrorKind::InvalidData);
+        }
+        other => panic!("expected a rejected tar entry, got {other:?}"),
+    }
+
+    drop(tempdir);
+}
+
 /// A backslash is an ordinary filename character on Unix but a
 /// separator on Windows, and these keys travel between the two through
 /// the shared `index.db`. pnpm folds `\` to `/` before validating

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5965,6 +5965,51 @@ fn streaming_extract_keys_a_root_level_entry_by_its_own_name() {
     drop(tempdir);
 }
 
+/// A flat archive keys its `package.json` at the package root, so the
+/// resolve-time metadata read has to recognize it as the manifest.
+/// Extraction and resolution disagreeing here is what named a `file:`
+/// dependency after the consumer's alias at version `0.0.0` while the
+/// `package.json` beside it said otherwise.
+#[tokio::test]
+async fn read_local_tarball_metadata_reads_a_manifest_at_the_archive_root() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("flat.tgz");
+
+    let mut builder = tar::Builder::new(Vec::new());
+    for (path, body) in [
+        ("package.json", &br#"{"name":"real-name","version":"9.9.9"}"#[..]),
+        ("index.js", &b"module.exports = 1\n"[..]),
+    ] {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        builder.append_data(&mut header, path, body).expect("append entry");
+    }
+    let tar_bytes = builder.into_inner().expect("finish tar");
+    std::fs::write(&tarball_path, gzip_bytes(&tar_bytes)).unwrap();
+
+    let metadata = read_local_tarball_metadata(&tarball_path)
+        .await
+        .expect("read the local tarball's metadata");
+
+    assert!(metadata.has_manifest_entry);
+    let manifest = metadata.manifest.expect("bundled manifest");
+    assert_eq!(manifest.get("name").and_then(serde_json::Value::as_str), Some("real-name"));
+    assert_eq!(manifest.get("version").and_then(serde_json::Value::as_str), Some("9.9.9"));
+
+    // The extraction the resolve-time read has to agree with.
+    let (tempdir, store_path) = tempdir_with_leaked_path();
+    let (_, pkg_files_idx) =
+        extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
+    assert_eq!(
+        pkg_files_idx.manifest.as_ref().and_then(|manifest| manifest["name"].as_str()),
+        Some("real-name"),
+    );
+    drop(tempdir);
+}
+
 /// A lone `.` names the archive root rather than a file inside it, so no
 /// key can address it. It stays rejected, unlike the root-level entries
 /// above that have a name to be keyed by.

--- a/pnpm/crates/tarball/src/tests.rs
+++ b/pnpm/crates/tarball/src/tests.rs
@@ -5866,12 +5866,14 @@ fn extract_keeps_only_regular_file_entries() {
 }
 
 /// Build a tar carrying one entry whose raw header name is `name`,
-/// bypassing `set_path`'s own validation so hostile names can be tested.
-fn tar_with_raw_entry_name(name: &[u8]) -> Vec<u8> {
+/// bypassing `set_path`'s own validation so hostile names can be
+/// tested. `set_path` drops a leading `./` from a multi-component path,
+/// so a dot-prefixed name only survives written this way.
+fn tar_with_raw_entry_name(name: &[u8], body: &[u8]) -> Vec<u8> {
     let mut tar_bytes = Vec::new();
     let mut builder = tar::Builder::new(&mut tar_bytes);
     let mut header = tar::Header::new_gnu();
-    header.set_size(5);
+    header.set_size(body.len() as u64);
     header.set_mode(0o644);
     header.set_entry_type(tar::EntryType::Regular);
     let raw = header.as_mut_bytes();
@@ -5880,7 +5882,7 @@ fn tar_with_raw_entry_name(name: &[u8]) -> Vec<u8> {
         *byte = 0;
     }
     header.set_cksum();
-    builder.append(&header, &b"bytes"[..]).expect("append entry");
+    builder.append(&header, body).expect("append entry");
     builder.finish().expect("finalize tar");
     drop(builder);
     tar_bytes
@@ -5890,7 +5892,7 @@ fn tar_with_raw_entry_name(name: &[u8]) -> Vec<u8> {
 fn extract_strips_only_one_component_from_a_dot_prefixed_entry_path() {
     let (tempdir, store_path) = tempdir_with_leaked_path();
 
-    let tar_bytes = tar_with_raw_entry_name(b"./package/package.json");
+    let tar_bytes = tar_with_raw_entry_name(b"./package/package.json", b"bytes");
     let (cas_paths, pkg_files_idx) =
         extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
 
@@ -5906,19 +5908,27 @@ fn extract_strips_only_one_component_from_a_dot_prefixed_entry_path() {
 /// when the source cannot store xattrs natively, and `tar czf README
 /// package` puts an ordinary file up there too.
 fn tar_with_root_level_entries() -> Vec<u8> {
+    tar_with_entries(&[
+        ("._package", b""),
+        ("README", b"a file that sits at the archive root\n"),
+        ("package/package.json", br#"{"name":"pkg-root-entry","version":"1.0.0"}"#),
+        ("package/index.js", b"module.exports = 'hello'\n"),
+    ])
+}
+
+/// Build an uncompressed tar carrying `entries` in order, each written
+/// verbatim as a regular file, so a caller can shape an archive that
+/// omits the top-level directory a published tarball wraps its payload
+/// in, or that carries an entry beside it at the archive root.
+fn tar_with_entries(entries: &[(&str, &[u8])]) -> Vec<u8> {
     let mut builder = tar::Builder::new(Vec::new());
-    for (path, body) in [
-        ("._package", &b""[..]),
-        ("README", &b"a file that sits at the archive root\n"[..]),
-        ("package/package.json", &br#"{"name":"pkg-root-entry","version":"1.0.0"}"#[..]),
-        ("package/index.js", &b"module.exports = 'hello'\n"[..]),
-    ] {
+    for (path, body) in entries {
         let mut header = tar::Header::new_gnu();
         header.set_size(body.len() as u64);
         header.set_mode(0o644);
         header.set_entry_type(tar::EntryType::Regular);
         header.set_cksum();
-        builder.append_data(&mut header, path, body).expect("append entry");
+        builder.append_data(&mut header, path, *body).expect("append entry");
     }
     builder.into_inner().expect("finish tar")
 }
@@ -5976,19 +5986,10 @@ async fn read_local_tarball_metadata_reads_a_manifest_at_the_archive_root() {
     let local_dir = tempdir().unwrap();
     let tarball_path = local_dir.path().join("flat.tgz");
 
-    let mut builder = tar::Builder::new(Vec::new());
-    for (path, body) in [
-        ("package.json", &br#"{"name":"real-name","version":"9.9.9"}"#[..]),
-        ("index.js", &b"module.exports = 1\n"[..]),
-    ] {
-        let mut header = tar::Header::new_gnu();
-        header.set_size(body.len() as u64);
-        header.set_mode(0o644);
-        header.set_entry_type(tar::EntryType::Regular);
-        header.set_cksum();
-        builder.append_data(&mut header, path, body).expect("append entry");
-    }
-    let tar_bytes = builder.into_inner().expect("finish tar");
+    let tar_bytes = tar_with_entries(&[
+        ("package.json", br#"{"name":"real-name","version":"9.9.9"}"#),
+        ("index.js", b"module.exports = 1\n"),
+    ]);
     std::fs::write(&tarball_path, gzip_bytes(&tar_bytes)).unwrap();
 
     let metadata = read_local_tarball_metadata(&tarball_path)
@@ -6011,6 +6012,30 @@ async fn read_local_tarball_metadata_reads_a_manifest_at_the_archive_root() {
     drop(tempdir);
 }
 
+/// A `./`-prefixed entry loses only its `./`, so `./package/package.json`
+/// keys as `package/package.json` and is a manifest in a subdirectory,
+/// not the package's own. The resolve-time read has to say so too, or it
+/// names the package after a manifest that extraction files one level
+/// down.
+#[tokio::test]
+async fn read_local_tarball_metadata_ignores_a_manifest_below_the_package_root() {
+    let local_dir = tempdir().unwrap();
+    let tarball_path = local_dir.path().join("dot-prefixed.tgz");
+
+    let tar_bytes = tar_with_raw_entry_name(
+        b"./package/package.json",
+        br#"{"name":"real-name","version":"9.9.9"}"#,
+    );
+    std::fs::write(&tarball_path, gzip_bytes(&tar_bytes)).unwrap();
+
+    let metadata = read_local_tarball_metadata(&tarball_path)
+        .await
+        .expect("read the local tarball's metadata");
+
+    assert!(!metadata.has_manifest_entry);
+    assert!(metadata.manifest.is_none(), "got {:?}", metadata.manifest);
+}
+
 /// A lone `.` names the archive root rather than a file inside it, so no
 /// key can address it. It stays rejected, unlike the root-level entries
 /// above that have a name to be keyed by.
@@ -6018,7 +6043,7 @@ async fn read_local_tarball_metadata_reads_a_manifest_at_the_archive_root() {
 fn extract_rejects_an_entry_naming_the_archive_root() {
     let (tempdir, store_path) = tempdir_with_leaked_path();
 
-    let tar_bytes = tar_with_raw_entry_name(b"./.");
+    let tar_bytes = tar_with_raw_entry_name(b"./.", b"bytes");
     let err = extract_tarball_entries(&tar_bytes, store_path, None)
         .expect_err("an entry naming the archive root must be rejected");
 
@@ -6041,7 +6066,7 @@ fn extract_rejects_an_entry_naming_the_archive_root() {
 fn extract_rejects_backslash_traversal_in_entry_path() {
     let (tempdir, store_path) = tempdir_with_leaked_path();
 
-    let tar_bytes = tar_with_raw_entry_name(br"package/..\..\evil.txt");
+    let tar_bytes = tar_with_raw_entry_name(br"package/..\..\evil.txt", b"bytes");
     let err = extract_tarball_entries(&tar_bytes, store_path, None)
         .expect_err("a backslash-spelled traversal must be rejected");
 
@@ -6062,7 +6087,7 @@ fn extract_rejects_backslash_traversal_in_entry_path() {
 fn extract_reads_a_windows_separator_entry_as_a_nested_path() {
     let (tempdir, store_path) = tempdir_with_leaked_path();
 
-    let tar_bytes = tar_with_raw_entry_name(br"package/bin\tool.js");
+    let tar_bytes = tar_with_raw_entry_name(br"package/bin\tool.js", b"bytes");
     let (cas_paths, _) =
         extract_tarball_entries(&tar_bytes, store_path, None).expect("extract the tarball");
 

--- a/pnpm/crates/testing-utils/src/fixtures.rs
+++ b/pnpm/crates/testing-utils/src/fixtures.rs
@@ -11,18 +11,14 @@ pub fn minimal_tarball(name: &str, version: &str) -> Vec<u8> {
 /// `package.json` at all.
 #[must_use]
 pub fn tarball_without_manifest() -> Vec<u8> {
-    tarball_entry("package/README.md", b"placeholder")
+    tarball_entries(&[("package/README.md", b"placeholder")])
 }
 
 /// Returns a gzipped package tarball whose only entry is `manifest`,
 /// written to `package/package.json`.
 #[must_use]
 pub fn tarball_with_manifest(manifest: &serde_json::Value) -> Vec<u8> {
-    tarball_entry("package/package.json", manifest.to_string().as_bytes())
-}
-
-fn tarball_entry(path: &str, contents: &[u8]) -> Vec<u8> {
-    tarball_entries(&[(path, contents)])
+    tarball_entries(&[("package/package.json", manifest.to_string().as_bytes())])
 }
 
 /// Returns a gzipped tarball carrying `entries` in order, each as a
@@ -41,6 +37,7 @@ pub fn tarball_entries(entries: &[(&str, &[u8])]) -> Vec<u8> {
         header.set_path(path).expect("set tar entry path");
         header.set_size(contents.len() as u64);
         header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
         header.set_cksum();
         builder.append(&header, *contents).expect("append entry to tar");
     }

--- a/pnpm/crates/testing-utils/src/fixtures.rs
+++ b/pnpm/crates/testing-utils/src/fixtures.rs
@@ -22,15 +22,28 @@ pub fn tarball_with_manifest(manifest: &serde_json::Value) -> Vec<u8> {
 }
 
 fn tarball_entry(path: &str, contents: &[u8]) -> Vec<u8> {
+    tarball_entries(&[(path, contents)])
+}
+
+/// Returns a gzipped tarball carrying `entries` in order, each as a
+/// regular file at the path given.
+///
+/// Entry paths are written verbatim, so a caller can build an archive
+/// that omits the top-level directory a published tarball wraps its
+/// payload in, or that carries an entry beside it at the archive root.
+#[must_use]
+pub fn tarball_entries(entries: &[(&str, &[u8])]) -> Vec<u8> {
     use std::io::Write;
 
     let mut builder = tar::Builder::new(Vec::new());
-    let mut header = tar::Header::new_gnu();
-    header.set_path(path).expect("set tar entry path");
-    header.set_size(contents.len() as u64);
-    header.set_mode(0o644);
-    header.set_cksum();
-    builder.append(&header, contents).expect("append entry to tar");
+    for (path, contents) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_path(path).expect("set tar entry path");
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append(&header, *contents).expect("append entry to tar");
+    }
     let tar_bytes = builder.into_inner().expect("finish tar");
 
     let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

pnpm 12 aborted an install when a package tarball carried a regular file at the archive root, beside the usual `package/` directory. pnpm 11 installs the same archive and so does npm. Closes pnpm/pnpm#14701.

`clean_archive_entry_path` dropped the top-level component from every entry path and rejected the entry when nothing remained. An entry at the archive root has no top-level directory on it to drop, so one such entry failed the whole archive with `ERR_PNPM_TARBALL_IO_ERROR`.

An entry of a single segment now keeps that segment, which is what pnpm 11 does. The second commit teaches the resolve-time manifest read the same rule, so a `file:` archive keeps the identity pnpm 11 gives it.

## The choice this makes

The issue was filed `state: needs design`, because the two other installers disagree:

| | `README` beside `package/` |
| --- | --- |
| pnpm 11 | installs it at the package root |
| npm | skips it |
| pnpm 12, before this PR | fails the install |

This PR matches pnpm 11 rather than npm. Skipping reads better on its own terms, since the entry is unplaceable and in the common case it is junk metadata, but the two stacks share `index.db`, so the choice decides what a shared store holds for these packages. That is the concern pnpm/pnpm#14165 raised for the sibling `./`-prefixed case, and pnpm/pnpm#14247 settled that one by matching pnpm 11 too.

The divergence is already observable: a store populated by pnpm 11 makes pnpm 12 install the root-level file happily today. Only pnpm 12's own extractor refused to write one.

Say so if you would rather have npm's behavior. It is a smaller diff than this one, but it needs a matching change in pnpm 11 to keep the shared store consistent, which is a behavior change in a maintenance-only release.

## Second commit: the resolve-time read had to learn the same rule

Caught in review. `is_root_manifest_entry_path` in `local_tarball.rs` dropped one component unconditionally, so it did not recognize a `package.json` at the archive root, while extraction now does. For a `file:` archive packed with no `package/` wrapper the two disagreed:

| | lockfile key | version | directory |
| --- | --- | --- | --- |
| pnpm 11.26.0 | `real-name@file:...` | `9.9.9` | `real-name` |
| first commit alone | `myalias@file:...` | `0.0.0` | `myalias` |
| both commits | `real-name@file:...` | `9.9.9` | `real-name` |

The package installed under the consumer's alias with a `package.json` beside it naming something else, and the two CLIs wrote different lockfile keys, so a mixed-CLI `--frozen-lockfile` install failed. Before the first commit the archive was rejected outright, so the divergence arrived with it. Remote tarballs were never affected, since they read the manifest from `pkg_files_idx.manifest`.

`is_root_manifest_entry_path` now asks `clean_archive_entry_path` the same question extraction asks, so the two cannot drift apart again.

Two related things checked while there:

- An archive with both `package.json` and `package/package.json` keeps the last entry. pnpm 11 collapses those two keys the same way and picks the same winner, verified on the same archive, so no change was needed.
- A flat archive's nested entries still lose their first component, so `lib/helper.js` lands at the package root and `lib/` is gone. pnpm 11 flattens identically, its `parseString` trimming through the first separator whatever that separator separates. That is consistent rather than divergent, but it does trade a loud failure for a quietly restructured package, so `flat_local_tarball_is_recorded_under_its_bundled_name` now pins it.

## Also here

- A lone `.` stays rejected. It names the archive root rather than a file inside it, so no key can address it. The message no longer blames a missing payload, which was never the cause: a zero-length root-level file failed identically.
- The first commit is unrelated. `cargo clippy -D warnings` fails on macOS on current `main`, because three imports in `cargo_deps/git/tests.rs` are used only by a test that `#[cfg]` compiles out there. It passes on Linux, so CI is green and the pre-push hook is not. Happy to split it out.

## Not addressed

A malformed archive is classified as a retryable fetch error, so the failing install above waited out `10s` and `1m` of backoff first, about 70 seconds for a defect that cannot change between attempts. `ERR_PNPM_TARBALL_IO_ERROR` is also the wrong code for a data error. Both are noted in the issue and left alone here to keep this diff to the extraction bug.

## Validation

- Reproduced the original failure with a real build, then confirmed the fix against all seven archive shapes in the issue's scope table.
- Compared against pnpm 11.26.0 on the same archives for the shapes where identity matters: lockfile key, recorded version, virtual-store directory, and installed file list all match.
- Each new test was run against the reverted implementation and fails there. The e2e test takes 73 seconds to fail, which is the retry backoff above.
- `cargo nextest run -p pnpm-tarball -p pnpm-cli -p pnpm-testing-utils`: 3606 of 3611 pass. The five that don't are unrelated and not introduced here — `pipeline_cache::symlinked_inputs_are_hashed_as_link_targets` and `run_recursive::recursive_run_bail_cancels_in_flight_processes` fail the same way on `main`, and the rest are macOS flakes that pass in isolation.

## Review follow-ups

Five commits on top, none of which change behavior.

- `d1390ce8c5` sets an explicit `Regular` typeflag on the `tarball_entries` fixture, which documented that it wrote regular files while leaving the typeflag at its header's NUL, and inlines `tarball_entry` now that it delegates without adding anything.
- `67fb5a6ec8` asks `clean_archive_entry_path` about a lone `.` before the top-level strip rather than after, since that is a property of the raw path, and names the flat-archive shape in the doc comment alongside the beside-`package/` one.
- `e3fe3d0920` pins the resolve-time negative case: `./package/package.json` keys as `package/package.json`, so it is a subdirectory manifest and the metadata read must not name the package after it. Extraction's side of that was already pinned. The two new archive builders also collapse into one `tar_with_entries` helper.

- `799bcb81fd` answers a measured cost the second commit introduced. Delegating to `clean_archive_entry_path` added about 90ns per archive entry to the resolve-time metadata read, so `archive_entry_segments` now borrows its segments instead of copying the path to fold `\` to `/` and allocating a `String` per segment. Splitting on both separators at once is the same partition. The cleaner goes from 73ns to 34ns per call, which also speeds up every extraction.
- `acbc9cd9a2` covers an absolute entry path, in both separators' spelling. The guard existed and nothing exercised it, and the commit above rewrote the line it lives on.

A separate finding, pre-existing on `main` and left out of this diff: `clean_archive_entry_path` does not reject a segment carrying a Windows drive prefix, so `package/C:evil.exe` cleans to `C:evil.exe` and `PathBuf::push` in `import_indexed_dir.rs` then discards the target directory. The two-segment form already reached that on `main`. Details in the review comment.

## Squash Commit Body

```text
`clean_archive_entry_path` dropped the top-level component from every
entry path and rejected the entry when nothing remained. An entry at the
archive root has no top-level directory on it to drop: `README` beside
`package/`, or the zero-length `._*` AppleDouble that macOS `bsdtar`
emits when the source cannot store xattrs natively. One such entry
failed the whole archive with ERR_PNPM_TARBALL_IO_ERROR, after
exhausting the network retries even for a purely local `file:` read.

An entry of a single segment now keeps that segment, which is what pnpm
11 does: `parseString` in `parseTarball.ts` advances past the first
separator, and a single segment has none, so pnpm keys the file by its
own name. Matching it keeps the `index.db` both implementations share
describing one file layout -- the concern pnpm/pnpm#14165 raised for the
sibling `./`-prefixed case, which pnpm/pnpm#14247 settled the same way.
npm instead skips the entry, since node-tar's `strip` leaves its path
empty, which resolves to the extraction directory and is dropped for a
non-directory. Skipping reads better on its own terms, but it would
diverge from pnpm 11 over a file pnpm 11 keys into the shared store.

A lone `.` stays rejected. It names the archive root rather than a file
inside it, so no key can address it, and the message no longer blames a
missing payload: a zero-length root-level file always had one.

Both extraction loops are covered, since a download routes between them
by size and the shared `index.db` must not be able to tell them apart.

The resolve-time manifest read had to learn the same rule.
`is_root_manifest_entry_path` dropped one path component unconditionally,
so it did not recognize a `package.json` sitting at the archive root with
no wrapping directory around it, while extraction now keys that entry as
the package's manifest. A `file:` archive packed without the `package/`
wrapper therefore resolved with no manifest at all and was recorded under
the alias its consumer gave it at version `0.0.0`, while the
`package.json` extracted beside it named something else -- a different
lockfile key than pnpm 11 writes for the same archive, so a mixed-CLI
`--frozen-lockfile` install failed. It now asks
`clean_archive_entry_path` whether the entry cleans to `package.json`,
which is the question extraction answers, so the two cannot drift apart
again. Remote tarballs were never affected: they read the manifest from
`pkg_files_idx.manifest`.

An archive carrying both `package.json` and `package/package.json` keeps
the last entry, which is what pnpm 11 does with the two keys it also
collapses into one.

Closes pnpm/pnpm#14701
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpm 11 already installs these
  archives, so this is a v12-only fix.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed installation of package tarballs containing files at the archive root, including macOS-generated metadata entries.
  * Fixed `file:` tarballs without a `package/` directory to use the bundled package name and version.
  * Improved support for flat tarball layouts and preserved valid root-level files.
  * Continued rejecting invalid archive-root entries, including absolute paths and the archive root itself.

* **Tests**
  * Added coverage for root-level files, flat archives, package metadata, and invalid archive entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

