### PR TITLE
fix: warn when package.json declares a workspaces field

### DIFF
--- a/.changeset/warn-about-yarn-workspaces-field.md
+++ b/.changeset/warn-about-yarn-workspaces-field.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+pnpm now warns when the root `package.json` declares a `workspaces` field and the project has no `pnpm-workspace.yaml`. The field selected no projects and the install ran as a single project without saying so [#2255](https://github.com/pnpm/pnpm/issues/2255).

--- a/.changeset/warn-about-yarn-workspaces-field.md
+++ b/.changeset/warn-about-yarn-workspaces-field.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-pnpm now warns when the root `package.json` declares a `workspaces` field and the project has no `pnpm-workspace.yaml`. The field selected no projects and the install ran as a single project without saying so [#2255](https://github.com/pnpm/pnpm/issues/2255).
+pnpm now warns when the root `package.json` declares a non-empty array-form `workspaces` field and the project has no `pnpm-workspace.yaml` [#2255](https://github.com/pnpm/pnpm/issues/2255). Such an install links no project and previously said nothing about why.

--- a/.changeset/warn-about-yarn-workspaces-field.md
+++ b/.changeset/warn-about-yarn-workspaces-field.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-pnpm now warns when the root `package.json` declares a non-empty array-form `workspaces` field and the project has no `pnpm-workspace.yaml` [#2255](https://github.com/pnpm/pnpm/issues/2255). Such an install links no project and previously said nothing about why.
+pnpm now warns when the root `package.json` declares a non-empty `workspaces` array and the project has no `pnpm-workspace.yaml`. Such an install linked no project and said nothing about why [#2255](https://github.com/pnpm/pnpm/issues/2255).

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -118,6 +118,7 @@ mod task_run_state;
 mod update_changeset;
 mod verify_deps;
 mod workspace_option;
+pub(crate) mod yarn_workspaces_field;
 
 /// The CLI grammar, built once per process. Constructing it walks every
 /// subcommand, and the passes that run before the parse each need the same

--- a/pnpm/crates/cli/src/cli_args.rs
+++ b/pnpm/crates/cli/src/cli_args.rs
@@ -96,6 +96,7 @@ pub mod view;
 pub mod whoami;
 pub mod why;
 pub mod with;
+pub(crate) mod yarn_workspaces_field;
 
 pub(crate) mod cli_command;
 pub(crate) mod package_manager;
@@ -118,7 +119,6 @@ mod task_run_state;
 mod update_changeset;
 mod verify_deps;
 mod workspace_option;
-pub(crate) mod yarn_workspaces_field;
 
 /// The CLI grammar, built once per process. Constructing it walks every
 /// subcommand, and the passes that run before the parse each need the same

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -5,6 +5,7 @@ use crate::{
         override_version_references::warn_deprecated_override_version_references,
         pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
+        yarn_workspaces_field::warn_unsupported_workspaces_field_in,
     },
 };
 use clap::{Args, ValueEnum};
@@ -409,6 +410,7 @@ impl InstallArgs {
         // to the full install path, which warns from
         // `derive_config_root_and_package_manager_to_sync`.
         warn_ignored_pnpm_manifest_fields_in(&config_root);
+        warn_unsupported_workspaces_field_in(&config_root, config.workspace_dir.as_deref());
         warn_deprecated_override_version_references(config, emit);
         // The scope covers the same projects the full install path would
         // report; an up-to-date run says so too rather than going quiet

--- a/pnpm/crates/cli/src/cli_args/install.rs
+++ b/pnpm/crates/cli/src/cli_args/install.rs
@@ -1,11 +1,12 @@
 use crate::{
     State,
     cli_args::{
-        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields_in, lockfile_dir::LockfileDirArg,
+        legacy_pnpm_field::warn_ignored_pnpm_manifest_fields, lockfile_dir::LockfileDirArg,
         override_version_references::warn_deprecated_override_version_references,
-        pipelines::InstallFamilySelection, recursive::discover_workspace_projects,
+        package_manager::read_root_manifest_json, pipelines::InstallFamilySelection,
+        recursive::discover_workspace_projects,
         supported_architectures::SupportedArchitecturesArgs,
-        yarn_workspaces_field::warn_unsupported_workspaces_field_in,
+        yarn_workspaces_field::warn_unsupported_workspaces_field,
     },
 };
 use clap::{Args, ValueEnum};
@@ -409,8 +410,9 @@ impl InstallArgs {
         // above: every `return false` before this point hands the command
         // to the full install path, which warns from
         // `derive_config_root_and_package_manager_to_sync`.
-        warn_ignored_pnpm_manifest_fields_in(&config_root);
-        warn_unsupported_workspaces_field_in(&config_root, config.workspace_dir.as_deref());
+        let root_manifest = read_root_manifest_json(&config_root);
+        warn_ignored_pnpm_manifest_fields(root_manifest.as_ref());
+        warn_unsupported_workspaces_field(root_manifest.as_ref(), config.workspace_dir.as_deref());
         warn_deprecated_override_version_references(config, emit);
         // The scope covers the same projects the full install path would
         // report; an up-to-date run says so too rather than going quiet

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field.rs
@@ -3,9 +3,8 @@
 //! that still carries one of the migrated keys gets a warning naming it,
 //! so the setting isn't silently dropped.
 
-use super::{config_warnings::emit_config_warning, package_manager::read_manifest_json};
+use super::config_warnings::emit_config_warning;
 use serde_json::Value;
-use std::path::Path;
 
 /// Keys pnpm reads from `pnpm-workspace.yaml` and never from the `pnpm`
 /// field of `package.json` — either because they moved there in v11, or
@@ -36,11 +35,7 @@ const MIGRATED_PNPM_FIELD_KEYS: &[&str] = &[
 ];
 
 /// Warn about every migrated key the root project manifest still
-/// declares under `pnpm`. This is a config-load warning, so it goes to
-/// stderr through [`emit_config_warning`] rather than the reporter. A
-/// manifest that could not be read is not this function's problem — the
-/// install path reports it with far more context — so `None` simply
-/// produces no warning.
+/// declares under `pnpm`.
 pub(crate) fn warn_ignored_pnpm_manifest_fields(manifest: Option<&Value>) {
     let ignored = ignored_pnpm_field_keys(manifest);
     if ignored.is_empty() {
@@ -52,16 +47,6 @@ pub(crate) fn warn_ignored_pnpm_manifest_fields(manifest: Option<&Value>) {
          The following keys were ignored: {keys}. \
          See https://pnpm.io/settings for the new home of each setting.",
     ));
-}
-
-/// [`warn_ignored_pnpm_manifest_fields`] for a caller that has not read
-/// the root manifest yet.
-pub(crate) fn warn_ignored_pnpm_manifest_fields_in(root_dir: &Path) {
-    warn_ignored_pnpm_manifest_fields(root_manifest(root_dir).as_ref());
-}
-
-fn root_manifest(root_dir: &Path) -> Option<Value> {
-    read_manifest_json(&root_dir.join("package.json")).ok().flatten()
 }
 
 fn ignored_pnpm_field_keys(manifest: Option<&Value>) -> Vec<String> {

--- a/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/legacy_pnpm_field/tests.rs
@@ -1,4 +1,5 @@
-use super::{ignored_pnpm_field_keys, root_manifest};
+use super::ignored_pnpm_field_keys;
+use crate::cli_args::package_manager::read_root_manifest_json;
 use std::{fs, path::Path};
 
 fn write_manifest(dir: &Path, contents: &str) {
@@ -6,7 +7,7 @@ fn write_manifest(dir: &Path, contents: &str) {
 }
 
 fn keys_in(dir: &Path) -> Vec<String> {
-    ignored_pnpm_field_keys(root_manifest(dir).as_ref())
+    ignored_pnpm_field_keys(read_root_manifest_json(dir).as_ref())
 }
 
 #[test]

--- a/pnpm/crates/cli/src/cli_args/package_manager.rs
+++ b/pnpm/crates/cli/src/cli_args/package_manager.rs
@@ -68,6 +68,15 @@ pub(crate) fn package_manager_to_sync(
     })
 }
 
+/// The root project's `package.json` as raw JSON, for the config-load
+/// warnings that inspect it before the install path reads the manifest
+/// properly. A manifest that is missing, unreadable, or malformed yields
+/// `None`: a warning has nothing to say about one, and the install path
+/// reports it with far more context.
+pub(crate) fn read_root_manifest_json(root_dir: &Path) -> Option<Value> {
+    read_manifest_json(&root_dir.join("package.json")).ok().flatten()
+}
+
 pub(crate) fn read_manifest_json(path: &Path) -> miette::Result<Option<Value>> {
     let content = match fs::read_to_string(path) {
         Ok(content) => content,

--- a/pnpm/crates/cli/src/cli_args/pipelines.rs
+++ b/pnpm/crates/cli/src/cli_args/pipelines.rs
@@ -20,6 +20,7 @@ use crate::{
         legacy_pnpm_field::warn_ignored_pnpm_manifest_fields,
         override_version_references::warn_deprecated_override_version_references,
         reporter::{ReporterType, reporter_emit},
+        yarn_workspaces_field::warn_unsupported_workspaces_field,
     },
     config_deps, ecosystem_add, ecosystem_install,
 };
@@ -1011,6 +1012,7 @@ pub(crate) fn derive_config_root(
     // install output. This is the install family's earliest point that
     // knows the root manifest's directory.
     warn_ignored_pnpm_manifest_fields(root_manifest.as_ref());
+    warn_unsupported_workspaces_field(root_manifest.as_ref(), cfg.workspace_dir.as_deref());
     warn_deprecated_override_version_references(cfg, reporter_emit(reporter));
     warn_unmatched_registry_options(cfg);
     warn_unapplied_package_configs(cfg);

--- a/pnpm/crates/cli/src/cli_args/yarn_workspaces_field.rs
+++ b/pnpm/crates/cli/src/cli_args/yarn_workspaces_field.rs
@@ -5,7 +5,7 @@
 //! project: no project is linked, and the failure gives no hint about why.
 //! A warning names the field and the file that replaces it.
 
-use super::{config_warnings::emit_config_warning, package_manager::read_manifest_json};
+use super::config_warnings::emit_config_warning;
 use serde_json::Value;
 use std::path::Path;
 
@@ -13,11 +13,6 @@ use std::path::Path;
 /// outside a pnpm workspace. Inside one the field is redundant rather than
 /// misleading: `pnpm-workspace.yaml` already selects the projects, so
 /// `workspace_dir` being set silences the warning.
-///
-/// This is a config-load warning, so it goes to stderr through
-/// [`emit_config_warning`] rather than the reporter. A manifest that could
-/// not be read is not this function's problem — the install path reports it
-/// with far more context — so `None` simply produces no warning.
 pub(crate) fn warn_unsupported_workspaces_field(
     manifest: Option<&Value>,
     workspace_dir: Option<&Path>,
@@ -29,16 +24,6 @@ pub(crate) fn warn_unsupported_workspaces_field(
         "The \"workspaces\" field in package.json is not supported by pnpm. \
          Create a \"pnpm-workspace.yaml\" file instead.",
     );
-}
-
-/// [`warn_unsupported_workspaces_field`] for a caller that has not read the
-/// root manifest yet.
-pub(crate) fn warn_unsupported_workspaces_field_in(root_dir: &Path, workspace_dir: Option<&Path>) {
-    warn_unsupported_workspaces_field(root_manifest(root_dir).as_ref(), workspace_dir);
-}
-
-fn root_manifest(root_dir: &Path) -> Option<Value> {
-    read_manifest_json(&root_dir.join("package.json")).ok().flatten()
 }
 
 /// Whether the manifest declares at least one Yarn workspace pattern.

--- a/pnpm/crates/cli/src/cli_args/yarn_workspaces_field.rs
+++ b/pnpm/crates/cli/src/cli_args/yarn_workspaces_field.rs
@@ -1,0 +1,57 @@
+//! The `workspaces` field of `package.json` is Yarn's and npm's way to
+//! declare a monorepo's projects. pnpm declares them in
+//! `pnpm-workspace.yaml` instead and never reads the manifest field, so a
+//! repository converted from Yarn without that file installs as a single
+//! project: no project is linked, and the failure gives no hint about why.
+//! A warning names the field and the file that replaces it.
+
+use super::{config_warnings::emit_config_warning, package_manager::read_manifest_json};
+use serde_json::Value;
+use std::path::Path;
+
+/// Warn when the root project manifest declares Yarn's `workspaces` field
+/// outside a pnpm workspace. Inside one the field is redundant rather than
+/// misleading: `pnpm-workspace.yaml` already selects the projects, so
+/// `workspace_dir` being set silences the warning.
+///
+/// This is a config-load warning, so it goes to stderr through
+/// [`emit_config_warning`] rather than the reporter. A manifest that could
+/// not be read is not this function's problem — the install path reports it
+/// with far more context — so `None` simply produces no warning.
+pub(crate) fn warn_unsupported_workspaces_field(
+    manifest: Option<&Value>,
+    workspace_dir: Option<&Path>,
+) {
+    if workspace_dir.is_some() || !declares_yarn_workspaces(manifest) {
+        return;
+    }
+    emit_config_warning(
+        "The \"workspaces\" field in package.json is not supported by pnpm. \
+         Create a \"pnpm-workspace.yaml\" file instead.",
+    );
+}
+
+/// [`warn_unsupported_workspaces_field`] for a caller that has not read the
+/// root manifest yet.
+pub(crate) fn warn_unsupported_workspaces_field_in(root_dir: &Path, workspace_dir: Option<&Path>) {
+    warn_unsupported_workspaces_field(root_manifest(root_dir).as_ref(), workspace_dir);
+}
+
+fn root_manifest(root_dir: &Path) -> Option<Value> {
+    read_manifest_json(&root_dir.join("package.json")).ok().flatten()
+}
+
+/// Whether the manifest declares at least one Yarn workspace pattern.
+///
+/// Only the array spelling counts, which is the spelling pnpm 11 warns
+/// about. Yarn also accepts an object carrying `packages`, and neither
+/// version warns about it yet; the two are kept aligned here.
+fn declares_yarn_workspaces(manifest: Option<&Value>) -> bool {
+    manifest
+        .and_then(|manifest| manifest.get("workspaces"))
+        .and_then(Value::as_array)
+        .is_some_and(|patterns| !patterns.is_empty())
+}
+
+#[cfg(test)]
+mod tests;

--- a/pnpm/crates/cli/src/cli_args/yarn_workspaces_field/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/yarn_workspaces_field/tests.rs
@@ -1,0 +1,53 @@
+use super::{declares_yarn_workspaces, root_manifest};
+use std::{fs, path::Path};
+
+fn write_manifest(dir: &Path, contents: &str) {
+    fs::write(dir.join("package.json"), contents).expect("write package.json");
+}
+
+fn declares_in(dir: &Path) -> bool {
+    declares_yarn_workspaces(root_manifest(dir).as_ref())
+}
+
+#[test]
+fn reports_a_manifest_declaring_workspace_patterns() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(dir.path(), r#"{"name":"x","workspaces":["packages/*"]}"#);
+    assert!(declares_in(dir.path()));
+}
+
+/// An editor-written manifest may open with a UTF-8 BOM, which every other
+/// manifest read in the CLI strips. The warning has to see the same field
+/// those reads do.
+#[test]
+fn reports_workspace_patterns_through_a_utf8_bom() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(dir.path(), "\u{feff}{\"workspaces\":[\"packages/*\"]}");
+    assert!(declares_in(dir.path()));
+}
+
+/// An empty array selects no project, so pnpm behaves the same with and
+/// without it. pnpm 11 does not warn about it either.
+#[test]
+fn ignores_an_empty_workspaces_array() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    write_manifest(dir.path(), r#"{"workspaces":[]}"#);
+    assert!(!declares_in(dir.path()));
+}
+
+/// Yarn's object spelling, and any other shape the field is given, is left
+/// to the reader pnpm 11 has: neither version warns about it.
+#[test]
+fn tolerates_absent_malformed_and_non_array_manifests() {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    assert!(!declares_in(dir.path()), "no manifest");
+
+    write_manifest(dir.path(), "{ not json");
+    assert!(!declares_in(dir.path()), "malformed manifest");
+
+    write_manifest(dir.path(), r#"{"name":"x"}"#);
+    assert!(!declares_in(dir.path()), "no workspaces field");
+
+    write_manifest(dir.path(), r#"{"workspaces":{"packages":["packages/*"]}}"#);
+    assert!(!declares_in(dir.path()), "object workspaces field");
+}

--- a/pnpm/crates/cli/src/cli_args/yarn_workspaces_field/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/yarn_workspaces_field/tests.rs
@@ -1,4 +1,5 @@
-use super::{declares_yarn_workspaces, root_manifest};
+use super::declares_yarn_workspaces;
+use crate::cli_args::package_manager::read_root_manifest_json;
 use std::{fs, path::Path};
 
 fn write_manifest(dir: &Path, contents: &str) {
@@ -6,7 +7,7 @@ fn write_manifest(dir: &Path, contents: &str) {
 }
 
 fn declares_in(dir: &Path) -> bool {
-    declares_yarn_workspaces(root_manifest(dir).as_ref())
+    declares_yarn_workspaces(read_root_manifest_json(dir).as_ref())
 }
 
 #[test]

--- a/pnpm/crates/cli/tests/suite/main.rs
+++ b/pnpm/crates/cli/tests/suite/main.rs
@@ -147,3 +147,4 @@ mod with;
 mod workspace_cycles;
 mod workspace_install;
 mod workspace_settings_check;
+mod yarn_workspaces_field;

--- a/pnpm/crates/cli/tests/suite/yarn_workspaces_field.rs
+++ b/pnpm/crates/cli/tests/suite/yarn_workspaces_field.rs
@@ -7,7 +7,8 @@
 use assert_cmd::prelude::*;
 use command_extra::CommandExtra;
 use pnpm_testing_utils::{
-    bin::CommandTempCwd, diagnostics::assert_diagnostic_contains as assert_contains,
+    bin::CommandTempCwd, command_env::CommandTestExt,
+    diagnostics::assert_diagnostic_contains as assert_contains,
 };
 use std::{
     fs,
@@ -97,7 +98,10 @@ fn write_manifest(workspace: &Path, contents: &str) {
 /// A fresh command per run: [`CommandTempCwd`] hands out one, and the
 /// repeat-install test needs a second.
 fn pacquet_in(workspace: &Path) -> Command {
-    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+    Command::cargo_bin("pnpm")
+        .expect("find the pnpm binary")
+        .with_current_dir(workspace)
+        .without_ambient_pnpm_config()
 }
 
 fn run(command: Command, root: &Path, args: &[&str]) -> Output {

--- a/pnpm/crates/cli/tests/suite/yarn_workspaces_field.rs
+++ b/pnpm/crates/cli/tests/suite/yarn_workspaces_field.rs
@@ -1,0 +1,131 @@
+//! The warning that names Yarn's `workspaces` field in the root manifest:
+//! what the user sees on stderr, and the installs that say it. Both install
+//! entry points warn — the full install path and the up-to-date
+//! short-circuit a repeat install takes — and neither says it inside a pnpm
+//! workspace, where `pnpm-workspace.yaml` already selects the projects.
+
+use assert_cmd::prelude::*;
+use command_extra::CommandExtra;
+use pnpm_testing_utils::{
+    bin::CommandTempCwd, diagnostics::assert_diagnostic_contains as assert_contains,
+};
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+/// The whole line as it reaches a terminal, label included: the wording is
+/// pnpm 11's, and a user grepping their CI log for it must find the same
+/// text under pnpm 12.
+const WARNING: &str = r#"[WARN] The "workspaces" field in package.json is not supported by pnpm. Create a "pnpm-workspace.yaml" file instead."#;
+
+#[test]
+fn an_install_warns_about_a_workspaces_field_with_no_pnpm_workspace_yaml() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        r#"{"name":"converted","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+    );
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_contains(&stderr(&output), WARNING);
+}
+
+/// The second install of an unchanged project never reaches the full
+/// install path, so the up-to-date short-circuit has to emit the warning
+/// itself. A converted repository whose install is already current is
+/// exactly the case that has no other hint about the ignored field.
+#[test]
+fn a_repeat_install_taking_the_up_to_date_path_warns_too() {
+    let CommandTempCwd { root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        r#"{"name":"converted","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+    );
+
+    let first = run(pacquet_in(&workspace), root.path(), &["install"]);
+    assert_success(&first);
+    let second = run(pacquet_in(&workspace), root.path(), &["install"]);
+
+    assert_success(&second);
+    let printed = format!("{}{}", stdout(&second), stderr(&second));
+    assert!(printed.contains("Already up to date"), "the short-circuit ran:\n{printed}");
+    assert_contains(&stderr(&second), WARNING);
+}
+
+/// Inside a pnpm workspace the field is redundant rather than misleading:
+/// `pnpm-workspace.yaml` selects the projects, and the install links them.
+#[test]
+fn a_workspaces_field_inside_a_pnpm_workspace_stays_quiet() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        r#"{"name":"converted","version":"1.0.0","private":true,"workspaces":["packages/*"]}"#,
+    );
+    fs::write(workspace.join("pnpm-workspace.yaml"), "packages:\n  - .\n")
+        .expect("write pnpm-workspace.yaml");
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_quiet(&output);
+}
+
+/// Yarn's object spelling is the documented limit of the check: pnpm 11
+/// does not warn about it either, and the two are kept aligned.
+#[test]
+fn an_object_form_workspaces_field_stays_quiet() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    write_manifest(
+        &workspace,
+        r#"{"name":"converted","version":"1.0.0","private":true,"workspaces":{"packages":["packages/*"]}}"#,
+    );
+
+    let output = run(pacquet, root.path(), &["install", "--lockfile-only"]);
+
+    assert_success(&output);
+    assert_quiet(&output);
+}
+
+fn write_manifest(workspace: &Path, contents: &str) {
+    fs::write(workspace.join("package.json"), contents).expect("write package.json");
+}
+
+/// A fresh command per run: [`CommandTempCwd`] hands out one, and the
+/// repeat-install test needs a second.
+fn pacquet_in(workspace: &Path) -> Command {
+    Command::cargo_bin("pnpm").expect("find the pnpm binary").with_current_dir(workspace)
+}
+
+fn run(command: Command, root: &Path, args: &[&str]) -> Output {
+    let mut command = command;
+    command.env("PNPM_HOME", root.join("pnpm-home"));
+    command.env("HOME", root);
+    command.env("XDG_CONFIG_HOME", root.join("xdg-config"));
+    command.args(args).output().expect("run pacquet")
+}
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command should succeed\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output),
+    );
+}
+
+fn assert_quiet(output: &Output) {
+    let stderr = stderr(output);
+    assert!(!stderr.contains("workspaces"), "expected no workspaces warning; got:\n{stderr}");
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}


### PR DESCRIPTION
## Summary

pnpm 11 warns when the root `package.json` carries Yarn's `workspaces` field and there is no `pnpm-workspace.yaml` (`pnpm11/config/reader/src/index.ts`). pnpm 12 has no such check, so a repository converted from Yarn installs as a single project and nothing says why its projects were never linked. Related to pnpm/pnpm#2255.

The check sits next to the existing legacy `pnpm` field warning, runs from the same two install entry points, and reuses pnpm 11's wording. It stays quiet inside a workspace.

Known limit, kept aligned with pnpm 11: only the array spelling warns. Yarn's object form with a `packages` key stays quiet in both versions.

## Squash Commit Body

```text
pnpm 12 ignored Yarn's `workspaces` field in the root package.json
without a word, so a repo converted from Yarn installed as a single
project with no hint about the missing pnpm-workspace.yaml. This brings
v12 in line with pnpm 11's warning, same wording, same trigger.

Related to pnpm/pnpm#2255
```

## Checklist

- [x] Checked the issue; no linked PR solves it.
- [x] Bug fixes are implemented in every affected version (pnpm 11 already warns).
- [x] Added a changeset.
- [x] Added or updated tests.

## Tests

`cargo test -p pnpm-cli --lib yarn_workspaces_field` passes 4/4. Inverting the emptiness check turns 3 of them red. pnpm 11's predicate and the new check, run over the same six manifest shapes, both warn on 2 of 6.

---
Written by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791575223&installation_model_id=426870&pr_number=14749&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14749&signature=fa76f1e8689fc670d639d9735f1fecb6d7055b19937162180f13723876c0a9af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added a warning when the root `package.json` declares a non-empty Yarn/npm-style `workspaces` array without a corresponding pnpm workspace configuration.
  * The warning appears consistently during regular installs and already-up-to-date installs, explaining that no projects will be linked.
  * Projects using pnpm workspace configuration, empty arrays, or unsupported workspace formats remain quiet.

* **Tests**
  * Added coverage for valid declarations, UTF-8 BOM files, empty workspace lists, malformed manifests, and unsupported formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->