### PR TITLE
test(install): cover overrides above workspace root

### DIFF
--- a/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_only/local_overrides.rs
@@ -13,19 +13,35 @@ use std::fs;
 
 #[test]
 fn frozen_replay_installs_local_overrides_at_different_importer_depths() {
+    assert_frozen_replay_installs_local_overrides(".");
+}
+
+#[test]
+fn frozen_replay_installs_local_overrides_above_the_workspace_root() {
+    assert_frozen_replay_installs_local_overrides("..");
+}
+
+fn assert_frozen_replay_installs_local_overrides(target_dir: &str) {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     write_project_manifest(&workspace, "root", ManifestDeps::default());
-    write_project_manifest(&workspace.join("linked"), "linked", ManifestDeps::default());
-    fs::write(workspace.join("vendored.tgz"), minimal_tarball("vendored", "1.0.0"))
-        .expect("write local tarball");
+    write_project_manifest(
+        &workspace.join(target_dir).join("linked"),
+        "linked",
+        ManifestDeps::default(),
+    );
+    fs::write(
+        workspace.join(target_dir).join("vendored.tgz"),
+        minimal_tarball("vendored", "1.0.0"),
+    )
+    .expect("write local tarball");
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
-        "packages: ['packages/*', 'packages/nested/*']\n\
+        format!("packages: ['packages/*', 'packages/nested/*']\n\
          storeDir: ../pacquet-store\n\
          cacheDir: ../pacquet-cache\n\
          enableGlobalVirtualStore: false\n\
          offline: true\n\
-         overrides:\n  vendored: file:./vendored.tgz\n  linked: link:./linked\n",
+         overrides:\n  vendored: file:{target_dir}/vendored.tgz\n  linked: link:{target_dir}/linked\n"),
     )
     .expect("write workspace settings");
     for (project, name) in [("packages/a", "a"), ("packages/nested/b", "b")] {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14710.

The reported bug is that `pnpm install --frozen-lockfile` fails with
`ERR_PNPM_OUTDATED_LOCKFILE` when a workspace `overrides` entry points at a
relative `file:` path that leaves the workspace root
(`my-lib: file:../tarballs/my-lib-1.0.0.tgz`). The lockfile records the
specifier relative to the importer, while the freshness check compared it
against the override anchored somewhere else, so two spellings of the same
path failed a string comparison.

The runtime fix for that anchoring already landed in pnpm/pnpm#14572, which
anchors the `VersionsOverrider` at the lockfile directory. This PR adds the
missing regression coverage for the above-the-root case the issue reports, so
the reported reproduction is pinned by a test.

`frozen_replay_installs_local_overrides_at_different_importer_depths` is
parameterized over the directory that holds the override targets, and a second
case runs it with `..` so the `file:` and `link:` targets sit outside the
workspace root, as in the issue.

Verified the test earns its place: reverting the pnpm/pnpm#14572 anchoring
(`VersionsOverrider::new(parsed, lockfile_dir)` back to the project directory)
makes both cases fail with `ERR_PNPM_OUTDATED_LOCKFILE`, reporting
`lockfile: file:../../vendored.tgz, manifest: file:vendored.tgz`. With the fix
in place both pass.

No changeset: this is test-only, and the user-visible fix already shipped with
its own changeset in pnpm/pnpm#14572.

## Squash Commit Body

```text
Extend frozen-install regression coverage for external local overrides at two
importer depths. The runtime fix already landed in pnpm/pnpm#14572. Restoring
the old freshness-check anchoring makes the new test fail with
ERR_PNPM_OUTDATED_LOCKFILE.

Closes pnpm/pnpm#14710.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added or updated tests.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ4BbWi6JUTSEqgThyBSQk

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791549312&installation_model_id=426870&pr_number=14734&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14734&signature=171384ff9a88ca86815ec3612dcfabab2cb50bad0033f86db8b9067c6b76ec27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded frozen-replay coverage for local overrides.
  * Added validation for overrides referencing paths above the workspace root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->