### PR TITLE
fix(cli): honor lockfile:false with onFail download

### DIFF
--- a/.changeset/lockfile-false-honors-devengines-download.md
+++ b/.changeset/lockfile-false-honors-devengines-download.md
@@ -3,4 +3,4 @@
 "pnpm": patch
 ---
 
-`lockfile: false` and `--no-lockfile` are honored when `devEngines.packageManager.onFail` is `download`. pnpm still switches to the pinned version, and it no longer creates a project `pnpm-lock.yaml` for that pin [#14728](https://github.com/pnpm/pnpm/issues/14728).
+pnpm no longer creates a project `pnpm-lock.yaml` when `devEngines.packageManager.onFail` is `download` and lockfile writing is turned off with `lockfile: false` or `--no-lockfile`. pnpm still switches to the pinned version [#14728](https://github.com/pnpm/pnpm/issues/14728).

--- a/.changeset/lockfile-false-honors-devengines-download.md
+++ b/.changeset/lockfile-false-honors-devengines-download.md
@@ -1,0 +1,6 @@
+---
+"pacquet": patch
+"pnpm": patch
+---
+
+`lockfile: false` and `--no-lockfile` are honored when `devEngines.packageManager.onFail` is `download`. pnpm still switches to the pinned version, and it no longer creates a project `pnpm-lock.yaml` for that pin [#14728](https://github.com/pnpm/pnpm/issues/14728).

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -394,11 +394,11 @@ fn resolve_package_manager_pin(
             return Ok(PinOutcome::Sync(None));
         }
         return Ok(PinOutcome::Sync(env_lockfile_sync(
+            config,
             root_manifest,
             roots,
             on_fail,
             ReadEnvLockfile::NotYet,
-            config,
         )?));
     }
     if switch_wanted && !process_state.executed_by_corepack {
@@ -410,11 +410,11 @@ fn resolve_package_manager_pin(
     }
     check_package_manager(pm, on_fail, process_state, input.emit)?;
     Ok(PinOutcome::Sync(env_lockfile_sync(
+        config,
         root_manifest,
         roots,
         on_fail,
         ReadEnvLockfile::NotYet,
-        config,
     )?))
 }
 
@@ -438,13 +438,7 @@ fn switch_or_sync(
         SwitchSource::LockedEnv { env, .. } => ReadEnvLockfile::Already(env),
         SwitchSource::Resolve { .. } => ReadEnvLockfile::NotYet,
     };
-    Ok(PinOutcome::Sync(env_lockfile_sync(
-        root_manifest,
-        roots,
-        on_fail,
-        read_lockfile,
-        config,
-    )?))
+    Ok(PinOutcome::Sync(env_lockfile_sync(config, root_manifest, roots, on_fail, read_lockfile)?))
 }
 
 /// pnpm's `syncEnvLockfile`: the pnpm version a project pins is recorded in
@@ -452,18 +446,16 @@ fn switch_or_sync(
 /// so the entry is the same whichever command a contributor happens to run
 /// first.
 ///
-/// `None` when the project doesn't pin a persisting pnpm version, or when the
-/// lockfile already records one that satisfies the pin.
+/// `None` when the project doesn't pin a persisting pnpm version, when
+/// `lockfile` is turned off, or when the lockfile already records a version
+/// that satisfies the pin.
 fn env_lockfile_sync(
+    config: &Config,
     root_manifest: &Value,
     roots: &PinRoots,
     on_fail: PmOnFail,
     read_lockfile: ReadEnvLockfile<'_>,
-    config: &Config,
 ) -> miette::Result<Option<PackageManagerToSync>> {
-    // `lockfile: false` / `--no-lockfile` opts out of writing pnpm-lock.yaml.
-    // onFail: download must still be able to switch versions, but it must not
-    // create a project lockfile the user asked not to have (pnpm/pnpm#14728).
     if !config.lockfile {
         return Ok(None);
     }
@@ -894,10 +886,9 @@ fn switch_target(
     }
     pm.on_fail = Some(on_fail.as_str().to_string());
 
-    // Project lockfile persistence also requires `config.lockfile`. When the
-    // user sets `lockfile: false`, keep onFail: download switching, but record
-    // the downloaded engine under the global env instead of creating a project
-    // pnpm-lock.yaml (pnpm/pnpm#14728).
+    // `lockfile: false` opts the project out of `pnpm-lock.yaml`, so the pin
+    // has nowhere in the project to persist to. The switch still happens —
+    // through the global env below (pnpm/pnpm#14728).
     let persist_lockfile = should_persist_package_manager_lockfile(&pm) && config.lockfile;
     if persist_lockfile
         && let Some(env) = read_env_lockfile(&roots.env)?

--- a/pnpm/crates/cli/src/cli_args/pre_command.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command.rs
@@ -398,6 +398,7 @@ fn resolve_package_manager_pin(
             roots,
             on_fail,
             ReadEnvLockfile::NotYet,
+            config,
         )?));
     }
     if switch_wanted && !process_state.executed_by_corepack {
@@ -408,7 +409,13 @@ fn resolve_package_manager_pin(
         return Ok(PinOutcome::Sync(None));
     }
     check_package_manager(pm, on_fail, process_state, input.emit)?;
-    Ok(PinOutcome::Sync(env_lockfile_sync(root_manifest, roots, on_fail, ReadEnvLockfile::NotYet)?))
+    Ok(PinOutcome::Sync(env_lockfile_sync(
+        root_manifest,
+        roots,
+        on_fail,
+        ReadEnvLockfile::NotYet,
+        config,
+    )?))
 }
 
 /// Switch to the pinned pnpm, unless the running one already is it — in
@@ -431,7 +438,13 @@ fn switch_or_sync(
         SwitchSource::LockedEnv { env, .. } => ReadEnvLockfile::Already(env),
         SwitchSource::Resolve { .. } => ReadEnvLockfile::NotYet,
     };
-    Ok(PinOutcome::Sync(env_lockfile_sync(root_manifest, roots, on_fail, read_lockfile)?))
+    Ok(PinOutcome::Sync(env_lockfile_sync(
+        root_manifest,
+        roots,
+        on_fail,
+        read_lockfile,
+        config,
+    )?))
 }
 
 /// pnpm's `syncEnvLockfile`: the pnpm version a project pins is recorded in
@@ -446,7 +459,14 @@ fn env_lockfile_sync(
     roots: &PinRoots,
     on_fail: PmOnFail,
     read_lockfile: ReadEnvLockfile<'_>,
+    config: &Config,
 ) -> miette::Result<Option<PackageManagerToSync>> {
+    // `lockfile: false` / `--no-lockfile` opts out of writing pnpm-lock.yaml.
+    // onFail: download must still be able to switch versions, but it must not
+    // create a project lockfile the user asked not to have (pnpm/pnpm#14728).
+    if !config.lockfile {
+        return Ok(None);
+    }
     let Some(package_manager) =
         package_manager_to_sync(root_manifest, &roots.manifest, Some(on_fail))
     else {
@@ -874,7 +894,11 @@ fn switch_target(
     }
     pm.on_fail = Some(on_fail.as_str().to_string());
 
-    let persist_lockfile = should_persist_package_manager_lockfile(&pm);
+    // Project lockfile persistence also requires `config.lockfile`. When the
+    // user sets `lockfile: false`, keep onFail: download switching, but record
+    // the downloaded engine under the global env instead of creating a project
+    // pnpm-lock.yaml (pnpm/pnpm#14728).
+    let persist_lockfile = should_persist_package_manager_lockfile(&pm) && config.lockfile;
     if persist_lockfile
         && let Some(env) = read_env_lockfile(&roots.env)?
         && let Some(version) = locked_package_manager_version(&env, &spec)?

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -472,6 +472,32 @@ fn pre_command_plan_skips_env_lockfile_sync_when_lockfile_is_disabled() {
     );
 }
 
+/// `lockfile: false` silences the pin record, not the switch: a pin the
+/// running pnpm cannot satisfy is still downloaded, and resolves outside the
+/// project because the project has no lockfile to resolve into
+/// (pnpm/pnpm#14728).
+#[test]
+fn pre_command_plan_still_switches_when_lockfile_is_disabled() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), "99.0.0");
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &config_overrides(&["--no-lockfile"]),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    let Some(PreCommandPlan::Switch(plan)) = plan else {
+        panic!("expected a switch plan, got {plan:?}");
+    };
+    assert_eq!(plan.target.spec, "99.0.0");
+    let SwitchSource::Resolve { env_root, .. } = &plan.target.source else {
+        panic!("expected a resolve target, got {:?}", plan.target.source);
+    };
+    assert_ne!(env_root.as_path(), root.path());
+}
+
 #[test]
 fn switch_target_uses_global_env_when_lockfile_is_disabled() {
     let root = TempDir::new().expect("tmp dir");

--- a/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
+++ b/pnpm/crates/cli/src/cli_args/pre_command/tests.rs
@@ -451,6 +451,57 @@ fn pre_command_plan_does_not_record_a_pin_the_pm_on_fail_setting_turned_off() {
     assert!(plan.is_none(), "unexpected pre-command plan: {plan:?}");
 }
 
+/// `lockfile: false` must suppress the project env-lockfile write even when
+/// `devEngines.packageManager.onFail: download` would otherwise persist the
+/// pin (pnpm/pnpm#14728). Download switching itself stays available.
+#[test]
+fn pre_command_plan_skips_env_lockfile_sync_when_lockfile_is_disabled() {
+    let root = TempDir::new().expect("tmp dir");
+    write_dev_engine_manifest(root.path(), PNPM_VERSION);
+
+    let plan = pre_command_plan_from_input(
+        &pre_command_input(root.path()),
+        &config_overrides(&["--no-lockfile"]),
+        SwitchProcessState { package_manager_switch_disabled: false, executed_by_corepack: false },
+    )
+    .expect("pre-command plan");
+
+    assert!(
+        plan.is_none(),
+        "lockfile: false must not schedule a project env lockfile sync, got {plan:?}",
+    );
+}
+
+#[test]
+fn switch_target_uses_global_env_when_lockfile_is_disabled() {
+    let root = TempDir::new().expect("tmp dir");
+    let global_pkg_dir = root.path().join("pnpm-home").join("global");
+    write_dev_engine_manifest(root.path(), "99.0.0");
+
+    let target = switch_target(
+        &Config {
+            lockfile: false,
+            global_pkg_dir: Some(global_pkg_dir.clone()),
+            ..Config::default()
+        },
+        &pin_roots(root.path()),
+        false,
+    )
+    .expect("target")
+    .expect("download pin should still produce a switch target");
+
+    let SwitchSource::Resolve {
+        env_root,
+        frozen_lockfile: false,
+        force_resync: false,
+        locked_version: None,
+    } = target.source
+    else {
+        panic!("expected resolve target into the global env, got {:?}", target.source);
+    };
+    assert_eq!(env_root, global_pkg_dir);
+}
+
 fn pin_roots(dir: &Path) -> PinRoots {
     PinRoots { manifest: dir.to_path_buf(), env: dir.to_path_buf() }
 }

--- a/pnpm/crates/cli/tests/suite/package_manager_check.rs
+++ b/pnpm/crates/cli/tests/suite/package_manager_check.rs
@@ -463,6 +463,38 @@ fn a_pinned_package_manager_is_recorded_in_the_lockfile_directory() {
     drop(mock_instance);
 }
 
+/// `lockfile: false` opts the project out of `pnpm-lock.yaml`, and an
+/// `onFail: download` pin is no exception: the pin it would otherwise record
+/// there does not bring the file back (pnpm/pnpm#14728).
+#[test]
+fn a_pinned_package_manager_writes_no_lockfile_when_the_lockfile_is_turned_off() {
+    let CommandTempCwd { pacquet, root, workspace, npmrc_info, .. } =
+        CommandTempCwd::init().add_mocked_registry_with_pnpm_version(pnpm_config::PNPM_VERSION);
+    let AddMockedRegistry { mock_instance, .. } = npmrc_info;
+    fs::write(workspace.join("pnpm-workspace.yaml"), "lockfile: false\n")
+        .expect("write the workspace manifest");
+    write_dev_engines_package_manager(
+        &workspace,
+        "pnpm",
+        pnpm_config::PNPM_VERSION,
+        Some("download"),
+    );
+
+    let output = run(
+        pacquet.with_env("PNPM_CONFIG_REGISTRY", mock_instance.url()),
+        root.path(),
+        &["install"],
+    );
+
+    assert_success(&output);
+    assert!(
+        !workspace.join("pnpm-lock.yaml").exists(),
+        "lockfile: false must leave the project without a pnpm-lock.yaml",
+    );
+
+    drop(mock_instance);
+}
+
 #[test]
 fn a_global_command_warns_instead_of_failing_the_package_manager_check() {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -53,6 +53,7 @@ const envLockfile: EnvLockfile = {
   },
 }
 const installPnpmToStore = jest.fn<(version: string, opts: object) => Promise<{ binDir: string }>>(async () => ({ binDir: '/store/bin' }))
+const isPackageManagerResolved = jest.fn<(envLockfile: EnvLockfile | undefined, pnpmVersion: string, specifier?: string) => boolean>(() => true)
 const readEnvLockfile = jest.fn<(rootDir: string) => Promise<EnvLockfile | null>>(async () => envLockfile)
 const resolvePackageManagerIntegrities = jest.fn<(version: string, opts: object) => Promise<EnvLockfile>>(async () => envLockfile)
 const spawnSync = jest.fn<(command: string, args: string[], options: object) => { status: number }>(() => ({ status: 0 }))
@@ -73,7 +74,7 @@ jest.unstable_mockModule('@pnpm/engine.pm.commands', () => ({
   installPnpmToStore,
 }))
 jest.unstable_mockModule('@pnpm/installing.env-installer', () => ({
-  isPackageManagerResolved: () => true,
+  isPackageManagerResolved,
   resolvePackageManagerIntegrities,
 }))
 jest.unstable_mockModule('@pnpm/lockfile.fs', () => ({
@@ -93,6 +94,8 @@ beforeEach(() => {
   closeStore.mockClear()
   createStoreController.mockClear()
   installPnpmToStore.mockClear()
+  isPackageManagerResolved.mockClear()
+  isPackageManagerResolved.mockReturnValue(true)
   readEnvLockfile.mockClear()
   readEnvLockfile.mockResolvedValue(envLockfile)
   resolvePackageManagerIntegrities.mockClear()
@@ -108,7 +111,7 @@ test('switchCliVersion does not save the project lockfile when lockfile is disab
   readEnvLockfile.mockResolvedValue(null)
 
   await expect(switchCliVersion({
-    lockfile: false,
+    useLockfile: false,
     registriesByScope: { default: 'https://registry.npmjs.org/' },
     virtualStoreDirMaxLength: 120,
   } as unknown as Config, {
@@ -127,6 +130,30 @@ test('switchCliVersion does not save the project lockfile when lockfile is disab
   }))
 
   exit.mockRestore()
+})
+
+test('switchCliVersion resolves nothing when the running pnpm satisfies a pin the lockfile cannot record (#14728)', async () => {
+  // Nothing was read, so nothing is recorded as resolved either.
+  isPackageManagerResolved.mockReturnValue(false)
+
+  await switchCliVersion({
+    useLockfile: false,
+    registriesByScope: { default: 'https://registry.npmjs.org/' },
+    virtualStoreDirMaxLength: 120,
+  } as unknown as Config, {
+    rootProjectManifestDir: '/repo',
+    wantedPackageManager: {
+      fromDevEngines: true,
+      name: 'pnpm',
+      onFail: 'download',
+      version: '^11.0.0',
+    },
+  } as unknown as ConfigContext)
+
+  expect(readEnvLockfile).not.toHaveBeenCalled()
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+  expect(createStoreController).not.toHaveBeenCalled()
+  expect(spawnSync).not.toHaveBeenCalled()
 })
 
 test('switchCliVersion uses trusted package-manager registries instead of project registries', async () => {

--- a/pnpm11/pnpm/src/switchCliVersion.test.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.test.ts
@@ -100,6 +100,35 @@ beforeEach(() => {
   spawnSync.mockClear()
 })
 
+test('switchCliVersion does not save the project lockfile when lockfile is disabled (#14728)', async () => {
+  const exit = jest.spyOn(process, 'exit').mockImplementation(((code?: string | number | null | undefined) => {
+    throw new Error(`exit ${code ?? 0}`)
+  }) as typeof process.exit)
+
+  readEnvLockfile.mockResolvedValue(null)
+
+  await expect(switchCliVersion({
+    lockfile: false,
+    registriesByScope: { default: 'https://registry.npmjs.org/' },
+    virtualStoreDirMaxLength: 120,
+  } as unknown as Config, {
+    rootProjectManifestDir: '/repo',
+    wantedPackageManager: {
+      fromDevEngines: true,
+      name: 'pnpm',
+      onFail: 'download',
+      version: '9.3.0',
+    },
+  } as unknown as ConfigContext)).rejects.toThrow('exit 0')
+
+  expect(readEnvLockfile).not.toHaveBeenCalled()
+  expect(resolvePackageManagerIntegrities).toHaveBeenCalledWith('9.3.0', expect.objectContaining({
+    save: false,
+  }))
+
+  exit.mockRestore()
+})
+
 test('switchCliVersion uses trusted package-manager registries instead of project registries', async () => {
   const exit = jest.spyOn(process, 'exit').mockImplementation(((code?: string | number | null | undefined) => {
     throw new Error(`exit ${code ?? 0}`)

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -19,7 +19,9 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
   const pm = context.wantedPackageManager
   if (pm == null || pm.name !== 'pnpm' || pm.version == null) return
 
-  const persistLockfile = shouldPersistLockfile(pm)
+  // lockfile: false keeps onFail: download switching, but skips writing the
+  // project's pnpm-lock.yaml (pnpm/pnpm#14728).
+  const persistLockfile = shouldPersistLockfile(pm) && config.lockfile !== false
 
   // In non-persist mode the env lockfile is intentionally not read, so there
   // is no cached resolution to compare against. Since the legacy

--- a/pnpm11/pnpm/src/switchCliVersion.ts
+++ b/pnpm11/pnpm/src/switchCliVersion.ts
@@ -19,25 +19,26 @@ export async function switchCliVersion (config: Config, context: ConfigContext):
   const pm = context.wantedPackageManager
   if (pm == null || pm.name !== 'pnpm' || pm.version == null) return
 
-  // lockfile: false keeps onFail: download switching, but skips writing the
-  // project's pnpm-lock.yaml (pnpm/pnpm#14728).
-  const persistLockfile = shouldPersistLockfile(pm) && config.lockfile !== false
+  const wantedVersion = pm.version
+  const satisfiesPin = (version: string): boolean =>
+    semver.satisfies(version, wantedVersion, { includePrerelease: true })
+
+  // `lockfile: false` opts the project out of pnpm-lock.yaml, so the version
+  // this switch resolves has nowhere in the project to persist to. Switching
+  // itself still happens (pnpm/pnpm#14728).
+  const persistLockfile = shouldPersistLockfile(pm) && config.useLockfile !== false
 
   // In non-persist mode the env lockfile is intentionally not read, so there
-  // is no cached resolution to compare against. Since the legacy
-  // `packageManager` field always carries an exact version, we can skip both
-  // resolution and store access when the running CLI already matches.
-  if (!persistLockfile && pm.version === packageManager.version) return
+  // is no recorded resolution to prefer over the running CLI. Whenever the
+  // running CLI satisfies the pin it is the one the project uses, so both
+  // resolution and store access can be skipped.
+  if (!persistLockfile && satisfiesPin(packageManager.version)) return
 
   let envLockfile = persistLockfile
     ? (await readEnvLockfile(context.rootProjectManifestDir) ?? undefined)
     : undefined
   let storeToUse: Awaited<ReturnType<typeof createStoreController>> | undefined
   const packageManagerConfig = getPackageManagerBootstrapConfig(config)
-
-  const wantedVersion = pm.version
-  const satisfiesPin = (version: string): boolean =>
-    semver.satisfies(version, wantedVersion, { includePrerelease: true })
 
   // Check if the env lockfile already has a resolved version that satisfies the wanted version/range.
   let pmVersion = envLockfile?.importers['.'].packageManagerDependencies?.['pnpm']?.version

--- a/pnpm11/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.test.ts
@@ -80,6 +80,15 @@ test('no-op when shouldPersistLockfile is false (legacy packageManager < v12)', 
   expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
 })
 
+test('no-op when lockfile is disabled (#14728)', async () => {
+  const dir = tempDir()
+  await syncEnvLockfile({ ...baseConfig, lockfile: false }, makeContext(dir, {
+    wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true, onFail: 'download' },
+  }))
+  expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()
+  expect(fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))).toBe(false)
+})
+
 test('no-op when running pnpm does not satisfy wanted range', async () => {
   const dir = tempDir()
   writeStaleEnvLockfile(dir, '9.0.0')

--- a/pnpm11/pnpm/src/syncEnvLockfile.test.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.test.ts
@@ -82,7 +82,7 @@ test('no-op when shouldPersistLockfile is false (legacy packageManager < v12)', 
 
 test('no-op when lockfile is disabled (#14728)', async () => {
   const dir = tempDir()
-  await syncEnvLockfile({ ...baseConfig, lockfile: false }, makeContext(dir, {
+  await syncEnvLockfile({ ...baseConfig, useLockfile: false }, makeContext(dir, {
     wantedPackageManager: { name: 'pnpm', version: packageManager.version, fromDevEngines: true, onFail: 'download' },
   }))
   expect(resolvePackageManagerIntegrities).not.toHaveBeenCalled()

--- a/pnpm11/pnpm/src/syncEnvLockfile.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.ts
@@ -23,6 +23,9 @@ export async function syncEnvLockfile (config: Config, context: ConfigContext): 
   const pm = context.wantedPackageManager
   if (pm == null || pm.name !== 'pnpm' || pm.version == null) return
   if (!shouldPersistLockfile(pm)) return
+  // lockfile: false / --no-lockfile opts out of writing pnpm-lock.yaml, including
+  // the packageManagerDependencies block (pnpm/pnpm#14728).
+  if (config.lockfile === false) return
   // The currently running pnpm must satisfy the wanted range. Otherwise,
   // recording it in the lockfile would cement an incompatible resolution —
   // checkPackageManager has already surfaced the mismatch to the user.

--- a/pnpm11/pnpm/src/syncEnvLockfile.ts
+++ b/pnpm11/pnpm/src/syncEnvLockfile.ts
@@ -15,17 +15,17 @@ import semver from 'semver'
  * The currently running pnpm version has already been verified by
  * checkPackageManager to satisfy the wanted range, so recording it is safe.
  *
- * No-op when the project does not pin a pnpm version, or when the recorded
- * entry both satisfies the wanted range and pins every package that version
- * is installed from.
+ * No-op when the project does not pin a pnpm version, when lockfile writing
+ * is turned off, or when the recorded entry both satisfies the wanted range
+ * and pins every package that version is installed from.
  */
 export async function syncEnvLockfile (config: Config, context: ConfigContext): Promise<void> {
   const pm = context.wantedPackageManager
   if (pm == null || pm.name !== 'pnpm' || pm.version == null) return
   if (!shouldPersistLockfile(pm)) return
-  // lockfile: false / --no-lockfile opts out of writing pnpm-lock.yaml, including
-  // the packageManagerDependencies block (pnpm/pnpm#14728).
-  if (config.lockfile === false) return
+  // The entry lives in pnpm-lock.yaml, which `lockfile: false` opts the
+  // project out of (pnpm/pnpm#14728).
+  if (config.useLockfile === false) return
   // The currently running pnpm must satisfy the wanted range. Otherwise,
   // recording it in the lockfile would cement an incompatible resolution —
   // checkPackageManager has already surfaced the mismatch to the user.

--- a/pnpm11/pnpm/test/switchingVersions.test.ts
+++ b/pnpm11/pnpm/test/switchingVersions.test.ts
@@ -321,6 +321,27 @@ test('devEngines.packageManager entries with a tarball resolution are repaired u
   expect(fs.readFileSync('pnpm-lock.yaml', 'utf8')).toBe(lockfile)
 })
 
+test('devEngines.packageManager with onFail=download writes no lockfile when lockfile is disabled (#14728)', async () => {
+  prepare()
+  const pnpmHome = path.resolve('pnpm')
+  const env = { PNPM_HOME: pnpmHome }
+  writeJsonFileSync('package.json', {
+    devEngines: {
+      packageManager: {
+        name: 'pnpm',
+        version: '9.3.0',
+        onFail: 'download',
+      },
+    },
+  })
+  writeYamlFileSync('pnpm-workspace.yaml', { lockfile: false })
+
+  const { stdout } = execPnpmSync(['help'], { env })
+
+  expect(stdout.toString()).toContain('Version 9.3.0')
+  expect(fs.existsSync('pnpm-lock.yaml')).toBe(false)
+})
+
 test('devEngines.packageManager without onFail=download does not switch version', async () => {
   prepare()
   const pnpmHome = path.resolve('pnpm')


### PR DESCRIPTION
## Summary

- Fixes pnpm/pnpm#14728: `lockfile: false` / `--no-lockfile` was ignored when `devEngines.packageManager.onFail` was `download`, so a project `pnpm-lock.yaml` still appeared.
- Rust (v12): skip the project env-lockfile sync when `config.lockfile` is false; keep `onFail: download` switching by recording the downloaded engine under the global env instead of the project lockfile.
- TypeScript (v11): the same gate in `syncEnvLockfile` and `switchCliVersion` (`save: false` when lockfile writing is disabled). The gate reads `config.useLockfile`, the resolved setting, so `--no-package-lock` and `packageLock: false` are honored too — `config.lockfile` alone stays unset unless the user spells it out, which is what pacquet's `config.lockfile` already folds `package_lock` into.
- TypeScript (v11): `switchCliVersion` returns as soon as the running pnpm satisfies the pin while persistence is off. Without a lockfile to read there is no recorded resolution to compare a range pin against, so it otherwise asked the registry on every command for a version it was already running.
- Adds unit coverage on both stacks plus a filesystem-backed regression test in each, and a changeset for `pacquet` and `pnpm`.

## Test plan

- [x] `cargo test -p pnpm-cli --lib 'cli_args::pre_command::tests'` (33 passed, including the two new `lockfile_is_disabled` cases)
- [x] `cargo test -p pnpm-cli --test suite package_manager_check` (46 passed, including `a_pinned_package_manager_writes_no_lockfile_when_the_lockfile_is_turned_off`, which runs a real `pnpm install` on the issue's repro and asserts no project lockfile appears)
- [x] `cargo fmt --check` and `cargo clippy -p pnpm-cli --all-targets`
- [x] jest `src/switchCliVersion.test.ts`, `src/syncEnvLockfile.test.ts`, `test/switchingVersions.test.ts`, `test/packageManagerCheck.test.ts` (89 passed, including the new e2e case asserting the switch to 9.3.0 still happens with no `pnpm-lock.yaml`)
- [x] Every new test was confirmed to fail with its fix disabled; the v11 e2e one fails on exactly the lockfile assertion, reproducing the issue.

Written by an agent (Cursor, GPT), with review fixes by an agent (Claude Code, claude-opus-5).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791580744&installation_model_id=426870&pr_number=14753&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14753&signature=65e4db38a0c0b01290837ab5214ad19c4f5a0ea99a1db593bb30750e8db7a386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - `lockfile: false` and `--no-lockfile` are now honored when automatically switching to a configured package manager version.
  - Automatic package-manager switching continues without creating or updating the project’s `pnpm-lock.yaml`.
  - When project lockfile persistence is disabled, related environment data is saved globally instead of in the project.
  - Compatible installed package-manager versions are used without unnecessary lockfile resolution or updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
