### PR TITLE
fix(package-manager): resolve promoted peer-suffixed dependencies

### DIFF
--- a/.changeset/promote-peer-suffixed-dependency.md
+++ b/.changeset/promote-peer-suffixed-dependency.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` and `pnpm add` no longer write a broken importer entry when a package that `pnpm-lock.yaml` already holds as a transitive dependency with resolved peer dependencies is added as a direct dependency. pnpm now resolves the new entry, so it records the peer-suffixed version that has a snapshot. It previously skipped resolution and recorded the bare version, which had no snapshot and left the package a dangling symlink in `node_modules`.

--- a/.changeset/promote-peer-suffixed-dependency.md
+++ b/.changeset/promote-peer-suffixed-dependency.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` and `pnpm add` no longer write a broken importer entry when a package that `pnpm-lock.yaml` already holds as a transitive dependency with resolved peer dependencies is added as a direct dependency. pnpm now resolves the new entry, so it records the peer-suffixed version that has a snapshot. It previously skipped resolution and recorded the bare version, which had no snapshot and left the package a dangling symlink in `node_modules`.
+`pnpm install` and `pnpm add` no longer leave a dangling symlink in `node_modules` when a project starts depending directly on a package that the lockfile holds only as a transitive dependency with resolved peer dependencies [#14714](https://github.com/pnpm/pnpm/issues/14714).

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -2010,9 +2010,11 @@ fn promoting_a_peer_suffixed_transitive_dependency_resolves_its_importer_edge() 
         .expect("load wanted lockfile")
         .expect("wanted lockfile");
     let snapshots = wanted.snapshots.as_ref().expect("snapshots");
+    let locked_abc: Vec<_> = snapshots.keys().filter(|key| key.name == abc).collect();
+    assert!(!locked_abc.is_empty(), "the fixture reaches abc through its parent");
     assert!(
-        snapshots.keys().filter(|key| key.name == abc).all(|key| !key.suffix.peer().is_empty()),
-        "the fixture only holds abc as a peer variant",
+        locked_abc.iter().all(|key| !key.suffix.peer().is_empty()),
+        "the fixture holds abc only as a peer variant: {locked_abc:?}",
     );
 
     dependencies["@pnpm.e2e/abc"] = "1.0.0".into();

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -2045,3 +2045,78 @@ fn promoting_a_peer_suffixed_transitive_dependency_resolves_its_importer_edge() 
 
     drop((root, mock_instance));
 }
+
+/// The new-importer shape of the same defect: a workspace member added
+/// after the lockfile was written declares `@pnpm.e2e/abc`, and its whole
+/// importer entry is written from the versions the lockfile already holds
+/// rather than one edge at a time.
+#[test]
+fn a_new_workspace_member_links_a_dependency_locked_only_as_a_peer_variant() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(
+        &workspace_yaml_path,
+        format!("{workspace_yaml}trustLockfile: true\npackages:\n  - packages/*\n"),
+    )
+    .expect("declare the workspace members");
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({ "name": "root", "version": "1.0.0" }).to_string(),
+    )
+    .expect("write the root package.json");
+    let dependencies = serde_json::json!({
+        "@pnpm.e2e/abc-parent-with-missing-peers": "1.0.0",
+        "@pnpm.e2e/peer-a": "1.0.0",
+        "@pnpm.e2e/peer-b": "1.0.0",
+        "@pnpm.e2e/peer-c": "1.0.0",
+    });
+    let existing = workspace.join("packages").join("existing");
+    fs::create_dir_all(&existing).expect("create the member directory");
+    fs::write(
+        existing.join("package.json"),
+        serde_json::json!({ "name": "existing", "version": "1.0.0", "dependencies": dependencies })
+            .to_string(),
+    )
+    .expect("write the member package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let mut added_dependencies = dependencies;
+    added_dependencies["@pnpm.e2e/abc"] = "1.0.0".into();
+    let added = workspace.join("packages").join("web-ui");
+    fs::create_dir_all(&added).expect("create the new member directory");
+    fs::write(
+        added.join("package.json"),
+        serde_json::json!({
+            "name": "web-ui",
+            "version": "1.0.0",
+            "dependencies": added_dependencies,
+        })
+        .to_string(),
+    )
+    .expect("write the new member package.json");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let abc: pnpm_lockfile::PkgName = "@pnpm.e2e/abc".parse().expect("package name");
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let edge =
+        &wanted.importers["packages/web-ui"].dependencies.as_ref().expect("dependencies")[&abc];
+    let linked: pnpm_lockfile::PackageKey =
+        format!("@pnpm.e2e/abc@{}", edge.version).parse().expect("snapshot key");
+    assert!(
+        wanted.snapshots.as_ref().expect("snapshots").contains_key(&linked),
+        "the new member's edge names a snapshot the lockfile holds: {}",
+        edge.version,
+    );
+    assert!(
+        added.join("node_modules").join("@pnpm.e2e").join("abc").join("package.json").exists(),
+        "the new member links to a package the virtual store holds",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
+++ b/pnpm/crates/cli/tests/suite/lockfile_resolution_reuse.rs
@@ -1978,3 +1978,68 @@ fn add_command_resolves_a_version_the_lockfile_does_not_hold() {
 
     drop((root, mock_instance));
 }
+
+/// `@pnpm.e2e/abc-parent-with-missing-peers` depends on `@pnpm.e2e/abc`,
+/// whose peers `peer-a`, `peer-b` and `peer-c` the root provides, so the
+/// lockfile holds `abc` only as a peer-suffixed snapshot. Promoting it to
+/// a direct dependency has to go through the resolver: the bare
+/// `abc@1.0.0` the `packages:` block names has no snapshot to link.
+#[test]
+fn promoting_a_peer_suffixed_transitive_dependency_resolves_its_importer_edge() {
+    let CommandTempCwd { workspace, root, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    let manifest_path = workspace.join("package.json");
+    let mut dependencies = serde_json::json!({
+        "@pnpm.e2e/abc-parent-with-missing-peers": "1.0.0",
+        "@pnpm.e2e/peer-a": "1.0.0",
+        "@pnpm.e2e/peer-b": "1.0.0",
+        "@pnpm.e2e/peer-c": "1.0.0",
+    });
+    fs::write(&manifest_path, serde_json::json!({ "dependencies": dependencies }).to_string())
+        .expect("write package.json");
+    let workspace_yaml_path = workspace.join("pnpm-workspace.yaml");
+    let workspace_yaml =
+        fs::read_to_string(&workspace_yaml_path).expect("read pnpm-workspace.yaml");
+    fs::write(&workspace_yaml_path, format!("{workspace_yaml}trustLockfile: true\n"))
+        .expect("enable trusted lockfile");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let abc: pnpm_lockfile::PkgName = "@pnpm.e2e/abc".parse().expect("package name");
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load wanted lockfile")
+        .expect("wanted lockfile");
+    let snapshots = wanted.snapshots.as_ref().expect("snapshots");
+    assert!(
+        snapshots.keys().filter(|key| key.name == abc).all(|key| !key.suffix.peer().is_empty()),
+        "the fixture only holds abc as a peer variant",
+    );
+
+    dependencies["@pnpm.e2e/abc"] = "1.0.0".into();
+    fs::write(&manifest_path, serde_json::json!({ "dependencies": dependencies }).to_string())
+        .expect("promote abc to a direct dependency");
+    pacquet_at(&workspace).with_arg("install").assert().success();
+
+    let wanted = pnpm_lockfile::Lockfile::load_wanted_from_dir(&workspace)
+        .expect("load updated wanted lockfile")
+        .expect("updated wanted lockfile");
+    let edge = &wanted.importers["."].dependencies.as_ref().expect("dependencies")[&abc];
+    let linked: pnpm_lockfile::PackageKey =
+        format!("@pnpm.e2e/abc@{}", edge.version).parse().expect("snapshot key");
+    assert!(
+        !linked.suffix.peer().is_empty(),
+        "the importer edge carries the peers abc resolved: {}",
+        edge.version,
+    );
+    assert!(
+        wanted.snapshots.as_ref().expect("snapshots").contains_key(&linked),
+        "the importer edge names a snapshot the lockfile holds: {}",
+        edge.version,
+    );
+    assert!(
+        workspace.join("node_modules").join("@pnpm.e2e").join("abc").join("package.json").exists(),
+        "the promoted dependency links to a package the virtual store holds",
+    );
+
+    drop((root, mock_instance));
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -342,8 +342,8 @@ fn retarget_importer_dependency(
 /// A move writes the bare version, so the lockfile has to hold that
 /// version with no peers resolved; which of several peer variants the
 /// edge would take instead is the resolver's call. An edge that stays put
-/// keeps the record it already carries, and an earlier pnpm may have left
-/// that naming a snapshot which was never written.
+/// keeps the record it already carries, which is looked up rather than
+/// assumed: nothing guarantees the lockfile on disk is self-consistent.
 fn retarget_names_a_snapshot(
     snapshots: Option<&LockedSnapshots>,
     wanted: &LockedPick,

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -318,12 +318,12 @@ fn retarget_importer_dependency(
         return false;
     };
     let moves = wanted.version != *version;
-    let already_suffixed = ver_peer.peer() != "";
-    if !retarget_names_a_snapshot(&wanted, moves, already_suffixed) {
+    let recorded = PackageKey::new(alias.clone(), ver_peer.clone());
+    if !retarget_names_a_snapshot(locked.snapshots, &wanted, moves, &recorded) {
         return false;
     }
     if moves {
-        if already_suffixed {
+        if recorded.suffix.peer() != "" {
             return false;
         }
         let Ok(moved) = wanted.version.to_string().parse() else {
@@ -339,12 +339,21 @@ fn retarget_importer_dependency(
 /// Whether the record a retarget leaves behind names a snapshot the
 /// lockfile holds.
 ///
-/// A move writes the bare version, and an edge that stays put keeps the
-/// suffix it already carries, so a version the lockfile holds only as a
-/// peer variant can be named by the second of those alone, and only when
-/// the record already spells a suffix out.
-fn retarget_names_a_snapshot(wanted: &LockedPick, moves: bool, already_suffixed: bool) -> bool {
-    !wanted.peer_suffixed || (!moves && already_suffixed)
+/// A move writes the bare version, so the lockfile has to hold that
+/// version with no peers resolved; which of several peer variants the
+/// edge would take instead is the resolver's call. An edge that stays put
+/// keeps the record it already carries, and an earlier pnpm may have left
+/// that naming a snapshot which was never written.
+fn retarget_names_a_snapshot(
+    snapshots: Option<&LockedSnapshots>,
+    wanted: &LockedPick,
+    moves: bool,
+    recorded: &PackageKey,
+) -> bool {
+    if moves {
+        return !wanted.peer_suffixed;
+    }
+    snapshots.is_some_and(|snapshots| snapshots.contains_key(recorded))
 }
 
 /// Whether the lockfile records no dependency of this project — the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -317,11 +317,15 @@ fn retarget_importer_dependency(
     ) else {
         return false;
     };
-    if wanted != *version {
-        if ver_peer.peer() != "" {
+    if wanted.version != *version {
+        // A move writes the bare version, so a target the lockfile holds
+        // only as a peer variant would name a snapshot that does not
+        // exist. An edge that stays put keeps the suffix it already
+        // carries, so only a move has to ask.
+        if wanted.peer_suffixed || ver_peer.peer() != "" {
             return false;
         }
-        let Ok(moved) = wanted.to_string().parse() else {
+        let Ok(moved) = wanted.version.to_string().parse() else {
             return false;
         };
         edits.dropped.record(alias, &*dependency);
@@ -346,7 +350,8 @@ fn records_no_dependencies(importer: &ProjectSnapshot) -> bool {
 ///
 /// `None` when a declared dependency needs the resolver: one that
 /// resolves to a directory rather than to a registry version, one whose
-/// specifier is not a semver range, and one no locked version satisfies.
+/// specifier is not a semver range, one no locked version satisfies, and
+/// one the lockfile holds only as a peer variant.
 fn importer_from_locked_versions(
     snapshots: Option<&LockedSnapshots>,
     manifest: &PackageManifest,
@@ -360,15 +365,18 @@ fn importer_from_locked_versions(
             return None;
         }
         let range = Range::parse(specifier).ok()?;
-        let version = locked_version_resolution_would_pick(
+        let pick = locked_version_resolution_would_pick(
             snapshots,
             alias,
             &range,
             plan.resolution_picks_lowest,
         )?;
+        if pick.peer_suffixed {
+            return None;
+        }
         let dependency = ResolvedDependencySpec {
             specifier: (*specifier).to_string(),
-            version: ImporterDepVersion::Regular(version.to_string().parse().ok()?),
+            version: ImporterDepVersion::Regular(pick.version.to_string().parse().ok()?),
         };
         importer_group(&mut importer, *group)
             .get_or_insert_default()
@@ -386,9 +394,9 @@ fn importer_from_locked_versions(
 /// in.
 ///
 /// Safe without resolving for the same reason a moved range is: the version
-/// and its subtree are already recorded, and a subtree that resolved a peer
-/// from outside itself would have left `alias` peer-suffixed, which
-/// [`locked_version_resolution_would_pick`] refuses.
+/// and its subtree are already recorded, and the record this writes carries
+/// no peer suffix, so a version the lockfile only holds as a peer variant is
+/// left to the resolver.
 ///
 /// `false` leaves the caller on the full-resolution path.
 fn add_importer_edge(
@@ -424,6 +432,10 @@ fn add_importer_edge(
     ) else {
         return false;
     };
+    if wanted.peer_suffixed {
+        return false;
+    }
+    let wanted = wanted.version;
     // `time` carries a publish date per direct dependency, and only a
     // resolution can look up the one for a package this promotes into that
     // position.
@@ -507,41 +519,66 @@ fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
 ///   for a direct dependency, but only when the run leaves the manifest
 ///   alone, so which end of the range applies is not a property of the
 ///   lockfile;
-/// - the alias appears under a key this cannot turn back into a plain
-///   reference: a peer-suffixed one, where picking a variant would be a
-///   guess, or a registry-qualified one, whose semver only pins a version
-///   within its named registry.
+/// - the alias appears under a registry-qualified key, whose semver only
+///   pins a version within its named registry.
 pub(crate) fn locked_version_resolution_would_pick(
     snapshots: Option<&LockedSnapshots>,
     alias: &PkgName,
     range: &Range,
     resolution_picks_lowest: bool,
-) -> Option<Version> {
-    let mut highest: Option<Version> = None;
-    let mut satisfying = 0_usize;
+) -> Option<LockedPick> {
+    let mut highest: Option<LockedPick> = None;
+    let mut several_versions_satisfy = false;
     for key in snapshots?.keys() {
         match locked_candidate(key, alias, range) {
             LockedCandidate::Unsupported => return None,
             LockedCandidate::Ignored => {}
-            LockedCandidate::Satisfying(version) => {
-                satisfying += 1;
-                if highest.as_ref().is_none_or(|best| version > *best) {
-                    highest = Some(version);
-                }
+            LockedCandidate::Satisfying(pick) => {
+                several_versions_satisfy |= keep_the_higher_version(&mut highest, pick);
             }
         }
     }
-    if satisfying > 1 && resolution_picks_lowest {
+    if resolution_picks_lowest && several_versions_satisfy {
         return None;
     }
     highest
 }
 
-/// What one locked package key contributes to the version pick.
+/// Fold one satisfying candidate into the running pick, and report whether
+/// it named a version other than the one already held.
+///
+/// A version several snapshots name is a peer variant as soon as one of
+/// them says so.
+fn keep_the_higher_version(highest: &mut Option<LockedPick>, pick: LockedPick) -> bool {
+    let Some(best) = highest else {
+        *highest = Some(pick);
+        return false;
+    };
+    if best.version == pick.version {
+        best.peer_suffixed |= pick.peer_suffixed;
+        return false;
+    }
+    if pick.version > best.version {
+        *best = pick;
+    }
+    true
+}
+
+/// The version [`locked_version_resolution_would_pick`] settles on.
+pub(crate) struct LockedPick {
+    pub(crate) version: Version,
+    /// Whether a snapshot names this version with a peer suffix. A record
+    /// written at the bare version would then name a snapshot the lockfile
+    /// does not hold, and which variant it should name instead is the
+    /// resolver's call.
+    pub(crate) peer_suffixed: bool,
+}
+
+/// What one locked snapshot key contributes to the version pick.
 enum LockedCandidate {
     /// The key names another package, or a version the range rejects.
     Ignored,
-    Satisfying(Version),
+    Satisfying(LockedPick),
     /// A key shape the fast path cannot reason about.
     Unsupported,
 }
@@ -550,14 +587,17 @@ fn locked_candidate(key: &PackageKey, alias: &PkgName, range: &Range) -> LockedC
     if &key.name != alias {
         return LockedCandidate::Ignored;
     }
-    if !key.suffix.peer().is_empty() || key.suffix.registry_qualified().is_some() {
+    if key.suffix.registry_qualified().is_some() {
         return LockedCandidate::Unsupported;
     }
     let Some(version) = key.suffix.version_semver() else {
         return LockedCandidate::Ignored;
     };
     if version.satisfies(range) {
-        return LockedCandidate::Satisfying(version.clone());
+        return LockedCandidate::Satisfying(LockedPick {
+            version: version.clone(),
+            peer_suffixed: !key.suffix.peer().is_empty(),
+        });
     }
     LockedCandidate::Ignored
 }

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -317,12 +317,13 @@ fn retarget_importer_dependency(
     ) else {
         return false;
     };
-    if wanted.version != *version {
-        // A move writes the bare version, so a target the lockfile holds
-        // only as a peer variant would name a snapshot that does not
-        // exist. An edge that stays put keeps the suffix it already
-        // carries, so only a move has to ask.
-        if wanted.peer_suffixed || ver_peer.peer() != "" {
+    let moves = wanted.version != *version;
+    let already_suffixed = ver_peer.peer() != "";
+    if !retarget_names_a_snapshot(&wanted, moves, already_suffixed) {
+        return false;
+    }
+    if moves {
+        if already_suffixed {
             return false;
         }
         let Ok(moved) = wanted.version.to_string().parse() else {
@@ -333,6 +334,17 @@ fn retarget_importer_dependency(
     }
     dependency.specifier = specifier.to_string();
     true
+}
+
+/// Whether the record a retarget leaves behind names a snapshot the
+/// lockfile holds.
+///
+/// A move writes the bare version, and an edge that stays put keeps the
+/// suffix it already carries, so a version the lockfile holds only as a
+/// peer variant can be named by the second of those alone, and only when
+/// the record already spells a suffix out.
+fn retarget_names_a_snapshot(wanted: &LockedPick, moves: bool, already_suffixed: bool) -> bool {
+    !wanted.peer_suffixed || (!moves && already_suffixed)
 }
 
 /// Whether the lockfile records no dependency of this project — the

--- a/pnpm/crates/package-manager/src/fast_update_importers.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers.rs
@@ -17,9 +17,11 @@ use std::{
     path::PathBuf,
 };
 
-/// The lockfile's `packages:` block, which an absorbed edge reads the
-/// version it points at out of.
-type LockedPackages = HashMap<PackageKey, pnpm_lockfile::PackageMetadata>;
+/// The lockfile's `snapshots:` block, which an absorbed edge reads the
+/// version it points at out of. Only its keys carry a peer suffix; the
+/// `packages:` key of a package that was resolved against a peer is the
+/// bare `name@version`, which names no snapshot an importer could link.
+type LockedSnapshots = HashMap<PackageKey, pnpm_lockfile::SnapshotEntry>;
 
 /// Each manifest alias with its specifier and the group it is
 /// effectively declared under. Keyed by [`PkgName`] so membership tests
@@ -157,8 +159,8 @@ pub(crate) fn apply_importers_update(
     if !drop_stale_importers(candidate, plan, edits) {
         return false;
     }
-    let Lockfile { packages, importers, time, .. } = candidate;
-    let locked = LockedInputs { packages: packages.as_ref(), time: time.as_ref() };
+    let Lockfile { snapshots, importers, time, .. } = candidate;
+    let locked = LockedInputs { snapshots: snapshots.as_ref(), time: time.as_ref() };
     for (importer_id, manifest, manifest_dependencies) in &plan.manifest_dependencies {
         let entry = ImporterUpdate { importer_id, manifest, manifest_dependencies };
         if !apply_one_importer_update(importers, &entry, locked, plan, edits) {
@@ -171,7 +173,7 @@ pub(crate) fn apply_importers_update(
 /// The lockfile halves an importer edge is replayed against.
 #[derive(Clone, Copy)]
 struct LockedInputs<'a> {
-    packages: Option<&'a LockedPackages>,
+    snapshots: Option<&'a LockedSnapshots>,
     time: Option<&'a BTreeMap<String, String>>,
 }
 
@@ -231,7 +233,7 @@ fn apply_one_importer_update(
     let records_nothing = importers.get(importer_id.as_str()).is_none_or(records_no_dependencies);
     if records_nothing && !manifest_dependencies.is_empty() {
         let Some(new_importer) =
-            importer_from_locked_versions(locked.packages, manifest, manifest_dependencies, plan)
+            importer_from_locked_versions(locked.snapshots, manifest, manifest_dependencies, plan)
         else {
             return false;
         };
@@ -268,7 +270,7 @@ fn apply_importer_edge(
             importer,
             alias,
             (specifier, target),
-            locked.packages,
+            locked.snapshots,
             locked.time,
             plan,
             edits,
@@ -308,7 +310,7 @@ fn retarget_importer_dependency(
         return false;
     };
     let Some(wanted) = locked_version_resolution_would_pick(
-        locked.packages,
+        locked.snapshots,
         alias,
         &range,
         plan.resolution_picks_lowest,
@@ -346,7 +348,7 @@ fn records_no_dependencies(importer: &ProjectSnapshot) -> bool {
 /// resolves to a directory rather than to a registry version, one whose
 /// specifier is not a semver range, and one no locked version satisfies.
 fn importer_from_locked_versions(
-    packages: Option<&HashMap<PackageKey, pnpm_lockfile::PackageMetadata>>,
+    snapshots: Option<&LockedSnapshots>,
     manifest: &PackageManifest,
     manifest_dependencies: &ManifestDependencies<'_>,
     plan: &ImportersPlan<'_, '_>,
@@ -359,7 +361,7 @@ fn importer_from_locked_versions(
         }
         let range = Range::parse(specifier).ok()?;
         let version = locked_version_resolution_would_pick(
-            packages,
+            snapshots,
             alias,
             &range,
             plan.resolution_picks_lowest,
@@ -393,7 +395,7 @@ fn add_importer_edge(
     importer: &mut ProjectSnapshot,
     alias: &PkgName,
     declared: (&str, DependencyGroup),
-    packages: Option<&LockedPackages>,
+    snapshots: Option<&LockedSnapshots>,
     time: Option<&BTreeMap<String, String>>,
     plan: &ImportersPlan<'_, '_>,
     edits: &mut GraphEdits,
@@ -414,9 +416,12 @@ fn add_importer_edge(
     let Ok(range) = Range::parse(specifier) else {
         return false;
     };
-    let Some(wanted) =
-        locked_version_resolution_would_pick(packages, alias, &range, plan.resolution_picks_lowest)
-    else {
+    let Some(wanted) = locked_version_resolution_would_pick(
+        snapshots,
+        alias,
+        &range,
+        plan.resolution_picks_lowest,
+    ) else {
         return false;
     };
     // `time` carries a publish date per direct dependency, and only a
@@ -507,14 +512,14 @@ fn link_resolves_to(from: &str, target: &str, importer_id: &str) -> bool {
 ///   guess, or a registry-qualified one, whose semver only pins a version
 ///   within its named registry.
 pub(crate) fn locked_version_resolution_would_pick(
-    packages: Option<&LockedPackages>,
+    snapshots: Option<&LockedSnapshots>,
     alias: &PkgName,
     range: &Range,
     resolution_picks_lowest: bool,
 ) -> Option<Version> {
     let mut highest: Option<Version> = None;
     let mut satisfying = 0_usize;
-    for key in packages?.keys() {
+    for key in snapshots?.keys() {
         match locked_candidate(key, alias, range) {
             LockedCandidate::Unsupported => return None,
             LockedCandidate::Ignored => {}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1666,3 +1666,39 @@ fn rejects_moving_a_range_onto_a_version_locked_only_as_a_peer_variant() {
         "the only locked 1.1.0 is a peer variant, which a moved edge cannot name unsuffixed",
     );
 }
+
+/// [`WITH_ONLY_A_PEER_VARIANT`] with the importer depending on the peer
+/// variant directly, the shape a package that resolved peers takes once
+/// it is a direct dependency.
+fn with_a_direct_peer_variant() -> Lockfile {
+    let mut subject = parsed_lockfile(WITH_ONLY_A_PEER_VARIANT);
+    subject
+        .importers
+        .get_mut(".")
+        .expect("importer")
+        .dependencies
+        .as_mut()
+        .expect("dependencies")
+        .insert(
+            "foo".parse().expect("alias"),
+            serde_saphyr::from_str("{specifier: ^1.0.0, version: 1.1.0(bar@2.0.0)}")
+                .expect("dependency"),
+        );
+    subject
+}
+
+#[test]
+fn updates_a_range_that_stays_on_the_peer_variant_the_importer_records() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),
+    );
+
+    let updated =
+        try_fast_update_importers(&with_a_direct_peer_variant(), &[(".".to_string(), &manifest)])
+            .expect("the edge stays on the version it already names, suffix and all");
+
+    let foo = &updated.importers["."].dependencies.as_ref().expect("dependencies")
+        [&"foo".parse::<PkgName>().expect("alias")];
+    assert_eq!(foo.specifier, "^1.1.0");
+    assert_eq!(foo.version.to_string(), "1.1.0(bar@2.0.0)");
+}

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -976,6 +976,9 @@ fn rejects_a_higher_version_that_exists_only_under_a_named_registry() {
     let packages = subject.packages.as_mut().expect("packages");
     let higher = packages.remove(&"foo@1.2.0".parse().expect("package key")).expect("foo@1.2.0");
     packages.insert("foo@work:1.2.0".parse().expect("package key"), higher);
+    let snapshots = subject.snapshots.as_mut().expect("snapshots");
+    let higher = snapshots.remove(&"foo@1.2.0".parse().expect("snapshot key")).expect("foo@1.2.0");
+    snapshots.insert("foo@work:1.2.0".parse().expect("snapshot key"), higher);
     let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0" } }));
 
     assert!(
@@ -1347,6 +1350,9 @@ fn rejects_a_range_when_the_alias_also_has_a_named_registry_key() {
     let packages = subject.packages.as_mut().expect("packages");
     let extra = packages[&"foo@1.2.0".parse::<PackageKey>().expect("package key")].clone();
     packages.insert("foo@work:1.4.0".parse().expect("package key"), extra);
+    let snapshots = subject.snapshots.as_mut().expect("snapshots");
+    let extra = snapshots[&"foo@1.2.0".parse::<PackageKey>().expect("snapshot key")].clone();
+    snapshots.insert("foo@work:1.4.0".parse().expect("snapshot key"), extra);
     let manifest = manifest_from(json!({ "dependencies": { "foo": "^1.1.0" } }));
 
     assert!(
@@ -1556,5 +1562,107 @@ fn a_resolve_needing_importer_vetoes_absorbable_siblings_in_either_order() {
             [&"foo".parse().expect("package name")]
             .specifier,
         ">=1 <2",
+    );
+}
+
+/// `foo` is reached only through `qux`, which resolved `bar` as `foo`'s
+/// peer, so the one snapshot of `foo` is the peer-suffixed variant while
+/// its `packages:` key is the bare `foo@1.1.0`. An importer edge written
+/// at that bare version would name a snapshot the lockfile does not hold.
+const WITH_ONLY_A_PEER_VARIANT: &str = r"
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      bar:
+        specifier: ^2.0.0
+        version: 2.0.0
+      qux:
+        specifier: ^5.0.0
+        version: 5.0.0
+packages:
+  bar@2.0.0:
+    resolution:
+      integrity: sha512-bar
+  foo@1.1.0:
+    resolution:
+      integrity: sha512-foo
+  qux@5.0.0:
+    resolution:
+      integrity: sha512-qux
+snapshots:
+  bar@2.0.0: {}
+  foo@1.1.0(bar@2.0.0):
+    dependencies:
+      bar: 2.0.0
+  qux@5.0.0:
+    dependencies:
+      foo: 1.1.0(bar@2.0.0)
+";
+
+#[test]
+fn rejects_adding_a_dependency_the_lockfile_holds_only_as_a_peer_variant() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.0.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_ONLY_A_PEER_VARIANT),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "the bare foo@1.1.0 names no snapshot, so which peer variant the edge takes is the resolver's call",
+    );
+}
+
+#[test]
+fn rejects_a_new_project_whose_dependency_is_locked_only_as_a_peer_variant() {
+    let existing = manifest_from(json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0" } }));
+    let added = manifest_from(json!({ "dependencies": { "foo": "^1.0.0" } }));
+
+    assert!(
+        try_fast_update_importers(
+            &parsed_lockfile(WITH_ONLY_A_PEER_VARIANT),
+            &[(".".to_string(), &existing), ("packages/a".to_string(), &added)],
+        )
+        .is_none(),
+        "a whole new importer is written from the same locked versions as a single edge",
+    );
+}
+
+/// [`WITH_ONLY_A_PEER_VARIANT`] with the importer already depending on a
+/// peerless `foo@1.0.0`, so a range that admits `1.1.0` would move onto
+/// the version held only as a peer variant.
+fn with_a_lower_peerless_foo() -> Lockfile {
+    let mut subject = parsed_lockfile(WITH_ONLY_A_PEER_VARIANT);
+    let packages = subject.packages.as_mut().expect("packages");
+    let metadata = packages[&"foo@1.1.0".parse::<PackageKey>().expect("package key")].clone();
+    packages.insert("foo@1.0.0".parse().expect("package key"), metadata);
+    subject.snapshots.as_mut().expect("snapshots").insert(
+        "foo@1.0.0".parse().expect("snapshot key"),
+        pnpm_lockfile::SnapshotEntry::default(),
+    );
+    let importer = subject.importers.get_mut(".").expect("importer");
+    importer.dependencies.as_mut().expect("dependencies").insert(
+        "foo".parse().expect("alias"),
+        pnpm_lockfile::ResolvedDependencySpec {
+            specifier: "1.0.0".to_string(),
+            version: pnpm_lockfile::ImporterDepVersion::Regular("1.0.0".parse().expect("version")),
+        },
+    );
+    subject
+}
+
+#[test]
+fn rejects_moving_a_range_onto_a_version_locked_only_as_a_peer_variant() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(&with_a_lower_peerless_foo(), &[(".".to_string(), &manifest)])
+            .is_none(),
+        "the only locked 1.1.0 is a peer variant, which a moved edge cannot name unsuffixed",
     );
 }

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1667,6 +1667,34 @@ fn rejects_moving_a_range_onto_a_version_locked_only_as_a_peer_variant() {
     );
 }
 
+/// [`WITH_ONLY_A_PEER_VARIANT`] with a second snapshot of the same
+/// version that resolved none of `foo`'s peers, the shape two parents
+/// leave behind when only one of them provides `bar`.
+fn with_a_bare_snapshot_beside_the_peer_variant() -> Lockfile {
+    let mut subject = parsed_lockfile(WITH_ONLY_A_PEER_VARIANT);
+    subject.snapshots.as_mut().expect("snapshots").insert(
+        "foo@1.1.0".parse().expect("snapshot key"),
+        pnpm_lockfile::SnapshotEntry::default(),
+    );
+    subject
+}
+
+#[test]
+fn rejects_adding_a_dependency_whose_version_is_locked_both_ways() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.0.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(
+            &with_a_bare_snapshot_beside_the_peer_variant(),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "a bare snapshot beside the peer variant does not say which of the two a direct edge takes",
+    );
+}
+
 /// [`WITH_ONLY_A_PEER_VARIANT`] with the importer depending on the peer
 /// variant directly, the shape a package that resolved peers takes once
 /// it is a direct dependency.

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1733,6 +1733,22 @@ fn updates_a_range_that_stays_on_the_peer_variant_the_importer_records() {
 }
 
 #[test]
+fn rejects_a_range_change_on_an_edge_whose_peer_suffix_names_no_snapshot() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(
+            &with_a_direct_foo_at("1.1.0(bar@1.0.0)"),
+            &[(".".to_string(), &manifest)],
+        )
+        .is_none(),
+        "the recorded suffix names no snapshot, so keeping the record would keep the link dangling",
+    );
+}
+
+#[test]
 fn rejects_a_range_change_on_a_bare_edge_the_lockfile_holds_only_as_a_peer_variant() {
     let manifest = manifest_from(
         json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),

--- a/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
+++ b/pnpm/crates/package-manager/src/fast_update_importers/tests.rs
@@ -1695,10 +1695,9 @@ fn rejects_adding_a_dependency_whose_version_is_locked_both_ways() {
     );
 }
 
-/// [`WITH_ONLY_A_PEER_VARIANT`] with the importer depending on the peer
-/// variant directly, the shape a package that resolved peers takes once
-/// it is a direct dependency.
-fn with_a_direct_peer_variant() -> Lockfile {
+/// [`WITH_ONLY_A_PEER_VARIANT`] with the importer depending on `foo`
+/// directly at `recorded`.
+fn with_a_direct_foo_at(recorded: &str) -> Lockfile {
     let mut subject = parsed_lockfile(WITH_ONLY_A_PEER_VARIANT);
     subject
         .importers
@@ -1709,7 +1708,7 @@ fn with_a_direct_peer_variant() -> Lockfile {
         .expect("dependencies")
         .insert(
             "foo".parse().expect("alias"),
-            serde_saphyr::from_str("{specifier: ^1.0.0, version: 1.1.0(bar@2.0.0)}")
+            serde_saphyr::from_str(&format!("{{specifier: ^1.0.0, version: {recorded}}}"))
                 .expect("dependency"),
         );
     subject
@@ -1721,12 +1720,27 @@ fn updates_a_range_that_stays_on_the_peer_variant_the_importer_records() {
         json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),
     );
 
-    let updated =
-        try_fast_update_importers(&with_a_direct_peer_variant(), &[(".".to_string(), &manifest)])
-            .expect("the edge stays on the version it already names, suffix and all");
+    let updated = try_fast_update_importers(
+        &with_a_direct_foo_at("1.1.0(bar@2.0.0)"),
+        &[(".".to_string(), &manifest)],
+    )
+    .expect("the edge stays on the version it already names, suffix and all");
 
     let foo = &updated.importers["."].dependencies.as_ref().expect("dependencies")
         [&"foo".parse::<PkgName>().expect("alias")];
     assert_eq!(foo.specifier, "^1.1.0");
     assert_eq!(foo.version.to_string(), "1.1.0(bar@2.0.0)");
+}
+
+#[test]
+fn rejects_a_range_change_on_a_bare_edge_the_lockfile_holds_only_as_a_peer_variant() {
+    let manifest = manifest_from(
+        json!({ "dependencies": { "bar": "^2.0.0", "qux": "^5.0.0", "foo": "^1.1.0" } }),
+    );
+
+    assert!(
+        try_fast_update_importers(&with_a_direct_foo_at("1.1.0"), &[(".".to_string(), &manifest)],)
+            .is_none(),
+        "the bare record names no snapshot, so leaving it in place would keep the link dangling",
+    );
 }

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -193,12 +193,15 @@ fn overridden_version(lockfile: &Lockfile, name: &PkgName, value: &str) -> Optio
     let range = Range::parse(value).ok()?;
     // `resolutionMode` only moves direct dependencies to the low end of
     // their range, and an override names a package at any depth.
-    crate::fast_update_importers::locked_version_resolution_would_pick(
+    let pick = crate::fast_update_importers::locked_version_resolution_would_pick(
         lockfile.snapshots.as_ref(),
         name,
         &range,
         false,
-    )
+    )?;
+    // The plan records the target as a bare version, and a peer variant is
+    // a key `build_replacement_plan` refuses to rewrite anyway.
+    (!pick.peer_suffixed).then_some(pick.version)
 }
 
 /// Work out which locked packages each entry of `overrides` moves, and

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -194,7 +194,7 @@ fn overridden_version(lockfile: &Lockfile, name: &PkgName, value: &str) -> Optio
     // `resolutionMode` only moves direct dependencies to the low end of
     // their range, and an override names a package at any depth.
     crate::fast_update_importers::locked_version_resolution_would_pick(
-        lockfile.packages.as_ref(),
+        lockfile.snapshots.as_ref(),
         name,
         &range,
         false,


### PR DESCRIPTION
## Summary

Promoting a package from a transitive to a direct dependency, when the lockfile holds it only as a peer-suffixed snapshot, leaves a dangling symlink in pnpm 12.

`pnpm install`, `pnpm add <pkg>@<range>` and `pnpm install --lockfile-only` all take the fast lockfile update ("Lockfile is up to date, resolution step is skipped") and write the importer edge at the bare version, e.g. `version: 1.6.0`, while the only snapshot is `use-sync-external-store@1.6.0(react@19.1.0)`. The virtual store never creates `node_modules/.pnpm/use-sync-external-store@1.6.0/`, so `apps/a/node_modules/use-sync-external-store` dangles and TypeScript fails with TS2307.

**Root cause.** `locked_version_resolution_would_pick` in `pnpm/crates/package-manager/src/fast_update_importers.rs` promises to refuse an alias recorded under a peer-suffixed key, but it iterated the lockfile's `packages:` block. In lockfile v9 those keys never carry a peer suffix, so the guard could never fire. The TypeScript CLI walks its merged in-memory `packages` map keyed by full dep path (`lockfileFormatConverters.ts`), which is why pnpm 11.26.0 resolves the same case correctly and writes `1.6.0(react@19.1.0)`.

**Fix.** Read the `snapshots:` block instead. Its keys are the ones an importer edge can name, and its peer-suffixed keys are exactly what the guard was written for. The pick reports whether a snapshot names the version it settled on with a peer suffix, and every reader that writes a bare record refuses it: a new edge in an existing importer (pnpm/pnpm#13807), a whole new importer (pnpm/pnpm#13803), and a range move onto another locked version (pnpm/pnpm#13477). An edge whose range change leaves it on the version it already names keeps the suffix it already carries, so it stays on the fast path. The override version pick in `fast_update_overrides.rs` shares the function and follows it; its plan already refused peer-suffixed targets, so nothing changes there.

Closes pnpm/pnpm#14714, which reports the new-workspace-package shape of the same defect (a new member declaring `vue` gets a bare `vue@3.5.42` edge while older members link `vue@3.5.42_typescript@6.0.3`). That report was reproduced against the mocked registry: a member added after the lockfile was written records `@pnpm.e2e/abc` at the bare `1.0.0` and its link dangles on `main`, and records the peer-suffixed version and links to a real package with this branch. `a_new_workspace_member_links_a_dependency_locked_only_as_a_peer_variant` is that reproduction.

Reproduced on pnpm 12.1.0 and 12.4.0 (`npx pnpm@<version>`); not present in pnpm 11.26.0. The patched binary resolves the edge to `1.6.0(react@19.1.0)` and the symlink resolves.

### Reproduction

```sh
mkdir -p repro/apps/a && cd repro
echo '{ "name": "repro-root", "private": true }' > package.json
printf 'packages:\n  - apps/*\n' > pnpm-workspace.yaml
echo '{ "name": "a", "private": true, "dependencies": { "react": "19.1.0", "react-redux": "9.2.0" } }' > apps/a/package.json
npx pnpm@12.4.0 install
# use-sync-external-store@1.6.0(react@19.1.0) is the only snapshot of it (transitive via react-redux)

echo '{ "name": "a", "private": true, "dependencies": { "react": "19.1.0", "react-redux": "9.2.0", "use-sync-external-store": "^1.5.0" } }' > apps/a/package.json
npx pnpm@12.4.0 install
# Lockfile is up to date, resolution step is skipped
# importers.apps/a.dependencies.use-sync-external-store.version: 1.6.0   <- no peer suffix, no such snapshot
ls apps/a/node_modules/use-sync-external-store/package.json
# No such file or directory (dangling symlink into node_modules/.pnpm/use-sync-external-store@1.6.0/)
```

Same result with `npx pnpm@12.4.0 add use-sync-external-store@^1.5.0 --filter a` and with `--lockfile-only`. pnpm 11.26.0 writes `version: 1.6.0(react@19.1.0)` and the link resolves.

## Squash Commit Body

```text
The fast lockfile update writes a new importer edge from the version the
lockfile already holds, and its version pick promised to refuse an alias
recorded under a peer-suffixed key, because which peer variant the edge
would take is the resolver's call. It read the `packages:` block, whose
keys never carry a peer suffix in lockfile v9, so the guard could not
fire: a package that had only ever been resolved against a peer looked
like a bare `name@version`, the edge was written at that bare version,
and no snapshot existed for it. The importer then linked
`node_modules/.pnpm/name@version/`, which the virtual store never
creates, leaving a dangling symlink and "Cannot find module" errors.

Read the `snapshots:` block instead. Its keys are the ones an importer
edge can name, and the peer-suffixed ones are exactly the shape the
guard was written for. The TypeScript CLI walks its merged in-memory
`packages` map, keyed by full dep path, which is why pnpm 11 resolves
this case correctly and pnpm 12 did not.

The new-importer path carries an end-to-end test of its own, because it
is the shape the issue reports.

The pick reports whether a snapshot names the version it settled on with
a peer suffix rather than refusing to settle at all, because a peer
suffix only blocks the records that are written bare. Three paths read
it: a new edge in an existing importer, a whole new importer, and a
range move onto another locked version. Each refuses a flagged pick,
with a unit test per path and an end-to-end test that promotes
`@pnpm.e2e/abc` from a transitive to a direct dependency and checks that
the recorded version names a snapshot the lockfile holds and links to a
package on disk. An edge that stays on the version it already names
keeps its suffix, so a narrowed range on a peer-dependent direct
dependency is still absorbed without resolving. The override version
pick shares the function and follows it to `snapshots:`; its own plan
already refused peer-suffixed targets, so its behavior is unchanged.

Two existing tests inserted a registry-qualified key into `packages:`
alone; they now mirror it into `snapshots:`, as any lockfile pnpm
writes does.

Closes pnpm/pnpm#14714.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (v12 only: pnpm 11.26.0 does not have the bug.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.

Tests run locally on the pinned toolchain (1.97.0): `cargo nextest run -p pnpm-package-manager` and the whole `lockfile_resolution_reuse` module of the CLI suite, plus `cargo fmt --check`, `cargo clippy --all-targets -- --deny warnings` on both crates, and `typos`.

## Follow-up review

A maintainer review found that vetoing the whole pick on any
peer-suffixed key took every dependency with peer dependencies off the
fast lockfile update, including a plain range edit on a direct
dependency that stays on the version it already names. The pick now
carries the peer suffix as a flag its callers consult, which keeps the
fix and restores that path; a regression test covers it. The end-to-end
fixture check no longer passes vacuously, and the changeset was
rewritten to the repository's release-note style.

---

Written by an agent (Claude Code, claude-fable-5-1), with a follow-up review by an agent (Claude Code, claude-opus-5).





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `pnpm install` or `pnpm add` could leave a dangling symlink in `node_modules` when promoting a transitive dependency with peer dependencies to a direct dependency.
  * Improved dependency resolution for workspace projects so existing peer-specific package versions are linked correctly.
  * Prevented updates from selecting incompatible peer-specific dependency variants.
  * Preserved valid peer-specific dependency links during compatible range updates.
  * Improved handling of dependency overrides when only peer-specific locked versions are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->