### PR TITLE
docs(cli): update description to remove "experimental" label in pnpm command

### DIFF
--- a/.changeset/lazy-taxis-whisper.md
+++ b/.changeset/lazy-taxis-whisper.md
@@ -1,5 +1,5 @@
 ---
-"@pnpm/cli.commands": patch
+"pacquet": patch
 ---
 
 update "about"

--- a/.changeset/lazy-taxis-whisper.md
+++ b/.changeset/lazy-taxis-whisper.md
@@ -1,0 +1,5 @@
+---
+"@pnpm/cli.commands": patch
+---
+
+update "about"

--- a/.changeset/lazy-taxis-whisper.md
+++ b/.changeset/lazy-taxis-whisper.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-update "about"
+The `pnpm --help` description no longer labels the package manager as experimental.

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -88,7 +88,7 @@ use pipe_trait::Pipe;
 use pnpm_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
-/// Package manager for Node.js written in rust.
+/// Package manager for Node.js written in Rust.
 #[derive(Debug, Parser)]
 #[clap(name = "pnpm")]
 #[clap(bin_name = "pnpm")]

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -88,13 +88,13 @@ use pipe_trait::Pipe;
 use pnpm_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
-/// Experimental package manager for node.js written in rust.
+/// Package manager for Node.js written in rust.
 #[derive(Debug, Parser)]
 #[clap(name = "pnpm")]
 #[clap(bin_name = "pnpm")]
 #[clap(version = pnpm_config::PNPM_VERSION)]
 #[clap(disable_version_flag = true)]
-#[clap(about = "Experimental package manager for node.js")]
+#[clap(about = "Package manager for Node.js")]
 pub struct CliArgs {
     #[clap(subcommand)]
     pub command: CliCommand,

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -88,13 +88,13 @@ use pipe_trait::Pipe;
 use pnpm_default_reporter::SummaryScope;
 use std::path::PathBuf;
 
-/// Package manager for Node.js written in Rust.
+/// Package manager.
 #[derive(Debug, Parser)]
 #[clap(name = "pnpm")]
 #[clap(bin_name = "pnpm")]
 #[clap(version = pnpm_config::PNPM_VERSION)]
 #[clap(disable_version_flag = true)]
-#[clap(about = "Package manager for Node.js")]
+#[clap(about = "Package manager")]
 pub struct CliArgs {
     #[clap(subcommand)]
     pub command: CliCommand,


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

I noticed this at the top of the `pn -h` output. I don't think it's considered "Experimental" anymore, but please correct it as you'd prefer.

<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
Updated description to remove "experimental" label in pnpm command.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791500772&installation_model_id=426870&pr_number=14712&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14712&signature=a42866a0a8d028daf6f6254e65f067fb92444bfe0fc01f6aabe9d7eba9bd71b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the command-line help text to remove the “Experimental” label.
  - Simplified the package manager description to “Package manager.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->