### PR TITLE
fix(cli): honor dedupe workspace selection

### DIFF
--- a/.changeset/fix-dedupe-workspace-selection.md
+++ b/.changeset/fix-dedupe-workspace-selection.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm dedupe` now processes all workspace projects with separate lockfiles and honors workspace filters. `--fail-if-no-match` now exits with an error when no projects match [pnpm/pnpm#14732](https://github.com/pnpm/pnpm/issues/14732).
+`pnpm dedupe` now processes all workspace projects by default, including workspaces with a separate lockfile per project. Workspace filters now select which projects to process. `--fail-if-no-match` now exits with an error when no projects match [pnpm/pnpm#14732](https://github.com/pnpm/pnpm/issues/14732).

--- a/.changeset/fix-dedupe-workspace-selection.md
+++ b/.changeset/fix-dedupe-workspace-selection.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm dedupe` now processes all workspace projects with separate lockfiles and honors workspace filters. `--fail-if-no-match` now exits with an error when no projects match [pnpm/pnpm#14732](https://github.com/pnpm/pnpm/issues/14732).

--- a/pnpm/crates/cli/src/cli_args/cli_command.rs
+++ b/pnpm/crates/cli/src/cli_args/cli_command.rs
@@ -837,6 +837,7 @@ impl CliCommand {
         matches!(
             self,
             CliCommand::Install(_)
+                | CliCommand::Dedupe(_)
                 | CliCommand::InstallTest(_)
                 | CliCommand::Import(_)
                 | CliCommand::List(_)

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -202,27 +202,31 @@ impl DedupeArgs {
         }
         .wrap_err("deduplicating dependencies")?;
 
-        let current = read_lockfile_snapshot(lockfile_path)?;
-        let deduped = parse_snapshot(current.as_deref(), lockfile_path);
-
         if self.check {
-            let mut guard = guard.unwrap();
-            if existing == current {
-                guard.disarm();
-                Ok(())
-            } else {
-                let diff = diff_lockfiles(
-                    parse_snapshot(existing.as_deref(), lockfile_path).as_ref(),
-                    deduped.as_ref(),
-                    ImporterDiffKey::Version,
-                );
-                emit_dedupe_check_error::<Reporter>(&diff);
-                Err(DedupeError::CheckIssues.into())
-            }
+            check_lockfile::<Reporter>(existing.as_deref(), guard.unwrap(), lockfile_path)
         } else {
             Ok(())
         }
     }
+}
+
+pub(crate) fn check_lockfile<Reporter: self::Reporter>(
+    existing: Option<&str>,
+    mut guard: LockfileGuard,
+    lockfile_path: &Path,
+) -> miette::Result<()> {
+    let current = read_lockfile_snapshot(lockfile_path)?;
+    if existing == current.as_deref() {
+        guard.disarm();
+        return Ok(());
+    }
+    let diff = diff_lockfiles(
+        parse_snapshot(existing, lockfile_path).as_ref(),
+        parse_snapshot(current.as_deref(), lockfile_path).as_ref(),
+        ImporterDiffKey::Version,
+    );
+    emit_dedupe_check_error::<Reporter>(&diff);
+    Err(DedupeError::CheckIssues.into())
 }
 
 #[derive(Debug, Display, Error, Diagnostic)]

--- a/pnpm/crates/cli/src/cli_args/dedupe.rs
+++ b/pnpm/crates/cli/src/cli_args/dedupe.rs
@@ -12,7 +12,8 @@ use crate::{
         deps_tree::render::{
             TreeNode, blue_bright_underline, gray, green, plain, red, render_archy,
         },
-        install::resolve_bool_override,
+        install::{resolve_bool_override, workspace_install_selection},
+        pipelines::InstallFamilySelection,
     },
 };
 use clap::Args;
@@ -34,7 +35,7 @@ use pnpm_store_dir::{SharedReadonlyStoreIndex, StoreIndex, store_index_key};
 use serde_json::{Map, Value, json};
 use tempfile::NamedTempFile;
 
-#[derive(Debug, Args)]
+#[derive(Debug, Clone, Args)]
 pub struct DedupeArgs {
     /// Check if running dedupe would result in changes without installing
     /// packages or editing the lockfile. Exits with a non-zero status code
@@ -109,6 +110,7 @@ impl DedupeArgs {
         existing: Option<String>,
         guard: Option<LockfileGuard>,
         lockfile_path: &Path,
+        selection: Option<&InstallFamilySelection>,
     ) -> miette::Result<()> {
         let State { tarball_mem_cache, http_client, config, manifest, lockfile, resolved_packages } =
             &state;
@@ -190,8 +192,11 @@ impl DedupeArgs {
             pnpmfile_hook_override: None,
             workspace_projects_override: None,
         };
+        let selection = selection.map(workspace_install_selection);
         if self.check {
-            install.run_lockfile_check::<Reporter>().await
+            install.run_lockfile_check::<Reporter>(selection).await
+        } else if let Some(selection) = selection {
+            install.run_selected::<Reporter>(selection).await
         } else {
             install.run::<Reporter>().await
         }

--- a/pnpm/crates/cli/src/cli_args/dispatch_install.rs
+++ b/pnpm/crates/cli/src/cli_args/dispatch_install.rs
@@ -548,8 +548,15 @@ pub(super) fn dedupe<'a>(ctx: &RunCtx<'a>, args: DedupeArgs) -> miette::Result<C
         args.apply_cli_config(cfg);
         let config_root = derive_config_root(cfg, dir, reporter)
             .wrap_err("derive workspace root and package manager policy")?;
-        let dedupe =
-            DedupePipeline { args, cfg, config_root, manifest_path: manifest_path.to_path_buf() };
+        let recursive_sort = cfg.sort;
+        let dedupe = DedupePipeline {
+            args,
+            cfg,
+            config_root,
+            prefix: dir.to_path_buf(),
+            manifest_path: manifest_path.to_path_buf(),
+            recursive_sort,
+        };
         match reporter {
             ReporterType::Default | ReporterType::AppendOnly => {
                 Box::pin(dedupe.run::<DefaultReporter>()).await?;

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -728,7 +728,7 @@ impl InstallArgs {
     }
 }
 
-fn workspace_install_selection(
+pub(crate) fn workspace_install_selection(
     selection: &InstallFamilySelection,
 ) -> WorkspaceInstallSelection<'_> {
     WorkspaceInstallSelection {

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -1056,12 +1056,14 @@ pub(crate) struct DedupePipeline {
     pub(crate) args: DedupeArgs,
     pub(crate) cfg: &'static mut Config,
     pub(crate) config_root: PathBuf,
+    pub(crate) prefix: PathBuf,
     pub(crate) manifest_path: PathBuf,
+    pub(crate) recursive_sort: bool,
 }
 
 impl DedupePipeline {
     pub(crate) async fn run<Reporter: self::Reporter + 'static>(self) -> miette::Result<()> {
-        let DedupePipeline { args, cfg, config_root, manifest_path } = self;
+        let DedupePipeline { args, cfg, config_root, prefix, manifest_path, recursive_sort } = self;
 
         let lockfile_path = config_root.join(cfg.wanted_lockfile_name());
 
@@ -1073,9 +1075,75 @@ impl DedupePipeline {
             args.check.then(|| dedupe::LockfileGuard::new(existing.clone(), &lockfile_path));
 
         config_deps::prepare::<Reporter>(cfg, &config_root, false).await?;
+        let plan = select_install_family_plan::<Reporter>(
+            cfg,
+            &prefix,
+            &manifest_path,
+            recursive_sort,
+            false,
+            false,
+        )?;
         let cfg: &'static Config = cfg;
-        let state = State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
-        Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path)).await
+        match plan {
+            InstallFamilyPlan::PerProject(projects) => {
+                DedicatedProjectRuns {
+                    config: cfg,
+                    projects,
+                    require_lockfile: false,
+                    http_client: Some(State::new_http_client(cfg)?),
+                }
+                .run(|state| {
+                    let args = args.clone();
+                    let root_lockfile_path = &lockfile_path;
+                    let root_existing = &existing;
+                    async move {
+                        let project_lockfile_path =
+                            state.lockfile_dir().join(state.config.wanted_lockfile_name());
+                        let existing = if args.check {
+                            if project_lockfile_path == *root_lockfile_path {
+                                root_existing.clone()
+                            } else {
+                                dedupe::read_lockfile_snapshot(&project_lockfile_path)?
+                            }
+                        } else {
+                            None
+                        };
+                        let guard = args.check.then(|| {
+                            dedupe::LockfileGuard::new(existing.clone(), &project_lockfile_path)
+                        });
+                        Box::pin(args.run::<Reporter>(
+                            state,
+                            existing,
+                            guard,
+                            &project_lockfile_path,
+                            None,
+                        ))
+                        .await
+                    }
+                })
+                .await
+            }
+            InstallFamilyPlan::Shared(selection) => {
+                if selection.selected_dirs.is_empty() {
+                    return Ok(());
+                }
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(
+                    state,
+                    existing,
+                    guard,
+                    &lockfile_path,
+                    Some(&selection),
+                ))
+                .await
+            }
+            InstallFamilyPlan::Single => {
+                let state =
+                    State::init(manifest_path, cfg, false).wrap_err("initialize the state")?;
+                Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path, None)).await
+            }
+        }
     }
 }
 

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -1093,35 +1093,18 @@ impl DedupePipeline {
                     http_client: Some(State::new_http_client(cfg)?),
                 }
                 .run(|state| {
-                    let args = args.clone();
-                    let root_lockfile_path = &lockfile_path;
-                    let root_existing = &existing;
-                    async move {
-                        let project_lockfile_path =
-                            state.lockfile_dir().join(state.config.wanted_lockfile_name());
-                        let existing = if args.check {
-                            if project_lockfile_path == *root_lockfile_path {
-                                root_existing.clone()
-                            } else {
-                                dedupe::read_lockfile_snapshot(&project_lockfile_path)?
-                            }
-                        } else {
-                            None
-                        };
-                        let guard = args.check.then(|| {
-                            dedupe::LockfileGuard::new(existing.clone(), &project_lockfile_path)
-                        });
-                        Box::pin(args.run::<Reporter>(
-                            state,
-                            existing,
-                            guard,
-                            &project_lockfile_path,
-                            None,
-                        ))
-                        .await
-                    }
+                    Box::pin(dedupe_dedicated_project::<Reporter>(
+                        args.clone(),
+                        state,
+                        &lockfile_path,
+                        existing.as_deref(),
+                    ))
                 })
-                .await
+                .await?;
+                if let Some(guard) = guard {
+                    dedupe::check_lockfile::<Reporter>(existing.as_deref(), guard, &lockfile_path)?;
+                }
+                Ok(())
             }
             InstallFamilyPlan::Shared(selection) => {
                 if selection.selected_dirs.is_empty() {
@@ -1145,6 +1128,26 @@ impl DedupePipeline {
             }
         }
     }
+}
+
+async fn dedupe_dedicated_project<Reporter: self::Reporter + 'static>(
+    args: DedupeArgs,
+    state: State,
+    root_lockfile_path: &Path,
+    root_existing: Option<&str>,
+) -> miette::Result<()> {
+    let lockfile_path = state.lockfile_dir().join(state.config.wanted_lockfile_name());
+    let existing = if args.check {
+        if lockfile_path == root_lockfile_path {
+            root_existing.map(str::to_string)
+        } else {
+            dedupe::read_lockfile_snapshot(&lockfile_path)?
+        }
+    } else {
+        None
+    };
+    let guard = args.check.then(|| dedupe::LockfileGuard::new(existing.clone(), &lockfile_path));
+    Box::pin(args.run::<Reporter>(state, existing, guard, &lockfile_path, None)).await
 }
 
 /// The reporter-generic body of `pacquet prune`: runs config-deps and

--- a/pnpm/crates/cli/src/cli_args/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/tests.rs
@@ -493,7 +493,7 @@ fn recursive_by_default_command_is_promoted_inside_workspace() {
     let workspace = tempfile::tempdir().expect("creates workspace");
     std::fs::write(workspace.path().join("pnpm-workspace.yaml"), "packages: []\n")
         .expect("writes workspace manifest");
-    for command in ["install", "import", "list", "why", "peers"] {
+    for command in ["install", "dedupe", "import", "list", "why", "peers"] {
         let mut parsed = CliArgs::try_parse_from([
             "pacquet",
             "--dir",
@@ -530,7 +530,7 @@ fn color_accepts_modes_and_boolean_spellings() {
 #[test]
 fn recursive_by_default_command_stays_non_recursive_outside_workspace() {
     let project = tempfile::tempdir().expect("creates project");
-    for command in ["list", "why", "peers"] {
+    for command in ["dedupe", "list", "why", "peers"] {
         let mut parsed = CliArgs::try_parse_from([
             "pacquet",
             "--dir",

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -552,7 +552,7 @@ fn write_catalog_workspace(workspace: &Path, shared: bool, version: &str) {
     fs::write(
         workspace.join("pnpm-workspace.yaml"),
         format!(
-            "packages:\n  - packages/*\nsharedWorkspaceLockfile: {shared}\ncatalog:\n  '@pnpm.e2e/foo': {version}\n"
+            "packages:\n  - packages/*\nsharedWorkspaceLockfile: {shared}\ncatalog:\n  '@pnpm.e2e/foo': {version}\n",
         ),
     ).expect("write workspace");
 }
@@ -662,6 +662,35 @@ fn dedupe_honors_fail_if_no_match() {
             let path = workspace.join(project).join("pnpm-lock.yaml");
             assert!(!path.exists(), "empty selection wrote {}", path.display());
         }
+    }
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn dedupe_check_detects_config_dependency_changes_when_root_is_unselected() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    create_catalog_projects(&workspace);
+    write_catalog_workspace(&workspace, false, "1.0.0");
+    pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+    let lockfiles =
+        [".", "packages/a", "packages/b"].map(|dir| workspace.join(dir).join("pnpm-lock.yaml"));
+    let snapshots: Vec<_> = lockfiles.iter().map(|path| fs::read(path).unwrap()).collect();
+    let workspace_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&workspace_path).unwrap();
+    yaml.push_str("\nconfigDependencies:\n  '@pnpm.e2e/foo': 100.0.0\n");
+    fs::write(&workspace_path, yaml).unwrap();
+
+    let output = pacquet_at(&workspace)
+        .with_args(["dedupe", "--check", "-F", "pkg-a"])
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let stdout = String::from_utf8(output.stdout).expect("stdout is UTF-8");
+    assert!(stdout.contains("ERR_PNPM_DEDUPE_CHECK_ISSUES"), "stdout:\n{stdout}");
+    for (path, snapshot) in lockfiles.iter().zip(snapshots) {
+        assert_eq!(fs::read(path).unwrap(), snapshot);
     }
     drop((root, npmrc_info));
 }

--- a/pnpm/crates/cli/tests/suite/dedupe.rs
+++ b/pnpm/crates/cli/tests/suite/dedupe.rs
@@ -1,3 +1,4 @@
+use crate::_utils::{importer_version, read_lockfile};
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{
@@ -545,4 +546,122 @@ fn dedupe_re_keys_a_hoisted_optional_peer_in_one_pass() {
     assert_eq!(second_pass, first_pass, "a second dedupe pass must change nothing");
 
     drop((root, mock_instance));
+}
+
+fn write_catalog_workspace(workspace: &Path, shared: bool, version: &str) {
+    fs::write(
+        workspace.join("pnpm-workspace.yaml"),
+        format!(
+            "packages:\n  - packages/*\nsharedWorkspaceLockfile: {shared}\ncatalog:\n  '@pnpm.e2e/foo': {version}\n"
+        ),
+    ).expect("write workspace");
+}
+
+fn create_catalog_projects(workspace: &Path) {
+    for (directory, name) in [(".", "root"), ("packages/a", "pkg-a"), ("packages/b", "pkg-b")] {
+        let project = workspace.join(directory);
+        fs::create_dir_all(&project).expect("create project");
+        fs::write(
+            project.join("package.json"),
+            serde_json::json!({
+                "name": name,
+                "version": "1.0.0",
+                "dependencies": { "@pnpm.e2e/foo": "catalog:" },
+            })
+            .to_string(),
+        )
+        .expect("write project manifest");
+    }
+}
+
+fn catalog_lockfile_version(workspace: &Path, project: &str, shared: bool) -> String {
+    let (path, importer) = if shared {
+        (workspace.join("pnpm-lock.yaml"), project)
+    } else {
+        (workspace.join(project).join("pnpm-lock.yaml"), ".")
+    };
+    importer_version(&read_lockfile(&path), importer, "@pnpm.e2e/foo")
+}
+
+#[test]
+fn dedupe_recurses_into_dedicated_lockfiles() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    for options in [vec![], vec!["-r"], vec!["--workspace-concurrency=1", "--no-sort"]] {
+        create_catalog_projects(&workspace);
+        write_catalog_workspace(&workspace, false, "1.0.0");
+        pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+        write_catalog_workspace(&workspace, false, "1.2.0");
+        pacquet_at(&workspace)
+            .with_args(["dedupe", "--lockfile-only"])
+            .with_args(options)
+            .assert()
+            .success();
+        for project in [".", "packages/a", "packages/b"] {
+            assert_eq!(catalog_lockfile_version(&workspace, project, false), "1.2.0");
+        }
+    }
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn dedupe_filters_workspace_projects_and_checks_without_writing() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    for shared in [false, true] {
+        create_catalog_projects(&workspace);
+        write_catalog_workspace(&workspace, shared, "1.0.0");
+        pacquet_at(&workspace).with_args(["install", "--lockfile-only"]).assert().success();
+        write_catalog_workspace(&workspace, shared, "1.2.0");
+        let lockfiles = if shared {
+            vec![workspace.join("pnpm-lock.yaml")]
+        } else {
+            [".", "packages/a", "packages/b"]
+                .map(|dir| workspace.join(dir).join("pnpm-lock.yaml"))
+                .to_vec()
+        };
+        let snapshots: Vec<_> = lockfiles.iter().map(|path| fs::read(path).unwrap()).collect();
+        pacquet_at(&workspace).with_args(["dedupe", "--check", "-F", "pkg-a"]).assert().failure();
+        for (path, snapshot) in lockfiles.iter().zip(snapshots) {
+            assert_eq!(fs::read(path).unwrap(), snapshot);
+        }
+        pacquet_at(&workspace)
+            .with_args(["dedupe", "--lockfile-only", "-F", "pkg-a"])
+            .assert()
+            .success();
+        assert_eq!(catalog_lockfile_version(&workspace, "packages/a", shared), "1.2.0");
+        let unselected_version = if shared { "1.2.0" } else { "1.0.0" };
+        assert_eq!(catalog_lockfile_version(&workspace, "packages/b", shared), unselected_version);
+        assert_eq!(catalog_lockfile_version(&workspace, ".", shared), unselected_version);
+        pacquet_at(&workspace)
+            .with_args(["dedupe", "--lockfile-only", "-F", "pkg-b", "--workspace-root"])
+            .assert()
+            .success();
+        assert_eq!(catalog_lockfile_version(&workspace, "packages/b", shared), "1.2.0");
+        assert_eq!(catalog_lockfile_version(&workspace, ".", shared), "1.2.0");
+    }
+    drop((root, npmrc_info));
+}
+
+#[test]
+fn dedupe_honors_fail_if_no_match() {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    for shared in [false, true] {
+        create_catalog_projects(&workspace);
+        write_catalog_workspace(&workspace, shared, "1.0.0");
+        pacquet_at(&workspace)
+            .with_args(["dedupe", "--lockfile-only", "-F", "no-such-pkg", "--fail-if-no-match"])
+            .assert()
+            .code(1);
+        pacquet_at(&workspace)
+            .with_args(["dedupe", "--lockfile-only", "-F", "no-such-pkg"])
+            .assert()
+            .success();
+        for project in [".", "packages/a", "packages/b"] {
+            let path = workspace.join(project).join("pnpm-lock.yaml");
+            assert!(!path.exists(), "empty selection wrote {}", path.display());
+        }
+    }
+    drop((root, npmrc_info));
 }

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -1005,9 +1005,11 @@ where
     /// `lockfileCheck`.
     pub async fn run_lockfile_check<Reporter: self::Reporter + 'static>(
         self,
+        selection: Option<WorkspaceInstallSelection<'_>>,
     ) -> Result<(), InstallError> {
         Box::pin(self.run_inner::<Reporter>(InstallRunOptions {
             lockfile_check: true,
+            selection,
             ..Default::default()
         }))
         .await


### PR DESCRIPTION
## Summary

Fixes pnpm/pnpm#14732.

`pnpm dedupe` now recurses through workspace projects by default and honors workspace selectors, including `--fail-if-no-match`. Workspaces with `sharedWorkspaceLockfile: false` dedupe each selected project's lockfile using the existing dependency ordering and workspace concurrency scheduler.

This is a pnpm v12 fix. The v11 implementation already declares dedupe recursive by default and delegates to workspace installation.

Validation: `just ready` passed, including 10,885 Rust tests, formatting, spelling, compilation, and Clippy. Dylint also passed.

## Squash Commit Body

```text
Route dedupe through the existing install-family workspace selection and
dedicated-project scheduler. Dedupe previously initialized only the active
project and bypassed selection, leaving separate workspace lockfiles stale.

Pass shared-workspace selection into the install and lockfile-check paths.
Keep per-project lockfile snapshots and restoration for dedupe --check,
including changes to the root lockfile when filters exclude the root.

Add CLI regression coverage for default and explicit recursion, filters,
workspace-root inclusion, no-match exit codes, shared and dedicated
lockfiles, and check-mode restoration. All three new regression tests fail
against the original implementation. A fourth regression test verifies
that configuration-dependency changes fail a check even when filters
exclude the root.

Closes pnpm/pnpm#14732.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

---
Written by an agent (Codex, GPT-6).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `pnpm dedupe` now processes all workspace projects with separate lockfiles by default.
  * Workspace filters are honored during deduplication and lockfile checks.
  * `--fail-if-no-match` now exits with an error when no projects match the filter.
  * `--check` can detect lockfile changes across selected workspace projects without writing updates.

* **Bug Fixes**
  * Improved deduplication behavior for shared and project-specific workspace lockfiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->