### PR TITLE
fix(executor): wait for an interrupted script before exiting

### DIFF
--- a/.changeset/wait-for-interrupted-scripts.md
+++ b/.changeset/wait-for-interrupted-scripts.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+pnpm now passes Ctrl+C on to the script or command it started and waits for it to shut down. pnpm used to exit first, so a script that was still writing landed on the shell prompt [#14723](https://github.com/pnpm/pnpm/issues/14723).

--- a/pnpm/crates/cli/src/cli_args/dlx.rs
+++ b/pnpm/crates/cli/src/cli_args/dlx.rs
@@ -578,11 +578,7 @@ fn run_bin(
         .and_then(|mut child| child.wait())
         .map_err(|source| DlxError::Spawn { command: program.command().to_string(), source })?;
     if !status.success() {
-        #[expect(
-            clippy::exit,
-            reason = "dlx propagates the spawned command's exit status, like pnpm"
-        )]
-        std::process::exit(status.code().unwrap_or(1));
+        pnpm_executor::exit_like(pnpm_executor::ScriptExit::Process(status));
     }
     Ok(())
 }

--- a/pnpm/crates/cli/src/cli_args/exec.rs
+++ b/pnpm/crates/cli/src/cli_args/exec.rs
@@ -6,7 +6,8 @@ use derive_more::{Display, Error};
 use miette::Diagnostic;
 use pnpm_config::Config;
 use pnpm_executor::{
-    ProcessTracker, ScriptOutput, StreamedScript, push_script_arg, select_shell, spawn_child,
+    ProcessTracker, ScriptExit, ScriptOutput, StreamedScript, exit_like, push_script_arg,
+    select_shell, spawn_child,
 };
 use pnpm_package_manager::{
     make_node_package_map_option, make_node_require_option, package_map_path_for_execution,
@@ -120,9 +121,9 @@ impl ExecArgs {
     /// Execute the subcommand in `dirs.run`, against the project at
     /// `dirs.project`.
     ///
-    /// On a non-zero child exit code this terminates the process with the
-    /// same code via [`std::process::exit`], matching pnpm's exec, which
-    /// returns `{ exitCode }` and lets the CLI exit with it.
+    /// A command that did not succeed ends pnpm the same way, matching
+    /// pnpm's exec, which returns `{ exitCode }` and lets the CLI exit
+    /// with it.
     pub fn run(
         self,
         dirs: ExecDirs<'_>,
@@ -134,9 +135,7 @@ impl ExecArgs {
         let status =
             spawn_in_dir(&command, dirs, config, self.shell_mode, ScriptOutput::Inherit, None)?;
         if !status.success() {
-            // Propagate the child's exit code. A signal-terminated child
-            // has no code; fall back to 1, matching pnpm's `exitCode ?? 1`.
-            std::process::exit(status.code().unwrap_or(1));
+            exit_like(ScriptExit::Process(status));
         }
         Ok(())
     }

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -8,7 +8,8 @@ use indexmap::IndexMap;
 use miette::{Diagnostic, IntoDiagnostic};
 use pnpm_config::Config;
 use pnpm_executor::{
-    ProcessTracker, RunScript, ScriptExit, ScriptOutput, ScriptsPrependNodePath, run_script,
+    ProcessTracker, RunScript, ScriptExit, ScriptOutput, ScriptsPrependNodePath, exit_like,
+    run_script,
 };
 use pnpm_injected_deps_syncer::{SyncInjectedDeps, sync_injected_deps};
 use pnpm_package_manager::{
@@ -428,7 +429,7 @@ fn run_one_script(
     }
     match run_stages(ctx, name, &main, args) {
         Ok(status) if status.success() => TaskCompletion::Passed,
-        Ok(status) => outcome.fail(status.code().unwrap_or(1)),
+        Ok(status) => outcome.fail(status),
         Err(error) => outcome.abort(error),
     }
 }
@@ -510,29 +511,29 @@ fn script_concurrency(
 /// the command exits with; a failure also cancels the scripts still
 /// running beside it.
 struct ScriptOutcome<'a> {
-    failure: Mutex<Option<i32>>,
+    failure: Mutex<Option<ScriptExit>>,
     abort: Mutex<Option<miette::Report>>,
     process_tracker: Option<&'a ProcessTracker>,
 }
 
 impl ScriptOutcome<'_> {
     /// The command's own result: an error that stopped a script, or the
-    /// exit code of the first script that failed.
+    /// end of the first script that failed.
     fn into_result(self) -> miette::Result<()> {
         if let Some(error) = self.abort.into_inner().expect("run abort lock is not poisoned") {
             return Err(error);
         }
-        if let Some(code) = self.failure.into_inner().expect("run failure lock is not poisoned") {
+        if let Some(exit) = self.failure.into_inner().expect("run failure lock is not poisoned") {
             // `run_stage` already emitted the `[ELIFECYCLE]` line.
-            std::process::exit(code);
+            exit_like(exit);
         }
         Ok(())
     }
 
-    fn fail(&self, code: i32) -> TaskCompletion {
+    fn fail(&self, exit: ScriptExit) -> TaskCompletion {
         let mut failure = self.failure.lock().expect("run failure lock is not poisoned");
         if failure.is_none() {
-            *failure = Some(code);
+            *failure = Some(exit);
         }
         self.cancel_siblings();
         TaskCompletion::Failed

--- a/pnpm/crates/cli/tests/suite/interrupt.rs
+++ b/pnpm/crates/cli/tests/suite/interrupt.rs
@@ -1,0 +1,290 @@
+#![cfg(unix)]
+
+use command_extra::CommandExtra;
+use pnpm_testing_utils::bin::CommandTempCwd;
+use serde_json::json;
+use std::{
+    fs,
+    os::unix::process::{CommandExt, ExitStatusExt},
+    path::Path,
+    process::{Child, Command, ExitStatus, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
+};
+
+/// How long a script is given to shut down before the test gives up. Well
+/// past the second the fixtures take, and short enough to report a stuck
+/// relay as a failure rather than as a suite-wide timeout.
+const SHUTDOWN_DEADLINE: Duration = Duration::from_mins(1);
+
+/// A script that shuts down on `SIGINT` the way a dev server does: not
+/// instantly, and writing as it goes.
+const GRACEFUL_SCRIPT: &str = r"const fs = require('node:fs')
+process.on('SIGINT', () => {
+  setTimeout(() => {
+    fs.writeFileSync('shut-down.txt', '')
+    process.exit(0)
+  }, 1000)
+})
+fs.writeFileSync('started.txt', '')
+setInterval(() => {}, 1000)
+";
+
+/// A `pre` script that shuts down on the first interrupt and lets the
+/// main script run after it.
+const PRE_SCRIPT: &str = r"const fs = require('node:fs')
+process.on('SIGINT', () => {
+  setTimeout(() => {
+    fs.writeFileSync('pre-shut-down.txt', '')
+    process.exit(0)
+  }, 200)
+})
+fs.writeFileSync('pre-started.txt', '')
+setInterval(() => {}, 1000)
+";
+
+/// A script that ignores every signal pnpm relays, so only pnpm's own
+/// escalation can end the run. It gives up on its own well after the
+/// test, so a failure cannot leave it running for the rest of the suite.
+const STUBBORN_SCRIPT: &str = r"const fs = require('node:fs')
+process.on('SIGINT', () => {})
+process.on('SIGTERM', () => {})
+setTimeout(() => process.exit(0), 30_000)
+fs.writeFileSync('started.txt', '')
+";
+
+/// A script that turns the interrupt into a different signal, so which
+/// one pnpm ends with says whether pnpm read its own signal or the
+/// script's outcome.
+const RESIGNALLING_SCRIPT: &str = r"const fs = require('node:fs')
+process.on('SIGINT', () => {
+  process.kill(process.pid, 'SIGUSR2')
+})
+fs.writeFileSync('started.txt', '')
+setInterval(() => {}, 1000)
+";
+
+/// An interrupted script keeps the terminal until it has shut down: pnpm
+/// stays alive for it, so the shell only gets its prompt back once the
+/// script has stopped writing
+/// ([pnpm/pnpm#14723](https://github.com/pnpm/pnpm/issues/14723)).
+#[test]
+fn run_waits_for_the_interrupted_script_to_shut_down() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project(&workspace, "test", GRACEFUL_SCRIPT);
+
+    let mut process = interruptible(pacquet.with_args(["run", "dev"]));
+    wait_for_file(&workspace.join("started.txt"), &mut process);
+    interrupt(&process);
+    let status = wait_for_shutdown(&mut process);
+
+    assert!(
+        workspace.join("shut-down.txt").exists(),
+        "the script must have finished shutting down before pnpm exited",
+    );
+    assert_eq!(status.code(), Some(0), "the script exited 0, so pnpm does too");
+
+    drop(root);
+}
+
+/// A script killed by a signal leaves pnpm no exit code to report, so
+/// pnpm re-raises the signal that killed it and the shell sees an
+/// interrupted command rather than a plain failure.
+#[test]
+fn run_ends_with_the_signal_that_killed_the_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project(&workspace, "test", RESIGNALLING_SCRIPT);
+
+    let mut process = interruptible(pacquet.with_args(["run", "dev"]));
+    wait_for_file(&workspace.join("started.txt"), &mut process);
+    interrupt(&process);
+    let status = wait_for_shutdown(&mut process);
+
+    assert_eq!(status.signal(), Some(libc::SIGUSR2), "pnpm should end the way the script did");
+
+    drop(root);
+}
+
+/// A recursive run gives each project's script a process group of its
+/// own, which the terminal's signals never reach. pnpm addresses those
+/// groups, so every project shuts down instead of being left behind.
+#[test]
+fn a_parallel_run_relays_the_interrupt_to_every_project() {
+    const PROJECTS: [&str; 2] = ["project-1", "project-2"];
+
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_workspace(&workspace, &PROJECTS, GRACEFUL_SCRIPT);
+
+    let mut process = interruptible(pacquet.with_args([
+        "-r",
+        "--filter=./project-*",
+        "--parallel",
+        "run",
+        "dev",
+    ]));
+    for project in PROJECTS {
+        wait_for_file(&workspace.join(project).join("started.txt"), &mut process);
+    }
+    interrupt(&process);
+    wait_for_shutdown(&mut process);
+
+    for project in PROJECTS {
+        assert!(
+            workspace.join(project).join("shut-down.txt").exists(),
+            "{project} should have finished shutting down before pnpm exited",
+        );
+    }
+
+    drop(root);
+}
+
+/// A script cannot trap the terminal by ignoring what pnpm relays: the
+/// third interrupt stops the waiting, and pnpm then ends the way the
+/// signal would have ended it all along.
+#[test]
+fn a_third_interrupt_ends_pnpm_even_when_the_script_ignores_them() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_project(&workspace, "test", STUBBORN_SCRIPT);
+
+    // The script outlives pnpm here by design, so its stdio is discarded
+    // rather than left holding the test harness's pipes open.
+    let mut process = interruptible(
+        pacquet.with_args(["run", "dev"]).with_stdout(Stdio::null()).with_stderr(Stdio::null()),
+    );
+    wait_for_file(&workspace.join("started.txt"), &mut process);
+    for _ in 0..3 {
+        interrupt(&process);
+        // Signals do not queue, so each has to be taken before the next.
+        sleep(Duration::from_millis(200));
+    }
+    let status = wait_for_shutdown(&mut process);
+
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGINT),
+        "pnpm should end as an unhandled interrupt would, not with a plain exit code",
+    );
+
+    drop(root);
+}
+
+/// Each script gets its own first interrupt. The escalation counts one
+/// burst of them, so an earlier Ctrl+C cannot make the next script's
+/// interrupt arrive as the forced `SIGTERM` of a second press.
+#[test]
+fn a_later_script_still_gets_a_plain_first_interrupt() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    let manifest = json!({
+        "name": "test",
+        "version": "0.0.0",
+        "scripts": { "predev": "exec node pre.js", "dev": "exec node dev.js" },
+    });
+    fs::write(workspace.join("package.json"), manifest.to_string()).expect("write package.json");
+    fs::write(workspace.join("pre.js"), PRE_SCRIPT).expect("write the pre script");
+    fs::write(workspace.join("dev.js"), GRACEFUL_SCRIPT).expect("write the script");
+
+    let mut process = interruptible(
+        pacquet.with_env("PNPM_CONFIG_ENABLE_PRE_POST_SCRIPTS", "true").with_args(["run", "dev"]),
+    );
+    wait_for_file(&workspace.join("pre-started.txt"), &mut process);
+    interrupt(&process);
+    wait_for_file(&workspace.join("started.txt"), &mut process);
+    interrupt(&process);
+    let status = wait_for_shutdown(&mut process);
+
+    assert!(
+        workspace.join("shut-down.txt").exists(),
+        "the main script should have handled an interrupt, not been terminated outright",
+    );
+    assert_eq!(status.code(), Some(0), "the script exited 0, so pnpm does too");
+
+    drop(root);
+}
+
+fn write_project(dir: &Path, name: &str, script: &str) {
+    let manifest =
+        json!({ "name": name, "version": "0.0.0", "scripts": { "dev": "exec node dev.js" } });
+    fs::write(dir.join("package.json"), manifest.to_string()).expect("write package.json");
+    fs::write(dir.join("dev.js"), script).expect("write the script");
+}
+
+fn write_workspace(workspace: &Path, projects: &[&str], script: &str) {
+    let packages = projects.iter().map(|name| format!("  - {name}")).collect::<Vec<_>>();
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!("packages:\n{}\n", packages.join("\n")),
+    )
+    .expect("write pnpm-workspace.yaml");
+    for name in projects {
+        let dir = workspace.join(name);
+        fs::create_dir_all(&dir).expect("create the project directory");
+        write_project(&dir, name, script);
+    }
+}
+
+/// Spawn pnpm able to receive the interrupt signals, which is the state
+/// a terminal hands a foreground command.
+///
+/// Both halves matter, and both are inherited through `exec`. The test
+/// harness may run with `SIGINT` ignored, which pnpm would then keep (as
+/// it must under `nohup`) and pass on to the script; and it may run with
+/// the signal blocked, which no change of disposition undoes.
+fn interruptible(mut command: Command) -> Child {
+    // SAFETY: `signal` and `sigprocmask` are async-signal-safe, which is
+    // all a `pre_exec` hook between `fork` and `exec` may call.
+    unsafe {
+        command.pre_exec(|| {
+            let mut unblocked: libc::sigset_t = std::mem::zeroed();
+            libc::sigemptyset(&raw mut unblocked);
+            libc::sigprocmask(libc::SIG_SETMASK, &raw const unblocked, std::ptr::null_mut());
+            for signal in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+                libc::signal(signal, libc::SIG_DFL);
+            }
+            Ok(())
+        });
+    }
+    command.spawn().expect("spawn `pnpm run dev`")
+}
+
+/// Send `SIGINT` to pnpm alone, which is what `kill -INT` does; a
+/// terminal would signal the whole foreground group at once.
+fn interrupt(process: &Child) {
+    let pid = i32::try_from(process.id()).expect("the pid fits in a pid_t");
+    // SAFETY: `pid` is the child this test spawned and has not waited for
+    // yet, so it is not a recycled process id.
+    let signalled = unsafe { libc::kill(pid, libc::SIGINT) };
+    assert_eq!(signalled, 0, "the interrupt should reach pnpm");
+}
+
+/// Wait for pnpm to end, so a relay that never reached the script fails
+/// the test with its own message instead of hanging the whole suite.
+fn wait_for_shutdown(process: &mut Child) -> ExitStatus {
+    let deadline = Instant::now() + SHUTDOWN_DEADLINE;
+    while Instant::now() < deadline {
+        if let Some(status) = process.try_wait().expect("poll pnpm") {
+            return status;
+        }
+        sleep(Duration::from_millis(20));
+    }
+    let _ = process.kill();
+    let _ = process.wait();
+    panic!("pnpm was still running {SHUTDOWN_DEADLINE:?} after the interrupt");
+}
+
+/// Wait until the script announces itself, so the interrupt cannot land
+/// before there is a child to relay it to.
+fn wait_for_file(path: &Path, process: &mut Child) {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return;
+        }
+        if let Some(status) = process.try_wait().expect("poll pnpm") {
+            panic!("pnpm exited with {status} before the script started");
+        }
+        sleep(Duration::from_millis(20));
+    }
+    let _ = process.kill();
+    let _ = process.wait();
+    panic!("the script did not start before the deadline");
+}

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -65,6 +65,7 @@ mod install_filters;
 mod install_runtimes;
 mod install_state;
 mod install_test;
+mod interrupt;
 mod licenses;
 mod lifecycle_scripts;
 mod link;

--- a/pnpm/crates/executor/Cargo.toml
+++ b/pnpm/crates/executor/Cargo.toml
@@ -25,7 +25,7 @@ tracing         = { workspace = true }
 libc = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { workspace = true, features = ["Win32_System_SystemInformation"] }
+windows-sys = { workspace = true, features = ["Win32_System_Console", "Win32_System_SystemInformation"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/pnpm/crates/executor/src/interrupt.rs
+++ b/pnpm/crates/executor/src/interrupt.rs
@@ -1,0 +1,314 @@
+//! Waiting for a script child that the terminal interrupted alongside pnpm.
+//!
+//! `Ctrl+C` raises `SIGINT` in every process of the terminal's foreground
+//! group, so it reaches pnpm and the script pnpm started at the same
+//! moment. Under the default disposition pnpm dies first and the shell
+//! draws its prompt while the script is still shutting down, so whatever
+//! the script writes next — or whatever the terminal answers a query the
+//! script left open — lands on that prompt. pnpm instead relays the signal
+//! to the children it started, waits for them, and ends the way they did.
+//!
+//! Every child spawned through [`crate::spawn_child`] registers here for
+//! the length of its run. The relay escalates so a script cannot trap the
+//! terminal: the first interrupt is passed on as it arrived, the second
+//! becomes `SIGTERM`, and the third stops the waiting and lets the signal
+//! take pnpm down.
+
+use crate::ScriptExit;
+use std::{
+    ptr,
+    sync::{
+        Once,
+        atomic::{AtomicI32, AtomicPtr, AtomicUsize, Ordering},
+    },
+};
+
+/// The number of interrupts pnpm relays to a child before it stops
+/// waiting for that child. Once every child it reaches has had them, the
+/// next interrupt ends pnpm instead.
+const RELAYED_INTERRUPTS: usize = 2;
+
+/// One running child: the process to signal, negated to address the whole
+/// process group when the child leads one, or `0` when the entry is free.
+///
+/// Entries form a list the signal handler walks, so they are leaked rather
+/// than freed, and the entry a finished child leaves behind is reused by
+/// the next one. The handler then only reads atomics, which is
+/// async-signal-safe, while the list itself has no fixed size: a table
+/// with one would stop covering children once a wide `--parallel` run
+/// filled it, and those children would survive the interrupt.
+struct RelayEntry {
+    target: AtomicI32,
+    /// Interrupts relayed to the child holding this entry. Counting per
+    /// child rather than per process is what gives a script that starts
+    /// later its own plain first interrupt, while still escalating for
+    /// one that sits through them.
+    relays: AtomicUsize,
+    next: AtomicPtr<RelayEntry>,
+}
+
+static RELAY_HEAD: AtomicPtr<RelayEntry> = AtomicPtr::new(ptr::null_mut());
+
+/// A claim in progress: the entry belongs to a spawn that has not
+/// published its child yet. No process or process group is ever
+/// `i32::MIN`, so it cannot collide with a real target.
+const CLAIMING: i32 = i32::MIN;
+
+/// A child's registration in the relay, released when dropped.
+pub(crate) struct SignalRelay {
+    entry: Option<&'static RelayEntry>,
+}
+
+impl Drop for SignalRelay {
+    fn drop(&mut self) {
+        if let Some(entry) = self.entry {
+            entry.target.store(0, Ordering::Release);
+        }
+    }
+}
+
+/// Relay the terminal signals pnpm receives to `pid` until the returned
+/// guard is dropped.
+///
+/// `own_process_group` says the child leads a process group of its own
+/// (see [`crate::ProcessTracker`]); the whole group is then signalled,
+/// because the terminal's signals never reach it.
+pub(crate) fn relay_to_child(pid: u32, own_process_group: bool) -> SignalRelay {
+    install_handler();
+    let Ok(pid) = i32::try_from(pid) else {
+        return SignalRelay { entry: None };
+    };
+    let target = if own_process_group { -pid } else { pid };
+    SignalRelay { entry: Some(claim_entry(target)) }
+}
+
+/// Take the first free entry for `target`, or extend the list with one.
+fn claim_entry(target: i32) -> &'static RelayEntry {
+    let mut next = RELAY_HEAD.load(Ordering::Acquire);
+    // SAFETY: every pointer in the list came from the `Box::leak` in
+    // `push_entry` and is never freed, so it stays dereferenceable.
+    while let Some(entry) = unsafe { next.as_ref() } {
+        // The plain read first keeps a scan past occupied entries to
+        // shared loads: a failing `compare_exchange` would still take
+        // each line exclusively, which is what a wide parallel run would
+        // pay for on every spawn.
+        if entry.target.load(Ordering::Relaxed) == 0
+            && entry
+                .target
+                .compare_exchange(0, CLAIMING, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+        {
+            // The entry is this thread's alone now, so the count can be
+            // cleared before the child is published. Clearing it before
+            // taking the entry would let a thread that lost the race wipe
+            // the escalation of whichever child won it.
+            entry.relays.store(0, Ordering::Relaxed);
+            entry.target.store(target, Ordering::Release);
+            return entry;
+        }
+        next = entry.next.load(Ordering::Acquire);
+    }
+    push_entry(target)
+}
+
+/// Add an entry for `target` at the head of the list. `next` is set before
+/// the head swings, so a handler walking the list concurrently either
+/// misses the new entry entirely or reads a complete one.
+fn push_entry(target: i32) -> &'static RelayEntry {
+    let entry: &'static RelayEntry = Box::leak(Box::new(RelayEntry {
+        target: AtomicI32::new(target),
+        relays: AtomicUsize::new(0),
+        next: AtomicPtr::new(ptr::null_mut()),
+    }));
+    let mut head = RELAY_HEAD.load(Ordering::Acquire);
+    loop {
+        entry.next.store(head, Ordering::Release);
+        match RELAY_HEAD.compare_exchange_weak(
+            head,
+            ptr::from_ref(entry).cast_mut(),
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return entry,
+            Err(current) => head = current,
+        }
+    }
+}
+
+/// Call `visit` with every registered child and report whether there was
+/// one. The walk allocates nothing, so a signal handler can run it.
+fn visit_targets(mut visit: impl FnMut(&RelayEntry, i32)) -> bool {
+    let mut visited = false;
+    let mut next = RELAY_HEAD.load(Ordering::Acquire);
+    // SAFETY: as in `claim_entry`, list entries are leaked and stay
+    // dereferenceable for the life of the process.
+    while let Some(entry) = unsafe { next.as_ref() } {
+        let target = entry.target.load(Ordering::Acquire);
+        if target != 0 && target != CLAIMING {
+            visited = true;
+            visit(entry, target);
+        }
+        next = entry.next.load(Ordering::Acquire);
+    }
+    visited
+}
+
+/// End pnpm the way `exit` ended.
+///
+/// A child killed by a signal makes pnpm re-raise that signal on itself,
+/// so the shell reports an interrupted command rather than a plain
+/// non-zero exit. Anything else exits with the child's code.
+#[cfg(unix)]
+#[expect(clippy::exit, reason = "the command's exit code is the script's")]
+pub fn exit_like(exit: ScriptExit) -> ! {
+    use std::os::unix::process::ExitStatusExt;
+
+    if let ScriptExit::Process(status) = exit
+        && let Some(signal) = status.signal()
+    {
+        die_from(signal);
+    }
+    std::process::exit(exit.code().unwrap_or(1));
+}
+
+/// End pnpm the way `exit` ended. Windows has no signals, so that is the
+/// script's exit code.
+#[cfg(not(unix))]
+#[expect(clippy::exit, reason = "the command's exit code is the script's")]
+pub fn exit_like(exit: ScriptExit) -> ! {
+    std::process::exit(exit.code().unwrap_or(1));
+}
+
+#[cfg(unix)]
+fn install_handler() {
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        for signal in [libc::SIGINT, libc::SIGTERM, libc::SIGHUP] {
+            install_handler_for(signal);
+        }
+    });
+}
+
+#[cfg(unix)]
+fn install_handler_for(signal: libc::c_int) {
+    // SAFETY: both calls take stack locals that outlive them, and a null
+    // `act` only reads the current disposition back.
+    unsafe {
+        let mut previous: libc::sigaction = std::mem::zeroed();
+        if libc::sigaction(signal, std::ptr::null(), &raw mut previous) != 0 {
+            return;
+        }
+        // A signal pnpm was started with ignored stays ignored, so pnpm
+        // under `nohup` or in a background job keeps that disposition,
+        // which its children inherit across `exec`.
+        if previous.sa_sigaction == libc::SIG_IGN {
+            return;
+        }
+        let mut action: libc::sigaction = std::mem::zeroed();
+        action.sa_sigaction = relay_signal as *const () as usize;
+        // `SA_RESTART` keeps the `waitpid` and the output pumps running
+        // underneath from failing with `EINTR` when the relay fires.
+        action.sa_flags = libc::SA_RESTART;
+        libc::sigemptyset(&raw mut action.sa_mask);
+        libc::sigaction(signal, &raw const action, std::ptr::null_mut());
+    }
+}
+
+/// Pass `signal` on to the running children, or end pnpm when there is no
+/// longer anything to wait for.
+///
+/// Everything it calls is async-signal-safe: atomic loads, `kill`,
+/// `signal`, `raise`, and `_exit`.
+#[cfg(unix)]
+extern "C" fn relay_signal(signal: libc::c_int) {
+    let mut still_listening = false;
+    let reached = visit_targets(|entry, target| {
+        // pnpm reaps a child before releasing its entry, so an entry that
+        // has turned over since the walk read it names a process pnpm no
+        // longer owns. Leave it alone, and leave the child that took the
+        // entry its own first interrupt.
+        if entry.target.load(Ordering::Acquire) != target {
+            return;
+        }
+        let step = entry.relays.fetch_add(1, Ordering::Relaxed);
+        if step >= RELAYED_INTERRUPTS {
+            return;
+        }
+        still_listening = true;
+        let relayed = if step == 0 { signal } else { libc::SIGTERM };
+        // SAFETY: `target` is a child pnpm spawned, or that child's
+        // process group. `ESRCH` from one that exited concurrently is
+        // harmless.
+        unsafe {
+            libc::kill(target, relayed);
+        }
+    });
+    // Nothing left to wait for, or every child has had its interrupt and
+    // its `SIGTERM` and sat through both.
+    if !reached || !still_listening {
+        die_from(signal);
+    }
+}
+
+/// End pnpm as `signal` would have ended it without this module.
+///
+/// The signal is unblocked first because a handler runs with its own
+/// signal blocked: `raise` would otherwise leave it pending until the
+/// handler returned, and the `_exit` below would report a plain exit code
+/// where the caller expects death by a signal.
+#[cfg(unix)]
+fn die_from(signal: libc::c_int) -> ! {
+    // SAFETY: `sigprocmask`, `signal`, `raise` and `_exit` are all
+    // async-signal-safe, and the set is a stack local that outlives the
+    // call. `raise` does not return once the signal is unblocked and back
+    // at its default disposition; `_exit` covers the impossible case.
+    unsafe {
+        let mut unblocked: libc::sigset_t = std::mem::zeroed();
+        libc::sigemptyset(&raw mut unblocked);
+        libc::sigaddset(&raw mut unblocked, signal);
+        libc::signal(signal, libc::SIG_DFL);
+        libc::sigprocmask(libc::SIG_UNBLOCK, &raw const unblocked, std::ptr::null_mut());
+        libc::raise(signal);
+        libc::_exit(128 + signal);
+    }
+}
+
+#[cfg(windows)]
+fn install_handler() {
+    use windows_sys::Win32::System::Console::SetConsoleCtrlHandler;
+
+    static INSTALLED: Once = Once::new();
+    INSTALLED.call_once(|| {
+        // SAFETY: the handler is a plain `extern "system"` function whose
+        // only state is this module's atomics.
+        unsafe {
+            SetConsoleCtrlHandler(Some(relay_console_event), 1);
+        }
+    });
+}
+
+/// Report a console interrupt as handled while children are still
+/// running, which is what keeps pnpm alive. The console delivers the same
+/// event to every process attached to it, so the children already have
+/// it and nothing needs relaying.
+///
+/// Returning `FALSE` passes the event on to the default handler, which
+/// terminates pnpm.
+#[cfg(windows)]
+unsafe extern "system" fn relay_console_event(event: u32) -> windows_sys::core::BOOL {
+    use windows_sys::Win32::System::Console::{CTRL_BREAK_EVENT, CTRL_C_EVENT};
+
+    if !matches!(event, CTRL_C_EVENT | CTRL_BREAK_EVENT) {
+        return 0;
+    }
+    let mut still_listening = false;
+    visit_targets(|entry, _| {
+        if entry.relays.fetch_add(1, Ordering::Relaxed) < RELAYED_INTERRUPTS {
+            still_listening = true;
+        }
+    });
+    windows_sys::core::BOOL::from(still_listening)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn install_handler() {}

--- a/pnpm/crates/executor/src/lib.rs
+++ b/pnpm/crates/executor/src/lib.rs
@@ -1,5 +1,6 @@
 pub use bundled_node_gyp::bundled_node_gyp_bin;
 pub use extend_path::{ScriptsPrependNodePath, extend_path};
+pub use interrupt::exit_like;
 pub use job_control::{JobGuard, arm_process_tree_cleanup};
 pub use lifecycle::{
     DEV_PREINSTALL_ALREADY_RAN_ENV, DEV_PREINSTALL_STAGE, LifecycleScriptError,
@@ -16,6 +17,7 @@ pub use shell_emulator::{EmulatedOutput, ShellEmulatorError, execute_emulated};
 
 mod bundled_node_gyp;
 mod extend_path;
+mod interrupt;
 mod job_control;
 mod lifecycle;
 mod make_env;

--- a/pnpm/crates/executor/src/process_tracker.rs
+++ b/pnpm/crates/executor/src/process_tracker.rs
@@ -112,27 +112,36 @@ impl ProcessTracker {
 /// Spawn a child and optionally register it for cancellation. The default
 /// tracker gives each Unix child its own process group; a foreground tracker
 /// preserves the caller's process group and discovers descendants at cancel.
+///
+/// Every child also joins the interrupt relay for as long as the returned
+/// handle lives, so a terminal signal reaches it and pnpm waits for it.
 pub fn spawn_child<'tracker>(
     command: &mut Command,
     process_tracker: Option<&'tracker ProcessTracker>,
 ) -> io::Result<SpawnedChild<'tracker>> {
-    if process_tracker.is_some_and(|tracker| tracker.separate_process_groups) {
+    let separate_process_group =
+        process_tracker.is_some_and(|tracker| tracker.separate_process_groups);
+    if separate_process_group {
         prepare_command(command);
     }
     let child = command.spawn()?;
     crate::job_control::assign_child(&child);
+    // Only Unix gives a child a process group of its own, and only then
+    // must a relayed signal address that group rather than the child.
+    let relay = crate::interrupt::relay_to_child(child.id(), cfg!(unix) && separate_process_group);
     let registration = process_tracker.map(|tracker| {
         tracker.register(RunningExecution::Process {
             pid: child.id(),
             separate_process_group: tracker.separate_process_groups,
         })
     });
-    Ok(SpawnedChild { child, _registration: registration })
+    Ok(SpawnedChild { child, _registration: registration, _relay: relay })
 }
 
 pub struct SpawnedChild<'tracker> {
     child: Child,
     _registration: Option<Registration<'tracker>>,
+    _relay: crate::interrupt::SignalRelay,
 }
 
 impl SpawnedChild<'_> {


### PR DESCRIPTION
## Summary

Closes pnpm/pnpm#14723.

Ctrl+C raises `SIGINT` in every process of the terminal's foreground group, so it reaches pnpm and the script pnpm started at the same moment. pnpm v12 had no handler for it, so it died first and the shell drew its prompt while the script was still shutting down. Anything the script wrote after that landed on the prompt, including a terminal's answer to a query the script had left open, which is the escape sequence the issue reports.

pnpm v11's `run` does not have this bug, so the reported regression is v12-only. Its lifecycle runner registers `SIGINT` and `SIGTERM` handlers for the length of a script, forwards the signal to the child, and waits.

pnpm v11's `pnpm exec` *does* abandon its child the same way, measured the same way (dies at 3.040, the script never finishes). That is a separate, pre-existing v11 bug, not the one this issue reports, so it is not fixed here. This PR leaves v12's `exec` ahead of v11's; say the word and I will open a follow-up for the v11 side.

Measured with a PTY harness (a fake shell that ignores `SIGINT`, a script that takes 800 ms to shut down on `SIGINT`, `^C` at t=3.0):

| | script finishes | pnpm exits |
| --- | --- | --- |
| pnpm 11.26.0 | 3.840 | 3.890, status 0 |
| pnpm 12 before | never (abandoned) | 3.067, killed by SIGINT |
| pnpm 12 after | 3.841 | 3.846, status 0 |

And for a script that does not handle `SIGINT` at all, v12 now prints `[ELIFECYCLE] Command failed.` and dies by `SIGINT`, which is what v11 does.

### What changed

Every child spawned through `spawn_child` joins a relay in the new `pnpm-executor` `interrupt` module for the length of its run. This covers `pnpm run`, `pnpm exec`, and install-time lifecycle scripts.

- A handler for `SIGINT`, `SIGTERM` and `SIGHUP` passes the signal on to the registered children and lets pnpm keep waiting. With no child left to wait for, it restores the default disposition and re-raises, so an idle pnpm still dies at once.
- A child in a process group of its own (concurrent recursive runs) is addressed by its group, since the terminal's own signals never reach it. Before this, Ctrl+C during a concurrent run left those children orphaned.
- The relay escalates the way v11's does, so a script cannot trap the terminal: the second interrupt is relayed as `SIGTERM` and the third takes pnpm down.
- Registrations live in an append-only list whose entries are leaked and reused rather than freed, so the handler only reads atomics (async-signal-safe, no allocation, no locking) and the list has no fixed size. A bounded table would stop covering children once a wide `--parallel` run filled it, and pnpm would then wait for children that never received the signal.
- A signal pnpm was started with ignored keeps that disposition, so `nohup` and background jobs are unaffected. The tests spawn pnpm with the interrupt signals unblocked and back at their default disposition, since both halves are inherited through `exec` and a harness that ignores or blocks `SIGINT` would otherwise leave the interrupt inert.
- Ending pnpm from inside the handler unblocks the signal before re-raising it. A handler runs with its own signal blocked, so `raise` would leave it pending until the handler returned and the `_exit` fallback would report a plain exit code where the caller expects death by a signal.

Not covered: with `shellEmulator: true` the script runs through `deno_task_shell` in-process and never reaches `spawn_child`, so Ctrl+C still ends pnpm immediately there. That is the behavior on main today; closing it needs cancellation through the emulator rather than a signal relay, so it is left to its own change.
- On Windows the console already delivers `CTRL_C_EVENT` to every process attached to it, so the handler only reports the event as handled while children are running.

pnpm now also ends the way the script did: a script killed by a signal makes pnpm re-raise that signal on itself rather than exit 1. That is v11's behavior, and without it surviving `SIGINT` would have turned an interrupted `pnpm run` into a plain failure.

### Tests

Three end-to-end tests in `crates/cli/tests/suite/interrupt.rs`, all verified to fail with the relay disabled and to pass with it:

- a script that takes a second to shut down has finished before pnpm exits, and pnpm exits with its code;
- a script that turns the interrupt into `SIGUSR2` makes pnpm end with `SIGUSR2`, not with the `SIGINT` it received itself;
- a two-project `pnpm -r --parallel run dev`, where each script has a process group of its own, has both scripts shut down before pnpm exits;
- a script that ignores `SIGINT` and `SIGTERM` cannot trap the terminal: the third interrupt ends pnpm, and ends it by the signal rather than with a plain exit code.

The tests are verified to pass with the interrupt signals normal, ignored, and blocked in the harness, since CI runs them blocked.

## Squash Commit Body

```text
Ctrl+C raises SIGINT in every process of the terminal's foreground group,
so it reaches pnpm and the script pnpm started at the same moment. pnpm
had no handler for it, so it died first and the shell drew its prompt
while the script was still shutting down. Anything the script wrote after
that landed on the prompt, including a terminal's answer to a query the
script had left open, which is what pnpm/pnpm#14723 reported as escape
sequences after Ctrl+C. pnpm v11 does not have this bug: its lifecycle
runner registers SIGINT and SIGTERM handlers for the length of a script.

Every child spawned through `spawn_child` now joins a relay in the new
`pnpm-executor` `interrupt` module for the length of its run. A handler
for SIGINT, SIGTERM and SIGHUP passes the signal on to those children and
lets pnpm keep waiting; with no child left to wait for it restores the
default disposition and re-raises, so an idle pnpm still dies at once. A
child in a process group of its own is addressed by its group, since the
terminal's own signals never reach it. The relay escalates the way v11's
does, so a script cannot trap the terminal: the second interrupt is
relayed as SIGTERM and the third takes pnpm down.

The table the handler reads is a fixed array of atomics because neither
locking nor allocating is async-signal-safe. A signal pnpm was started
with ignored keeps that disposition, so `nohup` and background jobs are
unaffected.

pnpm now also ends the way the script did: a script killed by a signal
makes pnpm re-raise that signal on itself rather than exit 1, so the
shell reports an interrupted command. That is v11's behavior too, and
without it surviving SIGINT would have turned an interrupted `pnpm run`
into a plain failure.

Closes pnpm/pnpm#14723
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [x] Updated the documentation if needed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLDM23ZK3mBj5G57CEoobY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `pnpm run`, `pnpm exec`, and `pnpm dlx` now preserve child process exit statuses, including signal-based termination.
  * Ctrl+C is forwarded to running scripts, and pnpm waits for them to shut down.
  * Repeated interrupts escalate to ensure unresponsive scripts can still be stopped.

* **Tests**
  * Added Unix coverage for interrupt handling across parallel, recursive, and lifecycle scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->