### PR TITLE
fix(deps-restorer): report a build the side-effects cache answered for

### DIFF
--- a/.changeset/report-cached-build-scripts.md
+++ b/.changeset/report-cached-build-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now reports the dependencies whose build scripts it skipped because their build output was restored from the side-effects cache. Such an install printed nothing at all for those packages, which read as though they had no build scripts. The report names each package, the stages that did not run, and the `sideEffectsCache` setting [#14717](https://github.com/pnpm/pnpm/issues/14717).

--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -1,12 +1,10 @@
 use super::{
-    CheckoutPackage, GitPackage, GitSource, Manifest, VendorSourceOptions, import_package,
-    vendor_source, vendored_package,
+    GitPackage, GitSource, Manifest, VendorSourceOptions, vendor_source, vendored_package,
 };
 use pnpm_reporter::SilentReporter;
 use pnpm_store_dir::StoreDir;
 use pnpm_testing_utils::git_repo::GitRepoFixture;
 use std::{
-    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::{Arc, atomic::AtomicU8},
@@ -392,7 +390,8 @@ fn a_crate_is_found_past_a_manifest_that_shares_its_name_and_reads_no_version() 
 #[cfg(all(unix, not(target_os = "macos")))]
 #[test]
 fn a_file_whose_name_is_not_utf8_is_refused() {
-    use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
+    use super::{CheckoutPackage, import_package};
+    use std::{collections::BTreeSet, ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
     let temp_dir = tempfile::tempdir().unwrap();
     let package_dir = temp_dir.path().join("crate");

--- a/pnpm/crates/cli/tests/suite/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/suite/side_effects_cache.rs
@@ -90,6 +90,93 @@ fn assert_side_effects_materialized(hoisted: bool) {
     drop((root, mock_instance));
 }
 
+/// A cache hit skips the scripts, so it emits no `pnpm:lifecycle` output.
+/// Without a report of its own the install is indistinguishable from one
+/// whose dependencies have no build scripts, which leaves a user whose
+/// script also writes outside the package directory nothing to go on.
+///
+/// Covers <https://github.com/pnpm/pnpm/issues/14717>.
+#[test]
+fn a_cached_build_is_reported_with_its_skipped_stages() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("allowBuilds:\n  '@pnpm.e2e/pre-and-postinstall-scripts-example': true\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    // The install that actually builds reports the build through
+    // `pnpm:lifecycle` and must not claim anything was restored.
+    let first_install = pacquet.with_arg("install").assert().success();
+    let built = String::from_utf8_lossy(&first_install.get_output().stdout).into_owned();
+    assert!(
+        built.contains("pre-and-postinstall-scripts-example postinstall$"),
+        "the first install must run and report the build:\n{built}",
+    );
+    assert!(
+        !built.contains("restored from the side-effects cache"),
+        "a build that ran must not be reported as restored:\n{built}",
+    );
+
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let restored = frozen_install_stdout(&workspace);
+    assert!(
+        !restored.contains("pre-and-postinstall-scripts-example postinstall$"),
+        "the warm reinstall must hit the cache rather than rebuild:\n{restored}",
+    );
+    // Every stage the build consists of, in run order. `prepare` is a
+    // project stage, so it is not among them.
+    assert!(
+        restored.contains(
+            "@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0 (preinstall, install, postinstall)"
+        ),
+        "the report must name the package and each stage that did not run:\n{restored}",
+    );
+    // `sideEffectsCache.read`, not `sideEffectsCache`: the gate consults
+    // `Config::side_effects_cache_read`, which `sideEffectsCacheReadonly`
+    // also turns on, so a reader who set the boolean to false would still
+    // see the skip and have followed dead advice.
+    assert!(
+        restored.contains("Set sideEffectsCache.read to false"),
+        "the report must name the setting that actually gates the skip:\n{restored}",
+    );
+
+    // The advice has to work from the state the reader is in, including
+    // the one where the boolean alone would not have been enough.
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    yaml.push_str("sideEffectsCacheReadonly: true\nsideEffectsCache:\n  read: false\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let rebuilt = frozen_install_stdout(&workspace);
+    assert!(
+        rebuilt.contains("pre-and-postinstall-scripts-example postinstall$"),
+        "following the report's advice must run the scripts again:\n{rebuilt}",
+    );
+    assert!(
+        !rebuilt.contains("restored from the side-effects cache"),
+        "and must stop reporting a restore:\n{rebuilt}",
+    );
+
+    drop((root, mock_instance));
+}
+
 /// A fresh `pacquet install --frozen-lockfile` against an existing
 /// workspace. The registry config lives in the workspace's `.npmrc` /
 /// `pnpm-workspace.yaml` and the mock registry is a process-global
@@ -102,4 +189,76 @@ fn run_frozen_install(workspace: &Path) {
         .with_args(["install", "--frozen-lockfile"])
         .assert()
         .success();
+}
+
+/// The report is about the install, not about one project in it, so it
+/// has to survive an install started from a workspace member — where the
+/// lockfile directory is the workspace root and the working directory is
+/// not. The default reporter drops a project-prefixed info message whose
+/// prefix is not the working directory, so a prefixed report would go
+/// missing exactly here.
+#[test]
+fn a_cached_build_is_reported_from_a_workspace_member() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("packages:\n  - packages/*\n");
+    yaml.push_str("allowBuilds:\n  '@pnpm.e2e/pre-and-postinstall-scripts-example': true\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0", "private": true }).to_string(),
+    )
+    .expect("write the root package.json");
+    let member = workspace.join("packages/a");
+    fs::create_dir_all(&member).expect("create the member dir");
+    fs::write(
+        member.join("package.json"),
+        serde_json::json!({
+            "name": "pkg-a",
+            "version": "1.0.0",
+            "dependencies": { "@pnpm.e2e/pre-and-postinstall-scripts-example": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write the member package.json");
+
+    pacquet.with_arg("install").assert().success();
+    fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(&member)
+        .with_args(["install", "--frozen-lockfile"])
+        .output()
+        .expect("run the install from the member");
+    assert!(output.status.success(), "install must succeed: {output:?}");
+    let restored = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        restored.contains(
+            "@pnpm.e2e/pre-and-postinstall-scripts-example@1.0.0 (preinstall, install, postinstall)"
+        ),
+        "the report must survive an install started from a workspace member:\n{restored}",
+    );
+
+    drop((root, mock_instance));
+}
+
+/// [`run_frozen_install`], returning what the install printed.
+fn frozen_install_stdout(workspace: &Path) -> String {
+    let output = Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .with_args(["install", "--frozen-lockfile"])
+        .output()
+        .expect("run the install");
+    assert!(output.status.success(), "install must succeed: {output:?}");
+    String::from_utf8_lossy(&output.stdout).into_owned()
 }

--- a/pnpm/crates/deps-restorer/src/build_modules.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules.rs
@@ -32,7 +32,7 @@ use pnpm_package_manifest::{
 };
 use pnpm_patching::{ExtendedPatchInfo, PatchApplyError, apply_patch_to_dir, preview_patch};
 use pnpm_reporter::{
-    LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
+    GlobalLog, LogEvent, LogLevel, Reporter, SkippedOptionalDependencyLog, SkippedOptionalPackage,
     SkippedOptionalReason,
 };
 use pnpm_workspace_task_scheduler::{ScheduleGraphOptions, TaskCompletion, schedule_graph};
@@ -360,6 +360,34 @@ pub struct BuildModulesOutput {
     pub mutated_slots: bool,
 }
 
+/// Report the builds the side-effects cache answered for, naming the
+/// packages, the stages that did not run, and the setting that decides
+/// this.
+///
+/// Without it a cache hit is indistinguishable from a package that has no
+/// build script: pnpm prints the `<pkg> <stage>$ <script>` line and its
+/// output for a build it runs, and printed nothing at all for one it
+/// restored. The overlay carries only what the scripts wrote inside the
+/// package, so a user whose script also writes elsewhere needs to know
+/// which setting made pnpm skip it.
+///
+/// Goes out on `pnpm:global` rather than `pnpm`, which carries a project
+/// prefix: the default reporter drops a prefixed info message whose
+/// prefix is not the working directory, which would lose the report on
+/// every install run from a workspace member.
+fn report_cached_builds<Reporter: self::Reporter>(cached_builds: &BTreeSet<String>) {
+    if cached_builds.is_empty() {
+        return;
+    }
+    let list = cached_builds.iter().cloned().collect::<Vec<_>>().join(", ");
+    Reporter::emit(&LogEvent::Global(GlobalLog {
+        level: LogLevel::Info,
+        message: format!(
+            "Build scripts restored from the side-effects cache instead of being run: {list}.\nSet sideEffectsCache.read to false to run them on every install.",
+        ),
+    }));
+}
+
 impl BuildModules<'_> {
     /// Run the build, reporting the packages that needed one but did
     /// not get it — see [`BuildModulesOutput`].
@@ -521,6 +549,10 @@ impl BuildModules<'_> {
         // sorted lexicographically — matches `dedupePackageNamesFromIgnoredBuilds`.
         // `Mutex` for the same parallelism reason as `deps_state_cache` above.
         let ignored_builds: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
+        // Same collection shape, for the packages whose scripts the
+        // side-effects cache answered for. Reported rather than returned:
+        // unlike `ignored_builds`, nothing persists this to `.modules.yaml`.
+        let cached_builds: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
 
         let first_error: Mutex<Option<BuildModulesError>> = Mutex::new(None);
         let on_node_skipped: fn(&PackageKey) = |_| {};
@@ -542,6 +574,7 @@ impl BuildModules<'_> {
             dep_graph.as_ref(),
             &deps_state_cache,
             &ignored_builds,
+            &cached_builds,
             layout,
             pkg_roots_by_key,
             gather_ancestor_bin_paths,
@@ -595,6 +628,9 @@ impl BuildModules<'_> {
         // so the canonical poison-recovery pattern is safe.
         let ignored_builds =
             ignored_builds.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner);
+        report_cached_builds::<Reporter>(
+            &cached_builds.into_inner().unwrap_or_else(std::sync::PoisonError::into_inner),
+        );
         Ok(BuildModulesOutput {
             ignored_builds: ignored_builds.into_iter().collect(),
             deferred_builds: deferred_builds(requires_build_map.iter(), ignore_scripts),

--- a/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/build_one_snapshot.rs
@@ -37,6 +37,10 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
     dep_graph: Option<&HashMap<PackageKey, pnpm_graph_hasher::DepsGraphNode<PackageKey>>>,
     deps_state_cache: &Mutex<pnpm_graph_hasher::DepsStateCache<PackageKey>>,
     ignored_builds: &Mutex<BTreeSet<String>>,
+    // Packages whose build scripts the side-effects cache answered for
+    // instead of running, as `name@version (stage[, stage])`. Folded into
+    // one report by `BuildModules::run`.
+    cached_builds: &Mutex<BTreeSet<String>>,
     layout: &crate::VirtualStoreLayout,
     pkg_roots_by_key: Option<&HashMap<PackageKey, Vec<PathBuf>>>,
     gather_ancestor_bin_paths: bool,
@@ -304,6 +308,21 @@ pub(crate) fn build_one_snapshot<Reporter: self::Reporter>(
             satisfied
         };
         if satisfied_by_cache {
+            // The scripts below will not run. The overlay reproduces only
+            // what they wrote inside the package, so anything they did
+            // elsewhere does not happen on this install — which the user
+            // can act on only if the skip is reported.
+            if should_run_scripts
+                && let Some(pkg_dir) = pkg_root_for_key(layout, pkg_roots_by_key, snapshot_key)
+            {
+                let stages = pnpm_executor::dependency_lifecycle_stages(&pkg_dir);
+                if !stages.is_empty() {
+                    cached_builds
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .insert(format!("{name}@{version} ({})", stages.join(", ")));
+                }
+            }
             return Ok(());
         }
     }

--- a/pnpm/crates/deps-restorer/src/build_modules/tests.rs
+++ b/pnpm/crates/deps-restorer/src/build_modules/tests.rs
@@ -1154,6 +1154,25 @@ fn using_side_effects_cache_skips_rebuild() {
     let any_lifecycle = captured.iter().any(|e| matches!(e, LogEvent::Lifecycle(_)));
     assert!(!any_lifecycle, "side-effects cache hit must skip lifecycle scripts: {captured:#?}");
 
+    // With no `pnpm:lifecycle` event, this report is the only thing
+    // telling the user the build did not run. It has to name the package,
+    // the stage that was skipped, and the setting that decided it.
+    let reports: Vec<&str> = captured
+        .iter()
+        .filter_map(|event| match event {
+            LogEvent::Global(log) => Some(log.message.as_str()),
+            _ => None,
+        })
+        .collect();
+    dbg!(&reports);
+    assert!(
+        reports.iter().any(|message| {
+            message.contains("@pnpm.e2e/failing-postinstall@1.0.0 (postinstall)")
+                && message.contains("sideEffectsCache")
+        }),
+        "a cache hit must be reported with the package, its skipped stage, and the setting: {reports:#?}",
+    );
+
     // The script was skipped, but the cached build output still has to
     // be materialized — the overlay's side-effect file must land in the
     // slot so the warm reinstall isn't left in its pre-build state.

--- a/pnpm/crates/executor/src/lib.rs
+++ b/pnpm/crates/executor/src/lib.rs
@@ -14,8 +14,8 @@ pub use extend_path::{ScriptsPrependNodePath, extend_path};
 pub use job_control::{JobGuard, arm_process_tree_cleanup};
 pub use lifecycle::{
     DEV_PREINSTALL_ALREADY_RAN_ENV, DEV_PREINSTALL_STAGE, LifecycleScriptError,
-    PROJECT_LIFECYCLE_STAGES, RunPostinstallHooks, StreamedScript, push_script_arg,
-    run_dev_preinstall_hook, run_lifecycle_hook, run_postinstall_hooks,
+    PROJECT_LIFECYCLE_STAGES, RunPostinstallHooks, StreamedScript, dependency_lifecycle_stages,
+    push_script_arg, run_dev_preinstall_hook, run_lifecycle_hook, run_postinstall_hooks,
     run_project_lifecycle_scripts,
 };
 pub use make_env::{EnvBuild, EnvOptions, VERIFY_DEPS_BEFORE_RUN_ENV, build_env};

--- a/pnpm/crates/executor/src/lifecycle.rs
+++ b/pnpm/crates/executor/src/lifecycle.rs
@@ -195,6 +195,27 @@ pub fn run_dev_preinstall_hook<Reporter: self::Reporter>(
     run_lifecycle_stages::<Reporter>(opts, &[DEV_PREINSTALL_STAGE])
 }
 
+/// The lifecycle stages [`run_postinstall_hooks`] would run for the
+/// dependency at `pkg_root`, in execution order.
+///
+/// Answers which stages a build consists of without running it, so a
+/// caller that reports on a build it did not run names the stages that
+/// build would have run. Shares its stage selection with the run path, so
+/// the two cannot disagree about which stages a package has.
+///
+/// A missing or unreadable manifest yields no stages, matching
+/// [`run_postinstall_hooks`], which has nothing to run in that case.
+#[must_use]
+pub fn dependency_lifecycle_stages(pkg_root: &Path) -> Vec<&'static str> {
+    let Ok(Some(manifest)) = safe_read_package_json_from_dir(pkg_root) else {
+        return Vec::new();
+    };
+    selected_lifecycle_scripts(&manifest, pkg_root, &DEPENDENCY_LIFECYCLE_STAGES)
+        .into_iter()
+        .map(|(stage, _script)| stage)
+        .collect()
+}
+
 /// Read the manifest at `opts.pkg_root` and run each of `stages` whose
 /// script is present, in order. Shared by [`run_postinstall_hooks`],
 /// [`run_project_lifecycle_scripts`], and [`run_dev_preinstall_hook`].
@@ -218,9 +239,10 @@ fn run_lifecycle_stages<Reporter: self::Reporter>(
         }
     };
 
-    let scripts = manifest.get("scripts").and_then(|v| v.as_object());
-    let get_script =
-        |name: &str| -> Option<&str> { scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str()) };
+    let selected = selected_lifecycle_scripts(&manifest, opts.pkg_root, stages);
+    if selected.is_empty() {
+        return Ok(false);
+    }
 
     // Snapshot the process env once for this package. Every stage reads
     // from this snapshot, which keeps the runs observably consistent
@@ -228,28 +250,44 @@ fn run_lifecycle_stages<Reporter: self::Reporter>(
     // thread-shared global.
     let parent_env: HashMap<String, String> = env::vars().collect();
 
-    let mut ran_any = false;
-
-    for &stage in stages {
-        let script = if stage == "install" {
-            get_script("install").map(String::from).or_else(|| {
-                (get_script("preinstall").is_none() && opts.pkg_root.join("binding.gyp").exists())
-                    .then(|| "node-gyp rebuild".to_string())
-            })
-        } else {
-            get_script(stage).map(String::from)
-        };
-
-        let Some(script) = script else { continue };
-        if script == "npx only-allow pnpm" {
-            continue;
-        }
-
-        run_lifecycle_hook::<Reporter>(stage, &script, opts, &manifest, &parent_env)?;
-        ran_any = true;
+    for (stage, script) in &selected {
+        run_lifecycle_hook::<Reporter>(stage, script, opts, &manifest, &parent_env)?;
     }
 
-    Ok(ran_any)
+    Ok(true)
+}
+
+/// The stages of `stages` that `manifest` defines a script for, in the
+/// order given, each paired with the script pnpm would run for it.
+///
+/// Single-sources the stage-selection rules, which are not a plain
+/// lookup: `install` falls back to `node-gyp rebuild` when neither
+/// `install` nor `preinstall` is defined and a `binding.gyp` sits in
+/// `pkg_root`, and the `npx only-allow pnpm` guard is dropped because it
+/// does nothing under pnpm.
+fn selected_lifecycle_scripts<'stage>(
+    manifest: &Value,
+    pkg_root: &Path,
+    stages: &[&'stage str],
+) -> Vec<(&'stage str, String)> {
+    let scripts = manifest.get("scripts").and_then(|v| v.as_object());
+    let get_script =
+        |name: &str| -> Option<&str> { scripts.and_then(|s| s.get(name)).and_then(|v| v.as_str()) };
+
+    stages
+        .iter()
+        .filter_map(|&stage| {
+            let script = if stage == "install" {
+                get_script("install").map(String::from).or_else(|| {
+                    (get_script("preinstall").is_none() && pkg_root.join("binding.gyp").exists())
+                        .then(|| "node-gyp rebuild".to_string())
+                })
+            } else {
+                get_script(stage).map(String::from)
+            }?;
+            (script != "npx only-allow pnpm").then_some((stage, script))
+        })
+        .collect()
 }
 
 /// Run a single lifecycle hook and emit `pnpm:lifecycle` events.

--- a/pnpm/crates/executor/src/lifecycle/tests.rs
+++ b/pnpm/crates/executor/src/lifecycle/tests.rs
@@ -1,6 +1,6 @@
 use super::{
     LifecycleScriptError, RunPostinstallHooks, STREAMED_OUTPUT_CHUNK_BYTES, StreamedScript,
-    run_postinstall_hooks,
+    dependency_lifecycle_stages, run_postinstall_hooks,
 };
 use crate::extend_path::ScriptsPrependNodePath;
 use pnpm_package_manifest::PackageManifestError;
@@ -599,4 +599,52 @@ fn shell_emulator_lifecycle_emits_stdio_and_a_failing_exit() {
         stdio.iter().any(|(s, l)| **s == LifecycleStdio::Stderr && *l == "BAD"),
         "stderr 'BAD' must be emitted: {stdio:?}",
     );
+}
+
+/// The stage list a caller reports on a skipped build with has to be the
+/// one [`run_postinstall_hooks`] would have run, including the rules that
+/// are not a plain lookup in `scripts`.
+#[test]
+fn dependency_lifecycle_stages_names_the_stages_that_would_run() {
+    let dir = tempdir().expect("create temp dir");
+    fs::write(
+        dir.path().join("package.json"),
+        br#"{"name":"pkg","version":"1.0.0","scripts":{"postinstall":"node -e 0","preinstall":"node -e 0","build":"node -e 0"}}"#,
+    )
+    .expect("write manifest");
+
+    // Run order, not manifest order, and `build` is not an install stage.
+    assert_eq!(dependency_lifecycle_stages(dir.path()), vec!["preinstall", "postinstall"]);
+}
+
+#[test]
+fn dependency_lifecycle_stages_reports_the_node_gyp_fallback_as_install() {
+    let dir = tempdir().expect("create temp dir");
+    fs::write(dir.path().join("package.json"), br#"{"name":"pkg","version":"1.0.0"}"#)
+        .expect("write manifest");
+    fs::write(dir.path().join("binding.gyp"), b"{}").expect("write binding.gyp");
+
+    // A package with no `scripts` at all still builds via `node-gyp
+    // rebuild`, which pnpm runs as the `install` stage.
+    assert_eq!(dependency_lifecycle_stages(dir.path()), vec!["install"]);
+}
+
+#[test]
+fn dependency_lifecycle_stages_omits_the_only_allow_guard() {
+    let dir = tempdir().expect("create temp dir");
+    fs::write(
+        dir.path().join("package.json"),
+        br#"{"name":"pkg","version":"1.0.0","scripts":{"preinstall":"npx only-allow pnpm"}}"#,
+    )
+    .expect("write manifest");
+
+    // pnpm never runs this guard, so a report must not claim it was
+    // skipped because of the cache.
+    assert!(dependency_lifecycle_stages(dir.path()).is_empty());
+}
+
+#[test]
+fn dependency_lifecycle_stages_is_empty_without_a_manifest() {
+    let dir = tempdir().expect("create temp dir");
+    assert!(dependency_lifecycle_stages(dir.path()).is_empty());
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`sideEffectsCache` is on by default and a cache hit skips a dependency's build scripts, restoring the recorded build output instead of running them. The skip emitted no `pnpm:lifecycle` events and nothing else, so the install printed nothing at all for that package and read exactly like one whose dependencies have no build scripts. Closes pnpm/pnpm#14717.

Before:

```
Progress: resolved 1, reused 1, downloaded 0, added 1, done

dependencies:
+ simple-git-hooks 2.11.1

Done in 134ms using pnpm v12.4.0
```

After:

```
Build scripts restored from the side-effects cache instead of being run: simple-git-hooks@2.11.1 (postinstall).
Set sideEffectsCache.read to false to run them on every install.
```

## Why this needs a report at all

The cache records only what the scripts wrote inside the package. A script that also writes elsewhere does not take effect on such an install: `simple-git-hooks` and `husky` write to `.git/hooks`, and a script seeding a shared download cache writes outside its own directory by definition.

The cache key does not include the consuming project, so this is not limited to reinstalls. A project's very first install can hit an entry seeded by an unrelated project on the same machine, which is how the issue's reproduction ends up with a checkout that has no git hook installed.

Skipping is documented behavior rather than a defect: the [`sideEffectsCache` docs](https://pnpm.io/settings/build#sideeffectscache) give the default as `true` and say to disable it when "the install scripts modify files *outside* the package directory (pnpm cannot track or cache these changes)." So this PR makes the skip visible and names the setting instead of changing when pnpm skips. The issue was filed before I found that documentation, and its framing is corrected in a comment there.

## Notes for reviewers

- **Wording follows the informational-message precedent, not the error-help one.** Bare camelCase, no quoting, matching `minimum_release_age.rs:132` (`(set minimumReleaseAgeStrict to true to gate these updates with a prompt)`) and `:25` (`or set minimumReleaseAgeStrict: false.`). miette `help(...)` strings backtick their settings instead (`self_update.rs:92`, `install.rs:792`), and pnpm 11 double-quotes them (`set "confirmModulesPurge" to "false"`); neither is this message's class. The two-line `<what happened>: <list>.\n<instruction>` shape matches the sibling ignored-builds report.
- **Emitted from `BuildModules::run`, not returned.** Unlike `ignored_builds`, nothing persists this to `.modules.yaml`, and `run` is the single funnel the resolving and frozen install paths share. Emitting there covers both without threading a sink through `MaterializationOutput`.
- **`pnpm:global`, not `pnpm`.** The `pnpm` channel carries a project prefix, and the default reporter drops a prefixed info message whose prefix is not the working directory. The prefix here is the lockfile directory, so a prefixed report went missing on every install started from a workspace member. I hit that while writing this and `a_cached_build_is_reported_from_a_workspace_member` pins it. `pnpm:global` has no prefix and always renders; `apply_materialization` and `lockfile_freshness` already use it for install-level messages.
- **The report reuses an existing channel deliberately.** No new `pnpm:` channel means `@pnpm/cli.default-reporter` routes it into its "other" stream unchanged and no NDJSON consumer meets a channel it does not know. The trade-off is that the entries are prose rather than structured. Happy to promote it to its own channel with `{ package, stages }` entries if you would rather have it machine-readable.
- **The stage names are not derived independently.** `dependency_lifecycle_stages` shares `selected_lifecycle_scripts` with the run path. The selection is not a plain lookup in `scripts`: `install` falls back to `node-gyp rebuild` for a package with a `binding.gyp` and no `install`/`preinstall` script, and the `npx only-allow pnpm` guard is dropped. A second copy of those rules could name a stage pnpm would not have run, or miss one it would.
- The first commit is unrelated and is the same one carried by pnpm/pnpm#14705: `cargo clippy -D warnings` fails on macOS on current `main` because three imports in `cargo_deps/git/tests.rs` are used only by a test that `#[cfg]` compiles out there. It passes on Linux, so CI is green and the pre-push hook is not. It will drop out of this PR once that one lands.

## Validation

- Reproduced the issue against released pnpm 12.4.0, then confirmed the report appears on the same two-project reproduction.
- Confirmed the report is silent where it should be: `--side-effects-cache=false`, `pnpm rebuild` (which bypasses the gate), and any install that actually runs the build.
- Confirmed it fires on the resolving path, the frozen path, and from inside a workspace member.
- Verified a three-stage package lists every stage in run order, `(preinstall, install, postinstall)`, and that `prepare` is excluded because it is a project stage.
- New tests: 4 unit tests for `dependency_lifecycle_stages` covering run order, the `node-gyp` fallback, the `only-allow` guard, and a missing manifest; an assertion added to `using_side_effects_cache_skips_rebuild`, which is where the absence of `pnpm:lifecycle` events is already pinned; and two e2e tests, `a_cached_build_is_reported_with_its_skipped_stages` and `a_cached_build_is_reported_from_a_workspace_member`.
- Each new test was run against a reverted implementation and fails there. The workspace-member test was checked specifically against the prefixed emit it exists to catch.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` is clean; `cargo fmt` and `taplo format` applied. `just ready` was not runnable in this environment (`just` and `typos` are not installed), so those steps are left to CI.
- Suites run green: `pnpm-executor` and `pnpm-deps-restorer` in full (548 tests), and the `side_effects_cache`, `lifecycle_scripts`, `global_virtual_store`, `local_tarball_dependency`, and `global` modules of `pnpm-cli`.

Two failures I saw locally are not from this change:

- `pipeline_cache::symlinked_inputs_are_hashed_as_link_targets` fails on `main` too. The first pipeline run reports `.#build: restored from cache` against a fresh cache directory while the task visibly executes. It is the workspace task cache, a subsystem this PR does not touch, and this PR's report does not appear in its output.
- `pnpr server::tests::compiler_cache::cargo::cargo_reuses_ci_compilation_with_fresh_checkout_and_backfills_disk` fails with `could not stop test sccache server: No such file or directory` because `sccache` is not installed here. Correctly non-tolerant per the testing policy.

`global::global_add_creates_a_missing_global_bin_dir` and `lockfile_resolution_reuse::an_unused_patch_is_recorded_without_resolution_and_a_used_one_is_not` each failed once under full-workspace parallel load and pass in isolation and on repeated module runs. The former installs a fixture with no `scripts` at all, so this PR's code path cannot execute for it.

## Squash Commit Body

```text
`sideEffectsCache` is on by default and a cache hit skips the package's
build scripts, restoring the recorded build output instead of running
them. The skip emitted no `pnpm:lifecycle` events and nothing else, so
the install printed nothing at all for that package and read exactly
like one whose dependencies have no build scripts. Nothing named the
setting that decided it either, so a user had no thread to pull.

That matters because the cache records only what the scripts wrote
inside the package. A script that also writes elsewhere -- a git-hook
installer, one seeding a shared download cache -- does not take effect
on such an install, and the cache key does not include the consuming
project, so a project's very first install can hit an entry seeded by an
unrelated one. Skipping is documented behavior: the `sideEffectsCache`
docs say to disable the setting when install scripts modify files
outside the package directory, which pnpm cannot track or cache. So this
reports the skip rather than changing when it happens.

The advice names `sideEffectsCache.read`, not `sideEffectsCache`. The
gate consults `Config::side_effects_cache_read`, which is also true when
`sideEffectsCacheReadonly` is set, so a reader with that setting who
turned the boolean off would still see the skip and would have followed
dead advice. `read: false` short-circuits the whole precedence chain.
It does not cover a configured `remoteSideEffectsCache`, which the gate
ORs in independently of the read setting.

`BuildModules::run` now folds the hits into one report naming each
package, the stages that did not run, and `sideEffectsCache`. It emits
from `run` rather than returning the list because, unlike
`ignored_builds`, nothing persists this to `.modules.yaml`; `run` is the
single funnel the resolving and frozen install paths share, so both
report without threading a sink through `MaterializationOutput`.

The report goes out on `pnpm:global`, not `pnpm`. The latter carries a
project prefix, and the default reporter drops a prefixed info message
whose prefix is not the working directory -- which is every install run
from a workspace member, since the prefix there is the lockfile
directory. `pnpm:global` has no prefix and always renders.

The stage names come from `dependency_lifecycle_stages`, which shares
`selected_lifecycle_scripts` with the run path. The selection is not a
plain lookup in `scripts` -- `install` falls back to `node-gyp rebuild`
for a package with a `binding.gyp` and no `install`/`preinstall` script,
and the `npx only-allow pnpm` guard is dropped -- so a report derived
from its own copy of those rules could name a stage pnpm would not have
run, or miss one it would.

An explicit `pnpm rebuild` bypasses the gate, so it reports nothing.

Closes pnpm/pnpm#14717
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpm 11 does not skip build
  scripts on its mainline install path, so there is nothing to report there.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).
