### PR TITLE
fix(cli): honor --no-bail for pattern script runs

### DIFF
--- a/.changeset/pattern-run-no-bail-siblings.md
+++ b/.changeset/pattern-run-no-bail-siblings.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run "/pattern/" --no-bail` now lets every matched script finish after one of them fails. The command then exits with `ERR_PNPM_RUN_FAILED`, as pnpm 11 does. Its message lists the scripts that failed, in the order they were selected [#14718](https://github.com/pnpm/pnpm/issues/14718).
+`pnpm run "/pattern/" --no-bail` now lets every matched script finish after one of them fails. The command then exits with `ERR_PNPM_RUN_FAILED`. Its message lists the scripts that failed, in the order they were selected [#14718](https://github.com/pnpm/pnpm/issues/14718).

--- a/.changeset/pattern-run-no-bail-siblings.md
+++ b/.changeset/pattern-run-no-bail-siblings.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-Honor `--no-bail` for non-recursive `/pattern/` script runs so a failing matched script no longer cancels its siblings [#14718](https://github.com/pnpm/pnpm/issues/14718).
+`pnpm run "/pattern/" --no-bail` now lets every matched script finish after one of them fails. The command then exits with `ERR_PNPM_RUN_FAILED` and lists the scripts that failed, as pnpm 11 does [#14718](https://github.com/pnpm/pnpm/issues/14718).

--- a/.changeset/pattern-run-no-bail-siblings.md
+++ b/.changeset/pattern-run-no-bail-siblings.md
@@ -2,4 +2,4 @@
 "pacquet": patch
 ---
 
-`pnpm run "/pattern/" --no-bail` now lets every matched script finish after one of them fails. The command then exits with `ERR_PNPM_RUN_FAILED` and lists the scripts that failed, as pnpm 11 does [#14718](https://github.com/pnpm/pnpm/issues/14718).
+`pnpm run "/pattern/" --no-bail` now lets every matched script finish after one of them fails. The command then exits with `ERR_PNPM_RUN_FAILED`, as pnpm 11 does. Its message lists the scripts that failed, in the order they were selected [#14718](https://github.com/pnpm/pnpm/issues/14718).

--- a/.changeset/pattern-run-no-bail-siblings.md
+++ b/.changeset/pattern-run-no-bail-siblings.md
@@ -1,0 +1,5 @@
+---
+"pacquet": patch
+---
+
+Honor `--no-bail` for non-recursive `/pattern/` script runs so a failing matched script no longer cancels its siblings [#14718](https://github.com/pnpm/pnpm/issues/14718).

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -62,10 +62,10 @@ pub struct RunArgs {
     #[clap(skip)]
     pub report_summary: bool,
 
-    /// Keep running the remaining matched scripts (or packages, for a
-    /// recursive run) after a script fails instead of aborting on the
-    /// first failure. Set from the global `--no-bail` flag; recursive
-    /// runs bail by default, and non-recursive pattern runs do too.
+    /// Keep running the remaining scripts after one fails instead of
+    /// aborting on the first failure (the global `--no-bail` flag).
+    /// Applies to a recursive run and to a `/pattern/` run that selects
+    /// several scripts; both bail by default.
     #[clap(skip)]
     pub no_bail: bool,
 
@@ -131,6 +131,10 @@ pub enum RunError {
     #[diagnostic(code(ERR_PNPM_UNSUPPORTED_SCRIPT_COMMAND_FORMAT))]
     UnsupportedScriptCommandFormat,
 
+    #[display("Some scripts failed: {failed} of {total}")]
+    #[diagnostic(code(ERR_PNPM_RUN_FAILED), help("{hint}"))]
+    SomeScriptsFailed { failed: usize, total: usize, hint: String },
+
     #[display("The --dry-run option is only supported with recursive runs")]
     #[diagnostic(
         code(ERR_PNPM_DRY_RUN_NOT_RECURSIVE),
@@ -171,8 +175,9 @@ impl RunArgs {
     ///
     /// The `resume_from` / `report_summary` fields are only meaningful
     /// for the recursive path (see [`Self::run_recursive`]) and are
-    /// ignored here. `no_bail` also applies to a non-recursive
-    /// `/pattern/` run that selects several scripts at once.
+    /// ignored here. `no_bail` applies once a `/pattern/` selects several
+    /// scripts: they all run, and the command ends with
+    /// [`RunError::SomeScriptsFailed`] if any of them failed.
     pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
         self.run_inner(ExecDirs::same(dir), config, reporter, false)
     }
@@ -251,10 +256,9 @@ impl RunArgs {
         let concurrency =
             script_concurrency(config, specified.len(), self.parallel, self.sequential);
         // Several scripts running at once share this process's terminal,
-        // so their output is prefixed. When bailing, their children are
-        // also tracked so a failure can cancel the siblings still running.
-        // `--no-bail` leaves every matched script alone, matching the
-        // recursive runner.
+        // so their output is prefixed. Their children are tracked only
+        // when a failure should cancel the siblings still running, which
+        // `--no-bail` rules out.
         let interleaved = specified.len() > 1 && concurrency > 1;
         let bail = !self.no_bail;
         let process_tracker = (interleaved && bail).then(ProcessTracker::foreground);
@@ -274,11 +278,13 @@ impl RunArgs {
             process_tracker: process_tracker.as_ref(),
         };
         let outcome = ScriptOutcome {
-            failure: Mutex::new(None),
+            failures: Mutex::new(Vec::new()),
             abort: Mutex::new(None),
             process_tracker: process_tracker.as_ref(),
+            bail,
+            total: specified.len(),
         };
-        run_selected_scripts(&ctx, &outcome, specified, args, concurrency, bail)?;
+        run_selected_scripts(&ctx, &outcome, specified, args, concurrency)?;
         outcome.into_result()
     }
 
@@ -403,14 +409,13 @@ fn run_selected_scripts(
     specified: Vec<String>,
     args: &[String],
     concurrency: usize,
-    bail: bool,
 ) -> miette::Result<()> {
     let tasks: IndexMap<String, Vec<String>> =
         specified.into_iter().map(|name| (name, Vec::new())).collect();
     let run_script = |name: String| run_one_script(ctx, outcome, &name, args);
     if concurrency == 1 || tasks.len() == 1 {
         for name in tasks.keys() {
-            if !matches!(run_script(name.clone()), TaskCompletion::Passed) && bail {
+            if !matches!(run_script(name.clone()), TaskCompletion::Passed) && outcome.bail {
                 break;
             }
         }
@@ -419,7 +424,7 @@ fn run_selected_scripts(
     let on_script_skipped = |_: &String| {};
     schedule_graph(
         &tasks,
-        &ScheduleGraphOptions::new(concurrency, bail, &run_script, &on_script_skipped),
+        &ScheduleGraphOptions::new(concurrency, outcome.bail, &run_script, &on_script_skipped),
     )
     .into_diagnostic()
 }
@@ -444,7 +449,7 @@ fn run_one_script(
     }
     match run_stages(ctx, name, &main, args) {
         Ok(status) if status.success() => TaskCompletion::Passed,
-        Ok(status) => outcome.fail(status),
+        Ok(status) => outcome.fail(name, status),
         Err(error) => outcome.abort(error),
     }
 }
@@ -522,35 +527,52 @@ fn script_concurrency(
     usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
 }
 
-/// Where a script's failure is recorded. The first failure is the one
-/// the command exits with. When a process tracker is present (the
-/// default bail path), a failure also cancels the scripts still running
-/// beside it; `--no-bail` omits the tracker so siblings finish.
+/// Where the failures of the `total` selected scripts are recorded.
+/// Under `--bail` the first failure is the one the command exits with,
+/// and the process tracker cancels the scripts still running beside it.
+/// Under `--no-bail` every script runs and the failures are reported
+/// together as [`RunError::SomeScriptsFailed`].
 struct ScriptOutcome<'a> {
-    failure: Mutex<Option<ScriptExit>>,
+    failures: Mutex<Vec<(String, ScriptExit)>>,
     abort: Mutex<Option<miette::Report>>,
     process_tracker: Option<&'a ProcessTracker>,
+    bail: bool,
+    total: usize,
 }
 
 impl ScriptOutcome<'_> {
-    /// The command's own result: an error that stopped a script, or the
-    /// end of the first script that failed.
+    /// The command's own result: an error that stopped a script, the end
+    /// of the first script that failed, or the `--no-bail` summary.
     fn into_result(self) -> miette::Result<()> {
         if let Some(error) = self.abort.into_inner().expect("run abort lock is not poisoned") {
             return Err(error);
         }
-        if let Some(exit) = self.failure.into_inner().expect("run failure lock is not poisoned") {
-            // `run_stage` already emitted the `[ELIFECYCLE]` line.
-            exit_like(exit);
+        let failures = self.failures.into_inner().expect("run failure lock is not poisoned");
+        if self.bail {
+            if let Some((_, exit)) = failures.first() {
+                // `run_stage` already emitted the `[ELIFECYCLE]` line.
+                exit_like(*exit);
+            }
+            return Ok(());
         }
-        Ok(())
+        if failures.is_empty() {
+            return Ok(());
+        }
+        let hint =
+            failures.iter().map(|(name, exit)| format!("{name}: {exit}")).collect::<Vec<_>>();
+        Err(RunError::SomeScriptsFailed {
+            failed: failures.len(),
+            total: self.total,
+            hint: hint.join("\n"),
+        }
+        .into())
     }
 
-    fn fail(&self, exit: ScriptExit) -> TaskCompletion {
-        let mut failure = self.failure.lock().expect("run failure lock is not poisoned");
-        if failure.is_none() {
-            *failure = Some(exit);
-        }
+    fn fail(&self, name: &str, exit: ScriptExit) -> TaskCompletion {
+        self.failures
+            .lock()
+            .expect("run failure lock is not poisoned")
+            .push((name.to_owned(), exit));
         self.cancel_siblings();
         TaskCompletion::Failed
     }

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -175,9 +175,9 @@ impl RunArgs {
     ///
     /// The `resume_from` / `report_summary` fields are only meaningful
     /// for the recursive path (see [`Self::run_recursive`]) and are
-    /// ignored here. `no_bail` applies once a `/pattern/` selects several
-    /// scripts: they all run, and the command ends with
-    /// [`RunError::SomeScriptsFailed`] if any of them failed.
+    /// ignored here. `no_bail` applies to a `/pattern/` run and, as in
+    /// pnpm 11, to a single selected script: every script runs, and the
+    /// command ends with [`RunError::SomeScriptsFailed`] if any failed.
     pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
         self.run_inner(ExecDirs::same(dir), config, reporter, false)
     }
@@ -282,9 +282,9 @@ impl RunArgs {
             abort: Mutex::new(None),
             process_tracker: process_tracker.as_ref(),
             bail,
-            total: specified.len(),
+            scripts: specified,
         };
-        run_selected_scripts(&ctx, &outcome, specified, args, concurrency)?;
+        run_selected_scripts(&ctx, &outcome, args, concurrency)?;
         outcome.into_result()
     }
 
@@ -406,12 +406,11 @@ fn resolve_main_script(ctx: &RunContext<'_>, name: &str) -> Result<Option<String
 fn run_selected_scripts(
     ctx: &RunContext<'_>,
     outcome: &ScriptOutcome<'_>,
-    specified: Vec<String>,
     args: &[String],
     concurrency: usize,
 ) -> miette::Result<()> {
     let tasks: IndexMap<String, Vec<String>> =
-        specified.into_iter().map(|name| (name, Vec::new())).collect();
+        outcome.scripts.iter().map(|name| (name.clone(), Vec::new())).collect();
     let run_script = |name: String| run_one_script(ctx, outcome, &name, args);
     if concurrency == 1 || tasks.len() == 1 {
         for name in tasks.keys() {
@@ -527,17 +526,17 @@ fn script_concurrency(
     usize::try_from(config.workspace_concurrency).unwrap_or(usize::MAX).max(1)
 }
 
-/// Where the failures of the `total` selected scripts are recorded.
-/// Under `--bail` the first failure is the one the command exits with,
-/// and the process tracker cancels the scripts still running beside it.
-/// Under `--no-bail` every script runs and the failures are reported
-/// together as [`RunError::SomeScriptsFailed`].
+/// Where the failures of the selected `scripts` are recorded. Under
+/// `--bail` the first failure is the one the command exits with, and the
+/// process tracker cancels the scripts still running beside it. Under
+/// `--no-bail` every script runs and the failures are reported together
+/// as [`RunError::SomeScriptsFailed`], in selection order.
 struct ScriptOutcome<'a> {
     failures: Mutex<Vec<(String, ScriptExit)>>,
     abort: Mutex<Option<miette::Report>>,
     process_tracker: Option<&'a ProcessTracker>,
     bail: bool,
-    total: usize,
+    scripts: Vec<String>,
 }
 
 impl ScriptOutcome<'_> {
@@ -547,7 +546,7 @@ impl ScriptOutcome<'_> {
         if let Some(error) = self.abort.into_inner().expect("run abort lock is not poisoned") {
             return Err(error);
         }
-        let failures = self.failures.into_inner().expect("run failure lock is not poisoned");
+        let mut failures = self.failures.into_inner().expect("run failure lock is not poisoned");
         if self.bail {
             if let Some((_, exit)) = failures.first() {
                 // `run_stage` already emitted the `[ELIFECYCLE]` line.
@@ -558,11 +557,12 @@ impl ScriptOutcome<'_> {
         if failures.is_empty() {
             return Ok(());
         }
+        failures.sort_by_key(|(name, _)| self.scripts.iter().position(|script| script == name));
         let hint =
             failures.iter().map(|(name, exit)| format!("{name}: {exit}")).collect::<Vec<_>>();
         Err(RunError::SomeScriptsFailed {
             failed: failures.len(),
-            total: self.total,
+            total: self.scripts.len(),
             hint: hint.join("\n"),
         }
         .into())

--- a/pnpm/crates/cli/src/cli_args/run.rs
+++ b/pnpm/crates/cli/src/cli_args/run.rs
@@ -62,10 +62,10 @@ pub struct RunArgs {
     #[clap(skip)]
     pub report_summary: bool,
 
-    /// Keep running the remaining packages after a script fails instead
-    /// of aborting on the first failure. Only meaningful together with
-    /// the global `-r` / `--recursive` flag (the `--no-bail` flag;
-    /// recursive runs bail by default).
+    /// Keep running the remaining matched scripts (or packages, for a
+    /// recursive run) after a script fails instead of aborting on the
+    /// first failure. Set from the global `--no-bail` flag; recursive
+    /// runs bail by default, and non-recursive pattern runs do too.
     #[clap(skip)]
     pub no_bail: bool,
 
@@ -169,9 +169,10 @@ impl RunArgs {
     /// the same code, matching pnpm where a failing script sets the
     /// process exit code.
     ///
-    /// The `resume_from` / `report_summary` / `no_bail` fields are only
-    /// meaningful for the recursive path (see [`Self::run_recursive`])
-    /// and are ignored here.
+    /// The `resume_from` / `report_summary` fields are only meaningful
+    /// for the recursive path (see [`Self::run_recursive`]) and are
+    /// ignored here. `no_bail` also applies to a non-recursive
+    /// `/pattern/` run that selects several scripts at once.
     pub fn run(self, dir: &Path, config: &Config, reporter: ReporterType) -> miette::Result<()> {
         self.run_inner(ExecDirs::same(dir), config, reporter, false)
     }
@@ -250,10 +251,13 @@ impl RunArgs {
         let concurrency =
             script_concurrency(config, specified.len(), self.parallel, self.sequential);
         // Several scripts running at once share this process's terminal,
-        // so their output is prefixed and their children are tracked for
-        // cancellation.
+        // so their output is prefixed. When bailing, their children are
+        // also tracked so a failure can cancel the siblings still running.
+        // `--no-bail` leaves every matched script alone, matching the
+        // recursive runner.
         let interleaved = specified.len() > 1 && concurrency > 1;
-        let process_tracker = interleaved.then(ProcessTracker::foreground);
+        let bail = !self.no_bail;
+        let process_tracker = (interleaved && bail).then(ProcessTracker::foreground);
         let dep_path = dir.to_string_lossy().into_owned();
         let ctx = RunContext {
             manifest,
@@ -274,7 +278,7 @@ impl RunArgs {
             abort: Mutex::new(None),
             process_tracker: process_tracker.as_ref(),
         };
-        run_selected_scripts(&ctx, &outcome, specified, args, concurrency)?;
+        run_selected_scripts(&ctx, &outcome, specified, args, concurrency, bail)?;
         outcome.into_result()
     }
 
@@ -399,13 +403,14 @@ fn run_selected_scripts(
     specified: Vec<String>,
     args: &[String],
     concurrency: usize,
+    bail: bool,
 ) -> miette::Result<()> {
     let tasks: IndexMap<String, Vec<String>> =
         specified.into_iter().map(|name| (name, Vec::new())).collect();
     let run_script = |name: String| run_one_script(ctx, outcome, &name, args);
     if concurrency == 1 || tasks.len() == 1 {
         for name in tasks.keys() {
-            if !matches!(run_script(name.clone()), TaskCompletion::Passed) {
+            if !matches!(run_script(name.clone()), TaskCompletion::Passed) && bail {
                 break;
             }
         }
@@ -414,7 +419,7 @@ fn run_selected_scripts(
     let on_script_skipped = |_: &String| {};
     schedule_graph(
         &tasks,
-        &ScheduleGraphOptions::new(concurrency, true, &run_script, &on_script_skipped),
+        &ScheduleGraphOptions::new(concurrency, bail, &run_script, &on_script_skipped),
     )
     .into_diagnostic()
 }
@@ -518,8 +523,9 @@ fn script_concurrency(
 }
 
 /// Where a script's failure is recorded. The first failure is the one
-/// the command exits with; a failure also cancels the scripts still
-/// running beside it.
+/// the command exits with. When a process tracker is present (the
+/// default bail path), a failure also cancels the scripts still running
+/// beside it; `--no-bail` omits the tracker so siblings finish.
 struct ScriptOutcome<'a> {
     failure: Mutex<Option<ScriptExit>>,
     abort: Mutex<Option<miette::Report>>,

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -1157,7 +1157,9 @@ fn no_bail_reports_a_single_failed_script() {
         .clone();
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("ERR_PNPM_RUN_FAILED") && stderr.contains("Some scripts failed: 1 of 1"),
+        stderr.contains("ERR_PNPM_RUN_FAILED")
+            && stderr.contains("Some scripts failed: 1 of 1")
+            && stderr.contains("check: exit"),
         "got: {stderr}",
     );
 

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -1036,6 +1036,44 @@ fn regexp_selected_scripts_cancel_siblings_after_failure() {
     drop(root);
 }
 
+/// `--no-bail` on a non-recursive `/pattern/` run must let every matched
+/// script finish, even after a sibling exits non-zero. This is the
+/// counterpart of [`regexp_selected_scripts_cancel_siblings_after_failure`]
+/// and matches the TypeScript CLI behaviour covered by #8705 / #14718.
+#[test]
+fn regexp_selected_scripts_no_bail_lets_siblings_finish() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {
+                "check:slow-ok": r#"node -e "const fs = require('fs'); setTimeout(() => { fs.writeFileSync('slow-ok-finished', ''); process.exit(0); }, 1000)""#,
+                "check:fast-fail": r#"node -e "const fs = require('fs'); setTimeout(() => { fs.writeFileSync('fast-fail-finished', ''); process.exit(1); }, 100)""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    assert_cmd::Command::from_std(pacquet)
+        .args(["--workspace-concurrency=2", "--no-bail", "run", "/^check:/"])
+        .timeout(Duration::from_mins(1))
+        .assert()
+        .failure();
+    assert!(
+        workspace.join("fast-fail-finished").exists(),
+        "the failing script should still run to completion under --no-bail",
+    );
+    assert!(
+        workspace.join("slow-ok-finished").exists(),
+        "the slow sibling must not be cancelled under --no-bail",
+    );
+
+    drop(root);
+}
+
 /// Flags on a selector say nothing about which scripts to pick, so pnpm
 /// rejects them instead of honouring a subset.
 #[cfg(unix)]

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -1036,12 +1036,15 @@ fn regexp_selected_scripts_cancel_siblings_after_failure() {
     drop(root);
 }
 
-/// `--no-bail` on a non-recursive `/pattern/` run must let every matched
-/// script finish, even after a sibling exits non-zero. This is the
-/// counterpart of [`regexp_selected_scripts_cancel_siblings_after_failure`]
-/// and matches the TypeScript CLI behaviour covered by #8705 / #14718.
-#[test]
-fn regexp_selected_scripts_no_bail_lets_siblings_finish() {
+/// `--no-bail` on a non-recursive `/pattern/` run lets every matched
+/// script finish, even after a sibling exits non-zero, and then reports
+/// the failures together as `ERR_PNPM_RUN_FAILED` with exit code 1. This
+/// is the counterpart of
+/// [`regexp_selected_scripts_cancel_siblings_after_failure`] and matches
+/// pnpm 11 ([pnpm/pnpm#14718](https://github.com/pnpm/pnpm/issues/14718)).
+/// The failing script is declared first so a sequential run has to keep
+/// going past it.
+fn assert_no_bail_lets_siblings_finish(workspace_concurrency: &str) {
     let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
     fs::write(
         workspace.join("package.json"),
@@ -1049,19 +1052,21 @@ fn regexp_selected_scripts_no_bail_lets_siblings_finish() {
             "name": "test",
             "version": "0.0.0",
             "scripts": {
+                "check:fast-fail": r#"node -e "const fs = require('fs'); setTimeout(() => { fs.writeFileSync('fast-fail-finished', ''); process.exit(3); }, 100)""#,
                 "check:slow-ok": r#"node -e "const fs = require('fs'); setTimeout(() => { fs.writeFileSync('slow-ok-finished', ''); process.exit(0); }, 1000)""#,
-                "check:fast-fail": r#"node -e "const fs = require('fs'); setTimeout(() => { fs.writeFileSync('fast-fail-finished', ''); process.exit(1); }, 100)""#,
             },
         })
         .to_string(),
     )
     .expect("write package.json");
 
-    assert_cmd::Command::from_std(pacquet)
-        .args(["--workspace-concurrency=2", "--no-bail", "run", "/^check:/"])
+    let output = assert_cmd::Command::from_std(pacquet)
+        .args([workspace_concurrency, "--no-bail", "run", "/^check:/"])
         .timeout(Duration::from_mins(1))
         .assert()
-        .failure();
+        .code(1)
+        .get_output()
+        .clone();
     assert!(
         workspace.join("fast-fail-finished").exists(),
         "the failing script should still run to completion under --no-bail",
@@ -1070,8 +1075,25 @@ fn regexp_selected_scripts_no_bail_lets_siblings_finish() {
         workspace.join("slow-ok-finished").exists(),
         "the slow sibling must not be cancelled under --no-bail",
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RUN_FAILED") && stderr.contains("Some scripts failed: 1 of 2"),
+        "stderr should summarise the failed scripts, got: {stderr}",
+    );
+    assert!(stderr.contains("check:fast-fail: exit"), "got: {stderr}");
+    assert!(!stderr.contains("check:slow-ok: exit"), "got: {stderr}");
 
     drop(root);
+}
+
+#[test]
+fn regexp_selected_scripts_no_bail_lets_siblings_finish() {
+    assert_no_bail_lets_siblings_finish("--workspace-concurrency=2");
+}
+
+#[test]
+fn regexp_selected_scripts_no_bail_runs_every_script_sequentially() {
+    assert_no_bail_lets_siblings_finish("--workspace-concurrency=1");
 }
 
 /// Flags on a selector say nothing about which scripts to pick, so pnpm

--- a/pnpm/crates/cli/tests/suite/run.rs
+++ b/pnpm/crates/cli/tests/suite/run.rs
@@ -1096,6 +1096,74 @@ fn regexp_selected_scripts_no_bail_runs_every_script_sequentially() {
     assert_no_bail_lets_siblings_finish("--workspace-concurrency=1");
 }
 
+/// With several failures under `--no-bail`, the listing follows the
+/// selection order, not the order the scripts finished in.
+#[test]
+fn no_bail_reports_failures_in_selection_order() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": {
+                "check:slow-fail": r#"node -e "setTimeout(() => process.exit(4), 500)""#,
+                "check:fast-fail": r#"node -e "process.exit(3)""#,
+            },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = assert_cmd::Command::from_std(pacquet)
+        .args(["--workspace-concurrency=2", "--no-bail", "run", "/^check:/"])
+        .timeout(Duration::from_mins(1))
+        .assert()
+        .code(1)
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Some scripts failed: 2 of 2"), "got: {stderr}");
+    let slow = stderr.find("check:slow-fail: exit").expect("slow-fail is listed");
+    let fast = stderr.find("check:fast-fail: exit").expect("fast-fail is listed");
+    assert!(slow < fast, "failures should follow the selection order, got: {stderr}");
+
+    drop(root);
+}
+
+/// As in pnpm 11, `--no-bail` also wraps a single selected script's
+/// failure in `ERR_PNPM_RUN_FAILED` with exit code 1 rather than exiting
+/// with the script's own status.
+#[test]
+fn no_bail_reports_a_single_failed_script() {
+    let CommandTempCwd { pacquet, root, workspace, .. } = CommandTempCwd::init();
+    fs::write(
+        workspace.join("package.json"),
+        json!({
+            "name": "test",
+            "version": "0.0.0",
+            "scripts": { "check": r#"node -e "process.exit(3)""# },
+        })
+        .to_string(),
+    )
+    .expect("write package.json");
+
+    let output = assert_cmd::Command::from_std(pacquet)
+        .args(["--no-bail", "run", "check"])
+        .timeout(Duration::from_mins(1))
+        .assert()
+        .code(1)
+        .get_output()
+        .clone();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERR_PNPM_RUN_FAILED") && stderr.contains("Some scripts failed: 1 of 1"),
+        "got: {stderr}",
+    );
+
+    drop(root);
+}
+
 /// Flags on a selector say nothing about which scripts to pick, so pnpm
 /// rejects them instead of honouring a subset.
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Fixes https://github.com/pnpm/pnpm/issues/14718: `pnpm run "/pattern/" --no-bail` was still cancelling sibling matched scripts on the first failure (regression vs pnpm 11 / https://github.com/pnpm/pnpm/issues/8705).
- Non-recursive pattern runs now honor `--no-bail` the same way the recursive runner does: skip the process tracker, pass `bail: false` into the scheduler, and keep going past a failure in the sequential (`--workspace-concurrency=1`) loop too.
- As in pnpm 11, a `--no-bail` run with failures ends with `ERR_PNPM_RUN_FAILED` (`Some scripts failed: N of M`), a per-script listing, and exit code 1, instead of the first failing script's exit code. Bail behaviour is unchanged.
- Adds regression tests next to the existing cancel-siblings coverage, at both concurrency levels.

## Test plan

- [x] `cargo nextest run -p pnpm-cli --test suite -E 'test(/regexp_selected_scripts_/)'` (4 passed) and the whole `run::` suite (40 passed)
- [x] The two new tests fail with the fix disabled (`bail` forced to `true`)
- [x] `cargo clippy --all-targets -D warnings` and `cargo dylint` on the cli crate
- [x] Compared against pnpm 11.26.0 on the repro from the issue: both scripts finish, `ERR_PNPM_RUN_FAILED Some scripts failed: 1 of 2`, exit 1

Written by an agent (Cursor, GPT). Review fixes and rebase by an agent (Claude Code, claude-fable-5-1).


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791581619&installation_model_id=426870&pr_number=14754&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14754&signature=5162d76aa68e664a7a124dc1fb20fe63d008ff40aa6ae999f42ade1283c11a64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `--no-bail` now works for both single-script and multiple-script selections made with non-recursive patterns.
  * Matching scripts continue running after one fails when `--no-bail` is enabled.
  * Failure summaries now list failed scripts in selection order and consistently report the overall command failure.
  * Running commands from subdirectories with non-npm project manifests now correctly finds scripts in the enclosing npm project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
