### PR TITLE
fix(cli): drop the duplicate imports that fail clippy and dylint on main

### DIFF
--- a/pnpm/crates/cli/src/cargo_deps/git/tests.rs
+++ b/pnpm/crates/cli/src/cargo_deps/git/tests.rs
@@ -10,11 +10,6 @@ use std::{
     sync::{Arc, atomic::AtomicU8},
 };
 
-#[cfg(all(unix, not(target_os = "macos")))]
-use super::{CheckoutPackage, import_package};
-#[cfg(all(unix, not(target_os = "macos")))]
-use std::collections::BTreeSet;
-
 fn manifest(text: &str) -> Manifest {
     Manifest { text: text.to_string(), document: toml::from_str(text).expect("parse manifest") }
 }


### PR DESCRIPTION
## Summary

Rust CI on `main` fails in the Clippy and Dylint jobs since pnpm/pnpm#14707 with `unused imports` in `pnpm/crates/cli/src/cargo_deps/git/tests.rs` (failing run: https://github.com/pnpm/pnpm/actions/runs/34398748506). That PR added module-level, Linux-gated imports of `CheckoutPackage`, `import_package`, and `BTreeSet`, but the only test that uses them already imports them inside its body. This PR removes the module-level duplicates.

Verified locally on Linux: `cargo clippy -p pnpm-cli --all-targets -- -D warnings`, `cargo dylint` on the same crate with `RUSTFLAGS="-D warnings"`, and the `cargo_deps::git::tests` suite all pass.

## Squash Commit Body

```text
The test that checks a non-UTF-8 file name already imports
CheckoutPackage, import_package, and BTreeSet inside its body. The
module-level copies added in pnpm/pnpm#14707 were therefore never
used, and `-D warnings` turned them into errors in the Clippy and
Dylint jobs of Rust CI on every Linux run.
```

## Checklist

- [x] New features are implemented only in the Rust pnpm v12 CLI. Bug fixes
  are implemented in every affected version.
- [x] Added a changeset (`pnpm changeset`) if this PR changes any published
  package. Not needed: test-only change with no user-visible effect.
- [x] Added or updated tests. Not needed: the change is inside a test file.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015wkuaN7Cj7ES7dAZmhe7vW

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791580360&installation_model_id=426870&pr_number=14752&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14752&signature=f55360b3b60da7c25827502eb1292a591602494f034e4d4ec56cdba27710a978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test import handling to improve platform-specific test compatibility.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->