### PR TITLE
fix(workspace-manifest-writer): preserve comments in exclude-list edits

### DIFF
--- a/.changeset/exclude-list-writer-keeps-comments.md
+++ b/.changeset/exclude-list-writer-keeps-comments.md
@@ -1,0 +1,7 @@
+---
+"pacquet": patch
+---
+
+`pnpm audit --fix` and the `minimumReleaseAgeStrict` approval prompt no longer drop the comments of `minimumReleaseAgeExclude` when they append an entry to the list in `pnpm-workspace.yaml`. The rest of the list is now left as written.
+
+The `trustPolicyExcludePrune` and `minimumReleaseAgeExcludePrune` cleanups leave the comments of the entries they keep in place, too.

--- a/pnpm/crates/cli/tests/suite/catalog.rs
+++ b/pnpm/crates/cli/tests/suite/catalog.rs
@@ -631,7 +631,7 @@ fn prunes_the_trust_policy_excludes() {
              trustPolicyExclude:\n  \
              - '{FOO}@1.0.0 || 2.0.0'\n  \
              - '@pnpm.e2e/bar@100.0.0'\n  \
-             - '@pnpm.e2e/*'\n",
+             - '@pnpm.e2e/*' # forward-looking\n",
         ),
     );
 
@@ -653,6 +653,10 @@ fn prunes_the_trust_policy_excludes() {
     assert!(
         workspace_yaml.contains("@pnpm.e2e/*"),
         "a glob exclude must survive:\n{workspace_yaml}",
+    );
+    assert!(
+        workspace_yaml.contains("# forward-looking"),
+        "a surviving entry must keep its comment:\n{workspace_yaml}",
     );
 
     drop((root, anchor));

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -11,7 +11,7 @@
 //! instead, and one neither can edit is reported through [`Inline`] so the
 //! caller can refuse the write.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use indexmap::IndexMap;
 use pnpm_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
@@ -730,34 +730,42 @@ fn reconcile_sequence_items(
     if item_idxs.is_empty() || item_idxs.len() != current.len() {
         return None;
     }
-    // Each item's span reaches to the next item line, so the comment and
-    // blank lines between two entries travel with the entry above them. The
-    // last span must not eat the blank line separating the block from the
-    // next one.
+    // A span reaches back over the comment and blank lines ahead of the
+    // entry — the TypeScript writer attaches them to the entry below, so
+    // pruning the entry above must leave them be — and ends where the next
+    // span begins. The first entry's span starts at its own line, since
+    // comments between the key and the list belong to no entry, and the
+    // last span stops before the blank run separating the block from the
+    // comments or keys that follow it.
     let block_end = all
         .get(leading_comment_start(&all, key_idx + 1, block_end_idx))
         .map_or(text.len(), |line| line.start);
     let last_item_end = blank_run_start(text, block_end);
-    let spans: Vec<(usize, usize)> = item_idxs
+    let starts: Vec<usize> =
+        item_idxs
+            .iter()
+            .enumerate()
+            .map(|(position, &idx)| {
+                if position == 0 { all[idx].start } else { all[comment_run_start(&all, idx)].start }
+            })
+            .collect();
+    let spans: Vec<(usize, usize)> = starts
         .iter()
         .enumerate()
-        .map(|(position, &idx)| {
-            let end = item_idxs.get(position + 1).map_or(last_item_end, |&next| all[next].start);
-            (all[idx].start, end)
+        .map(|(position, &start)| {
+            (start, starts.get(position + 1).copied().unwrap_or(last_item_end))
         })
         .collect();
-    // First-come claim of each surviving entry's line, like the TypeScript
+    // First-come claim of each surviving entry's lines, like the TypeScript
     // writer's node reuse: duplicate values claim their lines in order.
-    let mut claimed = vec![false; current.len()];
-    let claims: Vec<Option<usize>> = items
-        .iter()
-        .map(|item| {
-            let idx = (0..current.len()).find(|&idx| !claimed[idx] && current[idx] == *item)?;
-            claimed[idx] = true;
-            Some(idx)
-        })
-        .collect();
+    let mut unclaimed: HashMap<&str, VecDeque<usize>> = HashMap::with_capacity(current.len());
+    for (idx, value) in current.iter().enumerate() {
+        unclaimed.entry(value.as_str()).or_default().push_back(idx);
+    }
+    let claims: Vec<Option<usize>> =
+        items.iter().map(|item| unclaimed.get_mut(item.as_str())?.pop_front()).collect();
     let indent = " ".repeat(item_indent);
+    let newline = if text[spans[0].0..last_item_end].contains("\r\n") { "\r\n" } else { "\n" };
     let mut body = String::new();
     for (item, claim) in items.iter().zip(claims) {
         if let Some(idx) = claim {
@@ -766,7 +774,7 @@ fn reconcile_sequence_items(
             body.push_str(&indent);
             body.push_str("- ");
             body.push_str(&render::render_value(item));
-            body.push('\n');
+            body.push_str(newline);
         }
     }
     let mut out = text.to_string();
@@ -778,6 +786,18 @@ fn reconcile_sequence_items(
 fn is_sequence_item_line(content: &str) -> bool {
     let trimmed = content.trim_start();
     trimmed == "-" || trimmed.starts_with("- ")
+}
+
+/// The first line of the run of comment and blank lines immediately ahead of
+/// the item line at `idx`: the run belongs to the entry below it, so it opens
+/// that entry's span. Only valid while a structural line sits above the run —
+/// the previous item, in the one caller.
+fn comment_run_start(all: &[Line<'_>], idx: usize) -> usize {
+    let mut start = idx;
+    while structural_indent(all[start - 1].content).is_none() {
+        start -= 1;
+    }
+    start
 }
 
 /// Render a top-level block whose value is a block sequence (`key:` then

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -583,8 +583,11 @@ pub(crate) fn set_minimum_release_age_excludes(manifest: &mut Manifest, items: &
 }
 
 /// Set `list`'s top-level block to `items` (the complete desired list),
-/// creating or replacing it, and removing it when `items` is empty. Returns
-/// whether anything changed.
+/// creating or replacing it, and removing it when `items` is empty. A
+/// block-style list whose entries are already on disk is reconciled entry by
+/// entry — an entry whose value survives keeps its lines, comments included,
+/// and only the changed entries are re-rendered. Returns whether anything
+/// changed.
 fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]) -> bool {
     let ExcludeList { key: block, decoded } = list;
 
@@ -599,7 +602,8 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
         return true;
     }
 
-    if decoded(manifest).as_deref().unwrap_or_default() == items {
+    let current: Vec<String> = decoded(manifest).as_deref().unwrap_or_default().to_vec();
+    if current == items {
         return false;
     }
 
@@ -617,6 +621,12 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
         // the public writer refuses such a manifest outright.
         Inline::Unsupported => return false,
         Inline::Block => {}
+    }
+
+    if let Some(new_text) = reconcile_sequence_items(text, block, &current, items) {
+        manifest.set_text(new_text);
+        *decoded(manifest) = Some(items.to_vec());
+        return true;
     }
 
     let rendered = render_top_level_sequence(block, items);
@@ -666,23 +676,108 @@ pub(crate) fn prune_trust_policy_excludes(
 /// Prune `list`'s entries against the versions the freshly resolved lockfile
 /// records. The per-entry decision lives in
 /// [`pnpm_config::version_policy::drop_unresolved_package_version_specs`]; the
-/// text edit is [`set_exclude_list`]'s block replace, so a pruned-to-empty
-/// list drops the block and an unchanged list is a no-op. A list that is
-/// absent or already empty is left verbatim — it has nothing to prune, and
-/// dropping the block would diverge from pnpm. Returns whether anything
-/// changed.
+/// write goes through [`set_exclude_list`]'s entry-by-entry reconciliation, so
+/// the comments of the surviving entries stay, a pruned-to-empty list drops
+/// the block, and an unchanged list is a no-op. A list that is absent or
+/// already empty is left verbatim — it has nothing to prune, and dropping the
+/// block would diverge from pnpm. Returns whether anything changed.
 fn prune_exclude_list(
     manifest: &mut Manifest,
     list: ExcludeList,
     resolved: &pnpm_config::version_policy::ResolvedPackageVersions,
 ) -> bool {
-    let current = (list.decoded)(manifest).as_deref().unwrap_or_default();
+    let current: Vec<String> = (list.decoded)(manifest).as_deref().unwrap_or_default().to_vec();
     if current.is_empty() {
         return false;
     }
     let pruned =
-        pnpm_config::version_policy::drop_unresolved_package_version_specs(current, resolved);
+        pnpm_config::version_policy::drop_unresolved_package_version_specs(&current, resolved);
     set_exclude_list(manifest, list, &pruned)
+}
+
+/// Line-level reconciliation of the block sequence `key` toward `items`,
+/// mirroring the TypeScript writer's node reuse: an entry whose value the
+/// list already holds keeps its lines verbatim — comments included — a value
+/// new to the list is rendered as a fresh line, and lines no entry claims are
+/// dropped, where a whole-block re-render would drop every comment in the
+/// block. `None` when the block is not a plain block sequence matching
+/// `current` (no items on disk, inline or multi-line flow style, or an item
+/// count the decoded list disagrees with), leaving the caller to fall back to
+/// the re-render.
+fn reconcile_sequence_items(
+    text: &str,
+    key: &str,
+    current: &[String],
+    items: &[String],
+) -> Option<String> {
+    let all = lines(text);
+    let key_idx = all.iter().position(|line| {
+        structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
+    })?;
+    let block_end_idx = (key_idx + 1..all.len())
+        .find(|&idx| structural_indent(all[idx].content) == Some(0))
+        .unwrap_or(all.len());
+    let item_indent =
+        (key_idx + 1..block_end_idx).find_map(|idx| structural_indent(all[idx].content))?;
+    let item_idxs: Vec<usize> = (key_idx + 1..block_end_idx)
+        .filter(|&idx| {
+            structural_indent(all[idx].content) == Some(item_indent)
+                && is_sequence_item_line(all[idx].content)
+        })
+        .collect();
+    // Pairing lines with decoded entries by position only holds when every
+    // entry is one `- item` line; anything else is left to the re-render.
+    if item_idxs.is_empty() || item_idxs.len() != current.len() {
+        return None;
+    }
+    // Each item's span reaches to the next item line, so the comment and
+    // blank lines between two entries travel with the entry above them. The
+    // last span must not eat the blank line separating the block from the
+    // next one.
+    let block_end = all
+        .get(leading_comment_start(&all, key_idx + 1, block_end_idx))
+        .map_or(text.len(), |line| line.start);
+    let last_item_end = blank_run_start(text, block_end);
+    let spans: Vec<(usize, usize)> = item_idxs
+        .iter()
+        .enumerate()
+        .map(|(position, &idx)| {
+            let end = item_idxs.get(position + 1).map_or(last_item_end, |&next| all[next].start);
+            (all[idx].start, end)
+        })
+        .collect();
+    // First-come claim of each surviving entry's line, like the TypeScript
+    // writer's node reuse: duplicate values claim their lines in order.
+    let mut claimed = vec![false; current.len()];
+    let claims: Vec<Option<usize>> = items
+        .iter()
+        .map(|item| {
+            let idx = (0..current.len()).find(|&idx| !claimed[idx] && current[idx] == *item)?;
+            claimed[idx] = true;
+            Some(idx)
+        })
+        .collect();
+    let indent = " ".repeat(item_indent);
+    let mut body = String::new();
+    for (item, claim) in items.iter().zip(claims) {
+        if let Some(idx) = claim {
+            body.push_str(&text[spans[idx].0..spans[idx].1]);
+        } else {
+            body.push_str(&indent);
+            body.push_str("- ");
+            body.push_str(&render::render_value(item));
+            body.push('\n');
+        }
+    }
+    let mut out = text.to_string();
+    out.replace_range(spans[0].0..last_item_end, &body);
+    Some(out)
+}
+
+/// Whether a structural line carries a block-sequence item (`- value`).
+fn is_sequence_item_line(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed == "-" || trimmed.starts_with("- ")
 }
 
 /// Render a top-level block whose value is a block sequence (`key:` then

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -11,7 +11,10 @@
 //! instead, and one neither can edit is reported through [`Inline`] so the
 //! caller can refuse the write.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    ops::Range,
+};
 
 use indexmap::IndexMap;
 use pnpm_catalogs_types::{Catalogs, DEFAULT_CATALOG_NAME};
@@ -703,16 +706,16 @@ fn prune_exclude_list(
 /// new to the list is rendered as a fresh line, and lines no entry claims are
 /// dropped, where a whole-block re-render would drop every comment in the
 /// block. `None` when the block is not a plain block sequence matching
-/// `current` (no items on disk, inline or multi-line flow style, or an item
-/// count the decoded list disagrees with), leaving the caller to fall back to
-/// the re-render.
+/// `current` (no items on disk, inline or multi-line flow style, an item
+/// count the decoded list disagrees with, or an entry whose value runs past
+/// its own line), leaving the caller to fall back to the re-render.
 fn reconcile_sequence_items(
     text: &str,
     key: &str,
     current: &[String],
     items: &[String],
 ) -> Option<String> {
-    let layout = item_layout(text, key, current.len())?;
+    let layout = item_layout(text, key, current)?;
     let body = rebuild_items(text, &layout, current, items);
     let mut out = text.to_string();
     out.replace_range(layout.spans.first()?.0..layout.spans.last()?.1, &body);
@@ -737,30 +740,20 @@ struct ItemLayout {
 }
 
 /// The [`ItemLayout`] of the top-level block sequence `key`. `None` unless
-/// the block holds exactly `count` items, each one `- item` line.
-fn item_layout(text: &str, key: &str, count: usize) -> Option<ItemLayout> {
+/// the block holds one `- item` line per entry of `current`, each carrying
+/// its whole value.
+fn item_layout(text: &str, key: &str, current: &[String]) -> Option<ItemLayout> {
     let all = lines(text);
     let key_idx = top_level_key_line(&all, key)?;
     let block_end_idx = (key_idx + 1..all.len())
         .find(|&idx| structural_indent(all[idx].content) == Some(0))
         .unwrap_or(all.len());
-    let indent =
-        (key_idx + 1..block_end_idx).find_map(|idx| structural_indent(all[idx].content))?;
-    let item_idxs: Vec<usize> = (key_idx + 1..block_end_idx)
-        .filter(|&idx| {
-            structural_indent(all[idx].content) == Some(indent)
-                && is_sequence_item_line(all[idx].content)
-        })
-        .collect();
-    // Pairing lines with decoded entries by position only holds when every
-    // entry is one `- item` line; anything else is left to the re-render.
-    if item_idxs.is_empty() || item_idxs.len() != count {
-        return None;
-    }
-    let block_end = all
-        .get(leading_comment_start(&all, key_idx + 1, block_end_idx))
-        .map_or(text.len(), |line| line.start);
-    let block_items_end = blank_run_start(text, block_end);
+    let (indent, item_idxs) = item_lines(&all, key_idx + 1..block_end_idx, current)?;
+    let block_items_end = blank_run_start(
+        text,
+        all.get(leading_comment_start(&all, key_idx + 1, block_end_idx))
+            .map_or(text.len(), |line| line.start),
+    );
     let starts: Vec<usize> =
         item_idxs
             .iter()
@@ -784,6 +777,32 @@ fn item_layout(text: &str, key: &str, count: usize) -> Option<ItemLayout> {
             "\n"
         },
     })
+}
+
+/// The indentation of `body`'s block-sequence item lines and their indices,
+/// paired one to one with `current`. `None` unless every entry of `current`
+/// is one whole `- item` line, since anything else breaks the pairing or
+/// leaves part of a value where the span logic would read comments.
+fn item_lines(
+    all: &[Line<'_>],
+    body: Range<usize>,
+    current: &[String],
+) -> Option<(usize, Vec<usize>)> {
+    let indent = body.clone().find_map(|idx| structural_indent(all[idx].content))?;
+    let item_idxs: Vec<usize> = body
+        .filter(|&idx| {
+            structural_indent(all[idx].content) == Some(indent)
+                && is_sequence_item_line(all[idx].content)
+        })
+        .collect();
+    if item_idxs.is_empty() || item_idxs.len() != current.len() {
+        return None;
+    }
+    item_idxs
+        .iter()
+        .zip(current)
+        .all(|(&idx, entry)| holds_whole_value(all[idx].content, entry))
+        .then_some((indent, item_idxs))
 }
 
 /// The item lines of `layout` rebuilt as `items`: an entry whose value
@@ -819,6 +838,22 @@ fn rebuild_items(text: &str, layout: &ItemLayout, current: &[String], items: &[S
 fn is_sequence_item_line(content: &str) -> bool {
     let trimmed = content.trim_start();
     trimmed == "-" || trimmed.starts_with("- ")
+}
+
+/// Whether the sequence-item line `content` carries the whole of `entry`.
+///
+/// A value that runs past its item line — a block scalar's body, a quoted
+/// scalar broken across lines — can hold blank and `#`-leading lines, which
+/// the span logic would take for the comments of the entry below and drop
+/// with it, silently rewriting this entry's value. A `trustPolicyExclude`
+/// entry truncated that way can widen into the bare `*` that excludes every
+/// package. Parsing the line on its own settles it: a value the line does not
+/// finish parses to something else, or not at all.
+fn holds_whole_value(content: &str, entry: &str) -> bool {
+    let Some(value) = content.trim_start().strip_prefix('-') else {
+        return false;
+    };
+    yaml_serde::from_str::<String>(value).is_ok_and(|parsed| parsed == entry)
 }
 
 /// The first line of the run of comment and blank lines immediately ahead of

--- a/pnpm/crates/workspace-manifest-writer/src/edit.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/edit.rs
@@ -602,10 +602,12 @@ fn set_exclude_list(manifest: &mut Manifest, list: ExcludeList, items: &[String]
         return true;
     }
 
-    let current: Vec<String> = decoded(manifest).as_deref().unwrap_or_default().to_vec();
-    if current == items {
+    if decoded(manifest).as_deref().unwrap_or_default() == items {
         return false;
     }
+    // `text` borrows the manifest for the rest of the write, so the
+    // reconciliation reads the current entries from a copy.
+    let current: Vec<String> = decoded(manifest).as_deref().unwrap_or_default().to_vec();
 
     let text = manifest.text();
     match locate_sequence(text, &[block]) {
@@ -686,12 +688,12 @@ fn prune_exclude_list(
     list: ExcludeList,
     resolved: &pnpm_config::version_policy::ResolvedPackageVersions,
 ) -> bool {
-    let current: Vec<String> = (list.decoded)(manifest).as_deref().unwrap_or_default().to_vec();
+    let current = (list.decoded)(manifest).as_deref().unwrap_or_default();
     if current.is_empty() {
         return false;
     }
     let pruned =
-        pnpm_config::version_policy::drop_unresolved_package_version_specs(&current, resolved);
+        pnpm_config::version_policy::drop_unresolved_package_version_specs(current, resolved);
     set_exclude_list(manifest, list, &pruned)
 }
 
@@ -710,37 +712,55 @@ fn reconcile_sequence_items(
     current: &[String],
     items: &[String],
 ) -> Option<String> {
+    let layout = item_layout(text, key, current.len())?;
+    let body = rebuild_items(text, &layout, current, items);
+    let mut out = text.to_string();
+    out.replace_range(layout.spans.first()?.0..layout.spans.last()?.1, &body);
+    Some(out)
+}
+
+/// Where a block sequence's items sit in the document, and how an item added
+/// to it has to be written to match them.
+struct ItemLayout {
+    /// One span per item, in document order. A span opens at the comment and
+    /// blank lines ahead of its item — the TypeScript writer attaches those
+    /// to the entry below, so pruning the entry above must leave them be —
+    /// and closes where the next span opens. The first span opens at its own
+    /// line, since comments between the key and the list belong to no entry,
+    /// and the last closes before the blank run that separates the block from
+    /// what follows it.
+    spans: Vec<(usize, usize)>,
+    /// Indentation of the item lines.
+    indent: usize,
+    /// The line ending the block is written with.
+    newline: &'static str,
+}
+
+/// The [`ItemLayout`] of the top-level block sequence `key`. `None` unless
+/// the block holds exactly `count` items, each one `- item` line.
+fn item_layout(text: &str, key: &str, count: usize) -> Option<ItemLayout> {
     let all = lines(text);
-    let key_idx = all.iter().position(|line| {
-        structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
-    })?;
+    let key_idx = top_level_key_line(&all, key)?;
     let block_end_idx = (key_idx + 1..all.len())
         .find(|&idx| structural_indent(all[idx].content) == Some(0))
         .unwrap_or(all.len());
-    let item_indent =
+    let indent =
         (key_idx + 1..block_end_idx).find_map(|idx| structural_indent(all[idx].content))?;
     let item_idxs: Vec<usize> = (key_idx + 1..block_end_idx)
         .filter(|&idx| {
-            structural_indent(all[idx].content) == Some(item_indent)
+            structural_indent(all[idx].content) == Some(indent)
                 && is_sequence_item_line(all[idx].content)
         })
         .collect();
     // Pairing lines with decoded entries by position only holds when every
     // entry is one `- item` line; anything else is left to the re-render.
-    if item_idxs.is_empty() || item_idxs.len() != current.len() {
+    if item_idxs.is_empty() || item_idxs.len() != count {
         return None;
     }
-    // A span reaches back over the comment and blank lines ahead of the
-    // entry — the TypeScript writer attaches them to the entry below, so
-    // pruning the entry above must leave them be — and ends where the next
-    // span begins. The first entry's span starts at its own line, since
-    // comments between the key and the list belong to no entry, and the
-    // last span stops before the blank run separating the block from the
-    // comments or keys that follow it.
     let block_end = all
         .get(leading_comment_start(&all, key_idx + 1, block_end_idx))
         .map_or(text.len(), |line| line.start);
-    let last_item_end = blank_run_start(text, block_end);
+    let block_items_end = blank_run_start(text, block_end);
     let starts: Vec<usize> =
         item_idxs
             .iter()
@@ -749,37 +769,50 @@ fn reconcile_sequence_items(
                 if position == 0 { all[idx].start } else { all[comment_run_start(&all, idx)].start }
             })
             .collect();
-    let spans: Vec<(usize, usize)> = starts
-        .iter()
-        .enumerate()
-        .map(|(position, &start)| {
-            (start, starts.get(position + 1).copied().unwrap_or(last_item_end))
-        })
-        .collect();
+    Some(ItemLayout {
+        spans: starts
+            .iter()
+            .enumerate()
+            .map(|(position, &start)| {
+                (start, starts.get(position + 1).copied().unwrap_or(block_items_end))
+            })
+            .collect(),
+        indent,
+        newline: if text[all[key_idx].start..block_items_end].contains("\r\n") {
+            "\r\n"
+        } else {
+            "\n"
+        },
+    })
+}
+
+/// The item lines of `layout` rebuilt as `items`: an entry whose value
+/// `current` already holds is copied out of `text` with the comments its span
+/// carries, and every other entry is rendered afresh.
+fn rebuild_items(text: &str, layout: &ItemLayout, current: &[String], items: &[String]) -> String {
     // First-come claim of each surviving entry's lines, like the TypeScript
     // writer's node reuse: duplicate values claim their lines in order.
     let mut unclaimed: HashMap<&str, VecDeque<usize>> = HashMap::with_capacity(current.len());
     for (idx, value) in current.iter().enumerate() {
         unclaimed.entry(value.as_str()).or_default().push_back(idx);
     }
-    let claims: Vec<Option<usize>> =
-        items.iter().map(|item| unclaimed.get_mut(item.as_str())?.pop_front()).collect();
-    let indent = " ".repeat(item_indent);
-    let newline = if text[spans[0].0..last_item_end].contains("\r\n") { "\r\n" } else { "\n" };
+    let indent = " ".repeat(layout.indent);
     let mut body = String::new();
-    for (item, claim) in items.iter().zip(claims) {
-        if let Some(idx) = claim {
-            body.push_str(&text[spans[idx].0..spans[idx].1]);
+    for item in items {
+        if let Some(idx) = unclaimed.get_mut(item.as_str()).and_then(VecDeque::pop_front) {
+            body.push_str(&text[layout.spans[idx].0..layout.spans[idx].1]);
         } else {
             body.push_str(&indent);
             body.push_str("- ");
             body.push_str(&render::render_value(item));
-            body.push_str(newline);
+        }
+        // A document that ends without a newline leaves its last span without
+        // one, which would splice the entry after it onto that same line.
+        if !body.ends_with('\n') {
+            body.push_str(layout.newline);
         }
     }
-    let mut out = text.to_string();
-    out.replace_range(spans[0].0..last_item_end, &body);
-    Some(out)
+    body
 }
 
 /// Whether a structural line carries a block-sequence item (`- value`).
@@ -1865,9 +1898,7 @@ fn collect_entries(all: &[Line<'_>], from: usize, to: usize, entry_indent: usize
 /// The starting offset of a top-level key's line.
 fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let all = lines(text);
-    let key_idx = all.iter().position(|line| {
-        structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
-    })?;
+    let key_idx = top_level_key_line(&all, key)?;
     // A flow collection written across several lines closes at column zero,
     // which would otherwise read as the next top-level key and leave the
     // closing bracket behind when the block is replaced or removed.
@@ -1879,12 +1910,14 @@ fn top_level_span(text: &str, key: &str) -> Option<TopLevelSpan> {
     let block_end = all
         .get(block_end_idx)
         .map_or_else(|| all.last().map_or(0, |line| line.end), |line| line.start);
-    all.get(key_idx)
-        .filter(|line| {
-            structural_indent(line.content) == Some(0)
-                && line_key(line.content).as_deref() == Some(key)
-        })
-        .map(|line| TopLevelSpan { key_line_start: line.start, block_end })
+    Some(TopLevelSpan { key_line_start: all[key_idx].start, block_end })
+}
+
+/// Index of the line declaring the top-level key `key`.
+fn top_level_key_line(all: &[Line<'_>], key: &str) -> Option<usize> {
+    all.iter().position(|line| {
+        structural_indent(line.content) == Some(0) && line_key(line.content).as_deref() == Some(key)
+    })
 }
 
 /// Index of the line where the flow collection written inline on
@@ -1926,10 +1959,7 @@ pub(crate) fn uses_blank_line_style(text: &str, top_level_keys: &[String]) -> bo
     let mut non_first = 0;
     let mut non_first_with_blank = 0;
     for key in &top_level_keys[1..] {
-        let Some(idx) = all.iter().position(|line| {
-            structural_indent(line.content) == Some(0)
-                && line_key(line.content).as_deref() == Some(key.as_str())
-        }) else {
+        let Some(idx) = top_level_key_line(&all, key) else {
             continue;
         };
         non_first += 1;

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1014,8 +1014,6 @@ fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewrit
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n");
 }
 
-/// A manifest whose last line has no newline gets one, so the added entry
-/// starts on its own line.
 #[test]
 fn minimum_release_age_exclude_add_ends_a_reused_last_line_that_has_no_newline() {
     let added = ["new@1.0.0".to_string()];
@@ -1944,6 +1942,17 @@ mod trust_policy_exclude_prune {
         let original = "trustPolicyExclude:\n  - foo@1.0.0\n  # reason for bar\n  - bar@2.0.0\n";
         let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
         assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0\n"));
+    }
+
+    /// A block scalar's body can hold `#`-leading lines that are its value
+    /// rather than comments, so such a block is re-rendered whole instead of
+    /// reconciled line by line, which would drop those lines with the entry
+    /// below them and widen the exclude to the bare `*`.
+    #[test]
+    fn keeps_a_block_scalar_entry_value_when_another_entry_is_pruned() {
+        let original = "trustPolicyExclude:\n  - >-\n    *\n    # note\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[])));
+        assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - '* # note'\n"));
     }
 
     #[test]

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -982,6 +982,41 @@ fn minimum_release_age_excludes_are_added_to_the_local_manifest_values() {
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - local@1.0.0 || 2.0.0\n");
 }
 
+/// An added entry must not cost the surviving entries their comments, so the
+/// merge edits item lines instead of re-rendering the block.
+#[test]
+fn minimum_release_age_exclude_add_keeps_the_existing_entries_comments() {
+    let added = ["new@1.0.0".to_string()];
+    let out = run_with(
+        Some("minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n"),
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .expect("written");
+
+    assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n  - new@1.0.0\n");
+}
+
+/// A merged rewrite replaces its own line only; the untouched entry below
+/// keeps its comment. The rewritten entry loses its comment, matching the
+/// TypeScript node-reuse behavior.
+#[test]
+fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewritten() {
+    let added = ["foo@2.0.0".to_string()];
+    let out = run_with(
+        Some("minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n  - bar@1.0.0 # pinned\n"),
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .expect("written");
+
+    assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n");
+}
+
 #[test]
 fn set_overrides_refuses_to_clobber_a_non_scalar_value() {
     let dir = TempDir::new().expect("temp dir");
@@ -1827,6 +1862,43 @@ mod trust_policy_exclude_prune {
         let original = "trustPolicyExclude: []\n";
         let out = run_trust_cleanup(Some(original), Some(&resolved(&[])));
         assert_eq!(out.as_deref(), Some(original));
+    }
+
+    /// A pruned entry must not cost the surviving entries their comments, so
+    /// the prune edits item lines instead of re-rendering the block.
+    #[test]
+    fn keeps_a_surviving_entrys_trailing_comment_when_another_entry_is_pruned() {
+        let original = "trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
+        assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n"));
+    }
+
+    /// A narrowed rewrite replaces its own line only; the untouched entry
+    /// below keeps its comment. The rewritten entry loses its comment,
+    /// matching the TypeScript node-reuse behavior.
+    #[test]
+    fn keeps_a_surviving_entrys_comment_when_a_narrowed_entry_is_rewritten() {
+        let original =
+            "trustPolicyExclude:\n  - foo@1.0.0 || 2.0.0 # both audited\n  - bar@1.0.0 # pinned\n";
+        let out = run_trust_cleanup(
+            Some(original),
+            Some(&resolved(&[("foo", &["2.0.0"]), ("bar", &["1.0.0"])])),
+        );
+        assert_eq!(
+            out.as_deref(),
+            Some("trustPolicyExclude:\n  - foo@2.0.0\n  - bar@1.0.0 # pinned\n")
+        );
+    }
+
+    #[test]
+    fn keeps_a_standalone_comment_above_the_list() {
+        let original =
+            "trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
+        assert_eq!(
+            out.as_deref(),
+            Some("trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n")
+        );
     }
 }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -982,8 +982,6 @@ fn minimum_release_age_excludes_are_added_to_the_local_manifest_values() {
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - local@1.0.0 || 2.0.0\n");
 }
 
-/// An added entry must not cost the surviving entries their comments, so the
-/// merge edits item lines instead of re-rendering the block.
 #[test]
 fn minimum_release_age_exclude_add_keeps_the_existing_entries_comments() {
     let added = ["new@1.0.0".to_string()];
@@ -999,9 +997,8 @@ fn minimum_release_age_exclude_add_keeps_the_existing_entries_comments() {
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n  - new@1.0.0\n");
 }
 
-/// A merged rewrite replaces its own line only; the untouched entry below
-/// keeps its comment. The rewritten entry loses its comment, matching the
-/// TypeScript node-reuse behavior.
+/// A rewritten entry loses its own comment, matching the TypeScript writer's
+/// node reuse.
 #[test]
 fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewritten() {
     let added = ["foo@2.0.0".to_string()];
@@ -1015,6 +1012,23 @@ fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewrit
     .expect("written");
 
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n");
+}
+
+/// A manifest whose last line has no newline gets one, so the added entry
+/// starts on its own line.
+#[test]
+fn minimum_release_age_exclude_add_ends_a_reused_last_line_that_has_no_newline() {
+    let added = ["new@1.0.0".to_string()];
+    let out = run_with(
+        Some("minimumReleaseAgeExclude:\n  - foo@1.0.0"),
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .expect("written");
+
+    assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0\n  - new@1.0.0\n");
 }
 
 #[test]
@@ -1879,8 +1893,6 @@ mod trust_policy_exclude_prune {
         assert_eq!(out.as_deref(), Some(original));
     }
 
-    /// A pruned entry must not cost the surviving entries their comments, so
-    /// the prune edits item lines instead of re-rendering the block.
     #[test]
     fn keeps_a_surviving_entry_trailing_comment_when_another_entry_is_pruned() {
         let original = "trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n  - bar@2.0.0\n";
@@ -1888,9 +1900,8 @@ mod trust_policy_exclude_prune {
         assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n"));
     }
 
-    /// A narrowed rewrite replaces its own line only; the untouched entry
-    /// below keeps its comment. The rewritten entry loses its comment,
-    /// matching the TypeScript node-reuse behavior.
+    /// A narrowed entry loses its own comment, matching the TypeScript
+    /// writer's node reuse.
     #[test]
     fn keeps_a_surviving_entry_comment_when_a_narrowed_entry_is_rewritten() {
         let original =
@@ -1928,8 +1939,6 @@ mod trust_policy_exclude_prune {
         );
     }
 
-    /// The comment travels with the entry below it, so pruning that entry
-    /// costs the comment, like the TypeScript writer.
     #[test]
     fn drops_a_comment_between_entries_with_the_entry_below_it() {
         let original = "trustPolicyExclude:\n  - foo@1.0.0\n  # reason for bar\n  - bar@2.0.0\n";
@@ -1937,7 +1946,6 @@ mod trust_policy_exclude_prune {
         assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0\n"));
     }
 
-    /// A blank line between two entries belongs to the entry below it too.
     #[test]
     fn keeps_a_blank_line_between_entries_when_the_entry_above_is_pruned() {
         let original = "trustPolicyExclude:\n  - foo@1.0.0\n\n  - bar@2.0.0\n";

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1017,8 +1017,6 @@ fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewrit
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n");
 }
 
-/// A CRLF block gets CRLF-rendered new entries, so an edit does not mix line
-/// endings within the block.
 #[test]
 fn minimum_release_age_exclude_add_matches_the_blocks_crlf_line_endings() {
     let added = ["new@1.0.0".to_string()];

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1901,7 +1901,7 @@ mod trust_policy_exclude_prune {
         );
         assert_eq!(
             out.as_deref(),
-            Some("trustPolicyExclude:\n  - foo@2.0.0\n  - bar@1.0.0 # pinned\n")
+            Some("trustPolicyExclude:\n  - foo@2.0.0\n  - bar@1.0.0 # pinned\n"),
         );
     }
 
@@ -1912,7 +1912,7 @@ mod trust_policy_exclude_prune {
         let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
         assert_eq!(
             out.as_deref(),
-            Some("trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n")
+            Some("trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n"),
         );
     }
 
@@ -1924,7 +1924,7 @@ mod trust_policy_exclude_prune {
         let out = run_trust_cleanup(Some(original), Some(&resolved(&[("bar", &["2.0.0"])])));
         assert_eq!(
             out.as_deref(),
-            Some("trustPolicyExclude:\n  # reason for bar\n  - bar@2.0.0\n")
+            Some("trustPolicyExclude:\n  # reason for bar\n  - bar@2.0.0\n"),
         );
     }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1017,6 +1017,23 @@ fn minimum_release_age_exclude_add_keeps_other_comments_when_one_entry_is_rewrit
     assert_eq!(out, "minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n");
 }
 
+/// A CRLF block gets CRLF-rendered new entries, so an edit does not mix line
+/// endings within the block.
+#[test]
+fn minimum_release_age_exclude_add_matches_the_blocks_crlf_line_endings() {
+    let added = ["new@1.0.0".to_string()];
+    let out = run_with(
+        Some("minimumReleaseAgeExclude:\r\n  - foo@1.0.0\r\n"),
+        &UpdateWorkspaceManifestOptions {
+            added_minimum_release_age_excludes: &added,
+            ..Default::default()
+        },
+    )
+    .expect("written");
+
+    assert_eq!(out, "minimumReleaseAgeExclude:\r\n  - foo@1.0.0\r\n  - new@1.0.0\r\n");
+}
+
 #[test]
 fn set_overrides_refuses_to_clobber_a_non_scalar_value() {
     let dir = TempDir::new().expect("temp dir");
@@ -1899,6 +1916,35 @@ mod trust_policy_exclude_prune {
             out.as_deref(),
             Some("trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n")
         );
+    }
+
+    /// A comment between two entries belongs to the entry below it, like the
+    /// TypeScript writer, so pruning the entry above leaves it in place.
+    #[test]
+    fn keeps_a_comment_between_entries_when_the_entry_above_is_pruned() {
+        let original = "trustPolicyExclude:\n  - foo@1.0.0\n  # reason for bar\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[("bar", &["2.0.0"])])));
+        assert_eq!(
+            out.as_deref(),
+            Some("trustPolicyExclude:\n  # reason for bar\n  - bar@2.0.0\n")
+        );
+    }
+
+    /// The comment travels with the entry below it, so pruning that entry
+    /// costs the comment, like the TypeScript writer.
+    #[test]
+    fn drops_a_comment_between_entries_with_the_entry_below_it() {
+        let original = "trustPolicyExclude:\n  - foo@1.0.0\n  # reason for bar\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
+        assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0\n"));
+    }
+
+    /// A blank line between two entries belongs to the entry below it too.
+    #[test]
+    fn keeps_a_blank_line_between_entries_when_the_entry_above_is_pruned() {
+        let original = "trustPolicyExclude:\n  - foo@1.0.0\n\n  - bar@2.0.0\n";
+        let out = run_trust_cleanup(Some(original), Some(&resolved(&[("bar", &["2.0.0"])])));
+        assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n\n  - bar@2.0.0\n"));
     }
 }
 

--- a/pnpm/crates/workspace-manifest-writer/src/tests.rs
+++ b/pnpm/crates/workspace-manifest-writer/src/tests.rs
@@ -1884,7 +1884,7 @@ mod trust_policy_exclude_prune {
     /// A pruned entry must not cost the surviving entries their comments, so
     /// the prune edits item lines instead of re-rendering the block.
     #[test]
-    fn keeps_a_surviving_entrys_trailing_comment_when_another_entry_is_pruned() {
+    fn keeps_a_surviving_entry_trailing_comment_when_another_entry_is_pruned() {
         let original = "trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n  - bar@2.0.0\n";
         let out = run_trust_cleanup(Some(original), Some(&resolved(&[("foo", &["1.0.0"])])));
         assert_eq!(out.as_deref(), Some("trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n"));
@@ -1894,7 +1894,7 @@ mod trust_policy_exclude_prune {
     /// below keeps its comment. The rewritten entry loses its comment,
     /// matching the TypeScript node-reuse behavior.
     #[test]
-    fn keeps_a_surviving_entrys_comment_when_a_narrowed_entry_is_rewritten() {
+    fn keeps_a_surviving_entry_comment_when_a_narrowed_entry_is_rewritten() {
         let original =
             "trustPolicyExclude:\n  - foo@1.0.0 || 2.0.0 # both audited\n  - bar@1.0.0 # pinned\n";
         let out = run_trust_cleanup(

--- a/pnpm11/workspace/workspace-manifest-writer/test/minimumReleaseAgeExcludePrune.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/minimumReleaseAgeExcludePrune.test.ts
@@ -204,3 +204,23 @@ test('entries added in the same write are never pruned, even when absent from th
     minimumReleaseAgeExclude: ['foo@1.0.0', 'bar@9.9.9'],
   })
 })
+
+test('entries added in the same write keep the existing comments', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n')
+  await updateWorkspaceManifest(dir, {
+    addedMinimumReleaseAgeExcludes: ['bar@1.0.0'],
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n  - bar@1.0.0\n')
+})
+
+test('entries added in the same write keep other comments when one entry is rewritten', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'minimumReleaseAgeExclude:\n  - foo@1.0.0 # audited\n  - bar@1.0.0 # pinned\n')
+  await updateWorkspaceManifest(dir, {
+    addedMinimumReleaseAgeExcludes: ['foo@2.0.0'],
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('minimumReleaseAgeExclude:\n  - foo@1.0.0 || 2.0.0\n  - bar@1.0.0 # pinned\n')
+})

--- a/pnpm11/workspace/workspace-manifest-writer/test/trustPolicyExcludePrune.test.ts
+++ b/pnpm11/workspace/workspace-manifest-writer/test/trustPolicyExcludePrune.test.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs'
 import path from 'node:path'
 
 import { expect, test } from '@jest/globals'
@@ -188,4 +189,37 @@ test('prune both exclude lists in one write when both settings are on', async ()
   expect(readYamlFileSync(filePath)).toStrictEqual({
     minimumReleaseAgeExclude: ['foo@1.0.0'],
   })
+})
+
+test('keep a surviving entry\'s trailing comment when another entry is pruned', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n  - bar@2.0.0\n')
+  await updateWorkspaceManifest(dir, {
+    resolvedPackageVersions: resolvedPackageVersions({ foo: ['1.0.0'] }),
+    trustPolicyExcludePrune: true,
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('trustPolicyExclude:\n  - foo@1.0.0 # trusted fork\n')
+})
+
+test('keep a surviving entry\'s comment when a narrowed entry is rewritten', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'trustPolicyExclude:\n  - foo@1.0.0 || 2.0.0 # both audited\n  - bar@1.0.0 # pinned\n')
+  await updateWorkspaceManifest(dir, {
+    resolvedPackageVersions: resolvedPackageVersions({ foo: ['2.0.0'], bar: ['1.0.0'] }),
+    trustPolicyExcludePrune: true,
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('trustPolicyExclude:\n  - foo@2.0.0\n  - bar@1.0.0 # pinned\n')
+})
+
+test('keep a standalone comment above the list', async () => {
+  const dir = tempDir(false)
+  const filePath = path.join(dir, WORKSPACE_MANIFEST_FILENAME)
+  fs.writeFileSync(filePath, 'trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n  - bar@2.0.0\n')
+  await updateWorkspaceManifest(dir, {
+    resolvedPackageVersions: resolvedPackageVersions({ foo: ['1.0.0'] }),
+    trustPolicyExcludePrune: true,
+  })
+  expect(fs.readFileSync(filePath, 'utf8')).toBe('trustPolicyExclude:\n  # pinned after the audit\n  - foo@1.0.0\n')
 })


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary
refs #14068
<!-- Describe what this PR changes and why, for reviewers. Link any related
issues here (Closes pnpm/pnpm#123, Fixes pnpm/pnpm#456, or Related to
pnpm/pnpm#123 for a partial fix). -->

## Squash Commit Body

<!-- This PR will be squash-merged, using the PR title as the commit subject.
Provide the body of that commit below.

This body is for developers reading the git history, so be as detailed as the
change warrants: explain the rationale, design decisions, and trade-offs. The
user-facing release note belongs in the changeset, not here. -->

```text
`pnpm audit --fix` and the `minimumReleaseAgeStrict` approval prompt no longer drop the comments of `minimumReleaseAgeExclude` when they append an entry to the list in `pnpm-workspace.yaml`. The rest of the list is now left as written.

The `trustPolicyExcludePrune` and `minimumReleaseAgeExcludePrune` cleanups leave the comments of the entries they keep in place, too.
```

## Checklist

<!-- Mark items with [x] once done. Remove items that don't apply. -->

- [ ] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [ ] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [ ] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [ ] Added or updated tests.
- [ ] Updated the documentation if needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14716"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791505088&installation_model_id=426870&pr_number=14716&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14716&signature=bd989264d436ebb7527ff4cfbf959ef5e8ed75b702c811740b33e1f28fb59dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved YAML comments when adding, updating, or pruning `minimumReleaseAgeExclude` and `trustPolicyExclude` entries.
  - Kept comments on unchanged and retained entries, including standalone comments above exclusion lists.
  - Preserved existing formatting and line-ending style for unaffected entries.

- **Tests**
  - Added coverage for comment preservation during exclusion-list updates, version changes, and cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->