### PR TITLE
refactor(package-manager): bring the rest of the crate under the bindings cap

### DIFF
--- a/pnpm/crates/cli/src/cli_args/add.rs
+++ b/pnpm/crates/cli/src/cli_args/add.rs
@@ -490,14 +490,14 @@ impl AddArgs {
             supported_architectures,
             lockfile_only: self.lockfile_only,
         }
-        .run_selected::<Reporter>(
-            &mut projects,
-            &project_dependencies,
-            &ordered_dirs,
-            selected_dirs.as_ref(),
-            install_dirs.as_ref(),
+        .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
+            projects: &mut projects,
+            project_dependencies: &project_dependencies,
+            ordered_dirs: &ordered_dirs,
+            selected_dirs: selected_dirs.as_ref(),
+            install_dirs: install_dirs.as_ref(),
             active_manifest_is_standin,
-        )
+        })
         .await
         .wrap_err("adding a new package")
     }

--- a/pnpm/crates/cli/src/cli_args/remove.rs
+++ b/pnpm/crates/cli/src/cli_args/remove.rs
@@ -123,14 +123,14 @@ impl RemoveArgs {
             supported_architectures: config.supported_architectures.clone(),
             lockfile_only: self.lockfile_only,
         }
-        .run_selected::<Reporter>(
-            &mut projects,
-            &project_dependencies,
-            &ordered_dirs,
-            selected_dirs.as_ref(),
-            install_dirs.as_ref(),
+        .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
+            projects: &mut projects,
+            project_dependencies: &project_dependencies,
+            ordered_dirs: &ordered_dirs,
+            selected_dirs: selected_dirs.as_ref(),
+            install_dirs: install_dirs.as_ref(),
             active_manifest_is_standin,
-        )
+        })
         .await
         .wrap_err("removing a package")
     }

--- a/pnpm/crates/cli/src/cli_args/update.rs
+++ b/pnpm/crates/cli/src/cli_args/update.rs
@@ -459,14 +459,14 @@ impl UpdateArgs {
                 lockfile_only: self.lockfile_only,
                 resolution_observer: None,
             }
-            .run_selected::<Reporter>(
-                &mut projects,
-                &project_dependencies,
-                &ordered_dirs,
-                selected_dirs.as_ref(),
-                install_dirs.as_ref(),
+            .run_selected::<Reporter>(pnpm_package_manager::SelectedProjects {
+                projects: &mut projects,
+                project_dependencies: &project_dependencies,
+                ordered_dirs: &ordered_dirs,
+                selected_dirs: selected_dirs.as_ref(),
+                install_dirs: install_dirs.as_ref(),
                 active_manifest_is_standin,
-            )
+            })
             .await
             .wrap_err("updating dependencies")?;
         }

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -518,13 +518,13 @@ struct AddSeed {
 }
 
 /// `dependency_groups` names the manifest group the new
-/// package is saved into (`prepare_manifest` above), not an
+/// package is saved into ([`prepare_manifest`]), not an
 /// include filter: like `remove`, the re-resolve walks every
 /// dependency group so the other groups' entries stay in the
 /// lockfile, the virtual store, and `node_modules`.
 /// `None` defers to `config.prefer_frozen_lockfile`, which is
 /// what lets the fast lockfile update absorb the manifest edit
-/// `prepare_manifest` just made. It only absorbs an addition the
+/// [`prepare_manifest`] just made. It only absorbs an addition the
 /// lockfile already holds a satisfying version for; anything else
 /// fails the freshness gate and reaches the resolver.
 /// A `catalog:` dependency's manifest specifier doesn't change when the version

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -535,7 +535,7 @@ fn add_install<'i>(
     owned: AddOwned,
     manifest: &'i PackageManifest,
     seed: AddSeed,
-) -> Install<'i, Vec<DependencyGroup>> {
+) -> Install<'i, impl Iterator<Item = DependencyGroup>> {
     let named_a_version = !seed.seed_policies.is_empty();
     Install {
         tarball_mem_cache: owned.tarball_mem_cache,
@@ -546,7 +546,7 @@ fn add_install<'i>(
         emit_initial_manifest: false,
         lockfile: MaybeLazyLockfile::Loaded(add.lockfile),
         lockfile_path: add.lockfile_path,
-        dependency_groups: included_direct_groups(add.config.optional).collect(),
+        dependency_groups: included_direct_groups(add.config.optional),
         frozen_lockfile: false,
         prefer_frozen_lockfile: named_a_version.then_some(false),
         ignore_manifest_check: false,

--- a/pnpm/crates/package-manager/src/add.rs
+++ b/pnpm/crates/package-manager/src/add.rs
@@ -1,7 +1,7 @@
 use crate::{
     CatalogDecision, CatalogModeDep, CatalogVersionMismatchError, DIRECT_GROUPS,
     ImporterUpdateSeedPolicy, Install, InstallError, ProjectMutation, ResolvedPackages,
-    UpdateSeedPolicy, WorkspaceInstallSelection,
+    SelectedProjects, UpdateSeedPolicy,
     catalog_cleanup::{
         WriteWorkspaceCatalogsError, post_install_prune, write_workspace_catalogs,
         write_workspace_catalogs_selected,
@@ -223,162 +223,92 @@ pub enum AddError {
     MinimumReleaseAgeExclude(#[error(source)] pnpm_config::version_policy::VersionPolicyError),
 }
 
-impl<DependencyGroupList> Add<'_, DependencyGroupList>
+impl<'a, DependencyGroupList> Add<'a, DependencyGroupList>
 where
     DependencyGroupList: IntoIterator<Item = DependencyGroup>,
 {
-    pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), AddError> {
-        let Add {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            dependency_groups,
-            package_names,
-            range_spec_style,
-            save_catalog_name,
-            resolved_packages,
-            supported_architectures,
-            lockfile_only,
-        } = self;
-        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        let dependency_groups: Option<Vec<DependencyGroup>> =
-            dependency_groups.map(|groups| groups.into_iter().collect());
+    /// Separate what every step reads from what the install consumes, and
+    /// the manifest the add rewrites.
+    fn split(self) -> (AddView<'a>, AddOwned, &'a mut PackageManifest) {
+        (
+            AddView {
+                resolved_packages: self.resolved_packages,
+                http_client: self.http_client,
+                config: self.config,
+                lockfile: self.lockfile,
+                lockfile_path: self.lockfile_path,
+                package_names: self.package_names,
+                range_spec_style: self.range_spec_style,
+                lockfile_only: self.lockfile_only,
+            },
+            AddOwned {
+                tarball_mem_cache: self.tarball_mem_cache,
+                http_client_arc: self.http_client_arc,
+                dependency_groups: self
+                    .dependency_groups
+                    .map(|groups| groups.into_iter().collect()),
+                save_catalog_name: self.save_catalog_name,
+                supported_architectures: self.supported_architectures,
+            },
+            self.manifest,
+        )
+    }
 
-        let latest_picker = tokio::sync::OnceCell::new();
-        let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
-        let fetch_locker = shared_packument_fetch_locker();
-        let catalog_ctx = read_catalog_ctx(manifest, config)?;
-        let workspace_packages = (config.link_workspace_packages.enabled_at_depth(0)
-            || config.save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
-            .then(|| workspace_packages_for_add(config))
+    pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), AddError> {
+        let (add, owned, manifest) = self.split();
+        begin::<Reporter>(add, &owned);
+        let resolution = AddResolution::new();
+        let catalog_ctx = read_catalog_ctx(manifest, add.config)?;
+        let workspace_packages = (add.config.link_workspace_packages.enabled_at_depth(0)
+            || add.config.save_workspace_protocol != SaveWorkspaceProtocol::Rolling)
+            .then(|| workspace_packages_for_add(add.config))
             .flatten();
         let updated_catalogs = prepare_manifest::<Reporter>(
             manifest,
-            http_client,
-            &http_client_arc,
-            config,
-            lockfile,
-            dependency_groups.as_deref(),
-            package_names,
-            &latest_picker,
-            range_spec_style,
-            save_catalog_name.as_deref(),
-            &catalog_ctx.catalogs,
-            &catalog_ctx.prefix,
-            &meta_cache,
-            &fetch_locker,
-            workspace_packages.as_ref(),
+            &AddResolveInputs {
+                add,
+                http_client_arc: &owned.http_client_arc,
+                resolution: &resolution,
+                save_catalog_name: owned.save_catalog_name.as_deref(),
+                catalogs: &catalog_ctx.catalogs,
+                prefix: &catalog_ctx.prefix,
+                workspace_packages: workspace_packages.as_ref(),
+            },
+            owned.dependency_groups.as_deref(),
         )
         .await?;
-
         // Write the new catalog entry to `pnpm-workspace.yaml` before the
         // install so the resolver reads it back and the lockfile's
         // `catalogs:` snapshot records the resolved version. The same
         // write runs the `catalogPrune` pass when configured.
         write_workspace_catalogs(
-            config,
+            add.config,
             Some(&catalog_ctx.workspace_dir),
             &updated_catalogs,
             manifest,
         )
         .map_err(AddError::WriteWorkspaceManifest)?;
         let (dropped_pins, preferred_versions_override) = catalog_version_requests(
-            package_names,
+            add.package_names,
             manifest,
             &catalog_ctx.catalogs,
-            lockfile,
-            config,
-            save_catalog_name.as_deref(),
+            add.lockfile,
+            add.config,
+            owned.save_catalog_name.as_deref(),
         );
-        // Scoped to this project's importer: a sibling that declares the same package
-        // keeps its pin, so its resolution stands.
-        let seed_policies = if dropped_pins.is_empty() {
-            BTreeMap::new()
-        } else {
-            let manifest_dir =
-                manifest.path().parent().expect("manifest path always has a parent dir");
-            BTreeMap::from([(
-                pnpm_workspace::importer_id_from_root_dir(
-                    config.lockfile_dir_for(manifest_dir),
-                    manifest_dir,
-                ),
-                ImporterUpdateSeedPolicy::DropOnly(unversioned_targets(dropped_pins)),
-            )])
-        };
-        let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
-            let mut catalogs = catalog_ctx.catalogs;
-            merge_catalogs(&mut catalogs, &updated_catalogs);
-            catalogs
-        });
-
-        // A `catalog:` dependency's manifest specifier doesn't change when the version
-        // behind it does, so the freshness gate would hold and the install would never
-        // reach the resolver.
-        let named_a_version = !seed_policies.is_empty();
-
-        let ignored_builds = Install {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
+        let ignored_builds = add_install(
+            add,
+            owned,
             manifest,
-            emit_initial_manifest: false,
-            lockfile: MaybeLazyLockfile::Loaded(lockfile),
-            lockfile_path,
-            // `dependency_groups` names the manifest group the new
-            // package is saved into (`prepare_manifest` above), not an
-            // include filter: like `remove`, the re-resolve walks every
-            // dependency group so the other groups' entries stay in the
-            // lockfile, the virtual store, and `node_modules`.
-            dependency_groups: included_direct_groups(config.optional),
-            frozen_lockfile: false,
-            // `None` defers to `config.prefer_frozen_lockfile`, which is
-            // what lets the fast lockfile update absorb the manifest edit
-            // `prepare_manifest` just made. It only absorbs an addition the
-            // lockfile already holds a satisfying version for; anything else
-            // fails the freshness gate and reaches the resolver.
-            prefer_frozen_lockfile: named_a_version.then_some(false),
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: false,
-            mutation: ProjectMutation::InstallSome,
-            installs_only: false,
-            resolved_packages,
-            supported_architectures,
-            node_linker: config.node_linker,
-            lockfile_only,
-            dry_run: false,
-            persist_policy_excludes: true,
-            // `add` keeps every lockfile pin; the freshly-added range
-            // is the only thing that re-resolves. `update`'s bump is a
-            // separate operation.
-            update_seed_policy: if seed_policies.is_empty() {
-                UpdateSeedPolicy::KeepAll
-            } else {
-                UpdateSeedPolicy::ByImporter {
-                    policies: seed_policies,
-                    // A catalog entry governs direct dependencies, so the pin is
-                    // withheld there and transitive occurrences of the same package
-                    // keep theirs.
-                    max_depth: UpdateDepth::new(0),
-                }
+            AddSeed {
+                seed_policies: project_seed_policy(add.config, manifest, dropped_pins),
+                preferred_versions_override,
+                catalogs_override: merged_catalogs_override(
+                    catalog_ctx.catalogs,
+                    &updated_catalogs,
+                ),
             },
-            preferred_versions_override: Some(preferred_versions_override),
-            auth_override: None,
-            resolution_observer: None,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: None,
-            workspace_projects_override: None,
-        }
+        )
         .run::<Reporter>()
         .await
         .pipe(defer_ignored_builds)
@@ -386,7 +316,7 @@ where
 
         persist_manifest::<Reporter>(manifest)?;
 
-        post_install_prune(config, Some(&catalog_ctx.workspace_dir), manifest)
+        post_install_prune(add.config, Some(&catalog_ctx.workspace_dir), manifest)
             .map_err(AddError::WriteWorkspaceManifest)?;
 
         if let Some(ignored_builds) = ignored_builds {
@@ -397,161 +327,263 @@ where
 
     pub async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
-        projects: &mut [pnpm_workspace::Project],
-        project_dependencies: &indexmap::IndexMap<PathBuf, Vec<PathBuf>>,
-        ordered_dirs: &[PathBuf],
-        selected_dirs: &HashSet<PathBuf>,
-        install_dirs: &HashSet<PathBuf>,
-        active_manifest_is_standin: bool,
+        selected: SelectedProjects<'_>,
     ) -> Result<(), AddError> {
-        let Add {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            dependency_groups,
-            package_names,
-            range_spec_style,
-            save_catalog_name,
-            resolved_packages,
-            supported_architectures,
-            lockfile_only,
-        } = self;
-        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        let dependency_groups: Option<Vec<DependencyGroup>> =
-            dependency_groups.map(|groups| groups.into_iter().collect());
-        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        let (add, owned, manifest) = self.split();
+        begin::<Reporter>(add, &owned);
+        let selected_indices = selected_project_indices(
+            selected.projects,
+            selected.ordered_dirs,
+            selected.selected_dirs,
+        );
         if selected_indices.is_empty() {
             return Ok(());
         }
         let prepared = prepare_selected_manifests::<Reporter>(
-            projects,
+            selected.projects,
             &selected_indices,
-            http_client,
-            &http_client_arc,
-            config,
-            lockfile,
-            dependency_groups.as_deref(),
-            package_names,
-            range_spec_style,
-            save_catalog_name.as_deref(),
+            add,
+            &owned,
         )
         .await?;
         write_workspace_catalogs_selected(
-            config,
+            add.config,
             &prepared.workspace_dir,
             &prepared.updated_catalogs,
-            projects,
+            selected.projects,
         )
         .map_err(AddError::WriteWorkspaceManifest)?;
-
-        // Scoped per importer: a project that wasn't selected keeps its pins, so its
-        // resolutions stand even when it declares the same package directly.
-        let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
-        let importer_root = config.lockfile_dir_for(manifest_dir);
-        let mut seed_policies = BTreeMap::new();
-        let mut preferred_versions_override = PreferredVersions::new();
-        for &index in &selected_indices {
-            let (names, preferred) = catalog_version_requests(
-                package_names,
-                &projects[index].manifest,
-                &prepared.catalogs,
-                lockfile,
-                config,
-                save_catalog_name.as_deref(),
-            );
-            if names.is_empty() {
-                continue;
-            }
-            let importer_id =
-                pnpm_workspace::importer_id_from_root_dir(importer_root, &projects[index].root_dir);
-            seed_policies.insert(
-                importer_id,
-                ImporterUpdateSeedPolicy::DropOnly(unversioned_targets(names)),
-            );
-            for (name, selectors) in preferred {
-                preferred_versions_override.entry(name).or_default().extend(selectors);
-            }
-        }
-        // A `catalog:` dependency's manifest specifier doesn't change when the version
-        // behind it does, so the freshness gate would hold and the install would never
-        // reach the resolver.
-        let named_a_version = !seed_policies.is_empty();
-
+        let seed = selected_add_seed(
+            add,
+            &owned,
+            manifest,
+            (selected.projects, &selected_indices),
+            prepared.catalogs_override,
+            &prepared.catalogs,
+        );
         let ignored_builds = Box::pin(
-            Install {
-                tarball_mem_cache,
-                http_client,
-                http_client_arc,
-                config,
-                manifest,
-                emit_initial_manifest: false,
-                lockfile: MaybeLazyLockfile::Loaded(lockfile),
-                lockfile_path,
-                // See the `dependency_groups` comment in [`Self::run`]:
-                // the save target must not narrow the install's include
-                // set.
-                dependency_groups: included_direct_groups(config.optional),
-                frozen_lockfile: false,
-                // See the `prefer_frozen_lockfile` comment in [`Self::run`].
-                prefer_frozen_lockfile: named_a_version.then_some(false),
-                ignore_manifest_check: false,
-                skip_runtimes: config.skip_runtimes,
-                trust_lockfile: config.trust_lockfile,
-                update_checksums: false,
-                mutation: ProjectMutation::InstallSome,
-                installs_only: false,
-                resolved_packages,
-                supported_architectures,
-                node_linker: config.node_linker,
-                lockfile_only,
-                dry_run: false,
-                persist_policy_excludes: true,
-                update_seed_policy: if seed_policies.is_empty() {
-                    UpdateSeedPolicy::KeepAll
-                } else {
-                    UpdateSeedPolicy::ByImporter {
-                        policies: seed_policies,
-                        // See the `DropOnly` in [`Self::run`].
-                        max_depth: UpdateDepth::new(0),
-                    }
-                },
-                preferred_versions_override: Some(preferred_versions_override),
-                auth_override: None,
-                resolution_observer: None,
-                peer_issues_sink: None,
-                deps_requiring_build_sink: None,
-                catalogs_override: prepared.catalogs_override,
-                disable_optimistic_repeat_install: false,
-                pnpmfile_hook_override: None,
-                workspace_projects_override: None,
-            }
-            .run_selected::<Reporter>(WorkspaceInstallSelection {
-                all_projects: projects,
-                project_dependencies,
-                ordered_dirs,
-                selected_dirs,
-                install_dirs,
-                active_manifest_is_standin,
-                workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
-            }),
+            add_install(add, owned, manifest, seed).run_selected::<Reporter>(selected.selection()),
         )
         .await
         .pipe(defer_ignored_builds)
         .map_err(AddError::Install)?;
 
-        persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
+        persist_selected_manifests::<Reporter>(selected.projects, &selected_indices)?;
 
-        post_install_prune(config, Some(&prepared.workspace_dir), manifest)
+        post_install_prune(add.config, Some(&prepared.workspace_dir), manifest)
             .map_err(AddError::WriteWorkspaceManifest)?;
         if let Some(ignored_builds) = ignored_builds {
             return Err(AddError::Install(ignored_builds));
         }
         Ok(())
+    }
+}
+
+/// The add's borrowed and `Copy` inputs, as one value every step reads.
+#[derive(Clone, Copy)]
+struct AddView<'a> {
+    resolved_packages: &'a ResolvedPackages,
+    http_client: &'a ThrottledClient,
+    config: &'static Config,
+    lockfile: Option<&'a Lockfile>,
+    lockfile_path: Option<&'a std::path::Path>,
+    package_names: &'a [String],
+    range_spec_style: RangeSpecStyle,
+    lockfile_only: bool,
+}
+
+/// The add's owned inputs, consumed by the install it runs.
+struct AddOwned {
+    tarball_mem_cache: std::sync::Arc<MemCache>,
+    http_client_arc: std::sync::Arc<ThrottledClient>,
+    dependency_groups: Option<Vec<DependencyGroup>>,
+    save_catalog_name: Option<String>,
+    supported_architectures: Option<pnpm_package_is_installable::SupportedArchitectures>,
+}
+
+fn begin<Reporter: self::Reporter>(add: AddView<'_>, owned: &AddOwned) {
+    add.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+    owned.http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+}
+
+/// What one add pass shares across the selectors it resolves, and across
+/// the projects a selected add touches: the `latest` picker (created on
+/// first use, so a pass that resolves no `latest` tag never builds one),
+/// the packument cache and the fetch locker.
+struct AddResolution<'a> {
+    latest_picker: tokio::sync::OnceCell<LatestPicker<'a>>,
+    meta_cache: std::sync::Arc<InMemoryPackageMetaCache>,
+    fetch_locker: PackumentFetchLocker,
+}
+
+impl AddResolution<'_> {
+    fn new() -> Self {
+        Self {
+            latest_picker: tokio::sync::OnceCell::new(),
+            meta_cache: std::sync::Arc::new(InMemoryPackageMetaCache::default()),
+            fetch_locker: shared_packument_fetch_locker(),
+        }
+    }
+}
+
+/// What every selector of an add resolves against.
+struct AddResolveInputs<'a, 'r> {
+    add: AddView<'a>,
+    http_client_arc: &'r std::sync::Arc<ThrottledClient>,
+    resolution: &'r AddResolution<'a>,
+    save_catalog_name: Option<&'r str>,
+    catalogs: &'r Catalogs,
+    prefix: &'r str,
+    workspace_packages: Option<&'r WorkspacePackages>,
+}
+
+/// Scoped to this project's importer: a sibling that declares the same package
+/// keeps its pin, so its resolution stands.
+fn project_seed_policy(
+    config: &Config,
+    manifest: &PackageManifest,
+    dropped_pins: HashSet<String>,
+) -> BTreeMap<String, ImporterUpdateSeedPolicy> {
+    if dropped_pins.is_empty() {
+        return BTreeMap::new();
+    }
+    let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
+    BTreeMap::from([(
+        pnpm_workspace::importer_id_from_root_dir(
+            config.lockfile_dir_for(manifest_dir),
+            manifest_dir,
+        ),
+        ImporterUpdateSeedPolicy::DropOnly(unversioned_targets(dropped_pins)),
+    )])
+}
+
+/// The catalogs the install resolves against when the add changed any,
+/// and none when the workspace manifest already says it all.
+fn merged_catalogs_override(
+    mut catalogs: Catalogs,
+    updated_catalogs: &Catalogs,
+) -> Option<Catalogs> {
+    if updated_catalogs.is_empty() {
+        return None;
+    }
+    merge_catalogs(&mut catalogs, updated_catalogs);
+    Some(catalogs)
+}
+
+/// Scoped per importer: a project that wasn't selected keeps its pins, so its
+/// resolutions stand even when it declares the same package directly.
+fn selected_add_seed(
+    add: AddView<'_>,
+    owned: &AddOwned,
+    manifest: &PackageManifest,
+    selected: (&[pnpm_workspace::Project], &[usize]),
+    catalogs_override: Option<Catalogs>,
+    catalogs: &Catalogs,
+) -> AddSeed {
+    let (projects, selected_indices) = selected;
+    let manifest_dir = manifest.path().parent().expect("manifest path always has a parent dir");
+    let importer_root = add.config.lockfile_dir_for(manifest_dir);
+    let mut seed_policies = BTreeMap::new();
+    let mut preferred_versions_override = PreferredVersions::new();
+    for &index in selected_indices {
+        let (names, preferred) = catalog_version_requests(
+            add.package_names,
+            &projects[index].manifest,
+            catalogs,
+            add.lockfile,
+            add.config,
+            owned.save_catalog_name.as_deref(),
+        );
+        if names.is_empty() {
+            continue;
+        }
+        seed_policies.insert(
+            pnpm_workspace::importer_id_from_root_dir(importer_root, &projects[index].root_dir),
+            ImporterUpdateSeedPolicy::DropOnly(unversioned_targets(names)),
+        );
+        for (name, selectors) in preferred {
+            preferred_versions_override.entry(name).or_default().extend(selectors);
+        }
+    }
+    AddSeed { seed_policies, preferred_versions_override, catalogs_override }
+}
+
+/// What the install resolves from: the importers whose catalog pins are
+/// withheld, the versions the add named, and the catalogs as it rewrote
+/// them.
+struct AddSeed {
+    seed_policies: BTreeMap<String, ImporterUpdateSeedPolicy>,
+    preferred_versions_override: PreferredVersions,
+    catalogs_override: Option<Catalogs>,
+}
+
+/// `dependency_groups` names the manifest group the new
+/// package is saved into (`prepare_manifest` above), not an
+/// include filter: like `remove`, the re-resolve walks every
+/// dependency group so the other groups' entries stay in the
+/// lockfile, the virtual store, and `node_modules`.
+/// `None` defers to `config.prefer_frozen_lockfile`, which is
+/// what lets the fast lockfile update absorb the manifest edit
+/// `prepare_manifest` just made. It only absorbs an addition the
+/// lockfile already holds a satisfying version for; anything else
+/// fails the freshness gate and reaches the resolver.
+/// A `catalog:` dependency's manifest specifier doesn't change when the version
+/// behind it does, so the freshness gate would hold and the install would never
+/// reach the resolver.
+fn add_install<'i>(
+    add: AddView<'i>,
+    owned: AddOwned,
+    manifest: &'i PackageManifest,
+    seed: AddSeed,
+) -> Install<'i, Vec<DependencyGroup>> {
+    let named_a_version = !seed.seed_policies.is_empty();
+    Install {
+        tarball_mem_cache: owned.tarball_mem_cache,
+        http_client: add.http_client,
+        http_client_arc: owned.http_client_arc,
+        config: add.config,
+        manifest,
+        emit_initial_manifest: false,
+        lockfile: MaybeLazyLockfile::Loaded(add.lockfile),
+        lockfile_path: add.lockfile_path,
+        dependency_groups: included_direct_groups(add.config.optional).collect(),
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: named_a_version.then_some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: add.config.skip_runtimes,
+        trust_lockfile: add.config.trust_lockfile,
+        update_checksums: false,
+        mutation: ProjectMutation::InstallSome,
+        installs_only: false,
+        resolved_packages: add.resolved_packages,
+        supported_architectures: owned.supported_architectures,
+        node_linker: add.config.node_linker,
+        lockfile_only: add.lockfile_only,
+        dry_run: false,
+        persist_policy_excludes: true,
+        // `add` keeps every lockfile pin; the freshly-added range
+        // is the only thing that re-resolves. `update`'s bump is a
+        // separate operation.
+        update_seed_policy: if named_a_version {
+            UpdateSeedPolicy::ByImporter {
+                policies: seed.seed_policies,
+                // A catalog entry governs direct dependencies, so the pin is
+                // withheld there and transitive occurrences of the same package
+                // keep theirs.
+                max_depth: UpdateDepth::new(0),
+            }
+        } else {
+            UpdateSeedPolicy::KeepAll
+        },
+        preferred_versions_override: Some(seed.preferred_versions_override),
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        deps_requiring_build_sink: None,
+        catalogs_override: seed.catalogs_override,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
     }
 }
 
@@ -646,33 +678,21 @@ struct SelectedAddPreparation {
     workspace_dir: PathBuf,
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "selected add preparation reuses the command's resolution inputs"
-)]
 async fn prepare_selected_manifests<Reporter: self::Reporter>(
     projects: &mut [pnpm_workspace::Project],
     selected_indices: &[usize],
-    http_client: &ThrottledClient,
-    http_client_arc: &std::sync::Arc<ThrottledClient>,
-    config: &'static Config,
-    lockfile: Option<&Lockfile>,
-    dependency_groups: Option<&[DependencyGroup]>,
-    package_names: &[String],
-    range_spec_style: RangeSpecStyle,
-    save_catalog_name: Option<&str>,
+    add: AddView<'_>,
+    owned: &AddOwned,
 ) -> Result<SelectedAddPreparation, AddError> {
     let first_index = *selected_indices.first().expect("selected add requires a project");
-    let catalog_ctx = read_catalog_ctx(&projects[first_index].manifest, config)?;
+    let catalog_ctx = read_catalog_ctx(&projects[first_index].manifest, add.config)?;
     let mut catalogs = catalog_ctx.catalogs;
     let mut updated_catalogs = Catalogs::new();
-    // One picker, packument cache, and fetch locker across every selected
+    // One resolution across every selected
     // project: the picker is created on first use (a selection that resolves
     // no `latest` tag never builds one), and the shared caches keep the same
     // package from being fetched once per project.
-    let latest_picker = tokio::sync::OnceCell::new();
-    let meta_cache = std::sync::Arc::new(InMemoryPackageMetaCache::default());
-    let fetch_locker = shared_packument_fetch_locker();
+    let resolution = AddResolution::new();
     // Indexed once, before the loop mutates any manifest: a
     // `workspace:` request saved into project A resolves against the
     // versions the projects declared on entry, not against a sibling
@@ -682,20 +702,16 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     for &index in selected_indices {
         let updates = prepare_manifest::<Reporter>(
             &mut projects[index].manifest,
-            http_client,
-            http_client_arc,
-            config,
-            lockfile,
-            dependency_groups,
-            package_names,
-            &latest_picker,
-            range_spec_style,
-            save_catalog_name,
-            &catalogs,
-            &catalog_ctx.prefix,
-            &meta_cache,
-            &fetch_locker,
-            workspace_packages.as_ref(),
+            &AddResolveInputs {
+                add,
+                http_client_arc: &owned.http_client_arc,
+                resolution: &resolution,
+                save_catalog_name: owned.save_catalog_name.as_deref(),
+                catalogs: &catalogs,
+                prefix: &catalog_ctx.prefix,
+                workspace_packages: workspace_packages.as_ref(),
+            },
+            owned.dependency_groups.as_deref(),
         )
         .await?;
         merge_catalogs(&mut catalogs, &updates);
@@ -711,16 +727,6 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     })
 }
 
-/// Resolve every selector against `catalogs` concurrently, then apply them
-/// to `manifest`.
-///
-/// Every selector is resolved before the manifest is touched so the
-/// `initial` manifest event still reports the pre-add shape exactly once,
-/// however many selectors a single `add` carries. `FuturesOrdered` overlaps
-/// the registry requests while keeping the buffered catalog warnings and the
-/// applied dependencies in selector order. The `latest_picker`,
-/// `meta_cache`, and `fetch_locker` are threaded in so one selected-add pass
-/// shares packument state across every project it touches.
 /// The manifest group `name` already occupies, in pnpm's
 /// `guessDependencyType` scan order.
 fn guess_dependency_group(manifest: &PackageManifest, name: &str) -> Option<DependencyGroup> {
@@ -729,48 +735,31 @@ fn guess_dependency_group(manifest: &PackageManifest, name: &str) -> Option<Depe
         .find(|&group| manifest.dependencies([group]).any(|(dep, _)| dep == name))
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "manifest preparation consumes the add command's resolution inputs"
-)]
-async fn prepare_manifest<'a, Reporter: self::Reporter>(
+/// Resolve every selector against `catalogs` concurrently, then apply them
+/// to `manifest`.
+///
+/// Every selector is resolved before the manifest is touched so the
+/// `initial` manifest event still reports the pre-add shape exactly once,
+/// however many selectors a single `add` carries. `FuturesOrdered` overlaps
+/// the registry requests while keeping the buffered catalog warnings and the
+/// applied dependencies in selector order. The resolution state is
+/// threaded in so one selected-add pass shares it across every project it
+/// touches.
+async fn prepare_manifest<Reporter: self::Reporter>(
     manifest: &mut PackageManifest,
-    http_client: &'a ThrottledClient,
-    http_client_arc: &std::sync::Arc<ThrottledClient>,
-    config: &'static Config,
-    lockfile: Option<&Lockfile>,
+    inputs: &AddResolveInputs<'_, '_>,
     dependency_groups: Option<&[DependencyGroup]>,
-    package_names: &[String],
-    latest_picker: &tokio::sync::OnceCell<LatestPicker<'a>>,
-    range_spec_style: RangeSpecStyle,
-    save_catalog_name: Option<&str>,
-    catalogs: &Catalogs,
-    prefix: &str,
-    meta_cache: &std::sync::Arc<InMemoryPackageMetaCache>,
-    fetch_locker: &PackumentFetchLocker,
-    workspace_packages: Option<&WorkspacePackages>,
 ) -> Result<Catalogs, AddError> {
     let resolved_dependencies = {
         let mut resolution_futures = FuturesOrdered::new();
-        for package_selector in package_names {
+        for package_selector in inputs.add.package_names {
             resolution_futures.push_back(resolve_added_dependency(
                 package_selector,
-                config,
                 manifest,
-                lockfile,
-                http_client,
-                http_client_arc,
-                latest_picker,
-                range_spec_style,
-                save_catalog_name,
-                catalogs,
-                prefix,
-                meta_cache,
-                fetch_locker,
-                workspace_packages,
+                inputs,
             ));
         }
-        let mut dependencies = Vec::with_capacity(package_names.len());
+        let mut dependencies = Vec::with_capacity(inputs.add.package_names.len());
         while let Some(result) = resolution_futures.next().await {
             let dependency = result?;
             if let Some(warning) = &dependency.warning {
@@ -885,51 +874,107 @@ struct ResolvedAddedDependency {
     warning: Option<LogEvent>,
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "resolving an add selector requires the shared resolution inputs"
-)]
-async fn resolve_added_dependency<'a>(
+async fn resolve_added_dependency(
     package_selector: &str,
-    config: &'static Config,
     manifest: &PackageManifest,
-    lockfile: Option<&Lockfile>,
-    http_client: &'a ThrottledClient,
-    http_client_arc: &std::sync::Arc<ThrottledClient>,
-    latest_picker: &tokio::sync::OnceCell<LatestPicker<'a>>,
-    range_spec_style: RangeSpecStyle,
-    save_catalog_name: Option<&str>,
-    catalogs: &Catalogs,
-    prefix: &str,
-    meta_cache: &std::sync::Arc<InMemoryPackageMetaCache>,
-    fetch_locker: &PackumentFetchLocker,
-    workspace_packages: Option<&WorkspacePackages>,
+    inputs: &AddResolveInputs<'_, '_>,
 ) -> Result<ResolvedAddedDependency, AddError> {
-    let parsed = pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency(package_selector);
-    let protocol = ProtocolSelector::parse(package_selector)?;
-    let aliasless = match (parsed.alias.as_deref(), parsed.bare_specifier.as_deref()) {
-        (None, Some(specifier)) if protocol.is_none() => {
-            resolve_aliasless_specifier(specifier, config, http_client_arc, manifest).await?
-        }
-        _ => None,
-    };
-    let (package_name, explicit_spec) = match (aliasless.as_ref(), protocol.as_ref()) {
-        (Some(dep), _) => (dep.package_name.as_str(), Some(dep.manifest_specifier.as_str())),
-        (None, Some(protocol)) => {
-            (protocol.package_name(), protocol.explicit_spec(package_selector))
-        }
-        (None, None) => split_name_spec(package_selector),
-    };
+    let selector = AddSelector::parse(package_selector, manifest, inputs).await?;
+    let package_name = selector.package_name(package_selector);
+    let prev_specifier = declared_specifier(manifest, package_name);
+    let bare_specifier = bare_save_specifier(
+        package_selector,
+        &selector,
+        prev_specifier.as_deref(),
+        manifest,
+        inputs,
+    )
+    .await?;
+    let mut updated_catalogs = Catalogs::new();
+    let outcome = decide_catalog_outcome(
+        inputs.add.config.catalog_mode,
+        inputs.save_catalog_name,
+        inputs.catalogs,
+        &CatalogModeDep {
+            alias: package_name,
+            bare_specifier: &bare_specifier,
+            prev_specifier: prev_specifier.as_deref(),
+        },
+        inputs.prefix,
+    )
+    .map_err(AddError::CatalogVersionMismatch)?;
+    let manifest_specifier = apply_catalog_decision(
+        outcome.decision,
+        package_name,
+        bare_specifier,
+        &mut updated_catalogs,
+    );
+    Ok(ResolvedAddedDependency {
+        package_name: package_name.to_string(),
+        manifest_specifier,
+        updated_catalogs,
+        warning: outcome.warning,
+    })
+}
 
-    // The dependency's current specifier, so a re-add keeps the
-    // existing range / `catalog:` reference rather than re-pinning to
-    // `^<latest>`. The scan order matches pnpm's `findSpec` /
-    // `guessDependencyType` (`DEPENDENCIES_OR_PEER_FIELDS`):
-    // `optionalDependencies`, `dependencies`, `devDependencies`,
-    // `peerDependencies` — the first-found specifier wins even when the
-    // add targets a different group ([`PackageManifest::add_dependency`]
-    // then removes the entry from its old group).
-    let prev_specifier = manifest
+/// A selector as parsed: its protocol, and the package an aliasless
+/// specifier names once resolved.
+struct AddSelector {
+    protocol: Option<ProtocolSelector>,
+    aliasless: Option<AliaslessDependency>,
+}
+
+impl AddSelector {
+    async fn parse(
+        package_selector: &str,
+        manifest: &PackageManifest,
+        inputs: &AddResolveInputs<'_, '_>,
+    ) -> Result<Self, AddError> {
+        let parsed =
+            pnpm_resolving_parse_wanted_dependency::parse_wanted_dependency(package_selector);
+        let protocol = ProtocolSelector::parse(package_selector)?;
+        let aliasless = match (parsed.alias.as_deref(), parsed.bare_specifier.as_deref()) {
+            (None, Some(specifier)) if protocol.is_none() => {
+                resolve_aliasless_specifier(
+                    specifier,
+                    inputs.add.config,
+                    inputs.http_client_arc,
+                    manifest,
+                )
+                .await?
+            }
+            _ => None,
+        };
+        Ok(Self { protocol, aliasless })
+    }
+
+    fn package_name<'s>(&'s self, package_selector: &'s str) -> &'s str {
+        match (self.aliasless.as_ref(), self.protocol.as_ref()) {
+            (Some(dep), _) => dep.package_name.as_str(),
+            (None, Some(protocol)) => protocol.package_name(),
+            (None, None) => split_name_spec(package_selector).0,
+        }
+    }
+
+    fn explicit_spec<'s>(&'s self, package_selector: &'s str) -> Option<&'s str> {
+        match (self.aliasless.as_ref(), self.protocol.as_ref()) {
+            (Some(dep), _) => Some(dep.manifest_specifier.as_str()),
+            (None, Some(protocol)) => protocol.explicit_spec(package_selector),
+            (None, None) => split_name_spec(package_selector).1,
+        }
+    }
+}
+
+/// The dependency's current specifier, so a re-add keeps the
+/// existing range / `catalog:` reference rather than re-pinning to
+/// `^<latest>`. The scan order matches pnpm's `findSpec` /
+/// `guessDependencyType` (`DEPENDENCIES_OR_PEER_FIELDS`):
+/// `optionalDependencies`, `dependencies`, `devDependencies`,
+/// `peerDependencies` — the first-found specifier wins even when the
+/// add targets a different group ([`PackageManifest::add_dependency`]
+/// then removes the entry from its old group).
+fn declared_specifier(manifest: &PackageManifest, package_name: &str) -> Option<String> {
+    manifest
         .dependencies([
             DependencyGroup::Optional,
             DependencyGroup::Prod,
@@ -937,127 +982,118 @@ async fn resolve_added_dependency<'a>(
             DependencyGroup::Peer,
         ])
         .find(|(name, _)| *name == package_name)
-        .map(|(_, spec)| spec.to_string());
+        .map(|(_, spec)| spec.to_string())
+}
 
-    // The bare specifier to reconcile against the catalogs:
-    // - an explicit `@<version>` is resolved to a concrete version and
-    //   recorded with the range operator it (or the existing entry)
-    //   pins — `pnpm add foo@^7` records `^7.8.4`, not
-    //   `^7`. Specifiers that aren't a plain registry range/tag/version
-    //   for this package (protocols, `npm:` aliases) stay verbatim;
-    // - an explicit `node@runtime:<spec>` is likewise pinned to the
-    //   picked Node.js version, so the `devEngines.runtime` entry the
-    //   saved dependency folds into records e.g. `26.5.0`, not the
-    //   requested `26`;
-    // - a `jsr:` selector is pinned the same way and rendered back under
-    //   its protocol — `pnpm add jsr:@scope/pkg` records `jsr:^1.2.3`;
-    // - a re-add with no version keeps the dependency's current
-    //   specifier verbatim (a `catalog:` reference, a range, or an
-    //   exact pin) — `pnpm add <existing>` without a
-    //   version leaves the declared range untouched;
-    // - a brand-new dependency fetches and pins the `latest` range.
-    let bare_specifier = if let Some(workspace_specifier) = workspace_save_specifier(
+/// The bare specifier to reconcile against the catalogs:
+/// - an explicit `@<version>` is resolved to a concrete version and
+///   recorded with the range operator it (or the existing entry)
+///   pins — `pnpm add foo@^7` records `^7.8.4`, not
+///   `^7`. Specifiers that aren't a plain registry range/tag/version
+///   for this package (protocols, `npm:` aliases) stay verbatim;
+/// - an explicit `node@runtime:<spec>` is likewise pinned to the
+///   picked Node.js version, so the `devEngines.runtime` entry the
+///   saved dependency folds into records e.g. `26.5.0`, not the
+///   requested `26`;
+/// - a `jsr:` selector is pinned the same way and rendered back under
+///   its protocol — `pnpm add jsr:@scope/pkg` records `jsr:^1.2.3`;
+/// - a re-add with no version keeps the dependency's current
+///   specifier verbatim (a `catalog:` reference, a range, or an
+///   exact pin) — `pnpm add <existing>` without a
+///   version leaves the declared range untouched;
+/// - a brand-new dependency fetches and pins the `latest` range.
+async fn bare_save_specifier(
+    package_selector: &str,
+    selector: &AddSelector,
+    prev_specifier: Option<&str>,
+    manifest: &PackageManifest,
+    inputs: &AddResolveInputs<'_, '_>,
+) -> Result<String, AddError> {
+    let package_name = selector.package_name(package_selector);
+    let explicit_spec = selector.explicit_spec(package_selector);
+    if let Some(workspace_specifier) = workspace_save_specifier(
         package_name,
         explicit_spec,
-        prev_specifier.as_deref(),
-        config,
-        range_spec_style,
-        workspace_packages,
+        prev_specifier,
+        inputs.add.config,
+        inputs.add.range_spec_style,
+        inputs.workspace_packages,
     ) {
-        workspace_specifier
-    } else if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
-        let mut node_resolver = NodeResolver::new_with_auth(
-            std::sync::Arc::clone(http_client_arc),
-            std::sync::Arc::clone(&config.auth_headers),
-        );
-        node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
-        node_resolver.offline = config.offline;
-        node_resolver.cache_dir = Some(config.cache_dir.clone());
-        node_resolver
-            .resolve_save_specifier(version_spec, prev_specifier.as_deref())
-            .await
-            .map_err(AddError::ResolveRuntimeSpec)?
-    } else if let Some(ProtocolSelector::Jsr(jsr)) = protocol.as_ref() {
-        resolve_jsr_save_specifier(
-            jsr,
-            config,
-            http_client,
-            range_spec_style,
-            lockfile,
+        return Ok(workspace_specifier);
+    }
+    if let Some(version_spec) = node_runtime_version_spec(package_name, explicit_spec) {
+        return resolve_node_runtime_specifier(version_spec, prev_specifier, inputs).await;
+    }
+    if let Some(ProtocolSelector::Jsr(jsr)) = selector.protocol.as_ref() {
+        return Ok(resolve_jsr_save_specifier(jsr, inputs.add, manifest, inputs.resolution)
+            .await?
+            .unwrap_or_else(|| package_selector.to_string()));
+    }
+    match (explicit_spec, prev_specifier) {
+        (Some(spec), prev) => Ok(resolve_explicit_registry_spec(
+            package_name,
+            spec,
+            prev,
+            inputs.add,
             manifest,
-            meta_cache,
-            fetch_locker,
+            inputs.resolution,
         )
         .await?
-        .unwrap_or_else(|| package_selector.to_string())
-    } else {
-        match (explicit_spec, prev_specifier.as_deref()) {
-            (Some(spec), prev) => resolve_explicit_registry_spec(
-                package_name,
-                spec,
-                prev,
-                config,
-                http_client,
-                range_spec_style,
-                lockfile,
-                manifest,
-                meta_cache,
-                fetch_locker,
-            )
-            .await?
-            .unwrap_or_else(|| normalized_save_specifier(spec)),
-            (None, Some(prev)) => prev.to_string(),
-            (None, None) => {
-                let latest = latest_picker
-                    .get_or_try_init(|| {
-                        std::future::ready(
-                            PickPolicy::from_config(config)
-                                .map(|policy| {
-                                    LatestPicker::new(
-                                        config,
-                                        http_client,
-                                        policy,
-                                        std::sync::Arc::clone(meta_cache),
-                                        std::sync::Arc::clone(fetch_locker),
-                                    )
-                                })
-                                .map_err(AddError::MinimumReleaseAgeExclude),
+        .unwrap_or_else(|| normalized_save_specifier(spec))),
+        (None, Some(prev)) => Ok(prev.to_string()),
+        (None, None) => pick_latest_range(package_name, inputs).await,
+    }
+}
+
+async fn resolve_node_runtime_specifier(
+    version_spec: &str,
+    prev_specifier: Option<&str>,
+    inputs: &AddResolveInputs<'_, '_>,
+) -> Result<String, AddError> {
+    let config = inputs.add.config;
+    let mut node_resolver = NodeResolver::new_with_auth(
+        std::sync::Arc::clone(inputs.http_client_arc),
+        std::sync::Arc::clone(&config.auth_headers),
+    );
+    node_resolver.node_download_mirrors.clone_from(&config.node_download_mirrors);
+    node_resolver.offline = config.offline;
+    node_resolver.cache_dir = Some(config.cache_dir.clone());
+    node_resolver
+        .resolve_save_specifier(version_spec, prev_specifier)
+        .await
+        .map_err(AddError::ResolveRuntimeSpec)
+}
+
+/// The range a brand-new dependency is saved with: its `latest` version
+/// under the configured range style.
+async fn pick_latest_range(
+    package_name: &str,
+    inputs: &AddResolveInputs<'_, '_>,
+) -> Result<String, AddError> {
+    let config = inputs.add.config;
+    let latest = inputs
+        .resolution
+        .latest_picker
+        .get_or_try_init(|| {
+            std::future::ready(
+                PickPolicy::from_config(config)
+                    .map(|policy| {
+                        LatestPicker::new(
+                            config,
+                            inputs.add.http_client,
+                            policy,
+                            std::sync::Arc::clone(&inputs.resolution.meta_cache),
+                            std::sync::Arc::clone(&inputs.resolution.fetch_locker),
                         )
                     })
-                    .await?
-                    .resolve(package_name, false)
-                    .await
-                    .map_err(|error| AddError::ResolveLatest {
-                        name: package_name.to_string(),
-                        error,
-                    })?;
-                calc_version_range(&latest.version, None, None, range_spec_style)
-            }
-        }
-    };
-
-    let mut updated_catalogs = Catalogs::new();
-    let dep = CatalogModeDep {
-        alias: package_name,
-        bare_specifier: &bare_specifier,
-        prev_specifier: prev_specifier.as_deref(),
-    };
-    let outcome =
-        decide_catalog_outcome(config.catalog_mode, save_catalog_name, catalogs, &dep, prefix)
-            .map_err(AddError::CatalogVersionMismatch)?;
-    let manifest_specifier = apply_catalog_decision(
-        outcome.decision,
-        package_name,
-        bare_specifier,
-        &mut updated_catalogs,
-    );
-
-    Ok(ResolvedAddedDependency {
-        package_name: package_name.to_string(),
-        manifest_specifier,
-        updated_catalogs,
-        warning: outcome.warning,
-    })
+                    .map_err(AddError::MinimumReleaseAgeExclude),
+            )
+        })
+        .await?
+        .resolve(package_name, false)
+        .await
+        .map_err(|error| AddError::ResolveLatest { name: package_name.to_string(), error })?;
+    Ok(calc_version_range(&latest.version, None, None, inputs.add.range_spec_style))
 }
 
 /// The package name and manifest specifier for an add selector that names
@@ -1370,28 +1406,18 @@ async fn resolve_aliasless_git(
 /// non-registry protocols (`git:`/`file:`/`workspace:`/URLs, which
 /// [`parse_bare_specifier`] rejects), `npm:` aliases (resolving them risks
 /// dropping the aliased target), and specifiers that resolve to no version.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "a resolve helper threading the install's resolution inputs"
-)]
 async fn resolve_explicit_registry_spec(
     package_name: &str,
     spec: &str,
     prev_specifier: Option<&str>,
-    config: &Config,
-    http_client: &ThrottledClient,
-    range_spec_style: RangeSpecStyle,
-    lockfile: Option<&Lockfile>,
+    add: AddView<'_>,
     manifest: &PackageManifest,
-    meta_cache: &InMemoryPackageMetaCache,
-    fetch_locker: &PackumentFetchLocker,
+    resolution: &AddResolution<'_>,
 ) -> Result<Option<String>, AddError> {
     if spec.starts_with("npm:") {
         return Ok(None);
     }
-    let registries: std::collections::HashMap<String, String> =
-        config.resolved_registries().into_iter().collect();
-    let registry = pick_registry_for_package(&registries, package_name, None);
+    let registry = package_registry(add.config, package_name);
     let Some(spec_parsed) = parse_bare_specifier(spec, Some(package_name), "latest", &registry)
     else {
         return Ok(None);
@@ -1407,7 +1433,7 @@ async fn resolve_explicit_registry_spec(
         return Ok(None);
     }
 
-    let policy = PickPolicy::from_config(config).map_err(AddError::MinimumReleaseAgeExclude)?;
+    let policy = PickPolicy::from_config(add.config).map_err(AddError::MinimumReleaseAgeExclude)?;
     // Bias the pick toward versions already present in the workspace, so a
     // dedup pick matches what the install locks (e.g. a sibling already on
     // `1.2.0` keeps `pnpm add foo@^1` on `1.2.0`). Seeded from the wanted
@@ -1415,10 +1441,16 @@ async fn resolve_explicit_registry_spec(
     // an unlocked sibling declaration may still differ — never an
     // inconsistency, since the install resolves the rewritten range.
     let preferred_versions = get_preferred_versions_from_lockfile_and_manifests(
-        lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()),
+        add.lockfile.and_then(|lockfile| lockfile.snapshots.as_ref()),
         &[manifest],
     );
-    let ctx = pick_package_context(http_client, config, &policy, meta_cache, fetch_locker);
+    let ctx = pick_package_context(
+        add.http_client,
+        add.config,
+        &policy,
+        &resolution.meta_cache,
+        &resolution.fetch_locker,
+    );
     let opts = PickPackageOptions {
         registry: &registry,
         preferred_version_selectors: preferred_versions.get(package_name),
@@ -1433,7 +1465,7 @@ async fn resolve_explicit_registry_spec(
         dry_run: false,
         optional: false,
         update_checksums: false,
-        trust_policy: Some(config.trust_policy),
+        trust_policy: Some(add.config.trust_policy),
         blocked_versions: None,
     };
 
@@ -1457,8 +1489,15 @@ async fn resolve_explicit_registry_spec(
         &picked.version,
         prev_pin,
         infer_range_spec_style(spec),
-        range_spec_style,
+        add.range_spec_style,
     )))
+}
+
+/// The registry `package_name` resolves against under the configured scopes.
+fn package_registry(config: &Config, package_name: &str) -> String {
+    let registries: std::collections::HashMap<String, String> =
+        config.resolved_registries().into_iter().collect();
+    pick_registry_for_package(&registries, package_name, None)
 }
 
 /// Whether `specifier` is a plain registry range/tag/version for
@@ -1677,19 +1716,11 @@ fn protocol_package_name(name: &str, selector: &str) -> Result<String, AddError>
 /// picked through the same registry path a plain `@jsr/<scope>__<name>` add
 /// takes. `None` when that pick finds no version — the caller then keeps the
 /// argument verbatim, as it does for any other unresolvable specifier.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "a resolve helper threading the install's resolution inputs"
-)]
 async fn resolve_jsr_save_specifier(
     spec: &JsrSpec,
-    config: &Config,
-    http_client: &ThrottledClient,
-    range_spec_style: RangeSpecStyle,
-    lockfile: Option<&Lockfile>,
+    add: AddView<'_>,
     manifest: &PackageManifest,
-    meta_cache: &InMemoryPackageMetaCache,
-    fetch_locker: &PackumentFetchLocker,
+    resolution: &AddResolution<'_>,
 ) -> Result<Option<String>, AddError> {
     let version_selector = spec.version_selector.as_deref().unwrap_or("latest");
     let range = resolve_explicit_registry_spec(
@@ -1699,13 +1730,9 @@ async fn resolve_jsr_save_specifier(
         // way pnpm reads it for an alias-less request: there is no alias to
         // find a manifest entry by.
         None,
-        config,
-        http_client,
-        range_spec_style,
-        lockfile,
+        add,
         manifest,
-        meta_cache,
-        fetch_locker,
+        resolution,
     )
     .await?;
     Ok(range.map(|range| format!("jsr:{range}")))

--- a/pnpm/crates/package-manager/src/add/tests.rs
+++ b/pnpm/crates/package-manager/src/add/tests.rs
@@ -1,7 +1,7 @@
 use super::{
-    Add, AddError, ProtocolSelector, node_runtime_version_spec, normalized_save_specifier,
-    persist_selected_manifests, prepare_selected_manifests, selected_project_indices,
-    workspace_save_specifier,
+    Add, AddError, AddOwned, AddView, ProtocolSelector, node_runtime_version_spec,
+    normalized_save_specifier, persist_selected_manifests, prepare_selected_manifests,
+    selected_project_indices, workspace_save_specifier,
 };
 use crate::ResolvedPackages;
 use pnpm_config::{Config, LinkWorkspacePackages};
@@ -19,6 +19,35 @@ use std::{
 use tempfile::tempdir;
 
 const SCOPED_TEST_INTEGRITY: &str = "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa==";
+
+/// The add inputs a manifest-preparation test varies, saving into
+/// `dependencies` with the major range style and no lockfile.
+fn test_add<'a>(
+    config: &'static Config,
+    http_client: &'a ThrottledClient,
+    package_names: &'a [String],
+    save_catalog_name: Option<&str>,
+) -> (AddView<'a>, AddOwned) {
+    (
+        AddView {
+            resolved_packages: Box::leak(Box::new(ResolvedPackages::default())),
+            http_client,
+            config,
+            lockfile: None,
+            lockfile_path: None,
+            package_names,
+            range_spec_style: RangeSpecStyle::Major,
+            lockfile_only: false,
+        },
+        AddOwned {
+            tarball_mem_cache: Arc::new(pnpm_tarball::MemCache::default()),
+            http_client_arc: Arc::new(ThrottledClient::default()),
+            dependency_groups: Some(vec![DependencyGroup::Prod]),
+            save_catalog_name: save_catalog_name.map(str::to_string),
+            supported_architectures: None,
+        },
+    )
+}
 
 #[test]
 fn explicit_npm_specifier_is_not_rewritten_as_a_workspace_dependency() {
@@ -874,22 +903,12 @@ async fn selected_add_prepares_and_persists_only_selected_projects() {
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let config = Box::leak(Box::new(Config::new()));
     let http_client = ThrottledClient::default();
-    let http_client_arc = Arc::new(ThrottledClient::default());
 
-    prepare_selected_manifests::<SilentReporter>(
-        &mut projects,
-        &indices,
-        &http_client,
-        &http_client_arc,
-        config,
-        None,
-        Some(&[DependencyGroup::Prod][..]),
-        std::slice::from_ref(&"foo@workspace:*".to_string()),
-        RangeSpecStyle::Major,
-        None,
-    )
-    .await
-    .expect("prepare selected manifests");
+    let packages = ["foo@workspace:*".to_string()];
+    let (add, owned) = test_add(config, &http_client, &packages, None);
+    prepare_selected_manifests::<SilentReporter>(&mut projects, &indices, add, &owned)
+        .await
+        .expect("prepare selected manifests");
     persist_selected_manifests::<SilentReporter>(&mut projects, &indices)
         .expect("persist selected manifests");
 
@@ -921,22 +940,13 @@ async fn selected_add_merges_catalog_updates_in_command_order() {
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let config = Box::leak(Box::new(Config::new()));
     let http_client = ThrottledClient::default();
-    let http_client_arc = Arc::new(ThrottledClient::default());
 
-    let prepared = prepare_selected_manifests::<SilentReporter>(
-        &mut projects,
-        &indices,
-        &http_client,
-        &http_client_arc,
-        config,
-        None,
-        Some(&[DependencyGroup::Prod][..]),
-        std::slice::from_ref(&"foo".to_string()),
-        RangeSpecStyle::Major,
-        Some("default"),
-    )
-    .await
-    .expect("prepare selected manifests");
+    let packages = ["foo".to_string()];
+    let (add, owned) = test_add(config, &http_client, &packages, Some("default"));
+    let prepared =
+        prepare_selected_manifests::<SilentReporter>(&mut projects, &indices, add, &owned)
+            .await
+            .expect("prepare selected manifests");
 
     assert_eq!(dependency_specifier(&projects[0].manifest, "foo"), Some("1.0.0"));
     assert_eq!(dependency_specifier(&projects[1].manifest, "foo"), Some("catalog:"));

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -254,7 +254,7 @@ pub fn dependencies_graph_to_lockfile(
 /// Each importer's snapshot reads only its own input plus the shared
 /// graph, so a workspace-scale importer list fans out across the
 /// rayon pool; the serial fold below keeps the first error in
-/// importer order, like the loop it replaces.
+/// importer order.
 fn build_importers(
     opts: &GraphToLockfileOptions<'_>,
 ) -> Result<HashMap<String, ProjectSnapshot>, DependenciesGraphToLockfileError> {

--- a/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
+++ b/pnpm/crates/package-manager/src/dependencies_graph_to_lockfile.rs
@@ -207,109 +207,41 @@ pub enum DependenciesGraphToLockfileError {
 pub fn dependencies_graph_to_lockfile(
     opts: GraphToLockfileOptions<'_>,
 ) -> Result<Lockfile, DependenciesGraphToLockfileError> {
-    let GraphToLockfileOptions {
-        importers: importer_inputs,
-        graph,
-        auto_install_peers,
-        dedupe_peers,
-        exclude_links_from_lockfile,
-        inject_workspace_packages,
-        peers_suffix_max_length,
-        overrides,
-        ignored_optional_dependencies,
-        patched_dependencies,
-        package_extensions_checksum,
-        pnpmfile_checksum,
-        catalogs,
-        registry,
-        registries_by_prefix,
-        registry_options_by_url,
-        lockfile_include_tarball_url,
-        previous_importers,
-        previous_packages,
-        update_reuse_scope,
-        update_reuse_scopes_by_importer,
-        time,
-    } = opts;
-
-    let optional_overrides = compute_corrected_optional(&importer_inputs, graph);
+    let optional_overrides = compute_corrected_optional(&opts.importers, opts.graph);
     let (packages, snapshots) = build_packages_and_snapshots(
-        graph,
+        opts.graph,
         &optional_overrides,
         &PackageMetadataSources {
-            registry,
-            registries_by_prefix,
-            registry_options_by_url,
-            lockfile_include_tarball_url,
-            previous_packages,
+            registry: opts.registry,
+            registries_by_prefix: opts.registries_by_prefix,
+            registry_options_by_url: opts.registry_options_by_url,
+            lockfile_include_tarball_url: opts.lockfile_include_tarball_url,
+            previous_packages: opts.previous_packages,
         },
     )?;
-
-    // Each importer's snapshot reads only its own input plus the shared
-    // graph, so a workspace-scale importer list fans out across the
-    // rayon pool; the serial fold below keeps the first error in
-    // importer order, like the loop it replaces.
-    let importer_results: Vec<(
-        &String,
-        Result<ProjectSnapshot, DependenciesGraphToLockfileError>,
-    )> = importer_inputs
-        .iter()
-        .collect::<Vec<_>>()
-        .into_par_iter()
-        .map(|(id, input)| {
-            let previous_importer = previous_importers.and_then(|imps| imps.get(id));
-            // Effective update scope for this importer, mirroring the resolver's
-            // `update_reuse_scope_for`: a global `None` (bare `update`) applies to
-            // every importer; otherwise the per-importer entry wins, falling back
-            // to the global. This is what lets a `pacquet update <name> --recursive`
-            // target the named dependency in the importer that declares it while
-            // leaving untouched importers on their global scope.
-            let effective_update_reuse_scope =
-                if matches!(update_reuse_scope, UpdateReuseScope::None) {
-                    &update_reuse_scope
-                } else {
-                    update_reuse_scopes_by_importer.get(id).unwrap_or(&update_reuse_scope)
-                };
-            let importer = build_importer(
-                input,
-                graph,
-                &ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers },
-                previous_importer,
-                effective_update_reuse_scope,
-            );
-            (id, importer)
-        })
-        .collect();
-    let mut importers: HashMap<String, ProjectSnapshot> =
-        HashMap::with_capacity(importer_inputs.len());
-    for (id, importer) in importer_results {
-        importers.insert(id.clone(), importer?);
-    }
-
-    let catalog_snapshots = build_catalog_snapshots(&importers, catalogs);
-
-    let lockfile_version = ComVer::new(9, 0);
+    let importers = build_importers(&opts)?;
     Ok(Lockfile {
-        lockfile_version: LockfileVersion::<9>::try_from(lockfile_version)
+        lockfile_version: LockfileVersion::<9>::try_from(ComVer::new(9, 0))
             .expect("the generated lockfile version is supported"),
         settings: Some(LockfileSettings {
-            auto_install_peers,
-            dedupe_peers: dedupe_peers.then_some(true),
-            exclude_links_from_lockfile,
-            inject_workspace_packages,
-            peers_suffix_max_length,
+            auto_install_peers: opts.auto_install_peers,
+            dedupe_peers: opts.dedupe_peers.then_some(true),
+            exclude_links_from_lockfile: opts.exclude_links_from_lockfile,
+            inject_workspace_packages: opts.inject_workspace_packages,
+            peers_suffix_max_length: opts.peers_suffix_max_length,
         }),
-        catalogs: catalog_snapshots,
-        overrides: overrides.filter(|map| !map.is_empty()),
-        package_extensions_checksum,
-        pnpmfile_checksum,
-        ignored_optional_dependencies: ignored_optional_dependencies
+        catalogs: build_catalog_snapshots(&importers, opts.catalogs),
+        overrides: opts.overrides.filter(|map| !map.is_empty()),
+        package_extensions_checksum: opts.package_extensions_checksum,
+        pnpmfile_checksum: opts.pnpmfile_checksum,
+        ignored_optional_dependencies: opts
+            .ignored_optional_dependencies
             .filter(|list| !list.is_empty()),
-        patched_dependencies: patched_dependencies.filter(|map| !map.is_empty()),
+        patched_dependencies: opts.patched_dependencies.filter(|map| !map.is_empty()),
         importers,
         packages: (!packages.is_empty()).then_some(packages),
         snapshots: (!snapshots.is_empty()).then_some(snapshots),
-        time: (!time.is_empty()).then_some(time),
+        time: (!opts.time.is_empty()).then_some(opts.time),
         // A freshly resolved lockfile, not a rewrite of the previous one,
         // so it starts with no foreign top-level keys. A host that records
         // its own block re-asserts it after the install (it is writing its
@@ -317,6 +249,60 @@ pub fn dependencies_graph_to_lockfile(
         // read-edit-write round trip lossless.
         extra: pnpm_lockfile::LockfileExtra::default(),
     })
+}
+
+/// Each importer's snapshot reads only its own input plus the shared
+/// graph, so a workspace-scale importer list fans out across the
+/// rayon pool; the serial fold below keeps the first error in
+/// importer order, like the loop it replaces.
+fn build_importers(
+    opts: &GraphToLockfileOptions<'_>,
+) -> Result<HashMap<String, ProjectSnapshot>, DependenciesGraphToLockfileError> {
+    let importer_results: Vec<(
+        &String,
+        Result<ProjectSnapshot, DependenciesGraphToLockfileError>,
+    )> = opts
+        .importers
+        .iter()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(id, input)| {
+            let importer = build_importer(
+                input,
+                opts.graph,
+                &ImporterLockfileFlags {
+                    exclude_links_from_lockfile: opts.exclude_links_from_lockfile,
+                    auto_install_peers: opts.auto_install_peers,
+                },
+                opts.previous_importers.and_then(|importers| importers.get(id)),
+                effective_update_reuse_scope(opts, id),
+            );
+            (id, importer)
+        })
+        .collect();
+    let mut importers: HashMap<String, ProjectSnapshot> =
+        HashMap::with_capacity(opts.importers.len());
+    for (id, importer) in importer_results {
+        importers.insert(id.clone(), importer?);
+    }
+    Ok(importers)
+}
+
+/// Effective update scope for this importer, mirroring the resolver's
+/// `update_reuse_scope_for`: a global `None` (bare `update`) applies to
+/// every importer; otherwise the per-importer entry wins, falling back
+/// to the global. This is what lets a `pacquet update <name> --recursive`
+/// target the named dependency in the importer that declares it while
+/// leaving untouched importers on their global scope.
+fn effective_update_reuse_scope<'o>(
+    opts: &'o GraphToLockfileOptions<'_>,
+    importer_id: &str,
+) -> &'o UpdateReuseScope {
+    if matches!(opts.update_reuse_scope, UpdateReuseScope::None) {
+        &opts.update_reuse_scope
+    } else {
+        opts.update_reuse_scopes_by_importer.get(importer_id).unwrap_or(&opts.update_reuse_scope)
+    }
 }
 
 /// Build the lockfile's `catalogs:` snapshot from the resolved importers.
@@ -383,69 +369,99 @@ fn build_importer(
     previous_importer: Option<&ProjectSnapshot>,
     update_reuse_scope: &UpdateReuseScope,
 ) -> Result<ProjectSnapshot, DependenciesGraphToLockfileError> {
-    let ImporterLockfileFlags { exclude_links_from_lockfile, auto_install_peers } = *flags;
-    let manifest = input.manifest;
-    let direct = &input.direct_dependencies_by_alias;
-
     let mut groups = ImporterDependencyGroups::default();
     let mut specifiers: HashMap<String, String> = HashMap::new();
-
-    let alias_to_group = manifest_alias_to_group(manifest);
-
-    for (alias, dep_path) in direct {
-        let Ok(name_for_key) = PkgName::parse(alias.as_str()) else { continue };
-        // Skip aliases the manifest doesn't declare. The resolver's
-        // `direct_dependencies_by_alias` includes auto-installed peers
-        // hoisted to the importer when `autoInstallPeers: true` is on,
-        // but only aliases declared in the manifest belong in the
-        // importer entry — transitive auto-installed peers never enter
-        // `importer.dependencies` / `importer.specifiers`, only the
-        // snapshots graph below. Writing them here would carry specifiers
-        // the manifest can't satisfy through `satisfies_package_manifest`
-        // and force every later install onto the fresh-resolve path.
-        let Some(specifier) = read_manifest_specifier(manifest, alias, auto_install_peers) else {
+    let alias_to_group = manifest_alias_to_group(input.manifest);
+    let sources = DirectEntrySources {
+        manifest: input.manifest,
+        graph,
+        flags,
+        previous_importer,
+        update_reuse_scope,
+    };
+    for (alias, dep_path) in &input.direct_dependencies_by_alias {
+        let Some((name_for_key, spec)) = importer_direct_entry(alias, dep_path, &sources)? else {
             continue;
         };
-        let Some(version) =
-            direct_dep_version(alias, dep_path, &specifier, graph, exclude_links_from_lockfile)?
-        else {
-            continue;
-        };
-        let version = preserved_link_version(
-            &version,
-            &PreservedLinkLookup {
-                previous_importer,
-                name_for_key: &name_for_key,
-                specifier: &specifier,
-                dep_path,
-                graph,
-                update_reuse_scope,
-            },
-        )
-        .unwrap_or(version);
-        let spec = ResolvedDependencySpec { specifier: specifier.clone(), version };
-        specifiers.insert(alias.clone(), specifier);
-        let group = alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod);
-        groups.insert(group, name_for_key, spec);
+        specifiers.insert(alias.clone(), spec.specifier.clone());
+        groups.insert(
+            alias_to_group.get(alias).copied().unwrap_or(DependencyGroup::Prod),
+            name_for_key,
+            spec,
+        );
     }
-
-    let dependencies_meta = manifest
-        .value()
-        .get("dependenciesMeta")
-        .filter(|value| value.as_object().is_some_and(|meta| !meta.is_empty()))
-        .cloned();
-    let (publish_directory, link_directory) = manifest_publish_config(manifest);
-    let ImporterDependencyGroups { prod, dev, optional } = groups;
-
+    let (publish_directory, link_directory) = manifest_publish_config(input.manifest);
     Ok(ProjectSnapshot {
         specifiers: (!specifiers.is_empty()).then_some(specifiers),
-        dependencies: (!prod.is_empty()).then_some(prod),
-        dev_dependencies: (!dev.is_empty()).then_some(dev),
-        optional_dependencies: (!optional.is_empty()).then_some(optional),
-        dependencies_meta,
+        dependencies: (!groups.prod.is_empty()).then_some(groups.prod),
+        dev_dependencies: (!groups.dev.is_empty()).then_some(groups.dev),
+        optional_dependencies: (!groups.optional.is_empty()).then_some(groups.optional),
+        dependencies_meta: input
+            .manifest
+            .value()
+            .get("dependenciesMeta")
+            .filter(|value| value.as_object().is_some_and(|meta| !meta.is_empty()))
+            .cloned(),
         publish_directory,
         link_directory,
     })
+}
+
+/// What every direct dependency's importer entry is read against.
+struct DirectEntrySources<'a> {
+    manifest: &'a PackageManifest,
+    graph: &'a DependenciesGraph,
+    flags: &'a ImporterLockfileFlags,
+    previous_importer: Option<&'a ProjectSnapshot>,
+    update_reuse_scope: &'a UpdateReuseScope,
+}
+
+/// One direct dependency's importer entry: the key it is recorded under and
+/// its specifier and resolved version. `None` leaves the alias out of the
+/// importer.
+fn importer_direct_entry(
+    alias: &str,
+    dep_path: &DepPath,
+    sources: &DirectEntrySources<'_>,
+) -> Result<Option<(PkgName, ResolvedDependencySpec)>, DependenciesGraphToLockfileError> {
+    let Ok(name_for_key) = PkgName::parse(alias) else { return Ok(None) };
+    // Skip aliases the manifest doesn't declare. The resolver's
+    // `direct_dependencies_by_alias` includes auto-installed peers
+    // hoisted to the importer when `autoInstallPeers: true` is on,
+    // but only aliases declared in the manifest belong in the
+    // importer entry — transitive auto-installed peers never enter
+    // `importer.dependencies` / `importer.specifiers`, only the
+    // snapshots graph below. Writing them here would carry specifiers
+    // the manifest can't satisfy through `satisfies_package_manifest`
+    // and force every later install onto the fresh-resolve path.
+    let Some(specifier) =
+        read_manifest_specifier(sources.manifest, alias, sources.flags.auto_install_peers)
+    else {
+        return Ok(None);
+    };
+    let Some(version) = direct_dep_version(
+        alias,
+        dep_path,
+        &specifier,
+        sources.graph,
+        sources.flags.exclude_links_from_lockfile,
+    )?
+    else {
+        return Ok(None);
+    };
+    let version = preserved_link_version(
+        &version,
+        &PreservedLinkLookup {
+            previous_importer: sources.previous_importer,
+            name_for_key: &name_for_key,
+            specifier: &specifier,
+            dep_path,
+            graph: sources.graph,
+            update_reuse_scope: sources.update_reuse_scope,
+        },
+    )
+    .unwrap_or(version);
+    Ok(Some((name_for_key, ResolvedDependencySpec { specifier, version })))
 }
 
 /// One importer's direct dependencies, split by the manifest group they were
@@ -779,59 +795,78 @@ fn build_packages_and_snapshots(
     // serial fold below walks them in the graph's iteration order, so
     // the first-of-a-key metadata insert and the first error stay the
     // ones the serial loop would have kept.
-    struct BuiltNode<'graph> {
-        node: &'graph pnpm_resolving_deps_resolver::DependenciesGraphNode,
-        snapshot_key: PackageKey,
-        snapshot: SnapshotEntry,
-    }
     let built: Vec<Result<Option<BuiltNode<'_>>, DependenciesGraphToLockfileError>> = graph
         .values()
         .collect::<Vec<_>>()
         .into_par_iter()
-        .map(|node| {
-            let dep_path = node.dep_path.as_str();
-            let snapshot_key = match dep_path.parse::<PackageKey>() {
-                Ok(snapshot_key) => Ok(snapshot_key),
-                // A workspace link is the one node with no row of its own —
-                // it resolves as its own importer and pnpm writes it none
-                // either.
-                Err(_) if dep_path.starts_with("link:") => return Ok(None),
-                Err(source) => Err(DependenciesGraphToLockfileError::UnkeyedDepPath {
-                    dep_path: dep_path.to_string(),
-                    source: Box::new(source),
-                }),
-            }?;
-            let snapshot = build_snapshot_entry(node, graph, optional_overrides);
-            Ok(Some(BuiltNode { node, snapshot_key, snapshot }))
-        })
+        .map(|node| build_node(node, graph, optional_overrides))
         .collect();
 
     let mut packages: HashMap<PackageKey, PackageMetadata> = HashMap::new();
     let mut snapshots: HashMap<PackageKey, SnapshotEntry> = HashMap::new();
     for built_node in built {
         let Some(BuiltNode { node, snapshot_key, snapshot }) = built_node? else { continue };
-        let metadata_key = snapshot_key.without_peer();
+        insert_package_metadata(&mut packages, node, snapshot_key.without_peer(), sources)?;
         snapshots.insert(snapshot_key, snapshot);
-
-        if let std::collections::hash_map::Entry::Vacant(entry) = packages.entry(metadata_key) {
-            let key = entry.key();
-            let (registry, include_tarball_url) = metadata_registry(key, sources);
-            let mut metadata = build_package_metadata(
-                node,
-                key,
-                LockfileFormOptions {
-                    registry,
-                    server_type: registry_server_type(sources.registry_options_by_url, registry),
-                    include_tarball_url,
-                },
-            )
-            .map_err(DependenciesGraphToLockfileError::LockfileForm)?;
-            carry_previous_deprecation(&mut metadata, key, sources);
-            entry.insert(metadata);
-        }
     }
 
     Ok((packages, snapshots))
+}
+
+struct BuiltNode<'graph> {
+    node: &'graph pnpm_resolving_deps_resolver::DependenciesGraphNode,
+    snapshot_key: PackageKey,
+    snapshot: SnapshotEntry,
+}
+
+/// A node's snapshot row under its key; `None` for a workspace link, which
+/// has no row of its own.
+fn build_node<'graph>(
+    node: &'graph DependenciesGraphNode,
+    graph: &DependenciesGraph,
+    optional_overrides: &HashMap<DepPath, bool>,
+) -> Result<Option<BuiltNode<'graph>>, DependenciesGraphToLockfileError> {
+    let dep_path = node.dep_path.as_str();
+    let snapshot_key = match dep_path.parse::<PackageKey>() {
+        Ok(snapshot_key) => Ok(snapshot_key),
+        // A workspace link is the one node with no row of its own —
+        // it resolves as its own importer and pnpm writes it none
+        // either.
+        Err(_) if dep_path.starts_with("link:") => return Ok(None),
+        Err(source) => Err(DependenciesGraphToLockfileError::UnkeyedDepPath {
+            dep_path: dep_path.to_string(),
+            source: Box::new(source),
+        }),
+    }?;
+    let snapshot = build_snapshot_entry(node, graph, optional_overrides);
+    Ok(Some(BuiltNode { node, snapshot_key, snapshot }))
+}
+
+/// Record a package's metadata under its peer-stripped key, once: the first
+/// node of a key in graph order wins.
+fn insert_package_metadata(
+    packages: &mut HashMap<PackageKey, PackageMetadata>,
+    node: &DependenciesGraphNode,
+    metadata_key: PackageKey,
+    sources: &PackageMetadataSources<'_>,
+) -> Result<(), DependenciesGraphToLockfileError> {
+    let std::collections::hash_map::Entry::Vacant(entry) = packages.entry(metadata_key) else {
+        return Ok(());
+    };
+    let (registry, include_tarball_url) = metadata_registry(entry.key(), sources);
+    let mut metadata = build_package_metadata(
+        node,
+        entry.key(),
+        LockfileFormOptions {
+            registry,
+            server_type: registry_server_type(sources.registry_options_by_url, registry),
+            include_tarball_url,
+        },
+    )
+    .map_err(DependenciesGraphToLockfileError::LockfileForm)?;
+    carry_previous_deprecation(&mut metadata, entry.key(), sources);
+    entry.insert(metadata);
+    Ok(())
 }
 
 /// The registry a package's metadata is written against, and whether its
@@ -889,9 +924,40 @@ fn build_package_metadata(
     lockfile_form: LockfileFormOptions<'_>,
 ) -> Result<PackageMetadata, LockfileFormError> {
     let manifest = node.resolve_result.manifest.as_deref();
+    let (peer_dependencies, peer_dependencies_meta) = build_peer_dep_blocks(node);
+    let resolution_version = match metadata_key.suffix.registry_qualified() {
+        Some((_, version)) => version.to_string(),
+        None => metadata_key.suffix.version().to_string(),
+    };
+    let resolution = node.resolve_result.resolution.to_lockfile_form(
+        &metadata_key.name.to_string(),
+        &resolution_version,
+        lockfile_form,
+    )?;
+    Ok(PackageMetadata {
+        version: explicit_version(node, metadata_key, &resolution, manifest),
+        resolution,
+        engines: read_engines(manifest),
+        cpu: read_string_list(manifest, "cpu"),
+        os: read_string_list(manifest, "os"),
+        libc: read_string_or_list(manifest, "libc"),
+        deprecated: manifest
+            .and_then(|manifest| manifest.get("deprecated"))
+            .and_then(Value::as_str)
+            .filter(|deprecated| !deprecated.is_empty())
+            .map(ToString::to_string),
+        has_bin: manifest_has_bin(manifest),
+        prepare: None,
+        bundled_dependencies: BundledDependencies::from_manifest(manifest),
+        peer_dependencies,
+        peer_dependencies_meta,
+    })
+}
 
-    let engines = manifest
-        .and_then(|m| m.get("engines"))
+/// The manifest's `engines`, without the ranges that constrain nothing.
+fn read_engines(manifest: Option<&Value>) -> Option<HashMap<String, String>> {
+    manifest
+        .and_then(|manifest| manifest.get("engines"))
         .and_then(|value| match value {
             Value::Object(map) => Some(
                 map.iter()
@@ -916,63 +982,32 @@ fn build_package_metadata(
                 .map(|(name, range)| (name, range.to_string()))
                 .collect::<HashMap<String, String>>()
         })
-        .filter(|map| !map.is_empty());
+        .filter(|map| !map.is_empty())
+}
 
-    let cpu = read_string_list(manifest, "cpu");
-    let os = read_string_list(manifest, "os");
-    let libc = read_string_or_list(manifest, "libc");
-
-    let deprecated = manifest
-        .and_then(|m| m.get("deprecated"))
-        .and_then(Value::as_str)
-        .filter(|deprecated| !deprecated.is_empty())
-        .map(ToString::to_string);
-
-    let has_bin = manifest_has_bin(manifest);
-
-    let bundled_dependencies = BundledDependencies::from_manifest(manifest);
-
-    let (peer_dependencies, peer_dependencies_meta) = build_peer_dep_blocks(node);
-
-    let resolution_version = match metadata_key.suffix.registry_qualified() {
-        Some((_, version)) => version.to_string(),
-        None => metadata_key.suffix.version().to_string(),
-    };
-    let resolution = node.resolve_result.resolution.to_lockfile_form(
-        &metadata_key.name.to_string(),
-        &resolution_version,
-        lockfile_form,
-    )?;
-
-    // Record `version` only for non-registry packages (depPath carries
-    // a `:`), and only when the manifest declares one and the resolution
-    // isn't a local directory. Registry packages omit it because their
-    // version is already the depPath suffix.
-    // A registry-qualified dep path carries a parseable semver of its own,
-    // so the explicit version field written for other `:`-containing dep
-    // paths would be redundant.
-    let version = (node.dep_path.as_str().contains(':')
+/// Record `version` only for non-registry packages (depPath carries
+/// a `:`), and only when the manifest declares one and the resolution
+/// isn't a local directory. Registry packages omit it because their
+/// version is already the depPath suffix.
+/// A registry-qualified dep path carries a parseable semver of its own,
+/// so the explicit version field written for other `:`-containing dep
+/// paths would be redundant.
+fn explicit_version(
+    node: &DependenciesGraphNode,
+    metadata_key: &PackageKey,
+    resolution: &LockfileResolution,
+    manifest: Option<&Value>,
+) -> Option<String> {
+    (node.dep_path.as_str().contains(':')
         && metadata_key.suffix.registry_qualified().is_none()
         && !matches!(resolution, LockfileResolution::Directory(_)))
     .then(|| {
-        manifest.and_then(|m| m.get("version")).and_then(Value::as_str).map(ToString::to_string)
+        manifest
+            .and_then(|manifest| manifest.get("version"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
     })
-    .flatten();
-
-    Ok(PackageMetadata {
-        resolution,
-        version,
-        engines,
-        cpu,
-        os,
-        libc,
-        deprecated,
-        has_bin,
-        prepare: None,
-        bundled_dependencies,
-        peer_dependencies,
-        peer_dependencies_meta,
-    })
+    .flatten()
 }
 
 /// Read a JSON array field off the resolver's manifest fragment and flatten it

--- a/pnpm/crates/package-manager/src/early_materializer.rs
+++ b/pnpm/crates/package-manager/src/early_materializer.rs
@@ -116,24 +116,12 @@ impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
         else {
             return;
         };
-        // Optional edges are left to the final pass, which knows which
-        // optional dependencies the installability pass skipped.
-        let dependencies: HashMap<PkgName, SnapshotDepRef> = package
-            .children
-            .iter()
-            .filter(|child| !child.optional)
-            .filter_map(|child| {
-                let alias = PkgName::parse(child.alias.as_str()).ok()?;
-                let key = child.pkg_id.parse::<PackageKey>().ok()?;
-                Some((alias, SnapshotDepRef::Alias(key)))
-            })
-            .collect();
         let job = SlotJob {
             package_url: package_url.to_string(),
             self_name: name_ver.name.clone(),
             virtual_node_modules_dir,
             package_dir,
-            dependencies,
+            dependencies: required_dependencies(&package.children),
         };
         lock(&self.slots).push((key, slot_dir));
         let shared = Arc::clone(&self.shared);
@@ -168,6 +156,23 @@ impl<Reporter: pnpm_reporter::Reporter + 'static> EarlyMaterializer<Reporter> {
         }
         self.shared.materialized.load(Ordering::Acquire)
     }
+}
+
+/// The edges the early slot links. Optional edges are left to the final
+/// pass, which knows which optional dependencies the installability pass
+/// skipped.
+fn required_dependencies(
+    children: &[pnpm_resolving_deps_resolver::FinalizedChild],
+) -> HashMap<PkgName, SnapshotDepRef> {
+    children
+        .iter()
+        .filter(|child| !child.optional)
+        .filter_map(|child| {
+            let alias = PkgName::parse(child.alias.as_str()).ok()?;
+            let key = child.pkg_id.parse::<PackageKey>().ok()?;
+            Some((alias, SnapshotDepRef::Alias(key)))
+        })
+        .collect()
 }
 
 struct SlotJob {

--- a/pnpm/crates/package-manager/src/fast_update_overrides.rs
+++ b/pnpm/crates/package-manager/src/fast_update_overrides.rs
@@ -435,41 +435,41 @@ fn apply_replacement(
     resolved: &HashMap<PkgName, ResolvedOverride>,
     target: &mut ReplacementTarget<'_>,
 ) -> Option<()> {
-    let ReplacementTarget { old_key, new_key, original_snapshots, snapshots, packages } = target;
-    let replacement = resolved.get(&old_key.name)?;
-    let old_snapshot = original_snapshots.get(*old_key)?;
+    let replacement = resolved.get(&target.old_key.name)?;
+    let old_snapshot = target.original_snapshots.get(target.old_key)?;
     let dependencies = validate_dependencies(
         effective_dependencies(&replacement.manifest)?,
         old_snapshot.dependencies.as_ref(),
-        original_snapshots,
+        target.original_snapshots,
         context.lockfile.packages.as_ref()?,
         plan,
-        new_key,
+        target.new_key,
     )?;
     let optional_dependencies = validate_dependencies(
         manifest_dependency_map(&replacement.manifest, "optionalDependencies")?,
         old_snapshot.optional_dependencies.as_ref(),
-        original_snapshots,
+        target.original_snapshots,
         context.lockfile.packages.as_ref()?,
         plan,
-        new_key,
+        target.new_key,
     )?;
     let snapshot = SnapshotEntry { dependencies, optional_dependencies, ..old_snapshot.clone() };
-    if let Some(existing) = snapshots.get(*new_key)
+    if let Some(existing) = target.snapshots.get(target.new_key)
         && existing != &snapshot
     {
         return None;
     }
-    snapshots.insert((*new_key).clone(), snapshot);
-    let metadata_key = new_key.without_peer();
-    let registry = pick_registry_for_package(context.registries, &old_key.name.to_string(), None);
+    target.snapshots.insert(target.new_key.clone(), snapshot);
+    let metadata_key = target.new_key.without_peer();
+    let registry =
+        pick_registry_for_package(context.registries, &target.old_key.name.to_string(), None);
     let metadata = package_metadata(
         &replacement.manifest,
         replacement
             .resolution
             .to_lockfile_form(
-                &old_key.name.to_string(),
-                &new_key.suffix.version().to_string(),
+                &target.old_key.name.to_string(),
+                &target.new_key.suffix.version().to_string(),
                 LockfileFormOptions {
                     registry: &registry,
                     server_type: registry_server_type(context.registry_options_by_url, &registry),
@@ -478,12 +478,12 @@ fn apply_replacement(
             )
             .ok()?,
     );
-    if let Some(existing) = packages.get(&metadata_key)
+    if let Some(existing) = target.packages.get(&metadata_key)
         && existing != &metadata
     {
         return None;
     }
-    packages.insert(metadata_key, metadata);
+    target.packages.insert(metadata_key, metadata);
     Some(())
 }
 

--- a/pnpm/crates/package-manager/src/install.rs
+++ b/pnpm/crates/package-manager/src/install.rs
@@ -72,6 +72,16 @@ mod lockfile_freshness;
 mod materialize;
 mod modules_state;
 mod prepare_modules_state;
+/// The dependency groups the install includes, as `.modules.yaml` records
+/// them and the dependency-graph walker observes them.
+pub(super) fn included_dependencies(dependency_groups: &[DependencyGroup]) -> IncludedDependencies {
+    IncludedDependencies {
+        dependencies: dependency_groups.contains(&DependencyGroup::Prod),
+        dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
+        optional_dependencies: dependency_groups.contains(&DependencyGroup::Optional),
+    }
+}
+
 mod run;
 mod workspace_state;
 

--- a/pnpm/crates/package-manager/src/install/lifecycle.rs
+++ b/pnpm/crates/package-manager/src/install/lifecycle.rs
@@ -136,7 +136,6 @@ fn link_dependencies_from_lockfile(
         .collect()
 }
 
-/// The projects the dependency order leaves out, by display path.
 fn projects_outside_order(
     projects: &[(PathBuf, &PackageManifest)],
     dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,

--- a/pnpm/crates/package-manager/src/install/lifecycle.rs
+++ b/pnpm/crates/package-manager/src/install/lifecycle.rs
@@ -53,82 +53,114 @@ pub(super) fn project_lifecycle_graph<'a>(
     let explicit_order_covers_projects = ordered_dirs.as_ref().is_some_and(|ordered_dirs| {
         normalized_project_dirs.iter().all(|project_dir| ordered_dirs.contains(project_dir))
     });
-    let lockfile_dependencies;
-    let fallback_dependencies;
-    let dependencies = if explicit_order_covers_projects {
-        ordered_dependencies.expect("checked as present")
-    } else if let Some(lockfile) = lockfile {
-        let included = normalized_project_dirs.clone();
-        let included_set = included.iter().cloned().collect::<HashSet<_>>();
-        let graph = projects
-            .iter()
-            .zip(&normalized_project_dirs)
-            .map(|((project_dir, _), normalized_project_dir)| {
-                let importer_id =
-                    pnpm_workspace::importer_id_from_root_dir(workspace_root, project_dir);
-                let dependencies = lockfile
-                    .importers
-                    .get(&importer_id)
-                    .into_iter()
-                    .flat_map(|snapshot| {
-                        [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]
-                            .into_iter()
-                            .filter_map(|group| snapshot.get_map_by_group(group))
-                            .flat_map(|dependencies| dependencies.values())
-                    })
-                    .filter_map(|dependency| match &dependency.version {
-                        pnpm_lockfile::ImporterDepVersion::Link(target) => {
-                            Some(pnpm_fs::lexical_normalize(&project_dir.join(target)))
-                        }
-                        _ => None,
-                    })
-                    .filter(|target| included_set.contains(target))
-                    .collect();
-                (normalized_project_dir.clone(), dependencies)
-            })
-            .collect::<IndexMap<_, _>>();
-        lockfile_dependencies = graph;
-        &lockfile_dependencies
-    } else if ordered_dependencies.is_some() {
-        return Err(InstallError::ProjectLifecycleOrder {
-            projects: normalized_project_dirs
-                .iter()
-                .filter(|project_dir| {
-                    !ordered_dirs
-                        .as_ref()
-                        .expect("ordered dependencies are present")
-                        .contains(*project_dir)
-                })
-                .map(|project_dir| project_dir.display().to_string())
-                .collect::<Vec<_>>()
-                .join(", "),
-        });
-    } else {
-        fallback_dependencies = normalized_project_dirs
-            .iter()
-            .cloned()
-            .map(|project_dir| (project_dir, Vec::new()))
-            .collect::<IndexMap<_, _>>();
-        &fallback_dependencies
-    };
+    let dependencies: std::borrow::Cow<IndexMap<PathBuf, Vec<PathBuf>>> =
+        if explicit_order_covers_projects {
+            std::borrow::Cow::Borrowed(ordered_dependencies.expect("checked as present"))
+        } else if let Some(lockfile) = lockfile {
+            std::borrow::Cow::Owned(link_dependencies_from_lockfile(
+                projects,
+                &normalized_project_dirs,
+                workspace_root,
+                lockfile,
+            ))
+        } else if let Some(ordered_dirs) = ordered_dirs {
+            return Err(InstallError::ProjectLifecycleOrder {
+                projects: normalized_project_dirs
+                    .iter()
+                    .filter(|project_dir| !ordered_dirs.contains(*project_dir))
+                    .map(|project_dir| project_dir.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            });
+        } else {
+            std::borrow::Cow::Owned(
+                normalized_project_dirs
+                    .iter()
+                    .cloned()
+                    .map(|project_dir| (project_dir, Vec::new()))
+                    .collect::<IndexMap<_, _>>(),
+            )
+        };
     let projects_by_dir = projects
         .iter()
         .map(|project| (pnpm_fs::lexical_normalize(&project.0), project))
         .collect::<HashMap<_, _>>();
+    let missing_projects = projects_outside_order(projects, &dependencies, &projects_by_dir);
+    if !missing_projects.is_empty() {
+        return Err(InstallError::ProjectLifecycleOrder { projects: missing_projects.join(", ") });
+    }
+    Ok(ProjectLifecycleGraph {
+        dependencies: retain_known_projects(&dependencies, &projects_by_dir),
+        projects_by_dir: projects_by_dir
+            .into_iter()
+            .map(|(dir, project)| (dir, project.clone()))
+            .collect(),
+    })
+}
+
+/// Each project's `link:` dependencies on the other projects, read off the
+/// lockfile's importer entries.
+fn link_dependencies_from_lockfile(
+    projects: &[(PathBuf, &PackageManifest)],
+    normalized_project_dirs: &[PathBuf],
+    workspace_root: &Path,
+    lockfile: &Lockfile,
+) -> IndexMap<PathBuf, Vec<PathBuf>> {
+    let included_set = normalized_project_dirs.iter().cloned().collect::<HashSet<_>>();
+    projects
+        .iter()
+        .zip(normalized_project_dirs)
+        .map(|((project_dir, _), normalized_project_dir)| {
+            let importer_id =
+                pnpm_workspace::importer_id_from_root_dir(workspace_root, project_dir);
+            let dependencies = lockfile
+                .importers
+                .get(&importer_id)
+                .into_iter()
+                .flat_map(|snapshot| {
+                    [DependencyGroup::Prod, DependencyGroup::Dev, DependencyGroup::Optional]
+                        .into_iter()
+                        .filter_map(|group| snapshot.get_map_by_group(group))
+                        .flat_map(|dependencies| dependencies.values())
+                })
+                .filter_map(|dependency| match &dependency.version {
+                    pnpm_lockfile::ImporterDepVersion::Link(target) => {
+                        Some(pnpm_fs::lexical_normalize(&project_dir.join(target)))
+                    }
+                    _ => None,
+                })
+                .filter(|target| included_set.contains(target))
+                .collect();
+            (normalized_project_dir.clone(), dependencies)
+        })
+        .collect()
+}
+
+/// The projects the dependency order leaves out, by display path.
+fn projects_outside_order(
+    projects: &[(PathBuf, &PackageManifest)],
+    dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,
+    projects_by_dir: &HashMap<PathBuf, &(PathBuf, &PackageManifest)>,
+) -> Vec<String> {
     let included: HashSet<PathBuf> = dependencies
         .keys()
         .map(|dir| pnpm_fs::lexical_normalize(dir))
         .filter(|dir| projects_by_dir.contains_key(dir))
         .collect();
-    let missing_projects = projects
+    projects
         .iter()
         .filter(|(project_dir, _)| !included.contains(&pnpm_fs::lexical_normalize(project_dir)))
         .map(|(project_dir, _)| project_dir.display().to_string())
-        .collect::<Vec<_>>();
-    if !missing_projects.is_empty() {
-        return Err(InstallError::ProjectLifecycleOrder { projects: missing_projects.join(", ") });
-    }
-    let dependencies = dependencies
+        .collect()
+}
+
+/// The dependency order normalized and narrowed to the projects the run
+/// knows.
+fn retain_known_projects(
+    dependencies: &IndexMap<PathBuf, Vec<PathBuf>>,
+    projects_by_dir: &HashMap<PathBuf, &(PathBuf, &PackageManifest)>,
+) -> IndexMap<PathBuf, Vec<PathBuf>> {
+    dependencies
         .iter()
         .filter_map(|(dir, project_dependencies)| {
             let dir = pnpm_fs::lexical_normalize(dir);
@@ -143,14 +175,7 @@ pub(super) fn project_lifecycle_graph<'a>(
                 )
             })
         })
-        .collect();
-    Ok(ProjectLifecycleGraph {
-        projects_by_dir: projects_by_dir
-            .into_iter()
-            .map(|(dir, project)| (dir, project.clone()))
-            .collect(),
-        dependencies,
-    })
+        .collect()
 }
 
 pub(super) fn modules_dir_basename(config: &Config) -> &std::ffi::OsStr {
@@ -248,6 +273,67 @@ pub(super) fn run_dev_preinstall<Reporter: self::Reporter>(
     .map_err(InstallError::ProjectLifecycleScript)
 }
 
+/// What every project's lifecycle run shares: the bin links come first, so
+/// a script sees its direct dependencies' bins, then the hooks run with
+/// the workspace root as `INIT_CWD`.
+struct ProjectScriptRunner<'a> {
+    config: &'a Config,
+    workspace_root: &'a Path,
+    modules_dir_basename: &'a std::ffi::OsStr,
+    scripts_prepend_node_path: ExecScriptsPrependNodePath,
+    extra_env: HashMap<String, String>,
+    link_options: pnpm_cmd_shim::LinkBinsOptions,
+}
+
+impl ProjectScriptRunner<'_> {
+    fn run<Reporter: self::Reporter>(
+        &self,
+        project_dir: &Path,
+        manifest: &PackageManifest,
+    ) -> Result<(), InstallError> {
+        let root_modules_dir = project_dir.join(self.modules_dir_basename);
+        link_project_bins(&root_modules_dir, &direct_dep_names(manifest), &self.link_options)
+            .map_err(InstallError::ProjectBinLink)?;
+        let dep_path = project_dir.to_string_lossy();
+        run_project_lifecycle_scripts::<Reporter>(&RunPostinstallHooks {
+            dep_path: &dep_path,
+            pkg_root: project_dir,
+            root_modules_dir: &root_modules_dir,
+            init_cwd: self.workspace_root,
+            extra_bin_paths: &self.config.extra_bin_paths,
+            extra_env: &self.extra_env,
+            node_execpath: None,
+            npm_execpath: None,
+            node_gyp_path: None,
+            user_agent: Some(&self.config.user_agent),
+            unsafe_perm: self.config.unsafe_perm,
+            node_gyp_bin: pnpm_executor::bundled_node_gyp_bin(),
+            scripts_prepend_node_path: self.scripts_prepend_node_path,
+            script_shell: self.config.script_shell.as_deref().map(Path::new),
+            shell_emulator: self.config.shell_emulator,
+            optional: false,
+        })
+        .map(drop)
+        .map_err(InstallError::ProjectLifecycleScript)
+    }
+}
+
+/// Every direct dependency name once, in declaration order across the groups.
+fn direct_dep_names(manifest: &PackageManifest) -> Vec<String> {
+    let mut direct_dep_names = Vec::new();
+    let mut seen = HashSet::new();
+    for (name, _) in manifest.dependencies([
+        DependencyGroup::Prod,
+        DependencyGroup::Dev,
+        DependencyGroup::Optional,
+    ]) {
+        if seen.insert(name) {
+            direct_dep_names.push(name.to_string());
+        }
+    }
+    direct_dep_names
+}
+
 /// Run workspace projects' own lifecycle scripts as soon as their dependency
 /// projects settle.
 pub(super) fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
@@ -256,48 +342,14 @@ pub(super) fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
     node_linker: NodeLinker,
     workspace_root: &Path,
 ) -> Result<(), InstallError> {
-    let modules_dir_basename = modules_dir_basename(config);
-    let scripts_prepend_node_path = exec_scripts_prepend_node_path(config);
-    let extra_env = project_lifecycle_extra_env(config, node_linker, workspace_root);
-    let link_options = crate::shim_link_options(config, node_linker);
-    let run_project =
-        |(project_dir, manifest): &(PathBuf, &PackageManifest)| -> Result<(), InstallError> {
-            let root_modules_dir = project_dir.join(modules_dir_basename);
-            let mut direct_dep_names = Vec::new();
-            let mut seen = HashSet::new();
-            for (name, _) in manifest.dependencies([
-                DependencyGroup::Prod,
-                DependencyGroup::Dev,
-                DependencyGroup::Optional,
-            ]) {
-                if seen.insert(name) {
-                    direct_dep_names.push(name.to_string());
-                }
-            }
-            link_project_bins(&root_modules_dir, &direct_dep_names, &link_options)
-                .map_err(InstallError::ProjectBinLink)?;
-            let dep_path = project_dir.to_string_lossy();
-            run_project_lifecycle_scripts::<Reporter>(&RunPostinstallHooks {
-                dep_path: &dep_path,
-                pkg_root: project_dir,
-                root_modules_dir: &root_modules_dir,
-                init_cwd: workspace_root,
-                extra_bin_paths: &config.extra_bin_paths,
-                extra_env: &extra_env,
-                node_execpath: None,
-                npm_execpath: None,
-                node_gyp_path: None,
-                user_agent: Some(&config.user_agent),
-                unsafe_perm: config.unsafe_perm,
-                node_gyp_bin: pnpm_executor::bundled_node_gyp_bin(),
-                scripts_prepend_node_path,
-                script_shell: config.script_shell.as_deref().map(Path::new),
-                shell_emulator: config.shell_emulator,
-                optional: false,
-            })
-            .map_err(InstallError::ProjectLifecycleScript)?;
-            Ok(())
-        };
+    let runner = ProjectScriptRunner {
+        config,
+        workspace_root,
+        modules_dir_basename: modules_dir_basename(config),
+        scripts_prepend_node_path: exec_scripts_prepend_node_path(config),
+        extra_env: project_lifecycle_extra_env(config, node_linker, workspace_root),
+        link_options: crate::shim_link_options(config, node_linker),
+    };
     let first_error: Mutex<Option<InstallError>> = Mutex::new(None);
     let on_node_skipped: fn(&PathBuf) = |_| {};
     let run_node = |project_dir: PathBuf| {
@@ -305,7 +357,7 @@ pub(super) fn run_projects_lifecycle_scripts<Reporter: self::Reporter>(
         if !project_requires_lifecycle_scripts(&project.0, project.1) {
             return TaskCompletion::Passed;
         }
-        match run_project(project) {
+        match runner.run::<Reporter>(&project.0, project.1) {
             Ok(()) => TaskCompletion::Passed,
             Err(error) => {
                 first_error

--- a/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
+++ b/pnpm/crates/package-manager/src/install/lockfile_freshness.rs
@@ -38,35 +38,32 @@ pub struct WantedLockfileSatisfactionCheck<'a> {
 pub async fn wanted_lockfile_satisfies_workspace(
     check: &WantedLockfileSatisfactionCheck<'_>,
 ) -> bool {
-    let WantedLockfileSatisfactionCheck {
-        config,
-        manifest,
-        catalogs,
-        lockfile,
-        ignore_manifest_check,
-    } = *check;
-    if lockfile.is_empty() {
+    if check.lockfile.is_empty() {
         return false;
     }
-    if config.config_dependencies.as_ref().is_some_and(|deps| !deps.is_empty()) {
+    if check.config.config_dependencies.as_ref().is_some_and(|deps| !deps.is_empty()) {
         return false;
     }
-    let Some(manifest_dir) = manifest.path().parent() else {
+    let Some(manifest_dir) = check.manifest.path().parent() else {
         return false;
     };
-    let Ok(workspace_dir_opt) = configured_or_discovered_workspace_dir(config, manifest_dir) else {
+    let Ok(workspace_dir_opt) = configured_or_discovered_workspace_dir(check.config, manifest_dir)
+    else {
         return false;
     };
     let workspace_root = workspace_dir_opt.clone().unwrap_or_else(|| manifest_dir.to_path_buf());
     // The importer ids below name projects relative to the directory the
-    // lockfile sits in, which `lockfileDir` can move away from the
+    // check.lockfile sits in, which `lockfileDir` can move away from the
     // workspace root — deriving them from the workspace instead would
-    // classify every importer the lockfile records as missing.
+    // classify every importer the check.lockfile records as missing.
     let lockfile_root =
-        super::lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
-    if !config.ignore_pnpmfile
-        && !pnpm_hooks::finder::find_pnpmfiles(&workspace_root, crate::pnpmfile_selection(config))
-            .is_empty()
+        super::lockfile_root_for(check.config, workspace_dir_opt.as_deref(), manifest_dir);
+    if !check.config.ignore_pnpmfile
+        && !pnpm_hooks::finder::find_pnpmfiles(
+            &workspace_root,
+            crate::pnpmfile_selection(check.config),
+        )
+        .is_empty()
     {
         return false;
     }
@@ -78,22 +75,26 @@ pub async fn wanted_lockfile_satisfies_workspace(
     else {
         return false;
     };
-    let project_manifests = build_project_manifests_list(manifest, workspace_projects.as_deref());
+    let project_manifests =
+        build_project_manifests_list(check.manifest, workspace_projects.as_deref());
     let manifest_freshness_inputs: Vec<(String, &PackageManifest)> = project_manifests
         .iter()
-        .map(|(project_dir, manifest)| {
-            (pnpm_workspace::importer_id_from_root_dir(&lockfile_root, project_dir), *manifest)
+        .map(|(project_dir, project_manifest)| {
+            (
+                pnpm_workspace::importer_id_from_root_dir(&lockfile_root, project_dir),
+                *project_manifest,
+            )
         })
         .collect();
     check_lockfile_freshness(
-        lockfile,
+        check.lockfile,
         &lockfile_root,
         &manifest_freshness_inputs,
-        config,
-        catalogs,
+        check.config,
+        check.catalogs,
         None,
         FreshnessScope {
-            ignore_manifest_check,
+            ignore_manifest_check: check.ignore_manifest_check,
             // Both stricter than the auto-frozen dispatch: the verdict
             // must imply the explicit-frozen gates pass, and a stale
             // importer needs the resolving path to prune it.

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -46,7 +46,6 @@ pub(super) struct PreparedModulesState<'install> {
         Option<super::LockfileVerificationOverride<'install>>,
 }
 
-/// What the previous install hoisted, when it left a modules record.
 pub(super) fn prior_hoisted_dependencies(
     previous_modules_metadata: Option<&Modules>,
 ) -> Option<&super::HoistedDependencies> {

--- a/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
+++ b/pnpm/crates/package-manager/src/install/prepare_modules_state.rs
@@ -58,94 +58,73 @@ pub(super) fn prior_hoisted_dependencies(
 pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + 'static>(
     inputs: PrepareModulesStateInputs<'_, 'install>,
 ) -> Result<Option<PreparedModulesState<'install>>, InstallError> {
-    let PrepareModulesStateInputs {
-        resolve_only,
-        take_frozen_path,
-        config,
-        filtered_install,
-        installs_only,
-        workspace_root,
-        included,
-        current_lockfile,
-        requested_importer_ids,
-        node_linker,
-        disable_optimistic_repeat_install,
-        lockfile,
-        supported_architectures,
-        rebuild,
-        resolution_verifiers,
-        derived_lockfile_path,
-        lockfile_verification_override,
-        lockfile_synthesized_from_current,
-        lockfile_was_fast_updated,
-        save_lockfile,
-        catalogs,
-        project_manifests,
-        effective_node_version,
-        prefix,
-    } = inputs;
-    let old_modules = read_old_modules(resolve_only, take_frozen_path, config)?;
+    let old_modules =
+        read_old_modules(inputs.resolve_only, inputs.take_frozen_path, inputs.config)?;
     let modules_manifest = old_modules.as_ref();
-    let previous_modules_metadata =
-        read_previous_modules_metadata(resolve_only, filtered_install, config)?;
-    let is_inconsistent = modules_layout_drifted(modules_manifest, config, node_linker);
+    let previous_modules_metadata = read_previous_modules_metadata(
+        inputs.resolve_only,
+        inputs.filtered_install,
+        inputs.config,
+    )?;
+    let is_inconsistent =
+        modules_layout_drifted(modules_manifest, inputs.config, inputs.node_linker);
 
-    if !resolve_only && is_inconsistent {
+    if !inputs.resolve_only && is_inconsistent {
         purge_inconsistent_modules_dir(&InconsistentModulesDir {
-            config,
-            workspace_root,
+            config: inputs.config,
+            workspace_root: inputs.workspace_root,
             modules_manifest,
-            installs_only,
-            filtered_install,
+            installs_only: inputs.installs_only,
+            filtered_install: inputs.filtered_install,
         })?;
     }
 
     prune_excluded_direct_deps(&ExcludedGroupPrune {
-        resolve_only,
+        resolve_only: inputs.resolve_only,
         is_inconsistent,
-        filtered_install,
-        config,
-        workspace_root,
-        included,
+        filtered_install: inputs.filtered_install,
+        config: inputs.config,
+        workspace_root: inputs.workspace_root,
+        included: inputs.included,
         modules_manifest,
-        current_lockfile,
-        requested_importer_ids,
+        current_lockfile: inputs.current_lockfile,
+        requested_importer_ids: inputs.requested_importer_ids,
     })?;
 
     let up_to_date = FrozenTreeUpToDate {
-        take_frozen_path,
-        filtered_install,
-        disable_optimistic_repeat_install,
-        config,
-        workspace_root,
-        node_linker,
-        included,
-        lockfile,
-        current_lockfile,
+        take_frozen_path: inputs.take_frozen_path,
+        filtered_install: inputs.filtered_install,
+        disable_optimistic_repeat_install: inputs.disable_optimistic_repeat_install,
+        config: inputs.config,
+        workspace_root: inputs.workspace_root,
+        node_linker: inputs.node_linker,
+        included: inputs.included,
+        lockfile: inputs.lockfile,
+        current_lockfile: inputs.current_lockfile,
         modules_manifest,
-        supported_architectures,
-        rebuild,
-        effective_node_version,
+        supported_architectures: inputs.supported_architectures,
+        rebuild: inputs.rebuild,
+        effective_node_version: inputs.effective_node_version,
     };
     if let Some((wanted_lockfile, modules)) = frozen_tree_up_to_date(&up_to_date) {
         report_up_to_date::<Reporter>(UpToDateInstall {
-            config,
-            workspace_root,
-            node_linker,
-            included,
+            config: inputs.config,
+            workspace_root: inputs.workspace_root,
+            node_linker: inputs.node_linker,
+            included: inputs.included,
             wanted_lockfile,
             modules,
-            supported_architectures,
-            catalogs,
-            project_manifests,
-            filtered_install,
-            prefix,
-            resolution_verifiers,
-            derived_lockfile_path,
-            lockfile_verification_override,
-            lockfile_synthesized_from_current,
-            lockfile_was_fast_updated,
-            save_lockfile,
+            supported_architectures: inputs.supported_architectures,
+            catalogs: inputs.catalogs,
+            project_manifests: inputs.project_manifests,
+            filtered_install: inputs.filtered_install,
+            prefix: inputs.prefix,
+            resolution_verifiers: inputs.resolution_verifiers,
+            derived_lockfile_path: inputs.derived_lockfile_path,
+            lockfile_verification_override: inputs.lockfile_verification_override,
+            lockfile_synthesized_from_current: inputs.lockfile_synthesized_from_current,
+            lockfile_was_fast_updated: inputs.lockfile_was_fast_updated,
+            save_lockfile: inputs.save_lockfile,
         })
         .await?;
         return Ok(None);
@@ -155,7 +134,7 @@ pub(super) async fn prepare_modules_state<'install, Reporter: self::Reporter + '
         old_modules,
         previous_modules_metadata,
         is_inconsistent,
-        lockfile_verification_override,
+        lockfile_verification_override: inputs.lockfile_verification_override,
     }))
 }
 
@@ -579,38 +558,19 @@ struct UpToDateInstall<'a, 'install> {
 async fn report_up_to_date<Reporter: self::Reporter + 'static>(
     context: UpToDateInstall<'_, '_>,
 ) -> Result<(), InstallError> {
-    let UpToDateInstall {
-        config,
-        workspace_root,
-        node_linker,
-        included,
-        wanted_lockfile,
-        modules,
-        supported_architectures,
-        catalogs,
-        project_manifests,
-        filtered_install,
-        prefix,
-        resolution_verifiers,
-        derived_lockfile_path,
-        lockfile_verification_override,
-        lockfile_synthesized_from_current,
-        lockfile_was_fast_updated,
-        save_lockfile,
-    } = context;
     // The full frozen path runs the offline structural
     // name gate before any materialization; the up-to-date
     // early return must not skip it (the resolution-verifier
     // fan-out below is policy-gated and can be empty).
-    pnpm_lockfile_verification::verify_lockfile_dependency_names(wanted_lockfile)
+    pnpm_lockfile_verification::verify_lockfile_dependency_names(context.wanted_lockfile)
         .map_err(InstallError::LockfileVerification)?;
     // Nothing to materialize means no fetch to overlap; verify
     // eagerly before the up-to-date early return.
     verify_up_to_date_lockfile::<Reporter>(
-        wanted_lockfile,
-        lockfile_verification_override,
-        resolution_verifiers,
-        (derived_lockfile_path, &config.cache_dir),
+        context.wanted_lockfile,
+        context.lockfile_verification_override,
+        context.resolution_verifiers,
+        (context.derived_lockfile_path, &context.config.cache_dir),
     )
     .await?;
     // Keep `strictDepBuilds` enforced on the up-to-date path: a
@@ -623,45 +583,50 @@ async fn report_up_to_date<Reporter: self::Reporter + 'static>(
     // `has_newly_allowed_ignored_builds` guard above returns `true`
     // on the same `from_config` error and skips this block — so a
     // bad policy is surfaced by the full install instead.
-    if config.strict_dep_builds
-        && let Ok(Some(package_names)) = unapproved_recorded_ignored_builds(modules, config)
+    if context.config.strict_dep_builds
+        && let Ok(Some(package_names)) =
+            unapproved_recorded_ignored_builds(context.modules, context.config)
     {
         return Err(InstallError::IgnoredBuilds { package_names });
     }
     Reporter::emit(&LogEvent::Pnpm(PnpmLog {
         level: LogLevel::Info,
         message: "Lockfile is up to date, resolution step is skipped".to_string(),
-        prefix: prefix.to_string(),
+        prefix: context.prefix.to_string(),
     }));
     Reporter::emit(&LogEvent::Stage(StageLog {
         level: LogLevel::Debug,
-        prefix: prefix.to_string(),
+        prefix: context.prefix.to_string(),
         stage: Stage::ImportingDone,
     }));
     save_merged_wanted_lockfile(
-        wanted_lockfile,
-        config,
-        workspace_root,
-        (lockfile_synthesized_from_current, lockfile_was_fast_updated, save_lockfile),
+        context.wanted_lockfile,
+        context.config,
+        context.workspace_root,
+        (
+            context.lockfile_synthesized_from_current,
+            context.lockfile_was_fast_updated,
+            context.save_lockfile,
+        ),
     )?;
     update_workspace_state(
-        workspace_root,
+        context.workspace_root,
         &build_workspace_state::<Host>(
-            workspace_root,
-            config,
-            node_linker,
-            included,
-            supported_architectures,
-            catalogs,
-            project_manifests,
-            filtered_install,
-            filesystem_now_ms(workspace_root),
+            context.workspace_root,
+            context.config,
+            context.node_linker,
+            context.included,
+            context.supported_architectures,
+            context.catalogs,
+            context.project_manifests,
+            context.filtered_install,
+            filesystem_now_ms(context.workspace_root),
         ),
     )
     .map_err(InstallError::WriteWorkspaceState)?;
     Reporter::emit(&LogEvent::Summary(SummaryLog {
         level: LogLevel::Debug,
-        prefix: prefix.to_string(),
+        prefix: context.prefix.to_string(),
     }));
     Ok(())
 }

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -376,11 +376,7 @@ impl RunMode {
                 .unwrap_or(install.config.prefer_frozen_lockfile),
             // The same set the dependency-graph walker observes, written to
             // `.modules.yaml` as `included`.
-            included: IncludedDependencies {
-                dependencies: owned.dependency_groups.contains(&DependencyGroup::Prod),
-                dev_dependencies: owned.dependency_groups.contains(&DependencyGroup::Dev),
-                optional_dependencies: owned.dependency_groups.contains(&DependencyGroup::Optional),
-            },
+            included: super::included_dependencies(&owned.dependency_groups),
             can_prompt: options.prompt_eligibility_override.unwrap_or_else(prompts_are_answerable),
             peer_issues_sink_is_none: owned.peer_issues_sink.is_none(),
             effective_node_version: super::effective_node_version(install.config, install.manifest),

--- a/pnpm/crates/package-manager/src/install/run.rs
+++ b/pnpm/crates/package-manager/src/install/run.rs
@@ -758,14 +758,7 @@ async fn load_lockfiles<'a, Reporter: self::Reporter + 'static>(
     // Spawn the installability host detection (`node --version`,
     // ~150 ms of node startup) as soon as the wanted lockfile is
     // parsed, so the probe overlaps planning on the frozen path and
-    // the whole resolution on the fresh path. A constraint-free
-    // lockfile spawns nothing — the probe's result would go unused
-    // (see `detect_installability_host` for why that matters) —
-    // and neither does `--force` (skips the checks) or a
-    // resolve-only pass (returns before them). The scan is of the
-    // *wanted* lockfile: a fresh resolve whose new graph gains
-    // constraints the old lockfile lacked just detects the host at
-    // its own site, as before.
+    // the whole resolution on the fresh path.
     let early_host_detection =
         needs_early_host_detection(install.config, mode.resolve_only, wanted.lockfile).then(|| {
             pnpm_deps_restorer::materialization_plan::HostDetection::spawn(
@@ -1756,8 +1749,8 @@ fn load_wanted_lockfile<'a, Reporter: self::Reporter>(
 /// unused (see `detect_installability_host` for why that matters) — and
 /// neither does `--force` (skips the checks) or a resolve-only pass (returns
 /// before them). The scan is of the *wanted* lockfile: a fresh resolve whose
-/// new graph gains constraints the old lockfile lacked just detects the host
-/// at its own site, as before.
+/// new graph gains constraints the old lockfile lacked detects the host at
+/// its own site.
 fn needs_early_host_detection(
     config: &Config,
     resolve_only: bool,

--- a/pnpm/crates/package-manager/src/install/workspace_state.rs
+++ b/pnpm/crates/package-manager/src/install/workspace_state.rs
@@ -45,20 +45,9 @@ pub struct UpToDateWorkspace {
 /// established error shape.
 #[must_use]
 pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<UpToDateWorkspace> {
-    let UpToDateFastPathCheck {
-        config,
-        manifest,
-        dependency_groups,
-        node_linker,
-        supported_architectures,
-    } = check;
-    let included = IncludedDependencies {
-        dependencies: dependency_groups.contains(&DependencyGroup::Prod),
-        dev_dependencies: dependency_groups.contains(&DependencyGroup::Dev),
-        optional_dependencies: dependency_groups.contains(&DependencyGroup::Optional),
-    };
-    let manifest_dir = manifest.path().parent()?;
-    let workspace_dir_opt = configured_or_discovered_workspace_dir(config, manifest_dir).ok()?;
+    let manifest_dir = check.manifest.path().parent()?;
+    let workspace_dir_opt =
+        configured_or_discovered_workspace_dir(check.config, manifest_dir).ok()?;
     let workspace_root = workspace_dir_opt.clone().unwrap_or_else(|| manifest_dir.to_path_buf());
     let workspace_manifest = workspace_dir_opt
         .as_deref()
@@ -66,48 +55,47 @@ pub fn install_already_up_to_date(check: &UpToDateFastPathCheck<'_>) -> Option<U
         .transpose()
         .ok()?
         .flatten();
-    let catalogs = match config.catalogs.clone() {
+    let catalogs = match check.config.catalogs.clone() {
         Some(catalogs) => catalogs,
         None => get_catalogs_from_workspace_manifest(workspace_manifest.as_ref()).ok()?,
     };
     let workspace_projects =
         load_workspace_projects(&workspace_root, workspace_manifest.as_ref()).ok()?;
-    let project_manifests = build_project_manifests_list(manifest, workspace_projects.as_deref());
+    let project_manifests =
+        build_project_manifests_list(check.manifest, workspace_projects.as_deref());
     // The lockfile the install wrote sits at its `lockfileDir`, which
     // both `sharedWorkspaceLockfile: false` and an explicit pin move away
     // from the discovered workspace root. The workspace *state* keeps its
     // own root, which only a pin moves — `state_root` below.
-    let lockfile_root = lockfile_root_for(config, workspace_dir_opt.as_deref(), manifest_dir);
-    let state_root = config.lockfile_dir.clone().unwrap_or_else(|| workspace_root.clone());
-    let lockfile = lazy_wanted_lockfile(config, &lockfile_root);
-    if strict_dep_builds_blocks_fast_path(config) {
+    let lockfile_root = lockfile_root_for(check.config, workspace_dir_opt.as_deref(), manifest_dir);
+    let state_root = check.config.lockfile_dir.clone().unwrap_or_else(|| workspace_root.clone());
+    let lockfile = lazy_wanted_lockfile(check.config, &lockfile_root);
+    if strict_dep_builds_blocks_fast_path(check.config) {
         return None;
     }
-    let up_to_date = check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
+    if check_optimistic_repeat_install(&OptimisticRepeatInstallCheck {
         workspace_root: &state_root,
-        config,
-        node_linker: *node_linker,
-        included,
-        supported_architectures: supported_architectures.as_ref(),
+        config: check.config,
+        node_linker: check.node_linker,
+        included: super::included_dependencies(&check.dependency_groups),
+        supported_architectures: check.supported_architectures.as_ref(),
         project_manifests: &project_manifests,
         is_workspace_install: workspace_manifest.is_some(),
         lockfile: MaybeLazyLockfile::Lazy(&lockfile),
         catalogs: &catalogs,
-    }) == OptimisticRepeatInstallDecision::UpToDate;
-    if !up_to_date {
+    }) != OptimisticRepeatInstallDecision::UpToDate
+    {
         return None;
     }
-    if gvs_build_markers_may_require_recovery(config) {
-        let wanted = lockfile.get().ok().flatten()?;
-        let effective_node_version = super::effective_node_version(config, manifest);
-        if gvs_build_marker_present(
-            wanted,
-            config,
+    if gvs_build_markers_may_require_recovery(check.config)
+        && gvs_build_marker_present(
+            lockfile.get().ok().flatten()?,
+            check.config,
             &lockfile_root,
-            effective_node_version.as_deref(),
-        ) {
-            return None;
-        }
+            super::effective_node_version(check.config, check.manifest).as_deref(),
+        )
+    {
+        return None;
     }
     Some(UpToDateWorkspace {
         root: state_root,
@@ -153,14 +141,16 @@ pub fn check_deps_status_before_run_at(
     // per-project lockfiles give every project its own lockfile, state
     // and single-importer list, so the gate reads the manifest of the
     // project the command runs in.
-    let shares_one_lockfile = config.shares_one_lockfile();
-    let manifest_dir = if shares_one_lockfile { workspace_root.as_path() } else { dir };
-    let manifest =
-        match read_gate_manifest(manifest_dir, workspace_dir_opt.is_some(), shares_one_lockfile) {
-            GateManifest::Found(manifest) => manifest,
-            GateManifest::NoManifest => return None,
-            GateManifest::Unreadable => return cannot_check(),
-        };
+    let manifest_dir = if config.shares_one_lockfile() { workspace_root.as_path() } else { dir };
+    let manifest = match read_gate_manifest(
+        manifest_dir,
+        workspace_dir_opt.is_some(),
+        config.shares_one_lockfile(),
+    ) {
+        GateManifest::Found(manifest) => manifest,
+        GateManifest::NoManifest => return None,
+        GateManifest::Unreadable => return cannot_check(),
+    };
     let Ok(workspace_manifest) =
         workspace_dir_opt.as_deref().map(pnpm_workspace::read_workspace_manifest).transpose()
     else {
@@ -185,7 +175,8 @@ pub fn check_deps_status_before_run_at(
     // The sibling projects only belong in the comparison when one
     // lockfile and one state file cover them all; a dedicated-lockfile
     // install records this project alone.
-    let Ok(workspace_projects) = shares_one_lockfile
+    let Ok(workspace_projects) = config
+        .shares_one_lockfile()
         .then(|| load_workspace_projects(&workspace_root, workspace_manifest.as_ref()))
         .transpose()
     else {
@@ -193,7 +184,6 @@ pub fn check_deps_status_before_run_at(
     };
     let workspace_projects = workspace_projects.flatten();
     let project_manifests = build_project_manifests_list(&manifest, workspace_projects.as_deref());
-    let lockfile = lazy_wanted_lockfile(config, &lockfile_root);
     Some(crate::check_deps_status_before_run(
         &OptimisticRepeatInstallCheck {
             workspace_root: &lockfile_root,
@@ -210,7 +200,7 @@ pub fn check_deps_status_before_run_at(
             },
             project_manifests: &project_manifests,
             is_workspace_install: workspace_manifest.is_some(),
-            lockfile: MaybeLazyLockfile::Lazy(&lockfile),
+            lockfile: MaybeLazyLockfile::Lazy(&lazy_wanted_lockfile(config, &lockfile_root)),
             catalogs: &catalogs,
         },
         &workspace_state,
@@ -345,42 +335,35 @@ pub(super) struct ProjectScriptsInputs<'a, 'manifest> {
 pub(super) fn projects_running_own_scripts<'manifest>(
     inputs: &ProjectScriptsInputs<'_, 'manifest>,
 ) -> Vec<(PathBuf, &'manifest PackageManifest)> {
-    let ProjectScriptsInputs {
-        mutation,
-        workspace_root,
-        active_project_dir,
-        selected_dirs,
-        project_manifests,
-        materialized_project_manifests,
-    } = *inputs;
-    let full_install = match mutation {
+    let full_install = match inputs.mutation {
         ProjectMutation::NoInstall | ProjectMutation::UninstallSome => return Vec::new(),
-        ProjectMutation::InstallWorkspace => return materialized_project_manifests.to_vec(),
+        ProjectMutation::InstallWorkspace => return inputs.materialized_project_manifests.to_vec(),
         ProjectMutation::InstallSelected => true,
         ProjectMutation::InstallSome => false,
     };
-    let mutated_dirs = match selected_dirs {
+    let mutated_dirs = match inputs.selected_dirs {
         Some(selected_dirs) => {
             selected_dirs.iter().map(|dir| pnpm_fs::lexical_normalize(dir)).collect()
         }
-        None => HashSet::from([pnpm_fs::lexical_normalize(active_project_dir)]),
+        None => HashSet::from([pnpm_fs::lexical_normalize(inputs.active_project_dir)]),
     };
     // pnpm's recursive dispatch pushes the workspace root into the
     // mutated importers as a plain `mutation: 'install'` whenever the
     // selection leaves it out, so the root installs in full — and runs
     // its own scripts — even when the command was pointed elsewhere.
-    let workspace_root = pnpm_fs::lexical_normalize(workspace_root);
+    let workspace_root = pnpm_fs::lexical_normalize(inputs.workspace_root);
     let root_was_pushed_in = !mutated_dirs.contains(&workspace_root);
     let is_pushed_root = |project_dir: &Path| root_was_pushed_in && project_dir == workspace_root;
     // A run that mutates only part of the workspace materializes the rest
     // from the lockfile alone; pnpm runs the scripts of everything it did
-    // mutate, whatever the mutation. Only when the mutated set covers the
-    // whole workspace does the `mutation === 'install'` filter decide.
-    let covers_workspace = project_manifests.iter().all(|(project_dir, _)| {
+    // mutate, whatever the inputs.mutation. Only when the mutated set covers the
+    // whole workspace does the `inputs.mutation === 'install'` filter decide.
+    let covers_workspace = inputs.project_manifests.iter().all(|(project_dir, _)| {
         let project_dir = pnpm_fs::lexical_normalize(project_dir);
         mutated_dirs.contains(&project_dir) || is_pushed_root(&project_dir)
     });
-    materialized_project_manifests
+    inputs
+        .materialized_project_manifests
         .iter()
         .filter(|(project_dir, _)| {
             let project_dir = pnpm_fs::lexical_normalize(project_dir);

--- a/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
+++ b/pnpm/crates/package-manager/src/install_with_fresh_lockfile.rs
@@ -1586,7 +1586,7 @@ impl UpdateReuseScopes {
 /// Runs between the resolvers being built and the resolve pass, in the
 /// order pnpm's install applies these: the pnpmfile's pre-resolution hook
 /// fires once the lockfile to resolve against is fixed, and a custom
-/// resolver may still widen the reuse scopes after that.
+/// resolver may still drop every reuse scope after that.
 async fn prepare_resolution<'a, Reporter: self::Reporter + 'static>(
     install: FreshInputs<'a>,
     owned: &mut OwnedInputs,

--- a/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
+++ b/pnpm/crates/package-manager/src/manifest_spec_bumps.rs
@@ -128,21 +128,27 @@ fn collect_importer_bumps(
                 manifest_specifier,
                 range_spec_style: bumps.range_spec_style,
             };
-            match spec_bump(&target) {
-                SpecBump::Skip => {}
-                SpecBump::Cataloged { catalog_name, alias } => {
-                    cataloged.insert((catalog_name, alias));
-                }
-                SpecBump::Manifest { alias, group, bumped } => {
-                    manifests
-                        .entry(importer_id.clone())
-                        .or_default()
-                        .insert(alias, (group, bumped));
-                }
-            }
+            record_spec_bump(&mut manifests, &mut cataloged, importer_id, spec_bump(&target));
         }
     }
     (manifests, cataloged)
+}
+
+fn record_spec_bump(
+    manifests: &mut ImporterBumps,
+    cataloged: &mut HashSet<(String, PkgName)>,
+    importer_id: &str,
+    bump: SpecBump,
+) {
+    match bump {
+        SpecBump::Skip => {}
+        SpecBump::Cataloged { catalog_name, alias } => {
+            cataloged.insert((catalog_name, alias));
+        }
+        SpecBump::Manifest { alias, group, bumped } => {
+            manifests.entry(importer_id.to_string()).or_default().insert(alias, (group, bumped));
+        }
+    }
 }
 
 /// Per importer id, the bumped range of each declaration and the group it is

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install.rs
@@ -169,55 +169,45 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
     check: &OptimisticRepeatInstallCheck<'_>,
     ignored_workspace_state_settings: &[&str],
 ) -> Decision {
-    let &OptimisticRepeatInstallCheck { workspace_root, config, is_workspace_install, .. } = check;
-    if let Some(reason) = config_blocks_fast_path(config) {
+    if let Some(reason) = config_blocks_fast_path(check.config) {
         return Decision::Skipped { reason };
     }
     // No workspace state means no previous install has completed
     // (or the file was deleted) — there's no `lastValidatedTimestamp`
     // to compare against.
-    let Ok(Some(state)) = load_workspace_state(workspace_root) else {
+    let Ok(Some(state)) = load_workspace_state(check.workspace_root) else {
         return Decision::Skipped { reason: "no workspace state on disk" };
     };
     if let Some(reason) = state_blocks_fast_path(check, &state, ignored_workspace_state_settings) {
         return Decision::Skipped { reason };
     }
-
     // The fast-path conclusion: walk every manifest and report up to
     // date when none have an mtime newer than
     // `workspaceState.lastValidatedTimestamp`. The walk has to
     // succeed (read errors mean we can't *prove* freshness, so fall
     // through).
-    let Some(manifest_stats) = stat_manifests(check.project_manifests) else {
+    let Some(drift) = ManifestDrift::stat(check, &state) else {
         return Decision::Skipped { reason: "failed to stat a project manifest" };
     };
-    let modified: Vec<&ManifestStat<'_>> = manifest_stats
-        .iter()
-        .filter(|stat| modified_at_or_after(stat.mtime, state.last_validated_timestamp))
-        .collect();
-
-    // A lockfile-only change — `git checkout`/stash-restore of just
-    // `pnpm-lock.yaml`, or an external rewrite — leaves every manifest
-    // untouched but still invalidates the install. Probe the wanted
-    // lockfile's mtime before the manifest-mtime exit so a lockfile
-    // modification is not missed.
-    let lockfile_modified =
-        wanted_lockfile_modified(workspace_root, config, state.last_validated_timestamp);
-    if let Some(decision) = early_repeat_verdict(check, &modified, lockfile_modified) {
+    let modified = drift.modified(&state);
+    if let Some(decision) = early_repeat_verdict(check, &modified, drift.lockfile_modified) {
         return decision;
     }
-
     // A newer mtime alone doesn't invalidate: the modified-manifests
     // branch re-checks the *content* against the wanted lockfile so a
     // rewrite that left the dependency fields intact — `touch`, a
     // `scripts` edit, `npm pkg set/delete` — still reports up to date.
     // When only the lockfile changed, every project is validated rather
     // than just the modified ones.
-    let projects_to_check: Vec<&ManifestStat<'_>> =
-        if lockfile_modified { manifest_stats.iter().collect() } else { modified };
-    let filesystem_now = is_workspace_install.then(|| filesystem_now_ms(workspace_root)).flatten();
-    match modified_manifests_match_lockfile(check, &state, &projects_to_check, config.dedupe_peers)
-    {
+    let projects_to_check = drift.projects_to_check(modified);
+    let filesystem_now =
+        check.is_workspace_install.then(|| filesystem_now_ms(check.workspace_root)).flatten();
+    match modified_manifests_match_lockfile(
+        check,
+        &state,
+        &projects_to_check,
+        check.config.dedupe_peers,
+    ) {
         Ok(loaded_current) => {
             match settle_repeat_install(check, &state, loaded_current, filesystem_now) {
                 Ok(()) => Decision::UpToDate,
@@ -225,6 +215,52 @@ pub(crate) fn check_optimistic_repeat_install_ignoring(
             }
         }
         Err(reason) => Decision::Skipped { reason },
+    }
+}
+
+/// Every project manifest's mtime against the last validation, and
+/// whether the wanted lockfile itself moved since.
+pub(crate) struct ManifestDrift<'a> {
+    stats: Vec<ManifestStat<'a>>,
+    //// A lockfile-only change — `git checkout`/stash-restore of just
+    //// `pnpm-lock.yaml`, or an external rewrite — leaves every manifest
+    //// untouched but still invalidates the install. Probe the wanted
+    //// lockfile's mtime before the manifest-mtime exit so a lockfile
+    //// modification is not missed.
+    pub(crate) lockfile_modified: bool,
+}
+
+impl<'a> ManifestDrift<'a> {
+    /// `None` when a manifest cannot be stat'd, which leaves freshness
+    /// unprovable.
+    pub(crate) fn stat(
+        check: &OptimisticRepeatInstallCheck<'a>,
+        state: &WorkspaceState,
+    ) -> Option<Self> {
+        Some(Self {
+            stats: stat_manifests(check.project_manifests)?,
+            lockfile_modified: wanted_lockfile_modified(
+                check.workspace_root,
+                check.config,
+                state.last_validated_timestamp,
+            ),
+        })
+    }
+
+    pub(crate) fn modified(&self, state: &WorkspaceState) -> Vec<&ManifestStat<'a>> {
+        self.stats
+            .iter()
+            .filter(|stat| modified_at_or_after(stat.mtime, state.last_validated_timestamp))
+            .collect()
+    }
+
+    /// The projects the content check covers: every one when the lockfile
+    /// itself changed, else the modified ones.
+    pub(crate) fn projects_to_check<'s>(
+        &'s self,
+        modified: Vec<&'s ManifestStat<'a>>,
+    ) -> Vec<&'s ManifestStat<'a>> {
+        if self.lockfile_modified { self.stats.iter().collect() } else { modified }
     }
 }
 

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/deps_status.rs
@@ -5,9 +5,8 @@ use super::{
     OptimisticRepeatInstallCheck, WorkspaceState, catalogs_cache_matches,
     current_lockfile_file_has_content, current_lockfile_unusable_with_non_empty_wanted,
     filesystem_now_ms, first_lockfile_requiring_conflict_safe_install,
-    first_project_missing_modules_dir, first_setting_drift, modified_at_or_after,
-    modified_manifests_match_lockfile, patches_modified_since, pnpmfiles_drift,
-    project_structure_matches, stat_manifests, update_workspace_state, wanted_lockfile_modified,
+    first_project_missing_modules_dir, first_setting_drift, modified_manifests_match_lockfile,
+    patches_modified_since, pnpmfiles_drift, project_structure_matches, update_workspace_state,
 };
 
 /// Outcome of [`check_deps_status_before_run`].
@@ -45,36 +44,30 @@ pub fn check_deps_status_before_run(
     check: &OptimisticRepeatInstallCheck<'_>,
     state: &WorkspaceState,
 ) -> RunDepsStatus {
-    let &OptimisticRepeatInstallCheck { workspace_root, config, node_linker, .. } = check;
-
     let install_args = install_args_from_state(state);
     let outdated =
         |issue: String| RunDepsStatus::Outdated { issue, install_args: install_args.clone() };
 
-    if node_linker == NodeLinker::Pnp {
+    if check.node_linker == NodeLinker::Pnp {
         return RunDepsStatus::SkippedPnp;
     }
     if let Some(issue) = first_static_drift(check, state) {
         return outdated(issue);
     }
 
-    let Some(manifest_stats) = stat_manifests(check.project_manifests) else {
+    let Some(drift) = super::ManifestDrift::stat(check, state) else {
         return outdated("Cannot check whether dependencies are outdated".to_string());
     };
-    let modified: Vec<&ManifestStat<'_>> = manifest_stats
-        .iter()
-        .filter(|stat| modified_at_or_after(stat.mtime, state.last_validated_timestamp))
-        .collect();
-    let lockfile_modified =
-        wanted_lockfile_modified(workspace_root, config, state.last_validated_timestamp);
-    if let Some(status) = early_content_verdict(check, &modified, lockfile_modified, &outdated) {
+    let modified = drift.modified(state);
+    if let Some(status) =
+        early_content_verdict(check, &modified, drift.lockfile_modified, &outdated)
+    {
         return status;
     }
 
-    let projects_to_check: Vec<&ManifestStat<'_>> =
-        if lockfile_modified { manifest_stats.iter().collect() } else { modified };
+    let projects_to_check = drift.projects_to_check(modified);
     let filesystem_now =
-        check.is_workspace_install.then(|| filesystem_now_ms(workspace_root)).flatten();
+        check.is_workspace_install.then(|| filesystem_now_ms(check.workspace_root)).flatten();
     // The TypeScript run/exec handler does not forward `dedupePeers`
     // into `checkDepsStatus`, so its pre-run lockfile check uses the
     // false default even when the workspace setting is true.

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
@@ -172,24 +172,10 @@ fn local_tarball_requires_install(
     dependency: &LocalTarballDependency,
 ) -> bool {
     let importer_id = importer_id_from_root_dir(workspace_root, &dependency.project_dir);
-    let Some(importer) = lockfile.importers.get(&importer_id) else { return true };
-    let Ok(alias) = PkgName::parse(&dependency.alias) else { return true };
-    let Some(resolved) = importer
-        .get_map_by_group(dependency.group)
-        .and_then(|dependencies| dependencies.get(&alias))
-    else {
-        return true;
-    };
-    let Some(package_key) = resolved.version.resolved_key(&alias).map(|key| key.without_peer())
-    else {
-        return dependency.must_be_local;
-    };
-    let Some(metadata) = lockfile.packages.as_ref().and_then(|packages| packages.get(&package_key))
-    else {
-        return true;
-    };
-    let LockfileResolution::Tarball(resolution) = &metadata.resolution else {
-        return dependency.must_be_local;
+    let resolution = match recorded_tarball(lockfile, &importer_id, dependency) {
+        RecordedTarball::Missing => return true,
+        RecordedTarball::NotATarball => return dependency.must_be_local,
+        RecordedTarball::Tarball(resolution) => resolution,
     };
     if !resolution.tarball.starts_with("file:") {
         return dependency.must_be_local;
@@ -205,6 +191,45 @@ fn local_tarball_requires_install(
         return true;
     };
     !file_matches_integrity(&recorded_path, integrity)
+}
+
+/// What the lockfile records for a local tarball dependency.
+enum RecordedTarball<'l> {
+    /// No importer, alias or package entry: the dependency was never
+    /// installed.
+    Missing,
+    /// Recorded, but not as a tarball.
+    NotATarball,
+    Tarball(&'l pnpm_lockfile::TarballResolution),
+}
+
+fn recorded_tarball<'l>(
+    lockfile: &'l Lockfile,
+    importer_id: &str,
+    dependency: &LocalTarballDependency,
+) -> RecordedTarball<'l> {
+    let Some(importer) = lockfile.importers.get(importer_id) else {
+        return RecordedTarball::Missing;
+    };
+    let Ok(alias) = PkgName::parse(&dependency.alias) else { return RecordedTarball::Missing };
+    let Some(resolved) = importer
+        .get_map_by_group(dependency.group)
+        .and_then(|dependencies| dependencies.get(&alias))
+    else {
+        return RecordedTarball::Missing;
+    };
+    let Some(package_key) = resolved.version.resolved_key(&alias).map(|key| key.without_peer())
+    else {
+        return RecordedTarball::NotATarball;
+    };
+    let Some(metadata) = lockfile.packages.as_ref().and_then(|packages| packages.get(&package_key))
+    else {
+        return RecordedTarball::Missing;
+    };
+    match &metadata.resolution {
+        LockfileResolution::Tarball(resolution) => RecordedTarball::Tarball(resolution),
+        _ => RecordedTarball::NotATarball,
+    }
 }
 
 fn file_matches_integrity(path: &Path, integrity: &Integrity) -> bool {

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/local_file_deps.rs
@@ -198,7 +198,6 @@ enum RecordedTarball<'l> {
     /// No importer, alias or package entry: the dependency was never
     /// installed.
     Missing,
-    /// Recorded, but not as a tarball.
     NotATarball,
     Tarball(&'l pnpm_lockfile::TarballResolution),
 }

--- a/pnpm/crates/package-manager/src/optimistic_repeat_install/manifest_agreement.rs
+++ b/pnpm/crates/package-manager/src/optimistic_repeat_install/manifest_agreement.rs
@@ -31,32 +31,28 @@ pub(crate) fn modified_manifests_match_lockfile(
     modified: &[&ManifestStat<'_>],
     dedupe_peers: bool,
 ) -> Result<Option<Lockfile>, &'static str> {
-    let &OptimisticRepeatInstallCheck {
-        workspace_root,
-        config,
-        project_manifests,
-        lockfile,
-        catalogs,
-        ..
-    } = check;
     let mut loaded_current: Option<Lockfile> = None;
     let mut wanted_is_current = false;
-    let lockfile = lockfile.get().map_err(|_| "the wanted lockfile cannot be read or parsed")?;
+    let lockfile =
+        check.lockfile.get().map_err(|_| "the wanted lockfile cannot be read or parsed")?;
     let (wanted, wanted_mtime): (&Lockfile, FileMtime) = if let Some(wanted) = lockfile {
-        let Some(mtime) = file_mtime(&workspace_root.join(config.wanted_lockfile_name())) else {
+        let Some(mtime) =
+            file_mtime(&check.workspace_root.join(check.config.wanted_lockfile_name()))
+        else {
             return Err(
                 "a manifest is newer than the last validation and the wanted lockfile cannot be stat'd",
             );
         };
         (wanted, mtime)
     } else {
-        let current_path = config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
+        let current_path = check.config.virtual_store_dir.join(Lockfile::CURRENT_FILE_NAME);
         let Some(mtime) = file_mtime(&current_path) else {
             return Err("a manifest is newer than the last validation and no lockfile is loaded");
         };
-        let current = Lockfile::load_current_from_virtual_store_dir(&config.virtual_store_dir)
-            .map_err(|_| "the current lockfile cannot be loaded")?
-            .ok_or("a manifest is newer than the last validation and no lockfile is loaded")?;
+        let current =
+            Lockfile::load_current_from_virtual_store_dir(&check.config.virtual_store_dir)
+                .map_err(|_| "the current lockfile cannot be loaded")?
+                .ok_or("a manifest is newer than the last validation and no lockfile is loaded")?;
         wanted_is_current = true;
         (&*loaded_current.insert(current), mtime)
     };
@@ -67,17 +63,26 @@ pub(crate) fn modified_manifests_match_lockfile(
         modified,
         &WantedLockfileStat { wanted, mtime: wanted_mtime, is_current: wanted_is_current },
     )?;
-
-    if to_check.is_empty() {
-        return Ok(loaded_current);
+    if !to_check.is_empty() {
+        check_projects_content(check, wanted, to_check, dedupe_peers)?;
     }
+    Ok(loaded_current)
+}
 
-    let parsed_overrides = crate::install::parse_config_overrides(config, catalogs)
+/// The full content check of the modified projects against the wanted
+/// lockfile, once its settings are known not to have drifted.
+fn check_projects_content(
+    check: &OptimisticRepeatInstallCheck<'_>,
+    wanted: &Lockfile,
+    to_check: &[&ManifestStat<'_>],
+    dedupe_peers: bool,
+) -> Result<(), &'static str> {
+    let parsed_overrides = crate::install::parse_config_overrides(check.config, check.catalogs)
         .map_err(|_| "pnpm.overrides cannot be parsed")?;
     if let Err(error) = crate::install::check_lockfile_settings_drift(
         wanted,
-        config,
-        catalogs,
+        check.config,
+        check.catalogs,
         crate::install::CheckLockfileSettingsDriftOptions {
             parsed_overrides: parsed_overrides.as_deref(),
             // `pnpmfileChecksum` needs no comparison here: reaching this
@@ -93,13 +98,13 @@ pub(crate) fn modified_manifests_match_lockfile(
         return Err("a lockfile setting drifted from the current configuration");
     }
 
-    let linked_ctx = LinkedPackagesContext::new(config, project_manifests);
+    let linked_ctx = LinkedPackagesContext::new(check.config, check.project_manifests);
     let ignored_optional_matcher = pnpm_config::matcher::create_matcher(
-        config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
+        check.config.ignored_optional_dependencies.as_deref().unwrap_or_default(),
     );
     let content_check = ProjectContentCheck {
-        workspace_root,
-        config,
+        workspace_root: check.workspace_root,
+        config: check.config,
         wanted,
         linked_ctx: &linked_ctx,
         ignored_optional_matcher: &ignored_optional_matcher,
@@ -108,7 +113,7 @@ pub(crate) fn modified_manifests_match_lockfile(
     for project in to_check {
         project_content_check(&content_check, project)?;
     }
-    Ok(loaded_current)
+    Ok(())
 }
 
 /// The lockfile the content check compares against, and how it was found.

--- a/pnpm/crates/package-manager/src/patch.rs
+++ b/pnpm/crates/package-manager/src/patch.rs
@@ -118,22 +118,7 @@ pub fn patch_candidates_from_lockfile(
     let alias = parsed.alias.clone().unwrap_or_else(|| raw_dependency.to_string());
     let bare_specifier = parsed.bare_specifier.clone();
 
-    let mut versions = Vec::new();
-    let mut seen = BTreeSet::new();
-    for (key, metadata) in current_lockfile.packages.as_ref().into_iter().flatten() {
-        let package_key = key.without_peer();
-        let name = package_key.name.to_string();
-        if name != package_name {
-            continue;
-        }
-        let version =
-            metadata.version.clone().unwrap_or_else(|| package_key.suffix.version().to_string());
-        let git_tarball_url = git_tarball_url(&metadata.resolution);
-        if seen.insert((name.clone(), version.clone(), git_tarball_url.clone())) {
-            versions.push(PatchCandidate { name, version, git_tarball_url, package_key });
-        }
-    }
-    versions.sort_by(compare_candidates);
+    let versions = lockfile_candidates(current_lockfile, package_name);
 
     let preferred_versions = match bare_specifier.as_deref() {
         Some(specifier) => versions
@@ -160,6 +145,28 @@ pub fn patch_candidates_from_lockfile(
     })
 }
 
+/// Every version of `package_name` the lockfile holds, each once, in
+/// version order.
+fn lockfile_candidates(current_lockfile: &Lockfile, package_name: &str) -> Vec<PatchCandidate> {
+    let mut versions = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (key, metadata) in current_lockfile.packages.as_ref().into_iter().flatten() {
+        let package_key = key.without_peer();
+        let name = package_key.name.to_string();
+        if name != package_name {
+            continue;
+        }
+        let version =
+            metadata.version.clone().unwrap_or_else(|| package_key.suffix.version().to_string());
+        let git_tarball_url = git_tarball_url(&metadata.resolution);
+        if seen.insert((name.clone(), version.clone(), git_tarball_url.clone())) {
+            versions.push(PatchCandidate { name, version, git_tarball_url, package_key });
+        }
+    }
+    versions.sort_by(compare_candidates);
+    versions
+}
+
 #[must_use]
 pub fn default_patch_target(set: &PatchCandidateSet) -> Option<PatchTarget> {
     if set.preferred_versions.len() != 1 {
@@ -180,21 +187,14 @@ pub fn default_patch_target(set: &PatchCandidateSet) -> Option<PatchTarget> {
 
 impl WritePackageForPatch<'_> {
     pub async fn run<Reporter: self::Reporter>(self) -> Result<(), WritePackageForPatchError> {
-        let WritePackageForPatch {
-            tarball_mem_cache,
-            http_client,
-            config,
-            current_lockfile,
-            target,
-            dest,
-        } = self;
-        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        let metadata = current_lockfile
+        self.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+        let metadata = self
+            .current_lockfile
             .packages
             .as_ref()
-            .and_then(|packages| packages.get(&target.package_key))
+            .and_then(|packages| packages.get(&self.target.package_key))
             .ok_or_else(|| WritePackageForPatchError::MissingPackageMetadata {
-                package_key: target.package_key.to_string(),
+                package_key: self.target.package_key.to_string(),
             })?;
 
         if !matches!(
@@ -202,92 +202,63 @@ impl WritePackageForPatch<'_> {
             LockfileResolution::Registry(_) | LockfileResolution::Tarball(_),
         ) {
             return Err(WritePackageForPatchError::UnsupportedResolution {
-                package: format!("{}@{}", target.alias, target.version),
+                package: format!("{}@{}", self.target.alias, self.target.version),
                 resolution_kind: resolution_kind(&metadata.resolution),
             });
         }
 
         let (tarball_url, integrity) =
-            tarball_url_and_integrity(&metadata.resolution, &target.package_key, config)
+            tarball_url_and_integrity(&metadata.resolution, &self.target.package_key, self.config)
                 .map_err(WritePackageForPatchError::TarballResolution)?;
-        let package_id = target.package_key.pkg_id();
+        let package_id = self.target.package_key.pkg_id();
 
-        validate_patch_destination(dest)?;
+        validate_patch_destination(self.dest)?;
 
-        let store_index = StoreIndex::open_shared(&config.store_dir, config.frozen_store).await;
+        let store_index =
+            StoreIndex::open_shared(&self.config.store_dir, self.config.frozen_store).await;
         let (store_index_writer, writer_task) =
-            StoreIndexWriter::spawn_for(&config.store_dir, config.frozen_store);
-        let verified_files_cache = SharedVerifiedFilesCache::default();
+            StoreIndexWriter::spawn_for(&self.config.store_dir, self.config.frozen_store);
 
         let result = async {
             let cas_paths = IngestTarballToStore {
-                http_client,
-                store_dir: &config.store_dir,
+                http_client: self.http_client,
+                store_dir: &self.config.store_dir,
                 store_index: store_index.clone(),
                 store_index_writer: Some(Arc::clone(&store_index_writer)),
-                verify_store_integrity: config.verify_store_integrity,
-                strict_store_pkg_content_check: config.strict_store_pkg_content_check,
-                verified_files_cache: SharedVerifiedFilesCache::clone(&verified_files_cache),
+                verify_store_integrity: self.config.verify_store_integrity,
+                strict_store_pkg_content_check: self.config.strict_store_pkg_content_check,
+                verified_files_cache: SharedVerifiedFilesCache::default(),
                 package_integrity: integrity,
                 package_unpacked_size: None,
                 package_file_count: None,
                 package_url: &tarball_url,
                 package_id: &package_id,
-                auth_headers: &config.auth_headers,
+                auth_headers: &self.config.auth_headers,
                 requester: "",
                 prefetched_cas_paths: None,
-                retry_opts: retry_opts_from_config(config),
+                retry_opts: retry_opts_from_config(self.config),
                 ignore_file_pattern: None,
-                offline: config.offline,
+                offline: self.config.offline,
                 progress_reported: None,
                 store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
                     append_manifest: None,
                 },
             }
-            .run_with_mem_cache::<Reporter>(tarball_mem_cache)
+            .run_with_mem_cache::<Reporter>(self.tarball_mem_cache)
             .await
             .map_err(WritePackageForPatchError::DownloadTarball)?;
-            let raw_cas_paths = (*cas_paths).clone();
-            let cas_paths = if let LockfileResolution::Tarball(t) = &metadata.resolution
-                && git_tarball_url(&metadata.resolution).is_some()
-            {
-                let allow_build_closure = |_dep_path: &str| false;
-                let files_index_file =
-                    git_hosted_store_index_key(&package_id, !config.ignore_scripts);
-                let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
-                    cas_paths: raw_cas_paths,
-                    path: t.path.as_deref(),
-                    allow_build: &allow_build_closure,
-                    ignore_scripts: config.ignore_scripts,
-                    unsafe_perm: config.unsafe_perm,
-                    user_agent: Some(&config.user_agent),
-                    scripts_prepend_node_path: executor_scripts_prepend_node_path(
-                        config.scripts_prepend_node_path,
-                    ),
-                    script_shell: None,
-                    node_execpath: None,
-                    npm_execpath: None,
-                    // Nothing here is allowed to build, so no package
-                    // manager has to be provided to it.
-                    pnpm_execpath: None,
-                    store_dir: &config.store_dir,
-                    package_id: &package_id,
-                    requester: "",
-                    store_index_writer: Some(&store_index_writer),
-                    files_index_file: &files_index_file,
-                }
-                .run::<Reporter>()
-                .await
-                .map_err(WritePackageForPatchError::GitFetch)?;
-                cas_paths
-            } else {
-                raw_cas_paths
-            };
-
+            let cas_paths = git_hosted_cas_paths::<Reporter>(
+                self.config,
+                &metadata.resolution,
+                (*cas_paths).clone(),
+                &package_id,
+                &store_index_writer,
+            )
+            .await?;
             import_indexed_dir::<Reporter>(
                 &AtomicU8::new(0),
                 PackageImportMethod::CloneOrCopy,
-                dest,
+                self.dest,
                 &cas_paths,
                 ImportIndexedDirOpts { force: true, ..ImportIndexedDirOpts::default() },
             )
@@ -298,6 +269,50 @@ impl WritePackageForPatch<'_> {
         shutdown_store_index_writer_for_patch(store_index_writer, writer_task).await;
         result
     }
+}
+
+/// The tarball's files, re-fetched through the git-hosted fetcher when the
+/// resolution is a git-hosted archive, whose subdirectory and prepare step
+/// the plain ingest does not apply.
+async fn git_hosted_cas_paths<Reporter: self::Reporter>(
+    config: &Config,
+    resolution: &LockfileResolution,
+    cas_paths: std::collections::HashMap<String, std::path::PathBuf>,
+    package_id: &str,
+    store_index_writer: &Arc<StoreIndexWriter>,
+) -> Result<std::collections::HashMap<String, std::path::PathBuf>, WritePackageForPatchError> {
+    let LockfileResolution::Tarball(tarball) = resolution else { return Ok(cas_paths) };
+    if git_tarball_url(resolution).is_none() {
+        return Ok(cas_paths);
+    }
+    let allow_build_closure = |_dep_path: &str| false;
+    let files_index_file = git_hosted_store_index_key(package_id, !config.ignore_scripts);
+    let GitFetchOutput { cas_paths, built: _built } = GitHostedTarballFetcher {
+        cas_paths,
+        path: tarball.path.as_deref(),
+        allow_build: &allow_build_closure,
+        ignore_scripts: config.ignore_scripts,
+        unsafe_perm: config.unsafe_perm,
+        user_agent: Some(&config.user_agent),
+        scripts_prepend_node_path: executor_scripts_prepend_node_path(
+            config.scripts_prepend_node_path,
+        ),
+        script_shell: None,
+        node_execpath: None,
+        npm_execpath: None,
+        // Nothing here is allowed to build, so no package
+        // manager has to be provided to it.
+        pnpm_execpath: None,
+        store_dir: &config.store_dir,
+        package_id,
+        requester: "",
+        store_index_writer: Some(store_index_writer),
+        files_index_file: &files_index_file,
+    }
+    .run::<Reporter>()
+    .await
+    .map_err(WritePackageForPatchError::GitFetch)?;
+    Ok(cas_paths)
 }
 
 fn validate_patch_destination(dest: &Path) -> Result<(), WritePackageForPatchError> {

--- a/pnpm/crates/package-manager/src/prefetching_resolver.rs
+++ b/pnpm/crates/package-manager/src/prefetching_resolver.rs
@@ -136,7 +136,8 @@ struct OwnedFetchCtx {
 /// `PhantomData` carries the type through.
 pub struct PrefetchingResolver<Reporter: self::Reporter> {
     inner: Box<dyn Resolver>,
-    ctx: OwnedFetchCtx,
+    /// Shared with every prefetch task the resolver spawns.
+    ctx: Arc<OwnedFetchCtx>,
     _phantom: PhantomData<fn() -> Reporter>,
 }
 
@@ -188,7 +189,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             custom_fetcher_session: custom_fetcher_session.cloned(),
             ignore_scripts: config.ignore_scripts,
         };
-        PrefetchingResolver { inner, ctx, _phantom: PhantomData }
+        PrefetchingResolver { inner, ctx: Arc::new(ctx), _phantom: PhantomData }
     }
 
     /// Populate remote tarball resolutions whose integrity can only be
@@ -230,71 +231,18 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let cell = Arc::clone(&self.ctx.integrity_cache.entry(cache_key).or_default());
         let resolution = cell
             .get_or_try_init(|| async {
-                if let Some(session) = self.ctx.custom_fetcher_session.as_ref() {
-                    let download = IngestTarballToStore {
-                        http_client: &self.ctx.http_client,
-                        store_dir: self.ctx.store_dir,
-                        store_index: self.ctx.store_index.clone(),
-                        store_index_writer: self.ctx.store_index_writer.clone(),
-                        verify_store_integrity: self.ctx.verify_store_integrity,
-                        strict_store_pkg_content_check: self.ctx.strict_store_pkg_content_check,
-                        verified_files_cache: Arc::clone(&self.ctx.verified_files_cache),
-                        package_integrity: None,
-                        package_unpacked_size: None,
-                        package_file_count: None,
-                        package_url: &package_url,
-                        package_id: &package_id,
-                        requester: &self.ctx.requester,
-                        prefetched_cas_paths: None,
-                        retry_opts: self.ctx.retry_opts,
-                        auth_headers: &self.ctx.auth_headers,
-                        ignore_file_pattern: None,
-                        offline: self.ctx.offline,
-                        progress_reported: Some(Arc::clone(&self.ctx.progress_reported)),
-                        store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
-                            append_manifest: None,
-                        },
-                    };
-                    let opts = serde_json::json!({
-                        "pkg": result.name_ver.as_ref().map_or_else(
-                            || serde_json::json!({}),
-                            |nv| serde_json::json!({
-                                "name": nv.name.to_string(), "version": nv.suffix.to_string(),
-                            }),
-                        ),
-                        "lockfileDir": lockfile_dir,
-                        "readManifest": true,
-                        "filesIndexFile": pnpm_store_dir::pick_store_index_key(
-                            None, false, &package_id, !self.ctx.ignore_scripts,
-                        ),
-                    });
-                    return session
-                        .resolve_tarball_integrity::<Reporter>(download, &result.resolution, opts)
+                match self.ctx.custom_fetcher_session.as_ref() {
+                    Some(session) => {
+                        self.discover_integrity_by_custom_fetcher(
+                            session,
+                            result,
+                            (&package_url, &package_id),
+                            lockfile_dir,
+                        )
                         .await
-                        .map_err(|error| Box::new(error) as ResolveError);
+                    }
+                    None => self.fetch_tarball_integrity(tarball, &package_url, &package_id).await,
                 }
-                // This fetch warms the mem cache, so the prefetch path should not
-                // spawn another task for the same URL.
-                self.ctx.spawned_urls.insert(package_url.clone());
-                let resolved = FetchTarballForResolution {
-                    http_client: &self.ctx.http_client,
-                    store_dir: self.ctx.store_dir,
-                    store_index_writer: self.ctx.store_index_writer.clone(),
-                    package_url: &package_url,
-                    package_id: &package_id,
-                    auth_headers: &self.ctx.auth_headers,
-                    retry_opts: self.ctx.retry_opts,
-                    // Only integrity is read off this fetch, and
-                    // git-hosted archives (the sole subdirectory-bearing
-                    // shape) are filtered out above.
-                    manifest_subdir: None,
-                }
-                .run::<SilentReporter>(Some(&self.ctx.mem_cache))
-                .await
-                .map_err(|err| Box::new(err) as ResolveError)?;
-                let mut resolution = tarball.clone();
-                resolution.integrity = Some(resolved.integrity);
-                Ok::<_, ResolveError>(LockfileResolution::Tarball(resolution))
             })
             .await?;
         if self.ctx.custom_fetcher_session.is_some() {
@@ -304,6 +252,90 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             tarball.integrity = resolution.integrity().cloned();
         }
         Ok(())
+    }
+
+    /// Discover a tarball's integrity through the pnpmfile's custom
+    /// fetcher, which may select different content for the same URL.
+    async fn discover_integrity_by_custom_fetcher(
+        &self,
+        session: &CustomFetcherSession,
+        result: &ResolveResult,
+        package: (&str, &str),
+        lockfile_dir: &Path,
+    ) -> Result<LockfileResolution, ResolveError> {
+        let (package_url, package_id) = package;
+        let download = IngestTarballToStore {
+            http_client: &self.ctx.http_client,
+            store_dir: self.ctx.store_dir,
+            store_index: self.ctx.store_index.clone(),
+            store_index_writer: self.ctx.store_index_writer.clone(),
+            verify_store_integrity: self.ctx.verify_store_integrity,
+            strict_store_pkg_content_check: self.ctx.strict_store_pkg_content_check,
+            verified_files_cache: Arc::clone(&self.ctx.verified_files_cache),
+            package_integrity: None,
+            package_unpacked_size: None,
+            package_file_count: None,
+            package_url,
+            package_id,
+            requester: &self.ctx.requester,
+            prefetched_cas_paths: None,
+            retry_opts: self.ctx.retry_opts,
+            auth_headers: &self.ctx.auth_headers,
+            ignore_file_pattern: None,
+            offline: self.ctx.offline,
+            progress_reported: Some(Arc::clone(&self.ctx.progress_reported)),
+            store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
+                append_manifest: None,
+            },
+        };
+        let opts = serde_json::json!({
+            "pkg": result.name_ver.as_ref().map_or_else(
+                || serde_json::json!({}),
+                |nv| serde_json::json!({
+                    "name": nv.name.to_string(), "version": nv.suffix.to_string(),
+                }),
+            ),
+            "lockfileDir": lockfile_dir,
+            "readManifest": true,
+            "filesIndexFile": pnpm_store_dir::pick_store_index_key(
+                None, false, package_id, !self.ctx.ignore_scripts,
+            ),
+        });
+        session
+            .resolve_tarball_integrity::<Reporter>(download, &result.resolution, opts)
+            .await
+            .map_err(|error| Box::new(error) as ResolveError)
+    }
+
+    /// Discover a tarball's integrity by fetching it into the store.
+    async fn fetch_tarball_integrity(
+        &self,
+        tarball: &pnpm_lockfile::TarballResolution,
+        package_url: &str,
+        package_id: &str,
+    ) -> Result<LockfileResolution, ResolveError> {
+        // This fetch warms the mem cache, so the prefetch path should not
+        // spawn another task for the same URL.
+        self.ctx.spawned_urls.insert(package_url.to_string());
+        let resolved = FetchTarballForResolution {
+            http_client: &self.ctx.http_client,
+            store_dir: self.ctx.store_dir,
+            store_index_writer: self.ctx.store_index_writer.clone(),
+            package_url,
+            package_id,
+            auth_headers: &self.ctx.auth_headers,
+            retry_opts: self.ctx.retry_opts,
+            // Only integrity is read off this fetch, and
+            // git-hosted archives (the sole subdirectory-bearing
+            // shape) are filtered out above.
+            manifest_subdir: None,
+        }
+        .run::<SilentReporter>(Some(&self.ctx.mem_cache))
+        .await
+        .map_err(|err| Box::new(err) as ResolveError)?;
+        let mut resolution = tarball.clone();
+        resolution.integrity = Some(resolved.integrity);
+        Ok::<_, ResolveError>(LockfileResolution::Tarball(resolution))
     }
 
     /// Inspect a fresh `ResolveResult` and, if it carries a tarball
@@ -364,20 +396,7 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
         let package_url = package_url.to_string();
         let package_unpacked_size = manifest_unpacked_size(result.manifest.as_deref());
         let package_file_count = manifest_file_count(result.manifest.as_deref());
-
-        let http_client = Arc::clone(&self.ctx.http_client);
-        let mem_cache = Arc::clone(&self.ctx.mem_cache);
-        let store_dir = self.ctx.store_dir;
-        let store_index = self.ctx.store_index.clone();
-        let store_index_writer = self.ctx.store_index_writer.clone();
-        let verified_files_cache = SharedVerifiedFilesCache::clone(&self.ctx.verified_files_cache);
-        let auth_headers = Arc::clone(&self.ctx.auth_headers);
-        let retry_opts = self.ctx.retry_opts;
-        let requester = Arc::clone(&self.ctx.requester);
-        let offline = self.ctx.offline;
-        let verify_store_integrity = self.ctx.verify_store_integrity;
-        let strict_store_pkg_content_check = self.ctx.strict_store_pkg_content_check;
-        let progress_reported = SharedReportedProgressKeys::clone(&self.ctx.progress_reported);
+        let ctx = Arc::clone(&self.ctx);
 
         tokio::spawn(async move {
             // Report prefetch progress through the install reporter as
@@ -392,33 +411,33 @@ impl<Reporter: self::Reporter + 'static> PrefetchingResolver<Reporter> {
             // Result is intentionally discarded — the `MemCache`
             // carries success / failure state to the install path.
             let download = IngestTarballToStore {
-                http_client: &http_client,
-                store_dir,
-                store_index,
-                store_index_writer,
-                verify_store_integrity,
-                strict_store_pkg_content_check,
-                verified_files_cache,
+                http_client: &ctx.http_client,
+                store_dir: ctx.store_dir,
+                store_index: ctx.store_index.clone(),
+                store_index_writer: ctx.store_index_writer.clone(),
+                verify_store_integrity: ctx.verify_store_integrity,
+                strict_store_pkg_content_check: ctx.strict_store_pkg_content_check,
+                verified_files_cache: SharedVerifiedFilesCache::clone(&ctx.verified_files_cache),
                 package_integrity: Some(&integrity),
                 package_unpacked_size,
                 package_file_count,
                 package_url: &package_url,
                 package_id: &package_id,
-                requester: &requester,
+                requester: &ctx.requester,
                 prefetched_cas_paths: None,
-                retry_opts,
-                auth_headers: &auth_headers,
+                retry_opts: ctx.retry_opts,
+                auth_headers: &ctx.auth_headers,
                 ignore_file_pattern: None,
-                offline,
-                progress_reported: Some(progress_reported),
+                offline: ctx.offline,
+                progress_reported: Some(SharedReportedProgressKeys::clone(&ctx.progress_reported)),
                 store_projection: pnpm_tarball::ArchiveStoreProjection::Package {
                     append_manifest: None,
                 },
             };
             let _ = if revision_addressed {
-                download.run_revision_addressed_with_mem_cache::<Reporter>(&mem_cache).await
+                download.run_revision_addressed_with_mem_cache::<Reporter>(&ctx.mem_cache).await
             } else {
-                download.run_with_mem_cache::<Reporter>(&mem_cache).await
+                download.run_with_mem_cache::<Reporter>(&ctx.mem_cache).await
             };
         });
     }

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -1,6 +1,5 @@
 use crate::{
-    Install, InstallError, ProjectMutation, ResolvedPackages, UpdateSeedPolicy,
-    WorkspaceInstallSelection,
+    Install, InstallError, ProjectMutation, ResolvedPackages, SelectedProjects, UpdateSeedPolicy,
     catalog_cleanup::{
         WriteWorkspaceCatalogsError, post_install_prune, write_workspace_catalogs,
         write_workspace_catalogs_selected,
@@ -84,87 +83,49 @@ pub enum RemoveError {
     Install(#[error(source)] InstallError),
 }
 
-impl Remove<'_> {
+impl<'a> Remove<'a> {
+    /// Separate what every step reads from what the install consumes, and
+    /// the manifest the removal rewrites.
+    fn split(self) -> (RemoveView<'a>, RemoveOwned, &'a mut PackageManifest) {
+        (
+            RemoveView {
+                resolved_packages: self.resolved_packages,
+                http_client: self.http_client,
+                config: self.config,
+                lockfile: self.lockfile,
+                lockfile_path: self.lockfile_path,
+                package_names: self.package_names,
+                save_type: self.save_type,
+                lockfile_only: self.lockfile_only,
+            },
+            RemoveOwned {
+                tarball_mem_cache: self.tarball_mem_cache,
+                http_client_arc: self.http_client_arc,
+                supported_architectures: self.supported_architectures,
+            },
+            self.manifest,
+        )
+    }
+
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), RemoveError> {
-        let Remove {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            package_names,
-            save_type,
-            resolved_packages,
-            supported_architectures,
-            lockfile_only,
-        } = self;
+        let (remove, owned, manifest) = self.split();
+        validate_removable(manifest, remove.package_names, remove.save_type)
+            .map_err(RemoveError::Validation)?;
+        prepare_manifest::<Reporter>(manifest, remove.package_names, remove.save_type);
 
-        validate_removable(manifest, package_names, save_type).map_err(RemoveError::Validation)?;
-        prepare_manifest::<Reporter>(manifest, package_names, save_type);
-
-        let ignored_builds = Install {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            emit_initial_manifest: false,
-            lockfile: MaybeLazyLockfile::Loaded(lockfile),
-            lockfile_path,
-            // `pnpm remove`'s `include` defaults to every dependency
-            // group (`production`/`dev`/`optional` !== false), so the
-            // re-resolve walks all three.
-            dependency_groups: included_direct_groups(config.optional),
-            frozen_lockfile: false,
-            // The manifest was just edited, but the drift is exactly the
-            // deleted importer edges, which the removal handler of the
-            // lockfile fast path absorbs without resolving. When it
-            // declines, the freshness check fails and the install
-            // re-resolves as it always did.
-            prefer_frozen_lockfile: None,
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: false,
-            // `pacquet remove` is a partial install (an
-            // `uninstallSome` mutation), so the root project's own
-            // lifecycle scripts must not run — they fire only on a full
-            // install.
-            mutation: ProjectMutation::UninstallSome,
-            installs_only: false,
-            resolved_packages,
-            supported_architectures,
-            node_linker: config.node_linker,
-            lockfile_only,
-            dry_run: false,
-            persist_policy_excludes: false,
-            // Removing a dependency must not bump the survivors: keep
-            // every remaining lockfile pin in the preferred-versions
-            // seed, same as `install` / `add`.
-            update_seed_policy: UpdateSeedPolicy::KeepAll,
-            preferred_versions_override: None,
-            auth_override: None,
-            resolution_observer: None,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override: None,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: None,
-            workspace_projects_override: None,
-        }
-        .run::<Reporter>()
-        .await
-        .pipe(defer_ignored_builds)
-        .map_err(RemoveError::Install)?;
+        let ignored_builds = remove_install(remove, owned, manifest)
+            .run::<Reporter>()
+            .await
+            .pipe(defer_ignored_builds)
+            .map_err(RemoveError::Install)?;
 
         persist_manifest::<Reporter>(manifest)?;
 
-        write_workspace_catalogs(config, None, &Catalogs::new(), manifest)
+        write_workspace_catalogs(remove.config, None, &Catalogs::new(), manifest)
             .map_err(RemoveError::WriteWorkspaceManifest)?;
 
-        post_install_prune(config, None, manifest).map_err(RemoveError::WriteWorkspaceManifest)?;
+        post_install_prune(remove.config, None, manifest)
+            .map_err(RemoveError::WriteWorkspaceManifest)?;
 
         if let Some(ignored_builds) = ignored_builds {
             return Err(RemoveError::Install(ignored_builds));
@@ -174,102 +135,128 @@ impl Remove<'_> {
 
     pub async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
-        projects: &mut [pnpm_workspace::Project],
-        project_dependencies: &indexmap::IndexMap<std::path::PathBuf, Vec<std::path::PathBuf>>,
-        ordered_dirs: &[std::path::PathBuf],
-        selected_dirs: &HashSet<std::path::PathBuf>,
-        install_dirs: &HashSet<std::path::PathBuf>,
-        active_manifest_is_standin: bool,
+        selected: SelectedProjects<'_>,
     ) -> Result<(), RemoveError> {
-        let Remove {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            package_names,
-            save_type,
-            resolved_packages,
-            supported_architectures,
-            lockfile_only,
-        } = self;
-        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        let (remove, owned, manifest) = self.split();
+        let selected_indices = selected_project_indices(
+            selected.projects,
+            selected.ordered_dirs,
+            selected.selected_dirs,
+        );
         if selected_indices.is_empty() {
             return Ok(());
         }
 
-        validate_selected_remove(package_names).map_err(RemoveError::Validation)?;
+        validate_selected_remove(remove.package_names).map_err(RemoveError::Validation)?;
         prepare_selected_manifests::<Reporter>(
-            projects,
+            selected.projects,
             &selected_indices,
-            package_names,
-            save_type,
+            remove.package_names,
+            remove.save_type,
         );
-        let workspace_root = config.workspace_dir.clone().unwrap_or_else(|| {
+        let workspace_root = remove.config.workspace_dir.clone().unwrap_or_else(|| {
             manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf()
         });
 
-        let ignored_builds = Install {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            emit_initial_manifest: false,
-            lockfile: MaybeLazyLockfile::Loaded(lockfile),
-            lockfile_path,
-            dependency_groups: included_direct_groups(config.optional),
-            frozen_lockfile: false,
-            prefer_frozen_lockfile: None,
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: false,
-            mutation: ProjectMutation::UninstallSome,
-            installs_only: false,
-            resolved_packages,
-            supported_architectures,
-            node_linker: config.node_linker,
-            lockfile_only,
-            dry_run: false,
-            persist_policy_excludes: false,
-            update_seed_policy: UpdateSeedPolicy::KeepAll,
-            preferred_versions_override: None,
-            auth_override: None,
-            resolution_observer: None,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override: None,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: None,
-            workspace_projects_override: None,
-        }
-        .run_selected::<Reporter>(WorkspaceInstallSelection {
-            all_projects: projects,
-            project_dependencies,
-            ordered_dirs,
-            selected_dirs,
-            install_dirs,
-            active_manifest_is_standin,
-            workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
-        })
-        .await
-        .pipe(defer_ignored_builds)
-        .map_err(RemoveError::Install)?;
+        let ignored_builds = remove_install(remove, owned, manifest)
+            .run_selected::<Reporter>(selected.selection())
+            .await
+            .pipe(defer_ignored_builds)
+            .map_err(RemoveError::Install)?;
 
-        persist_selected_manifests::<Reporter>(projects, &selected_indices)?;
+        persist_selected_manifests::<Reporter>(selected.projects, &selected_indices)?;
 
-        write_workspace_catalogs_selected(config, &workspace_root, &Catalogs::new(), projects)
-            .map_err(RemoveError::WriteWorkspaceManifest)?;
+        write_workspace_catalogs_selected(
+            remove.config,
+            &workspace_root,
+            &Catalogs::new(),
+            selected.projects,
+        )
+        .map_err(RemoveError::WriteWorkspaceManifest)?;
 
-        post_install_prune(config, Some(&workspace_root), manifest)
+        post_install_prune(remove.config, Some(&workspace_root), manifest)
             .map_err(RemoveError::WriteWorkspaceManifest)?;
         if let Some(ignored_builds) = ignored_builds {
             return Err(RemoveError::Install(ignored_builds));
         }
         Ok(())
+    }
+}
+
+/// The removal's borrowed and `Copy` inputs, as one value every step reads.
+#[derive(Clone, Copy)]
+struct RemoveView<'a> {
+    resolved_packages: &'a ResolvedPackages,
+    http_client: &'a ThrottledClient,
+    config: &'static Config,
+    lockfile: Option<&'a Lockfile>,
+    lockfile_path: Option<&'a std::path::Path>,
+    package_names: &'a [String],
+    save_type: Option<DependencyGroup>,
+    lockfile_only: bool,
+}
+
+/// The removal's owned inputs, consumed by the install it runs.
+struct RemoveOwned {
+    tarball_mem_cache: Arc<MemCache>,
+    http_client_arc: Arc<ThrottledClient>,
+    supported_architectures: Option<pnpm_package_is_installable::SupportedArchitectures>,
+}
+
+/// `pnpm remove`'s `include` defaults to every dependency
+/// group (`production`/`dev`/`optional` !== false), so the
+/// re-resolve walks all three.
+/// The manifest was just edited, but the drift is exactly the
+/// deleted importer edges, which the removal handler of the
+/// lockfile fast path absorbs without resolving. When it
+/// declines, the freshness check fails and the install
+/// re-resolves as it always did.
+/// `pacquet remove` is a partial install (an
+/// `uninstallSome` mutation), so the root project's own
+/// lifecycle scripts must not run — they fire only on a full
+/// install.
+/// Removing a dependency must not bump the survivors: keep
+/// every remaining lockfile pin in the preferred-versions
+/// seed, same as `install` / `add`.
+fn remove_install<'i>(
+    remove: RemoveView<'i>,
+    owned: RemoveOwned,
+    manifest: &'i PackageManifest,
+) -> Install<'i, Vec<DependencyGroup>> {
+    Install {
+        tarball_mem_cache: owned.tarball_mem_cache,
+        http_client: remove.http_client,
+        http_client_arc: owned.http_client_arc,
+        config: remove.config,
+        manifest,
+        emit_initial_manifest: false,
+        lockfile: MaybeLazyLockfile::Loaded(remove.lockfile),
+        lockfile_path: remove.lockfile_path,
+        dependency_groups: included_direct_groups(remove.config.optional).collect(),
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: None,
+        ignore_manifest_check: false,
+        skip_runtimes: remove.config.skip_runtimes,
+        trust_lockfile: remove.config.trust_lockfile,
+        update_checksums: false,
+        mutation: ProjectMutation::UninstallSome,
+        installs_only: false,
+        resolved_packages: remove.resolved_packages,
+        supported_architectures: owned.supported_architectures,
+        node_linker: remove.config.node_linker,
+        lockfile_only: remove.lockfile_only,
+        dry_run: false,
+        persist_policy_excludes: false,
+        update_seed_policy: UpdateSeedPolicy::KeepAll,
+        preferred_versions_override: None,
+        auth_override: None,
+        resolution_observer: None,
+        peer_issues_sink: None,
+        deps_requiring_build_sink: None,
+        catalogs_override: None,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: None,
+        workspace_projects_override: None,
     }
 }
 

--- a/pnpm/crates/package-manager/src/remove.rs
+++ b/pnpm/crates/package-manager/src/remove.rs
@@ -222,7 +222,7 @@ fn remove_install<'i>(
     remove: RemoveView<'i>,
     owned: RemoveOwned,
     manifest: &'i PackageManifest,
-) -> Install<'i, Vec<DependencyGroup>> {
+) -> Install<'i, impl Iterator<Item = DependencyGroup>> {
     Install {
         tarball_mem_cache: owned.tarball_mem_cache,
         http_client: remove.http_client,
@@ -232,7 +232,7 @@ fn remove_install<'i>(
         emit_initial_manifest: false,
         lockfile: MaybeLazyLockfile::Loaded(remove.lockfile),
         lockfile_path: remove.lockfile_path,
-        dependency_groups: included_direct_groups(remove.config.optional).collect(),
+        dependency_groups: included_direct_groups(remove.config.optional),
         frozen_lockfile: false,
         prefer_frozen_lockfile: None,
         ignore_manifest_check: false,

--- a/pnpm/crates/package-manager/src/tarball_prefetch.rs
+++ b/pnpm/crates/package-manager/src/tarball_prefetch.rs
@@ -107,46 +107,25 @@ pub(crate) fn spawn_tarball_download(download: TarballDownload) {
 async fn run_tarball_download(
     download: TarballDownload,
 ) -> Result<Arc<HashMap<String, PathBuf>>, TarballError> {
-    let TarballDownload {
-        http_client,
-        mem_cache,
-        store_dir,
-        store_index,
-        store_index_writer,
-        verified_files_cache,
-        auth_headers,
-        retry_opts,
-        requester,
-        offline,
-        verify_store_integrity,
-        strict_store_pkg_content_check,
-        package_id,
-        package_url,
-        integrity,
-        package_unpacked_size,
-        package_file_count,
-        revision_addressed,
-    } = download;
-
-    let download = IngestTarballToStore {
-        http_client: &http_client,
-        store_dir,
-        store_index,
-        store_index_writer,
-        verify_store_integrity,
-        strict_store_pkg_content_check,
-        verified_files_cache,
-        package_integrity: Some(&integrity),
-        package_unpacked_size,
-        package_file_count,
-        package_url: &package_url,
-        package_id: &package_id,
-        requester: &requester,
+    let ingest = IngestTarballToStore {
+        http_client: &download.http_client,
+        store_dir: download.store_dir,
+        store_index: download.store_index,
+        store_index_writer: download.store_index_writer,
+        verify_store_integrity: download.verify_store_integrity,
+        strict_store_pkg_content_check: download.strict_store_pkg_content_check,
+        verified_files_cache: download.verified_files_cache,
+        package_integrity: Some(&download.integrity),
+        package_unpacked_size: download.package_unpacked_size,
+        package_file_count: download.package_file_count,
+        package_url: &download.package_url,
+        package_id: &download.package_id,
+        requester: &download.requester,
         prefetched_cas_paths: None,
-        retry_opts,
-        auth_headers: &auth_headers,
+        retry_opts: download.retry_opts,
+        auth_headers: &download.auth_headers,
         ignore_file_pattern: None,
-        offline,
+        offline: download.offline,
         // The client prefetch routes through `SilentReporter`, so
         // there's no install reporter to dedup progress events
         // against — the frozen materialization install emits its own
@@ -154,10 +133,10 @@ async fn run_tarball_download(
         progress_reported: None,
         store_projection: pnpm_tarball::ArchiveStoreProjection::Package { append_manifest: None },
     };
-    if revision_addressed {
-        download.run_revision_addressed_with_mem_cache::<SilentReporter>(&mem_cache).await
+    if download.revision_addressed {
+        ingest.run_revision_addressed_with_mem_cache::<SilentReporter>(&download.mem_cache).await
     } else {
-        download.run_with_mem_cache::<SilentReporter>(&mem_cache).await
+        ingest.run_with_mem_cache::<SilentReporter>(&download.mem_cache).await
     }
 }
 

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -291,152 +291,89 @@ fn update_mutation(packages: &[String], latest: bool) -> ProjectMutation {
     }
 }
 
-impl Update<'_> {
+impl<'a> Update<'a> {
+    /// Separate what every step reads from what one of them consumes, and
+    /// the manifest the update rewrites.
+    fn split(self) -> (UpdateView<'a>, UpdateOwned, &'a mut PackageManifest) {
+        (
+            UpdateView {
+                resolved_packages: self.resolved_packages,
+                http_client: self.http_client,
+                config: self.config,
+                lockfile: self.lockfile,
+                lockfile_path: self.lockfile_path,
+                packages: self.packages,
+                latest: self.latest,
+                patches: self.patches,
+                save_exact: self.save_exact,
+                save: self.save,
+                depth: self.depth,
+                workspace_packages: self.workspace_packages,
+                lockfile_only: self.lockfile_only,
+            },
+            UpdateOwned {
+                tarball_mem_cache: self.tarball_mem_cache,
+                http_client_arc: self.http_client_arc,
+                include_direct: self.include_direct,
+                supported_architectures: self.supported_architectures,
+                resolution_observer: self.resolution_observer,
+            },
+            self.manifest,
+        )
+    }
+
     pub async fn run<Reporter: self::Reporter + 'static>(self) -> Result<(), UpdateError> {
-        let Update {
-            tarball_mem_cache,
-            resolved_packages,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            packages,
-            latest,
-            patches,
-            save_exact,
-            save,
-            include_direct,
-            depth,
-            workspace_packages,
-            supported_architectures,
-            lockfile_only,
-            resolution_observer,
-        } = self;
-        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-
-        crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
-            .map_err(UpdateError::MinimumReleaseAge)?;
-
-        let manifest_dir =
-            manifest.path().parent().expect("manifest path always has a parent dir").to_path_buf();
-        let workspace_root = crate::install::lockfile_root_dir(config, &manifest_dir)
-            .map_err(UpdateError::FindWorkspaceDir)?;
-        let read_package_hook = (!save && !config.ignore_pnpmfile)
-            .then(|| update_read_package_hook::<Reporter>(&workspace_root, config))
-            .transpose()?
-            .flatten();
-        let mut read_package_hooked_manifest_paths = HashSet::new();
-        if let Some((hook, log)) = read_package_hook.as_ref() {
-            apply_read_package_hook_to_update_manifest(manifest, hook, log).await?;
-            read_package_hooked_manifest_paths.insert(manifest.path().to_path_buf());
-        }
-        let lockfile_specifier_project_manifests =
-            (!save).then(|| vec![(manifest_dir.clone(), manifest.clone())]);
-        if !latest && depth > 0 {
-            let selectors =
-                packages.iter().map(|input| parse_update_param(input)).collect::<Vec<_>>();
+        let (update, owned, manifest) = self.split();
+        begin::<Reporter>(update, &owned)?;
+        let site = UpdateSite::find::<Reporter>(update, manifest)?;
+        let unsaved = site.hook_update_manifest(update, manifest).await?;
+        if !update.latest && update.depth > 0 {
             reject_versions_of_indirect_update_specs::<Reporter>(
-                &selectors,
+                &parse_selectors(update.packages),
                 &[manifest],
-                &include_direct,
+                &owned.include_direct,
                 &package_manifest_prefix(manifest),
             )?;
         }
         let mut latest_chain = None;
-        let Some(prepared) = prepare_manifest::<Reporter>(
-            manifest,
-            &http_client_arc,
-            config,
-            lockfile,
-            packages,
-            latest,
-            save_exact,
-            save,
-            &include_direct,
-            depth,
-            workspace_packages,
-            None,
-            &mut latest_chain,
-            lockfile_only,
-            resolution_observer.as_ref(),
-        )
-        .await?
+        let Some(prepared) =
+            prepare_manifest::<Reporter>(manifest, update, &owned, None, &mut latest_chain).await?
         else {
-            return nothing_to_update(depth, packages, latest);
+            return nothing_to_update(update.depth, update.packages, update.latest);
         };
-        if save {
+        if update.save {
             write_workspace_catalogs(
-                config,
+                update.config,
                 prepared.workspace_dir_for_catalogs.as_deref(),
                 &prepared.updated_catalogs,
                 manifest,
             )
             .map_err(UpdateError::WriteWorkspaceManifest)?;
         }
-        let UpdatePreparation {
-            seed_policy,
-            preferred_versions_override,
-            persist_manifest: should_persist_manifest,
-            catalogs_override,
-            workspace_dir_for_catalogs,
-            bump_targets,
-            ..
-        } = prepared;
-        let seed_policy = if patches { UpdateSeedPolicy::RefreshRevisions } else { seed_policy };
-        let bumps_range_spec_style = RangeSpecStyle::from_save_options(save_exact, None);
-        let importer_id = pnpm_workspace::importer_id_from_root_dir(&workspace_root, &manifest_dir);
-        let bumps = (!bump_targets.is_empty()).then(|| ManifestSpecBumps {
-            targets: BTreeMap::from([(importer_id.clone(), bump_targets)]),
-            range_spec_style: bumps_range_spec_style,
+        let importer_id =
+            pnpm_workspace::importer_id_from_root_dir(&site.workspace_root, manifest_dir(manifest));
+        let bumps = (!prepared.bump_targets.is_empty()).then(|| ManifestSpecBumps {
+            targets: BTreeMap::from([(importer_id.clone(), prepared.bump_targets)]),
+            range_spec_style: RangeSpecStyle::from_save_options(update.save_exact, None),
             applied: Mutex::default(),
         });
-        let install = Install {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            emit_initial_manifest: false,
-            lockfile: MaybeLazyLockfile::Loaded(lockfile),
-            lockfile_path,
-            // `include` is always all-true for updates: the materialized
-            // `node_modules` layout must not change just because the
-            // update scope was narrowed.
-            dependency_groups: included_direct_groups(config.optional),
-            frozen_lockfile: false,
-            // `update` always re-resolves against the registry, so the
-            // auto-frozen / repeat-install fast paths must not fire.
-            prefer_frozen_lockfile: Some(false),
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: patches,
-            mutation: update_mutation(packages, latest),
-            installs_only: true,
-            resolved_packages,
-            supported_architectures,
-            node_linker: config.node_linker,
-            lockfile_only,
-            dry_run: false,
-            persist_policy_excludes: save,
-            update_seed_policy: seed_policy,
-            preferred_versions_override: Some(preferred_versions_override),
-            auth_override: None,
-            resolution_observer,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: read_package_hook.as_ref().map(|(hook, _)| Arc::clone(hook)),
-            workspace_projects_override: None,
-        };
         let ignored_builds = run_update_install::<Reporter, _>(
-            install,
-            lockfile_specifier_project_manifests,
-            read_package_hooked_manifest_paths,
+            update_install(
+                update,
+                owned,
+                manifest,
+                UpdateSeed {
+                    policy: if update.patches {
+                        UpdateSeedPolicy::RefreshRevisions
+                    } else {
+                        prepared.seed_policy
+                    },
+                    preferred_versions_override: prepared.preferred_versions_override,
+                    catalogs_override: prepared.catalogs_override,
+                },
+                site.read_package_hook.as_ref(),
+            ),
+            unsaved,
             bumps.as_ref(),
         )
         .await?;
@@ -444,13 +381,13 @@ impl Update<'_> {
         let applied = bumps.map(|bumps| bumps.applied.into_inner().expect("never poisoned"));
         settle_update_manifest::<Reporter>(
             manifest,
-            config,
+            update.config,
             SettleUpdate {
-                save,
-                should_persist_manifest,
+                save: update.save,
+                should_persist_manifest: prepared.persist_manifest,
                 importer_id: &importer_id,
                 applied: applied.as_ref(),
-                workspace_dir_for_catalogs: workspace_dir_for_catalogs.as_deref(),
+                workspace_dir_for_catalogs: prepared.workspace_dir_for_catalogs.as_deref(),
             },
         )?;
 
@@ -462,193 +399,333 @@ impl Update<'_> {
 
     pub async fn run_selected<Reporter: self::Reporter + 'static>(
         self,
-        projects: &mut [pnpm_workspace::Project],
-        project_dependencies: &indexmap::IndexMap<PathBuf, Vec<PathBuf>>,
-        ordered_dirs: &[PathBuf],
-        selected_dirs: &HashSet<PathBuf>,
-        install_dirs: &HashSet<PathBuf>,
-        active_manifest_is_standin: bool,
+        selected: SelectedProjects<'_>,
     ) -> Result<(), UpdateError> {
-        let Update {
-            tarball_mem_cache,
-            resolved_packages,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            lockfile,
-            lockfile_path,
-            packages,
-            latest,
-            patches,
-            save_exact,
-            save,
-            include_direct,
-            depth,
-            workspace_packages,
-            supported_architectures,
-            lockfile_only,
-            resolution_observer,
-        } = self;
-        http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-        http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
-
-        crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(config, save)
-            .map_err(UpdateError::MinimumReleaseAge)?;
-
-        let selected_indices = selected_project_indices(projects, ordered_dirs, selected_dirs);
+        let (update, owned, manifest) = self.split();
+        begin::<Reporter>(update, &owned)?;
+        let selected_indices = selected_project_indices(
+            selected.projects,
+            selected.ordered_dirs,
+            selected.selected_dirs,
+        );
         if selected_indices.is_empty() {
             return Ok(());
         }
-        let workspace_root = crate::install::lockfile_root_dir(
-            config,
-            manifest.path().parent().expect("manifest path always has a parent dir"),
-        )
-        .map_err(UpdateError::FindWorkspaceDir)?;
-        let read_package_hook = (!save && !config.ignore_pnpmfile)
-            .then(|| update_read_package_hook::<Reporter>(&workspace_root, config))
-            .transpose()?
-            .flatten();
-        let mut read_package_hooked_manifest_paths = HashSet::new();
-        if let Some((hook, log)) = read_package_hook.as_ref() {
-            hook_selected_manifests(
-                projects,
-                manifest,
-                hook,
-                log,
-                &mut read_package_hooked_manifest_paths,
-            )
+        let site = UpdateSite::find::<Reporter>(update, manifest)?;
+        let unsaved = site
+            .hook_selected_manifests(update, selected.projects, manifest, &selected_indices)
             .await?;
-        }
-        let lockfile_specifier_project_manifests = (!save).then(|| {
-            selected_indices
-                .iter()
-                .map(|&index| (projects[index].root_dir.clone(), projects[index].manifest.clone()))
-                .collect::<Vec<_>>()
-        });
         let mut prepared = prepare_selected_manifests::<Reporter>(
-            projects,
+            selected.projects,
             &selected_indices,
-            &workspace_root,
-            &http_client_arc,
-            config,
-            lockfile,
-            packages,
-            latest,
-            save_exact,
-            save,
-            &include_direct,
-            depth,
-            workspace_packages,
-            lockfile_only,
-            resolution_observer.as_ref(),
+            &site.workspace_root,
+            update,
+            &owned,
         )
         .await?;
         if !prepared.any_work {
             return Ok(());
         }
-        if save {
-            let workspace_dir =
-                prepared.workspace_dir_for_catalogs.as_deref().unwrap_or(&workspace_root);
+        if update.save {
             write_workspace_catalogs_selected(
-                config,
-                workspace_dir,
+                update.config,
+                site.catalogs_dir(prepared.workspace_dir_for_catalogs.as_deref()),
                 &prepared.updated_catalogs,
-                projects,
+                selected.projects,
             )
             .map_err(UpdateError::WriteWorkspaceManifest)?;
         }
 
         let bumps = (!prepared.bump_targets.is_empty()).then(|| ManifestSpecBumps {
             targets: std::mem::take(&mut prepared.bump_targets),
-            range_spec_style: RangeSpecStyle::from_save_options(save_exact, None),
+            range_spec_style: RangeSpecStyle::from_save_options(update.save_exact, None),
             applied: Mutex::default(),
         });
-        let install = Install {
-            tarball_mem_cache,
-            http_client,
-            http_client_arc,
-            config,
-            manifest,
-            emit_initial_manifest: false,
-            lockfile: MaybeLazyLockfile::Loaded(lockfile),
-            lockfile_path,
-            dependency_groups: included_direct_groups(config.optional),
-            frozen_lockfile: false,
-            prefer_frozen_lockfile: Some(false),
-            ignore_manifest_check: false,
-            skip_runtimes: config.skip_runtimes,
-            trust_lockfile: config.trust_lockfile,
-            update_checksums: patches,
-            mutation: update_mutation(packages, latest),
-            installs_only: true,
-            resolved_packages,
-            supported_architectures,
-            node_linker: config.node_linker,
-            lockfile_only,
-            dry_run: false,
-            persist_policy_excludes: save,
-            update_seed_policy: selected_seed_policy(
-                patches,
-                std::mem::take(&mut prepared.seed_policies),
-                depth,
-            ),
-            preferred_versions_override: Some(prepared.preferred_versions_override),
-            auth_override: None,
-            resolution_observer,
-            peer_issues_sink: None,
-            deps_requiring_build_sink: None,
-            catalogs_override: prepared.catalogs_override,
-            disable_optimistic_repeat_install: false,
-            pnpmfile_hook_override: read_package_hook.as_ref().map(|(hook, _)| Arc::clone(hook)),
-            workspace_projects_override: None,
-        };
-        let selection = WorkspaceInstallSelection {
-            all_projects: projects,
-            project_dependencies,
-            ordered_dirs,
-            selected_dirs,
-            install_dirs,
-            active_manifest_is_standin,
-            workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
-        };
         let ignored_builds = run_selected_update_install::<Reporter, _>(
-            install,
-            selection,
-            lockfile_specifier_project_manifests,
-            read_package_hooked_manifest_paths,
+            update_install(
+                update,
+                owned,
+                manifest,
+                UpdateSeed {
+                    policy: selected_seed_policy(
+                        update.patches,
+                        std::mem::take(&mut prepared.seed_policies),
+                        update.depth,
+                    ),
+                    preferred_versions_override: std::mem::take(
+                        &mut prepared.preferred_versions_override,
+                    ),
+                    catalogs_override: prepared.catalogs_override.take(),
+                },
+                site.read_package_hook.as_ref(),
+            ),
+            selected.selection(),
+            unsaved,
             bumps.as_ref(),
         )
         .await?;
 
-        let applied = bumps.map(|bumps| bumps.applied.into_inner().expect("never poisoned"));
-        let persist_indices = bumped_persist_indices::<Reporter>(
-            projects,
-            &workspace_root,
-            applied.as_ref(),
-            prepared.persist_indices,
-        );
-        persist_selected_manifests::<Reporter>(projects, &persist_indices)?;
-        if save
-            && let Some(applied) = applied.as_ref().filter(|applied| !applied.catalogs.is_empty())
-        {
-            let workspace_dir =
-                prepared.workspace_dir_for_catalogs.as_deref().unwrap_or(&workspace_root);
-            write_workspace_catalogs_selected(config, workspace_dir, &applied.catalogs, projects)
-                .map_err(UpdateError::WriteWorkspaceManifest)?;
-        }
-
-        if save {
-            let workspace_dir =
-                prepared.workspace_dir_for_catalogs.as_deref().unwrap_or(&workspace_root);
-            post_install_prune(config, Some(workspace_dir), manifest)
-                .map_err(UpdateError::WriteWorkspaceManifest)?;
-        }
+        settle_selected_update::<Reporter>(
+            update,
+            &site,
+            selected.projects,
+            manifest,
+            prepared,
+            bumps,
+        )?;
         if let Some(ignored_builds) = ignored_builds {
             return Err(UpdateError::Install(ignored_builds));
         }
         Ok(())
     }
+}
+
+/// The update's borrowed and `Copy` inputs, as one value every step reads.
+#[derive(Clone, Copy)]
+struct UpdateView<'a> {
+    resolved_packages: &'a ResolvedPackages,
+    http_client: &'a ThrottledClient,
+    config: &'static Config,
+    lockfile: Option<&'a Lockfile>,
+    lockfile_path: Option<&'a Path>,
+    packages: &'a [String],
+    latest: bool,
+    patches: bool,
+    save_exact: bool,
+    save: bool,
+    depth: usize,
+    workspace_packages: Option<&'a WorkspacePackages>,
+    lockfile_only: bool,
+}
+
+/// The update's owned inputs, consumed by the install it runs.
+struct UpdateOwned {
+    tarball_mem_cache: Arc<MemCache>,
+    http_client_arc: Arc<ThrottledClient>,
+    include_direct: Vec<DependencyGroup>,
+    supported_architectures: Option<pnpm_package_is_installable::SupportedArchitectures>,
+    resolution_observer: Option<Arc<dyn crate::ResolutionObserver>>,
+}
+
+/// The projects a recursive update runs over, and the selection that
+/// narrows the install to them.
+pub struct SelectedProjects<'s> {
+    pub projects: &'s mut [pnpm_workspace::Project],
+    pub project_dependencies: &'s indexmap::IndexMap<PathBuf, Vec<PathBuf>>,
+    pub ordered_dirs: &'s [PathBuf],
+    pub selected_dirs: &'s HashSet<PathBuf>,
+    pub install_dirs: &'s HashSet<PathBuf>,
+    pub active_manifest_is_standin: bool,
+}
+
+impl SelectedProjects<'_> {
+    fn selection(&self) -> WorkspaceInstallSelection<'_> {
+        WorkspaceInstallSelection {
+            all_projects: self.projects,
+            project_dependencies: self.project_dependencies,
+            ordered_dirs: self.ordered_dirs,
+            selected_dirs: self.selected_dirs,
+            install_dirs: self.install_dirs,
+            active_manifest_is_standin: self.active_manifest_is_standin,
+            workspace_cycles: crate::PrecomputedWorkspaceCycles::Unknown,
+        }
+    }
+}
+
+/// Route the clients' warnings through the reporter and refuse a save the
+/// strict minimum release age forbids, before anything is read.
+fn begin<Reporter: self::Reporter>(
+    update: UpdateView<'_>,
+    owned: &UpdateOwned,
+) -> Result<(), UpdateError> {
+    update.http_client.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+    owned.http_client_arc.set_warning_handler(pnpm_reporter::emit_global_warning::<Reporter>);
+    crate::minimum_release_age::ensure_strict_minimum_release_age_can_save(
+        update.config,
+        update.save,
+    )
+    .map_err(UpdateError::MinimumReleaseAge)
+}
+
+fn manifest_dir(manifest: &PackageManifest) -> &Path {
+    manifest.path().parent().expect("manifest path always has a parent dir")
+}
+
+fn parse_selectors(packages: &[String]) -> Vec<ParsedSelector> {
+    packages.iter().map(|input| parse_update_param(input)).collect()
+}
+
+/// Where the update runs: the lockfile root, and the pnpmfile's
+/// read-package hook when `--no-save` must show the resolver the manifests
+/// as the hook rewrites them.
+struct UpdateSite {
+    workspace_root: PathBuf,
+    read_package_hook: Option<ReadPackageHook>,
+}
+
+impl UpdateSite {
+    fn find<Reporter: self::Reporter>(
+        update: UpdateView<'_>,
+        manifest: &PackageManifest,
+    ) -> Result<Self, UpdateError> {
+        let workspace_root =
+            crate::install::lockfile_root_dir(update.config, manifest_dir(manifest))
+                .map_err(UpdateError::FindWorkspaceDir)?;
+        let read_package_hook = (!update.save && !update.config.ignore_pnpmfile)
+            .then(|| update_read_package_hook::<Reporter>(&workspace_root, update.config))
+            .transpose()?
+            .flatten();
+        Ok(Self { workspace_root, read_package_hook })
+    }
+
+    /// Where the workspace manifest's catalogs are written: the directory the
+    /// preparation found them in, else the lockfile root.
+    fn catalogs_dir<'d>(&'d self, prepared: Option<&'d Path>) -> &'d Path {
+        prepared.unwrap_or(&self.workspace_root)
+    }
+
+    async fn hook_update_manifest(
+        &self,
+        update: UpdateView<'_>,
+        manifest: &mut PackageManifest,
+    ) -> Result<UnsavedManifests, UpdateError> {
+        let mut hooked_paths = HashSet::new();
+        if let Some((hook, log)) = self.read_package_hook.as_ref() {
+            apply_read_package_hook_to_update_manifest(manifest, hook, log).await?;
+            hooked_paths.insert(manifest.path().to_path_buf());
+        }
+        Ok(UnsavedManifests {
+            hooked_paths,
+            lockfile_specifiers: (!update.save)
+                .then(|| vec![(manifest_dir(manifest).to_path_buf(), manifest.clone())]),
+        })
+    }
+
+    async fn hook_selected_manifests(
+        &self,
+        update: UpdateView<'_>,
+        projects: &mut [pnpm_workspace::Project],
+        manifest: &mut PackageManifest,
+        selected_indices: &[usize],
+    ) -> Result<UnsavedManifests, UpdateError> {
+        let mut hooked_paths = HashSet::new();
+        if let Some((hook, log)) = self.read_package_hook.as_ref() {
+            hook_selected_manifests(projects, manifest, hook, log, &mut hooked_paths).await?;
+        }
+        Ok(UnsavedManifests {
+            hooked_paths,
+            lockfile_specifiers: (!update.save).then(|| {
+                selected_indices
+                    .iter()
+                    .map(|&index| {
+                        (projects[index].root_dir.clone(), projects[index].manifest.clone())
+                    })
+                    .collect()
+            }),
+        })
+    }
+}
+
+/// What `--no-save` hands the install: the manifest paths the read-package
+/// hook already rewrote, and the on-disk manifests the lockfile's importer
+/// specifiers come from.
+struct UnsavedManifests {
+    hooked_paths: HashSet<PathBuf>,
+    lockfile_specifiers: Option<Vec<(PathBuf, PackageManifest)>>,
+}
+
+/// What the resolve seeds from: the pins it keeps or drops, the versions it
+/// prefers, and the catalogs as the update rewrote them.
+struct UpdateSeed {
+    policy: UpdateSeedPolicy,
+    preferred_versions_override: PreferredVersions,
+    catalogs_override: Option<Catalogs>,
+}
+
+/// `include` is always all-true for updates: the materialized
+/// `node_modules` layout must not change just because the
+/// update scope was narrowed.
+/// `update` always re-resolves against the registry, so the
+/// auto-frozen / repeat-install fast paths must not fire.
+fn update_install<'i>(
+    update: UpdateView<'i>,
+    owned: UpdateOwned,
+    manifest: &'i PackageManifest,
+    seed: UpdateSeed,
+    read_package_hook: Option<&ReadPackageHook>,
+) -> Install<'i, Vec<DependencyGroup>> {
+    Install {
+        tarball_mem_cache: owned.tarball_mem_cache,
+        http_client: update.http_client,
+        http_client_arc: owned.http_client_arc,
+        config: update.config,
+        manifest,
+        emit_initial_manifest: false,
+        lockfile: MaybeLazyLockfile::Loaded(update.lockfile),
+        lockfile_path: update.lockfile_path,
+        dependency_groups: included_direct_groups(update.config.optional).collect(),
+        frozen_lockfile: false,
+        prefer_frozen_lockfile: Some(false),
+        ignore_manifest_check: false,
+        skip_runtimes: update.config.skip_runtimes,
+        trust_lockfile: update.config.trust_lockfile,
+        update_checksums: update.patches,
+        mutation: update_mutation(update.packages, update.latest),
+        installs_only: true,
+        resolved_packages: update.resolved_packages,
+        supported_architectures: owned.supported_architectures,
+        node_linker: update.config.node_linker,
+        lockfile_only: update.lockfile_only,
+        dry_run: false,
+        persist_policy_excludes: update.save,
+        update_seed_policy: seed.policy,
+        preferred_versions_override: Some(seed.preferred_versions_override),
+        auth_override: None,
+        resolution_observer: owned.resolution_observer,
+        peer_issues_sink: None,
+        deps_requiring_build_sink: None,
+        catalogs_override: seed.catalogs_override,
+        disable_optimistic_repeat_install: false,
+        pnpmfile_hook_override: read_package_hook.map(|(hook, _)| Arc::clone(hook)),
+        workspace_projects_override: None,
+    }
+}
+
+/// Write back the manifests the update rewrote and the catalogs the install
+/// settled on, then prune the workspace manifest.
+fn settle_selected_update<Reporter: self::Reporter>(
+    update: UpdateView<'_>,
+    site: &UpdateSite,
+    projects: &mut [pnpm_workspace::Project],
+    manifest: &PackageManifest,
+    prepared: SelectedUpdatePreparation,
+    bumps: Option<ManifestSpecBumps>,
+) -> Result<(), UpdateError> {
+    let applied = bumps.map(|bumps| bumps.applied.into_inner().expect("never poisoned"));
+    let persist_indices = bumped_persist_indices::<Reporter>(
+        projects,
+        &site.workspace_root,
+        applied.as_ref(),
+        prepared.persist_indices,
+    );
+    persist_selected_manifests::<Reporter>(projects, &persist_indices)?;
+    let workspace_dir = site.catalogs_dir(prepared.workspace_dir_for_catalogs.as_deref());
+    if update.save
+        && let Some(applied) = applied.as_ref().filter(|applied| !applied.catalogs.is_empty())
+    {
+        write_workspace_catalogs_selected(
+            update.config,
+            workspace_dir,
+            &applied.catalogs,
+            projects,
+        )
+        .map_err(UpdateError::WriteWorkspaceManifest)?;
+    }
+    if update.save {
+        post_install_prune(update.config, Some(workspace_dir), manifest)
+            .map_err(UpdateError::WriteWorkspaceManifest)?;
+    }
+    Ok(())
 }
 
 /// A selector that matched nothing at depth 0 is an error; anything else
@@ -662,20 +739,19 @@ fn nothing_to_update(depth: usize, packages: &[String], latest: bool) -> Result<
 
 async fn run_update_install<Reporter, DependencyGroupList>(
     install: Install<'_, DependencyGroupList>,
-    lockfile_specifier_project_manifests: Option<Vec<(PathBuf, PackageManifest)>>,
-    read_package_hooked_manifest_paths: HashSet<PathBuf>,
+    unsaved: UnsavedManifests,
     bumps: Option<&ManifestSpecBumps>,
 ) -> Result<Option<crate::InstallError>, UpdateError>
 where
     Reporter: self::Reporter + 'static,
     DependencyGroupList: IntoIterator<Item = DependencyGroup> + Send,
 {
-    match lockfile_specifier_project_manifests {
+    match unsaved.lockfile_specifiers {
         Some(manifests) => {
             install
                 .run_with_lockfile_specifier_project_manifests::<Reporter>(
                     manifests,
-                    read_package_hooked_manifest_paths,
+                    unsaved.hooked_paths,
                 )
                 .await
         }
@@ -770,21 +846,20 @@ fn selected_seed_policy(
 async fn run_selected_update_install<Reporter, DependencyGroupList>(
     install: Install<'_, DependencyGroupList>,
     selection: WorkspaceInstallSelection<'_>,
-    lockfile_specifier_project_manifests: Option<Vec<(PathBuf, PackageManifest)>>,
-    read_package_hooked_manifest_paths: HashSet<PathBuf>,
+    unsaved: UnsavedManifests,
     bumps: Option<&ManifestSpecBumps>,
 ) -> Result<Option<crate::InstallError>, UpdateError>
 where
     Reporter: self::Reporter + 'static,
     DependencyGroupList: IntoIterator<Item = DependencyGroup> + Send,
 {
-    match lockfile_specifier_project_manifests {
+    match unsaved.lockfile_specifiers {
         Some(manifests) => {
             install
                 .run_selected_with_lockfile_specifier_project_manifests::<Reporter>(
                     selection,
                     manifests,
-                    read_package_hooked_manifest_paths,
+                    unsaved.hooked_paths,
                 )
                 .await
         }
@@ -920,46 +995,44 @@ async fn apply_read_package_hook_to_update_manifest(
     Ok(())
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "manifest preparation consumes the update command's matching inputs"
-)]
 async fn prepare_manifest<Reporter: self::Reporter>(
     manifest: &mut PackageManifest,
-    http_client_arc: &Arc<ThrottledClient>,
-    config: &Config,
-    lockfile: Option<&Lockfile>,
-    packages: &[String],
-    latest: bool,
-    save_exact: bool,
-    save: bool,
-    include_direct: &[DependencyGroup],
-    depth: usize,
-    workspace_packages: Option<&WorkspacePackages>,
+    update: UpdateView<'_>,
+    owned: &UpdateOwned,
     catalogs_seed: Option<&Catalogs>,
     latest_chain: &mut Option<LatestResolverChain>,
-    lockfile_only: bool,
-    resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
 ) -> Result<Option<UpdatePreparation>, UpdateError> {
-    // `pacquet update` has no `--save-prefix` flag yet, so `save_exact`
-    // selects between an exact pin and the default caret range.
-    let range_spec_style = RangeSpecStyle::from_save_options(save_exact, None);
-    let selectors = packages.iter().map(|input| parse_update_param(input)).collect::<Vec<_>>();
-    if latest {
-        reject_versioned_latest_selectors(packages, &selectors)?;
-    }
+    let Some(decision) =
+        decide_update::<Reporter>(manifest, update, owned, catalogs_seed, latest_chain).await?
+    else {
+        return Ok(None);
+    };
+    apply_update_decision::<Reporter>(manifest, update, decision).map(Some)
+}
 
+/// What the seed-policy decision settled: the plan, the policy, the direct
+/// dependencies as the manifest declared them, and the catalogs consulted.
+struct UpdateDecision {
+    plan: UpdatePlan,
+    seed_policy: UpdateSeedPolicy,
+    direct: Vec<(String, DependencyGroup, String)>,
+    catalog_ctx: Option<CatalogCtx>,
+}
+
+async fn decide_update<Reporter: self::Reporter>(
+    manifest: &PackageManifest,
+    update: UpdateView<'_>,
+    owned: &UpdateOwned,
+    catalogs_seed: Option<&Catalogs>,
+    latest_chain: &mut Option<LatestResolverChain>,
+) -> Result<Option<UpdateDecision>, UpdateError> {
+    let selectors = parse_selectors(update.packages);
+    if update.latest {
+        reject_versioned_latest_selectors(update.packages, &selectors)?;
+    }
     // Snapshot direct dependencies before mutation so matching and rewrites
     // both see the original manifest shape.
-    let direct = include_direct
-        .iter()
-        .flat_map(|&group| {
-            manifest
-                .dependencies([group])
-                .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
+    let direct = declared_direct(manifest, &owned.include_direct);
     // Catalogs stay lazy unless an earlier selected project already produced
     // the complete in-memory catalog set for this batch.
     let mut catalog_ctx = catalogs_seed
@@ -968,93 +1041,139 @@ async fn prepare_manifest<Reporter: self::Reporter>(
     let scope = UpdateScope {
         selectors: &selectors,
         direct: &direct,
-        lockfile,
-        config,
-        latest,
-        save,
-        depth,
-        max_depth: UpdateDepth::new(depth),
-        range_spec_style,
-        updates_all_groups: DIRECT_GROUPS.iter().all(|group| include_direct.contains(group)),
+        lockfile: update.lockfile,
+        config: update.config,
+        latest: update.latest,
+        save: update.save,
+        depth: update.depth,
+        max_depth: UpdateDepth::new(update.depth),
+        // `pacquet update` has no `--save-prefix` flag yet, so `save_exact`
+        // selects between an exact pin and the default caret range.
+        range_spec_style: RangeSpecStyle::from_save_options(update.save_exact, None),
+        updates_all_groups: updates_all_groups(&owned.include_direct),
         // Bare-name selectors with depth update matching names at any depth.
         use_name_matcher: !selectors.is_empty()
             && selectors.iter().all(|selector| selector.version.is_none())
-            && depth > 0
-            && !latest,
+            && update.depth > 0
+            && !update.latest,
     };
-
-    // `--workspace` with nothing to link falls through to the ordinary
-    // branches below: a selector that matched no direct dependency still
-    // updates that name deeper in the graph, and an empty selector list
-    // still updates every direct dependency.
-    let workspace_targets = workspace_packages
-        .map(|packages| workspace_link_targets(&selectors, &direct, packages, config))
-        .transpose()?
-        .unwrap_or_default();
-
     let mut plan = UpdatePlan::default();
-    let seed_policy = {
-        let rewrite_ctx = LatestRewriteCtx {
+    let Some(seed_policy) = select_seed_policy::<Reporter>(
+        &scope,
+        &mut plan,
+        &LatestRewriteCtx {
             manifest,
-            config,
-            http_client_arc,
-            resolution_observer,
-            range_spec_style,
-            lockfile_only,
-        };
-        let selected = select_seed_policy::<Reporter>(
-            &scope,
-            &mut plan,
-            &rewrite_ctx,
-            latest_chain,
-            &mut catalog_ctx,
-            (workspace_packages, workspace_targets),
-        )
-        .await?;
-        match selected {
-            Some(seed_policy) => seed_policy,
-            None => return Ok(None),
-        }
+            config: update.config,
+            http_client_arc: &owned.http_client_arc,
+            resolution_observer: owned.resolution_observer.as_ref(),
+            range_spec_style: scope.range_spec_style,
+            lockfile_only: update.lockfile_only,
+        },
+        latest_chain,
+        &mut catalog_ctx,
+        (update.workspace_packages, workspace_targets(update, &selectors, &direct)?),
+    )
+    .await?
+    else {
+        return Ok(None);
     };
+    Ok(Some(UpdateDecision { plan, seed_policy, direct, catalog_ctx }))
+}
 
+/// The direct dependencies of the groups the update covers, as
+/// `(name, group, specifier)`.
+fn declared_direct(
+    manifest: &PackageManifest,
+    include_direct: &[DependencyGroup],
+) -> Vec<(String, DependencyGroup, String)> {
+    include_direct
+        .iter()
+        .flat_map(|&group| {
+            manifest
+                .dependencies([group])
+                .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
+                .collect::<Vec<_>>()
+        })
+        .collect()
+}
+
+fn updates_all_groups(include_direct: &[DependencyGroup]) -> bool {
+    DIRECT_GROUPS.iter().all(|group| include_direct.contains(group))
+}
+
+/// `--workspace` with nothing to link falls through to the ordinary
+/// branches below: a selector that matched no direct dependency still
+/// updates that name deeper in the graph, and an empty selector list
+/// still updates every direct dependency.
+fn workspace_targets(
+    update: UpdateView<'_>,
+    selectors: &[ParsedSelector],
+    direct: &[(String, DependencyGroup, String)],
+) -> Result<Vec<WorkspaceLinkTarget>, UpdateError> {
+    Ok(update
+        .workspace_packages
+        .map(|packages| workspace_link_targets(selectors, direct, packages, update.config))
+        .transpose()?
+        .unwrap_or_default())
+}
+
+fn apply_update_decision<Reporter: self::Reporter>(
+    manifest: &mut PackageManifest,
+    update: UpdateView<'_>,
+    decision: UpdateDecision,
+) -> Result<UpdatePreparation, UpdateError> {
+    let UpdateDecision { mut plan, seed_policy, direct, mut catalog_ctx } = decision;
     // Reconcile only manifest rewrites. Existing `catalog:` references retain
     // their group, and non-manual catalog modes may promote direct versions.
     let mut updated_catalogs = Catalogs::new();
     let workspace_dir_for_catalogs = reconcile_catalog_rewrites::<Reporter>(
         manifest,
-        config,
-        latest,
+        update.config,
+        update.latest,
         &direct,
         &mut plan.rewrites,
         &mut catalog_ctx,
         &mut updated_catalogs,
     )?;
-
     // `--no-save` still mutates the in-memory manifest used for resolution,
     // while leaving package.json and reporter manifest events untouched.
-    let persist_manifest = save && !plan.rewrites.is_empty();
+    let persist_manifest = update.save && !plan.rewrites.is_empty();
     if persist_manifest {
         emit_initial_package_manifest::<Reporter>(manifest);
     }
-    for (name, group, specifier) in &plan.rewrites {
-        manifest.add_dependency(name, specifier, *group).map_err(UpdateError::UpdateManifest)?;
-    }
-    // The install must resolve against the complete catalog set even when
-    // `--no-save` deliberately skips the workspace-manifest write.
-    let catalogs_override = (!updated_catalogs.is_empty()).then(|| {
-        let mut merged = catalog_ctx.as_ref().map(|ctx| ctx.catalogs.clone()).unwrap_or_default();
-        merge_catalogs(&mut merged, &updated_catalogs);
-        merged
-    });
-    Ok(Some(UpdatePreparation {
+    apply_rewrites(manifest, &plan.rewrites)?;
+    Ok(UpdatePreparation {
         seed_policy,
         preferred_versions_override: plan.preferred_versions_override,
         persist_manifest,
         bump_targets: plan.bump_targets,
+        catalogs_override: merged_catalogs_override(catalog_ctx.as_ref(), &updated_catalogs),
         updated_catalogs,
-        catalogs_override,
         workspace_dir_for_catalogs,
-    }))
+    })
+}
+
+fn apply_rewrites(
+    manifest: &mut PackageManifest,
+    rewrites: &[(String, DependencyGroup, String)],
+) -> Result<(), UpdateError> {
+    for (name, group, specifier) in rewrites {
+        manifest.add_dependency(name, specifier, *group).map_err(UpdateError::UpdateManifest)?;
+    }
+    Ok(())
+}
+
+/// The install must resolve against the complete catalog set even when
+/// `--no-save` deliberately skips the workspace-manifest write.
+fn merged_catalogs_override(
+    catalog_ctx: Option<&CatalogCtx>,
+    updated_catalogs: &Catalogs,
+) -> Option<Catalogs> {
+    (!updated_catalogs.is_empty()).then(|| {
+        let mut merged = catalog_ctx.map(|ctx| ctx.catalogs.clone()).unwrap_or_default();
+        merge_catalogs(&mut merged, updated_catalogs);
+        merged
+    })
 }
 
 /// `--latest` forbids versioned selectors.
@@ -1612,26 +1731,12 @@ fn reconcile_rewrite<Reporter: self::Reporter>(
     }
 }
 
-#[expect(
-    clippy::too_many_arguments,
-    reason = "selected update preparation reuses the command's matching inputs"
-)]
 async fn prepare_selected_manifests<Reporter: self::Reporter>(
     projects: &mut [pnpm_workspace::Project],
     selected_indices: &[usize],
     workspace_root: &Path,
-    http_client_arc: &Arc<ThrottledClient>,
-    config: &Config,
-    lockfile: Option<&Lockfile>,
-    packages: &[String],
-    latest: bool,
-    save_exact: bool,
-    save: bool,
-    include_direct: &[DependencyGroup],
-    depth: usize,
-    workspace_packages: Option<&WorkspacePackages>,
-    lockfile_only: bool,
-    resolution_observer: Option<&Arc<dyn crate::ResolutionObserver>>,
+    update: UpdateView<'_>,
+    owned: &UpdateOwned,
 ) -> Result<SelectedUpdatePreparation, UpdateError> {
     // One picker across every selected project: it is created on first
     // use, so a selection that resolves no `latest` tag never builds one.
@@ -1643,14 +1748,14 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     // sibling only reaches it transitively. `--depth 0` reports
     // `NoPackageInDependencies` instead, and `--latest` rejects versioned
     // selectors outright.
-    if !latest && depth > 0 {
-        let selectors = packages.iter().map(|input| parse_update_param(input)).collect::<Vec<_>>();
+    if !update.latest && update.depth > 0 {
+        let selectors = parse_selectors(update.packages);
         let manifests =
             selected_indices.iter().map(|&index| &projects[index].manifest).collect::<Vec<_>>();
         reject_versions_of_indirect_update_specs::<Reporter>(
             &selectors,
             &manifests,
-            include_direct,
+            &owned.include_direct,
             &workspace_root.to_string_lossy(),
         )?;
     }
@@ -1658,20 +1763,10 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     for &index in selected_indices {
         let Some(prepared) = prepare_manifest::<Reporter>(
             &mut projects[index].manifest,
-            http_client_arc,
-            config,
-            lockfile,
-            packages,
-            latest,
-            save_exact,
-            save,
-            include_direct,
-            depth,
-            workspace_packages,
+            update,
+            owned,
             prepared_all.catalogs_override.as_ref(),
             &mut latest_chain,
-            lockfile_only,
-            resolution_observer,
         )
         .await?
         else {
@@ -1685,7 +1780,7 @@ async fn prepare_selected_manifests<Reporter: self::Reporter>(
     // A recursive `--latest` that matches nothing is an error, unlike the
     // single-project one that quietly returns: with no project left to
     // mutate there is nothing for the run to have meant.
-    if depth == 0 && !packages.is_empty() && !prepared_all.any_work {
+    if update.depth == 0 && !update.packages.is_empty() && !prepared_all.any_work {
         return Err(UpdateError::NoPackageInDependencies);
     }
 

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -1092,7 +1092,6 @@ fn declared_direct(
             manifest
                 .dependencies([group])
                 .map(move |(name, spec)| (name.to_string(), group, spec.to_string()))
-                .collect::<Vec<_>>()
         })
         .collect()
 }

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -519,7 +519,7 @@ pub struct SelectedProjects<'s> {
 }
 
 impl SelectedProjects<'_> {
-    fn selection(&self) -> WorkspaceInstallSelection<'_> {
+    pub(crate) fn selection(&self) -> WorkspaceInstallSelection<'_> {
         WorkspaceInstallSelection {
             all_projects: self.projects,
             project_dependencies: self.project_dependencies,

--- a/pnpm/crates/package-manager/src/update.rs
+++ b/pnpm/crates/package-manager/src/update.rs
@@ -653,7 +653,7 @@ fn update_install<'i>(
     manifest: &'i PackageManifest,
     seed: UpdateSeed,
     read_package_hook: Option<&ReadPackageHook>,
-) -> Install<'i, Vec<DependencyGroup>> {
+) -> Install<'i, impl Iterator<Item = DependencyGroup>> {
     Install {
         tarball_mem_cache: owned.tarball_mem_cache,
         http_client: update.http_client,
@@ -663,7 +663,7 @@ fn update_install<'i>(
         emit_initial_manifest: false,
         lockfile: MaybeLazyLockfile::Loaded(update.lockfile),
         lockfile_path: update.lockfile_path,
-        dependency_groups: included_direct_groups(update.config.optional).collect(),
+        dependency_groups: included_direct_groups(update.config.optional),
         frozen_lockfile: false,
         prefer_frozen_lockfile: Some(false),
         ignore_manifest_check: false,

--- a/pnpm/crates/package-manager/src/update/tests.rs
+++ b/pnpm/crates/package-manager/src/update/tests.rs
@@ -1,17 +1,51 @@
 use super::{
-    KeptRangeVerdict, UpdateError, apply_bumped_manifest_specs, expand_update_selectors,
-    insert_update_target, is_workspace_local_path_specifier, judge_against_kept_range,
-    parse_update_param, persist_selected_manifests, prepare_selected_manifests,
-    reject_versions_of_indirect_update_specs, selected_project_indices, update_target_name,
+    KeptRangeVerdict, UpdateError, UpdateOwned, UpdateView, apply_bumped_manifest_specs,
+    expand_update_selectors, insert_update_target, is_workspace_local_path_specifier,
+    judge_against_kept_range, parse_update_param, persist_selected_manifests,
+    prepare_selected_manifests, reject_versions_of_indirect_update_specs, selected_project_indices,
+    update_target_name,
 };
 use pnpm_config::{CatalogMode, Config};
-use pnpm_network::ThrottledClient;
 use pnpm_package_manifest::{DependencyGroup, PackageManifest};
 use pnpm_reporter::SilentReporter;
 use pnpm_workspace::Project;
 use serde_json::json;
 use std::collections::{BTreeMap, HashSet};
 use tempfile::tempdir;
+
+/// The update inputs a manifest-preparation test varies, over a leaked
+/// config and idle clients.
+fn test_update(
+    config: Config,
+    packages: &[String],
+    latest: bool,
+    save: bool,
+) -> (UpdateView<'_>, UpdateOwned) {
+    (
+        UpdateView {
+            resolved_packages: Box::leak(Box::new(super::ResolvedPackages::default())),
+            http_client: Box::leak(Box::new(pnpm_network::ThrottledClient::default())),
+            config: Box::leak(Box::new(config)),
+            lockfile: None,
+            lockfile_path: None,
+            packages,
+            latest,
+            patches: false,
+            save_exact: false,
+            save,
+            depth: 0,
+            workspace_packages: None,
+            lockfile_only: false,
+        },
+        UpdateOwned {
+            tarball_mem_cache: std::sync::Arc::new(pnpm_tarball::MemCache::default()),
+            http_client_arc: std::sync::Arc::new(pnpm_network::ThrottledClient::default()),
+            include_direct: vec![DependencyGroup::Prod],
+            supported_architectures: None,
+            resolution_observer: None,
+        },
+    )
+}
 
 #[test]
 fn parses_bare_name_without_version() {
@@ -203,24 +237,15 @@ async fn selected_update_prepares_and_persists_only_selected_projects() {
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let config = Config::new();
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages = ["foo@2.0.0".to_string()];
+    let (update, owned) = test_update(config, &packages, false, true);
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &indices,
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &["foo@2.0.0".to_string()],
-        false,
-        false,
-        true,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await
     .expect("prepare selected manifests");
@@ -248,24 +273,15 @@ async fn selected_update_no_save_mutates_in_memory_without_persisting() {
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let mut config = Config::new();
     config.catalog_mode = CatalogMode::Prefer;
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages = ["foo@1.5.0".to_string()];
+    let (update, owned) = test_update(config, &packages, false, false);
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &indices,
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &["foo@1.5.0".to_string()],
-        false,
-        false,
-        false,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await
     .expect("prepare selected manifests");
@@ -295,24 +311,15 @@ async fn selected_update_no_save_skips_a_selector_outside_the_kept_range() {
     let selected_dirs = ordered_dirs.iter().cloned().collect::<HashSet<_>>();
     let indices = selected_project_indices(&projects, &ordered_dirs, &selected_dirs);
     let config = Config::new();
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages = ["foo@2.0.0".to_string()];
+    let (update, owned) = test_update(config, &packages, false, false);
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &indices,
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &["foo@2.0.0".to_string()],
-        false,
-        false,
-        false,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await
     .expect("prepare selected manifests");
@@ -331,24 +338,15 @@ async fn selected_update_depth_zero_skips_projects_without_a_matching_dependency
     let mut projects = [project_without_foo(dir.path(), "a"), project_with_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
     let config = Config::new();
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages = ["foo@2.0.0".to_string()];
+    let (update, owned) = test_update(config, &packages, false, true);
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &selected_indices,
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &["foo@2.0.0".to_string()],
-        false,
-        false,
-        true,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await
     .expect("prepare selected manifests");
@@ -366,24 +364,15 @@ async fn selected_update_latest_depth_zero_errors_when_no_project_matches() {
     let mut projects = [project_without_foo(dir.path(), "a"), project_without_foo(dir.path(), "b")];
     let selected_indices = [0, 1];
     let config = Config::new();
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages = ["foo".to_string()];
+    let (update, owned) = test_update(config, &packages, true, true);
     let prepared = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &selected_indices,
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &["foo".to_string()],
-        true,
-        false,
-        true,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await;
 
@@ -413,24 +402,15 @@ async fn latest_leaves_specifiers_no_resolver_claims() {
         let dir = tempdir().expect("create tempdir");
         let mut projects = [project_with_foo_specifier(dir.path(), "a", specifier)];
         let config = unroutable_registry_config();
-        let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+        let packages: [String; 0] = [];
+        let (update, owned) = test_update(config, &packages, true, true);
         let prepared = prepare_selected_manifests::<SilentReporter>(
             &mut projects,
             &[0],
             dir.path(),
-            &http_client,
-            &config,
-            None,
-            &[],
-            true,
-            false,
-            true,
-            &[DependencyGroup::Prod],
-            0,
-            None,
-            false,
-            None,
+            update,
+            &owned,
         )
         .await
         .unwrap_or_else(|error| {
@@ -450,24 +430,15 @@ async fn latest_rewrites_a_specifier_the_npm_resolver_claims() {
     let dir = tempdir().expect("create tempdir");
     let mut projects = [project_with_foo(dir.path(), "a")];
     let config = unroutable_registry_config();
-    let http_client = std::sync::Arc::new(ThrottledClient::default());
 
+    let packages: [String; 0] = [];
+    let (update, owned) = test_update(config, &packages, true, true);
     let result = prepare_selected_manifests::<SilentReporter>(
         &mut projects,
         &[0],
         dir.path(),
-        &http_client,
-        &config,
-        None,
-        &[],
-        true,
-        false,
-        true,
-        &[DependencyGroup::Prod],
-        0,
-        None,
-        false,
-        None,
+        update,
+        &owned,
     )
     .await;
 

--- a/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
+++ b/pnpm/crates/package-manager/src/warn_on_stale_convergence_overrides.rs
@@ -51,43 +51,50 @@ where
 {
     let mut stale = Vec::new();
     for override_entry in parsed_overrides.iter().filter(|entry| entry.converge) {
-        let name = &override_entry.target_pkg.name;
-        let Some(ranges) = converge_declared_ranges.get(name) else { continue };
-        let Ok(current) = Version::parse(&override_entry.new_bare_specifier) else { continue };
-        // The collector only records parseable ranges, so a `None`
-        // here is unreachable in practice; bailing out keeps the
-        // "satisfies EVERY collected range" guarantee if it ever
-        // happens.
-        let Some(parsed_ranges) =
-            ranges.iter().map(|range| parse_declared_range(range)).collect::<Option<Vec<_>>>()
-        else {
+        let Some(ranges) = converge_declared_ranges.get(&override_entry.target_pkg.name) else {
             continue;
         };
-        if parsed_ranges.is_empty() {
-            continue;
-        }
-        let mut candidates: Vec<Version> = ranges
+        let candidates = ranges
             .iter()
-            .map(|range| resolve_range(name.clone(), range.clone()))
+            .map(|range| resolve_range(override_entry.target_pkg.name.clone(), range.clone()))
             .pipe(future::join_all)
-            .await
-            .into_iter()
-            .flatten()
-            .collect();
-        candidates.retain(|candidate| *candidate > current);
-        candidates.sort_unstable_by(|lhs, rhs| rhs.cmp(lhs));
-        let best = candidates
-            .into_iter()
-            .find(|candidate| parsed_ranges.iter().all(|range| range.satisfies(candidate)));
-        if let Some(best) = best {
+            .await;
+        if let Some(best) =
+            better_convergence(override_entry, ranges, candidates.into_iter().flatten())
+        {
             stale.push(StaleConvergenceOverride {
-                name: name.clone(),
+                name: override_entry.target_pkg.name.clone(),
                 current_value: override_entry.new_bare_specifier.clone(),
                 best,
             });
         }
     }
     stale
+}
+
+/// The newest resolved candidate past the override's value that satisfies
+/// every declared range, when one exists.
+fn better_convergence(
+    override_entry: &VersionOverride,
+    ranges: &HashSet<String>,
+    candidates: impl Iterator<Item = Version>,
+) -> Option<Version> {
+    let current = Version::parse(&override_entry.new_bare_specifier).ok()?;
+    // The collector only records parseable ranges, so a `None`
+    // here is unreachable in practice; bailing out keeps the
+    // "satisfies EVERY collected range" guarantee if it ever
+    // happens.
+    let parsed_ranges =
+        ranges.iter().map(|range| parse_declared_range(range)).collect::<Option<Vec<_>>>()?;
+    if parsed_ranges.is_empty() {
+        return None;
+    }
+    let mut candidates: Vec<Version> =
+        candidates.filter(|candidate| *candidate > current).collect();
+    candidates.sort_unstable_by(|lhs, rhs| rhs.cmp(lhs));
+    candidates
+        .into_iter()
+        .find(|candidate| parsed_ranges.iter().all(|range| range.satisfies(candidate)))
 }
 
 /// Resolve the best version `range` admits for `name` through the


### PR DESCRIPTION
## Summary

Stacked on pnpm/pnpm#14751 (pnpm/pnpm#14746, pnpm/pnpm#14748 and pnpm/pnpm#14750 are merged); the thirteen commits on top are this PR. Seventh installment of adopting `perfectionist::too_many_local_bindings` at `max_bindings = 12`. Related to pnpm/pnpm#14562.

Closes out `pnpm-package-manager`: after this, no function in the crate is over the cap. The twenty-five sites it clears fall into a few shapes:

- **The three commands run as steps over one view of their inputs.** `Update`, `Add` and `Remove` each took the command apart into a dozen-plus names in both `run` and `run_selected` and built a near-identical `Install` literal in each. Each now splits once into a `Copy` view and the owned values the install consumes, and builds the install through one `update_install` / `add_install` / `remove_install`. The recursive runs take their six selection parameters as one `SelectedProjects` (shared by all three; the CLI's three call sites changed accordingly), and the update's `--no-save` inputs travel as `UnsavedManifests`.
- **The resolution inputs a command threads become one value.** `pnpm add` passed fifteen parameters from `prepare_manifest` through `resolve_added_dependency` into the resolvers; they are one `AddResolveInputs` around an `AddResolution` (the `latest` picker and the packument caches a pass shares). Resolving a selector is now parsing it, finding its save specifier and deciding its catalog outcome. `pnpm update`'s `prepare_manifest` decides and applies as two steps and reads the view instead of fifteen parameters.
- **The lockfile builder names its steps.** `dependencies_graph_to_lockfile` reads its options in place; an importer's direct entry, a node's snapshot row and a package's metadata insert are each one function.
- **The prefetching resolver shares its context with the tasks it spawns** through an `Arc`, so a spawned download clones one handle instead of thirteen fields, and its two integrity-discovery routes are methods.
- **The rest** are single extractions: the patch's candidate scan and git-hosted re-fetch, the client tarball download read in place, the repeat-install checks sharing a `ManifestDrift`, the local-tarball lookup, the spec-bump sink, the override rewrite's in-place target, the stale-convergence ranking, the early materializer's required edges.

No user-visible behavior changes; no changeset. Nothing is cloned or allocated that was not before: the `update` and `add` installs now move their client and metadata-cache handles instead of cloning them, the prefetch spawn clones one `Arc` where it cloned six, and one `Arc` wraps the prefetch context once per install.

## Squash Commit Body

```text
Bring pnpm-package-manager fully under the twelve-name cap.

Run update, add and remove as steps over one Copy view of their inputs,
building each install through one function and taking the recursive
selection as SelectedProjects. Bundle the add's resolution inputs and
shared picker and caches, and resolve a selector as parse, save
specifier and catalog outcome. Build the lockfile's importers, nodes
and metadata as steps. Share the prefetch context with its spawned
tasks through an Arc. Extract the remaining single steps: the patch
candidate scan and git-hosted re-fetch, the client tarball download,
the repeat-install manifest drift, the local-tarball lookup, the spec
bump sink, the override rewrite target, the stale-convergence ranking
and the early materializer's required edges.

Related to pnpm/pnpm#14562.
```

## Checklist

- [x] I checked the referenced issue and verified that none of the PRs
  already linked to it solves it.
- [x] Added or updated tests.

---
Written by an agent (Claude Code, claude-fable-5-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019kR4Ev797PFQ6iaC3AtzRw

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/pnpm/codesmith/pnpm/pr/14755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791582420&installation_model_id=426870&pr_number=14755&repository=pnpm%2Fpnpm&return_to=https%3A%2F%2Fgithub.com%2Fpnpm%2Fpnpm%2Fpull%2F14755&signature=c595cd7b34e34d39e4f77f47ef8a01fc7a311f691ab69337e0eb037d78265bf2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the internal workflows supporting package installation, dependency resolution, workspace selection, manifest handling, lifecycle scripts, lockfiles, and package fetching.
  - Unified project-selection handling across add, remove, update, and install operations while preserving existing command behavior.
  - Streamlined dependency graph generation and materialization workflows.

- **Tests**
  - Updated test coverage and helpers for the reorganized package-management workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

