### PR TITLE
test(testing-utils): detach git fixtures from the contributor's global config

### DIFF
--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,12 +1,10 @@
 use super::{
-    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
-    vendor_source, vendored_package,
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
-    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -392,7 +390,8 @@ fn a_crate_is_found_past_a_manifest_that_shares_its_name_and_reads_no_version() 
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn a_file_whose_name_is_not_utf8_is_refused() {
-    use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+    use super::{CheckoutPackage, import_package};
+    use std::{collections::BTreeSet, ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
     let temp_dir = tempfile::tempdir().unwrap();
     let package_dir = temp_dir.path().join("crate");

--- a/pnpm/crates/cli/tests/suite/exec_recursive.rs
+++ b/pnpm/crates/cli/tests/suite/exec_recursive.rs
@@ -270,14 +270,12 @@ fn recursive_exec_diff_selector_selects_changed_projects() {
             String::from_utf8_lossy(&output.stderr),
         );
     };
-    git(&["init", "--initial-branch=main"]);
-    git(&["config", "user.email", "x@y.z"]);
-    git(&["config", "user.name", "xyz"]);
+    pnpm_testing_utils::git_repo::init_isolated_repo(&workspace);
     git(&["add", "."]);
-    git(&["commit", "-m", "base", "--no-gpg-sign"]);
+    git(&["commit", "-m", "base"]);
     fs::write(workspace.join("project-1").join("changed.js"), "").expect("write changed file");
     git(&["add", "."]);
-    git(&["commit", "-m", "change project-1", "--no-gpg-sign"]);
+    git(&["commit", "-m", "change project-1"]);
 
     pacquet
         .with_arg("-r")

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -329,17 +329,11 @@ fn symlinked_input_project(project: &std::path::Path, task_settings: &str) {
     )
     .unwrap();
     Command::new("git").current_dir(project).args(["add", "-A"]).assert().success();
-    let tracked = Command::new("git")
-        .current_dir(project)
-        .args(["ls-files", "--cached"])
-        .output()
-        .unwrap()
-        .stdout;
-    let tracked = String::from_utf8(tracked).unwrap();
+    let inputs = pnpm_testing_utils::git_repo::tracked_files(project);
     assert!(
-        tracked.lines().any(|path| path == "CLAUDE.md"),
-        "the link the task reads must be a tracked input, or nothing below tests what it \
-         claims to; git reported:\n{tracked}",
+        inputs.iter().any(|path| path == "CLAUDE.md"),
+        "the link the task reads must be one of the files pnpm hashes, or nothing below tests \
+         what it claims to; git reported: {inputs:?}",
     );
 }
 

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -329,7 +329,7 @@ fn symlinked_input_project(project: &std::path::Path, task_settings: &str) {
     )
     .unwrap();
     Command::new("git").current_dir(project).args(["add", "-A"]).assert().success();
-    let inputs = pnpm_testing_utils::git_repo::tracked_files(project);
+    let inputs = pnpm_testing_utils::git_repo::unignored_files(project);
     assert!(
         inputs.iter().any(|path| path == "CLAUDE.md"),
         "the link the task reads must be one of the files pnpm hashes, or nothing below tests \

--- a/pnpm/crates/cli/tests/suite/pipeline_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cache.rs
@@ -5,7 +5,7 @@ use std::{fs, process::Command};
 #[test]
 fn configured_environment_changes_invalidate_task_outputs() {
     let project = tempfile::tempdir().unwrap();
-    assert!(Command::new("git").arg("init").arg(project.path()).output().unwrap().status.success());
+    pnpm_testing_utils::git_repo::init_isolated_repo(project.path());
     fs::create_dir(project.path().join("src")).unwrap();
     fs::write(project.path().join("src/input"), "source").unwrap();
     fs::write(project.path().join(".gitignore"), "out/\nnode_modules/\nhook-count\n").unwrap();
@@ -310,7 +310,7 @@ fn projects_rooted_in_submodules_bypass_task_caching() {
 fn symlinked_input_project(project: &std::path::Path, task_settings: &str) {
     use std::os::unix::fs::symlink;
 
-    assert!(Command::new("git").arg("init").arg(project).output().unwrap().status.success());
+    pnpm_testing_utils::git_repo::init_isolated_repo(project);
     fs::write(project.join("AGENTS.md"), "shared text").unwrap();
     fs::write(project.join("NOTES.md"), "shared text").unwrap();
     symlink("AGENTS.md", project.join("CLAUDE.md")).unwrap();
@@ -329,6 +329,18 @@ fn symlinked_input_project(project: &std::path::Path, task_settings: &str) {
     )
     .unwrap();
     Command::new("git").current_dir(project).args(["add", "-A"]).assert().success();
+    let tracked = Command::new("git")
+        .current_dir(project)
+        .args(["ls-files", "--cached"])
+        .output()
+        .unwrap()
+        .stdout;
+    let tracked = String::from_utf8(tracked).unwrap();
+    assert!(
+        tracked.lines().any(|path| path == "CLAUDE.md"),
+        "the link the task reads must be a tracked input, or nothing below tests what it \
+         claims to; git reported:\n{tracked}",
+    );
 }
 
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
+++ b/pnpm/crates/cli/tests/suite/pipeline_cargo_cache.rs
@@ -49,7 +49,7 @@ fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
     let second_worktree = root.join("b");
     let cache = temp.path().join("cache");
     fs::create_dir_all(first_worktree.join("src")).unwrap();
-    git(&first_worktree, &["init"]);
+    pnpm_testing_utils::git_repo::init_isolated_repo(&first_worktree);
     fs::write(first_worktree.join(".gitignore"), "target/\nnode_modules/\n").unwrap();
     fs::write(
         first_worktree.join("Cargo.toml"),
@@ -81,20 +81,7 @@ fn cargo_state_is_shared_between_worktrees_and_survives_cache_deletion() {
     );
     pnpm(&first_worktree, &cache, &["install"]);
     git(&first_worktree, &["add", "."]);
-    git(
-        &first_worktree,
-        &[
-            "-c",
-            "user.name=Fixture",
-            "-c",
-            "user.email=fixture@example.com",
-            "-c",
-            "commit.gpgsign=false",
-            "commit",
-            "-m",
-            "fixture",
-        ],
-    );
+    git(&first_worktree, &["commit", "-m", "fixture"]);
     git(&first_worktree, &["worktree", "add", "--detach", second_worktree.to_str().unwrap()]);
 
     let first = pnpm(&first_worktree, &cache, &["pipeline", "--full"]);

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -146,7 +146,7 @@ pub fn init_isolated_repo(path: &Path) {
     override_global_config(path);
 }
 
-/// The paths every tracked and untracked-but-not-ignored file in `repo`,
+/// The paths of every tracked and untracked-but-not-ignored file in `repo`,
 /// as `git` reports them.
 ///
 /// A test that asserts on pnpm's cache keys can check its own premise

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -45,7 +45,7 @@ impl GitRepoFixture {
         git(&work, &["init", "-q", "-b", "main"]);
         git(&work, &["config", "user.email", "test@example.invalid"]);
         git(&work, &["config", "user.name", "Test"]);
-        detach_from_global_config(&work);
+        override_global_config(&work);
         git(&work, &["remote", "add", "origin", &bare.to_string_lossy()]);
 
         Self { work, bare }
@@ -128,19 +128,42 @@ impl GitRepoFixture {
     }
 }
 
-/// `git init` a repository at `path` that the contributor's own global
-/// git configuration cannot reach, for a test that needs a repo without
-/// the work tree and bare clone [`GitRepoFixture`] pairs up.
+/// `git init` a repository at `path` on branch `main`, for a test that
+/// needs a repo without the work tree and bare clone [`GitRepoFixture`]
+/// pairs up.
+///
+/// Overrides the user-global `core.excludesFile`, `core.hooksPath`, and
+/// `gpgsign` settings, so a contributor's own git configuration cannot
+/// change what the repo ignores, what it runs on commit, or whether it
+/// demands a signing key. Configuration beyond those still reaches it.
 pub fn init_isolated_repo(path: &Path) {
     fs::create_dir_all(path).expect("create git repo directory");
-    git(path, &["init", "-q"]);
+    // `-b`, so a contributor's `init.defaultBranch` cannot rename the
+    // branch out from under a test, as it does not for `GitRepoFixture`.
+    git(path, &["init", "-q", "-b", "main"]);
     git(path, &["config", "user.email", "test@example.invalid"]);
     git(path, &["config", "user.name", "Test"]);
-    detach_from_global_config(path);
+    override_global_config(path);
 }
 
-/// Override, in `repo`'s local configuration, the user-global settings
-/// that would otherwise decide what the repo does.
+/// The paths every tracked and untracked-but-not-ignored file in `repo`,
+/// as `git` reports them.
+///
+/// A test that asserts on pnpm's cache keys can check its own premise
+/// with this: pnpm derives a task's inputs from the same listing, so a
+/// fixture file missing here is a file the cache key cannot see.
+#[must_use]
+pub fn tracked_files(repo: &Path) -> Vec<String> {
+    git(repo, &["ls-files", "--cached", "--others", "--exclude-standard"])
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+/// Override, in `repo`'s local configuration, the three user-global
+/// settings that would otherwise change what a fixture repo does:
+/// `core.excludesFile`, `core.hooksPath`, and `gpgsign`. Configuration
+/// this does not name still reaches the repo.
 ///
 /// `git ls-files --exclude-standard` consults the user-global excludes
 /// file, and pnpm builds a task's cache inputs from that listing. A
@@ -149,11 +172,16 @@ pub fn init_isolated_repo(path: &Path) {
 /// asserting that editing it invalidates the task would fail on their
 /// machine alone. Local configuration also covers the `git` that pnpm
 /// itself spawns inside the repo, not just the fixture's own calls.
-fn detach_from_global_config(repo: &Path) {
-    // A path that does not exist, which git reads as an empty ignore
-    // list. `/dev/null` would not work on Windows.
-    let absent_excludes = repo.join(".git/info/absent-global-excludes");
-    git(repo, &["config", "core.excludesFile", &absent_excludes.to_string_lossy()]);
+fn override_global_config(repo: &Path) {
+    // Paths that do not exist: git reads a missing excludes file as an
+    // empty ignore list, and a missing hooks directory as no hooks.
+    // `/dev/null` would not work on Windows.
+    let absent = repo.join(".git/info/absent-global-config");
+    let absent = absent.to_string_lossy();
+    git(repo, &["config", "core.excludesFile", &absent]);
+    // A user-global `core.hooksPath` would otherwise run the
+    // contributor's own hooks — arbitrary code — on a fixture's commits.
+    git(repo, &["config", "core.hooksPath", &absent]);
     // Neutralise a user-global `gpgsign = true`, which would
     // otherwise demand a real signing key for every commit and tag.
     git(repo, &["config", "commit.gpgsign", "false"]);

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -41,11 +41,12 @@ impl GitRepoFixture {
         fs::create_dir_all(&work).expect("create git work tree");
         fs::create_dir_all(&bare).expect("create bare repo directory");
 
-        git(&bare, &["init", "-q", "--bare"]);
+        git(&bare, &["init", "-q", "--bare", "-b", "main"]);
+        override_global_config(&bare, &bare);
         git(&work, &["init", "-q", "-b", "main"]);
         git(&work, &["config", "user.email", "test@example.invalid"]);
         git(&work, &["config", "user.name", "Test"]);
-        override_global_config(&work);
+        override_global_config(&work, &work.join(".git"));
         git(&work, &["remote", "add", "origin", &bare.to_string_lossy()]);
 
         Self { work, bare }
@@ -128,9 +129,9 @@ impl GitRepoFixture {
     }
 }
 
-/// `git init` a repository at `path` on branch `main`, for a test that
-/// needs a repo without the work tree and bare clone [`GitRepoFixture`]
-/// pairs up.
+/// `git init` a repository at `path` on branch `main`, whatever the
+/// contributor's `init.defaultBranch`, for a test that needs a repo
+/// without the work tree and bare clone [`GitRepoFixture`] pairs up.
 ///
 /// Overrides the user-global `core.excludesFile`, `core.hooksPath`, and
 /// `gpgsign` settings, so a contributor's own git configuration cannot
@@ -138,32 +139,31 @@ impl GitRepoFixture {
 /// demands a signing key. Configuration beyond those still reaches it.
 pub fn init_isolated_repo(path: &Path) {
     fs::create_dir_all(path).expect("create git repo directory");
-    // `-b`, so a contributor's `init.defaultBranch` cannot rename the
-    // branch out from under a test, as it does not for `GitRepoFixture`.
     git(path, &["init", "-q", "-b", "main"]);
     git(path, &["config", "user.email", "test@example.invalid"]);
     git(path, &["config", "user.name", "Test"]);
-    override_global_config(path);
+    override_global_config(path, &path.join(".git"));
 }
 
-/// The paths of every tracked and untracked-but-not-ignored file in `repo`,
-/// as `git` reports them.
+/// The path of every file in `repo` that git does not ignore, tracked or
+/// not, as `git ls-files --cached --others --exclude-standard` lists them.
 ///
 /// A test that asserts on pnpm's cache keys can check its own premise
 /// with this: pnpm derives a task's inputs from the same listing, so a
 /// fixture file missing here is a file the cache key cannot see.
 #[must_use]
-pub fn tracked_files(repo: &Path) -> Vec<String> {
+pub fn unignored_files(repo: &Path) -> Vec<String> {
     git(repo, &["ls-files", "--cached", "--others", "--exclude-standard"])
         .lines()
         .map(str::to_string)
         .collect()
 }
 
-/// Override, in `repo`'s local configuration, the three user-global
-/// settings that would otherwise change what a fixture repo does:
-/// `core.excludesFile`, `core.hooksPath`, and `gpgsign`. Configuration
-/// this does not name still reaches the repo.
+/// Override, in the local configuration of the repo at `repo` whose git
+/// directory is `git_dir`, the three user-global settings that would
+/// otherwise change what a fixture repo does: `core.excludesFile`,
+/// `core.hooksPath`, and `gpgsign`. Configuration this does not name
+/// still reaches the repo.
 ///
 /// `git ls-files --exclude-standard` consults the user-global excludes
 /// file, and pnpm builds a task's cache inputs from that listing. A
@@ -172,11 +172,14 @@ pub fn tracked_files(repo: &Path) -> Vec<String> {
 /// asserting that editing it invalidates the task would fail on their
 /// machine alone. Local configuration also covers the `git` that pnpm
 /// itself spawns inside the repo, not just the fixture's own calls.
-fn override_global_config(repo: &Path) {
-    // Paths that do not exist: git reads a missing excludes file as an
-    // empty ignore list, and a missing hooks directory as no hooks.
+///
+/// A bare repo needs this too: `git push` runs the receiving side's
+/// `pre-receive` and `update` hooks from that repo's `core.hooksPath`.
+fn override_global_config(repo: &Path, git_dir: &Path) {
+    // A path that does not exist: git reads a missing excludes file as
+    // an empty ignore list, and a missing hooks directory as no hooks.
     // `/dev/null` would not work on Windows.
-    let absent = repo.join(".git/info/absent-global-config");
+    let absent = git_dir.join("absent-global-config");
     let absent = absent.to_string_lossy();
     git(repo, &["config", "core.excludesFile", &absent]);
     // A user-global `core.hooksPath` would otherwise run the

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -41,9 +41,9 @@ impl GitRepoFixture {
         fs::create_dir_all(&work).expect("create git work tree");
         fs::create_dir_all(&bare).expect("create bare repo directory");
 
-        git(&bare, &["init", "-q", "--bare", "-b", "main"]);
+        git(&bare, &["init", "-q", "--bare", "-b", "main", "--template="]);
         override_global_config(&bare, &bare);
-        git(&work, &["init", "-q", "-b", "main"]);
+        git(&work, &["init", "-q", "-b", "main", "--template="]);
         git(&work, &["config", "user.email", "test@example.invalid"]);
         git(&work, &["config", "user.name", "Test"]);
         override_global_config(&work, &work.join(".git"));
@@ -133,13 +133,15 @@ impl GitRepoFixture {
 /// contributor's `init.defaultBranch`, for a test that needs a repo
 /// without the work tree and bare clone [`GitRepoFixture`] pairs up.
 ///
-/// Overrides the user-global `core.excludesFile`, `core.hooksPath`, and
-/// `gpgsign` settings, so a contributor's own git configuration cannot
-/// change what the repo ignores, what it runs on commit, or whether it
-/// demands a signing key. Configuration beyond those still reaches it.
+/// Overrides the user-global `core.excludesFile`, `core.attributesFile`,
+/// `core.hooksPath`, and `gpgsign` settings and skips the user-global
+/// `init.templateDir`, so a contributor's own git configuration cannot
+/// change what the repo ignores, what it runs on staging and commit, or
+/// whether it demands a signing key. Configuration beyond those still
+/// reaches it.
 pub fn init_isolated_repo(path: &Path) {
     fs::create_dir_all(path).expect("create git repo directory");
-    git(path, &["init", "-q", "-b", "main"]);
+    git(path, &["init", "-q", "-b", "main", "--template="]);
     git(path, &["config", "user.email", "test@example.invalid"]);
     git(path, &["config", "user.name", "Test"]);
     override_global_config(path, &path.join(".git"));
@@ -160,10 +162,10 @@ pub fn unignored_files(repo: &Path) -> Vec<String> {
 }
 
 /// Override, in the local configuration of the repo at `repo` whose git
-/// directory is `git_dir`, the three user-global settings that would
-/// otherwise change what a fixture repo does: `core.excludesFile`,
-/// `core.hooksPath`, and `gpgsign`. Configuration this does not name
-/// still reaches the repo.
+/// directory is `git_dir`, the user-global settings that would otherwise
+/// change what a fixture repo does: `core.excludesFile`,
+/// `core.attributesFile`, `core.hooksPath`, and `gpgsign`. Configuration
+/// this does not name still reaches the repo.
 ///
 /// `git ls-files --exclude-standard` consults the user-global excludes
 /// file, and pnpm builds a task's cache inputs from that listing. A
@@ -175,15 +177,21 @@ pub fn unignored_files(repo: &Path) -> Vec<String> {
 ///
 /// A bare repo needs this too: `git push` runs the receiving side's
 /// `pre-receive` and `update` hooks from that repo's `core.hooksPath`.
+///
+/// The repo must have been created with `git init --template=`, since
+/// a user-global `init.templateDir` would otherwise seed `info/exclude`,
+/// which no configuration setting overrides.
 fn override_global_config(repo: &Path, git_dir: &Path) {
-    // A path that does not exist: git reads a missing excludes file as
-    // an empty ignore list, and a missing hooks directory as no hooks.
-    // `/dev/null` would not work on Windows.
+    // A path that does not exist: git reads a missing excludes or
+    // attributes file as empty, and a missing hooks directory as no
+    // hooks. `/dev/null` would not work on Windows.
     let absent = git_dir.join("absent-global-config");
     let absent = absent.to_string_lossy();
     git(repo, &["config", "core.excludesFile", &absent]);
-    // A user-global `core.hooksPath` would otherwise run the
-    // contributor's own hooks — arbitrary code — on a fixture's commits.
+    // User-global attributes can assign a `clean` filter to a fixture's
+    // files, and a user-global `core.hooksPath` its own hooks: either
+    // runs the contributor's arbitrary code on `git add` and commit.
+    git(repo, &["config", "core.attributesFile", &absent]);
     git(repo, &["config", "core.hooksPath", &absent]);
     // Neutralise a user-global `gpgsign = true`, which would
     // otherwise demand a real signing key for every commit and tag.

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -45,10 +45,7 @@ impl GitRepoFixture {
         git(&work, &["init", "-q", "-b", "main"]);
         git(&work, &["config", "user.email", "test@example.invalid"]);
         git(&work, &["config", "user.name", "Test"]);
-        // Neutralise a user-global `gpgsign = true`, which would
-        // otherwise demand a real signing key for every commit and tag.
-        git(&work, &["config", "commit.gpgsign", "false"]);
-        git(&work, &["config", "tag.gpgsign", "false"]);
+        detach_from_global_config(&work);
         git(&work, &["remote", "add", "origin", &bare.to_string_lossy()]);
 
         Self { work, bare }
@@ -129,6 +126,38 @@ impl GitRepoFixture {
     pub fn git_url_at(&self, committish: &str) -> String {
         format!("git+{}#{committish}", self.file_url())
     }
+}
+
+/// `git init` a repository at `path` that the contributor's own global
+/// git configuration cannot reach, for a test that needs a repo without
+/// the work tree and bare clone [`GitRepoFixture`] pairs up.
+pub fn init_isolated_repo(path: &Path) {
+    fs::create_dir_all(path).expect("create git repo directory");
+    git(path, &["init", "-q"]);
+    git(path, &["config", "user.email", "test@example.invalid"]);
+    git(path, &["config", "user.name", "Test"]);
+    detach_from_global_config(path);
+}
+
+/// Override, in `repo`'s local configuration, the user-global settings
+/// that would otherwise decide what the repo does.
+///
+/// `git ls-files --exclude-standard` consults the user-global excludes
+/// file, and pnpm builds a task's cache inputs from that listing. A
+/// contributor who ignores one of a fixture's file names globally would
+/// otherwise watch the file drop out of the hashed inputs, and the test
+/// asserting that editing it invalidates the task would fail on their
+/// machine alone. Local configuration also covers the `git` that pnpm
+/// itself spawns inside the repo, not just the fixture's own calls.
+fn detach_from_global_config(repo: &Path) {
+    // A path that does not exist, which git reads as an empty ignore
+    // list. `/dev/null` would not work on Windows.
+    let absent_excludes = repo.join(".git/info/absent-global-excludes");
+    git(repo, &["config", "core.excludesFile", &absent_excludes.to_string_lossy()]);
+    // Neutralise a user-global `gpgsign = true`, which would
+    // otherwise demand a real signing key for every commit and tag.
+    git(repo, &["config", "commit.gpgsign", "false"]);
+    git(repo, &["config", "tag.gpgsign", "false"]);
 }
 
 /// Run `git` with `args` in `cwd` and return its stdout.

--- a/pnpm/crates/testing-utils/src/git_repo.rs
+++ b/pnpm/crates/testing-utils/src/git_repo.rs
@@ -134,11 +134,11 @@ impl GitRepoFixture {
 /// without the work tree and bare clone [`GitRepoFixture`] pairs up.
 ///
 /// Overrides the user-global `core.excludesFile`, `core.attributesFile`,
-/// `core.hooksPath`, and `gpgsign` settings and skips the user-global
-/// `init.templateDir`, so a contributor's own git configuration cannot
-/// change what the repo ignores, what it runs on staging and commit, or
-/// whether it demands a signing key. Configuration beyond those still
-/// reaches it.
+/// `core.hooksPath`, `core.fsmonitor`, and `gpgsign` settings and skips
+/// the user-global `init.templateDir`, so a contributor's own git
+/// configuration cannot change what the repo ignores, what it runs on
+/// staging and commit, or whether it demands a signing key.
+/// Configuration beyond those still reaches it.
 pub fn init_isolated_repo(path: &Path) {
     fs::create_dir_all(path).expect("create git repo directory");
     git(path, &["init", "-q", "-b", "main", "--template="]);
@@ -164,8 +164,8 @@ pub fn unignored_files(repo: &Path) -> Vec<String> {
 /// Override, in the local configuration of the repo at `repo` whose git
 /// directory is `git_dir`, the user-global settings that would otherwise
 /// change what a fixture repo does: `core.excludesFile`,
-/// `core.attributesFile`, `core.hooksPath`, and `gpgsign`. Configuration
-/// this does not name still reaches the repo.
+/// `core.attributesFile`, `core.hooksPath`, `core.fsmonitor`, and
+/// `gpgsign`. Configuration this does not name still reaches the repo.
 ///
 /// `git ls-files --exclude-standard` consults the user-global excludes
 /// file, and pnpm builds a task's cache inputs from that listing. A
@@ -189,10 +189,13 @@ fn override_global_config(repo: &Path, git_dir: &Path) {
     let absent = absent.to_string_lossy();
     git(repo, &["config", "core.excludesFile", &absent]);
     // User-global attributes can assign a `clean` filter to a fixture's
-    // files, and a user-global `core.hooksPath` its own hooks: either
-    // runs the contributor's arbitrary code on `git add` and commit.
+    // files, a user-global `core.hooksPath` its own hooks, and a
+    // user-global `core.fsmonitor` a command git consults whenever it
+    // refreshes the index: each runs the contributor's arbitrary code on
+    // `git add` and commit.
     git(repo, &["config", "core.attributesFile", &absent]);
     git(repo, &["config", "core.hooksPath", &absent]);
+    git(repo, &["config", "core.fsmonitor", "false"]);
     // Neutralise a user-global `gpgsign = true`, which would
     // otherwise demand a real signing key for every commit and tag.
     git(repo, &["config", "commit.gpgsign", "false"]);


### PR DESCRIPTION
## Summary

`pipeline_cache::symlinked_inputs_are_hashed_as_link_targets` fails on any machine whose global git excludes file lists `CLAUDE.md`, and passes everywhere else. The fixture stages a symlink under that name and asserts that retargeting it invalidates the task, but a globally ignored name is never staged and never appears in the `git ls-files --cached --others --exclude-standard` listing pnpm hashes into a task's cache key. The link is then not an input, retargeting it changes nothing, and pnpm correctly reports the cache hit the test refuses.

The symlink hashing under test is correct, so this fixes the fixtures rather than the product. `override_global_config` sets `core.excludesFile`, `core.attributesFile`, `core.hooksPath`, `core.fsmonitor`, and `gpgsign` in a fixture repo's own local configuration, which also governs the `git` pnpm spawns inside that repo. Every fixture `git init` passes `--template=`, since a global `init.templateDir` seeds `info/exclude` and no setting overrides that file. `GitRepoFixture::init` applies it to both its work tree and its bare repo, since `git push` into the bare repo runs `pre-receive` and `update` from that repo's own `core.hooksPath`. Both inits pass `-b main`, so `init.defaultBranch` cannot rename the branch out from under a test or leave the bare `HEAD` on a branch the mirror never pushes.

`init_isolated_repo` gives the suites that call `git init` themselves the same isolation: `pipeline_cache`, `pipeline_cargo_cache`, and `exec_recursive`. The last two commit into their repos, and a global `core.hooksPath` whose `pre-commit` fails broke both.

`symlinked_input_project` now asserts the link is staged before any caching assertion runs, via a new `git_repo::unignored_files`. Without it the failure named neither git nor the ignore rule behind it, which is what made this expensive to diagnose.

Closes pnpm/pnpm#14713

The `fix(cargo)` commit is cherry-picked from pnpm/pnpm#14705. Those two imports are unused only on macOS, where the test that uses them is compiled out, so the pre-push clippy gate rejects every push from a Mac until one of the two PRs lands. It can be dropped from this branch once that one merges.

No changeset: test-only, with no change to what pnpm does.

### Verification

The affected suites were run with `GIT_CONFIG_GLOBAL` pointed at a hostile configuration: a global excludes file listing `CLAUDE.md`, a `core.hooksPath` whose `pre-commit`, `pre-receive`, `update`, and `pre-push` hooks all exit 1, an `init.templateDir` whose `info/exclude` lists `CLAUDE.md`, a `core.attributesFile` assigning `*.md` a required `clean` filter that exits 1, a `core.fsmonitor` command that exits 1, `init.defaultBranch = trunk`, and `commit.gpgsign = tag.gpgsign = true`.

- Under that configuration, `patch`, `git_hosted_install`, `pipeline_cache`, `pipeline_watch`, `cargo_install`, `pipeline_cargo_cache`, and `exec_recursive` pass (117 tests), as do the `cargo_deps::git` unit tests (18).
- Before the bare-repo override, the same configuration rejected every `GitRepoFixture` mirror with `pre-receive hook declined`; before the `init_isolated_repo` switch, `pipeline_cargo_cache` and `exec_recursive` failed on the `pre-commit` hook. A repo initialised without `--template=` inherited the template's `info/exclude` and dropped `CLAUDE.md` from the listing, and without the `core.attributesFile` override the clean filter failed `git add`. Without the `core.fsmonitor` override, `git add` ran the global fsmonitor command.
- The four cache runs in the originally failing test go miss, hit, miss, miss again with the fix, and only run 3 differed before it.
- Reverting only the `core.excludesFile` line makes the new staging assertion fire with its own message rather than the cache assertion, so the guard works.

## Squash Commit Body

```text
`pipeline_cache::symlinked_inputs_are_hashed_as_link_targets` builds a
project whose tracked input is a symlink named `CLAUDE.md`, and asserts
that retargeting the link invalidates the task. On a machine whose
`core.excludesFile` ignores that name, `git add -A` never stages the link
and the `git ls-files --cached --others --exclude-standard` pnpm runs to
collect cache inputs never lists it. The link is then not part of the
task's cache key, retargeting it changes nothing, and pnpm correctly
reports the hit the test refuses.

The symlink hashing the test covers is right, so the fixtures are what
need fixing. `override_global_config` sets `core.excludesFile`,
`core.attributesFile`, `core.hooksPath`, `core.fsmonitor`, and `gpgsign`
in a fixture repo's own local configuration. Local configuration also reaches the
`git` pnpm itself spawns inside the repo, so one setting covers the
fixture's staging and the listing under test. The placeholder path is
inside the git directory rather than `/dev/null` so it holds on Windows
too. Every fixture `git init` passes `--template=`, because a global
`init.templateDir` seeds `info/exclude` and no setting overrides that
file.

`GitRepoFixture::init` applies the overrides to its bare repo as well as
its work tree: `git push` runs `pre-receive` and `update` from the
receiving repo's own `core.hooksPath`, so a contributor's global hooks
rejected every mirror. Both inits pass `-b main`, so `init.defaultBranch`
cannot leave the bare `HEAD` on a branch the mirror never pushes.

`init_isolated_repo` gives the suites that `git init` their own repos
the same isolation without the work tree and bare clone pair
`GitRepoFixture` exists to provide. `pipeline_cargo_cache` and
`exec_recursive` commit into theirs, and a global `pre-commit` hook
failed both.

`symlinked_input_project` now checks that the link is staged before any
caching assertion runs, because the failure this produced named neither
git nor the ignore rule that caused it.

Closes pnpm/pnpm#14713
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791504852&installation_model_id=426870&pr_number=14715&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14715&signature=9e85939ccfbb3859db3ff1628ec1faa2a71e2e6f8c969a29669df4d09cc78076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Git repository test isolation so local and global Git settings do not affect results.
  * Standardized repository setup across pipeline cache and recursive execution tests.
  * Added validation that symlinked task inputs are included among unignored files.
  * Updated repository file discovery and invalid filename test setup without changing expected behavior.
  * Ensured test repositories use the `main` branch consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


