### PR TITLE
fix(package-manager): apply ignoredOptionalDependencies when resolving

### DIFF
--- a/.changeset/fix-ignored-optional-dependencies.md
+++ b/.changeset/fix-ignored-optional-dependencies.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install`, `pnpm add`, and `pnpm dedupe` now apply `ignoredOptionalDependencies`. Matching optional dependencies are left out of the lockfile and are not installed. pnpm 12 installed them whenever it resolved dependencies from scratch [pnpm/pnpm#14729](https://github.com/pnpm/pnpm/issues/14729).

--- a/pnpm/crates/cli/tests/suite/optional_dependencies.rs
+++ b/pnpm/crates/cli/tests/suite/optional_dependencies.rs
@@ -1233,3 +1233,166 @@ fn cli_architecture_flags_invalidate_the_up_to_date_fast_path() {
 
     drop((root, npmrc_info)); // cleanup
 }
+
+/// Regression test for pnpm/pnpm#14729: every command that resolves from
+/// scratch has to honour `ignoredOptionalDependencies`, not just the
+/// lockfile rewrite that absorbs a widened pattern list.
+#[test]
+fn fresh_resolution_ignores_optional_dependencies_by_name() {
+    check_fresh_resolution_ignores_optional_dependencies("[is-positive]");
+}
+
+#[test]
+fn fresh_resolution_ignores_optional_dependencies_by_pattern() {
+    check_fresh_resolution_ignores_optional_dependencies("['is-*', '!is-negative']");
+}
+
+fn check_fresh_resolution_ignores_optional_dependencies(patterns: &str) {
+    let CommandTempCwd { root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    append_workspace_yaml_key(&workspace, "ignoredOptionalDependencies", patterns);
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-good-optional": "1.0.0",
+                "is-positive": "1.0.0"
+            },
+            "optionalDependencies": {
+                "is-positive": "1.0.0",
+                "is-negative": "1.0.0"
+            }
+        }),
+    );
+
+    for args in [
+        vec!["install", "--lockfile-only"],
+        vec!["install", "--frozen-lockfile"],
+        vec!["dedupe"],
+        vec!["add", "is-odd@1.0.0", "--lockfile-only"],
+    ] {
+        Command::cargo_bin("pnpm")
+            .unwrap()
+            .with_current_dir(&workspace)
+            .with_args(&args)
+            .assert()
+            .success();
+        let text = fs::read_to_string(workspace.join(Lockfile::FILE_NAME)).unwrap();
+        assert!(!text.contains("is-positive@"), "ignored package after {args:?}:\n{text}");
+        let lockfile = read_wanted_lockfile(&workspace);
+        assert_eq!(
+            lockfile.ignored_optional_dependencies,
+            Some(serde_saphyr::from_str::<Vec<String>>(patterns).unwrap()),
+        );
+        let importer = &lockfile.importers["."];
+        let ignored: PkgName = "is-positive".parse().unwrap();
+        assert!(
+            importer.dependencies.as_ref().is_none_or(|deps| !deps.contains_key(&ignored)),
+            "ignored duplicate regular dependency: {importer:?}",
+        );
+        assert!(
+            importer
+                .optional_dependencies
+                .as_ref()
+                .is_some_and(|deps| !deps.contains_key(&ignored)
+                    && deps.contains_key(&"is-negative".parse().unwrap())),
+            "retained optional dependencies: {importer:?}",
+        );
+        assert!(
+            is_absent(&workspace.join("node_modules/is-positive")),
+            "ignored direct dependency was linked after {args:?}",
+        );
+        assert!(
+            is_absent(
+                &workspace
+                    .join("node_modules/@pnpm.e2e/pkg-with-good-optional/node_modules/is-positive")
+            ),
+            "ignored transitive dependency was linked after {args:?}",
+        );
+    }
+    drop((root, npmrc_info));
+}
+
+/// A package that is both a required dependency of the root and an ignored
+/// optional of a dependency still installs. `ignoredOptionalDependencies`
+/// drops optional declarations, not the package.
+#[test]
+fn ignored_optional_dependencies_preserve_required_occurrences() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    append_workspace_yaml_key(&workspace, "ignoredOptionalDependencies", "[is-positive]");
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "dependencies": {
+                "@pnpm.e2e/pkg-with-good-optional": "1.0.0",
+                "is-positive": "1.0.0"
+            }
+        }),
+    );
+    pacquet.with_arg("install").assert().success();
+    let lockfile = read_wanted_lockfile(&workspace);
+    let name: PkgName = "is-positive".parse().unwrap();
+    assert_eq!(
+        lockfile.importers["."].dependencies.as_ref().unwrap()[&name].version.to_string(),
+        "1.0.0",
+    );
+    let parent = &lockfile.snapshots.as_ref().unwrap()
+        [&"@pnpm.e2e/pkg-with-good-optional@1.0.0".parse().unwrap()];
+    assert!(
+        parent.optional_dependencies.as_ref().is_none_or(|deps| !deps.contains_key(&name)),
+        "ignored optional edge: {parent:?}",
+    );
+    assert!(
+        workspace.join("node_modules/is-positive/package.json").exists(),
+        "required occurrence must be installed",
+    );
+    drop((root, npmrc_info));
+}
+
+/// `ignoredOptionalDependencies` runs last in the read-package hook chain,
+/// so it also removes optional dependencies that `packageExtensions` and the
+/// pnpmfile's `readPackage` introduced rather than only the ones the package
+/// publishes.
+#[test]
+fn ignored_optional_dependencies_apply_after_manifest_hooks() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    append_workspace_yaml_key(&workspace, "ignoredOptionalDependencies", "[is-negative, is-odd]");
+    append_workspace_yaml_key(
+        &workspace,
+        "packageExtensions",
+        "\n  '@pnpm.e2e/pkg-with-good-optional':\n    optionalDependencies:\n      is-negative: 1.0.0",
+    );
+    fs::write(
+        workspace.join(".pnpmfile.mjs"),
+        r"
+export const hooks = {
+  readPackage(pkg) {
+    if (pkg.name === '@pnpm.e2e/pkg-with-good-optional') {
+      return { ...pkg, optionalDependencies: { ...pkg.optionalDependencies, 'is-odd': '1.0.0' } }
+    }
+    return pkg
+  }
+}
+",
+    )
+    .unwrap();
+    write_manifest(
+        &workspace,
+        &serde_json::json!({
+            "dependencies": { "@pnpm.e2e/pkg-with-good-optional": "1.0.0" }
+        }),
+    );
+
+    pacquet.with_args(["install", "--lockfile-only"]).assert().success();
+
+    let text = fs::read_to_string(workspace.join(Lockfile::FILE_NAME)).unwrap();
+    assert!(!text.contains("is-negative@"), "packageExtensions optional was kept:\n{text}");
+    assert!(!text.contains("is-odd@"), "readPackage optional was kept:\n{text}");
+    assert!(
+        text.contains("is-positive@"),
+        "an optional dependency no pattern matches must survive:\n{text}",
+    );
+    drop((root, npmrc_info));
+}

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile/manifest_transforms.rs
@@ -1,6 +1,6 @@
 //! pnpm's built-in read-package hook chain: `packageExtensions` (the
 //! compatibility DB plus the user's), legacy deploy's workspace
-//! injection, and `pnpm.overrides`.
+//! injection, `pnpm.overrides`, and `ignoredOptionalDependencies`.
 //!
 //! Owns the *transform* half of the resolve inputs. The seeds, options,
 //! and reuse decisions the same resolve consumes live in
@@ -15,19 +15,25 @@ use crate::{
 };
 use indexmap::IndexMap;
 use pnpm_catalogs_types::Catalogs;
-use pnpm_config::Config;
+use pnpm_config::{
+    Config,
+    matcher::{Matcher, create_matcher},
+};
 use pnpm_package_manifest::PackageManifest;
 use pnpm_resolving_deps_resolver::{DependencyOverrider, ManifestHook};
+use serde_json::Value;
 use std::{collections::BTreeMap, path::Path, sync::Arc};
 
 /// pnpm's built-in read-package hook chain for the manifests fresh
 /// resolution consumes, plus the pieces later phases read off it.
 ///
 /// The order matches `createReadPackageHook`: packageExtensions first,
-/// then the pnpmfile and deploy hook, then overrides. The hooks stay
-/// separate because the resolver interleaves the pnpmfile's `readPackage` between them:
-/// packageExtensions → readPackage → deploy → overrides. This prevents a
-/// hook that replaces the manifest from erasing the deploy injection or overrides.
+/// then the pnpmfile and deploy hook, then overrides, then the
+/// `ignoredOptionalDependencies` removal. The hooks stay separate because
+/// the resolver interleaves the pnpmfile's `readPackage` between them:
+/// packageExtensions → readPackage → deploy → overrides → ignored optionals.
+/// This prevents a hook that replaces the manifest from erasing the deploy
+/// injection, the overrides, or the removal.
 pub(super) struct ManifestTransforms {
     pub parsed_overrides: Option<Vec<pnpm_config_parse_overrides::VersionOverride>>,
     pub resolved_overrides: Option<IndexMap<String, String>>,
@@ -60,11 +66,14 @@ pub(super) fn build_manifest_transforms(
         .as_ref()
         .map(|parsed| Arc::new(VersionsOverrider::new(parsed, lockfile_dir)));
 
+    let ignored_optional_matcher =
+        create_matcher(config.ignored_optional_dependencies.as_deref().unwrap_or_default());
     let mut effective_importer_manifests = BTreeMap::new();
     if compat_package_extender.is_some()
         || package_extender.is_some()
         || versions_overrider.as_ref().is_some_and(|overrider| !overrider.is_empty())
         || deploy_manifest_hook
+        || !ignored_optional_matcher.is_empty()
     {
         // Every importer's transform is independent — a clone of its own
         // manifest plus in-place rewrites — so a workspace-scale set fans
@@ -76,6 +85,7 @@ pub(super) fn build_manifest_transforms(
             package_extender: package_extender.as_ref(),
             versions_overrider: versions_overrider.as_ref(),
             deploy_manifest_hook,
+            ignored_optional_matcher: &ignored_optional_matcher,
         };
         effective_importer_manifests = importer_manifests
             .par_iter()
@@ -98,6 +108,15 @@ pub(super) fn build_manifest_transforms(
     });
     let deploy_manifest_hook: Option<ManifestHook> =
         deploy_manifest_hook.then(|| Arc::new(apply_deploy_manifest_hook_to_arc) as ManifestHook);
+    let ignored_optional_hook = (!ignored_optional_matcher.is_empty()).then(|| {
+        Arc::new(move |mut manifest: Arc<Value>| {
+            let ignored = ignored_optional_names(&manifest, &ignored_optional_matcher);
+            if !ignored.is_empty() {
+                remove_ignored_dependencies(Arc::make_mut(&mut manifest), &ignored);
+            }
+            manifest
+        }) as ManifestHook
+    });
     let override_bare_specifier: Option<Arc<DependencyOverrider>> =
         active_overrider.map(|overrider| {
             let overrider = Arc::clone(overrider);
@@ -115,7 +134,9 @@ pub(super) fn build_manifest_transforms(
             compat_package_extensions_hook,
             package_extensions_hook,
         ),
-        overrides_hook: compose_manifest_hooks(deploy_manifest_hook, overrides_hook),
+        overrides_hook: [deploy_manifest_hook, overrides_hook, ignored_optional_hook]
+            .into_iter()
+            .fold(None, compose_manifest_hooks),
         override_bare_specifier,
         effective_importer_manifests,
     })
@@ -138,6 +159,7 @@ struct ImporterTransforms<'a> {
     package_extender: Option<&'a Arc<crate::PackageExtender>>,
     versions_overrider: Option<&'a Arc<VersionsOverrider>>,
     deploy_manifest_hook: bool,
+    ignored_optional_matcher: &'a Matcher,
 }
 
 fn transform_importer_manifest(
@@ -158,5 +180,41 @@ fn transform_importer_manifest(
         let manifest_dir = cloned.path().parent().map(Path::to_path_buf);
         overrider.apply(&mut cloned, manifest_dir.as_deref());
     }
+    let ignored = ignored_optional_names(cloned.value(), transforms.ignored_optional_matcher);
+    if !ignored.is_empty() {
+        remove_ignored_dependencies(cloned.value_mut(), &ignored);
+    }
     cloned
+}
+
+/// The `optionalDependencies` entries `ignoredOptionalDependencies` matches.
+///
+/// Callers query this before mutating, so a shared manifest with no match
+/// skips the copy-on-write clone — the common case across the thousands of
+/// dependency manifests one resolve reads.
+fn ignored_optional_names(manifest: &Value, matcher: &Matcher) -> Vec<String> {
+    if matcher.is_empty() {
+        return Vec::new();
+    }
+    manifest
+        .get("optionalDependencies")
+        .and_then(Value::as_object)
+        .into_iter()
+        .flat_map(serde_json::Map::keys)
+        .filter(|name| matcher.matches(name))
+        .cloned()
+        .collect()
+}
+
+/// Drop `ignored` from `optionalDependencies` and from `dependencies` alike.
+/// A package listed in both fields is optional, so ignoring it has to clear
+/// both declarations or the required one would pull it back in.
+fn remove_ignored_dependencies(manifest: &mut Value, ignored: &[String]) {
+    for field in ["optionalDependencies", "dependencies"] {
+        if let Some(dependencies) = manifest.get_mut(field).and_then(Value::as_object_mut) {
+            for name in ignored {
+                dependencies.remove(name);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`ignoredOptionalDependencies` has had no effect in pnpm 12. Closes pnpm/pnpm#14729.

pnpm 12 threaded the setting into the lockfile freshness check and into the fast lockfile rewrite that absorbs a widened pattern list, but never into the read-package hook chain a fresh resolve runs. The setting was therefore honoured only when an existing lockfile could be rewritten in place. Any resolution from scratch pulled the ignored packages back in and dropped the setting from the lockfile, which is why an up-to-date lockfile hid the regression and it surfaced later on `pnpm dedupe`, `pnpm add`, and the first install that had to resolve.

The fix adds the removal as the last hook in the chain, matching `createReadPackageHook`'s order, and applies the same removal to the importer manifests the resolve reads.

Verified against the issue's own reproduction: `grep -c parcel pnpm-lock.yaml` now prints 1, and the lockfile records `ignoredOptionalDependencies`.

## Squash Commit Body

```text
pnpm 12 threaded `ignoredOptionalDependencies` into the lockfile
freshness check and into the fast lockfile rewrite that absorbs a
widened pattern list, but never into the read-package hook chain a
fresh resolve runs. The setting was therefore honoured only when an
existing lockfile could be rewritten in place; any resolution from
scratch pulled the ignored packages back in and dropped the setting
from the lockfile. An up-to-date lockfile hid the regression, so it
surfaced later on `pnpm dedupe`, `pnpm add`, and the first install
that had to resolve.

Add the removal as the last hook in the chain, matching
`createReadPackageHook`'s order, and apply the same removal to the
importer manifests the resolve reads. Running last is what lets it
also drop the optional dependencies that `packageExtensions` and the
pnpmfile's `readPackage` introduce, rather than only the ones a
package publishes.

Closes pnpm/pnpm#14729
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

### Notes on the checklist

This is v12-only. pnpm 11 wires `createOptionalDependenciesRemover` into
`createReadPackageHook` correctly, matching the issue's report that 11.26.0
behaves as expected, so there is nothing to fix in `pnpm11/`.

Four tests were added to `optional_dependencies.rs`, covering removal by name
and by pattern across `install --lockfile-only`, `install --frozen-lockfile`,
`dedupe`, and `add`; a package that is both a required dependency and an
ignored optional; and removal of optional dependencies introduced by
`packageExtensions` and by the pnpmfile's `readPackage`. Each was checked to
fail with the fix reverted.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JtYF6AmaoERa1BUW5xBZq1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791553788&installation_model_id=426870&pr_number=14738&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14738&signature=dbcb755781fa8efee4f85284fe473cfe9814e1c336b7da91318c67d15275ae53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `ignoredOptionalDependencies` is now consistently honored by `pnpm install`, `pnpm add`, and `pnpm dedupe`.
  * Ignored optional dependencies are excluded from installation and lockfiles, including during fresh dependency resolution.
  * Name and pattern matching are supported consistently across these commands.
  * Optional dependencies introduced by package extensions or configuration hooks are also filtered correctly.
  * Required dependencies continue to install even when they match an ignored optional dependency name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->