### PR TITLE
fix(binary-fetcher): unpack zip archives into a random directory

### DIFF
--- a/.changeset/wild-poems-tickle.md
+++ b/.changeset/wild-poems-tickle.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-pnpm now unpacks a downloaded runtime archive into a randomly named directory inside the store. Extraction used to reuse a fixed path, so on a store shared by several users another user could plant a symlink there and redirect a write outside the store.
+pnpm now unpacks a downloaded runtime archive into a randomly named directory inside the store. It previously used a predictable path, where another user of a shared store could plant a symlink and redirect the write outside the store ([GHSA-vwc7-r8mq-g2x9](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9)).

--- a/.changeset/wild-poems-tickle.md
+++ b/.changeset/wild-poems-tickle.md
@@ -1,0 +1,6 @@
+---
+"@pnpm/fetching.binary-fetcher": patch
+"pnpm": patch
+---
+
+pnpm now unpacks a downloaded runtime archive into a randomly named directory inside the store. Extraction used to reuse a fixed path, so on a store shared by several users another user could plant a symlink there and redirect a write outside the store.

--- a/__patches__/adm-zip@0.6.0.patch
+++ b/__patches__/adm-zip@0.6.0.patch
@@ -1,0 +1,79 @@
+diff --git a/util/errors.js b/util/errors.js
+index ad594ed6289e44f1cf8b058ff09834ee4f64ed5a..e1ab082d0aa320a8ec4e0f8191bea99fa514c665 100644
+--- a/util/errors.js
++++ b/util/errors.js
+@@ -30,6 +30,7 @@ const errors = {
+     /* ADM-ZIP error messages */
+     CANT_EXTRACT_FILE: "Could not extract the file",
+     CANT_OVERRIDE: "Target file already exists",
++    SYMLINK_ESCAPE: 'Refusing to extract "{0}": a symbolic link redirects it outside the extraction directory',
+     DISK_ENTRY_TOO_LARGE: "Number of disk entries is too large",
+     NO_ZIP: "No zip file was loaded",
+     NO_ENTRY: "Entry doesn't exist",
+diff --git a/util/utils.js b/util/utils.js
+index 8b8efaed31d64a4aa456d4b0905fac2599805ffe..84980cb4e7505f3ee485f85a2e33642569f2b255 100644
+--- a/util/utils.js
++++ b/util/utils.js
+@@ -337,6 +337,49 @@ Utils.findLast = function (arr, callback) {
+     return void 0;
+ };
+ 
++// Resolve the deepest already-existing ancestor of `target`, following symlinks, and
++// re-append the part that does not exist yet. Extraction creates directories as it
++// goes, so the destination is usually only partly present when this runs.
++const realpathOfNearestExisting = function (/*string*/ target) {
++    let current = target;
++    for (;;) {
++        try {
++            return pth.join(fsystem.realpathSync(current), pth.relative(current, target));
++        } catch (err) {
++            if (err.code !== "ENOENT" && err.code !== "ENOTDIR") throw err;
++            const parent = pth.dirname(current);
++            if (parent === current) return target;
++            current = parent;
++        }
++    }
++};
++
++// Comparing only the string form of an entry name against the extraction root (see
++// Utils.sanitize) does not stop a symbolic link already present in the destination from
++// redirecting the write, because writeFileTo opens with fs.openSync(path, "w"), which
++// resolves symlinks (GHSA-vwc7-r8mq-g2x9). Re-check containment against the resolved
++// path, which catches a link at any component of the destination.
++const assertNoSymlinkEscape = function (/*string*/ prefix, /*string*/ path) {
++    const realRoot = realpathOfNearestExisting(prefix);
++    // The final component is resolved separately from its parents: it is the one
++    // writeFileTo opens, and a link there points at the file to be overwritten rather
++    // than at a directory that would move `real` out of the root on its own.
++    const real = pth.join(realpathOfNearestExisting(pth.dirname(path)), pth.basename(path));
++    let linkStat = null;
++    try {
++        linkStat = fsystem.lstatSync(real);
++    } catch (err) {
++        if (err.code !== "ENOENT" && err.code !== "ENOTDIR") throw err;
++    }
++    if (linkStat !== null && linkStat.isSymbolicLink()) {
++        throw Errors.SYMLINK_ESCAPE(path);
++    }
++    if (real !== realRoot && !real.startsWith(realRoot + pth.sep)) {
++        throw Errors.SYMLINK_ESCAPE(path);
++    }
++    return path;
++};
++
+ // make absolute paths taking prefix as root folder
+ Utils.sanitize = function (/*string*/ prefix, /*string*/ name) {
+     prefix = pth.resolve(pth.normalize(prefix));
+@@ -344,10 +387,10 @@ Utils.sanitize = function (/*string*/ prefix, /*string*/ name) {
+     for (var i = 0, l = parts.length; i < l; i++) {
+         var path = pth.normalize(pth.join(prefix, parts.slice(i, l).join(pth.sep)));
+         if (path === prefix || path.startsWith(prefix + pth.sep)) {
+-            return path;
++            return assertNoSymlinkEscape(prefix, path);
+         }
+     }
+-    return pth.normalize(pth.join(prefix, pth.basename(name)));
++    return assertNoSymlinkEscape(prefix, pth.normalize(pth.join(prefix, pth.basename(name))));
+ };
+ 
+ // converts buffer, Uint8Array, string types to buffer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -941,6 +941,7 @@ packageExtensionsChecksum: sha256-dCLe+IoExfAcR32yX7G/Rkg9Pl+KZvrZU0shhI7/1sE=
 pnpmfileChecksum: sha256-C2XY6+pe0kqyHiBBFj5dX5DnhJzLAwdcic3kR7l3o5w=
 
 patchedDependencies:
+  adm-zip@0.6.0: 9cdeae3cec436dee9971705a4a173c06cc2ff0d3f3f6f829e8fe71c44e6278fb
   graceful-fs@4.2.11: 68ebc232025360cb3dcd3081f4067f4e9fc022ab6b6f71a3230e86c7a5b337d1
   normalize-registry-url@2.0.1: e80227ac379f28c9f982c0588f5dfbcd517912bdd3a5c77a75e944c328fd8932
 
@@ -4588,7 +4589,7 @@ importers:
         version: link:../../worker
       adm-zip:
         specifier: 'catalog:'
-        version: 0.6.0
+        version: 0.6.0(patch_hash=9cdeae3cec436dee9971705a4a173c06cc2ff0d3f3f6f829e8fe71c44e6278fb)
       is-subdir:
         specifier: 'catalog:'
         version: 2.0.0
@@ -19112,7 +19113,7 @@ snapshots:
       '@pnpm/fetcher-base': 1001.2.2
       '@pnpm/fetching-types': 1000.2.1
       '@pnpm/worker': 1000.6.11(@pnpm/logger@1001.0.1)(@types/node@22.19.19)
-      adm-zip: 0.6.0
+      adm-zip: 0.6.0(patch_hash=9cdeae3cec436dee9971705a4a173c06cc2ff0d3f3f6f829e8fe71c44e6278fb)
       is-subdir: 1.2.0
       rename-overwrite: 6.0.6
       ssri: 10.0.5
@@ -20646,7 +20647,7 @@ snapshots:
 
   acorn@8.18.0: {}
 
-  adm-zip@0.6.0: {}
+  adm-zip@0.6.0(patch_hash=9cdeae3cec436dee9971705a4a173c06cc2ff0d3f3f6f829e8fe71c44e6278fb): {}
 
   agent-base@7.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -109,6 +109,11 @@ auditConfig:
     - GHSA-ffrw-9mx8-89p8
     - GHSA-mh29-5h37-fv8m
     - GHSA-w5hq-g745-h8pq
+    # GHSA-vwc7-r8mq-g2x9: adm-zip follows pre-existing destination symlinks during
+    # extraction. No patched adm-zip release exists. @pnpm/fetching.binary-fetcher
+    # extracts into a freshly created randomly named directory, so there is no
+    # predictable path at which a symlink can be planted.
+    - GHSA-vwc7-r8mq-g2x9
     # GHSA-h67p-54hq-rp68: js-yaml quadratic-complexity DoS in merge key handling.
     # Patched only in >=4.1.2 with no v3 fix; @yarnpkg/parsers requires the js-yaml 3
     # API (yaml.safeLoad), so its transitive js-yaml cannot be upgraded.

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -531,6 +531,7 @@ packageExtensions:
       unified: '*'
 
 patchedDependencies:
+  adm-zip@0.6.0: __patches__/adm-zip@0.6.0.patch
   graceful-fs@4.2.11: __patches__/graceful-fs@4.2.11.patch
   normalize-registry-url@2.0.1: __patches__/normalize-registry-url@2.0.1.patch
 

--- a/pnpm11/fetching/binary-fetcher/src/index.ts
+++ b/pnpm11/fetching/binary-fetcher/src/index.ts
@@ -209,13 +209,34 @@ async function extractZipToTarget (
   ignoreEntry?: RegExp
 ): Promise<void> {
   const zip = new AdmZip(zipPath)
-  const nodeDir = basename === '' ? targetDir : path.dirname(targetDir)
+  // AdmZip opens every destination with `fs.openSync(path, 'w')`, which resolves symlinks
+  // (GHSA-vwc7-r8mq-g2x9, unpatched). Extracting into a freshly created random directory
+  // instead of `targetDir`'s parent leaves no predictable path at which another user
+  // sharing the store could plant a symlink and redirect a write out of the store.
+  const extractionRoot = basename === ''
+    ? targetDir
+    : await fsPromises.mkdtemp(path.join(path.dirname(targetDir), '_unzip_'))
 
-  // Validate basename/prefix doesn't escape the target directory
-  if (basename !== '') {
-    validatePathSecurity(nodeDir, basename)
+  try {
+    if (basename !== '') {
+      validatePathSecurity(extractionRoot, basename)
+    }
+    extractEntries(zip, { extractionRoot, basename, ignoreEntry })
+    await renameOverwrite(path.join(extractionRoot, basename), targetDir)
+  } finally {
+    if (extractionRoot !== targetDir) {
+      await fsPromises.rm(extractionRoot, { recursive: true, force: true })
+    }
   }
+}
 
+interface ExtractEntriesOptions {
+  extractionRoot: string
+  basename: string
+  ignoreEntry?: RegExp
+}
+
+function extractEntries (zip: AdmZip, { extractionRoot, basename, ignoreEntry }: ExtractEntriesOptions): void {
   const basenamePrefix = basename === '' ? '' : `${basename}/`
   // Normalize `ignoreEntry` to a stateless regex. `.test()` on a `/g` or `/y` regex
   // advances `lastIndex` between calls, which would cause inconsistent skips across
@@ -232,18 +253,15 @@ async function extractZipToTarget (
   for (const entry of zip.getEntries()) {
     if (entry.isDirectory) continue
     const entryPath = entry.entryName
-    validatePathSecurity(nodeDir, entryPath)
+    validatePathSecurity(extractionRoot, entryPath)
     if (testEntry) {
       const relative = basenamePrefix && entryPath.startsWith(basenamePrefix)
         ? entryPath.slice(basenamePrefix.length)
         : entryPath
       if (testEntry(relative)) continue
     }
-    zip.extractEntryTo(entry, nodeDir, true, true)
+    zip.extractEntryTo(entry, extractionRoot, true, true)
   }
-
-  const extractedDir = path.join(nodeDir, basename)
-  await renameOverwrite(extractedDir, targetDir)
 }
 
 function toStatelessTester (regex: RegExp | undefined): ((input: string) => boolean) | undefined {

--- a/pnpm11/fetching/binary-fetcher/src/index.ts
+++ b/pnpm11/fetching/binary-fetcher/src/index.ts
@@ -209,10 +209,9 @@ async function extractZipToTarget (
   ignoreEntry?: RegExp
 ): Promise<void> {
   const zip = new AdmZip(zipPath)
-  // AdmZip opens every destination with `fs.openSync(path, 'w')`, which resolves symlinks
-  // (GHSA-vwc7-r8mq-g2x9, unpatched). Extracting into a freshly created random directory
-  // instead of `targetDir`'s parent leaves no predictable path at which another user
-  // sharing the store could plant a symlink and redirect a write out of the store.
+  // The extraction directory must not be guessable: AdmZip opens each destination with
+  // `fs.openSync(path, 'w')`, which resolves symlinks (GHSA-vwc7-r8mq-g2x9, unpatched),
+  // so a symlink planted at a known path redirects the write out of the store.
   const extractionRoot = basename === ''
     ? targetDir
     : await fsPromises.mkdtemp(path.join(path.dirname(targetDir), '_unzip_'))

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -458,36 +458,44 @@ describe('extractZipToTarget security', () => {
   })
 })
 
+// A symlink to a file cannot be a junction, and creating one on Windows needs
+// Developer Mode or elevation.
+const itOnNonWindows = process.platform === 'win32' ? it.skip : it
+
 describe('adm-zip patch (__patches__/adm-zip@0.6.0.patch)', () => {
   // The patch makes Utils.sanitize re-check containment against the resolved path.
-  // Without it adm-zip writes through the link and these assertions clobber the target.
-  it.each([
-    ['a symlinked parent directory', (root: string, outside: string) => {
-      fs.mkdirSync(path.join(root, 'node-v1'), { recursive: true })
-      fs.symlinkSync(outside, path.join(root, 'node-v1', 'bin'), 'junction')
-    }],
-    ['a symlinked destination file', (root: string, outside: string) => {
-      fs.mkdirSync(path.join(root, 'node-v1', 'bin'), { recursive: true })
-      fs.symlinkSync(path.join(outside, 'node'), path.join(root, 'node-v1', 'bin', 'node'))
-    }],
-  ])('refuses to extract through %s', (_name, plantSymlink) => {
+  // Without it adm-zip follows the link and clobbers the file outside the root.
+  function extractOverSymlink (plantSymlink: (paths: { root: string, outside: string }) => void): string {
     const dir = temporaryDirectory()
     const outside = path.join(dir, 'outside')
     fs.mkdirSync(outside)
     fs.writeFileSync(path.join(outside, 'node'), 'original')
     const root = path.join(dir, 'root')
     fs.mkdirSync(root)
-    plantSymlink(root, outside)
+    plantSymlink({ root, outside })
 
     const zip = new AdmZip()
     zip.addFile('node-v1/bin/node', Buffer.from('overwritten'))
-
     expect(() => {
       for (const entry of zip.getEntries()) {
         if (!entry.isDirectory) zip.extractEntryTo(entry, root, true, true)
       }
     }).toThrow(/symbolic link/)
-    expect(fs.readFileSync(path.join(outside, 'node'), 'utf8')).toBe('original')
+    return fs.readFileSync(path.join(outside, 'node'), 'utf8')
+  }
+
+  it('refuses to extract through a symlinked parent directory', () => {
+    expect(extractOverSymlink(({ root, outside }) => {
+      fs.mkdirSync(path.join(root, 'node-v1'), { recursive: true })
+      fs.symlinkSync(outside, path.join(root, 'node-v1', 'bin'), 'junction')
+    })).toBe('original')
+  })
+
+  itOnNonWindows('refuses to extract through a symlinked destination file', () => {
+    expect(extractOverSymlink(({ root, outside }) => {
+      fs.mkdirSync(path.join(root, 'node-v1', 'bin'), { recursive: true })
+      fs.symlinkSync(path.join(outside, 'node'), path.join(root, 'node-v1', 'bin', 'node'))
+    })).toBe('original')
   })
 })
 

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -169,6 +169,65 @@ describe('extractZipToTarget security', () => {
     })
   })
 
+  describe('destination symlink following', () => {
+    it('does not write through a symlink planted next to the target directory', async () => {
+      // AdmZip resolves symlinks when it opens a destination (GHSA-vwc7-r8mq-g2x9), so
+      // extraction must not happen at a path an attacker sharing the store can predict.
+      const parentDir = temporaryDirectory()
+      const targetDir = path.join(parentDir, 'target')
+      fs.mkdirSync(targetDir)
+      const outsideDir = path.join(parentDir, 'outside')
+      fs.mkdirSync(outsideDir)
+      fs.writeFileSync(path.join(outsideDir, 'node'), 'original')
+      fs.mkdirSync(path.join(parentDir, 'node-v20.0.0'))
+      // 'junction' keeps this working on Windows, where symlinking needs privileges.
+      fs.symlinkSync(outsideDir, path.join(parentDir, 'node-v20.0.0', 'bin'), 'junction')
+
+      const zip = new AdmZip()
+      zip.addFile('node-v20.0.0/bin/node', Buffer.from('overwritten'))
+      const zipBuffer = zip.toBuffer()
+      const integrity = ssri.fromData(zipBuffer).toString()
+
+      await downloadAndUnpackZip(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockFetch(zipBuffer) as any,
+        {
+          url: 'https://example.com/node.zip',
+          integrity,
+          basename: 'node-v20.0.0',
+        },
+        targetDir
+      )
+
+      expect(fs.readFileSync(path.join(outsideDir, 'node'), 'utf8')).toBe('original')
+      expect(fs.readFileSync(path.join(targetDir, 'bin', 'node'), 'utf8')).toBe('overwritten')
+    })
+
+    it('leaves no extraction directory behind in the store', async () => {
+      const parentDir = temporaryDirectory()
+      const targetDir = path.join(parentDir, 'target')
+      fs.mkdirSync(targetDir)
+
+      const zip = new AdmZip()
+      zip.addFile('node-v20.0.0/bin/node', Buffer.from('binary'))
+      const zipBuffer = zip.toBuffer()
+      const integrity = ssri.fromData(zipBuffer).toString()
+
+      await downloadAndUnpackZip(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        createMockFetch(zipBuffer) as any,
+        {
+          url: 'https://example.com/node.zip',
+          integrity,
+          basename: 'node-v20.0.0',
+        },
+        targetDir
+      )
+
+      expect(fs.readdirSync(parentDir)).toStrictEqual(['target'])
+    })
+  })
+
   describe('legitimate ZIP extraction', () => {
     it('should successfully extract a normal ZIP file', async () => {
       const targetDir = temporaryDirectory()

--- a/pnpm11/fetching/binary-fetcher/test/index.ts
+++ b/pnpm11/fetching/binary-fetcher/test/index.ts
@@ -203,6 +203,33 @@ describe('extractZipToTarget security', () => {
       expect(fs.readFileSync(path.join(targetDir, 'bin', 'node'), 'utf8')).toBe('overwritten')
     })
 
+    it('leaves no extraction directory behind when extraction fails', async () => {
+      const parentDir = temporaryDirectory()
+      const targetDir = path.join(parentDir, 'target')
+      fs.mkdirSync(targetDir)
+
+      const zip = new AdmZip()
+      zip.addFile('node-v20.0.0/bin/node', Buffer.from('binary'))
+      const zipBuffer = zip.toBuffer()
+      const integrity = ssri.fromData(zipBuffer).toString()
+
+      await expect(
+        downloadAndUnpackZip(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          createMockFetch(zipBuffer) as any,
+          {
+            url: 'https://example.com/node.zip',
+            integrity,
+            // Rejected by validatePathSecurity after the extraction directory exists.
+            basename: '../evil',
+          },
+          targetDir
+        )
+      ).rejects.toMatchObject({ code: 'ERR_PNPM_PATH_TRAVERSAL' })
+
+      expect(fs.readdirSync(parentDir)).toStrictEqual(['target'])
+    })
+
     it('leaves no extraction directory behind in the store', async () => {
       const parentDir = temporaryDirectory()
       const targetDir = path.join(parentDir, 'target')
@@ -428,6 +455,39 @@ describe('extractZipToTarget security', () => {
       expect(fs.existsSync(path.join(targetDir, 'corepack'))).toBe(false)
     })
 
+  })
+})
+
+describe('adm-zip patch (__patches__/adm-zip@0.6.0.patch)', () => {
+  // The patch makes Utils.sanitize re-check containment against the resolved path.
+  // Without it adm-zip writes through the link and these assertions clobber the target.
+  it.each([
+    ['a symlinked parent directory', (root: string, outside: string) => {
+      fs.mkdirSync(path.join(root, 'node-v1'), { recursive: true })
+      fs.symlinkSync(outside, path.join(root, 'node-v1', 'bin'), 'junction')
+    }],
+    ['a symlinked destination file', (root: string, outside: string) => {
+      fs.mkdirSync(path.join(root, 'node-v1', 'bin'), { recursive: true })
+      fs.symlinkSync(path.join(outside, 'node'), path.join(root, 'node-v1', 'bin', 'node'))
+    }],
+  ])('refuses to extract through %s', (_name, plantSymlink) => {
+    const dir = temporaryDirectory()
+    const outside = path.join(dir, 'outside')
+    fs.mkdirSync(outside)
+    fs.writeFileSync(path.join(outside, 'node'), 'original')
+    const root = path.join(dir, 'root')
+    fs.mkdirSync(root)
+    plantSymlink(root, outside)
+
+    const zip = new AdmZip()
+    zip.addFile('node-v1/bin/node', Buffer.from('overwritten'))
+
+    expect(() => {
+      for (const entry of zip.getEntries()) {
+        if (!entry.isDirectory) zip.extractEntryTo(entry, root, true, true)
+      }
+    }).toThrow(/symbolic link/)
+    expect(fs.readFileSync(path.join(outside, 'node'), 'utf8')).toBe('original')
   })
 })
 


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

`pnpm audit` reports [GHSA-vwc7-r8mq-g2x9](https://github.com/advisories/GHSA-vwc7-r8mq-g2x9) against adm-zip, which `@pnpm/fetching.binary-fetcher` uses to unpack runtime archives. There is no patched adm-zip release, so this fixes the exposure on our side.

adm-zip's `Utils.writeFileTo` opens each destination with `fs.openSync(path, "w")`, which resolves symlinks, while `Utils.sanitize` only compares the entry name as a string against the extraction root. A symlink that already exists at a destination therefore redirects the write anywhere the process can write.

`extractZipToTarget` extracted prefixed archives into `path.dirname(targetDir)`, which is the store's shared `tmp` directory, so every entry landed at the fixed path `<store>/tmp/<prefix>/...`. On a store shared by several users, another user could pre-create a symlink there and have pnpm overwrite an arbitrary file. It now extracts into a directory created with `mkdtemp` next to `targetDir`, leaving no predictable destination to plant a link at.

Two things this is not, for the record:

- A malicious archive cannot exploit it on its own. adm-zip 0.6.0 has no symlink handling at all, so it never creates the link from an entry, and we verify `ssri` integrity before extracting.
- pnpm v12 is unaffected. `pnpm/crates/tarball/src/zip_archive.rs` writes every zip entry straight into the CAS under its content hash and never reconstructs a tree at a predictable path.

## The adm-zip patch

Randomizing the directory stops a symlink from being planted in advance, but it does not re-validate anything during extraction. `__patches__/adm-zip@0.6.0.patch` adds that second layer: `Utils.sanitize` now re-checks containment against the *resolved* path rather than the entry string, which catches a symlink at any component of the destination, and rejects a link at the final component that `writeFileTo` would open.

`sanitize` is the right seam — it is the single point all three affected APIs (`extractAllTo`, `extractAllToAsync`, `extractEntryTo`) funnel through, and the only one that knows the extraction root. Both sides are resolved before comparison, so a store reached through a symlink such as macOS `/tmp` still works.

The patch also covers the second, older `@pnpm/fetching.binary-fetcher@1005.0.4` that `@pnpm/meta-updater` pulls into this repo.

A sub-entry TOCTOU window remains and is not closable portably: the race-free primitive is `O_NOFOLLOW`, which Node only exposes where the platform defines it (`#ifdef O_NOFOLLOW` in `node_constants.cc`), and MSVC does not. Windows is where the Node.js runtime arrives as a zip, and Node exposes no `openat`.

The advisory is added to `auditConfig.ignoreGhsas` since no upgrade exists to take. `pnpm audit` matches name and version from the lockfile and has no notion of a patch, so this entry is needed either way.

## Squash Commit Body

```text
AdmZip's Utils.writeFileTo opens each destination with fs.openSync(path,
"w"), which resolves symlinks, and Utils.sanitize only compares the entry
name as a string against the extraction root (GHSA-vwc7-r8mq-g2x9). A
symlink that already exists at a destination therefore redirects the write
anywhere the process can write. No patched adm-zip release exists.

extractZipToTarget extracted prefixed archives into path.dirname(targetDir),
which is the store's shared tmp directory, so every entry landed at the
fixed path <store>/tmp/<prefix>/... Node.js on Windows and Bun on every
platform set a prefix; Deno does not and already extracted into the random
directory from cafs.tempDir(). On a store shared by several users, another
user could pre-create a symlink at that fixed path and have pnpm overwrite
an arbitrary file. pnpm's own validatePathSecurity does not help: it checks
the entry string, which is exactly the check the advisory calls
insufficient.

Extract into a directory created with mkdtemp next to targetDir instead,
on the same filesystem so the rename stays cheap, and remove it afterwards.
That leaves no predictable destination to plant a link at, independent of
what adm-zip does.

The advisory is added to auditConfig.ignoreGhsas since no upgrade exists.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (v12 is not affected; it writes
  zip entries directly into the CAS.)
- [x] Added a changeset (`pnpm change`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests. (Both symlink variants and both cleanup paths were
  sabotage-checked: each fails with its own fix removed.)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UKJG4moqqVYzpNpJWpc9Z1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved security when unpacking downloaded runtime archives into shared stores.
  - Extraction now uses a unique temporary location, preventing planted symlinks from redirecting files outside the intended store.
  - Added protections against symlink-based path escapes during archive extraction.
  - Temporary extraction directories are cleaned up after successful or failed installation attempts.
  - Added safeguards to prevent files outside the intended extraction area from being modified.
  - Improved cleanup and failure handling when archive extraction is interrupted or rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->