### PR TITLE
fix(store-dir): rebuild when the side-effects cache has nothing to restore

### DIFF
--- a/.changeset/side-effects-cache-empty-overlay.md
+++ b/.changeset/side-effects-cache-empty-overlay.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+`pnpm install` now runs a dependency's build scripts when the side-effects cache has no build output to restore in their place. Such a build was skipped and nothing was materialized for it, so a script whose whole effect lands outside its own package directory, such as a git-hook installer, never took effect [#14717](https://github.com/pnpm/pnpm/issues/14717).

--- a/.changeset/side-effects-cache-empty-overlay.md
+++ b/.changeset/side-effects-cache-empty-overlay.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` now runs a dependency's build scripts when the side-effects cache has no build output to restore in their place. Such a build was skipped and nothing was materialized for it, so a script whose whole effect lands outside its own package directory, such as a git-hook installer, never took effect [#14717](https://github.com/pnpm/pnpm/issues/14717).
+`pnpm install` now runs a dependency's build scripts again when its side-effects cache entry has no files to restore. Such builds were skipped and nothing was put in their place, so a script whose whole effect lands outside its own package directory, such as a git-hook installer, never took effect [#14717](https://github.com/pnpm/pnpm/issues/14717).

--- a/.changeset/side-effects-cache-empty-overlay.md
+++ b/.changeset/side-effects-cache-empty-overlay.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm install` now runs a dependency's build scripts again when its side-effects cache entry has no files to restore. Such builds were skipped and nothing was put in their place, so a script whose whole effect lands outside its own package directory, such as a git-hook installer, never took effect [#14717](https://github.com/pnpm/pnpm/issues/14717).
+`pnpm install` now runs a dependency's build scripts again when its side-effects cache entry has no files to restore. Such builds were skipped and nothing was put in their place, so a script whose whole effect lands outside its own package directory, such as a git-hook installer, never took effect. The same applies to an artifact from the shared side-effects cache, and pnpm no longer publishes such empty artifacts [#14717](https://github.com/pnpm/pnpm/issues/14717).

--- a/pnpm/crates/cli/tests/suite/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/suite/side_effects_cache.rs
@@ -90,6 +90,75 @@ fn assert_side_effects_materialized(hoisted: bool) {
     drop((root, mock_instance));
 }
 
+/// A build whose whole effect lands outside the package directory — a
+/// git-hook installer, a script seeding a shared download cache — has
+/// nothing for the side-effects cache to record. The cache still gets a row
+/// for it, because a row is written whenever a script ran, but restoring
+/// that row materializes nothing. Taking it as a cache hit would skip the
+/// scripts and put nothing in their place, so the effect never happens at
+/// all. pnpm 11 rebuilds here and so must pacquet.
+///
+/// Regression for <https://github.com/pnpm/pnpm/issues/14717>.
+#[test]
+fn a_build_with_nothing_to_restore_runs_on_every_install() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry();
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+
+    let yaml_path = workspace.join("pnpm-workspace.yaml");
+    let mut yaml = fs::read_to_string(&yaml_path).expect("read pnpm-workspace.yaml");
+    if !yaml.ends_with('\n') {
+        yaml.push('\n');
+    }
+    yaml.push_str("allowBuilds:\n  '@pnpm.e2e/postinstall-writes-outside-package': true\n");
+    fs::write(&yaml_path, yaml).expect("write pnpm-workspace.yaml");
+
+    fs::write(
+        workspace.join("package.json"),
+        serde_json::json!({
+            "dependencies": { "@pnpm.e2e/postinstall-writes-outside-package": "1.0.0" },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    // The package's postinstall appends one byte here, so the file's length
+    // is the number of installs that actually ran it. It lives outside the
+    // workspace, which is the whole point: nothing the script does is
+    // inside the package, so the recorded diff is empty.
+    let log = root.path().join("outside-log");
+    fs::write(&log, "").expect("create the log");
+    let runs = || fs::read_to_string(&log).expect("read the log").len();
+
+    pacquet
+        .with_arg("install")
+        .with_env("PNPM_E2E_OUTSIDE_LOG", log.to_string_lossy().as_ref())
+        .assert()
+        .success();
+    assert_eq!(runs(), 1, "the first install runs the postinstall");
+
+    for install in 2..=3 {
+        fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
+        let output = Command::cargo_bin("pnpm")
+            .expect("find the pnpm binary")
+            .with_current_dir(&workspace)
+            .with_args(["install", "--frozen-lockfile"])
+            .with_env("PNPM_E2E_OUTSIDE_LOG", log.to_string_lossy().as_ref())
+            .output()
+            .expect("run the install");
+        assert!(output.status.success(), "install must succeed: {output:?}");
+        assert_eq!(
+            runs(),
+            install,
+            "install {install} must run the postinstall again, since the cache has nothing to \
+             restore in its place:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+        );
+    }
+
+    drop((root, mock_instance));
+}
+
 /// A fresh `pacquet install --frozen-lockfile` against an existing
 /// workspace. The registry config lives in the workspace's `.npmrc` /
 /// `pnpm-workspace.yaml` and the mock registry is a process-global

--- a/pnpm/crates/cli/tests/suite/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/suite/side_effects_cache.rs
@@ -2,7 +2,10 @@
 
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
-use pnpm_testing_utils::bin::{AddMockedRegistry, CommandTempCwd};
+use pnpm_testing_utils::{
+    bin::{AddMockedRegistry, CommandTempCwd},
+    command_env::CommandTestExt,
+};
 use std::{fs, path::Path, process::Command};
 
 /// Regression for <https://github.com/pnpm/pnpm/issues/12042#issuecomment-4682732058>:
@@ -141,6 +144,7 @@ fn a_build_with_nothing_to_restore_runs_on_every_install() {
         fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
         let output = Command::cargo_bin("pnpm")
             .expect("find the pnpm binary")
+            .without_ambient_pnpm_config()
             .with_current_dir(&workspace)
             .with_args(["install", "--frozen-lockfile"])
             .with_env("PNPM_E2E_OUTSIDE_LOG", log.to_string_lossy().as_ref())
@@ -167,6 +171,7 @@ fn a_build_with_nothing_to_restore_runs_on_every_install() {
 fn run_frozen_install(workspace: &Path) {
     Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
+        .without_ambient_pnpm_config()
         .with_current_dir(workspace)
         .with_args(["install", "--frozen-lockfile"])
         .assert()

--- a/pnpm/crates/cli/tests/suite/side_effects_cache.rs
+++ b/pnpm/crates/cli/tests/suite/side_effects_cache.rs
@@ -93,13 +93,10 @@ fn assert_side_effects_materialized(hoisted: bool) {
     drop((root, mock_instance));
 }
 
-/// A build whose whole effect lands outside the package directory — a
-/// git-hook installer, a script seeding a shared download cache — has
-/// nothing for the side-effects cache to record. The cache still gets a row
-/// for it, because a row is written whenever a script ran, but restoring
-/// that row materializes nothing. Taking it as a cache hit would skip the
-/// scripts and put nothing in their place, so the effect never happens at
-/// all. pnpm 11 rebuilds here and so must pacquet.
+/// A build whose whole effect lands outside the package directory, such as
+/// a git-hook installer, leaves the side-effects cache nothing to restore.
+/// Such a row must not count as a cache hit: skipping the scripts would
+/// put nothing in their place, so the effect would never happen.
 ///
 /// Regression for <https://github.com/pnpm/pnpm/issues/14717>.
 #[test]
@@ -142,11 +139,7 @@ fn a_build_with_nothing_to_restore_runs_on_every_install() {
 
     for install in 2..=3 {
         fs::remove_dir_all(workspace.join("node_modules")).expect("remove node_modules");
-        let output = Command::cargo_bin("pnpm")
-            .expect("find the pnpm binary")
-            .without_ambient_pnpm_config()
-            .with_current_dir(&workspace)
-            .with_args(["install", "--frozen-lockfile"])
+        let output = frozen_install_command(&workspace)
             .with_env("PNPM_E2E_OUTSIDE_LOG", log.to_string_lossy().as_ref())
             .output()
             .expect("run the install");
@@ -169,11 +162,13 @@ fn a_build_with_nothing_to_restore_runs_on_every_install() {
 /// singleton kept alive by the caller, so this only needs its own
 /// command — no extra `CommandTempCwd` / registry.
 fn run_frozen_install(workspace: &Path) {
+    frozen_install_command(workspace).assert().success();
+}
+
+fn frozen_install_command(workspace: &Path) -> Command {
     Command::cargo_bin("pnpm")
         .expect("find the pnpm binary")
         .without_ambient_pnpm_config()
         .with_current_dir(workspace)
         .with_args(["install", "--frozen-lockfile"])
-        .assert()
-        .success();
 }

--- a/pnpm/crates/deps-restorer/src/shared_side_effects.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects.rs
@@ -587,6 +587,16 @@ async fn apply_resolved_artifact(
     side_effects_maps_by_snapshot: &mut SideEffectsMapsBySnapshot,
 ) {
     let Some(group) = context.groups.get(input_key) else { return };
+    // See `SideEffectsDiff::is_empty`: an artifact with nothing to restore
+    // must not stand in for the build.
+    if artifact.payload.manifest.is_empty() {
+        tracing::debug!(
+            target: "pacquet::install",
+            input_key,
+            "remote side-effects artifact restores nothing; building locally instead",
+        );
+        return;
+    }
     let Some((first_snapshot, _, _)) = group.snapshots.first() else { return };
     let Some(base) = context.base_cas_paths.get(first_snapshot) else { return };
     let staged = match stage_artifact(context, artifact, base).await {
@@ -1075,6 +1085,9 @@ impl SharedSideEffectsPublisher {
         diff: pnpm_store_dir::SideEffectsDiff,
         store: &pnpm_store_dir::StoreDir,
     ) -> Result<(), String> {
+        if diff.is_empty() {
+            return Ok(());
+        }
         let Some(subject) = self.subject(&snapshot_key.without_peer(), metadata) else {
             return Ok(());
         };

--- a/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
+++ b/pnpm/crates/deps-restorer/src/shared_side_effects/tests.rs
@@ -223,19 +223,35 @@ mod restore {
         )
     }
 
+    /// The one built file, as an artifact lists it.
+    fn built_manifest() -> ArtifactManifest {
+        ArtifactManifest {
+            added: vec![ArtifactFile {
+                path: BUILT_FILE.to_string(),
+                integrity: integrity_of(built_bytes()),
+                mode: BUILT_MODE,
+                size: built_bytes().len() as u64,
+            }],
+            deleted: Vec::new(),
+        }
+    }
+
     /// Sign the artifact the server offers for `request`'s one candidate.
     ///
     /// The input key and source integrity are echoed from the request because
     /// both are derived from the host's node major and the lockfile, and the
     /// client discards any variant that does not match the candidate it asked
     /// about.
-    fn signed_response(request: &[u8], compatibility_tag: &str) -> String {
+    fn signed_response(
+        request: &[u8],
+        compatibility_tag: &str,
+        manifest: ArtifactManifest,
+    ) -> String {
         let request: ResolveArtifactsRequest =
             serde_json::from_slice(request).expect("resolve request");
         let [candidate] = request.candidates.as_slice() else {
             panic!("expected exactly one candidate, got {}", request.candidates.len());
         };
-        let bytes = built_bytes();
         let payload = ArtifactPayload {
             kind: ARTIFACT_KIND.to_string(),
             subject: candidate.subject.clone(),
@@ -250,15 +266,7 @@ mod restore {
             compatibility: CompatibilityConstraints::Tagged {
                 tags: vec![compatibility_tag.to_string()],
             },
-            manifest: ArtifactManifest {
-                added: vec![ArtifactFile {
-                    path: BUILT_FILE.to_string(),
-                    integrity: integrity_of(bytes),
-                    mode: BUILT_MODE,
-                    size: bytes.len() as u64,
-                }],
-                deleted: Vec::new(),
-            },
+            manifest,
         };
         // Signed the way a publisher signs, so the fixture cannot drift from
         // the wire format the client verifies — and so a payload this test
@@ -305,15 +313,7 @@ mod restore {
                 environment: BTreeMap::new(),
             },
             compatibility: CompatibilityConstraints::Tagged { tags: supported_tags.clone() },
-            manifest: ArtifactManifest {
-                added: vec![ArtifactFile {
-                    path: BUILT_FILE.to_string(),
-                    integrity: integrity_of(built_bytes()),
-                    mode: BUILT_MODE,
-                    size: built_bytes().len() as u64,
-                }],
-                deleted: Vec::new(),
-            },
+            manifest: built_manifest(),
         };
         let envelope = SignedArtifactEnvelope::sign(
             &payload,
@@ -366,10 +366,27 @@ mod restore {
         ),);
     }
 
-    /// Restore against a server that offers the artifact, asserting that the
-    /// blob endpoint was hit exactly `expected_downloads` times, and return
-    /// the path the resulting overlay maps the built file to.
+    /// Restore against a server that offers the built file, asserting that
+    /// the blob endpoint was hit exactly `expected_downloads` times, and
+    /// return the path the resulting overlay maps the built file to.
     async fn restore(store_dir: &StoreDir, expected_downloads: usize) -> PathBuf {
+        let snapshot_key: PackageKey = SNAPSHOT.parse().expect("snapshot key");
+        let side_effects = apply(store_dir, built_manifest(), expected_downloads).await;
+        let maps = side_effects.get(&snapshot_key).expect("the snapshot must be restored");
+        let [overlay] = maps.values().collect::<Vec<_>>()[..] else {
+            panic!("expected one cache key, got {}", maps.len());
+        };
+        overlay.get(BUILT_FILE).expect("the built file must be in the overlay").clone()
+    }
+
+    /// Apply the shared cache against a server that offers `manifest` for
+    /// the one snapshot, asserting that the blob endpoint was hit exactly
+    /// `expected_downloads` times.
+    async fn apply(
+        store_dir: &StoreDir,
+        manifest: ArtifactManifest,
+        expected_downloads: usize,
+    ) -> SideEffectsMapsBySnapshot {
         let snapshots = snapshots();
         let packages = packages();
         let platform = super::super::artifact_platform(&snapshots)
@@ -393,7 +410,12 @@ mod restore {
             .mock("POST", "/-/pnpr/v0/artifacts/resolve")
             .with_header("content-type", "application/json")
             .with_body_from_request(move |request| {
-                signed_response(request.body().expect("resolve body"), &compatibility_tag).into()
+                signed_response(
+                    request.body().expect("resolve body"),
+                    &compatibility_tag,
+                    manifest.clone(),
+                )
+                .into()
             })
             .create_async()
             .await;
@@ -438,12 +460,7 @@ mod restore {
         handshake.assert_async().await;
         resolve.assert_async().await;
         blob.assert_async().await;
-
-        let maps = side_effects.get(&snapshot_key).expect("the snapshot must be restored");
-        let [overlay] = maps.values().collect::<Vec<_>>()[..] else {
-            panic!("expected one cache key, got {}", maps.len());
-        };
-        overlay.get(BUILT_FILE).expect("the built file must be in the overlay").clone()
+        side_effects
     }
 
     #[tokio::test]
@@ -496,5 +513,128 @@ mod restore {
         let restored = restore(&store_dir, 0).await;
 
         assert_eq!(restored, seeded);
+    }
+
+    /// An artifact that names no files is a build whose whole effect landed
+    /// outside the package directory. See `SideEffectsDiff::is_empty` for
+    /// why it must leave the snapshot unbuilt rather than stand in for the
+    /// build.
+    #[tokio::test]
+    #[cfg_attr(
+        not(any(
+            all(
+                target_os = "linux",
+                target_env = "gnu",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ),
+            all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")),
+            all(target_os = "windows", any(target_arch = "x86_64", target_arch = "aarch64"))
+        )),
+        ignore = "the remote side-effects cache only serves glibc Linux, macOS, and Windows on x64 and arm64"
+    )]
+    async fn an_artifact_with_nothing_to_restore_leaves_the_snapshot_unbuilt() {
+        let store = tempfile::tempdir().expect("tempdir");
+        let store_dir = StoreDir::new(store.path());
+        let empty = ArtifactManifest { added: Vec::new(), deleted: Vec::new() };
+
+        let side_effects = apply(&store_dir, empty, 0).await;
+
+        let snapshot_key: PackageKey = SNAPSHOT.parse().expect("snapshot key");
+        assert!(
+            !side_effects.contains_key(&snapshot_key),
+            "an empty artifact must not count as built: {side_effects:?}",
+        );
+    }
+
+    /// The publisher's config: the consumer config plus the fixture signing
+    /// key, so the artifacts it signs verify against `trusted_keys`.
+    fn publishing_config(server: &str, store_dir: &StoreDir) -> Config {
+        let mut config = config(server, store_dir);
+        let settings = config.remote_side_effects_cache.as_mut().expect("cache settings");
+        settings.publish = Some(true);
+        settings.key_id = Some(KEY_ID.to_string());
+        settings.builder_id = Some("ci/main/1".to_string());
+        settings.private_key = Some(
+            BASE64.encode(secret_key().to_pkcs8_der().expect("fixture private key").as_bytes()),
+        );
+        config
+    }
+
+    /// Publish `diff` for the fixture snapshot from a blocking thread, the
+    /// way the build phase does.
+    async fn publish(config: Config, store_dir: StoreDir, diff: SideEffectsDiff) {
+        tokio::task::spawn_blocking(move || {
+            let snapshots = snapshots();
+            let publisher = super::super::shared_side_effects_publisher(&config, Some(&snapshots))
+                .expect("the config enables publishing on a supported platform");
+            let snapshot_key: PackageKey = SNAPSHOT.parse().expect("snapshot key");
+            let packages = packages();
+            let graph = HashMap::from([(
+                snapshot_key.clone(),
+                pnpm_graph_hasher::DepsGraphNode {
+                    full_pkg_id: SNAPSHOT.to_string(),
+                    children: indexmap::IndexMap::new(),
+                },
+            )]);
+            publisher.publish(
+                &snapshot_key,
+                packages.get(&snapshot_key).expect("package metadata"),
+                &graph,
+                None,
+                diff,
+                &store_dir,
+            )
+        })
+        .await
+        .expect("publish thread")
+        .expect("publish");
+    }
+
+    /// A build that changed nothing inside its package is not shared: a
+    /// consumer could restore nothing from it, and would skip its own build
+    /// for nothing. The built diff that follows proves the endpoint is
+    /// reachable, so the silence above is the guard and not the harness.
+    #[tokio::test]
+    #[cfg_attr(
+        not(any(
+            all(
+                target_os = "linux",
+                target_env = "gnu",
+                any(target_arch = "x86_64", target_arch = "aarch64")
+            ),
+            all(target_os = "macos", any(target_arch = "x86_64", target_arch = "aarch64")),
+            all(target_os = "windows", any(target_arch = "x86_64", target_arch = "aarch64"))
+        )),
+        ignore = "the remote side-effects cache only serves glibc Linux, macOS, and Windows on x64 and arm64"
+    )]
+    async fn a_diff_with_nothing_to_restore_is_not_published() {
+        let store = tempfile::tempdir().expect("tempdir");
+        let store_dir = StoreDir::new(store.path());
+        let mut server = mockito::Server::new_async().await;
+        let config = publishing_config(&server.url(), &store_dir);
+
+        let untouched = server.mock("PUT", "/-/pnpr/v0/artifacts").expect(0).create_async().await;
+        let empty = SideEffectsDiff { added: None, deleted: None, remote_origin: None };
+        publish(config.clone(), store_dir.clone(), empty).await;
+        untouched.assert_async().await;
+        untouched.remove_async().await;
+
+        let published = server.mock("PUT", "/-/pnpr/v0/artifacts").expect(1).create_async().await;
+        store_dir.write_cas_file(built_bytes(), true).expect("seed the built file");
+        let built = SideEffectsDiff {
+            added: Some(HashMap::from([(
+                BUILT_FILE.to_string(),
+                CafsFileInfo {
+                    checked_at: None,
+                    digest: pnpm_pnpr_client::blob_id(&integrity_of(built_bytes())).unwrap(),
+                    mode: BUILT_MODE,
+                    size: built_bytes().len() as u64,
+                },
+            )])),
+            deleted: None,
+            remote_origin: None,
+        };
+        publish(config, store_dir, built).await;
+        published.assert_async().await;
     }
 }

--- a/pnpm/crates/shared-artifact-protocol/src/lib.rs
+++ b/pnpm/crates/shared-artifact-protocol/src/lib.rs
@@ -152,6 +152,15 @@ pub struct ArtifactManifest {
     pub deleted: Vec<String>,
 }
 
+impl ArtifactManifest {
+    /// Whether the artifact names no added and no deleted files, so
+    /// restoring it would change nothing inside the package directory.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty() && self.deleted.is_empty()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactPayload {

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -150,6 +150,8 @@ pub type FilesMap = HashMap<String, PathBuf>;
 /// entry by the dep-state cache key (`<engine>` or
 /// `<engine>;deps=…;patch=…`, produced by `pnpm-graph-hasher`'s
 /// `calc_dep_state`) to decide whether the package is already built.
+/// A cache key whose recorded diff has nothing to restore is absent, so
+/// presence of an entry means there is build output to materialize.
 #[derive(Debug)]
 pub struct VerifyResult {
     pub passed: bool,
@@ -280,6 +282,22 @@ fn overlay_for(
     base_files: &FilesMap,
 ) -> Option<FilesMap> {
     let SideEffectsDiff { added, deleted, .. } = diff;
+    // A row that records no in-package change is not a build to restore.
+    // `calculate_diff` writes one whenever a script ran, so a build whose
+    // whole effect lands outside the package directory — a git-hook
+    // installer, a shared download cache — gets an empty row. Treating that
+    // as a cache hit skips the scripts and materializes nothing, so the
+    // effect simply never happens. Dropping it rebuilds instead, which is
+    // also what pnpm 11 does: `checkPkgFilesIntegrity` adds a row to
+    // `sideEffectsMaps` only under `if (added) ... else if (deleted)`.
+    if added.iter().flatten().next().is_none() && deleted.iter().flatten().next().is_none() {
+        tracing::debug!(
+            target: "pacquet::store_index",
+            cache_key,
+            "side-effects row records no in-package change; dropping this cache_key entry entirely so the importer falls back to rebuild",
+        );
+        return None;
+    }
     let mut overlay: FilesMap = HashMap::with_capacity(base_files.len());
     for (filename, info) in added.iter().flatten() {
         overlay.insert(filename.clone(), overlay_path(store_dir, cache_key, filename, info)?);

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -281,13 +281,7 @@ fn overlay_for(
     diff: &SideEffectsDiff,
     base_files: &FilesMap,
 ) -> Option<FilesMap> {
-    let SideEffectsDiff { added, deleted, .. } = diff;
-    // A row is written whenever a build script ran, so a build whose whole
-    // effect lands outside the package directory (a git-hook installer, a
-    // shared download cache) records an empty row. Taking that as a cache
-    // hit would skip the scripts and materialize nothing in their place, so
-    // the row is dropped and the importer rebuilds, as pnpm 11 does.
-    if added.as_ref().is_none_or(HashMap::is_empty) && deleted.as_ref().is_none_or(Vec::is_empty) {
+    if diff.is_empty() {
         tracing::debug!(
             target: "pacquet::store_index",
             cache_key,
@@ -295,6 +289,7 @@ fn overlay_for(
         );
         return None;
     }
+    let SideEffectsDiff { added, deleted, .. } = diff;
     let mut overlay: FilesMap = HashMap::with_capacity(base_files.len());
     for (filename, info) in added.iter().flatten() {
         overlay.insert(filename.clone(), overlay_path(store_dir, cache_key, filename, info)?);

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -282,14 +282,11 @@ fn overlay_for(
     base_files: &FilesMap,
 ) -> Option<FilesMap> {
     let SideEffectsDiff { added, deleted, .. } = diff;
-    // A row that records no in-package change is not a build to restore.
-    // `calculate_diff` writes one whenever a script ran, so a build whose
-    // whole effect lands outside the package directory — a git-hook
-    // installer, a shared download cache — gets an empty row. Treating that
-    // as a cache hit skips the scripts and materializes nothing, so the
-    // effect simply never happens. Dropping it rebuilds instead, which is
-    // also what pnpm 11 does: `checkPkgFilesIntegrity` adds a row to
-    // `sideEffectsMaps` only under `if (added) ... else if (deleted)`.
+    // A row is written whenever a build script ran, so a build whose whole
+    // effect lands outside the package directory (a git-hook installer, a
+    // shared download cache) records an empty row. Taking that as a cache
+    // hit would skip the scripts and materialize nothing in their place, so
+    // the row is dropped and the importer rebuilds, as pnpm 11 does.
     if added.as_ref().is_none_or(HashMap::is_empty) && deleted.as_ref().is_none_or(Vec::is_empty) {
         tracing::debug!(
             target: "pacquet::store_index",

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity.rs
@@ -290,7 +290,7 @@ fn overlay_for(
     // effect simply never happens. Dropping it rebuilds instead, which is
     // also what pnpm 11 does: `checkPkgFilesIntegrity` adds a row to
     // `sideEffectsMaps` only under `if (added) ... else if (deleted)`.
-    if added.iter().flatten().next().is_none() && deleted.iter().flatten().next().is_none() {
+    if added.as_ref().is_none_or(HashMap::is_empty) && deleted.as_ref().is_none_or(Vec::is_empty) {
         tracing::debug!(
             target: "pacquet::store_index",
             cache_key,

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -439,6 +439,66 @@ fn no_side_effects_yields_none() {
     assert!(result.side_effects_maps.is_none());
 }
 
+/// `calculate_diff` records a row whenever a script ran, even one that
+/// changed nothing inside the package — a build whose whole effect lands
+/// elsewhere. Restoring that row materializes nothing, so treating it as a
+/// cache hit would skip the scripts and drop the effect. pnpm 11 rebuilds
+/// here and so must pacquet.
+#[test]
+fn side_effects_overlay_with_nothing_to_restore_drops_cache_key_entry() {
+    let tmp = tempdir().unwrap();
+    let store_dir = StoreDir::new(tmp.path());
+    let base_digest = sha512_hex(b"base");
+    let entry = PackageFilesIndex {
+        manifest: None,
+        requires_build: None,
+        requires_prepare: None,
+        algo: "sha512".into(),
+        files: HashMap::from([("a.js".to_string(), info(&base_digest, 4, 0o644, None))]),
+        side_effects: Some(HashMap::from([(
+            "k1".to_string(),
+            SideEffectsDiff { added: None, deleted: None, remote_origin: None },
+        )])),
+        remote_side_effects_quarantine: None,
+    };
+    let result = build_file_maps_from_index(&store_dir, entry);
+    let maps = result.side_effects_maps.expect("a configured cache stays `Some`");
+    assert!(!maps.contains_key("k1"), "an empty row is not a build to restore: {maps:?}");
+}
+
+/// The empty-row drop keys off having nothing to restore, not off `added`.
+/// A build that only removes files did happen and its removal is
+/// reproducible, so the entry has to survive.
+#[test]
+fn side_effects_overlay_with_only_deletions_keeps_cache_key_entry() {
+    let tmp = tempdir().unwrap();
+    let store_dir = StoreDir::new(tmp.path());
+    let base_digest = sha512_hex(b"base");
+    let entry = PackageFilesIndex {
+        manifest: None,
+        requires_build: None,
+        requires_prepare: None,
+        algo: "sha512".into(),
+        files: HashMap::from([
+            ("a.js".to_string(), info(&base_digest, 4, 0o644, None)),
+            ("gone.js".to_string(), info(&base_digest, 4, 0o644, None)),
+        ]),
+        side_effects: Some(HashMap::from([(
+            "k1".to_string(),
+            SideEffectsDiff {
+                added: None,
+                deleted: Some(vec!["gone.js".to_string()]),
+                remote_origin: None,
+            },
+        )])),
+        remote_side_effects_quarantine: None,
+    };
+    let result = build_file_maps_from_index(&store_dir, entry);
+    let overlay = result.side_effects_maps.unwrap().remove("k1").expect("entry survives");
+    assert!(overlay.contains_key("a.js"), "base survives: {overlay:?}");
+    assert!(!overlay.contains_key("gone.js"), "deleted drops: {overlay:?}");
+}
+
 #[test]
 fn side_effects_overlay_adds_and_drops_correctly() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
+++ b/pnpm/crates/store-dir/src/check_pkg_files_integrity/tests.rs
@@ -439,11 +439,10 @@ fn no_side_effects_yields_none() {
     assert!(result.side_effects_maps.is_none());
 }
 
-/// `calculate_diff` records a row whenever a script ran, even one that
-/// changed nothing inside the package — a build whose whole effect lands
-/// elsewhere. Restoring that row materializes nothing, so treating it as a
-/// cache hit would skip the scripts and drop the effect. pnpm 11 rebuilds
-/// here and so must pacquet.
+/// An empty row is a build whose whole effect landed outside the package
+/// directory. See `overlay_for` for why it must not count as a cache hit.
+///
+/// Regression for <https://github.com/pnpm/pnpm/issues/14717>.
 #[test]
 fn side_effects_overlay_with_nothing_to_restore_drops_cache_key_entry() {
     let tmp = tempdir().unwrap();
@@ -466,9 +465,8 @@ fn side_effects_overlay_with_nothing_to_restore_drops_cache_key_entry() {
     assert!(!maps.contains_key("k1"), "an empty row is not a build to restore: {maps:?}");
 }
 
-/// The empty-row drop keys off having nothing to restore, not off `added`.
-/// A build that only removes files did happen and its removal is
-/// reproducible, so the entry has to survive.
+/// The empty-row drop keys off having nothing to restore, not off `added`
+/// alone: a build that only removes files is still reproducible from its row.
 #[test]
 fn side_effects_overlay_with_only_deletions_keeps_cache_key_entry() {
     let tmp = tempdir().unwrap();

--- a/pnpm/crates/store-dir/src/store_index.rs
+++ b/pnpm/crates/store-dir/src/store_index.rs
@@ -1193,6 +1193,23 @@ pub struct SideEffectsDiff {
     pub remote_origin: Option<RemoteSideEffectsOrigin>,
 }
 
+impl SideEffectsDiff {
+    /// Whether the diff names no added and no deleted files.
+    ///
+    /// A diff is recorded whenever a build script ran, so a build whose
+    /// whole effect lands outside the package directory (a git-hook
+    /// installer, a shared download cache) records an empty one.
+    /// Restoring it materializes nothing, so treating it as a cache hit
+    /// would skip the scripts and put nothing in their place. Readers
+    /// drop such a diff and rebuild, as pnpm 11 does, and publishers do
+    /// not share it.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.added.as_ref().is_none_or(HashMap::is_empty)
+            && self.deleted.as_ref().is_none_or(Vec::is_empty)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RemoteSideEffectsOrigin {

--- a/pnpr/.fixtures/packages/@pnpm.e2e/postinstall-writes-outside-package/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/postinstall-writes-outside-package/1.0.0/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@pnpm.e2e/postinstall-writes-outside-package",
+  "version": "1.0.0",
+  "description": "A package whose postinstall leaves nothing inside its own directory, like a git-hook installer. Appends to the file named by PNPM_E2E_OUTSIDE_LOG so a test can count how many installs ran it.",
+  "scripts": {
+    "postinstall": "node -e 'require(\"fs\").appendFileSync(process.env.PNPM_E2E_OUTSIDE_LOG, \"x\")'"
+  }
+}

--- a/pnpr/.fixtures/packages/@pnpm.e2e/postinstall-writes-outside-package/1.0.0/package.json
+++ b/pnpr/.fixtures/packages/@pnpm.e2e/postinstall-writes-outside-package/1.0.0/package.json
@@ -3,6 +3,6 @@
   "version": "1.0.0",
   "description": "A package whose postinstall leaves nothing inside its own directory, like a git-hook installer. Appends to the file named by PNPM_E2E_OUTSIDE_LOG so a test can count how many installs ran it.",
   "scripts": {
-    "postinstall": "node -e 'require(\"fs\").appendFileSync(process.env.PNPM_E2E_OUTSIDE_LOG, \"x\")'"
+    "postinstall": "node -e \"require('fs').appendFileSync(process.env.PNPM_E2E_OUTSIDE_LOG, 'x')\""
   }
 }


### PR DESCRIPTION
<!-- A maintainer will only start reviewing once CodeRabbit has approved and
CI is green. Please wait for those to pass before expecting human review. -->

## Summary

Closes pnpm/pnpm#14717.

pnpm 12 skips a dependency's build scripts on a side-effects cache hit even when the matched cache row has nothing to restore, so the scripts don't run and nothing is materialized in their place. A build whose whole effect lands outside its own package directory — a git-hook installer, a script seeding a shared download cache — therefore never takes effect. pnpm 11 rebuilds in this case.

A row is recorded whenever a build script ran, and a build that changed nothing inside the package directory produces an empty one. Both stacks write that row; only the read paths differed:

- pnpm 11 `checkPkgFilesIntegrity` (`store/cafs/src/checkPkgFilesIntegrity.ts:89`) adds a row to `sideEffectsMaps` only under `if (added) … else if (deleted)`. An empty row matches neither branch, so it is dropped, `sideEffectsCacheKey` is never set, `isBuilt` stays `false`, and the build runs.
- pnpm 12 `build_side_effects_maps` turned every row into an overlay. An empty row became an overlay equal to the base files, and the `is_built` gate took it as a hit.

This PR drops the row at the same point pnpm 11 does. An entry's presence now means there is build output to materialize, which is what the `is_built` gate already assumed.

The reproduction in the issue, run against this build:

```
project a hook: .git/hooks/pre-commit
project b hook: .git/hooks/pre-commit
```

On 12.3.2 project b's hook is `MISSING`.

## Notes for reviewers

- **The drop keys off having nothing to restore, not off `added` being absent.** A row carrying only `deleted` still counts as a hit: that build happened and its effect is reproducible from the row. `side_effects_overlay_with_only_deletions_keeps_cache_key_entry` pins that, so the fix can't quietly widen into "only `added` rows count."
- **Nothing downstream needed a matching change.** `prefetch.rs:257` already filters an empty `side_effects_maps` out of the prefetch result, so a package whose only row is dropped contributes no entry to `side_effects_maps_by_snapshot` and the frozen-install fast path at `build_phase.rs:210` still sees an empty table. I checked the remote path too: `shared_side_effects.rs` builds `side_effects_maps_by_snapshot` from resolved artifacts directly rather than through `build_side_effects_maps`, so a remote artifact with real content is unaffected.
- **A row with only `remote_origin` set and no `added`/`deleted` is dropped as well.** Same reasoning, and it matches pnpm 11, whose check looks only at `added`/`deleted`.
- **The write path is unchanged.** pnpm 11 also stores the empty row, so removing it on write would be the divergence rather than the fix, and it would change the store's on-disk contents for no benefit.
- **This is v12-only.** pnpm 11 already behaves correctly here, so there is nothing to fix in `pnpm11/`. Verified by measurement rather than by reading — see the table below.

## Validation

Measured with one project per cell, a fresh store per pnpm version, and `node_modules` wiped between the two installs. `ran / ran` means the build script ran on both installs.

| build script | 11.5.2 | 11.26.0 | 12.3.2 | this PR |
| --- | --- | --- | --- | --- |
| prints only, no in-package change | ran / ran | ran / ran | ran / **skipped** | ran / ran |
| writes a file into the package | ran / skipped | ran / skipped | ran / skipped | ran / skipped |

The second row is the legitimate cache hit and still skips, with the cached file restored. Only the first row changes, and it now matches both pnpm 11 versions.

- Reproduced the issue's two-project `simple-git-hooks` scenario against released 12.3.2 (project b's hook missing), then confirmed both projects get the hook with this build.
- New tests: `a_build_with_nothing_to_restore_runs_on_every_install` (e2e, asserts the postinstall runs on three consecutive installs), plus `side_effects_overlay_with_nothing_to_restore_drops_cache_key_entry` and `side_effects_overlay_with_only_deletions_keeps_cache_key_entry` (unit).
- Each new test was run against a reverted implementation and fails there. The e2e failure is the reported bug exactly: install 2 prints a clean successful install and the script does not run.
- New registry fixture `@pnpm.e2e/postinstall-writes-outside-package`, whose postinstall appends a byte to a file named by an env var and leaves its own directory untouched. Its diff is empty by construction, which is what the test needs.
- Suites run green: `pnpm-store-dir`, `pnpm-deps-restorer`, and `pnpm-tarball` in full (766 tests), and the `side_effects_cache`, `lifecycle_scripts`, `global_virtual_store`, and `local_tarball_dependency` modules of `pnpm-cli` (95 tests). Both `side_effects_materialized_on_warm_frozen_reinstall` variants pass, which are the tests that would catch an over-broad drop.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` and `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps` are clean; `cargo fmt` and `taplo format` applied. `just ready` was not runnable in this environment (`just` and `typos` are not installed), so those steps are left to CI.

## Squash Commit Body

```text
A side-effects row is recorded whenever a build script ran, including a
build that changed nothing inside the package directory. `calculate_diff`
returns `added: None, deleted: None` for that case and the row is stored
anyway, so a package whose whole build effect lands elsewhere -- a
git-hook installer, a script seeding a shared download cache -- gets an
empty row.

`build_side_effects_maps` turned every row into an overlay, so an empty
one became an overlay equal to the base files and the `is_built` gate
took it as a hit. The scripts were skipped and nothing was materialized
in their place: the package directory after such an install is
byte-identical to the pristine tarball, and the build's effect never
happens at all. The cache key does not include the consuming project, so
this is not limited to reinstalls -- a project's first install can hit a
row an unrelated project seeded on the same machine.

pnpm 11 drops the row instead. Its `checkPkgFilesIntegrity` adds to
`sideEffectsMaps` only under `if (added) ... else if (deleted)`, so an
empty row matches neither branch, `sideEffectsCacheKey` is never set,
`isBuilt` stays false, and the build runs. Both stacks write the same
empty row and only their read paths differed, so this drops it at the
same point pnpm 11 does. An entry's presence now means there is build
output to materialize, which is what the `is_built` gate already assumed.

A row carrying only `deleted` still counts as a hit. That build did
happen and its effect is reproducible from the row.

`prefetch.rs` already filters an empty `side_effects_maps` out of the
prefetch result, so a package whose only row is dropped contributes no
entry at all and the frozen-install fast path in `build_phase` still
sees an empty table.

Closes pnpm/pnpm#14717
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version. (pnpm 11 already rebuilds in
  this case, so there is nothing to fix there — see the table above.)
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Keep it short and written for pnpm users — it becomes a release note.
- [x] Added or updated tests.
- [ ] Updated the documentation if needed.

---
Written by an agent (Claude Code, claude-opus-5).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `pnpm install` now reruns dependency build scripts when the side-effects cache has no files to restore.
  * Build scripts that produce effects outside their package directory now run correctly on repeated installs, including frozen-lockfile installs.
  * Side-effects cache entries containing only deletions continue to restore correctly.

* **Tests**
  * Added coverage for repeated installs and side-effects cache entries with empty or deletion-only changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->