### PR TITLE
perf(lockfile): normalize hash input in place

### DIFF
--- a/.changeset/lockfile-hash-normalization.md
+++ b/.changeset/lockfile-hash-normalization.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Reduced memory allocations when pnpm verifies large lockfiles [#14706](https://github.com/pnpm/pnpm/issues/14706).

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,16 +1,19 @@
 use super::{
-    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
-    vendor_source, vendored_package,
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
-    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
 };
+
+#[cfg(all(unix, not(target_os = "macos")))]
+use super::{CheckoutPackage, import_package};
+#[cfg(all(unix, not(target_os = "macos")))]
+use std::collections::BTreeSet;
 
 fn manifest(text: &str) -> Manifest {
     Manifest { text: text.to_string(), document: toml::from_str(text).expect("parse manifest") }

--- a/pnpm/crates/lockfile-verification/src/hash_lockfile.rs
+++ b/pnpm/crates/lockfile-verification/src/hash_lockfile.rs
@@ -19,7 +19,6 @@
 use std::io;
 
 use pnpm_lockfile::Lockfile;
-use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
 
 /// Sha256 hex digest of the lockfile content.
@@ -33,39 +32,11 @@ pub fn hash_lockfile(lockfile: &Lockfile) -> String {
     let mut value = serde_json::to_value(lockfile)
         .expect("Lockfile serializes; serde_json::Value supports all JSON-shape variants");
     pnpm_lockfile::prune_time(&mut value);
-    let normalized = normalize(value);
+    value.sort_all_objects();
     let mut hasher = HashWriter(Sha256::new());
-    serde_json::to_writer(&mut hasher, &normalized)
+    serde_json::to_writer(&mut hasher, &value)
         .expect("HashWriter is infallible; serde_json::to_writer cannot fail otherwise");
     format!("{:x}", hasher.0.finalize())
-}
-
-/// Walk a [`Value`] and rebuild every map with sorted keys. Arrays
-/// are left in place — the lockfile's only array-shaped fields are
-/// `ignoredOptionalDependencies` (which is semantically a set the
-/// install treats as ordered for diff stability) and dependency-name
-/// lists inside individual entries (where order matches the manifest
-/// section it came from).
-///
-/// `serde_json::Map` is backed by `IndexMap` under the
-/// `preserve_order` workspace feature, so a fresh `Map` populated in
-/// sorted-key order serialises in that order.
-fn normalize(value: Value) -> Value {
-    match value {
-        Value::Object(map) => {
-            let mut keys: Vec<String> = map.keys().cloned().collect();
-            keys.sort();
-            let mut sorted = Map::with_capacity(keys.len());
-            for key in keys {
-                let inner =
-                    map.get(&key).cloned().expect("key came from the same map we're walking");
-                sorted.insert(key, normalize(inner));
-            }
-            Value::Object(sorted)
-        }
-        Value::Array(items) => Value::Array(items.into_iter().map(normalize).collect()),
-        other => other,
-    }
 }
 
 /// `io::Write` adapter that feeds bytes into a [`Sha256`] as they

--- a/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
+++ b/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
@@ -46,8 +46,10 @@ fn parse(yaml: &str) -> Lockfile {
     serde_saphyr::from_str(yaml).expect("parse fixture lockfile")
 }
 
+/// Recorded verifications carry this digest, so a change to the hashed
+/// bytes orphans every cache entry written before it.
 #[test]
-fn hash_matches_verification_cache_digests() {
+fn hash_matches_pinned_digests() {
     for (yaml, expected) in [
         (LOCKFILE_YAML, "c8991e89c9a1098fa78aeb75d8bc7f4c6e5d2781258875e4f9436e03913351ea"),
         (NESTED_LOCKFILE_YAML, "48e073ddc4599b78202df75cd29b986928e7823a2535c6e9d4f001f44e546361"),
@@ -56,6 +58,8 @@ fn hash_matches_verification_cache_digests() {
     }
 }
 
+/// The lockfile's arrays are ordered data (dependency-name lists follow
+/// their manifest section), so only object keys are normalized.
 #[test]
 fn array_order_affects_hash() {
     let original = parse(NESTED_LOCKFILE_YAML);
@@ -73,8 +77,8 @@ fn hash_is_stable_across_calls() {
     assert_eq!(first.len(), 64, "sha256 hex digest is 64 chars");
 }
 
-/// `HashMap` key iteration is non-deterministic; the normalize step
-/// is what makes the hash stable.
+/// `HashMap` key iteration is non-deterministic; sorting every object
+/// before hashing is what makes the hash stable.
 #[test]
 fn key_order_in_yaml_does_not_affect_hash() {
     let original = parse(LOCKFILE_YAML);

--- a/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
+++ b/pnpm/crates/lockfile-verification/src/hash_lockfile/tests.rs
@@ -30,8 +30,38 @@ importers:
         version: 4.17.21
 ";
 
+const NESTED_LOCKFILE_YAML: &str = "lockfileVersion: '9.0'
+ignoredOptionalDependencies:
+  - zebra
+  - alpha
+metadata:
+  z: null
+  a:
+    - z: 'café'
+      a: { z: true, a: 42 }
+    - [ { z: false, a: -7 }, 3.5, '雪' ]
+";
+
 fn parse(yaml: &str) -> Lockfile {
     serde_saphyr::from_str(yaml).expect("parse fixture lockfile")
+}
+
+#[test]
+fn hash_matches_verification_cache_digests() {
+    for (yaml, expected) in [
+        (LOCKFILE_YAML, "c8991e89c9a1098fa78aeb75d8bc7f4c6e5d2781258875e4f9436e03913351ea"),
+        (NESTED_LOCKFILE_YAML, "48e073ddc4599b78202df75cd29b986928e7823a2535c6e9d4f001f44e546361"),
+    ] {
+        assert_eq!(hash_lockfile(&parse(yaml)), expected);
+    }
+}
+
+#[test]
+fn array_order_affects_hash() {
+    let original = parse(NESTED_LOCKFILE_YAML);
+    let reordered =
+        parse(&NESTED_LOCKFILE_YAML.replace("  - zebra\n  - alpha", "  - alpha\n  - zebra"));
+    assert_ne!(hash_lockfile(&original), hash_lockfile(&reordered));
 }
 
 #[test]


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

Sort the owned lockfile JSON tree in place before hashing it. This removes recursive cloning and map reconstruction from Rust v12 verification while preserving the serialized bytes, SHA-256 digests, array order, and time-entry pruning.

Closes https://github.com/pnpm/pnpm/issues/14706.

The change uses the existing serde_json dependency and keeps the streaming hash writer. TypeScript v11 uses a different object-hashing implementation and does not need this change.

The full workspace check also exposed three imports used only by a Cargo test disabled on macOS. Apply that test's existing platform condition to the imports so workspace Clippy passes on macOS. Test behavior is unchanged.

Validation:

- All push-hook checks passed: TypeScript build/lint, Rust formatting, Clippy, rustdoc, custom Dylint rules, spelling, and TOML formatting.

- All 65 lockfile-verification tests passed, including fixed digests captured from the unchanged implementation and the existing verification-cache reuse tests.
- The fixed-digest test failed when normalization was deliberately limited to the root object. The recursive implementation was restored with git restore.
- `just ready` passed through mbx: workspace check, 10,862 tests passed (11 suite skips), formatting, spelling, and Clippy.
- Installed the documented sccache 0.17.0 prerequisite after its absence stopped the first full run; the affected compiler-cache test then passed alone and in the full run.

Allocation measurement used a temporary release-mode harness with Rust 1.97.0, serde_json 1.0.151, and indexmap 2.14.0. It compared the removed helper with sort_all_objects on identical synthetic lockfile JSON, including package resolutions, engines, architecture arrays, snapshots, and dependency maps. Input construction and cloning, output serialization, and hashing were outside the allocation counter. Serialized outputs matched on every run. Counts were identical across 11 runs per case:

| Packages | Recursive helper allocations | In-place allocations | Recursive helper allocated bytes | In-place allocated bytes |
| --- | ---: | ---: | ---: | ---: |
| 100 | 11,017 | 0 | 815,683 | 0 |
| 3,000 | 330,019 | 0 | 24,676,007 | 0 |

These are normalization-only allocation totals, not peak memory or full-install measurements. The harness is not part of the product change.

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Sort the owned JSON tree with serde_json before streaming it into SHA-256.
Remove the recursive helper that cloned keys and nested values at every
object level. Preserve pruning, array order, and exact existing digests.

Add fixed-digest compatibility coverage and an array-order test. Existing
cache tests continue to cover reuse across lockfile paths.

Gate the existing platform-specific Cargo test imports to match their test
and keep the macOS workspace lint check passing.

Closes https://github.com/pnpm/pnpm/issues/14706.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791487430&installation_model_id=426870&pr_number=14707&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14707&signature=ba44cf35ff599825b7d9b198ef683e155ec5d7e7c3f3ccc22aa5b79c5efd6980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced memory usage when verifying large lockfiles.

- **Bug Fixes**
  - Improved consistency of lockfile verification when object key ordering differs.
  - Improved hashing reliability for nested data, including arrays, nulls, booleans, numbers, and Unicode values.
  - Array ordering remains significant when calculating lockfile hashes.

- **Chores**
  - Added a patch-level package release for these lockfile verification improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->